### PR TITLE
fix: incrementally ramp up Ray autoscaler resource requests to avoid exceeding cluster capacity

### DIFF
--- a/src/daft-distributed/src/python/ray/worker_manager.rs
+++ b/src/daft-distributed/src/python/ray/worker_manager.rs
@@ -17,6 +17,9 @@ use crate::scheduling::{
 
 const REFRESH_INTERVAL_SECS: Duration = Duration::from_secs(5);
 const DEFAULT_AUTOSCALE_INTERVAL_SECS: u64 = 5;
+// Environment variable Ray itself reads to configure its autoscaler reconciliation period.
+// We read the same variable so our rate-limit matches Ray's actual cycle length.
+const RAY_AUTOSCALER_UPDATE_INTERVAL_ENV: &str = "AUTOSCALER_UPDATE_INTERVAL_S";
 
 struct RayWorkerManagerState {
     ray_workers: HashMap<WorkerId, RaySwordfishWorker>,
@@ -78,7 +81,7 @@ impl RayWorkerManager {
                 max_resources_requested: ResourceRequest::default(),
                 last_autoscale_request_time: None,
                 autoscale_interval_secs: Duration::from_secs(
-                    std::env::var("AUTOSCALER_UPDATE_INTERVAL_S")
+                    std::env::var(RAY_AUTOSCALER_UPDATE_INTERVAL_ENV)
                         .ok()
                         .and_then(|val| val.parse::<u64>().ok())
                         .unwrap_or(DEFAULT_AUTOSCALE_INTERVAL_SECS),

--- a/src/daft-distributed/src/python/ray/worker_manager.rs
+++ b/src/daft-distributed/src/python/ray/worker_manager.rs
@@ -16,11 +16,14 @@ use crate::scheduling::{
 };
 
 const REFRESH_INTERVAL_SECS: Duration = Duration::from_secs(5);
+const DEFAULT_AUTOSCALE_INTERVAL_SECS: u64 = 5;
 
 struct RayWorkerManagerState {
     ray_workers: HashMap<WorkerId, RaySwordfishWorker>,
     last_refresh: Option<Instant>,
     max_resources_requested: ResourceRequest,
+    last_autoscale_request_time: Option<Instant>,
+    autoscale_interval_secs: Duration,
 }
 
 impl RayWorkerManagerState {
@@ -73,6 +76,13 @@ impl RayWorkerManager {
                 ray_workers: HashMap::new(),
                 last_refresh: None,
                 max_resources_requested: ResourceRequest::default(),
+                last_autoscale_request_time: None,
+                autoscale_interval_secs: Duration::from_secs(
+                    std::env::var("AUTOSCALER_UPDATE_INTERVAL_S")
+                        .ok()
+                        .and_then(|val| val.parse::<u64>().ok())
+                        .unwrap_or(DEFAULT_AUTOSCALE_INTERVAL_SECS),
+                ),
             })),
         }
     }
@@ -157,21 +167,41 @@ impl WorkerManager for RayWorkerManager {
         Ok(())
     }
 
+    /// Autoscale the Ray cluster by requesting resources from Ray's autoscaler.
+    ///
+    /// Constraints we operate under:
+    /// - `ray.autoscaler.sdk.request_resources(bundles=...)` **replaces** the current demand
+    ///   (it is not additive). Each call overwrites the previous request.
+    /// - Ray's autoscaler reconciliation loop checks the request every ~5 seconds by default
+    ///   (configurable via `AUTOSCALER_UPDATE_INTERVAL_S`). Calls between cycles overwrite
+    ///   each other — only the latest value at reconciliation time is processed.
+    /// - If the requested bundles exceed the cluster's maximum capacity (e.g., KubeRay
+    ///   `maxReplicas`), the autoscaler refuses to scale **at all** — not even partially.
+    ///
+    /// Algorithm: to avoid exceeding the cluster's unknown max capacity, we ramp up demand
+    /// gradually. Each autoscaler cycle, we send one more bundle than the previous request
+    /// (tracked via `max_resources_requested` as a high-water mark). The high-water mark is
+    /// floored to current cluster resources so the very first cycle immediately requests
+    /// scaling beyond current capacity.
     fn try_autoscale(&self, bundles: Vec<TaskResourceRequest>) -> DaftResult<()> {
-        let (requested_num_cpus, requested_num_gpus, requested_memory_bytes) =
-            bundles.iter().fold((0.0, 0.0, 0), |acc, bundle| {
-                (
-                    acc.0 + bundle.resource_request.num_cpus().unwrap_or(0.0),
-                    acc.1 + bundle.resource_request.num_gpus().unwrap_or(0.0),
-                    acc.2 + bundle.resource_request.memory_bytes().unwrap_or(0),
-                )
-            });
-
         let mut state = self
             .state
             .lock()
             .expect("Failed to lock RayWorkerManagerState");
 
+        // 1. Only attempt to grow the request once per Ray autoscaler reconciliation cycle.
+        //    Sending more frequently would just overwrite the previous value before Ray processes it.
+        if let Some(last_time) = state.last_autoscale_request_time
+            && last_time.elapsed() < state.autoscale_interval_secs
+        {
+            return Ok(());
+        }
+
+        // 2. Floor the high-water mark to at least the current cluster's total resources.
+        //    On cold start (high-water mark is 0), this lets us skip straight to requesting
+        //    beyond current capacity on the very first cycle. When new workers join between
+        //    cycles, this jumps the mark up so we don't waste cycles re-requesting resources
+        //    the cluster already has.
         let (cluster_num_cpus, cluster_num_gpus, cluster_memory_bytes) = state
             .ray_workers
             .values()
@@ -182,43 +212,76 @@ impl WorkerManager for RayWorkerManager {
                     acc.2 + worker.total_memory_bytes(),
                 )
             });
+        let high_water_mark_cpus = state
+            .max_resources_requested
+            .num_cpus()
+            .unwrap_or(0.0)
+            .max(cluster_num_cpus);
+        let high_water_mark_gpus = state
+            .max_resources_requested
+            .num_gpus()
+            .unwrap_or(0.0)
+            .max(cluster_num_gpus);
+        let high_water_mark_memory = state
+            .max_resources_requested
+            .memory_bytes()
+            .unwrap_or(0)
+            .max(cluster_memory_bytes);
 
-        let resource_request_greater_than_current_capacity = requested_num_cpus > cluster_num_cpus
-            || requested_num_gpus > cluster_num_gpus
-            || requested_memory_bytes > cluster_memory_bytes;
-
-        let resource_request_greater_than_max_requested = requested_num_cpus
-            > state.max_resources_requested.num_cpus().unwrap_or(0.0)
-            || requested_num_gpus > state.max_resources_requested.num_gpus().unwrap_or(0.0)
-            || requested_memory_bytes > state.max_resources_requested.memory_bytes().unwrap_or(0);
-
-        // Only autoscale if we need more capacity AND this is greater than we've seen before
-        if resource_request_greater_than_current_capacity
-            && resource_request_greater_than_max_requested
-        {
-            state.max_resources_requested = ResourceRequest::try_new_internal(
-                Some(requested_num_cpus),
-                Some(requested_num_gpus),
-                Some(requested_memory_bytes),
-            )?;
-            let python_bundles = bundles
-                .iter()
-                .map(|bundle| {
-                    let mut dict = HashMap::new();
-                    dict.insert("CPU", bundle.num_cpus().ceil() as i64);
-                    dict.insert("GPU", bundle.num_gpus().ceil() as i64);
-                    dict.insert("memory", bundle.memory_bytes() as i64);
-                    dict
-                })
-                .collect::<Vec<_>>();
-
-            Python::attach(|py| -> DaftResult<()> {
-                let flotilla_module = py.import(pyo3::intern!(py, "daft.runners.flotilla"))?;
-                flotilla_module
-                    .call_method1(pyo3::intern!(py, "try_autoscale"), (python_bundles,))?;
-                Ok(())
-            })?;
+        // 3. Accumulate bundles one at a time until the running total surpasses the
+        //    high-water mark in any resource dimension (CPU, GPU, or memory). This ensures
+        //    each cycle's request is exactly one bundle larger than the previous max —
+        //    gradual enough to avoid exceeding an unknown cluster capacity limit.
+        let mut cpu_sum = 0.0;
+        let mut gpu_sum = 0.0;
+        let mut memory_sum = 0;
+        let mut surpassed = false;
+        let mut selected_bundles = Vec::new();
+        for bundle in &bundles {
+            cpu_sum += bundle.resource_request.num_cpus().unwrap_or(0.0);
+            gpu_sum += bundle.resource_request.num_gpus().unwrap_or(0.0);
+            memory_sum += bundle.resource_request.memory_bytes().unwrap_or(0);
+            selected_bundles.push(bundle);
+            if cpu_sum > high_water_mark_cpus
+                || gpu_sum > high_water_mark_gpus
+                || memory_sum > high_water_mark_memory
+            {
+                surpassed = true;
+                break;
+            }
         }
+
+        // 4. If we went through all pending bundles without surpassing the high-water mark,
+        //    the remaining demand is smaller than what we previously requested. Skip this
+        //    cycle — Ray still holds our previous (larger) request, so no downscale occurs.
+        if !surpassed {
+            return Ok(());
+        }
+
+        // 5. Send the selected bundles to Ray's autoscaler via request_resources().
+        let python_bundles = selected_bundles
+            .iter()
+            .map(|bundle| {
+                let mut dict = HashMap::new();
+                dict.insert("CPU", bundle.num_cpus().ceil() as i64);
+                dict.insert("GPU", bundle.num_gpus().ceil() as i64);
+                dict.insert("memory", bundle.memory_bytes() as i64);
+                dict
+            })
+            .collect::<Vec<_>>();
+
+        Python::attach(|py| -> DaftResult<()> {
+            let flotilla_module = py.import(pyo3::intern!(py, "daft.runners.flotilla"))?;
+            flotilla_module.call_method1(pyo3::intern!(py, "try_autoscale"), (python_bundles,))?;
+            Ok(())
+        })?;
+
+        // 6. Record this request as the new high-water mark so the next cycle will
+        //    request exactly one bundle more, and so we never send a smaller request.
+        state.max_resources_requested =
+            ResourceRequest::try_new_internal(Some(cpu_sum), Some(gpu_sum), Some(memory_sum))?;
+        state.last_autoscale_request_time = Some(Instant::now());
+
         Ok(())
     }
 }

--- a/src/daft-distributed/src/python/ray/worker_manager.rs
+++ b/src/daft-distributed/src/python/ray/worker_manager.rs
@@ -170,6 +170,10 @@ impl WorkerManager for RayWorkerManager {
     /// Autoscale the Ray cluster by requesting resources from Ray's autoscaler.
     ///
     /// Constraints we operate under:
+    /// - There is no reliable programmatic way for Daft to know the cluster's true autoscaling
+    ///   ceiling ahead of time (for example, KubeRay `maxReplicas` or other external limits).
+    /// - Daft can only observe currently registered Ray workers; it cannot directly account for
+    ///   capacity that has already been requested but is still provisioning.
     /// - `ray.autoscaler.sdk.request_resources(bundles=...)` is **asynchronous** and each
     ///   call **replaces** the current demand (it is not additive).
     /// - Ray's autoscaler reconciliation loop processes the request every ~5 seconds by default

--- a/src/daft-distributed/src/python/ray/worker_manager.rs
+++ b/src/daft-distributed/src/python/ray/worker_manager.rs
@@ -170,19 +170,22 @@ impl WorkerManager for RayWorkerManager {
     /// Autoscale the Ray cluster by requesting resources from Ray's autoscaler.
     ///
     /// Constraints we operate under:
-    /// - `ray.autoscaler.sdk.request_resources(bundles=...)` **replaces** the current demand
-    ///   (it is not additive). Each call overwrites the previous request.
-    /// - Ray's autoscaler reconciliation loop checks the request every ~5 seconds by default
+    /// - `ray.autoscaler.sdk.request_resources(bundles=...)` is **asynchronous** and each
+    ///   call **replaces** the current demand (it is not additive).
+    /// - Ray's autoscaler reconciliation loop processes the request every ~5 seconds by default
     ///   (configurable via `AUTOSCALER_UPDATE_INTERVAL_S`). Calls between cycles overwrite
     ///   each other — only the latest value at reconciliation time is processed.
     /// - If the requested bundles exceed the cluster's maximum capacity (e.g., KubeRay
     ///   `maxReplicas`), the autoscaler refuses to scale **at all** — not even partially.
+    /// - We cannot detect whether the Ray autoscaler accepted or rejected the request, and
+    ///   observing new workers is not a reliable signal for whether a request succeeded, since
+    ///   node provisioning time varies (seconds to minutes depending on the environment).
     ///
-    /// Algorithm: to avoid exceeding the cluster's unknown max capacity, we ramp up demand
-    /// gradually. Each autoscaler cycle, we send one more bundle than the previous request
-    /// (tracked via `max_resources_requested` as a high-water mark). The high-water mark is
-    /// floored to current cluster resources so the very first cycle immediately requests
-    /// scaling beyond current capacity.
+    /// Algorithm: since we cannot detect failures and don't know the cluster's max capacity,
+    /// we ramp up demand gradually. In each autoscaler cycle, we send one more bundle than the
+    /// previous request (tracked via `max_resources_requested` as a high-water mark). The
+    /// high-water mark is floored to current cluster resources so the very first cycle
+    /// immediately requests scaling beyond current capacity.
     fn try_autoscale(&self, bundles: Vec<TaskResourceRequest>) -> DaftResult<()> {
         let mut state = self
             .state

--- a/src/daft-distributed/src/scheduling/scheduler/default.rs
+++ b/src/daft-distributed/src/scheduling/scheduler/default.rs
@@ -152,8 +152,8 @@ impl<T: Task> Scheduler<T> for DefaultScheduler<T> {
         // If we need to autoscale, return the resource requests of the pending tasks
         let needs_autoscaling = self.needs_autoscaling();
         needs_autoscaling.then(|| {
-            self.pending_tasks
-                .iter()
+            super::pending_tasks_in_priority_order(&self.pending_tasks)
+                .into_iter()
                 .map(|task| task.task.resource_request().clone())
                 .collect()
         })
@@ -651,6 +651,54 @@ mod tests {
 
         // Should request 4 workers (ratio 5 total demand / 1 capacity = 5.0 > default threshold 1.25)
         assert_eq!(scheduler.get_autoscaling_request().unwrap().len(), 4);
+    }
+
+    #[test]
+    fn test_default_scheduler_autoscaling_request_follows_priority_order() {
+        let mut scheduler: DefaultScheduler<MockTask> = setup_scheduler(&HashMap::new());
+
+        let tasks = vec![
+            PendingTask::new(
+                MockTaskBuilder::default()
+                    .with_priority(1)
+                    .with_resource_request(
+                        ResourceRequest::try_new_internal(Some(1.0), None, None).unwrap(),
+                    )
+                    .build(),
+                crate::utils::channel::create_oneshot_channel().0,
+                tokio_util::sync::CancellationToken::new(),
+            ),
+            PendingTask::new(
+                MockTaskBuilder::default()
+                    .with_priority(3)
+                    .with_resource_request(
+                        ResourceRequest::try_new_internal(Some(3.0), None, None).unwrap(),
+                    )
+                    .build(),
+                crate::utils::channel::create_oneshot_channel().0,
+                tokio_util::sync::CancellationToken::new(),
+            ),
+            PendingTask::new(
+                MockTaskBuilder::default()
+                    .with_priority(2)
+                    .with_resource_request(
+                        ResourceRequest::try_new_internal(Some(2.0), None, None).unwrap(),
+                    )
+                    .build(),
+                crate::utils::channel::create_oneshot_channel().0,
+                tokio_util::sync::CancellationToken::new(),
+            ),
+        ];
+
+        scheduler.enqueue_tasks(tasks);
+
+        let autoscaling_request = scheduler.get_autoscaling_request().unwrap();
+        let requested_cpus = autoscaling_request
+            .iter()
+            .map(TaskResourceRequest::num_cpus)
+            .collect::<Vec<_>>();
+
+        assert_eq!(requested_cpus, vec![3.0, 2.0, 1.0]);
     }
 
     #[test]

--- a/src/daft-distributed/src/scheduling/scheduler/linear.rs
+++ b/src/daft-distributed/src/scheduling/scheduler/linear.rs
@@ -140,8 +140,8 @@ impl<T: Task> Scheduler<T> for LinearScheduler<T> {
         // If we need to autoscale, return the resource requests of the pending tasks
         let needs_autoscaling = self.needs_autoscaling();
         needs_autoscaling.then(|| {
-            self.pending_tasks
-                .iter()
+            super::pending_tasks_in_priority_order(&self.pending_tasks)
+                .into_iter()
                 .next()
                 .map(|task| vec![task.task.resource_request().clone()])
                 .unwrap_or_default()
@@ -151,6 +151,8 @@ impl<T: Task> Scheduler<T> for LinearScheduler<T> {
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
+
+    use common_resource_request::ResourceRequest;
 
     use super::*;
     use crate::scheduling::{
@@ -254,6 +256,51 @@ mod tests {
         } else {
             panic!("Task should have worker affinity strategy");
         }
+    }
+
+    #[test]
+    fn test_linear_scheduler_autoscaling_request_follows_priority_order() {
+        let mut scheduler: LinearScheduler<MockTask> = setup_scheduler(&HashMap::new());
+
+        let tasks = vec![
+            PendingTask::new(
+                MockTaskBuilder::default()
+                    .with_priority(1)
+                    .with_resource_request(
+                        ResourceRequest::try_new_internal(Some(1.0), None, None).unwrap(),
+                    )
+                    .build(),
+                crate::utils::channel::create_oneshot_channel().0,
+                tokio_util::sync::CancellationToken::new(),
+            ),
+            PendingTask::new(
+                MockTaskBuilder::default()
+                    .with_priority(3)
+                    .with_resource_request(
+                        ResourceRequest::try_new_internal(Some(3.0), None, None).unwrap(),
+                    )
+                    .build(),
+                crate::utils::channel::create_oneshot_channel().0,
+                tokio_util::sync::CancellationToken::new(),
+            ),
+            PendingTask::new(
+                MockTaskBuilder::default()
+                    .with_priority(2)
+                    .with_resource_request(
+                        ResourceRequest::try_new_internal(Some(2.0), None, None).unwrap(),
+                    )
+                    .build(),
+                crate::utils::channel::create_oneshot_channel().0,
+                tokio_util::sync::CancellationToken::new(),
+            ),
+        ];
+
+        scheduler.enqueue_tasks(tasks);
+
+        let autoscaling_request = scheduler.get_autoscaling_request().unwrap();
+
+        assert_eq!(autoscaling_request.len(), 1);
+        assert_eq!(autoscaling_request[0].num_cpus(), 3.0);
     }
 
     #[test]

--- a/src/daft-distributed/src/scheduling/scheduler/mod.rs
+++ b/src/daft-distributed/src/scheduling/scheduler/mod.rs
@@ -1,4 +1,7 @@
-use std::{cmp::Ordering, collections::HashMap};
+use std::{
+    cmp::Ordering,
+    collections::{BinaryHeap, HashMap},
+};
 
 use super::{
     task::{SchedulingStrategy, Task, TaskDetails},
@@ -26,6 +29,15 @@ pub(super) trait Scheduler<T: Task>: Send + Sync {
     fn schedule_tasks(&mut self) -> Vec<ScheduledTask<T>>;
     fn get_autoscaling_request(&mut self) -> Option<Vec<TaskResourceRequest>>;
     fn num_pending_tasks(&self) -> usize;
+}
+
+fn pending_tasks_in_priority_order<T: Task>(
+    pending_tasks: &BinaryHeap<PendingTask<T>>,
+) -> Vec<&PendingTask<T>> {
+    let mut ordered_tasks = pending_tasks.iter().collect::<Vec<_>>();
+    // Match the order that repeated BinaryHeap::pop() calls would produce.
+    ordered_tasks.sort_unstable_by(|a, b| b.cmp(a));
+    ordered_tasks
 }
 
 pub(crate) struct PendingTask<T: Task> {

--- a/tests/integration/ray/test_autoscaling.py
+++ b/tests/integration/ray/test_autoscaling.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import time
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
+import ray
 
 import daft
 from daft import col
@@ -17,6 +19,10 @@ pytestmark = [
         reason="Autoscaling tests require Ray runner to be in use",
     ),
 ]
+
+
+def _num_worker_nodes() -> int:
+    return sum(1 for node in ray.nodes() if node["Alive"] and node["Resources"].get("CPU", 0) > 0)
 
 
 def test_basic_autoscaling_cluster():
@@ -88,3 +94,39 @@ def test_basic_autoscaling_gpu_cluster():
         df = daft.from_pydict({"x": [1, 2, 3, 4, 5], "y": [6, 7, 8, 9, 10]})
         result = df.select(fake_gpu_udf(col("x"))).to_pydict()
         assert result["x"] == [["0", "1"]] * 5
+
+
+def test_autoscaling_cluster_when_pending_tasks_exceed_cluster_cpu_cap(tmp_path):
+    head_resources = {"CPU": 0}
+    worker_node_types = {
+        "worker": {
+            "resources": {"CPU": 2},
+            "node_config": {},
+            "min_workers": 0,
+            "max_workers": 3,
+        }
+    }
+
+    for i in range(8):
+        (tmp_path / f"part-{i}.csv").write_text(f"x\n{i}\n")
+
+    with autoscaling_cluster_context(head_resources, worker_node_types):
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(lambda: daft.read_csv(str(tmp_path / "*.csv")).collect().to_pydict())
+
+            saw_worker = False
+            deadline = time.monotonic() + 20
+            while time.monotonic() < deadline:
+                worker_count = _num_worker_nodes()
+                assert worker_count <= 3
+                if worker_count > 0:
+                    saw_worker = True
+                if future.done():
+                    break
+                time.sleep(0.25)
+
+            remaining_timeout = max(1, deadline - time.monotonic())
+            result = future.result(timeout=remaining_timeout)
+            assert saw_worker, "Expected Ray autoscaler to start at least one worker node"
+
+    assert sorted(result["x"]) == list(range(8))


### PR DESCRIPTION
## Summary

Addresses https://github.com/Eventual-Inc/Daft/issues/6526

Fix Ray autoscaling requests so they ramp up incrementally instead of the maximum requests for the task. This makes the autoscaling behavior deterministic and better aligned with the scheduler when pending demand exceeds cluster capacity.

Autoscaling algorithm details are comments in the source code

## Changes
  - update Ray autoscaling request construction to use pending tasks in scheduler priority order
  - add focused scheduler tests covering autoscaling request ordering
  - add a Ray integration regression test for the capped-cluster autoscaling case using read_csv

## Validation

  - cargo test -p daft-distributed autoscaling_request_follows_priority_order -- --nocapture
  - DAFT_RUNNER=ray python -m pytest -o addopts='' -v tests/integration/ray/
    test_autoscaling.py::test_autoscaling_cluster_when_pending_tasks_exceed_cluster_cpu_cap

I tested scale-up works in my ray cluster with 40 cpus max and 0 initial workers
```python
daft.set_runner_ray()

# Attempt to read 100 parquet files
df = daft.read_parquet("s3://.../test-data/*.parquet")
df = df.repartition(100)
df = df.collect()
```
