### PR TITLE
fix(docs): correct mkdocstrings YAML indentation in file_types.md

### DIFF
--- a/docs/api/datatypes/file_types.md
+++ b/docs/api/datatypes/file_types.md
@@ -1,13 +1,13 @@
 The `File` DataType provides first-class support for handling file data across local and remote storage, enabling seamless file operations in distributed environments.
 
 ::: daft.file.File
-options:
-filters: ["!^_"]
+    options:
+        filters: ["!^_"]
 
 ::: daft.file.AudioFile
-options:
-filters: ["!^_"]
+    options:
+        filters: ["!^_"]
 
 ::: daft.file.VideoFile
-options:
-filters: ["!^_"]
+    options:
+        filters: ["!^_"]


### PR DESCRIPTION
The options blocks for File, AudioFile, and VideoFile directives were not properly indented, causing mkdocstrings to fail parsing them.

Slack thread: https://eventualgroup.slack.com/archives/C0ARMCJKZCN/p1775773895238729?thread_ts=1775723553.838859&cid=C0ARMCJKZCN

https://claude.ai/code/session_01KxQJt5yK2SCS8eAAWNT4qW

## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
