### PR TITLE
feat(dataframe): add DataFrame.count_distinct() and GroupedDataFrame.count_distinct() methods

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -4043,6 +4043,8 @@ class DataFrame:
             return expr.skew()
         elif op == "product":
             return expr.product()
+        elif op == "count_distinct":
+            return expr.count_distinct()
 
         raise NotImplementedError(f"Aggregation {op} is not implemented.")
 
@@ -4316,6 +4318,32 @@ class DataFrame:
             (Showing first 1 of 1 rows)
         """
         return self._apply_agg_fn(Expression.any_value, cols)
+
+    @DataframePublicAPI
+    def count_distinct(self, *cols: ColumnInputType) -> "DataFrame":
+        """Performs a global count of distinct values on the DataFrame.
+
+        Args:
+            *cols (Union[str, Expression]): columns to count distinct values
+        Returns:
+            DataFrame: Globally aggregated count of distinct values. Should be a single row.
+
+        Examples:
+            >>> import daft
+            >>> df = daft.from_pydict({"col_a": [1, 2, 2, 3, 3, 3]})
+            >>> df = df.count_distinct("col_a")
+            >>> df.show()
+            ╭────────╮
+            │ col_a  │
+            │ ---    │
+            │ UInt64 │
+            ╞════════╡
+            │ 3      │
+            ╰────────╯
+            <BLANKLINE>
+            (Showing first 1 of 1 rows)
+        """
+        return self._apply_agg_fn(Expression.count_distinct, cols)
 
     @DataframePublicAPI
     def count(self, *cols: ColumnInputType | int) -> "DataFrame":
@@ -5739,6 +5767,36 @@ class GroupedDataFrame:
 
         """
         return self.df._apply_agg_fn(Expression.product, cols, self.group_by)
+
+    def count_distinct(self, *cols: ColumnInputType) -> DataFrame:
+        """Performs grouped count of distinct values on this GroupedDataFrame.
+
+        Args:
+            *cols (Union[str, Expression]): columns to count distinct values
+
+        Returns:
+            DataFrame: DataFrame with grouped count of distinct values per column.
+
+        Examples:
+            >>> import daft
+            >>> df = daft.from_pydict({"keys": ["a", "a", "a", "b", "b", "b"], "vals": [1, 1, 2, 3, 3, 3]})
+            >>> df = df.groupby("keys").count_distinct("vals")
+            >>> df = df.sort("keys")
+            >>> df.show()
+            ╭────────┬────────╮
+            │ keys   ┆ vals   │
+            │ ---    ┆ ---    │
+            │ String ┆ UInt64 │
+            ╞════════╪════════╡
+            │ a      ┆ 2      │
+            ├╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┤
+            │ b      ┆ 1      │
+            ╰────────┴────────╯
+            <BLANKLINE>
+            (Showing first 2 of 2 rows)
+
+        """
+        return self.df._apply_agg_fn(Expression.count_distinct, cols, self.group_by)
 
     def list_agg(self, *cols: ColumnInputType) -> DataFrame:
         """Performs grouped list on this GroupedDataFrame.

--- a/tests/dataframe/test_dataframe_count_distinct.py
+++ b/tests/dataframe/test_dataframe_count_distinct.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import pytest
+
+import daft
+from daft import DataType, col
+
+
+def test_global_count_distinct_basic(make_df, with_morsel_size):
+    df = make_df({"a": [1, 2, 2, 3, 3, 3]})
+    result = df.count_distinct("a").collect()
+    assert result.to_pydict()["a"] == [3]
+
+
+def test_global_count_distinct_all_same(make_df, with_morsel_size):
+    df = make_df({"a": [5, 5, 5]})
+    result = df.count_distinct("a").collect()
+    assert result.to_pydict()["a"] == [1]
+
+
+def test_global_count_distinct_all_unique(make_df, with_morsel_size):
+    df = make_df({"a": [1, 2, 3, 4, 5]})
+    result = df.count_distinct("a").collect()
+    assert result.to_pydict()["a"] == [5]
+
+
+def test_global_count_distinct_with_nulls(make_df, with_morsel_size):
+    df = make_df({"a": [1, None, 2, None, 2]})
+    result = df.count_distinct("a").collect()
+    assert result.to_pydict()["a"] == [2]
+
+
+def test_global_count_distinct_all_nulls(make_df, with_morsel_size):
+    df = make_df({"a": [None, None, None]}).with_column("a", col("a").cast(DataType.int64()))
+    result = df.count_distinct("a").collect()
+    assert result.to_pydict()["a"] == [0]
+
+
+def test_global_count_distinct_strings(make_df, with_morsel_size):
+    df = make_df({"a": ["foo", "bar", "foo", "baz", "bar"]})
+    result = df.count_distinct("a").collect()
+    assert result.to_pydict()["a"] == [3]
+
+
+def test_global_count_distinct_multiple_cols(make_df, with_morsel_size):
+    df = make_df({"a": [1, 1, 2, 2], "b": ["x", "y", "x", "x"]})
+    result = df.count_distinct("a", "b").collect()
+    row = result.to_pydict()
+    assert row["a"] == [2]
+    assert row["b"] == [2]
+
+
+@pytest.mark.parametrize("repartition_nparts", [1, 2, 4])
+def test_global_count_distinct_multi_partition(make_df, repartition_nparts, with_morsel_size):
+    df = make_df({"a": [1, 2, 2, 3, 3, 3]}, repartition=repartition_nparts)
+    result = df.count_distinct("a").collect()
+    assert result.to_pydict()["a"] == [3]
+
+
+def test_global_count_distinct_empty_partitions(with_morsel_size):
+    # Stress the distributed pipeline (Set → Concat → count_distinct) when some partitions are empty.
+    df = daft.from_pydict({"a": [1, 2, 2, 3, 3, 3]})
+    empty_df = daft.from_pydict({"a": [1]}).where(col("a") != 1).collect()
+    df = df.concat(empty_df).into_partitions(2).collect()
+    result = df.count_distinct("a").collect()
+    assert result.to_pydict()["a"] == [3]
+
+
+def test_grouped_count_distinct_basic(make_df, with_morsel_size):
+    df = make_df({"keys": ["a", "a", "a", "b", "b"], "vals": [1, 1, 2, 3, 3]})
+    result = df.groupby("keys").count_distinct("vals").sort("keys").collect()
+    row = result.to_pydict()
+    assert row["keys"] == ["a", "b"]
+    assert row["vals"] == [2, 1]
+
+
+def test_grouped_count_distinct_with_nulls(make_df, with_morsel_size):
+    df = make_df({"keys": ["a", "a", "a", "b", "b"], "vals": [1, None, 1, None, None]})
+    result = df.groupby("keys").count_distinct("vals").sort("keys").collect()
+    row = result.to_pydict()
+    assert row["keys"] == ["a", "b"]
+    assert row["vals"] == [1, 0]
+
+
+def test_grouped_count_distinct_all_columns(make_df, with_morsel_size):
+    df = make_df({"keys": ["a", "a", "b", "b"], "x": [1, 1, 2, 3], "y": ["p", "q", "p", "p"]})
+    result = df.groupby("keys").count_distinct().sort("keys").collect()
+    row = result.to_pydict()
+    assert row["x"] == [1, 2]
+    assert row["y"] == [2, 1]

--- a/tests/dataframe/test_pivot.py
+++ b/tests/dataframe/test_pivot.py
@@ -137,6 +137,7 @@ def test_pivot_with_nulls(make_df, repartition_nparts, with_morsel_size):
         ("min", {"group": ["A", "B"], "1": [10, 30]}),
         ("count", {"group": ["A", "B"], "1": [2, 2]}),
         ("product", {"group": ["A", "B"], "1": [200, 1200]}),
+        ("count_distinct", {"group": ["A", "B"], "1": [2, 2]}),
     ],
 )
 def test_pivot_with_different_aggs(make_df, repartition_nparts, agg_fn, expected, with_morsel_size):


### PR DESCRIPTION
## Changes Made

Add `DataFrame.count_distinct()` and `GroupedDataFrame.count_distinct()` methods.

Also wires `"count_distinct"` into the `_map_agg_string_to_expr` dispatcher, enabling `df.pivot(..., agg_fn="count_distinct")` — covered by a new case in `test_pivot_with_different_aggs`.

## Related Issues

Closes #6657