### PR TITLE
feat(dataframe): add DataFrame.product() and GroupedDataFrame.product() methods

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -4041,6 +4041,8 @@ class DataFrame:
             return expr.string_agg()
         elif op == "skew":
             return expr.skew()
+        elif op == "product":
+            return expr.product()
 
         raise NotImplementedError(f"Aggregation {op} is not implemented.")
 
@@ -4207,6 +4209,33 @@ class DataFrame:
 
         """
         return self._apply_agg_fn(Expression.skew, cols)
+
+    @DataframePublicAPI
+    def product(self, *cols: ColumnInputType) -> "DataFrame":
+        """Performs a global product on the DataFrame.
+
+        Args:
+            *cols (Union[str, Expression]): columns to product
+
+        Returns:
+            DataFrame: Globally aggregated products. Should be a single row.
+
+        Examples:
+            >>> import daft
+            >>> df = daft.from_pydict({"col_a": [1, 2, 3]})
+            >>> df = df.product("col_a")
+            >>> df.show()
+            ╭───────╮
+            │ col_a │
+            │ ---   │
+            │ Int64 │
+            ╞═══════╡
+            │ 6     │
+            ╰───────╯
+            <BLANKLINE>
+            (Showing first 1 of 1 rows)
+        """
+        return self._apply_agg_fn(Expression.product, cols)
 
     @DataframePublicAPI
     def min(self, *cols: ColumnInputType) -> "DataFrame":
@@ -5680,6 +5709,36 @@ class GroupedDataFrame:
             DataFrame: DataFrame with the grouped skew per column.
         """
         return self.df._apply_agg_fn(Expression.skew, cols, self.group_by)
+
+    def product(self, *cols: ColumnInputType) -> DataFrame:
+        """Performs grouped product on this GroupedDataFrame.
+
+        Args:
+            *cols (Union[str, Expression]): columns to product
+
+        Returns:
+            DataFrame: DataFrame with grouped products.
+
+        Examples:
+            >>> import daft
+            >>> df = daft.from_pydict({"keys": ["a", "a", "a", "b"], "col_a": [1, 2, 3, 100]})
+            >>> df = df.groupby("keys").product()
+            >>> df = df.sort("keys")
+            >>> df.show()
+            ╭────────┬───────╮
+            │ keys   ┆ col_a │
+            │ ---    ┆ ---   │
+            │ String ┆ Int64 │
+            ╞════════╪═══════╡
+            │ a      ┆ 6     │
+            ├╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
+            │ b      ┆ 100   │
+            ╰────────┴───────╯
+            <BLANKLINE>
+            (Showing first 2 of 2 rows)
+
+        """
+        return self.df._apply_agg_fn(Expression.product, cols, self.group_by)
 
     def list_agg(self, *cols: ColumnInputType) -> DataFrame:
         """Performs grouped list on this GroupedDataFrame.

--- a/tests/dataframe/test_dataframe_product.py
+++ b/tests/dataframe/test_dataframe_product.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import functools
+import operator
+
+import pytest
+
+from daft import DataType, col
+
+
+def test_global_product_basic(make_df, with_morsel_size):
+    df = make_df({"a": [1, 2, 3]})
+    result = df.product("a").collect()
+    row = result.to_pydict()
+    assert row["a"] == [6]
+
+
+def test_global_product_single_value(make_df, with_morsel_size):
+    df = make_df({"a": [42]})
+    result = df.product("a").collect()
+    row = result.to_pydict()
+    assert row["a"] == [42]
+
+
+def test_global_product_with_nulls(make_df, with_morsel_size):
+    df = make_df({"a": [2, None, 3, None, 5]})
+    result = df.product("a").collect()
+    row = result.to_pydict()
+    assert row["a"] == [30]
+
+
+def test_global_product_all_nulls(make_df, with_morsel_size):
+    df = make_df({"a": [None, None, None]}).with_column("a", col("a").cast(DataType.int64()))
+    result = df.product("a").collect()
+    assert result.to_pydict()["a"] == [None]
+
+
+def test_global_product_with_zero(make_df, with_morsel_size):
+    df = make_df({"a": [1, 2, 0, 4]})
+    result = df.product("a").collect()
+    row = result.to_pydict()
+    assert row["a"] == [0]
+
+
+def test_global_product_negative_values(make_df, with_morsel_size):
+    df = make_df({"a": [-1, 2, -3]})
+    result = df.product("a").collect()
+    row = result.to_pydict()
+    assert row["a"] == [6]
+
+
+def test_global_product_floats(make_df, with_morsel_size):
+    df = make_df({"a": [1.5, 2.0, 4.0]})
+    result = df.product("a").collect()
+    row = result.to_pydict()
+    assert abs(row["a"][0] - 12.0) < 1e-10
+
+
+def test_global_product_multiple_cols(make_df, with_morsel_size):
+    df = make_df({"a": [1, 2, 3], "b": [4, 5, 6]})
+    result = df.product("a", "b").collect()
+    row = result.to_pydict()
+    assert row["a"] == [6]
+    assert row["b"] == [120]
+
+
+@pytest.mark.parametrize("repartition_nparts", [1, 2, 4])
+def test_global_product_multi_partition(make_df, repartition_nparts, with_morsel_size):
+    data = [1, 2, 3, 4, 5]
+    expected = functools.reduce(operator.mul, data, 1)
+    df = make_df({"a": data}, repartition=repartition_nparts)
+    result = df.product("a").collect()
+    row = result.to_pydict()
+    assert row["a"] == [expected]
+
+
+def test_grouped_product_basic(make_df, with_morsel_size):
+    df = make_df({"keys": ["a", "a", "a", "b", "b"], "vals": [1, 2, 3, 4, 5]})
+    result = df.groupby("keys").product("vals").sort("keys").collect()
+    row = result.to_pydict()
+    assert row["keys"] == ["a", "b"]
+    assert row["vals"] == [6, 20]
+
+
+def test_grouped_product_with_nulls(make_df, with_morsel_size):
+    df = make_df({"keys": ["a", "a", "a", "b", "b"], "vals": [2, None, 3, None, 5]})
+    result = df.groupby("keys").product("vals").sort("keys").collect()
+    row = result.to_pydict()
+    assert row["keys"] == ["a", "b"]
+    assert row["vals"] == [6, 5]
+
+
+def test_grouped_product_all_columns(make_df, with_morsel_size):
+    df = make_df({"keys": ["a", "a", "b", "b"], "x": [2, 3, 4, 5], "y": [10, 10, 2, 2]})
+    result = df.groupby("keys").product().sort("keys").collect()
+    row = result.to_pydict()
+    assert row["x"] == [6, 20]
+    assert row["y"] == [100, 4]

--- a/tests/dataframe/test_pivot.py
+++ b/tests/dataframe/test_pivot.py
@@ -136,6 +136,7 @@ def test_pivot_with_nulls(make_df, repartition_nparts, with_morsel_size):
         ("max", {"group": ["A", "B"], "1": [20, 40]}),
         ("min", {"group": ["A", "B"], "1": [10, 30]}),
         ("count", {"group": ["A", "B"], "1": [2, 2]}),
+        ("product", {"group": ["A", "B"], "1": [200, 1200]}),
     ],
 )
 def test_pivot_with_different_aggs(make_df, repartition_nparts, agg_fn, expected, with_morsel_size):


### PR DESCRIPTION
## Changes Made

Add `DataFrame.product()` and `GroupedDataFrame.product()` methods.

Also wires `"product"` into the `_map_agg_string_to_expr` dispatcher, enabling `df.pivot(..., agg_fn="product")` — covered by a new case in `test_pivot_with_different_aggs`.

## Related Issues

closes #6654