### PR TITLE
perf: Do a 1-stage aggregation for distributed ListAgg

### DIFF
--- a/src/daft-distributed/src/pipeline_node/aggregate.rs
+++ b/src/daft-distributed/src/pipeline_node/aggregate.rs
@@ -236,7 +236,11 @@ fn split_groupby_aggs(
 impl LogicalPlanToPipelineNodeTranslator {
     /// Generate PipelineNodes for aggregates with no pre-aggregation.
     /// This is only necessary if the pre-aggregation (first stage aggregation) is empty.
-    /// That is currently only applicable for MapGroup aggregations
+    /// That is currently only applicable for:
+    /// - MapGroups aggregations, because they can't be decomposed
+    /// - ApproxCountDistinct aggregations, because we can't merge HLL sketches
+    /// - List aggregations, because it is more efficient to do a single post-repartition aggregate
+    /// - Decimal128 aggregations, because it messed with the supertyping logic
     fn gen_without_pre_agg(
         &mut self,
         input_node: DistributedPipelineNode,
@@ -387,14 +391,13 @@ impl LogicalPlanToPipelineNodeTranslator {
         )?;
 
         if split_details.first_stage_aggs.is_empty()
-        // Special case for ApproxCountDistinct
-        // Right now, we can't do a pre-aggregation because we can't recursively merge HLL sketches
-        // TODO: Look for alternative approaches for this
+        // Special case for:
+        // - ApproxCountDistinct: we can't recursively merge HLL sketches  TODO: Look for alternative approaches for this
+        // - List: it is more efficient to do a single post-repartition aggregate
+        // - Decimal128: we can't do a pre-aggregation because decimal dtype will change in swordfish's own two stage aggregation
             || aggregations
                 .iter()
-                .any(|agg| matches!(agg.as_ref(), AggExpr::ApproxCountDistinct(_)))
-            // Special case for Decimal128
-            // Right now, we can't do a pre-aggregation because decimal dtype will change in swordfish's own two stage aggregation
+                .any(|agg| matches!(agg.as_ref(), AggExpr::ApproxCountDistinct(_) | AggExpr::List(_)))
             || split_details
                 .first_stage_schema
                 .fields()


### PR DESCRIPTION
## Changes Made

ListAgg would probably not benefit much from a pre-aggregation, because we're not reducing the amount of data in the aggregation column. We're just re-arranging the column. The pre-agg might help a bit, since we are effectively partially rearranging, but agg-concat is fairly inefficient anyways.

Long term, for all aggregations, I think some sort of adaptive technique with cardinality sampling would be much nicer (on top of improving our planner stats)