### PR TITLE
perf(inline-agg): add Utf8/Binary single-column fast path

### DIFF
--- a/src/daft-recordbatch/src/ops/inline_agg.rs
+++ b/src/daft-recordbatch/src/ops/inline_agg.rs
@@ -1638,7 +1638,15 @@ mod tests {
         .unwrap();
         let vals = Int64Array::from_iter(
             Field::new("val", DataType::Int64),
-            vec![Some(10), Some(20), Some(30), Some(40), Some(50), Some(60), Some(70)],
+            vec![
+                Some(10),
+                Some(20),
+                Some(30),
+                Some(40),
+                Some(50),
+                Some(60),
+                Some(70),
+            ],
         )
         .into_series();
         let schema = Schema::new(vec![

--- a/src/daft-recordbatch/src/ops/inline_agg.rs
+++ b/src/daft-recordbatch/src/ops/inline_agg.rs
@@ -3,11 +3,13 @@ use std::{
     hash::{BuildHasherDefault, Hash},
 };
 
+use arrow_array::Array;
 use common_error::DaftResult;
 use daft_core::{
     array::ops::arrow::comparison::build_multi_array_is_equal,
     count_mode::CountMode,
     datatypes::*,
+    prelude::AsArrow,
     series::{IntoSeries, Series},
     utils::identity_hash_set::{IdentityBuildHasher, IndexHash},
 };
@@ -786,6 +788,97 @@ where
 }
 
 // ---------------------------------------------------------------------------
+// Single-column byte-key fast path (FNV hash on borrowed slices)
+// ---------------------------------------------------------------------------
+//
+// Used for Utf8 and Binary single-column group-bys. Keys are borrowed slices
+// into the arrow buffers, which remain alive for the duration of the call,
+// so we can avoid the comparator closure used by the generic hash path.
+
+fn agg_single_col_bytes<'a, K>(
+    len: usize,
+    null_count: usize,
+    mut value_at: impl FnMut(usize) -> &'a K,
+    mut optional_at: impl FnMut(usize) -> Option<&'a K>,
+    accumulators: &mut [AggAccumulator],
+) -> DaftResult<Vec<u64>>
+where
+    K: ?Sized + Hash + Eq + 'a,
+{
+    let initial_capacity = std::cmp::min(len, 1024).max(1);
+    let mut groupkey_indices: Vec<u64> = Vec::with_capacity(initial_capacity);
+    let mut num_groups: u32 = 0;
+    let mut group_ids: Vec<u32> = Vec::with_capacity(len);
+    let mut group_sizes: Vec<u64> = Vec::with_capacity(initial_capacity);
+
+    if null_count == 0 {
+        let mut group_map = FnvHashMap::<&'a K, u32>::with_capacity_and_hasher(
+            initial_capacity,
+            BuildHasherDefault::default(),
+        );
+        for row_idx in 0..len {
+            let val = value_at(row_idx);
+            let gid = match group_map.entry(val) {
+                Vacant(e) => {
+                    let gid = num_groups;
+                    num_groups = num_groups.checked_add(1).ok_or_else(|| {
+                        common_error::DaftError::ComputeError(
+                            "Number of groups exceeds u32::MAX in inline aggregation".into(),
+                        )
+                    })?;
+                    e.insert(gid);
+                    groupkey_indices.push(row_idx as u64);
+                    group_sizes.push(1);
+                    gid
+                }
+                Occupied(e) => {
+                    let gid = *e.get();
+                    group_sizes[gid as usize] += 1;
+                    gid
+                }
+            };
+            group_ids.push(gid);
+        }
+    } else {
+        let mut group_map = FnvHashMap::<Option<&'a K>, u32>::with_capacity_and_hasher(
+            initial_capacity,
+            BuildHasherDefault::default(),
+        );
+        for row_idx in 0..len {
+            let val = optional_at(row_idx);
+            let gid = match group_map.entry(val) {
+                Vacant(e) => {
+                    let gid = num_groups;
+                    num_groups = num_groups.checked_add(1).ok_or_else(|| {
+                        common_error::DaftError::ComputeError(
+                            "Number of groups exceeds u32::MAX in inline aggregation".into(),
+                        )
+                    })?;
+                    e.insert(gid);
+                    groupkey_indices.push(row_idx as u64);
+                    group_sizes.push(1);
+                    gid
+                }
+                Occupied(e) => {
+                    let gid = *e.get();
+                    group_sizes[gid as usize] += 1;
+                    gid
+                }
+            };
+            group_ids.push(gid);
+        }
+    }
+
+    let result = GroupingResult {
+        groupkey_indices,
+        group_ids,
+        group_sizes,
+    };
+    accumulate(accumulators, &result);
+    Ok(result.groupkey_indices)
+}
+
+// ---------------------------------------------------------------------------
 // Generic multi-column hash path
 // ---------------------------------------------------------------------------
 
@@ -883,6 +976,27 @@ macro_rules! dispatch_single_col_int {
     };
 }
 
+/// Dispatch single-column Utf8/Binary groupby to the byte-key fast path.
+macro_rules! dispatch_single_col_bytes {
+    ($col:expr, $accumulators:expr, $($dtype:ident => $downcast:ident => $key:ty),+ $(,)?) => {
+        match $col.data_type() {
+            $(
+                DataType::$dtype => {
+                    let inner = $col.$downcast()?.as_arrow()?;
+                    Some(agg_single_col_bytes::<$key>(
+                        inner.len(),
+                        inner.null_count(),
+                        |i| inner.value(i),
+                        |i| (!inner.is_null(i)).then(|| inner.value(i)),
+                        $accumulators,
+                    )?)
+                }
+            )+
+            _ => None,
+        }
+    };
+}
+
 impl RecordBatch {
     pub(crate) fn agg_groupby_inline(
         &self,
@@ -907,7 +1021,7 @@ impl RecordBatch {
             output_names.push(name);
         }
 
-        // 3. Dispatch: single-column integer → FNV fast path, otherwise generic.
+        // 3. Dispatch: single-column typed fast paths, otherwise generic.
         let groupkey_indices = if groupby_physical.num_columns() == 1 {
             let col = groupby_physical.get_column(0);
             let fast_result = dispatch_single_col_int!(
@@ -915,6 +1029,14 @@ impl RecordBatch {
                 Int8 => i8, Int16 => i16, Int32 => i32, Int64 => i64,
                 UInt8 => u8, UInt16 => u16, UInt32 => u32, UInt64 => u64,
             );
+            let fast_result = match fast_result {
+                Some(indices) => Some(indices),
+                None => dispatch_single_col_bytes!(
+                    col, &mut accumulators,
+                    Utf8 => utf8 => str,
+                    Binary => binary => [u8],
+                ),
+            };
             match fast_result {
                 Some(indices) => indices,
                 None => agg_generic_hash_path(&groupby_physical, &mut accumulators)?,
@@ -1318,6 +1440,47 @@ mod tests {
         assert_batches_equal(&inline_result, &fallback_result);
     }
 
+    /// Helper for groupby where the aggregated column is entirely null.
+    fn make_all_null_vals_test_batch() -> (RecordBatch, Vec<BoundExpr>, Schema) {
+        let keys = Int64Array::from_iter(
+            Field::new("key", DataType::Int64),
+            vec![Some(1), Some(2), Some(1), Some(2), Some(1)],
+        )
+        .into_series();
+        let vals = Int64Array::from_iter(
+            Field::new("val", DataType::Int64),
+            vec![None, None, None, None, None],
+        )
+        .into_series();
+        let schema = Schema::new(vec![
+            Field::new("key", DataType::Int64),
+            Field::new("val", DataType::Int64),
+        ]);
+        let rb = RecordBatch::from_nonempty_columns(vec![keys, vals]).unwrap();
+        let group_by = vec![BoundExpr::try_new(resolved_col("key"), &schema).unwrap()];
+        (rb, group_by, schema)
+    }
+
+    #[test]
+    fn test_inline_all_null_vals_min_matches_fallback() {
+        let (rb, group_by, schema) = make_all_null_vals_test_batch();
+        let bound_agg =
+            vec![BoundAggExpr::try_new(AggExpr::Min(resolved_col("val")), &schema).unwrap()];
+        let inline_result = rb.agg_groupby_inline(&bound_agg, &group_by).unwrap();
+        let fallback_result = rb.agg_groupby_fallback(&bound_agg, &group_by).unwrap();
+        assert_batches_equal(&inline_result, &fallback_result);
+    }
+
+    #[test]
+    fn test_inline_all_null_vals_max_matches_fallback() {
+        let (rb, group_by, schema) = make_all_null_vals_test_batch();
+        let bound_agg =
+            vec![BoundAggExpr::try_new(AggExpr::Max(resolved_col("val")), &schema).unwrap()];
+        let inline_result = rb.agg_groupby_inline(&bound_agg, &group_by).unwrap();
+        let fallback_result = rb.agg_groupby_fallback(&bound_agg, &group_by).unwrap();
+        assert_batches_equal(&inline_result, &fallback_result);
+    }
+
     // --- Float64 with NaN tests (validates f64::min/f64::max NaN handling) ---
 
     /// Helper for float-keyed groupby tests with NaN values.
@@ -1397,6 +1560,185 @@ mod tests {
     #[test]
     fn test_inline_i8_max_matches_fallback() {
         let (rb, group_by, schema) = make_i8_val_test_batch();
+        let bound_agg =
+            vec![BoundAggExpr::try_new(AggExpr::Max(resolved_col("val")), &schema).unwrap()];
+        let inline_result = rb.agg_groupby_inline(&bound_agg, &group_by).unwrap();
+        let fallback_result = rb.agg_groupby_fallback(&bound_agg, &group_by).unwrap();
+        assert_batches_equal(&inline_result, &fallback_result);
+    }
+
+    // --- Byte-key fast path tests (Utf8 and Binary) ---
+
+    /// Helper for Utf8-keyed groupby with NO null keys (exercises the
+    /// `null_count == 0` fast branch in `agg_single_col_bytes`).
+    fn make_utf8_key_no_nulls_test_batch() -> (RecordBatch, Vec<BoundExpr>, Schema) {
+        let keys = Series::from_arrow(
+            Arc::new(Field::new("key", DataType::Utf8)),
+            Arc::new(arrow::array::LargeStringArray::from(vec![
+                "alpha", "beta", "alpha", "gamma", "beta", "alpha",
+            ])),
+        )
+        .unwrap();
+        let vals = Int64Array::from_iter(
+            Field::new("val", DataType::Int64),
+            vec![Some(10), Some(20), None, Some(40), Some(50), Some(60)],
+        )
+        .into_series();
+        let schema = Schema::new(vec![
+            Field::new("key", DataType::Utf8),
+            Field::new("val", DataType::Int64),
+        ]);
+        let rb = RecordBatch::from_nonempty_columns(vec![keys, vals]).unwrap();
+        let group_by = vec![BoundExpr::try_new(resolved_col("key"), &schema).unwrap()];
+        (rb, group_by, schema)
+    }
+
+    /// Helper for Utf8-keyed groupby with null keys.
+    fn make_utf8_key_with_nulls_test_batch() -> (RecordBatch, Vec<BoundExpr>, Schema) {
+        let keys = Series::from_arrow(
+            Arc::new(Field::new("key", DataType::Utf8)),
+            Arc::new(arrow::array::LargeStringArray::from(vec![
+                Some("alpha"),
+                None,
+                Some("alpha"),
+                Some(""),
+                None,
+                Some("beta"),
+            ])),
+        )
+        .unwrap();
+        let vals = Int64Array::from_iter(
+            Field::new("val", DataType::Int64),
+            vec![Some(1), Some(2), Some(3), Some(4), Some(5), Some(6)],
+        )
+        .into_series();
+        let schema = Schema::new(vec![
+            Field::new("key", DataType::Utf8),
+            Field::new("val", DataType::Int64),
+        ]);
+        let rb = RecordBatch::from_nonempty_columns(vec![keys, vals]).unwrap();
+        let group_by = vec![BoundExpr::try_new(resolved_col("key"), &schema).unwrap()];
+        (rb, group_by, schema)
+    }
+
+    /// Helper for Binary-keyed groupby (with a null key and an empty key).
+    fn make_binary_key_test_batch() -> (RecordBatch, Vec<BoundExpr>, Schema) {
+        let keys = Series::from_arrow(
+            Arc::new(Field::new("key", DataType::Binary)),
+            Arc::new(arrow::array::LargeBinaryArray::from_opt_vec(vec![
+                Some(b"hello".as_ref()),
+                Some(b"world".as_ref()),
+                Some(b"hello".as_ref()),
+                None,
+                Some(b"".as_ref()),
+                Some(b"hello".as_ref()),
+                None,
+            ])),
+        )
+        .unwrap();
+        let vals = Int64Array::from_iter(
+            Field::new("val", DataType::Int64),
+            vec![Some(10), Some(20), Some(30), Some(40), Some(50), Some(60), Some(70)],
+        )
+        .into_series();
+        let schema = Schema::new(vec![
+            Field::new("key", DataType::Binary),
+            Field::new("val", DataType::Int64),
+        ]);
+        let rb = RecordBatch::from_nonempty_columns(vec![keys, vals]).unwrap();
+        let group_by = vec![BoundExpr::try_new(resolved_col("key"), &schema).unwrap()];
+        (rb, group_by, schema)
+    }
+
+    #[test]
+    fn test_inline_utf8_key_no_nulls_count_matches_fallback() {
+        let (rb, group_by, schema) = make_utf8_key_no_nulls_test_batch();
+        let bound_agg = vec![
+            BoundAggExpr::try_new(AggExpr::Count(resolved_col("val"), CountMode::All), &schema)
+                .unwrap(),
+        ];
+        let inline_result = rb.agg_groupby_inline(&bound_agg, &group_by).unwrap();
+        let fallback_result = rb.agg_groupby_fallback(&bound_agg, &group_by).unwrap();
+        assert_batches_equal(&inline_result, &fallback_result);
+    }
+
+    #[test]
+    fn test_inline_utf8_key_no_nulls_sum_matches_fallback() {
+        let (rb, group_by, schema) = make_utf8_key_no_nulls_test_batch();
+        let bound_agg =
+            vec![BoundAggExpr::try_new(AggExpr::Sum(resolved_col("val")), &schema).unwrap()];
+        let inline_result = rb.agg_groupby_inline(&bound_agg, &group_by).unwrap();
+        let fallback_result = rb.agg_groupby_fallback(&bound_agg, &group_by).unwrap();
+        assert_batches_equal(&inline_result, &fallback_result);
+    }
+
+    #[test]
+    fn test_inline_utf8_key_no_nulls_max_matches_fallback() {
+        let (rb, group_by, schema) = make_utf8_key_no_nulls_test_batch();
+        let bound_agg =
+            vec![BoundAggExpr::try_new(AggExpr::Max(resolved_col("val")), &schema).unwrap()];
+        let inline_result = rb.agg_groupby_inline(&bound_agg, &group_by).unwrap();
+        let fallback_result = rb.agg_groupby_fallback(&bound_agg, &group_by).unwrap();
+        assert_batches_equal(&inline_result, &fallback_result);
+    }
+
+    #[test]
+    fn test_inline_utf8_key_with_nulls_count_matches_fallback() {
+        let (rb, group_by, schema) = make_utf8_key_with_nulls_test_batch();
+        let bound_agg = vec![
+            BoundAggExpr::try_new(AggExpr::Count(resolved_col("val"), CountMode::All), &schema)
+                .unwrap(),
+        ];
+        let inline_result = rb.agg_groupby_inline(&bound_agg, &group_by).unwrap();
+        let fallback_result = rb.agg_groupby_fallback(&bound_agg, &group_by).unwrap();
+        assert_batches_equal(&inline_result, &fallback_result);
+    }
+
+    #[test]
+    fn test_inline_utf8_key_with_nulls_sum_matches_fallback() {
+        let (rb, group_by, schema) = make_utf8_key_with_nulls_test_batch();
+        let bound_agg =
+            vec![BoundAggExpr::try_new(AggExpr::Sum(resolved_col("val")), &schema).unwrap()];
+        let inline_result = rb.agg_groupby_inline(&bound_agg, &group_by).unwrap();
+        let fallback_result = rb.agg_groupby_fallback(&bound_agg, &group_by).unwrap();
+        assert_batches_equal(&inline_result, &fallback_result);
+    }
+
+    #[test]
+    fn test_inline_utf8_key_with_nulls_min_matches_fallback() {
+        let (rb, group_by, schema) = make_utf8_key_with_nulls_test_batch();
+        let bound_agg =
+            vec![BoundAggExpr::try_new(AggExpr::Min(resolved_col("val")), &schema).unwrap()];
+        let inline_result = rb.agg_groupby_inline(&bound_agg, &group_by).unwrap();
+        let fallback_result = rb.agg_groupby_fallback(&bound_agg, &group_by).unwrap();
+        assert_batches_equal(&inline_result, &fallback_result);
+    }
+
+    #[test]
+    fn test_inline_binary_key_count_matches_fallback() {
+        let (rb, group_by, schema) = make_binary_key_test_batch();
+        let bound_agg = vec![
+            BoundAggExpr::try_new(AggExpr::Count(resolved_col("val"), CountMode::All), &schema)
+                .unwrap(),
+        ];
+        let inline_result = rb.agg_groupby_inline(&bound_agg, &group_by).unwrap();
+        let fallback_result = rb.agg_groupby_fallback(&bound_agg, &group_by).unwrap();
+        assert_batches_equal(&inline_result, &fallback_result);
+    }
+
+    #[test]
+    fn test_inline_binary_key_sum_matches_fallback() {
+        let (rb, group_by, schema) = make_binary_key_test_batch();
+        let bound_agg =
+            vec![BoundAggExpr::try_new(AggExpr::Sum(resolved_col("val")), &schema).unwrap()];
+        let inline_result = rb.agg_groupby_inline(&bound_agg, &group_by).unwrap();
+        let fallback_result = rb.agg_groupby_fallback(&bound_agg, &group_by).unwrap();
+        assert_batches_equal(&inline_result, &fallback_result);
+    }
+
+    #[test]
+    fn test_inline_binary_key_max_matches_fallback() {
+        let (rb, group_by, schema) = make_binary_key_test_batch();
         let bound_agg =
             vec![BoundAggExpr::try_new(AggExpr::Max(resolved_col("val")), &schema).unwrap()];
         let inline_result = rb.agg_groupby_inline(&bound_agg, &group_by).unwrap();


### PR DESCRIPTION
## Overview

Adds a single-column fast path in `inline_agg.rs` for Utf8 and Binary group-by keys, mirroring the existing integer fast path (`agg_single_col_int`). This is for item #2 on the grouped-aggregation optimization roadmap in #6585.

## Background

Today, single-column integer group-bys take a specialized FNV-hashed fast path (`agg_single_col_int<T>`), while every other single-column key type  (like Utf8 and Binary) falls through to `agg_generic_hash_path`. The generic path computes per-row hashes via `hash_rows()` and uses a `build_multi_array_is_equal` comparator closure, which is necessary for the multi-column case but wasteful when grouping by a single string or bytes column.

## Changes

### `agg_single_col_bytes<'a, K>`

A new byte-key analog of `agg_single_col_int`. Generic over `K: ?Sized + Hash + Eq`, so it monomorphizes to `str` (Utf8) and `[u8]` (Binary) at the call site. Keys are borrowed slices into the underlying arrow buffer — no allocation, no comparator closure.

Like the integer fast path, it has two branches:

- **`null_count == 0`**: `FnvHashMap<&K, u32>` — no `Option` wrapping, one word narrower key.
- **`null_count > 0`**: `FnvHashMap<Option<&K>, u32>`.

Both branches build the same dense `group_ids` / `group_sizes` / `groupkey_indices` triple consumed by the existing `accumulate()` helper, and preserve the `u32::MAX` overflow guard from the integer path.

### Dispatch

A new `dispatch_single_col_bytes!` macro mirrors the existing `dispatch_single_col_int!` macro. The single-column dispatch in `agg_groupby_inline` tries integer first, then byte-key, then falls through to the generic path:

```rust
let fast_result = dispatch_single_col_int!(col, &mut accumulators, ...);
let fast_result = match fast_result {
    Some(indices) => Some(indices),
    None => dispatch_single_col_bytes!(
        col, &mut accumulators,
        Utf8 => utf8 => str,
        Binary => binary => [u8],
    ),
};
```

### Tests

Nine new tests:

- **Utf8 no-nulls** (count/sum/max) -> exercises the `null_count == 0` branch.
- **Utf8 with nulls** (count/sum/min) -> includes empty string `""` and null keys.
- **Binary** (count/sum/max) -> includes empty bytes `b""` and null keys.

Plus an additional pair of min/max tests over an all-null value column, placed alongside the existing nullable integer-key min/max tests. This covers the accumulator edge case @desmondcheongzx mentioned in  #6604.

The original string-key tests (`make_test_batch`) already use Utf8 keys and now uses the new fast path.


## Related

- Roadmap: #6585
- Min/max accumulators (prior PR): #6604