### PR TITLE
feat(stats): add phase-aware SortStats for distributed Sort operator

### DIFF
--- a/src/daft-distributed/src/pipeline_node/sort.rs
+++ b/src/daft-distributed/src/pipeline_node/sort.rs
@@ -58,7 +58,8 @@ impl RuntimeStats for SortStats {
         // All phases contribute duration
         self.base.add_duration_us(snapshot.duration_us());
 
-        // For row counts, ignore snapshots from the sample and repartition phases.
+        // For row counts, ignore snapshots from the sample and repartition phases
+        // (if they occurred - skipped for the single-partition case).
         // The final sort phase produces two snapshots:
         // * a Source snapshot from the in_memory_scan, which we also ignore to avoid double-counting rows_out
         // * a Default snapshot from the sort, which we report as the rows_in and rows_out for the distributed operator

--- a/src/daft-distributed/src/pipeline_node/sort.rs
+++ b/src/daft-distributed/src/pipeline_node/sort.rs
@@ -41,12 +41,12 @@ const SAMPLE_PHASE: &str = "sample";
 const REPARTITION_PHASE: &str = "repartition";
 const FINAL_SORT_PHASE: &str = "final-sort";
 
-pub struct SortStats {
+struct SortStats {
     base: BaseCounters,
 }
 
 impl SortStats {
-    pub fn new(meter: &Meter, context: &PipelineNodeContext) -> Self {
+    fn new(meter: &Meter, context: &PipelineNodeContext) -> Self {
         Self {
             base: BaseCounters::new(meter, context),
         }

--- a/src/daft-distributed/src/pipeline_node/sort.rs
+++ b/src/daft-distributed/src/pipeline_node/sort.rs
@@ -1,7 +1,11 @@
 use std::{future, sync::Arc};
 
 use common_error::DaftResult;
-use common_metrics::ops::{NodeCategory, NodeType};
+use common_metrics::{
+    Meter, StatSnapshot,
+    ops::{NodeCategory, NodeInfo, NodeType},
+    snapshot::StatSnapshotImpl,
+};
 use daft_dsl::expr::bound_expr::BoundExpr;
 use daft_local_plan::{
     LocalNodeContext, LocalPhysicalPlan, RepartitionWriteBackend, SamplingMethod,
@@ -26,8 +30,51 @@ use crate::{
         scheduler::{SchedulerHandle, SubmittedTask},
         task::{SwordfishTask, SwordfishTaskBuilder},
     },
+    statistics::{
+        RuntimeStats,
+        stats::{BaseCounters, RuntimeStatsRef},
+    },
     utils::channel::{Sender, create_channel},
 };
+
+const SAMPLE_PHASE: &str = "sample";
+const REPARTITION_PHASE: &str = "repartition";
+const FINAL_SORT_PHASE: &str = "final-sort";
+
+pub struct SortStats {
+    base: BaseCounters,
+}
+
+impl SortStats {
+    pub fn new(meter: &Meter, context: &PipelineNodeContext) -> Self {
+        Self {
+            base: BaseCounters::new(meter, context),
+        }
+    }
+}
+
+impl RuntimeStats for SortStats {
+    fn handle_worker_node_stats(&self, node_info: &NodeInfo, snapshot: &StatSnapshot) {
+        // All phases contribute duration
+        self.base.add_duration_us(snapshot.duration_us());
+
+        // For row counts, ignore snapshots from the sample and repartition phases.
+        // The final sort phase produces two snapshots:
+        // * a Source snapshot from the in_memory_scan, which we also ignore to avoid double-counting rows_out
+        // * a Default snapshot from the sort, which we report as the rows_in and rows_out for the distributed operator
+        if let StatSnapshot::Default(snapshot) = snapshot
+            && let Some(phase) = &node_info.node_phase
+            && phase == FINAL_SORT_PHASE
+        {
+            self.base.add_rows_in(snapshot.rows_in);
+            self.base.add_rows_out(snapshot.rows_out);
+        }
+    }
+
+    fn export_snapshot(&self) -> StatSnapshot {
+        self.base.export_default_snapshot()
+    }
+}
 
 /// Computes partition boundaries from sampled data for range partitioning.
 /// Takes already-sampled materialized outputs and computes boundaries that divide the data
@@ -128,25 +175,29 @@ pub(crate) fn create_sample_tasks(
     materialized_outputs
         .into_iter()
         .map(|mo| {
-            let (in_memory_scan, psets) = MaterializedOutput::into_in_memory_scan_with_psets(
-                vec![mo],
-                input_schema.clone(),
-                pipeline_node.node_id(),
-            );
+            let (in_memory_scan, psets) =
+                MaterializedOutput::into_in_memory_scan_with_psets_and_phase(
+                    vec![mo],
+                    input_schema.clone(),
+                    pipeline_node.node_id(),
+                    SAMPLE_PHASE,
+                );
             let sample = LocalPhysicalPlan::sample(
                 in_memory_scan,
                 SamplingMethod::Size(sample_size),
                 true,
                 None,
                 StatsState::NotMaterialized,
-                LocalNodeContext::new(Some(pipeline_node.node_id() as usize)),
+                LocalNodeContext::new(Some(pipeline_node.node_id() as usize))
+                    .with_phase(SAMPLE_PHASE),
             );
             let plan = LocalPhysicalPlan::project(
                 sample,
                 sample_by.clone(),
                 sample_schema.clone(),
                 StatsState::NotMaterialized,
-                LocalNodeContext::new(Some(pipeline_node.node_id() as usize)),
+                LocalNodeContext::new(Some(pipeline_node.node_id() as usize))
+                    .with_phase(SAMPLE_PHASE),
             );
             let mut builder =
                 SwordfishTaskBuilder::new(plan, pipeline_node, pipeline_node.node_id())
@@ -181,13 +232,13 @@ pub(crate) fn create_range_repartition_tasks(
     materialized_outputs
         .into_iter()
         .map(|mo| {
-            let in_memory_source_plan = LocalPhysicalPlan::in_memory_scan(
-                node_id,
-                input_schema.clone(),
-                mo.size_bytes(),
-                StatsState::NotMaterialized,
-                LocalNodeContext::new(Some(node_id as usize)),
-            );
+            let (in_memory_source_plan, psets) =
+                MaterializedOutput::into_in_memory_scan_with_psets_and_phase(
+                    vec![mo],
+                    input_schema.clone(),
+                    node_id,
+                    REPARTITION_PHASE,
+                );
             let plan = LocalPhysicalPlan::repartition_write(
                 in_memory_source_plan,
                 num_partitions,
@@ -200,11 +251,11 @@ pub(crate) fn create_range_repartition_tasks(
                     descending.clone(),
                 )),
                 StatsState::NotMaterialized,
-                LocalNodeContext::new(Some(node_id as usize)),
+                LocalNodeContext::new(Some(node_id as usize)).with_phase(REPARTITION_PHASE),
             );
             let mut builder =
                 SwordfishTaskBuilder::new(plan, pipeline_node, pipeline_node.node_id())
-                    .with_psets(node_id, mo.into_inner().0);
+                    .with_psets(node_id, psets);
             if let Some(salt) = fingerprint_salt {
                 builder = builder.extend_fingerprint(salt);
             }
@@ -284,6 +335,7 @@ impl SortNode {
         }
 
         if materialized_outputs.len() == 1 {
+            // TODO repro and handle this case?
             let (in_memory_scan, psets) = MaterializedOutput::into_in_memory_scan_with_psets(
                 materialized_outputs,
                 self.config.schema.clone(),
@@ -364,7 +416,7 @@ impl SortNode {
                 self.config.schema.clone(),
                 total_size_bytes,
                 StatsState::NotMaterialized,
-                LocalNodeContext::new(Some(self.node_id() as usize)),
+                LocalNodeContext::new(Some(self.node_id() as usize)).with_phase(FINAL_SORT_PHASE),
             );
             let plan = LocalPhysicalPlan::sort(
                 in_memory_source_plan,
@@ -372,7 +424,7 @@ impl SortNode {
                 self.descending.clone(),
                 self.nulls_first.clone(),
                 StatsState::NotMaterialized,
-                LocalNodeContext::new(Some(self.node_id() as usize)),
+                LocalNodeContext::new(Some(self.node_id() as usize)).with_phase(FINAL_SORT_PHASE),
             );
             let task = SwordfishTaskBuilder::new(plan, self.as_ref(), self.node_id())
                 .with_psets(self.node_id(), partition_group);
@@ -393,6 +445,10 @@ impl PipelineNodeImpl for SortNode {
 
     fn children(&self) -> Vec<DistributedPipelineNode> {
         vec![self.child.clone()]
+    }
+
+    fn make_runtime_stats(&self, meter: &Meter) -> RuntimeStatsRef {
+        Arc::new(SortStats::new(meter, self.context()))
     }
 
     fn multiline_display(&self, _verbose: bool) -> Vec<String> {

--- a/src/daft-distributed/src/pipeline_node/sort.rs
+++ b/src/daft-distributed/src/pipeline_node/sort.rs
@@ -335,19 +335,21 @@ impl SortNode {
         }
 
         if materialized_outputs.len() == 1 {
-            // TODO repro and handle this case?
-            let (in_memory_scan, psets) = MaterializedOutput::into_in_memory_scan_with_psets(
-                materialized_outputs,
-                self.config.schema.clone(),
-                self.node_id(),
-            );
+            // skip straight to the final sort phase
+            let (in_memory_scan, psets) =
+                MaterializedOutput::into_in_memory_scan_with_psets_and_phase(
+                    materialized_outputs,
+                    self.config.schema.clone(),
+                    self.node_id(),
+                    FINAL_SORT_PHASE,
+                );
             let plan = LocalPhysicalPlan::sort(
                 in_memory_scan,
                 self.sort_by.clone(),
                 self.descending.clone(),
                 self.nulls_first.clone(),
                 StatsState::NotMaterialized,
-                LocalNodeContext::new(Some(self.node_id() as usize)),
+                LocalNodeContext::new(Some(self.node_id() as usize)).with_phase(FINAL_SORT_PHASE),
             );
             let task = SwordfishTaskBuilder::new(plan, self.as_ref(), self.node_id())
                 .with_psets(self.node_id(), psets);


### PR DESCRIPTION
## Summary
- Sort creates sample, repartition, and final-sort tasks; without phase filtering, all task stats get summed together, inflating row counts
- Adds `SortStats` (following `LimitStats` pattern) that only counts `rows_in`/`rows_out` from the sort task of the `FINAL_SORT_PHASE`, ignoring sample and repartition phases
- Tags all internal local plans with appropriate phase constants (`sample`, `repartition`, `final-sort`)

## Test plan
- [x] Run distributed Sort query and verify `rows_in`/`rows_out` reflect only the final sort, not sampling/repartitioning