### PR TITLE
fix: Fix nightly Daft version resolution in Ray runtime env

### DIFF
--- a/benchmarking/utils.py
+++ b/benchmarking/utils.py
@@ -17,7 +17,7 @@ def daft_uv_runtime_env() -> dict:
     daft_pkg = f"daft[aws]=={daft_version}" if daft_version else "daft[aws]"
     uv_env: dict = {"packages": [daft_pkg]}
     if daft_index_url:
-        uv_env["uv_pip_install_options"] = ["--index-url", daft_index_url, "--extra-index-url", "https://pypi.org/simple/"]
+        uv_env["uv_pip_install_options"] = ["--extra-index-url", daft_index_url, "--index-strategy", "unsafe-best-match"]
     return uv_env
 
 


### PR DESCRIPTION
## Summary
- uv's `--extra-index-url` takes priority over `--index-url` — we had them backwards in the Ray runtime env config, so PyPI's stable release was winning over the nightly dev build
- Swaps the index flags and adds `--index-strategy unsafe-best-match` so explicit version pins from PyPI still resolve

## Test plan
- [x] Verified locally with `uv pip install --dry-run` that unpinned resolves to nightly dev build
- [x] Verified locally that explicit version pins still resolve from PyPI