### PR TITLE
fix: broadcast zero-field StructArray to requested length

### DIFF
--- a/src/daft-core/src/array/ops/broadcast.rs
+++ b/src/daft-core/src/array/ops/broadcast.rs
@@ -214,16 +214,16 @@ impl Broadcastable for StructArray {
         }
 
         if self.is_valid(0) {
+            let field = Arc::new(Field::new(self.name(), self.data_type().clone()));
+            if self.children.is_empty() {
+                return Ok(Self::new_empty(field, num, None));
+            }
             let broadcasted_children = self
                 .children
                 .iter()
                 .map(|child| child.broadcast(num))
                 .collect::<DaftResult<Vec<_>>>()?;
-            Ok(Self::new(
-                Arc::new(Field::new(self.name(), self.data_type().clone())),
-                broadcasted_children,
-                None,
-            ))
+            Ok(Self::new(field, broadcasted_children, None))
         } else {
             Ok(Self::full_null(self.name(), self.data_type(), num))
         }

--- a/tests/recordbatch/test_broadcasts.py
+++ b/tests/recordbatch/test_broadcasts.py
@@ -21,3 +21,19 @@ def test_broadcast_fixed_size_list():
         [col("x"), lit(data).cast(daft.DataType.fixed_size_list(daft.DataType.int64(), 3))]
     )
     assert new_table.to_pydict() == {"x": [1, 2, 3], "literal": [data for _ in range(3)]}
+
+
+def test_broadcast_empty_struct():
+    # Regression test for https://github.com/Eventual-Inc/Daft/issues/6659
+    # daft.lit({}) should broadcast the empty struct to every row.
+    df = daft.from_pydict({"id": ["a", "b", "c"]})
+    df = df.with_column("meta", daft.lit({}))
+    result = df.to_pydict()
+    assert result == {"id": ["a", "b", "c"], "meta": [{}, {}, {}]}
+
+    rows = list(df.iter_rows())
+    assert rows == [
+        {"id": "a", "meta": {}},
+        {"id": "b", "meta": {}},
+        {"id": "c", "meta": {}},
+    ]


### PR DESCRIPTION
## Changes Made

StructArray::broadcast rebuilt the array via Self::new(..., [], None), which fell through to len = 0 when children were empty and no null buffer was provided. For daft.lit({}), this made the column come back as an empty list and crashed iter_rows().

Use StructArray::new_empty with the explicit broadcast length for the zero-field case.

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

## Related Issues
Closes #6659

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
