### PR TITLE
feat(dashboard): add DAFT_RAY_DASHBOARD_URL env var override

### DIFF
--- a/daft/runners/ray_runner.py
+++ b/daft/runners/ray_runner.py
@@ -587,22 +587,26 @@ class RayRunner(Runner[ray.ObjectRef]):
         # Notify query start
         ray_dashboard_url = None
         if os.environ.get("RAY_DISABLE_DASHBOARD") != "1":
-            try:
-                if ray.is_initialized():
-                    ray_dashboard_url = ray.worker.get_dashboard_url()
-                    if ray_dashboard_url:
-                        if not ray_dashboard_url.startswith("http"):
-                            ray_dashboard_url = f"http://{ray_dashboard_url}"
+            # Allow override for hosted environments where the Ray dashboard
+            # is exposed via an authenticated ingress proxy.
+            ray_dashboard_url = os.environ.get("DAFT_RAY_DASHBOARD_URL")
+            if not ray_dashboard_url:
+                try:
+                    if ray.is_initialized():
+                        ray_dashboard_url = ray.worker.get_dashboard_url()
+                        if ray_dashboard_url:
+                            if not ray_dashboard_url.startswith("http"):
+                                ray_dashboard_url = f"http://{ray_dashboard_url}"
 
-                        # Try to append Job ID
-                        try:
-                            job_id = ray.get_runtime_context().get_job_id()
-                            if job_id:
-                                ray_dashboard_url = f"{ray_dashboard_url}/#/jobs/{job_id}"
-                        except Exception:
-                            pass
-            except Exception:
-                pass
+                            # Try to append Job ID
+                            try:
+                                job_id = ray.get_runtime_context().get_job_id()
+                                if job_id:
+                                    ray_dashboard_url = f"{ray_dashboard_url}/#/jobs/{job_id}"
+                            except Exception:
+                                pass
+                except Exception:
+                    pass
 
         entrypoint = "python " + " ".join(sys.argv)
         dashboard_url = os.environ.get("DAFT_DASHBOARD_URL")

--- a/daft/runners/ray_runner.py
+++ b/daft/runners/ray_runner.py
@@ -535,6 +535,45 @@ def _ray_num_cpus_provider(ttl_seconds: int = 1) -> Generator[int, None, None]:
             yield last_num_cpus_queried
 
 
+def _resolve_ray_dashboard_url() -> str | None:
+    """Resolve the Ray dashboard URL to surface in query metadata.
+
+    This is display-only: the result is rendered as a link in the Daft dashboard and is
+    never used for HTTP calls or Ray communication.
+
+    `DAFT_RAY_DASHBOARD_URL` takes precedence over Ray's own discovery so that hosted
+    environments can point at an authenticated ingress proxy. It is honored even when
+    `RAY_DISABLE_DASHBOARD=1`, since disabling Ray's built-in dashboard says nothing
+    about whether an externally hosted one exists.
+    """
+    url: str | None = os.environ.get("DAFT_RAY_DASHBOARD_URL")
+    if not url:
+        if os.environ.get("RAY_DISABLE_DASHBOARD") == "1":
+            return None
+        try:
+            if not ray.is_initialized():
+                return None
+            url = ray.worker.get_dashboard_url()
+        except Exception:
+            return None
+        if not url:
+            return None
+
+    if not url.startswith("http"):
+        url = f"http://{url}"
+
+    # Try to append Job ID, unless the configured URL already points at a specific route.
+    if "#" not in url:
+        try:
+            job_id = ray.get_runtime_context().get_job_id()
+            if job_id:
+                url = f"{url.rstrip('/')}/#/jobs/{job_id}"
+        except Exception:
+            pass
+
+    return url
+
+
 class RayRunner(Runner[ray.ObjectRef]):
     name = "ray"
 
@@ -585,28 +624,7 @@ class RayRunner(Runner[ray.ObjectRef]):
         unoptimized_plan_json = builder.repr_json()
 
         # Notify query start
-        ray_dashboard_url = None
-        if os.environ.get("RAY_DISABLE_DASHBOARD") != "1":
-            # Allow override for hosted environments where the Ray dashboard
-            # is exposed via an authenticated ingress proxy.
-            ray_dashboard_url = os.environ.get("DAFT_RAY_DASHBOARD_URL")
-            if not ray_dashboard_url:
-                try:
-                    if ray.is_initialized():
-                        ray_dashboard_url = ray.worker.get_dashboard_url()
-                        if ray_dashboard_url:
-                            if not ray_dashboard_url.startswith("http"):
-                                ray_dashboard_url = f"http://{ray_dashboard_url}"
-
-                            # Try to append Job ID
-                            try:
-                                job_id = ray.get_runtime_context().get_job_id()
-                                if job_id:
-                                    ray_dashboard_url = f"{ray_dashboard_url}/#/jobs/{job_id}"
-                            except Exception:
-                                pass
-                except Exception:
-                    pass
+        ray_dashboard_url = _resolve_ray_dashboard_url()
 
         entrypoint = "python " + " ".join(sys.argv)
         dashboard_url = os.environ.get("DAFT_DASHBOARD_URL")

--- a/daft/runners/ray_runner.py
+++ b/daft/runners/ray_runner.py
@@ -559,7 +559,9 @@ def _resolve_ray_dashboard_url() -> str | None:
         if not url:
             return None
 
-    if not url.startswith("http"):
+    # Match the scheme check the dashboard frontend does when rendering the link, so a
+    # hostname that merely starts with "http" (e.g. "http-proxy.internal") still gets one.
+    if not url.startswith(("http://", "https://")):
         url = f"http://{url}"
 
     # Try to append Job ID, unless the configured URL already points at a specific route.

--- a/docs/observability/dashboard.md
+++ b/docs/observability/dashboard.md
@@ -88,6 +88,23 @@ python script.py
 
 To make the UI accessible to humans (not just Daft processes), expose the dashboard port through whatever mechanism your platform uses — a Kubernetes `Service` plus `Ingress`, an SSH tunnel, `ray attach --port-forward`, or a cloud load balancer.
 
+### Linking to the Ray Dashboard
+
+Each query records a link to the Ray dashboard so you can jump from a Daft query to the corresponding Ray job. By default Daft asks Ray for that address, which yields a cluster-internal URL like `http://10.0.0.5:8265` — not reachable from your browser if the Ray dashboard is served through an ingress proxy.
+
+Set `DAFT_RAY_DASHBOARD_URL` on the driver to override it with the address humans actually use:
+
+```bash
+export DAFT_RAY_DASHBOARD_URL=https://ray.example.com
+```
+
+Notes:
+
+- The value is used verbatim except that Daft prepends `http://` if you omit a scheme, and appends the current Ray job route (`/#/jobs/<job_id>`) unless the URL already contains a `#` fragment.
+- The URL is display-only — Daft never makes requests to it, so it does not need to be reachable from the cluster.
+- The override is honored even when `RAY_DISABLE_DASHBOARD=1`, since Ray's built-in dashboard being off says nothing about whether an externally hosted one exists.
+- Prefer this over Ray's `RAY_OVERRIDE_DASHBOARD_URL`, which strips the scheme from the value it is given (Ray stores URLs without a protocol), so an `https://` ingress ends up rendered as `http://`.
+
 ### Production Readiness
 
 - The dashboard has no built-in authentication. Do not expose it directly to the public internet. Place it behind an authenticating ingress or a VPN.

--- a/tests/ray/test_ray_dashboard_url.py
+++ b/tests/ray/test_ray_dashboard_url.py
@@ -100,3 +100,11 @@ def test_empty_env_override_falls_back_to_autodetection(monkeypatch, fake_ray):
     monkeypatch.setenv("DAFT_RAY_DASHBOARD_URL", "")
 
     assert ray_runner._resolve_ray_dashboard_url() == "http://127.0.0.1:8265/#/jobs/job-1"
+
+
+def test_override_hostname_starting_with_http_still_gets_a_scheme(monkeypatch, fake_ray):
+    """A bare hostname like `http-proxy.internal` must not be mistaken for a full URL."""
+    fake_ray(job_id=None)
+    monkeypatch.setenv("DAFT_RAY_DASHBOARD_URL", "http-proxy.example.com")
+
+    assert ray_runner._resolve_ray_dashboard_url() == "http://http-proxy.example.com"

--- a/tests/ray/test_ray_dashboard_url.py
+++ b/tests/ray/test_ray_dashboard_url.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import pytest
+
+from daft.runners import ray_runner
+
+
+@pytest.fixture(autouse=True)
+def clear_dashboard_env(monkeypatch):
+    monkeypatch.delenv("DAFT_RAY_DASHBOARD_URL", raising=False)
+    monkeypatch.delenv("RAY_DISABLE_DASHBOARD", raising=False)
+
+
+class _FakeRuntimeContext:
+    def __init__(self, job_id: str | None) -> None:
+        self._job_id = job_id
+
+    def get_job_id(self) -> str | None:
+        return self._job_id
+
+
+@pytest.fixture
+def fake_ray(monkeypatch):
+    """Stub out the Ray calls made by `_resolve_ray_dashboard_url`."""
+
+    def configure(*, initialized: bool = True, dashboard_url: str | None = None, job_id: str | None = "job-1"):
+        monkeypatch.setattr(ray_runner.ray, "is_initialized", lambda: initialized)
+        monkeypatch.setattr(ray_runner.ray.worker, "get_dashboard_url", lambda: dashboard_url)
+        monkeypatch.setattr(ray_runner.ray, "get_runtime_context", lambda: _FakeRuntimeContext(job_id))
+
+    return configure
+
+
+def test_autodetected_url_is_normalized_and_gets_job_id(fake_ray):
+    fake_ray(dashboard_url="127.0.0.1:8265")
+
+    assert ray_runner._resolve_ray_dashboard_url() == "http://127.0.0.1:8265/#/jobs/job-1"
+
+
+def test_autodetection_skipped_when_ray_dashboard_disabled(monkeypatch, fake_ray):
+    fake_ray(dashboard_url="127.0.0.1:8265")
+    monkeypatch.setenv("RAY_DISABLE_DASHBOARD", "1")
+
+    assert ray_runner._resolve_ray_dashboard_url() is None
+
+
+def test_autodetection_returns_none_when_ray_not_initialized(fake_ray):
+    fake_ray(initialized=False)
+
+    assert ray_runner._resolve_ray_dashboard_url() is None
+
+
+def test_autodetection_tolerates_ray_errors(monkeypatch):
+    def _raise() -> bool:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(ray_runner.ray, "is_initialized", _raise)
+
+    assert ray_runner._resolve_ray_dashboard_url() is None
+
+
+def test_env_override_takes_precedence(monkeypatch, fake_ray):
+    fake_ray(dashboard_url="127.0.0.1:8265")
+    monkeypatch.setenv("DAFT_RAY_DASHBOARD_URL", "https://ray.example.com")
+
+    assert ray_runner._resolve_ray_dashboard_url() == "https://ray.example.com/#/jobs/job-1"
+
+
+def test_env_override_preserves_https_scheme(monkeypatch, fake_ray):
+    fake_ray(job_id=None)
+    monkeypatch.setenv("DAFT_RAY_DASHBOARD_URL", "https://ray.example.com/dashboard/")
+
+    assert ray_runner._resolve_ray_dashboard_url() == "https://ray.example.com/dashboard/"
+
+
+def test_env_override_without_scheme_is_normalized(monkeypatch, fake_ray):
+    fake_ray(job_id=None)
+    monkeypatch.setenv("DAFT_RAY_DASHBOARD_URL", "my-proxy.example.com")
+
+    assert ray_runner._resolve_ray_dashboard_url() == "http://my-proxy.example.com"
+
+
+def test_env_override_honored_when_ray_dashboard_disabled(monkeypatch, fake_ray):
+    fake_ray(job_id=None)
+    monkeypatch.setenv("RAY_DISABLE_DASHBOARD", "1")
+    monkeypatch.setenv("DAFT_RAY_DASHBOARD_URL", "https://ray.example.com")
+
+    assert ray_runner._resolve_ray_dashboard_url() == "https://ray.example.com"
+
+
+def test_env_override_with_explicit_route_is_left_alone(monkeypatch, fake_ray):
+    fake_ray(dashboard_url="127.0.0.1:8265")
+    monkeypatch.setenv("DAFT_RAY_DASHBOARD_URL", "https://ray.example.com/#/overview")
+
+    assert ray_runner._resolve_ray_dashboard_url() == "https://ray.example.com/#/overview"
+
+
+def test_empty_env_override_falls_back_to_autodetection(monkeypatch, fake_ray):
+    fake_ray(dashboard_url="127.0.0.1:8265")
+    monkeypatch.setenv("DAFT_RAY_DASHBOARD_URL", "")
+
+    assert ray_runner._resolve_ray_dashboard_url() == "http://127.0.0.1:8265/#/jobs/job-1"


### PR DESCRIPTION
## Changes Made

Modified the Ray dashboard URL detection logic in `daft/runners/ray_runner.py` to support an environment variable override (`DAFT_RAY_DASHBOARD_URL`). This allows hosted environments where the Ray dashboard is exposed via an authenticated ingress proxy to specify a custom dashboard URL instead of relying on the default Ray worker discovery mechanism.

This is display-only — ray_dashboard_url is never used for HTTP calls or Ray communication. It's rendered as a clickable link in the Daft dashboard frontend.

## Why not use Ray's `RAY_OVERRIDE_DASHBOARD_URL`?

First, `ray.worker.get_dashboard_url` (which Daft currently uses to get the dashboard URL and which respects the override) emits a deprecation warning.

Second, Ray internally stores all URLs without protocol as an architectural convention. `RAY_OVERRIDE_DASHBOARD_URL` is processed through `_remove_protocol_from_url()` which strips the scheme, and all downstream consumers hardcode `http://` back. This means:

* Operator sets: `RAY_OVERRIDE_DASHBOARD_URL=https://ray.example.com`
* Ray strips to: `ray.example.com`
* Daft re-adds: `http://ray.example.com`  ← wrong scheme

In hosted environments where the Ray dashboard is behind an HTTPS ingress proxy, the resulting http:// link is incorrect. The DAFT_RAY_DASHBOARD_URL override bypasses Ray's protocol-stripping convention and uses the URL exactly as provided, preserving the operator's intended scheme.

## Related Issues

<!-- Link to related GitHub issues if applicable -->

https://claude.ai/code/session_01MT4thV77Jv5zD9RUfkvbPK