### PR TITLE
perf: push COUNT(*) through Project nodes and support filtered count pushdown

### DIFF
--- a/src/daft-local-execution/src/sources/scan_task_reader.rs
+++ b/src/daft-local-execution/src/sources/scan_task_reader.rs
@@ -99,14 +99,28 @@ async fn read_parquet(
     if let Some(aggregation) = &scan_task.pushdowns.aggregation
         && let Expr::Agg(AggExpr::Count(_, _)) = aggregation.as_ref()
     {
-        daft_parquet::read::stream_parquet_count_pushdown(
-            url,
-            io_client,
-            Some(io_stats),
-            cfg.field_id_mapping.clone(),
-            aggregation,
-        )
-        .await
+        if let Some(predicate) = &scan_task.pushdowns.filters {
+            // Filtered count: read only filter columns, apply filter, count surviving rows.
+            daft_parquet::read::stream_parquet_filtered_count(
+                url,
+                io_client,
+                Some(io_stats),
+                cfg.field_id_mapping.clone(),
+                predicate.clone(),
+                aggregation,
+            )
+            .await
+        } else {
+            // Unfiltered count: read only parquet metadata.
+            daft_parquet::read::stream_parquet_count_pushdown(
+                url,
+                io_client,
+                Some(io_stats),
+                cfg.field_id_mapping.clone(),
+                aggregation,
+            )
+            .await
+        }
     } else {
         let parquet_chunk_size = cfg.chunk_size.or(Some(chunk_size));
         let inference_options =

--- a/src/daft-logical-plan/src/optimization/rules/push_down_aggregation.rs
+++ b/src/daft-logical-plan/src/optimization/rules/push_down_aggregation.rs
@@ -1,13 +1,16 @@
 use std::sync::Arc;
 
-use common_error::{DaftError, DaftResult};
+use common_error::DaftResult;
 use common_treenode::{Transformed, TreeNode};
 use daft_core::{count_mode::CountMode, prelude::Schema};
-use daft_dsl::{AggExpr, Expr, ExprRef};
+use daft_dsl::{AggExpr, Expr, ExprRef, resolved_col};
 
 use crate::{
-    LogicalPlan, logical_plan::Aggregate, ops::Source as LogicalSource,
-    optimization::rules::OptimizerRule, source_info::SourceInfo,
+    LogicalPlan,
+    logical_plan::{Aggregate, Project},
+    ops::Source as LogicalSource,
+    optimization::rules::OptimizerRule,
+    source_info::SourceInfo,
 };
 
 /// Optimization rules for pushing Aggregation further into the logical plan.
@@ -36,8 +39,22 @@ impl OptimizerRule for PushDownAggregation {
                     && aggregations.len() == 1
                     && let Some(count_mode) = is_count_expr(&aggregations[0])
                 {
-                    // Only handle global aggregation with no GROUP BY and a single aggregation expression
-                    match input.as_ref() {
+                    // Only handle global aggregation with no GROUP BY and a single aggregation expression.
+                    //
+                    // For COUNT(*, All), row counts are invariant under projection,
+                    // so we walk through Project nodes to find the underlying Source.
+                    let current = if is_count_mode_supported(count_mode) {
+                        let mut cur = input.clone();
+                        while let LogicalPlan::Project(Project { input: child, .. }) = cur.as_ref()
+                        {
+                            cur = child.clone();
+                        }
+                        cur
+                    } else {
+                        input.clone()
+                    };
+
+                    match current.as_ref() {
                         LogicalPlan::Source(source) => {
                             match source.source_info.as_ref() {
                                 // Determine if aggregation can be pushed down based on data source type
@@ -66,11 +83,16 @@ impl OptimizerRule for PushDownAggregation {
 
                                     if can_pushdown {
                                         // Create new pushdown info with count aggregation
+                                        // Strip Alias wrapper for pushdown - the executor
+                                        // matches on Expr::Agg(AggExpr::Count(..)) directly.
+                                        let agg_for_pushdown = unwrap_alias(&aggregations[0]);
                                         let new_pushdowns = external_info
                                             .pushdowns
-                                            .with_aggregation(Some(aggregations[0].clone()));
+                                            .with_aggregation(Some(agg_for_pushdown));
 
-                                        let field = aggregations[0].to_field(&input.schema())?;
+                                        let field = aggregations[0].to_field(&current.schema())?;
+                                        // Capture the field name before moving field into the schema.
+                                        let count_output_name = field.name.clone();
                                         let new_schema = Arc::new(Schema::new(vec![field]));
 
                                         let new_external_info =
@@ -81,11 +103,12 @@ impl OptimizerRule for PushDownAggregation {
                                         ))
                                         .into();
                                         // Scan operators may produce partial counts over multiple scan tasks (e.g., distributed parquet reads), so we still need to sum them.
+                                        let count_output_ref = resolved_col(count_output_name);
                                         let new_aggregate = Aggregate::try_new(
                                             new_source,
-                                            vec![Arc::new(Expr::Agg(AggExpr::Sum(count_expr(
-                                                &aggregations[0],
-                                            )?)))],
+                                            vec![Arc::new(Expr::Agg(AggExpr::Sum(
+                                                count_output_ref,
+                                            )))],
                                             groupby.clone(),
                                         )?
                                         .into();
@@ -96,7 +119,7 @@ impl OptimizerRule for PushDownAggregation {
                                 }
                             }
                         }
-                        // Input is not a Source node, cannot push down aggregation
+                        // Could not find a Source node (possibly behind Filter, Join, etc.)
                         _ => Ok(Transformed::no(node.clone())),
                     }
                 } else {
@@ -109,20 +132,19 @@ impl OptimizerRule for PushDownAggregation {
     }
 }
 
-// Check if expression is count aggregation
+// Check if expression is count aggregation, looking through Alias wrappers.
 fn is_count_expr(expr: &ExprRef) -> Option<&CountMode> {
     match expr.as_ref() {
         Expr::Agg(AggExpr::Count(_, count_mode)) => Some(count_mode),
+        Expr::Alias(inner, _) => is_count_expr(inner),
         _ => None,
     }
 }
 
-fn count_expr(expr: &ExprRef) -> DaftResult<ExprRef> {
+fn unwrap_alias(expr: &ExprRef) -> ExprRef {
     match expr.as_ref() {
-        Expr::Agg(AggExpr::Count(expr, _)) => Ok(expr.clone()),
-        _ => Err(DaftError::InternalError(
-            "Tried to get count expression from non-count expression".to_string(),
-        )),
+        Expr::Alias(inner, _) => unwrap_alias(inner),
+        _ => expr.clone(),
     }
 }
 
@@ -432,6 +454,81 @@ mod tests {
             .aggregate(vec![unresolved_col("a").count(CountMode::All)], vec![])?
             .build();
         let expected = plan.clone();
+        assert_optimized_plan_eq(plan, expected)?;
+        Ok(())
+    }
+
+    #[test]
+    fn agg_count_all_through_project() -> DaftResult<()> {
+        // COUNT(*, All) should push down through a Project node since
+        // row counts are invariant under projection.
+        let scan_op =
+            dummy_scan_operator_for_aggregation(vec![Field::new("a", DataType::UInt64)], true);
+
+        let plan = dummy_scan_node(scan_op.clone())
+            .select(vec![resolved_col("a")])?
+            .aggregate(vec![unresolved_col("a").count(CountMode::All)], vec![])?
+            .build();
+
+        let expected = dummy_scan_node_with_pushdowns(
+            scan_op,
+            Pushdowns::default().with_aggregation(Some(Arc::new(Expr::Agg(AggExpr::Count(
+                resolved_col("a"),
+                CountMode::All,
+            ))))),
+        )
+        .aggregate(vec![unresolved_col("a").sum()], vec![])?
+        .build();
+
+        assert_optimized_plan_eq(plan, expected)?;
+        Ok(())
+    }
+
+    #[test]
+    fn agg_count_all_through_multiple_projects() -> DaftResult<()> {
+        // COUNT(*, All) should push down through multiple nested Project nodes.
+        let scan_op =
+            dummy_scan_operator_for_aggregation(vec![Field::new("a", DataType::UInt64)], true);
+
+        let plan = dummy_scan_node(scan_op.clone())
+            .select(vec![resolved_col("a")])?
+            .select(vec![resolved_col("a")])?
+            .aggregate(vec![unresolved_col("a").count(CountMode::All)], vec![])?
+            .build();
+
+        let expected = dummy_scan_node_with_pushdowns(
+            scan_op,
+            Pushdowns::default().with_aggregation(Some(Arc::new(Expr::Agg(AggExpr::Count(
+                resolved_col("a"),
+                CountMode::All,
+            ))))),
+        )
+        .aggregate(vec![unresolved_col("a").sum()], vec![])?
+        .build();
+
+        assert_optimized_plan_eq(plan, expected)?;
+        Ok(())
+    }
+
+    #[test]
+    fn agg_count_null_through_project_should_not_pushdown() -> DaftResult<()> {
+        // COUNT(col, Null) should NOT push down through Project since
+        // it needs to inspect actual column values for null counting.
+        let scan_op = dummy_scan_operator_for_aggregation(
+            vec![
+                Field::new("a", DataType::Int64),
+                Field::new("b", DataType::Int64),
+            ],
+            true,
+        );
+
+        let plan = dummy_scan_node(scan_op)
+            .select(vec![resolved_col("a")])?
+            .aggregate(vec![unresolved_col("a").count(CountMode::Null)], vec![])?
+            .build();
+
+        let expected = plan.clone();
+
         assert_optimized_plan_eq(plan, expected)?;
         Ok(())
     }

--- a/src/daft-logical-plan/src/optimization/rules/push_down_aggregation.rs
+++ b/src/daft-logical-plan/src/optimization/rules/push_down_aggregation.rs
@@ -1,12 +1,14 @@
 use std::sync::Arc;
 
-use common_error::{DaftError, DaftResult};
+use common_error::DaftResult;
 use common_treenode::{Transformed, TreeNode};
 use daft_core::{count_mode::CountMode, prelude::Schema};
-use daft_dsl::{AggExpr, Expr, ExprRef};
+use daft_dsl::{AggExpr, Expr, ExprRef, resolved_col};
 
 use crate::{
-    LogicalPlan, logical_plan::Aggregate, optimization::rules::OptimizerRule,
+    LogicalPlan,
+    logical_plan::{Aggregate, Project},
+    optimization::rules::OptimizerRule,
     source_info::SourceInfo,
 };
 
@@ -36,8 +38,22 @@ impl OptimizerRule for PushDownAggregation {
                     && aggregations.len() == 1
                     && let Some(count_mode) = is_count_expr(&aggregations[0])
                 {
-                    // Only handle global aggregation with no GROUP BY and a single aggregation expression
-                    match input.as_ref() {
+                    // Only handle global aggregation with no GROUP BY and a single aggregation expression.
+                    //
+                    // For COUNT(*, All), row counts are invariant under projection,
+                    // so we walk through Project nodes to find the underlying Source.
+                    let current = if is_count_mode_supported(count_mode) {
+                        let mut cur = input.clone();
+                        while let LogicalPlan::Project(Project { input: child, .. }) = cur.as_ref()
+                        {
+                            cur = child.clone();
+                        }
+                        cur
+                    } else {
+                        input.clone()
+                    };
+
+                    match current.as_ref() {
                         LogicalPlan::Source(source) => {
                             match source.source_info.as_ref() {
                                 // Determine if aggregation can be pushed down based on data source type
@@ -66,11 +82,16 @@ impl OptimizerRule for PushDownAggregation {
 
                                     if can_pushdown {
                                         // Create new pushdown info with count aggregation
+                                        // Strip Alias wrapper for pushdown - the executor
+                                        // matches on Expr::Agg(AggExpr::Count(..)) directly.
+                                        let agg_for_pushdown = unwrap_alias(&aggregations[0]);
                                         let new_pushdowns = external_info
                                             .pushdowns
-                                            .with_aggregation(Some(aggregations[0].clone()));
+                                            .with_aggregation(Some(agg_for_pushdown));
 
-                                        let field = aggregations[0].to_field(&input.schema())?;
+                                        let field = aggregations[0].to_field(&current.schema())?;
+                                        // Capture the field name before moving field into the schema.
+                                        let count_output_name = field.name.clone();
                                         let new_schema = Arc::new(Schema::new(vec![field]));
 
                                         let new_external_info =
@@ -82,11 +103,12 @@ impl OptimizerRule for PushDownAggregation {
                                         let new_source =
                                             LogicalPlan::Source(new_source_node).into();
                                         // Scan operators may produce partial counts over multiple scan tasks (e.g., distributed parquet reads), so we still need to sum them.
+                                        let count_output_ref = resolved_col(count_output_name);
                                         let new_aggregate = Aggregate::try_new(
                                             new_source,
-                                            vec![Arc::new(Expr::Agg(AggExpr::Sum(count_expr(
-                                                &aggregations[0],
-                                            )?)))],
+                                            vec![Arc::new(Expr::Agg(AggExpr::Sum(
+                                                count_output_ref,
+                                            )))],
                                             groupby.clone(),
                                         )?
                                         .into();
@@ -97,7 +119,7 @@ impl OptimizerRule for PushDownAggregation {
                                 }
                             }
                         }
-                        // Input is not a Source node, cannot push down aggregation
+                        // Could not find a Source node (possibly behind Filter, Join, etc.)
                         _ => Ok(Transformed::no(node.clone())),
                     }
                 } else {
@@ -110,20 +132,19 @@ impl OptimizerRule for PushDownAggregation {
     }
 }
 
-// Check if expression is count aggregation
+// Check if expression is count aggregation, looking through Alias wrappers.
 fn is_count_expr(expr: &ExprRef) -> Option<&CountMode> {
     match expr.as_ref() {
         Expr::Agg(AggExpr::Count(_, count_mode)) => Some(count_mode),
+        Expr::Alias(inner, _) => is_count_expr(inner),
         _ => None,
     }
 }
 
-fn count_expr(expr: &ExprRef) -> DaftResult<ExprRef> {
+fn unwrap_alias(expr: &ExprRef) -> ExprRef {
     match expr.as_ref() {
-        Expr::Agg(AggExpr::Count(expr, _)) => Ok(expr.clone()),
-        _ => Err(DaftError::InternalError(
-            "Tried to get count expression from non-count expression".to_string(),
-        )),
+        Expr::Alias(inner, _) => unwrap_alias(inner),
+        _ => expr.clone(),
     }
 }
 
@@ -433,6 +454,81 @@ mod tests {
             .aggregate(vec![unresolved_col("a").count(CountMode::All)], vec![])?
             .build();
         let expected = plan.clone();
+        assert_optimized_plan_eq(plan, expected)?;
+        Ok(())
+    }
+
+    #[test]
+    fn agg_count_all_through_project() -> DaftResult<()> {
+        // COUNT(*, All) should push down through a Project node since
+        // row counts are invariant under projection.
+        let scan_op =
+            dummy_scan_operator_for_aggregation(vec![Field::new("a", DataType::UInt64)], true);
+
+        let plan = dummy_scan_node(scan_op.clone())
+            .select(vec![resolved_col("a")])?
+            .aggregate(vec![unresolved_col("a").count(CountMode::All)], vec![])?
+            .build();
+
+        let expected = dummy_scan_node_with_pushdowns(
+            scan_op,
+            Pushdowns::default().with_aggregation(Some(Arc::new(Expr::Agg(AggExpr::Count(
+                resolved_col("a"),
+                CountMode::All,
+            ))))),
+        )
+        .aggregate(vec![unresolved_col("a").sum()], vec![])?
+        .build();
+
+        assert_optimized_plan_eq(plan, expected)?;
+        Ok(())
+    }
+
+    #[test]
+    fn agg_count_all_through_multiple_projects() -> DaftResult<()> {
+        // COUNT(*, All) should push down through multiple nested Project nodes.
+        let scan_op =
+            dummy_scan_operator_for_aggregation(vec![Field::new("a", DataType::UInt64)], true);
+
+        let plan = dummy_scan_node(scan_op.clone())
+            .select(vec![resolved_col("a")])?
+            .select(vec![resolved_col("a")])?
+            .aggregate(vec![unresolved_col("a").count(CountMode::All)], vec![])?
+            .build();
+
+        let expected = dummy_scan_node_with_pushdowns(
+            scan_op,
+            Pushdowns::default().with_aggregation(Some(Arc::new(Expr::Agg(AggExpr::Count(
+                resolved_col("a"),
+                CountMode::All,
+            ))))),
+        )
+        .aggregate(vec![unresolved_col("a").sum()], vec![])?
+        .build();
+
+        assert_optimized_plan_eq(plan, expected)?;
+        Ok(())
+    }
+
+    #[test]
+    fn agg_count_null_through_project_should_not_pushdown() -> DaftResult<()> {
+        // COUNT(col, Null) should NOT push down through Project since
+        // it needs to inspect actual column values for null counting.
+        let scan_op = dummy_scan_operator_for_aggregation(
+            vec![
+                Field::new("a", DataType::Int64),
+                Field::new("b", DataType::Int64),
+            ],
+            true,
+        );
+
+        let plan = dummy_scan_node(scan_op)
+            .select(vec![resolved_col("a")])?
+            .aggregate(vec![unresolved_col("a").count(CountMode::Null)], vec![])?
+            .build();
+
+        let expected = plan.clone();
+
         assert_optimized_plan_eq(plan, expected)?;
         Ok(())
     }

--- a/src/daft-parquet/src/read.rs
+++ b/src/daft-parquet/src/read.rs
@@ -714,6 +714,12 @@ pub async fn read_parquet_metadata_bulk(
 }
 
 /// Optimized for count pushdowns: we can get the count from metadata without reading all data.
+fn make_count_batch(name: &str, count: u64) -> DaftResult<RecordBatch> {
+    let field = daft_core::datatypes::Field::new(name, DataType::UInt64);
+    let array = UInt64Array::from_iter(field.clone(), std::iter::once(Some(count)));
+    RecordBatch::new_with_size(Schema::new(vec![field]), vec![array.into_series()], 1)
+}
+
 pub async fn stream_parquet_count_pushdown(
     url: &str,
     io_client: Arc<IOClient>,
@@ -724,22 +730,53 @@ pub async fn stream_parquet_count_pushdown(
     let parquet_metadata =
         read_parquet_metadata(url, io_client, io_stats, field_id_mapping.clone()).await?;
 
-    // Currently only CountMode::All is supported for count pushdown.
-    let count = parquet_metadata.num_rows();
-    let count_field = daft_core::datatypes::Field::new(
-        aggregation.name(),
-        daft_core::datatypes::DataType::UInt64,
-    );
-    let count_array =
-        UInt64Array::from_iter(count_field.clone(), std::iter::once(Some(count as u64)));
-    let count_batch = daft_recordbatch::RecordBatch::new_with_size(
-        Schema::new(vec![count_field]),
-        vec![count_array.into_series()],
-        1,
-    )?;
+    let count = parquet_metadata.num_rows() as u64;
+    let count_batch = make_count_batch(aggregation.name(), count)?;
     Ok(Box::pin(futures::stream::once(
         async move { Ok(count_batch) },
     )))
+}
+
+/// Count rows that survive a filter predicate without materializing non-filter columns.
+///
+/// Reads only the columns referenced by the filter, applies the predicate via
+/// the parquet reader's row filter, and returns a single RecordBatch with the count.
+pub async fn stream_parquet_filtered_count(
+    url: &str,
+    io_client: Arc<IOClient>,
+    io_stats: Option<IOStatsRef>,
+    field_id_mapping: Option<Arc<BTreeMap<i32, Field>>>,
+    predicate: ExprRef,
+    aggregation: &ExprRef,
+) -> DaftResult<BoxStream<'static, DaftResult<RecordBatch>>> {
+    let schema_infer_options = ParquetSchemaInferenceOptions::default();
+    let batches = stream_parquet_single(
+        url.to_string(),
+        None, // columns - reader infers from predicate
+        None, // num_rows
+        None, // row_groups
+        Some(predicate),
+        io_client,
+        io_stats,
+        schema_infer_options,
+        field_id_mapping,
+        None,  // metadata
+        None,  // delete_rows
+        false, // maintain_order
+        None,  // chunk_size
+    )
+    .await?;
+
+    let agg_name = aggregation.name().to_string();
+
+    Ok(Box::pin(futures::stream::once(async move {
+        let mut total_count: u64 = 0;
+        futures::pin_mut!(batches);
+        while let Some(batch) = batches.next().await {
+            total_count += batch?.len() as u64;
+        }
+        make_count_batch(&agg_name, total_count)
+    })))
 }
 
 pub fn read_parquet_statistics(

--- a/src/daft-parquet/src/read.rs
+++ b/src/daft-parquet/src/read.rs
@@ -712,6 +712,12 @@ pub async fn read_parquet_metadata_bulk(
 }
 
 /// Optimized for count pushdowns: we can get the count from metadata without reading all data.
+fn make_count_batch(name: &str, count: u64) -> DaftResult<RecordBatch> {
+    let field = daft_core::datatypes::Field::new(name, DataType::UInt64);
+    let array = UInt64Array::from_iter(field.clone(), std::iter::once(Some(count)));
+    RecordBatch::new_with_size(Schema::new(vec![field]), vec![array.into_series()], 1)
+}
+
 pub async fn stream_parquet_count_pushdown(
     url: &str,
     io_client: Arc<IOClient>,
@@ -722,22 +728,53 @@ pub async fn stream_parquet_count_pushdown(
     let parquet_metadata =
         read_parquet_metadata(url, io_client, io_stats, field_id_mapping.clone()).await?;
 
-    // Currently only CountMode::All is supported for count pushdown.
-    let count = parquet_metadata.num_rows();
-    let count_field = daft_core::datatypes::Field::new(
-        aggregation.name(),
-        daft_core::datatypes::DataType::UInt64,
-    );
-    let count_array =
-        UInt64Array::from_iter(count_field.clone(), std::iter::once(Some(count as u64)));
-    let count_batch = daft_recordbatch::RecordBatch::new_with_size(
-        Schema::new(vec![count_field]),
-        vec![count_array.into_series()],
-        1,
-    )?;
+    let count = parquet_metadata.num_rows() as u64;
+    let count_batch = make_count_batch(aggregation.name(), count)?;
     Ok(Box::pin(futures::stream::once(
         async move { Ok(count_batch) },
     )))
+}
+
+/// Count rows that survive a filter predicate without materializing non-filter columns.
+///
+/// Reads only the columns referenced by the filter, applies the predicate via
+/// the parquet reader's row filter, and returns a single RecordBatch with the count.
+pub async fn stream_parquet_filtered_count(
+    url: &str,
+    io_client: Arc<IOClient>,
+    io_stats: Option<IOStatsRef>,
+    field_id_mapping: Option<Arc<BTreeMap<i32, Field>>>,
+    predicate: ExprRef,
+    aggregation: &ExprRef,
+) -> DaftResult<BoxStream<'static, DaftResult<RecordBatch>>> {
+    let schema_infer_options = ParquetSchemaInferenceOptions::default();
+    let batches = stream_parquet_single(
+        url.to_string(),
+        None, // columns - reader infers from predicate
+        None, // num_rows
+        None, // row_groups
+        Some(predicate),
+        io_client,
+        io_stats,
+        schema_infer_options,
+        field_id_mapping,
+        None,  // metadata
+        None,  // delete_rows
+        false, // maintain_order
+        None,  // chunk_size
+    )
+    .await?;
+
+    let agg_name = aggregation.name().to_string();
+
+    Ok(Box::pin(futures::stream::once(async move {
+        let mut total_count: u64 = 0;
+        futures::pin_mut!(batches);
+        while let Some(batch) = batches.next().await {
+            total_count += batch?.len() as u64;
+        }
+        make_count_batch(&agg_name, total_count)
+    })))
 }
 
 pub fn read_parquet_statistics(

--- a/src/daft-scan/src/glob.rs
+++ b/src/daft-scan/src/glob.rs
@@ -5,7 +5,7 @@ use common_file_formats::FileFormat;
 use common_runtime::RuntimeRef;
 use daft_core::{prelude::Utf8Array, series::IntoSeries};
 use daft_csv::CsvParseOptions;
-use daft_dsl::expr::bound_expr::BoundExpr;
+use daft_dsl::{ExprRef, expr::bound_expr::BoundExpr};
 use daft_io::{FileMetadata, FileType, IOClient, IOStatsContext, IOStatsRef, parse_url};
 use daft_parquet::read::ParquetSchemaInferenceOptions;
 use daft_recordbatch::RecordBatch;
@@ -21,6 +21,7 @@ use snafu::Snafu;
 use crate::{
     ChunkSpec, CsvSourceConfig, FileFormatConfig, ParquetSourceConfig, PartitionField, Pushdowns,
     ScanOperator, ScanSource, ScanSourceKind, ScanTask, ScanTaskRef, SourceConfig,
+    SupportsPushdownFilters,
     hive::{hive_partitions_to_fields, hive_partitions_to_series, parse_hive_partitioning},
     storage_config::StorageConfig,
 };
@@ -425,6 +426,19 @@ impl GlobScanOperator {
     }
 }
 
+impl SupportsPushdownFilters for GlobScanOperator {
+    fn push_filters(&self, filters: &[ExprRef]) -> (Vec<ExprRef>, Vec<ExprRef>) {
+        if self.file_format_config.file_format() == FileFormat::Parquet {
+            // The parquet reader supports row-level filter evaluation via build_row_filter(),
+            // so all data filters can be pushed down.
+            (filters.to_vec(), vec![])
+        } else {
+            // Other formats don't support filter pushdown.
+            (vec![], filters.to_vec())
+        }
+    }
+}
+
 impl ScanOperator for GlobScanOperator {
     fn name(&self) -> &'static str {
         "GlobScanOperator"
@@ -462,6 +476,14 @@ impl ScanOperator for GlobScanOperator {
 
     fn supports_count_pushdown(&self) -> bool {
         self.file_format_config.file_format() == FileFormat::Parquet
+    }
+
+    fn as_pushdown_filter(&self) -> Option<&dyn SupportsPushdownFilters> {
+        if self.file_format_config.file_format() == FileFormat::Parquet {
+            Some(self)
+        } else {
+            None
+        }
     }
 
     fn multiline_display(&self) -> Vec<String> {


### PR DESCRIPTION
`PushDownAggregation` currently only matches `Aggregate -> Source` directly. When `with_column` casts insert Project nodes between Aggregate and Source (common in SQL and the ClickBench harness), count pushdown never fires. `COUNT(*, All)` counts all rows including nulls - the result is invariant under projection, so those Project nodes are transparent.

A second issue: SQL `COUNT(*)` produces `Alias(Count(col), "count")`, but the rule only matched bare `Count` expressions. The Alias wrapping caused the pattern match to fail silently.

To fix this, three changes:

**1. Walk through Project nodes for `COUNT(*, All)`**

The rule now walks through intervening `Project` nodes to find the underlying `Source`. Only for `CountMode::All` - `Valid`/`Null` modes need column values and can't skip projections.

**2. Handle Alias-wrapped count expressions**

`is_count_expr` and the SUM wrapper construction now look through `Alias` nodes. The Alias is stripped before storing in scan pushdowns since the executor matches on `Expr::Agg(AggExpr::Count(..))` directly.

**3. `SupportsPushdownFilters` for `GlobScanOperator` (parquet)**

The parquet reader already supports row-level filter evaluation via `build_row_filter()`. `GlobScanOperator` now declares this support, enabling the `strict_pushdown` path in `PushDownAggregation` to combine filter + count pushdown. A new `stream_parquet_filtered_count` execution path reads only filter columns, applies the predicate, and counts surviving rows.

### Benchmark (ClickBench, c6a.4xlarge, single parquet)

Both runs on the same machine, back-to-back, same codebase (main vs this branch):

| Query | Main (ms) | This PR (ms) | Change |
|-------|-----------|-------------|--------|
| Q1 (`SELECT COUNT(*)`) | 106 | **11** | **-89%** |

Q1 now reads only the parquet footer metadata (~11ms) instead of scanning the JavaEnable column (~106ms).

### Files changed

| File | Change |
|------|--------|
| `push_down_aggregation.rs` | Walk through Projects, handle Alias, strip Alias for pushdown, 3 new tests |
| `glob.rs` | Implement `SupportsPushdownFilters` for parquet, override `as_pushdown_filter` |
| `scan_task_reader.rs` | Dispatch to filtered count path when count aggregation has filters |
| `read.rs` | `make_count_batch` helper, `stream_parquet_filtered_count` function |