### PR TITLE
feat(dashboard): Support event log import to dashboard

### DIFF
--- a/daft/subscribers/event_log.py
+++ b/daft/subscribers/event_log.py
@@ -152,14 +152,20 @@ class EventLogSubscriber(Subscriber):
 
     def on_query_started(self, event: QueryStarted) -> None:
         self._query_starts[event.query_id] = _mono_ms()
+        payload = {
+            "plan": event.metadata.unoptimized_plan,
+            "runner": event.metadata.runner,
+            "entrypoint": event.metadata.entrypoint,
+            "daft_version": event.metadata.daft_version,
+            "python_version": event.metadata.python_version,
+        }
+        if event.metadata.ray_version is not None:
+            payload["runner_version"] = event.metadata.ray_version
+
         self._write_event(
             event.query_id,
             "query_started",
-            {
-                "plan": event.metadata.unoptimized_plan,
-                "runner": event.metadata.runner,
-                "entrypoint": event.metadata.entrypoint,
-            },
+            payload,
         )
 
     def on_query_finished(self, event: QueryFinished) -> None:

--- a/daft/subscribers/event_log.py
+++ b/daft/subscribers/event_log.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import atexit
 import json
 import time
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -40,8 +40,8 @@ def _json_default(obj: object) -> object:
     return str(obj)
 
 
-def _iso_now() -> str:
-    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+def _epoch_now() -> float:
+    return time.time()
 
 
 def _mono_ms() -> float:
@@ -122,7 +122,11 @@ class EventLogSubscriber(Subscriber):
         query_file = self._get_query_file(query_id)
         if query_file is None:
             return
-        record: dict[str, Any] = {"event": event_name, "ts": _iso_now(), "query_id": query_id}
+        record: dict[str, Any] = {
+            "event": event_name,
+            "timestamp": _epoch_now(),
+            "query_id": query_id,
+        }
         record.update(payload)
         try:
             query_file.write(json.dumps(record, default=_json_default) + "\n")
@@ -144,11 +148,14 @@ class EventLogSubscriber(Subscriber):
 
     def on_query_started(self, event: QueryStarted) -> None:
         self._query_starts[event.query_id] = _mono_ms()
-        self._write_event(event.query_id, "query_started", {})
         self._write_event(
             event.query_id,
-            "plan_unoptimized",
-            {"plan": event.metadata.unoptimized_plan},
+            "query_started",
+            {
+                "plan": event.metadata.unoptimized_plan,
+                "runner": event.metadata.runner,
+                "entrypoint": event.metadata.entrypoint,
+            },
         )
 
     def on_query_finished(self, event: QueryFinished) -> None:
@@ -181,7 +188,7 @@ class EventLogSubscriber(Subscriber):
     def on_result_produced(self, event: ResultProduced) -> None:
         self._write_event(
             event.query_id,
-            "result_out",
+            "result_produced",
             {
                 "rows": event.num_rows,
             },
@@ -197,19 +204,17 @@ class EventLogSubscriber(Subscriber):
         start = self._optimization_starts.pop(event.query_id, None)
         duration_ms = round(_mono_ms() - start) if start is not None else None
 
-        payload: dict[str, Any] = {}
+        payload: dict[str, Any] = {"plan": event.optimized_plan}
         if duration_ms is not None:
             payload["duration_ms"] = duration_ms
 
         self._write_event(event.query_id, "optimization_ended", payload)
-        self._write_event(event.query_id, "plan_optimized", {"plan": event.optimized_plan})
 
     # Execution
 
     def on_execution_started(self, event: ExecutionStarted) -> None:
         self._exec_starts[event.query_id] = _mono_ms()
-        self._write_event(event.query_id, "execution_started", {})
-        self._write_event(event.query_id, "plan_physical", {"plan": event.physical_plan})
+        self._write_event(event.query_id, "execution_started", {"physical_plan": event.physical_plan})
 
     def on_operator_start(self, event: OperatorStarted) -> None:
         query_id = event.query_id
@@ -254,7 +259,7 @@ class EventLogSubscriber(Subscriber):
         if duration_ms is not None:
             payload["duration_ms"] = duration_ms
 
-        self._write_event(query_id, "operator_finished", payload)
+        self._write_event(query_id, "operator_ended", payload)
 
     def on_execution_finished(self, event: ExecutionFinished) -> None:
         duration_ms = event.duration_ms

--- a/daft/subscribers/event_log.py
+++ b/daft/subscribers/event_log.py
@@ -24,9 +24,13 @@ if TYPE_CHECKING:
         Stats,
     )
 
+from typing import TYPE_CHECKING
+
 from daft.context import get_context
-from daft.daft import QueryEndState
 from daft.subscribers.abc import Subscriber
+
+if TYPE_CHECKING:
+    from daft.daft import QueryEndState
 
 _EVENT_LOG_ALIAS = "_daft_event_log"
 _DEFAULT_EVENT_LOG_DIR = Path("~/.daft/events").expanduser()
@@ -167,17 +171,7 @@ class EventLogSubscriber(Subscriber):
         payload: dict[str, Any] = {}
         if duration_ms is not None:
             payload["duration_ms"] = round(duration_ms)
-
-        if event.result.end_state == QueryEndState.Finished:
-            payload["status"] = "ok"
-        elif event.result.end_state == QueryEndState.Failed:
-            payload["status"] = "failed"
-            if event.result.error_message:
-                payload["error_message"] = event.result.error_message
-        elif event.result.end_state == QueryEndState.Canceled:
-            payload["status"] = "canceled"
-        else:
-            payload["status"] = "dead"
+        payload["state"] = query_state_str(event.result.end_state)
 
         self._write_event(event.query_id, "query_ended", payload)
         self._clear_query_state(event.query_id)
@@ -272,6 +266,10 @@ class EventLogSubscriber(Subscriber):
             payload["duration_ms"] = round(duration_ms)
 
         self._write_event(event.query_id, "execution_ended", payload)
+
+
+def query_state_str(state: QueryEndState) -> str:
+    return state.__str__().removeprefix("QueryEndState.")
 
 
 _EVENT_LOG_SUBSCRIBER: EventLogSubscriber | None = None

--- a/src/daft-cli/src/dashboard.rs
+++ b/src/daft-cli/src/dashboard.rs
@@ -52,6 +52,9 @@ struct StartArgs {
     /// The directory used to store the LOG file
     #[arg(long)]
     log_dir: Option<String>,
+    /// (experimental) Path to event log for importing a query into the dashboard
+    #[arg(long)]
+    event_log_file: Option<String>,
 }
 
 #[derive(Args)]
@@ -153,12 +156,12 @@ fn start(py: Python, opts: StartArgs) {
     let filter = Directive::from_str(if opts.verbose { "INFO" } else { "ERROR" })
         .expect("Failed to parse tracing filter");
 
-    let addr = opts.addr;
-    let port = opts.port;
+    let server_options = daft_dashboard::ServerOptions::new(opts.addr, opts.port)
+        .with_event_log(opts.event_log_file);
 
-    print_addr_warning(addr);
+    print_addr_warning(server_options.addr());
 
-    let socket_addr = build_socket_addr(addr, port);
+    let socket_addr = build_socket_addr(server_options.addr(), server_options.port());
 
     let _ = tracing_subscriber::registry()
         .with(
@@ -192,7 +195,7 @@ fn start(py: Python, opts: StartArgs) {
                 .magenta()
                 .underlined(),
         );
-        daft_dashboard::launch_server(addr, port, async move { shutdown_rx.await.unwrap() })
+        daft_dashboard::launch_server(server_options, async move { shutdown_rx.await.unwrap() })
             .await
             .expect("Failed to launch dashboard server");
     });

--- a/src/daft-dashboard/src/engine.rs
+++ b/src/daft-dashboard/src/engine.rs
@@ -40,12 +40,20 @@ async fn query_start(
     Path(query_id): Path<QueryID>,
     Json(args): Json<StartQueryArgs>,
 ) -> StatusCode {
+    apply_query_start(&state, query_id, args)
+}
+
+pub(crate) fn apply_query_start(
+    state: &DashboardState,
+    query_id: QueryID,
+    args: StartQueryArgs,
+) -> StatusCode {
     if state.queries.contains_key(&query_id) {
         return StatusCode::BAD_REQUEST;
     }
 
     let query_info = QueryInfo {
-        id: query_id.clone().into(),
+        id: query_id.clone(),
         start_sec: args.start_sec,
         unoptimized_plan: args.unoptimized_plan,
         runner: args
@@ -61,11 +69,11 @@ async fn query_start(
 
     state.queries.insert(query_id.clone(), query_info);
 
-    // Ping clients
     let Some(query_info) = state.queries.get(&query_id) else {
         tracing::error!("Query `{}` not found", query_id);
         return StatusCode::BAD_REQUEST;
     };
+
     state.ping_clients_on_query_update(query_info.value());
     StatusCode::OK
 }
@@ -80,6 +88,14 @@ async fn plan_start(
     State(state): State<Arc<DashboardState>>,
     Path(query_id): Path<QueryID>,
     Json(args): Json<PlanStartArgs>,
+) -> StatusCode {
+    apply_plan_start(&state, query_id, args)
+}
+
+pub(crate) fn apply_plan_start(
+    state: &DashboardState,
+    query_id: QueryID,
+    args: PlanStartArgs,
 ) -> StatusCode {
     let query_info = state.queries.get_mut(&query_id);
     let Some(mut query_info) = query_info else {
@@ -110,6 +126,14 @@ async fn plan_end(
     State(state): State<Arc<DashboardState>>,
     Path(query_id): Path<QueryID>,
     Json(args): Json<PlanEndArgs>,
+) -> StatusCode {
+    apply_plan_end(&state, query_id, args)
+}
+
+pub(crate) fn apply_plan_end(
+    state: &DashboardState,
+    query_id: QueryID,
+    args: PlanEndArgs,
 ) -> StatusCode {
     let query_info = state.queries.get_mut(&query_id);
     let Some(mut query_info) = query_info else {
@@ -188,6 +212,14 @@ async fn exec_start(
     Path(query_id): Path<QueryID>,
     Json(args): Json<ExecStartArgs>,
 ) -> StatusCode {
+    apply_exec_start(&state, query_id, args)
+}
+
+pub(crate) fn apply_exec_start(
+    state: &DashboardState,
+    query_id: QueryID,
+    args: ExecStartArgs,
+) -> StatusCode {
     tracing::info!("Received exec_start for query {}", query_id);
     let query_info = state.queries.get_mut(&query_id);
     let Some(mut query_info) = query_info else {
@@ -245,6 +277,15 @@ async fn exec_op_start(
     State(state): State<Arc<DashboardState>>,
     Path((query_id, op_id)): Path<(QueryID, usize)>,
 ) -> StatusCode {
+    apply_operator_start(&state, query_id, op_id, secs_from_epoch())
+}
+
+pub(crate) fn apply_operator_start(
+    state: &DashboardState,
+    query_id: QueryID,
+    operator_id: usize,
+    timestamp: f64,
+) -> StatusCode {
     let query_info = state.queries.get_mut(&query_id);
     let Some(mut query_info) = query_info else {
         tracing::error!("Query {} not found in exec_op_start", query_id);
@@ -255,11 +296,11 @@ async fn exec_op_start(
         return StatusCode::OK;
     };
 
-    if let Some(op) = exec_info.operators.get_mut(&op_id) {
+    if let Some(op) = exec_info.operators.get_mut(&operator_id) {
         op.status = OperatorStatus::Executing;
-        op.start_sec = Some(secs_from_epoch());
+        op.start_sec = Some(timestamp);
     } else {
-        tracing::warn!("Operator {} not found for query {}", op_id, query_id);
+        tracing::warn!("Operator {} not found for query {}", operator_id, query_id);
     }
 
     state.ping_clients_on_operator_update(query_info.value());
@@ -269,6 +310,15 @@ async fn exec_op_start(
 async fn exec_op_end(
     State(state): State<Arc<DashboardState>>,
     Path((query_id, op_id)): Path<(QueryID, usize)>,
+) -> StatusCode {
+    apply_operator_end(&state, query_id, op_id, secs_from_epoch())
+}
+
+pub(crate) fn apply_operator_end(
+    state: &DashboardState,
+    query_id: QueryID,
+    operator_id: usize,
+    timestamp: f64,
 ) -> StatusCode {
     let query_info = state.queries.get_mut(&query_id);
     let Some(mut query_info) = query_info else {
@@ -280,11 +330,11 @@ async fn exec_op_end(
         return StatusCode::OK;
     };
 
-    if let Some(op) = exec_info.operators.get_mut(&op_id) {
+    if let Some(op) = exec_info.operators.get_mut(&operator_id) {
         op.status = OperatorStatus::Finished;
-        op.end_sec = Some(secs_from_epoch());
+        op.end_sec = Some(timestamp);
     } else {
-        tracing::warn!("Operator {} not found for query {}", op_id, query_id);
+        tracing::warn!("Operator {} not found for query {}", operator_id, query_id);
     }
 
     state.ping_clients_on_operator_update(query_info.value());
@@ -385,6 +435,14 @@ async fn exec_emit_stats(
     Path(query_id): Path<QueryID>,
     Json(args): Json<ExecEmitStatsArgsRecv>,
 ) -> StatusCode {
+    apply_emit_stats(&state, query_id, args)
+}
+
+pub(crate) fn apply_emit_stats(
+    state: &DashboardState,
+    query_id: QueryID,
+    args: ExecEmitStatsArgsRecv,
+) -> StatusCode {
     let query_info = state.queries.get_mut(&query_id);
     let Some(mut query_info) = query_info else {
         tracing::error!("Query {} not found in exec_emit_stats", query_id);
@@ -452,6 +510,14 @@ async fn exec_end(
     Path(query_id): Path<QueryID>,
     Json(args): Json<ExecEndArgs>,
 ) -> StatusCode {
+    apply_exec_end(&state, query_id, args)
+}
+
+pub(crate) fn apply_exec_end(
+    state: &DashboardState,
+    query_id: QueryID,
+    args: ExecEndArgs,
+) -> StatusCode {
     tracing::info!("Received exec_end for query {}", query_id);
     let query_info = state.queries.get_mut(&query_id);
     let Some(mut query_info) = query_info else {
@@ -511,6 +577,14 @@ async fn query_end(
     State(state): State<Arc<DashboardState>>,
     Path(query_id): Path<QueryID>,
     Json(args): Json<FinalizeArgs>,
+) -> StatusCode {
+    apply_query_end(&state, query_id, args)
+}
+
+pub(crate) fn apply_query_end(
+    state: &DashboardState,
+    query_id: QueryID,
+    args: FinalizeArgs,
 ) -> StatusCode {
     let query_info = state.queries.get_mut(&query_id);
     let Some(mut query_info) = query_info else {

--- a/src/daft-dashboard/src/events.rs
+++ b/src/daft-dashboard/src/events.rs
@@ -1,17 +1,10 @@
+/// Event protocol under construction - expect breaking changes to
+/// both the log file format and Rust types
 use std::collections::HashMap;
 
-use common_metrics::{BYTES_READ_KEY, BYTES_WRITTEN_KEY, DURATION_KEY};
+use common_metrics::{BYTES_READ_KEY, BYTES_WRITTEN_KEY, DURATION_KEY, QueryEndState};
 use serde::{Deserialize, de::Deserializer};
 use serde_json::Value;
-
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum QueryEndStatus {
-    Ok,
-    Failed,
-    Canceled,
-    Dead,
-}
 
 #[derive(Debug, Clone, Deserialize)]
 #[allow(dead_code)]
@@ -35,7 +28,7 @@ pub struct QueryStarted {
 pub struct QueryEnded {
     pub query_id: String,
     pub timestamp: f64,
-    pub status: QueryEndStatus,
+    pub state: QueryEndState,
     pub error_message: Option<String>,
 }
 

--- a/src/daft-dashboard/src/events.rs
+++ b/src/daft-dashboard/src/events.rs
@@ -22,6 +22,9 @@ pub struct QueryStarted {
     pub runner: Option<String>,
     pub entrypoint: Option<String>,
     pub dashboard_url: Option<String>,
+    pub daft_version: Option<String>,
+    pub runner_version: Option<String>,
+    pub python_version: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/daft-dashboard/src/events.rs
+++ b/src/daft-dashboard/src/events.rs
@@ -1,0 +1,179 @@
+use std::collections::HashMap;
+
+use common_metrics::{BYTES_READ_KEY, BYTES_WRITTEN_KEY, DURATION_KEY};
+use serde::{Deserialize, de::Deserializer};
+use serde_json::Value;
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum QueryEndStatus {
+    Ok,
+    Failed,
+    Canceled,
+    Dead,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[allow(dead_code)]
+pub struct EventLogStarted {
+    pub query_id: String,
+    pub timestamp: f64,
+    pub daft_version: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct QueryStarted {
+    pub query_id: String,
+    pub timestamp: f64,
+    pub plan: String,
+    pub runner: Option<String>,
+    pub entrypoint: Option<String>,
+    pub dashboard_url: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct QueryEnded {
+    pub query_id: String,
+    pub timestamp: f64,
+    pub status: QueryEndStatus,
+    pub error_message: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct OptimizationStarted {
+    pub query_id: String,
+    pub timestamp: f64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct OptimizationEnded {
+    pub query_id: String,
+    pub timestamp: f64,
+    pub plan: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ExecutionStarted {
+    pub query_id: String,
+    pub timestamp: f64,
+    pub physical_plan: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ExecutionEnded {
+    pub query_id: String,
+    pub timestamp: f64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[allow(dead_code)]
+pub struct OperatorStarted {
+    pub query_id: String,
+    pub timestamp: f64,
+    pub node_id: usize,
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[allow(dead_code)]
+pub struct OperatorEnded {
+    pub query_id: String,
+    pub timestamp: f64,
+    pub node_id: usize,
+    pub name: String,
+    pub duration_ms: Option<f64>,
+}
+
+/// Public metric representation, decoupled from internal common_metrics::Stat.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(tag = "type", content = "value", rename_all = "snake_case")]
+pub enum MetricValue {
+    Count(u64),
+    Bytes(u64),
+    Percent(f64),
+    Float(f64),
+    DurationMicros(u64),
+}
+
+fn deserialize_metrics<'de, D>(deserializer: D) -> Result<HashMap<String, MetricValue>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw = HashMap::<String, Value>::deserialize(deserializer)?;
+    raw.into_iter()
+        .map(|(name, value)| {
+            let metric = match value {
+                Value::Object(_) => serde_json::from_value::<MetricValue>(value)
+                    .map_err(serde::de::Error::custom)?,
+                Value::Number(n) if name == DURATION_KEY => {
+                    MetricValue::DurationMicros(n.as_u64().ok_or_else(|| {
+                        serde::de::Error::custom(format!(
+                            "expected u64 duration metric for key {name}"
+                        ))
+                    })?)
+                }
+                Value::Number(n) if name == BYTES_READ_KEY || name == BYTES_WRITTEN_KEY => {
+                    MetricValue::Bytes(n.as_u64().ok_or_else(|| {
+                        serde::de::Error::custom(format!(
+                            "expected u64 bytes metric for key {name}"
+                        ))
+                    })?)
+                }
+                Value::Number(n) if n.is_u64() => MetricValue::Count(n.as_u64().unwrap()),
+                Value::Number(n) => MetricValue::Float(n.as_f64().ok_or_else(|| {
+                    serde::de::Error::custom(format!("expected numeric metric for key {name}"))
+                })?),
+                _ => {
+                    return Err(serde::de::Error::custom(format!(
+                        "invalid metric value for key {name}"
+                    )));
+                }
+            };
+            Ok((name, metric))
+        })
+        .collect()
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[allow(dead_code)]
+pub struct Stats {
+    pub query_id: String,
+    pub timestamp: f64,
+    pub node_id: usize,
+    #[serde(deserialize_with = "deserialize_metrics")]
+    pub metrics: HashMap<String, MetricValue>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[allow(dead_code)]
+pub struct ProcessStats {
+    pub query_id: String,
+    pub timestamp: f64,
+    #[serde(deserialize_with = "deserialize_metrics")]
+    pub metrics: HashMap<String, MetricValue>,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct ResultProduced {
+    pub query_id: String,
+    pub timestamp: f64,
+    #[serde(alias = "rows")]
+    pub num_rows: u64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "event", rename_all = "snake_case")]
+pub enum Event {
+    EventLogStarted(EventLogStarted),
+    QueryStarted(QueryStarted),
+    QueryEnded(QueryEnded),
+    OptimizationStarted(OptimizationStarted),
+    OptimizationEnded(OptimizationEnded),
+    ExecutionStarted(ExecutionStarted),
+    ExecutionEnded(ExecutionEnded),
+    OperatorStarted(OperatorStarted),
+    OperatorEnded(OperatorEnded),
+    Stats(Stats),
+    ProcessStats(ProcessStats),
+    ResultProduced(ResultProduced),
+}

--- a/src/daft-dashboard/src/import.rs
+++ b/src/daft-dashboard/src/import.rs
@@ -1,0 +1,217 @@
+use std::{
+    collections::HashMap,
+    fmt,
+    fs::File,
+    io,
+    io::{BufRead, BufReader},
+    path::Path,
+    sync::Arc,
+    time::Duration,
+};
+
+use axum::http::StatusCode;
+use common_metrics::{QueryEndState, Stat};
+
+use crate::{
+    engine::{
+        ExecEmitStatsArgsRecv, ExecEndArgs, ExecStartArgs, FinalizeArgs, PlanEndArgs,
+        PlanStartArgs, StartQueryArgs, apply_emit_stats, apply_exec_end, apply_exec_start,
+        apply_operator_end, apply_operator_start, apply_plan_end, apply_plan_start,
+        apply_query_end, apply_query_start,
+    },
+    events::{Event, MetricValue, QueryEndStatus},
+    state::DashboardState,
+};
+
+#[derive(Debug)]
+pub(crate) enum EventLogError {
+    Io(io::Error),
+    Json(serde_json::Error),
+    ImportStatus { status: StatusCode },
+}
+
+impl fmt::Display for EventLogError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(err) => write!(f, "I/O error while importing event log: {err}"),
+            Self::Json(err) => write!(f, "JSON parse error while importing event log: {err}"),
+            Self::ImportStatus { status } => {
+                write!(f, "event import returned non-success status: {status}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for EventLogError {}
+
+impl From<io::Error> for EventLogError {
+    fn from(err: io::Error) -> Self {
+        Self::Io(err)
+    }
+}
+
+impl From<serde_json::Error> for EventLogError {
+    fn from(err: serde_json::Error) -> Self {
+        Self::Json(err)
+    }
+}
+
+fn parse_query_end_state(status: &QueryEndStatus) -> QueryEndState {
+    match status {
+        QueryEndStatus::Ok => QueryEndState::Finished,
+        QueryEndStatus::Canceled => QueryEndState::Canceled,
+        QueryEndStatus::Failed => QueryEndState::Failed,
+        QueryEndStatus::Dead => QueryEndState::Dead,
+    }
+}
+
+fn metric_value_to_stat(value: &MetricValue) -> Stat {
+    match value {
+        MetricValue::Count(v) => Stat::Count(*v),
+        MetricValue::Bytes(v) => Stat::Bytes(*v),
+        MetricValue::Percent(v) => Stat::Percent(*v),
+        MetricValue::Float(v) => Stat::Float(*v),
+        MetricValue::DurationMicros(v) => Stat::Duration(Duration::from_micros(*v)),
+    }
+}
+
+fn metrics_to_stats(metrics: &HashMap<String, MetricValue>) -> HashMap<String, Stat> {
+    metrics
+        .iter()
+        .map(|(name, value)| (name.clone(), metric_value_to_stat(value)))
+        .collect()
+}
+
+pub(crate) fn import_event_log(
+    path: impl AsRef<Path>,
+    state: Arc<DashboardState>,
+) -> Result<(), EventLogError> {
+    let path = path.as_ref();
+    let file = File::open(path)?;
+    let reader = BufReader::new(file);
+    let source = path.display().to_string();
+    import_events(reader, &source, state.as_ref())
+}
+
+fn import_events<R: BufRead>(
+    reader: R,
+    source: &str,
+    state: &DashboardState,
+) -> Result<(), EventLogError> {
+    for (line_num, line) in reader.lines().enumerate() {
+        let json_str = line?;
+        if json_str.trim().is_empty() {
+            continue;
+        }
+
+        let event = match serde_json::from_str::<Event>(&json_str) {
+            Ok(event) => event,
+            Err(err) => {
+                tracing::warn!(
+                    source = %source,
+                    line = line_num + 1,
+                    error = %err,
+                    json = %json_str,
+                    "failed to parse event"
+                );
+                continue;
+            }
+        };
+
+        if let Err(err) = import_event(&event, state) {
+            tracing::warn!(
+                source = %source,
+                line = line_num + 1,
+                error = %err,
+                json = %json_str,
+                "failed to import event"
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn import_event(event: &Event, state: &DashboardState) -> Result<(), EventLogError> {
+    let status = match event {
+        Event::QueryStarted(e) => apply_query_start(
+            state,
+            e.query_id.clone().into(),
+            StartQueryArgs {
+                start_sec: e.timestamp,
+                unoptimized_plan: e.plan.clone().into(),
+                runner: e.runner.clone(),
+                ray_dashboard_url: e.dashboard_url.clone(),
+                entrypoint: e.entrypoint.clone(),
+            },
+        ),
+        Event::OptimizationStarted(e) => apply_plan_start(
+            state,
+            e.query_id.clone().into(),
+            PlanStartArgs {
+                plan_start_sec: e.timestamp,
+            },
+        ),
+        Event::OptimizationEnded(e) => apply_plan_end(
+            state,
+            e.query_id.clone().into(),
+            PlanEndArgs {
+                plan_end_sec: e.timestamp,
+                optimized_plan: e.plan.clone().into(),
+            },
+        ),
+        Event::ExecutionStarted(e) => apply_exec_start(
+            state,
+            e.query_id.clone().into(),
+            ExecStartArgs {
+                exec_start_sec: e.timestamp,
+                physical_plan: e.physical_plan.clone().into(),
+            },
+        ),
+        Event::OperatorStarted(e) => {
+            apply_operator_start(state, e.query_id.clone().into(), e.node_id, e.timestamp)
+        }
+        Event::OperatorEnded(e) => {
+            apply_operator_end(state, e.query_id.clone().into(), e.node_id, e.timestamp)
+        }
+        Event::Stats(e) => apply_emit_stats(
+            state,
+            e.query_id.clone().into(),
+            ExecEmitStatsArgsRecv {
+                source_id: e.query_id.clone(),
+                stats: vec![(e.node_id, metrics_to_stats(&e.metrics))],
+            },
+        ),
+        Event::ExecutionEnded(e) => apply_exec_end(
+            state,
+            e.query_id.clone().into(),
+            ExecEndArgs {
+                exec_end_sec: e.timestamp,
+            },
+        ),
+        Event::QueryEnded(e) => apply_query_end(
+            state,
+            e.query_id.clone().into(),
+            FinalizeArgs {
+                end_sec: e.timestamp,
+                end_state: parse_query_end_state(&e.status),
+                error_message: e.error_message.clone(),
+                results: None,
+            },
+        ),
+        // TODO handle results from the event log.
+        // We don't write data out in the event log
+        // so at this point it does not make sense to send
+        // this event to dashboard.
+        Event::ResultProduced(_e) => return Ok(()),
+        // TODO add support in  dashboard for process stats
+        Event::ProcessStats(_e) => return Ok(()),
+        Event::EventLogStarted(_e) => return Ok(()),
+    };
+
+    if status.is_success() {
+        Ok(())
+    } else {
+        Err(EventLogError::ImportStatus { status })
+    }
+}

--- a/src/daft-dashboard/src/import.rs
+++ b/src/daft-dashboard/src/import.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 use axum::http::StatusCode;
-use common_metrics::{QueryEndState, Stat};
+use common_metrics::Stat;
 
 use crate::{
     engine::{
@@ -19,7 +19,7 @@ use crate::{
         apply_operator_end, apply_operator_start, apply_plan_end, apply_plan_start,
         apply_query_end, apply_query_start,
     },
-    events::{Event, MetricValue, QueryEndStatus},
+    events::{Event, MetricValue},
     state::DashboardState,
 };
 
@@ -53,15 +53,6 @@ impl From<io::Error> for EventLogError {
 impl From<serde_json::Error> for EventLogError {
     fn from(err: serde_json::Error) -> Self {
         Self::Json(err)
-    }
-}
-
-fn parse_query_end_state(status: &QueryEndStatus) -> QueryEndState {
-    match status {
-        QueryEndStatus::Ok => QueryEndState::Finished,
-        QueryEndStatus::Canceled => QueryEndState::Canceled,
-        QueryEndStatus::Failed => QueryEndState::Failed,
-        QueryEndStatus::Dead => QueryEndState::Dead,
     }
 }
 
@@ -196,7 +187,7 @@ fn import_event(event: &Event, state: &DashboardState) -> Result<(), EventLogErr
             e.query_id.clone().into(),
             FinalizeArgs {
                 end_sec: e.timestamp,
-                end_state: parse_query_end_state(&e.status),
+                end_state: e.state.clone(),
                 error_message: e.error_message.clone(),
                 results: None,
             },

--- a/src/daft-dashboard/src/import.rs
+++ b/src/daft-dashboard/src/import.rs
@@ -90,7 +90,9 @@ pub(crate) fn import_event_log(
     let file = File::open(path)?;
     let reader = BufReader::new(file);
     let source = path.display().to_string();
-    import_events(reader, &source, state.as_ref())
+    import_events(reader, &source, state.as_ref())?;
+    eprintln!("✅ Success! event log imported from {}", path.display());
+    Ok(())
 }
 
 fn import_events<R: BufRead>(

--- a/src/daft-dashboard/src/import.rs
+++ b/src/daft-dashboard/src/import.rs
@@ -136,6 +136,9 @@ fn import_event(event: &Event, state: &DashboardState) -> Result<(), EventLogErr
                 runner: e.runner.clone(),
                 ray_dashboard_url: e.dashboard_url.clone(),
                 entrypoint: e.entrypoint.clone(),
+                daft_version: e.daft_version.clone(),
+                ray_version: e.runner_version.clone(),
+                python_version: e.python_version.clone(),
             },
         ),
         Event::OptimizationStarted(e) => apply_plan_start(

--- a/src/daft-dashboard/src/lib.rs
+++ b/src/daft-dashboard/src/lib.rs
@@ -326,6 +326,15 @@ pub async fn launch_server(
     options: ServerOptions,
     shutdown_fn: impl Future<Output = ()> + Send + 'static,
 ) -> std::io::Result<()> {
+    // Import event log file if provided
+    if let Some(path) = options.event_log_path.as_ref()
+        && let Err(err) = import_event_log(path, GLOBAL_DASHBOARD_STATE.clone())
+    {
+        eprintln!(
+            "WARNING: failed to import event log from {path}: {err}. continuing without imported events"
+        );
+    }
+
     let app = Router::new()
         .nest("/engine", engine::routes())
         .nest("/client", client::routes())
@@ -355,15 +364,6 @@ pub async fn launch_server(
     let addr = options.addr;
     let port = options.port;
     let listener = TcpListener::bind((addr, port)).await?;
-
-    if let Some(path) = options.event_log_path.as_ref()
-        && let Err(err) = import_event_log(path, GLOBAL_DASHBOARD_STATE.clone())
-    {
-        eprintln!(
-            "WARNING: failed to import event log from {path}: {err}. continuing without imported events"
-        );
-    }
-
     axum::serve(listener, app)
         .with_graceful_shutdown(shutdown_fn)
         .await

--- a/src/daft-dashboard/src/lib.rs
+++ b/src/daft-dashboard/src/lib.rs
@@ -323,8 +323,6 @@ async fn ping() -> StatusCode {
 }
 
 pub async fn launch_server(
-    //addr: IpAddr,
-    //port: u16,
     options: ServerOptions,
     shutdown_fn: impl Future<Output = ()> + Send + 'static,
 ) -> std::io::Result<()> {

--- a/src/daft-dashboard/src/lib.rs
+++ b/src/daft-dashboard/src/lib.rs
@@ -1,6 +1,8 @@
 pub(crate) mod assets;
 pub(crate) mod client;
 pub mod engine;
+pub(crate) mod events;
+pub(crate) mod import;
 #[cfg(feature = "python")]
 pub mod python;
 pub(crate) mod state;
@@ -29,11 +31,54 @@ use tower_http::{
 };
 use tracing::Level;
 
-use crate::state::{DashboardState, GLOBAL_DASHBOARD_STATE};
+use crate::{
+    import::import_event_log,
+    state::{DashboardState, GLOBAL_DASHBOARD_STATE},
+};
 
 // NOTE(void001): default listen to all ipv4 address, which pose a security risk in production environment
 pub const DEFAULT_SERVER_ADDR: Ipv4Addr = Ipv4Addr::UNSPECIFIED;
 pub const DEFAULT_SERVER_PORT: u16 = 3238;
+
+#[derive(Debug, Clone)]
+pub struct ServerOptions {
+    addr: IpAddr,
+    port: u16,
+    event_log_path: Option<String>,
+}
+
+impl ServerOptions {
+    pub fn new(addr: IpAddr, port: u16) -> Self {
+        Self {
+            addr,
+            port,
+            event_log_path: None,
+        }
+    }
+
+    pub fn addr(&self) -> IpAddr {
+        self.addr
+    }
+
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
+    pub fn with_event_log(mut self, path: Option<String>) -> Self {
+        self.event_log_path.clone_from(&path);
+        self
+    }
+}
+
+impl Default for ServerOptions {
+    fn default() -> Self {
+        Self {
+            addr: IpAddr::V4(DEFAULT_SERVER_ADDR),
+            port: DEFAULT_SERVER_PORT,
+            event_log_path: None,
+        }
+    }
+}
 
 fn generate_interactive_html(
     record_batch: &RecordBatch,
@@ -278,8 +323,9 @@ async fn ping() -> StatusCode {
 }
 
 pub async fn launch_server(
-    addr: IpAddr,
-    port: u16,
+    //addr: IpAddr,
+    //port: u16,
+    options: ServerOptions,
     shutdown_fn: impl Future<Output = ()> + Send + 'static,
 ) -> std::io::Result<()> {
     let app = Router::new()
@@ -308,7 +354,18 @@ pub async fn launch_server(
         .with_state(GLOBAL_DASHBOARD_STATE.clone());
 
     // Start the server
+    let addr = options.addr;
+    let port = options.port;
     let listener = TcpListener::bind((addr, port)).await?;
+
+    if let Some(path) = options.event_log_path.as_ref()
+        && let Err(err) = import_event_log(path, GLOBAL_DASHBOARD_STATE.clone())
+    {
+        eprintln!(
+            "WARNING: failed to import event log from {path}: {err}. continuing without imported events"
+        );
+    }
+
     axum::serve(listener, app)
         .with_graceful_shutdown(shutdown_fn)
         .await

--- a/src/daft-dashboard/src/python.rs
+++ b/src/daft-dashboard/src/python.rs
@@ -11,7 +11,7 @@ use tokio::{
     sync::oneshot,
 };
 
-use crate::{DEFAULT_SERVER_PORT, state::GLOBAL_DASHBOARD_STATE};
+use crate::{DEFAULT_SERVER_PORT, ServerOptions, state::GLOBAL_DASHBOARD_STATE};
 
 static DASHBOARD_ENABLED: AtomicBool = AtomicBool::new(false);
 static RUNNING_PORT: AtomicU16 = AtomicU16::new(DEFAULT_SERVER_PORT);
@@ -110,12 +110,9 @@ pub fn launch(noop_if_initialized: bool, port: Option<u16>) -> PyResult<Connecti
     let _ = std::thread::spawn(move || {
         DASHBOARD_ENABLED.store(true, Ordering::SeqCst);
         let res = tokio_runtime().block_on(async {
-            super::launch_server(
-                std::net::IpAddr::V4(super::DEFAULT_SERVER_ADDR),
-                port,
-                async move { recv.await.unwrap() },
-            )
-            .await
+            let options =
+                ServerOptions::new(std::net::IpAddr::V4(super::DEFAULT_SERVER_ADDR), port);
+            super::launch_server(options, async move { recv.await.unwrap() }).await
         });
         DASHBOARD_ENABLED.store(false, Ordering::SeqCst);
         res

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -83,7 +83,7 @@ def test_event_log_subscriber_writes_query_lifecycle_events(tmp_path):
 
     query_ended = events[-1]
     assert query_ended["query_id"] == query_id
-    assert query_ended["status"] == "ok"
+    assert query_ended["state"] == "Finished"
     assert query_ended["duration_ms"] >= 0
 
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -75,7 +75,11 @@ def test_event_log_subscriber_writes_query_lifecycle_events(tmp_path):
 
     events = _load_events(tmp_path / query_id / "events.jsonl")
     event_names = [event["event"] for event in events]
-    assert event_names == ["event_log_started", "query_started", "plan_unoptimized", "query_ended"]
+    assert event_names == ["event_log_started", "query_started", "query_ended"]
+
+    query_started = events[1]
+    assert query_started["query_id"] == query_id
+    assert query_started["plan"] == metadata.unoptimized_plan
 
     query_ended = events[-1]
     assert query_ended["query_id"] == query_id
@@ -111,8 +115,9 @@ def test_event_log_subscriber_preserves_optimization_lifecycle_schema(tmp_path):
 
     events = _load_events(tmp_path / query_id / "events.jsonl")
     event_names = [event["event"] for event in events]
-    assert event_names == ["event_log_started", "optimization_started", "optimization_ended", "plan_optimized"]
+    assert event_names == ["event_log_started", "optimization_started", "optimization_ended"]
     assert events[2]["duration_ms"] >= 0
+    assert events[2]["plan"] == '{"nodes":{}}'
 
 
 def test_on_query_end_clears_stale_timing_state_for_failed_query(tmp_path):


### PR DESCRIPTION
## Changes Made

Add support for replaying NDJSON event log files into the dashboard at startup via `--event-log-file`. This enables offline/post-hoc analysis of recorded query runs. This is experimental for now.


Start dashboard with a file to import
```
(.venv) chris@Mac daft % daft dashboard start  --event-log-file ~/work/daft-scripts/event-logs/query/events.jsonl
🚀 Launching the Daft dashboard!
⚠️ Listening on all network interfaces (0.0.0.0)! This is not recommended in production.
█  To get started, run your Daft script with env `DAFT_DASHBOARD_URL="http://0.0.0.0:3238" python ...`
✨ View the dashboard at http://0.0.0.0:3238. Press Ctrl+C to shutdown
✅ Success! event log imported from /Users/chris/work/daft-scripts/event-logs/query/events.jsonl
```


<img width="1515" height="896" alt="Screenshot 2026-04-08 at 2 00 40 PM" src="https://github.com/user-attachments/assets/b97bc83d-87ef-4348-a5b3-562ce62b05d3" />
<img width="1510" height="891" alt="Screenshot 2026-04-08 at 2 00 46 PM" src="https://github.com/user-attachments/assets/48cd3887-1085-4810-a77f-48d20f998e33" />



