### PR TITLE
feat: Expose Subscribers through nicer APIs

### DIFF
--- a/daft/__init__.py
+++ b/daft/__init__.py
@@ -62,8 +62,12 @@ from daft.catalog import (
     Table,
 )
 from daft.context import (
+    get_context,
+    attach_subscriber,
+    detach_subscriber,
     set_execution_config,
     set_planning_config,
+    with_subscriber,
     execution_config_ctx,
     planning_config_ctx,
 )
@@ -196,6 +200,7 @@ __all__ = [
     "attach_catalog",
     "attach_function",
     "attach_provider",
+    "attach_subscriber",
     "attach_table",
     "cls",
     "col",
@@ -214,6 +219,7 @@ __all__ = [
     "detach_catalog",
     "detach_function",
     "detach_provider",
+    "detach_subscriber",
     "detach_table",
     "drop_namespace",
     "drop_table",
@@ -230,6 +236,7 @@ __all__ = [
     "func",
     "functions",
     "get_catalog",
+    "get_context",
     "get_function",
     "get_or_create_runner",
     "get_or_infer_runner_type",
@@ -281,5 +288,6 @@ __all__ = [
     "sql",
     "sql_expr",
     "udf",
+    "with_subscriber",
     "write_table",
 ]

--- a/daft/context.py
+++ b/daft/context.py
@@ -107,6 +107,51 @@ def get_context() -> DaftContext:
 
 
 @contextlib.contextmanager
+def with_subscriber(alias: str, subscriber: Subscriber) -> Generator[None, None, None]:
+    """Context manager that attaches a subscriber to the current context, and detaches it afterwards.
+
+    Args:
+        alias (str): Alias of subscriber to attach
+        subscriber (Subscriber): Subscriber instance that will receive events
+
+    Examples:
+        >>> with daft.with_subscriber("my_subscriber", ...):
+        ...     df = daft.from_pydict({"x": [1, 2, 3]})
+        ...     df = df.with_column("y", df["x"] + 1)
+        ...     df = df.limit(5)
+        ...     df.collect()
+    """
+    ctx = get_context()
+    try:
+        ctx.attach_subscriber(alias, subscriber)
+        yield
+    finally:
+        ctx.detach_subscriber(alias)
+
+
+def attach_subscriber(alias: str, subscriber: Subscriber) -> DaftContext:
+    """Attaches a subscriber to the current context.
+
+    Args:
+        alias (str): Name-based alias for the subscriber
+        subscriber (Subscriber): Subscriber instance that will receive events
+    """
+    ctx = get_context()
+    ctx.attach_subscriber(alias, subscriber)
+    return ctx
+
+
+def detach_subscriber(alias: str) -> None:
+    """Detaches a subscriber from the current context.
+
+    Args:
+        alias (str): Alias of subscriber to detach
+    """
+    ctx = get_context()
+    ctx.detach_subscriber(alias)
+
+
+@contextlib.contextmanager
 def planning_config_ctx(**kwargs: Any) -> Generator[None, None, None]:
     """Context manager that wraps set_planning_config to reset the config to its original setting afternwards."""
     original_config = get_context().daft_planning_config

--- a/daft/context.py
+++ b/daft/context.py
@@ -122,8 +122,8 @@ def with_subscriber(alias: str, subscriber: Subscriber) -> Generator[None, None,
         ...     df.collect()
     """
     ctx = get_context()
+    ctx.attach_subscriber(alias, subscriber)
     try:
-        ctx.attach_subscriber(alias, subscriber)
         yield
     finally:
         ctx.detach_subscriber(alias)

--- a/tests/test_subscribers.py
+++ b/tests/test_subscribers.py
@@ -84,8 +84,7 @@ class MockSubscriber(Subscriber):
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 def test_capture_states(monkeypatch):
     subscriber = MockSubscriber()
-    ctx = daft.context.get_context()
-    ctx.attach_subscriber("mock", subscriber)
+    daft.attach_subscriber("mock", subscriber)
 
     def inject_keyboard_interrupt():
         threading.Timer(2.0, lambda: signal.raise_signal(signal.SIGINT)).start()
@@ -152,10 +151,8 @@ def test_show_fires_query_end():
     on_query_end so the dashboard transitions out of Finalizing.
     """
     subscriber = MockSubscriber()
-    ctx = daft.context.get_context()
-    ctx.attach_subscriber("mock", subscriber)
 
-    try:
+    with daft.with_subscriber("mock", subscriber):
         # Sanity check: .collect() on a transformed DataFrame fires on_query_end.
         df = daft.from_pydict({"x": list(range(100))})
         df = df.with_column("y", daft.col("x") + 1)
@@ -176,41 +173,37 @@ def test_show_fires_query_end():
             "on_query_end was not called — query would be stuck in Finalizing on the dashboard"
         )
         assert subscriber.end_states[query_id] == QueryEndState.Finished
-    finally:
-        ctx.detach_subscriber("mock")
 
 
 def test_subscriber_template():
     subscriber = MockSubscriber()
-    ctx = daft.context.get_context()
-    ctx.attach_subscriber("mock", subscriber)
 
-    df = daft.from_pydict({"x": [1, 2, 3]})
-    df = df.with_column("y", df["x"] + 1)
-    df = df.limit(5)
+    with daft.with_subscriber("mock", subscriber):
+        df = daft.from_pydict({"x": [1, 2, 3]})
+        df = df.with_column("y", df["x"] + 1)
+        df = df.limit(5)
 
-    output_schema = df.schema()
-    unoptimized_plan_json = df._builder.repr_json()
-    df = df.collect()
+        output_schema = df.schema()
+        unoptimized_plan_json = df._builder.repr_json()
+        df = df.collect()
 
-    query_id = next(iter(subscriber.query_metadata.keys()))
-    # Subscriber now receives JSON representation
-    assert subscriber.query_metadata[query_id].unoptimized_plan == unoptimized_plan_json
-    assert subscriber.query_metadata[query_id].output_schema == output_schema._schema
-    # Optimized plan should be different from unoptimized plan
-    assert subscriber.query_optimized_plan[query_id] != unoptimized_plan_json
+        query_id = next(iter(subscriber.query_metadata.keys()))
+        # Subscriber now receives JSON representation
+        assert subscriber.query_metadata[query_id].unoptimized_plan == unoptimized_plan_json
+        assert subscriber.query_metadata[query_id].output_schema == output_schema._schema
+        # Optimized plan should be different from unoptimized plan
+        assert subscriber.query_optimized_plan[query_id] != unoptimized_plan_json
 
-    # Verify ResultProduced events delivered the expected row count
-    assert subscriber.query_result_rows[query_id] == 3
+        # Verify ResultProduced events delivered the expected row count
+        assert subscriber.query_result_rows[query_id] == 3
 
-    # Test stats
-    for _, stats in subscriber.query_node_stats[query_id].items():
-        for stat_name, stat_value in stats.items():
-            if stat_name == "rows_in" or stat_name == "rows_out":
-                assert stat_value == 3
+        # Test stats
+        for _, stats in subscriber.query_node_stats[query_id].items():
+            for stat_name, stat_value in stats.items():
+                if stat_name == "rows_in" or stat_name == "rows_out":
+                    assert stat_value == 3
 
     # Verify detach
-    ctx.detach_subscriber("mock")
     df = daft.from_pydict({"x": [1, 2, 3]})
     df = df.with_column("y", df["x"] + 1)
     df.collect()
@@ -226,10 +219,8 @@ def test_execution_events_inherit_from_event_base():
 
 def test_csv_scan_reports_bytes_read(tmp_path):
     subscriber = MockSubscriber()
-    ctx = daft.context.get_context()
-    ctx.attach_subscriber("mock", subscriber)
 
-    try:
+    with daft.with_subscriber("mock", subscriber):
         csv_path = tmp_path / "input.csv"
         csv_path.write_text("a,b\n1,2\n3,4\n5,6\n")
 
@@ -242,5 +233,3 @@ def test_csv_scan_reports_bytes_read(tmp_path):
         ]
         assert bytes_read_values, "Expected at least one source node to report bytes.read"
         assert any(value > 0 for value in bytes_read_values)
-    finally:
-        ctx.detach_subscriber("mock")


### PR DESCRIPTION
## Changes Made

Just expose some nicer APIs for working with subscribers. I don't think these APIs will change too much, but ik the actual subscriber class will change a bunch. Happy to add warnings indicating that this is an experimental API, but I want to implement OpenLineage support through this. Wdyt?

