### PR TITLE
perf: Parallelize post-groupby op

### DIFF
--- a/src/daft-local-execution/src/pipeline.rs
+++ b/src/daft-local-execution/src/pipeline.rs
@@ -938,6 +938,7 @@ fn physical_plan_to_pipeline(
             limit,
             stats_state,
             context,
+            schema,
             ..
         }) => {
             let sink = TopNSink::new(
@@ -946,6 +947,7 @@ fn physical_plan_to_pipeline(
                 nulls_first.clone(),
                 *limit as usize,
                 offset.map(|x| x as usize),
+                schema.clone(),
             );
             let child_node = physical_plan_to_pipeline(input, cfg, ctx, input_senders)?;
             BlockingSinkNode::new(

--- a/src/daft-local-execution/src/pipeline.rs
+++ b/src/daft-local-execution/src/pipeline.rs
@@ -938,7 +938,6 @@ fn physical_plan_to_pipeline(
             limit,
             stats_state,
             context,
-            schema,
             ..
         }) => {
             let sink = TopNSink::new(
@@ -947,7 +946,6 @@ fn physical_plan_to_pipeline(
                 nulls_first.clone(),
                 *limit as usize,
                 offset.map(|x| x as usize),
-                schema.clone(),
             );
             let child_node = physical_plan_to_pipeline(input, cfg, ctx, input_senders)?;
             BlockingSinkNode::new(

--- a/src/daft-local-execution/src/sinks/dedup.rs
+++ b/src/daft-local-execution/src/sinks/dedup.rs
@@ -160,8 +160,7 @@ impl BlockingSink for DedupSink {
                         .collect::<DaftResult<Vec<_>>>()?;
 
                     // Concatenate the results and return
-                    let concated = MicroPartition::concat(results)?;
-                    Ok(BlockingSinkOutput::Partitions(vec![concated]))
+                    Ok(BlockingSinkOutput::Partitions(results))
                 },
                 Span::current(),
             )

--- a/src/daft-local-execution/src/sinks/grouped_aggregate.rs
+++ b/src/daft-local-execution/src/sinks/grouped_aggregate.rs
@@ -405,8 +405,7 @@ impl BlockingSink for GroupedAggregateSink {
                         .await
                         .into_iter()
                         .collect::<DaftResult<Vec<_>>>()?;
-                    let concated = MicroPartition::concat(results)?;
-                    Ok(BlockingSinkOutput::Partitions(vec![concated]))
+                    Ok(BlockingSinkOutput::Partitions(results))
                 },
                 Span::current(),
             )

--- a/src/daft-local-execution/src/sinks/top_n.rs
+++ b/src/daft-local-execution/src/sinks/top_n.rs
@@ -1,19 +1,17 @@
-use std::{sync::Arc, time::Instant};
+use std::sync::Arc;
 
 use common_error::DaftResult;
 use common_metrics::ops::NodeType;
-use daft_core::prelude::SchemaRef;
 use daft_dsl::expr::bound_expr::BoundExpr;
 use daft_micropartition::MicroPartition;
 use itertools::Itertools;
 use tracing::{Span, instrument};
 
-use super::blocking_sink::{
-    BlockingSink, BlockingSinkFinalizeResult, BlockingSinkOutput, BlockingSinkSinkResult,
-};
+use super::blocking_sink::{BlockingSink, BlockingSinkFinalizeResult, BlockingSinkSinkResult};
 use crate::{
     ExecutionTaskSpawner,
     pipeline::{InputId, NodeName},
+    sinks::blocking_sink::BlockingSinkOutput,
 };
 
 /// Parameters for the TopN that both the state and sinker need
@@ -25,8 +23,6 @@ struct TopNParams {
     // Limit Parameters
     limit: usize,
     offset: Option<usize>,
-    // Output Schema
-    schema: SchemaRef,
 }
 
 /// Current status of the TopN operation
@@ -71,7 +67,6 @@ impl TopNSink {
         nulls_first: Vec<bool>,
         limit: usize,
         offset: Option<usize>,
-        schema: SchemaRef,
     ) -> Self {
         Self {
             params: Arc::new(TopNParams {
@@ -80,7 +75,6 @@ impl TopNSink {
                 nulls_first,
                 limit,
                 offset,
-                schema,
             }),
         }
     }
@@ -102,7 +96,6 @@ impl BlockingSink for TopNSink {
         spawner
             .spawn(
                 async move {
-                    let start = Instant::now();
                     // Find the top N values in the input micro-partition
                     let limit = params.limit + params.offset.unwrap_or(0);
                     let top_input_rows = input.top_n(
@@ -115,8 +108,6 @@ impl BlockingSink for TopNSink {
 
                     // Append to the collection of existing top N values
                     state.append(top_input_rows);
-                    let time = start.elapsed();
-                    eprintln!("time: {:?}", time);
                     Ok(state)
                 },
                 Span::current(),
@@ -134,30 +125,10 @@ impl BlockingSink for TopNSink {
         spawner
             .spawn(
                 async move {
-                    let start = Instant::now();
-                    let mut joinset = tokio::task::JoinSet::new();
-                    for mut state in states {
-                        let params = params.clone();
-                        joinset.spawn(async move {
-                            let parts = state.finalize();
-                            let concated =
-                                MicroPartition::concat_or_empty(parts, params.schema.clone())?;
-                            let final_output = concated.top_n(
-                                &params.sort_by,
-                                &params.descending,
-                                &params.nulls_first,
-                                params.limit,
-                                Some(0),
-                            )?;
-                            Ok(final_output)
-                        });
-                    }
-
-                    let parts = joinset
-                        .join_all()
-                        .await
+                    let parts: Vec<MicroPartition> = states
                         .into_iter()
-                        .collect::<DaftResult<Vec<_>>>()?;
+                        .flat_map(|mut state| state.finalize())
+                        .collect();
                     let concated = MicroPartition::concat(parts)?;
                     let final_output = concated.top_n(
                         &params.sort_by,
@@ -166,8 +137,6 @@ impl BlockingSink for TopNSink {
                         params.limit,
                         params.offset,
                     )?;
-                    let final_time = start.elapsed();
-                    eprintln!("final_time: {:?}", final_time);
                     Ok(BlockingSinkOutput::Partitions(vec![final_output]))
                 },
                 Span::current(),

--- a/src/daft-local-execution/src/sinks/top_n.rs
+++ b/src/daft-local-execution/src/sinks/top_n.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use common_error::DaftResult;
 use common_metrics::ops::NodeType;
+use daft_core::prelude::SchemaRef;
 use daft_dsl::expr::bound_expr::BoundExpr;
 use daft_micropartition::MicroPartition;
 use itertools::Itertools;
@@ -24,6 +25,8 @@ struct TopNParams {
     // Limit Parameters
     limit: usize,
     offset: Option<usize>,
+    // Output Schema
+    schema: SchemaRef,
 }
 
 /// Current status of the TopN operation
@@ -68,6 +71,7 @@ impl TopNSink {
         nulls_first: Vec<bool>,
         limit: usize,
         offset: Option<usize>,
+        schema: SchemaRef,
     ) -> Self {
         Self {
             params: Arc::new(TopNParams {
@@ -76,6 +80,7 @@ impl TopNSink {
                 nulls_first,
                 limit,
                 offset,
+                schema,
             }),
         }
     }
@@ -131,7 +136,8 @@ impl BlockingSink for TopNSink {
                         let params = params.clone();
                         joinset.spawn(async move {
                             let parts = state.finalize();
-                            let concated = MicroPartition::concat(parts)?;
+                            let concated =
+                                MicroPartition::concat_or_empty(parts, params.schema.clone())?;
                             let final_output = concated.top_n(
                                 &params.sort_by,
                                 &params.descending,

--- a/src/daft-local-execution/src/sinks/top_n.rs
+++ b/src/daft-local-execution/src/sinks/top_n.rs
@@ -102,6 +102,7 @@ impl BlockingSink for TopNSink {
         spawner
             .spawn(
                 async move {
+                    let start = Instant::now();
                     // Find the top N values in the input micro-partition
                     let limit = params.limit + params.offset.unwrap_or(0);
                     let top_input_rows = input.top_n(
@@ -114,6 +115,8 @@ impl BlockingSink for TopNSink {
 
                     // Append to the collection of existing top N values
                     state.append(top_input_rows);
+                    let time = start.elapsed();
+                    eprintln!("time: {:?}", time);
                     Ok(state)
                 },
                 Span::current(),
@@ -131,6 +134,7 @@ impl BlockingSink for TopNSink {
         spawner
             .spawn(
                 async move {
+                    let start = Instant::now();
                     let mut joinset = tokio::task::JoinSet::new();
                     for mut state in states {
                         let params = params.clone();
@@ -149,19 +153,12 @@ impl BlockingSink for TopNSink {
                         });
                     }
 
-                    let start = Instant::now();
                     let parts = joinset
                         .join_all()
                         .await
                         .into_iter()
                         .collect::<DaftResult<Vec<_>>>()?;
-                    let sub_time = start.elapsed();
-                    eprintln!("sub_time: {:?}", sub_time);
-                    let start = Instant::now();
                     let concated = MicroPartition::concat(parts)?;
-                    let concat_time = start.elapsed();
-                    eprintln!("concat_time: {:?}", concat_time);
-                    let start = Instant::now();
                     let final_output = concated.top_n(
                         &params.sort_by,
                         &params.descending,

--- a/src/daft-local-execution/src/sinks/top_n.rs
+++ b/src/daft-local-execution/src/sinks/top_n.rs
@@ -126,10 +126,28 @@ impl BlockingSink for TopNSink {
         spawner
             .spawn(
                 async move {
-                    let parts: Vec<MicroPartition> = states
+                    let mut joinset = tokio::task::JoinSet::new();
+                    for mut state in states {
+                        let params = params.clone();
+                        joinset.spawn(async move {
+                            let parts = state.finalize();
+                            let concated = MicroPartition::concat(parts)?;
+                            let final_output = concated.top_n(
+                                &params.sort_by,
+                                &params.descending,
+                                &params.nulls_first,
+                                params.limit,
+                                Some(0),
+                            )?;
+                            Ok(final_output)
+                        });
+                    }
+
+                    let parts = joinset
+                        .join_all()
+                        .await
                         .into_iter()
-                        .flat_map(|mut state| state.finalize())
-                        .collect();
+                        .collect::<DaftResult<Vec<_>>>()?;
                     let concated = MicroPartition::concat(parts)?;
                     let final_output = concated.top_n(
                         &params.sort_by,

--- a/src/daft-local-execution/src/sinks/top_n.rs
+++ b/src/daft-local-execution/src/sinks/top_n.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Instant};
 
 use common_error::DaftResult;
 use common_metrics::ops::NodeType;
@@ -149,12 +149,19 @@ impl BlockingSink for TopNSink {
                         });
                     }
 
+                    let start = Instant::now();
                     let parts = joinset
                         .join_all()
                         .await
                         .into_iter()
                         .collect::<DaftResult<Vec<_>>>()?;
+                    let sub_time = start.elapsed();
+                    eprintln!("sub_time: {:?}", sub_time);
+                    let start = Instant::now();
                     let concated = MicroPartition::concat(parts)?;
+                    let concat_time = start.elapsed();
+                    eprintln!("concat_time: {:?}", concat_time);
+                    let start = Instant::now();
                     let final_output = concated.top_n(
                         &params.sort_by,
                         &params.descending,
@@ -162,6 +169,8 @@ impl BlockingSink for TopNSink {
                         params.limit,
                         params.offset,
                     )?;
+                    let final_time = start.elapsed();
+                    eprintln!("final_time: {:?}", final_time);
                     Ok(BlockingSinkOutput::Partitions(vec![final_output]))
                 },
                 Span::current(),

--- a/tests/dataframe/test_aggregations.py
+++ b/tests/dataframe/test_aggregations.py
@@ -608,10 +608,8 @@ def test_groupby_result_partitions_smaller_than_input(shuffle_aggregation_defaul
                 ]
             )
 
-            df = df.collect()
-
             if get_tests_daft_runner_name() != "native":
-                assert df._result.num_partitions() == min(min_partitions, partition_size)
+                assert df.num_partitions() == min(min_partitions, partition_size)
 
 
 @pytest.mark.parametrize("repartition_nparts", [1, 2, 4])


### PR DESCRIPTION
## Changes Made

Noticed in ClickBench that we were not parallelizing any immediate blocking sinks that occurred after a groupby because the GroupBy would only return 1 micropartition and blocking sinks dont split into buffers. Since insertion into the buffer will already concat input MicroPartitions, we don't need to proactively do it inside of the GroupBy, so removed it