### PR TITLE
feat: implement batch 3 temporal functions (make_date, make_timestamp, make_timestamp_ltz, last_day, next_day)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2718,6 +2718,7 @@ version = "0.3.0-dev0"
 dependencies = [
  "arrow-array",
  "chrono",
+ "chrono-tz",
  "common-error",
  "daft-core",
  "daft-dsl",

--- a/daft/functions/__init__.py
+++ b/daft/functions/__init__.py
@@ -75,6 +75,11 @@ from .datetime import (
     timestamp_millis,
     timestamp_micros,
     from_unixtime,
+    last_day,
+    make_date,
+    make_timestamp,
+    make_timestamp_ltz,
+    next_day,
 )
 from .distance import cosine_distance, dot_product, euclidean_distance
 from .similarity import (
@@ -360,6 +365,7 @@ __all__ = [
     "jaccard_similarity",
     "jq",
     "lag",
+    "last_day",
     "lead",
     "left",
     "length",
@@ -389,6 +395,9 @@ __all__ = [
     "lower",
     "lpad",
     "lstrip",
+    "make_date",
+    "make_timestamp",
+    "make_timestamp_ltz",
     "map_get",
     "max",
     "mean",
@@ -401,6 +410,7 @@ __all__ = [
     "month",
     "nanosecond",
     "negate",
+    "next_day",
     "normalize",
     "not_nan",
     "not_null",

--- a/daft/functions/datetime.py
+++ b/daft/functions/datetime.py
@@ -1555,7 +1555,9 @@ def make_timestamp_ltz(
     Examples:
         >>> import daft
         >>> from daft.functions import make_timestamp_ltz
-        >>> make_timestamp_ltz(daft.col("y"), daft.col("m"), daft.col("d"), daft.col("h"), daft.col("mi"), daft.col("s"))
+        >>> make_timestamp_ltz(
+        ...     daft.col("y"), daft.col("m"), daft.col("d"), daft.col("h"), daft.col("mi"), daft.col("s")
+        ... )
         make_timestamp_ltz(col(y), col(m), col(d), col(h), col(mi), col(s))
     """
     year = Expression._to_expression(year)

--- a/daft/functions/datetime.py
+++ b/daft/functions/datetime.py
@@ -1454,3 +1454,155 @@ def from_unixtime(expr: Expression, format: str | None = None) -> Expression:
     if format is not None:
         return Expression._call_builtin_scalar_fn("from_unixtime", expr, format=format)
     return Expression._call_builtin_scalar_fn("from_unixtime", expr)
+
+
+def make_date(year: Expression, month: Expression, day: Expression) -> Expression:
+    """Creates a date from year, month, and day integer components.
+
+    Invalid dates (e.g., Feb 30) return null.
+
+    Args:
+        year: integer expression for the year.
+        month: integer expression for the month (1-12).
+        day: integer expression for the day (1-31).
+
+    Returns:
+        Expression: a Date expression.
+
+    Examples:
+        >>> import daft
+        >>> from daft.functions import make_date
+        >>> make_date(daft.col("y"), daft.col("m"), daft.col("d"))
+        make_date(col(y), col(m), col(d))
+    """
+    year = Expression._to_expression(year)
+    month = Expression._to_expression(month)
+    day = Expression._to_expression(day)
+    return Expression._call_builtin_scalar_fn("make_date", year, month, day)
+
+
+def make_timestamp(
+    year: Expression,
+    month: Expression,
+    day: Expression,
+    hour: Expression,
+    minute: Expression,
+    second: Expression,
+    timezone: str | None = None,
+) -> Expression:
+    """Creates a timestamp from individual date/time components.
+
+    The ``second`` parameter accepts fractional values for sub-second precision.
+    Invalid component combinations return null.
+
+    Args:
+        year: integer expression for the year.
+        month: integer expression for the month (1-12).
+        day: integer expression for the day (1-31).
+        hour: integer expression for the hour (0-23).
+        minute: integer expression for the minute (0-59).
+        second: numeric expression for the second (0-59, may include fractional part).
+        timezone: optional timezone string (e.g. ``"UTC"``). When provided the
+            returned timestamp carries this timezone metadata.
+
+    Returns:
+        Expression: a Timestamp(microseconds) expression.
+
+    Examples:
+        >>> import daft
+        >>> from daft.functions import make_timestamp
+        >>> make_timestamp(daft.col("y"), daft.col("m"), daft.col("d"), daft.col("h"), daft.col("mi"), daft.col("s"))
+        make_timestamp(col(y), col(m), col(d), col(h), col(mi), col(s))
+    """
+    year = Expression._to_expression(year)
+    month = Expression._to_expression(month)
+    day = Expression._to_expression(day)
+    hour = Expression._to_expression(hour)
+    minute = Expression._to_expression(minute)
+    second = Expression._to_expression(second)
+    return Expression._call_builtin_scalar_fn(
+        "make_timestamp", year, month, day, hour, minute, second, timezone=timezone
+    )
+
+
+def make_timestamp_ltz(
+    year: Expression,
+    month: Expression,
+    day: Expression,
+    hour: Expression,
+    minute: Expression,
+    second: Expression,
+    timezone: str | None = None,
+) -> Expression:
+    """Creates a UTC timestamp from individual date/time components.
+
+    When ``timezone`` is provided, the components are interpreted in that
+    timezone and converted to UTC. Without a timezone the components are
+    treated as UTC directly.
+
+    Args:
+        year: integer expression for the year.
+        month: integer expression for the month (1-12).
+        day: integer expression for the day (1-31).
+        hour: integer expression for the hour (0-23).
+        minute: integer expression for the minute (0-59).
+        second: numeric expression for the second (0-59, may include fractional part).
+        timezone: optional source timezone string (e.g. ``"US/Eastern"``).
+
+    Returns:
+        Expression: a Timestamp(microseconds, UTC) expression.
+
+    Examples:
+        >>> import daft
+        >>> from daft.functions import make_timestamp_ltz
+        >>> make_timestamp_ltz(daft.col("y"), daft.col("m"), daft.col("d"), daft.col("h"), daft.col("mi"), daft.col("s"))
+        make_timestamp_ltz(col(y), col(m), col(d), col(h), col(mi), col(s))
+    """
+    year = Expression._to_expression(year)
+    month = Expression._to_expression(month)
+    day = Expression._to_expression(day)
+    hour = Expression._to_expression(hour)
+    minute = Expression._to_expression(minute)
+    second = Expression._to_expression(second)
+    return Expression._call_builtin_scalar_fn(
+        "make_timestamp_ltz", year, month, day, hour, minute, second, timezone=timezone
+    )
+
+
+def last_day(expr: Expression) -> Expression:
+    """Returns the last day of the month for the given date or timestamp.
+
+    Args:
+        expr: a Date or Timestamp expression.
+
+    Returns:
+        Expression: a Date expression representing the last day of that month.
+
+    Examples:
+        >>> import daft
+        >>> from daft.functions import last_day
+        >>> last_day(daft.col("dt"))
+        last_day(col(dt))
+    """
+    expr = Expression._to_expression(expr)
+    return Expression._call_builtin_scalar_fn("last_day", expr)
+
+
+def next_day(expr: Expression, day_of_week: str) -> Expression:
+    """Returns the next occurrence of the specified day of the week after the given date.
+
+    Args:
+        expr: a Date or Timestamp expression.
+        day_of_week: the target weekday (e.g. ``"Monday"``, ``"Mon"``).
+
+    Returns:
+        Expression: a Date expression for the next occurrence of that weekday.
+
+    Examples:
+        >>> import daft
+        >>> from daft.functions import next_day
+        >>> next_day(daft.col("dt"), "Monday")
+        next_day(col(dt), lit("Monday"))
+    """
+    expr = Expression._to_expression(expr)
+    return Expression._call_builtin_scalar_fn("next_day", expr, day_of_week=day_of_week)

--- a/src/daft-functions-temporal/Cargo.toml
+++ b/src/daft-functions-temporal/Cargo.toml
@@ -1,6 +1,7 @@
 [dependencies]
 arrow-array = {workspace = true}
 chrono = {workspace = true}
+chrono-tz = {workspace = true}
 common-error = {path = "../common/error", default-features = false}
 daft-core = {path = "../daft-core", default-features = false}
 daft-dsl = {path = "../daft-dsl", default-features = false}

--- a/src/daft-functions-temporal/src/date_construction.rs
+++ b/src/daft-functions-temporal/src/date_construction.rs
@@ -141,6 +141,14 @@ impl ScalarUDF for MakeTimestamp {
 
         let field_name = year_arr.name().to_string();
 
+        // If a timezone is provided, parse it for offset conversion
+        let src_tz: Option<chrono_tz::Tz> = match &timezone {
+            Some(tz_str) => Some(tz_str.parse::<chrono_tz::Tz>().map_err(|_| {
+                common_error::DaftError::ValueError(format!("Invalid timezone: {tz_str}"))
+            })?),
+            None => None,
+        };
+
         let values: Vec<Option<i64>> = year_arr
             .into_iter()
             .zip(month_arr.into_iter())
@@ -164,9 +172,16 @@ impl ScalarUDF for MakeTimestamp {
                         whole_secs,
                         frac_micros,
                     )?;
-                    let dt = chrono::NaiveDateTime::new(date, time);
-                    let epoch = chrono::NaiveDateTime::new(UNIX_EPOCH, chrono::NaiveTime::MIN);
-                    dt.signed_duration_since(epoch).num_microseconds()
+                    let naive_dt = chrono::NaiveDateTime::new(date, time);
+
+                    if let Some(tz) = src_tz {
+                        use chrono::TimeZone;
+                        let local_dt = tz.from_local_datetime(&naive_dt).single()?;
+                        Some(local_dt.timestamp_micros())
+                    } else {
+                        let epoch = chrono::NaiveDateTime::new(UNIX_EPOCH, chrono::NaiveTime::MIN);
+                        naive_dt.signed_duration_since(epoch).num_microseconds()
+                    }
                 }
                 _ => None,
             })

--- a/src/daft-functions-temporal/src/date_construction.rs
+++ b/src/daft-functions-temporal/src/date_construction.rs
@@ -1,0 +1,397 @@
+use std::sync::Arc;
+
+use arrow_array::{Date32Array, TimestampMicrosecondArray};
+use chrono::NaiveDate;
+use daft_core::datatypes::TimeUnit;
+use daft_dsl::functions::prelude::*;
+
+const UNIX_EPOCH: NaiveDate = match NaiveDate::from_ymd_opt(1970, 1, 1) {
+    Some(d) => d,
+    None => unreachable!(),
+};
+
+// --- MakeDate ---
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct MakeDate;
+
+#[derive(FunctionArgs)]
+struct MakeDateArgs<T> {
+    year: T,
+    month: T,
+    day: T,
+}
+
+#[typetag::serde]
+impl ScalarUDF for MakeDate {
+    fn name(&self) -> &'static str {
+        "make_date"
+    }
+
+    fn call(
+        &self,
+        inputs: FunctionArgs<Series>,
+        _ctx: &daft_dsl::functions::scalar::EvalContext,
+    ) -> DaftResult<Series> {
+        let MakeDateArgs { year, month, day } = inputs.try_into()?;
+        let year_i32 = year.cast(&DataType::Int32)?;
+        let month_i32 = month.cast(&DataType::Int32)?;
+        let day_i32 = day.cast(&DataType::Int32)?;
+
+        let year_arr = year_i32.i32()?;
+        let month_arr = month_i32.i32()?;
+        let day_arr = day_i32.i32()?;
+
+        let field_name = year_arr.name().to_string();
+
+        let values: Vec<Option<i32>> = year_arr
+            .into_iter()
+            .zip(month_arr.into_iter())
+            .zip(day_arr.into_iter())
+            .map(|((y, m), d)| match (y, m, d) {
+                (Some(y), Some(m), Some(d)) => NaiveDate::from_ymd_opt(y, m as u32, d as u32)
+                    .map(|date| date.signed_duration_since(UNIX_EPOCH).num_days() as i32),
+                _ => None,
+            })
+            .collect();
+
+        let arrow_arr: arrow_array::ArrayRef = Arc::new(Date32Array::from(values));
+        Series::from_arrow(Arc::new(Field::new(field_name, DataType::Date)), arrow_arr)
+    }
+
+    fn get_return_field(
+        &self,
+        inputs: FunctionArgs<ExprRef>,
+        schema: &Schema,
+    ) -> DaftResult<Field> {
+        let MakeDateArgs { year, month, day } = inputs.try_into()?;
+        let year_field = year.to_field(schema)?;
+        let month_field = month.to_field(schema)?;
+        let day_field = day.to_field(schema)?;
+        ensure!(
+            year_field.dtype.is_integer(),
+            TypeError: "Expected integer for year, got {}",
+            year_field.dtype
+        );
+        ensure!(
+            month_field.dtype.is_integer(),
+            TypeError: "Expected integer for month, got {}",
+            month_field.dtype
+        );
+        ensure!(
+            day_field.dtype.is_integer(),
+            TypeError: "Expected integer for day, got {}",
+            day_field.dtype
+        );
+        Ok(Field::new(year_field.name, DataType::Date))
+    }
+}
+
+// --- MakeTimestamp ---
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct MakeTimestamp;
+
+#[derive(FunctionArgs)]
+struct MakeTimestampArgs<T> {
+    year: T,
+    month: T,
+    day: T,
+    hour: T,
+    minute: T,
+    second: T,
+    #[arg(optional)]
+    timezone: Option<String>,
+}
+
+#[typetag::serde]
+impl ScalarUDF for MakeTimestamp {
+    fn name(&self) -> &'static str {
+        "make_timestamp"
+    }
+
+    fn call(
+        &self,
+        inputs: FunctionArgs<Series>,
+        _ctx: &daft_dsl::functions::scalar::EvalContext,
+    ) -> DaftResult<Series> {
+        let MakeTimestampArgs {
+            year,
+            month,
+            day,
+            hour,
+            minute,
+            second,
+            timezone,
+        } = inputs.try_into()?;
+
+        let year_i32 = year.cast(&DataType::Int32)?;
+        let month_i32 = month.cast(&DataType::Int32)?;
+        let day_i32 = day.cast(&DataType::Int32)?;
+        let hour_i32 = hour.cast(&DataType::Int32)?;
+        let minute_i32 = minute.cast(&DataType::Int32)?;
+        let second_f64 = second.cast(&DataType::Float64)?;
+
+        let year_arr = year_i32.i32()?;
+        let month_arr = month_i32.i32()?;
+        let day_arr = day_i32.i32()?;
+        let hour_arr = hour_i32.i32()?;
+        let minute_arr = minute_i32.i32()?;
+        let second_arr = second_f64.f64()?;
+
+        let field_name = year_arr.name().to_string();
+
+        let values: Vec<Option<i64>> = year_arr
+            .into_iter()
+            .zip(month_arr.into_iter())
+            .zip(day_arr.into_iter())
+            .zip(hour_arr.into_iter())
+            .zip(minute_arr.into_iter())
+            .zip(second_arr.into_iter())
+            .map(|(((((y, mo), d), h), mi), s)| match (y, mo, d, h, mi, s) {
+                (Some(y), Some(mo), Some(d), Some(h), Some(mi), Some(s)) => {
+                    let whole_secs = s as u32;
+                    let frac_micros = ((s - whole_secs as f64) * 1_000_000.0).round() as u32;
+                    let date = NaiveDate::from_ymd_opt(y, mo as u32, d as u32)?;
+                    let time = chrono::NaiveTime::from_hms_micro_opt(
+                        h as u32,
+                        mi as u32,
+                        whole_secs,
+                        frac_micros,
+                    )?;
+                    let dt = chrono::NaiveDateTime::new(date, time);
+                    let epoch = chrono::NaiveDateTime::new(UNIX_EPOCH, chrono::NaiveTime::MIN);
+                    dt.signed_duration_since(epoch).num_microseconds()
+                }
+                _ => None,
+            })
+            .collect();
+
+        let arrow_arr: arrow_array::ArrayRef = Arc::new(TimestampMicrosecondArray::from(values));
+        Series::from_arrow(
+            Arc::new(Field::new(
+                field_name,
+                DataType::Timestamp(TimeUnit::Microseconds, timezone),
+            )),
+            arrow_arr,
+        )
+    }
+
+    fn get_return_field(
+        &self,
+        inputs: FunctionArgs<ExprRef>,
+        schema: &Schema,
+    ) -> DaftResult<Field> {
+        let MakeTimestampArgs {
+            year,
+            month,
+            day,
+            hour,
+            minute,
+            second,
+            timezone,
+        } = inputs.try_into()?;
+        let year_field = year.to_field(schema)?;
+        let month_field = month.to_field(schema)?;
+        let day_field = day.to_field(schema)?;
+        let hour_field = hour.to_field(schema)?;
+        let minute_field = minute.to_field(schema)?;
+        let second_field = second.to_field(schema)?;
+        ensure!(
+            year_field.dtype.is_integer(),
+            TypeError: "Expected integer for year, got {}",
+            year_field.dtype
+        );
+        ensure!(
+            month_field.dtype.is_integer(),
+            TypeError: "Expected integer for month, got {}",
+            month_field.dtype
+        );
+        ensure!(
+            day_field.dtype.is_integer(),
+            TypeError: "Expected integer for day, got {}",
+            day_field.dtype
+        );
+        ensure!(
+            hour_field.dtype.is_integer(),
+            TypeError: "Expected integer for hour, got {}",
+            hour_field.dtype
+        );
+        ensure!(
+            minute_field.dtype.is_integer(),
+            TypeError: "Expected integer for minute, got {}",
+            minute_field.dtype
+        );
+        ensure!(
+            second_field.dtype.is_numeric(),
+            TypeError: "Expected numeric for second, got {}",
+            second_field.dtype
+        );
+        Ok(Field::new(
+            year_field.name,
+            DataType::Timestamp(TimeUnit::Microseconds, timezone),
+        ))
+    }
+}
+
+// --- MakeTimestampLtz ---
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct MakeTimestampLtz;
+
+#[derive(FunctionArgs)]
+struct MakeTimestampLtzArgs<T> {
+    year: T,
+    month: T,
+    day: T,
+    hour: T,
+    minute: T,
+    second: T,
+    #[arg(optional)]
+    timezone: Option<String>,
+}
+
+#[typetag::serde]
+impl ScalarUDF for MakeTimestampLtz {
+    fn name(&self) -> &'static str {
+        "make_timestamp_ltz"
+    }
+
+    fn call(
+        &self,
+        inputs: FunctionArgs<Series>,
+        _ctx: &daft_dsl::functions::scalar::EvalContext,
+    ) -> DaftResult<Series> {
+        let MakeTimestampLtzArgs {
+            year,
+            month,
+            day,
+            hour,
+            minute,
+            second,
+            timezone,
+        } = inputs.try_into()?;
+
+        let year_i32 = year.cast(&DataType::Int32)?;
+        let month_i32 = month.cast(&DataType::Int32)?;
+        let day_i32 = day.cast(&DataType::Int32)?;
+        let hour_i32 = hour.cast(&DataType::Int32)?;
+        let minute_i32 = minute.cast(&DataType::Int32)?;
+        let second_f64 = second.cast(&DataType::Float64)?;
+
+        let year_arr = year_i32.i32()?;
+        let month_arr = month_i32.i32()?;
+        let day_arr = day_i32.i32()?;
+        let hour_arr = hour_i32.i32()?;
+        let minute_arr = minute_i32.i32()?;
+        let second_arr = second_f64.f64()?;
+
+        let field_name = year_arr.name().to_string();
+
+        // If a source timezone is provided, parse it for offset conversion
+        let src_tz: Option<chrono_tz::Tz> = match &timezone {
+            Some(tz_str) => Some(tz_str.parse::<chrono_tz::Tz>().map_err(|_| {
+                common_error::DaftError::ValueError(format!("Invalid timezone: {tz_str}"))
+            })?),
+            None => None,
+        };
+
+        let values: Vec<Option<i64>> = year_arr
+            .into_iter()
+            .zip(month_arr.into_iter())
+            .zip(day_arr.into_iter())
+            .zip(hour_arr.into_iter())
+            .zip(minute_arr.into_iter())
+            .zip(second_arr.into_iter())
+            .map(|(((((y, mo), d), h), mi), s)| match (y, mo, d, h, mi, s) {
+                (Some(y), Some(mo), Some(d), Some(h), Some(mi), Some(s)) => {
+                    let whole_secs = s as u32;
+                    let frac_micros = ((s - whole_secs as f64) * 1_000_000.0).round() as u32;
+                    let date = NaiveDate::from_ymd_opt(y, mo as u32, d as u32)?;
+                    let time = chrono::NaiveTime::from_hms_micro_opt(
+                        h as u32,
+                        mi as u32,
+                        whole_secs,
+                        frac_micros,
+                    )?;
+                    let naive_dt = chrono::NaiveDateTime::new(date, time);
+
+                    if let Some(tz) = src_tz {
+                        use chrono::TimeZone;
+                        let local_dt = tz.from_local_datetime(&naive_dt).single()?;
+                        Some(local_dt.timestamp_micros())
+                    } else {
+                        let epoch = chrono::NaiveDateTime::new(UNIX_EPOCH, chrono::NaiveTime::MIN);
+                        naive_dt.signed_duration_since(epoch).num_microseconds()
+                    }
+                }
+                _ => None,
+            })
+            .collect();
+
+        let arrow_arr: arrow_array::ArrayRef = Arc::new(TimestampMicrosecondArray::from(values));
+        Series::from_arrow(
+            Arc::new(Field::new(
+                field_name,
+                DataType::Timestamp(TimeUnit::Microseconds, Some("UTC".to_string())),
+            )),
+            arrow_arr,
+        )
+    }
+
+    fn get_return_field(
+        &self,
+        inputs: FunctionArgs<ExprRef>,
+        schema: &Schema,
+    ) -> DaftResult<Field> {
+        let MakeTimestampLtzArgs {
+            year,
+            month,
+            day,
+            hour,
+            minute,
+            second,
+            ..
+        } = inputs.try_into()?;
+        let year_field = year.to_field(schema)?;
+        let month_field = month.to_field(schema)?;
+        let day_field = day.to_field(schema)?;
+        let hour_field = hour.to_field(schema)?;
+        let minute_field = minute.to_field(schema)?;
+        let second_field = second.to_field(schema)?;
+        ensure!(
+            year_field.dtype.is_integer(),
+            TypeError: "Expected integer for year, got {}",
+            year_field.dtype
+        );
+        ensure!(
+            month_field.dtype.is_integer(),
+            TypeError: "Expected integer for month, got {}",
+            month_field.dtype
+        );
+        ensure!(
+            day_field.dtype.is_integer(),
+            TypeError: "Expected integer for day, got {}",
+            day_field.dtype
+        );
+        ensure!(
+            hour_field.dtype.is_integer(),
+            TypeError: "Expected integer for hour, got {}",
+            hour_field.dtype
+        );
+        ensure!(
+            minute_field.dtype.is_integer(),
+            TypeError: "Expected integer for minute, got {}",
+            minute_field.dtype
+        );
+        ensure!(
+            second_field.dtype.is_numeric(),
+            TypeError: "Expected numeric for second, got {}",
+            second_field.dtype
+        );
+        Ok(Field::new(
+            year_field.name,
+            DataType::Timestamp(TimeUnit::Microseconds, Some("UTC".to_string())),
+        ))
+    }
+}

--- a/src/daft-functions-temporal/src/date_construction.rs
+++ b/src/daft-functions-temporal/src/date_construction.rs
@@ -151,7 +151,12 @@ impl ScalarUDF for MakeTimestamp {
             .map(|(((((y, mo), d), h), mi), s)| match (y, mo, d, h, mi, s) {
                 (Some(y), Some(mo), Some(d), Some(h), Some(mi), Some(s)) => {
                     let whole_secs = s as u32;
-                    let frac_micros = ((s - whole_secs as f64) * 1_000_000.0).round() as u32;
+                    let frac_micros_raw = ((s - whole_secs as f64) * 1_000_000.0).round() as u32;
+                    let (whole_secs, frac_micros) = if frac_micros_raw >= 1_000_000 {
+                        (whole_secs + 1, 0)
+                    } else {
+                        (whole_secs, frac_micros_raw)
+                    };
                     let date = NaiveDate::from_ymd_opt(y, mo as u32, d as u32)?;
                     let time = chrono::NaiveTime::from_hms_micro_opt(
                         h as u32,
@@ -306,7 +311,12 @@ impl ScalarUDF for MakeTimestampLtz {
             .map(|(((((y, mo), d), h), mi), s)| match (y, mo, d, h, mi, s) {
                 (Some(y), Some(mo), Some(d), Some(h), Some(mi), Some(s)) => {
                     let whole_secs = s as u32;
-                    let frac_micros = ((s - whole_secs as f64) * 1_000_000.0).round() as u32;
+                    let frac_micros_raw = ((s - whole_secs as f64) * 1_000_000.0).round() as u32;
+                    let (whole_secs, frac_micros) = if frac_micros_raw >= 1_000_000 {
+                        (whole_secs + 1, 0)
+                    } else {
+                        (whole_secs, frac_micros_raw)
+                    };
                     let date = NaiveDate::from_ymd_opt(y, mo as u32, d as u32)?;
                     let time = chrono::NaiveTime::from_hms_micro_opt(
                         h as u32,

--- a/src/daft-functions-temporal/src/date_navigation.rs
+++ b/src/daft-functions-temporal/src/date_navigation.rs
@@ -87,8 +87,7 @@ pub struct NextDay;
 #[derive(FunctionArgs)]
 struct NextDayArgs<T> {
     input: T,
-    #[arg(optional)]
-    day_of_week: Option<String>,
+    day_of_week: String,
 }
 
 fn parse_weekday(s: &str) -> DaftResult<Weekday> {
@@ -118,12 +117,7 @@ impl ScalarUDF for NextDay {
         _ctx: &daft_dsl::functions::scalar::EvalContext,
     ) -> DaftResult<Series> {
         let NextDayArgs { input, day_of_week } = inputs.try_into()?;
-        let dow_str = day_of_week.ok_or_else(|| {
-            common_error::DaftError::ValueError(
-                "next_day requires a day_of_week argument".to_string(),
-            )
-        })?;
-        let target_weekday = parse_weekday(&dow_str)?;
+        let target_weekday = parse_weekday(&day_of_week)?;
 
         let date_series = input.cast(&DataType::Date)?;
         let date_arr = date_series.date()?;

--- a/src/daft-functions-temporal/src/date_navigation.rs
+++ b/src/daft-functions-temporal/src/date_navigation.rs
@@ -1,0 +1,169 @@
+use std::sync::Arc;
+
+use arrow_array::Date32Array;
+use chrono::{Datelike, NaiveDate, Weekday};
+use daft_core::prelude::AsArrow;
+use daft_dsl::functions::prelude::*;
+
+const UNIX_EPOCH: NaiveDate = match NaiveDate::from_ymd_opt(1970, 1, 1) {
+    Some(d) => d,
+    None => unreachable!(),
+};
+
+fn days_to_date(days: i32) -> NaiveDate {
+    UNIX_EPOCH + chrono::Duration::days(days as i64)
+}
+
+fn date_to_days(date: NaiveDate) -> i32 {
+    date.signed_duration_since(UNIX_EPOCH).num_days() as i32
+}
+
+// --- LastDay ---
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct LastDay;
+
+#[typetag::serde]
+impl ScalarUDF for LastDay {
+    fn name(&self) -> &'static str {
+        "last_day"
+    }
+
+    fn call(
+        &self,
+        inputs: FunctionArgs<Series>,
+        _ctx: &daft_dsl::functions::scalar::EvalContext,
+    ) -> DaftResult<Series> {
+        let daft_dsl::functions::UnaryArg { input } = inputs.try_into()?;
+        let date_series = input.cast(&DataType::Date)?;
+        let date_arr = date_series.date()?;
+        let arr = date_arr.as_arrow()?;
+
+        let values: Vec<Option<i32>> = arr
+            .iter()
+            .map(|opt_days| {
+                opt_days.map(|days| {
+                    let d = days_to_date(days);
+                    let (y, m) = (d.year(), d.month());
+                    let last = if m == 12 {
+                        NaiveDate::from_ymd_opt(y + 1, 1, 1)
+                    } else {
+                        NaiveDate::from_ymd_opt(y, m + 1, 1)
+                    }
+                    .unwrap()
+                        - chrono::Duration::days(1);
+                    date_to_days(last)
+                })
+            })
+            .collect();
+
+        let arrow_arr: arrow_array::ArrayRef = Arc::new(Date32Array::from(values));
+        Series::from_arrow(
+            Arc::new(Field::new(date_arr.name().to_string(), DataType::Date)),
+            arrow_arr,
+        )
+    }
+
+    fn get_return_field(
+        &self,
+        inputs: FunctionArgs<ExprRef>,
+        schema: &Schema,
+    ) -> DaftResult<Field> {
+        let daft_dsl::functions::UnaryArg { input } = inputs.try_into()?;
+        let field = input.to_field(schema)?;
+        ensure!(
+            matches!(field.dtype, DataType::Date | DataType::Timestamp(..)),
+            TypeError: "Expected date or timestamp input, got {}",
+            field.dtype
+        );
+        Ok(Field::new(field.name, DataType::Date))
+    }
+}
+
+// --- NextDay ---
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct NextDay;
+
+#[derive(FunctionArgs)]
+struct NextDayArgs<T> {
+    input: T,
+    #[arg(optional)]
+    day_of_week: Option<String>,
+}
+
+fn parse_weekday(s: &str) -> DaftResult<Weekday> {
+    match s.to_lowercase().as_str() {
+        "monday" | "mon" | "mo" => Ok(Weekday::Mon),
+        "tuesday" | "tue" | "tu" => Ok(Weekday::Tue),
+        "wednesday" | "wed" | "we" => Ok(Weekday::Wed),
+        "thursday" | "thu" | "th" => Ok(Weekday::Thu),
+        "friday" | "fri" | "fr" => Ok(Weekday::Fri),
+        "saturday" | "sat" | "sa" => Ok(Weekday::Sat),
+        "sunday" | "sun" | "su" => Ok(Weekday::Sun),
+        _ => Err(common_error::DaftError::ValueError(format!(
+            "Invalid day of week: '{s}'. Expected: Monday/Mon, Tuesday/Tue, etc."
+        ))),
+    }
+}
+
+#[typetag::serde]
+impl ScalarUDF for NextDay {
+    fn name(&self) -> &'static str {
+        "next_day"
+    }
+
+    fn call(
+        &self,
+        inputs: FunctionArgs<Series>,
+        _ctx: &daft_dsl::functions::scalar::EvalContext,
+    ) -> DaftResult<Series> {
+        let NextDayArgs { input, day_of_week } = inputs.try_into()?;
+        let dow_str = day_of_week.ok_or_else(|| {
+            common_error::DaftError::ValueError(
+                "next_day requires a day_of_week argument".to_string(),
+            )
+        })?;
+        let target_weekday = parse_weekday(&dow_str)?;
+
+        let date_series = input.cast(&DataType::Date)?;
+        let date_arr = date_series.date()?;
+        let arr = date_arr.as_arrow()?;
+
+        let values: Vec<Option<i32>> = arr
+            .iter()
+            .map(|opt_days| {
+                opt_days.map(|days| {
+                    let d = days_to_date(days);
+                    // Advance 1-7 days to find the next occurrence of target_weekday
+                    let mut next = d + chrono::Duration::days(1);
+                    while next.weekday() != target_weekday {
+                        next += chrono::Duration::days(1);
+                    }
+                    date_to_days(next)
+                })
+            })
+            .collect();
+
+        let arrow_arr: arrow_array::ArrayRef = Arc::new(Date32Array::from(values));
+        Series::from_arrow(
+            Arc::new(Field::new(date_arr.name().to_string(), DataType::Date)),
+            arrow_arr,
+        )
+    }
+
+    fn get_return_field(
+        &self,
+        inputs: FunctionArgs<ExprRef>,
+        schema: &Schema,
+    ) -> DaftResult<Field> {
+        let NextDayArgs { input, .. } = inputs.try_into()?;
+        let field = input.to_field(schema)?;
+        ensure!(
+            matches!(field.dtype, DataType::Date | DataType::Timestamp(..)),
+            TypeError: "Expected date or timestamp input, got {}",
+            field.dtype
+        );
+        Ok(Field::new(field.name, DataType::Date))
+    }
+}

--- a/src/daft-functions-temporal/src/date_navigation.rs
+++ b/src/daft-functions-temporal/src/date_navigation.rs
@@ -42,17 +42,16 @@ impl ScalarUDF for LastDay {
         let values: Vec<Option<i32>> = arr
             .iter()
             .map(|opt_days| {
-                opt_days.map(|days| {
+                opt_days.and_then(|days| {
                     let d = days_to_date(days);
                     let (y, m) = (d.year(), d.month());
-                    let last = if m == 12 {
+                    let first_of_next = if m == 12 {
                         NaiveDate::from_ymd_opt(y + 1, 1, 1)
                     } else {
                         NaiveDate::from_ymd_opt(y, m + 1, 1)
-                    }
-                    .unwrap()
-                        - chrono::Duration::days(1);
-                    date_to_days(last)
+                    }?;
+                    let last = first_of_next - chrono::Duration::days(1);
+                    Some(date_to_days(last))
                 })
             })
             .collect();

--- a/src/daft-functions-temporal/src/lib.rs
+++ b/src/daft-functions-temporal/src/lib.rs
@@ -11,8 +11,6 @@ mod unix_timestamp;
 
 use common_error::{DaftResult, ensure};
 use current::{CurrentDate, CurrentTimestamp, CurrentTimezone};
-use date_construction::{MakeDate, MakeTimestamp, MakeTimestampLtz};
-use date_navigation::{LastDay, NextDay};
 use daft_core::{
     prelude::{DataType, Field, Schema},
     series::Series,
@@ -22,6 +20,8 @@ use daft_dsl::{
     functions::{FunctionArgs, FunctionModule, FunctionRegistry, ScalarUDF, UnaryArg},
 };
 use date_arithmetic::{DateAdd, DateDiff, DateSub};
+use date_construction::{MakeDate, MakeTimestamp, MakeTimestampLtz};
+use date_navigation::{LastDay, NextDay};
 use epoch_conversions::{
     DateFromUnixDate, FromUnixtime, TimestampMicros, TimestampMillis, TimestampSeconds,
 };

--- a/src/daft-functions-temporal/src/lib.rs
+++ b/src/daft-functions-temporal/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod current;
 pub mod date_arithmetic;
+pub mod date_construction;
+pub mod date_navigation;
 pub mod epoch_conversions;
 mod time;
 mod to_string;
@@ -9,6 +11,8 @@ mod unix_timestamp;
 
 use common_error::{DaftResult, ensure};
 use current::{CurrentDate, CurrentTimestamp, CurrentTimezone};
+use date_construction::{MakeDate, MakeTimestamp, MakeTimestampLtz};
+use date_navigation::{LastDay, NextDay};
 use daft_core::{
     prelude::{DataType, Field, Schema},
     series::Series,
@@ -130,5 +134,10 @@ impl FunctionModule for TemporalFunctions {
         parent.add_fn(TimestampMillis);
         parent.add_fn(TimestampMicros);
         parent.add_fn(FromUnixtime);
+        parent.add_fn(MakeDate);
+        parent.add_fn(MakeTimestamp);
+        parent.add_fn(MakeTimestampLtz);
+        parent.add_fn(LastDay);
+        parent.add_fn(NextDay);
     }
 }

--- a/src/daft-sql/src/modules/temporal.rs
+++ b/src/daft-sql/src/modules/temporal.rs
@@ -8,6 +8,8 @@ use daft_dsl::{
 use daft_functions_temporal::{
     current::{CurrentDate, CurrentTimestamp, CurrentTimezone},
     date_arithmetic::{DateAdd, DateDiff, DateSub},
+    date_construction::{MakeDate, MakeTimestamp, MakeTimestampLtz},
+    date_navigation::{LastDay, NextDay},
     epoch_conversions::{
         DateFromUnixDate, FromUnixtime, TimestampMicros, TimestampMillis, TimestampSeconds,
     },
@@ -39,6 +41,11 @@ impl SQLModule for SQLModuleTemporal {
         parent.add_fn("timestamp_millis", SQLTimestampMillis);
         parent.add_fn("timestamp_micros", SQLTimestampMicros);
         parent.add_fn("from_unixtime", SQLFromUnixtime);
+        parent.add_fn("make_date", SQLMakeDate);
+        parent.add_fn("make_timestamp", SQLMakeTimestamp);
+        parent.add_fn("make_timestamp_ltz", SQLMakeTimestampLtz);
+        parent.add_fn("last_day", SQLLastDay);
+        parent.add_fn("next_day", SQLNextDay);
     }
 }
 
@@ -452,5 +459,258 @@ impl SQLFunction for SQLFromUnixtime {
 
     fn arg_names(&self) -> &'static [&'static str] {
         &["seconds", "format"]
+    }
+}
+
+// --- Date construction SQL functions ---
+
+pub struct SQLMakeDate;
+
+impl SQLFunction for SQLMakeDate {
+    fn to_expr(
+        &self,
+        inputs: &[ast::FunctionArg],
+        planner: &crate::planner::SQLPlanner,
+    ) -> SQLPlannerResult<ExprRef> {
+        if inputs.len() != 3 {
+            invalid_operation_err!(
+                "make_date expects 3 arguments (year, month, day), got {}",
+                inputs.len()
+            );
+        }
+        let year = planner.plan_function_arg(&inputs[0])?.into_inner();
+        let month = planner.plan_function_arg(&inputs[1])?.into_inner();
+        let day = planner.plan_function_arg(&inputs[2])?.into_inner();
+
+        let args = vec![
+            FunctionArg::unnamed(year),
+            FunctionArg::unnamed(month),
+            FunctionArg::unnamed(day),
+        ];
+
+        Ok(BuiltinScalarFn {
+            func: BuiltinScalarFnVariant::Sync(Arc::new(MakeDate)),
+            inputs: FunctionArgs::new_unchecked(args),
+        }
+        .into())
+    }
+
+    fn docstrings(&self, _alias: &str) -> String {
+        "Creates a date from year, month, and day components.".to_string()
+    }
+
+    fn arg_names(&self) -> &'static [&'static str] {
+        &["year", "month", "day"]
+    }
+}
+
+pub struct SQLMakeTimestamp;
+
+impl SQLFunction for SQLMakeTimestamp {
+    fn to_expr(
+        &self,
+        inputs: &[ast::FunctionArg],
+        planner: &crate::planner::SQLPlanner,
+    ) -> SQLPlannerResult<ExprRef> {
+        match inputs.len() {
+            6 | 7 => {}
+            _ => invalid_operation_err!(
+                "make_timestamp expects 6 or 7 arguments (year, month, day, hour, minute, second[, timezone]), got {}",
+                inputs.len()
+            ),
+        }
+        let year = planner.plan_function_arg(&inputs[0])?.into_inner();
+        let month = planner.plan_function_arg(&inputs[1])?.into_inner();
+        let day = planner.plan_function_arg(&inputs[2])?.into_inner();
+        let hour = planner.plan_function_arg(&inputs[3])?.into_inner();
+        let minute = planner.plan_function_arg(&inputs[4])?.into_inner();
+        let second = planner.plan_function_arg(&inputs[5])?.into_inner();
+
+        let mut args = vec![
+            FunctionArg::unnamed(year),
+            FunctionArg::unnamed(month),
+            FunctionArg::unnamed(day),
+            FunctionArg::unnamed(hour),
+            FunctionArg::unnamed(minute),
+            FunctionArg::unnamed(second),
+        ];
+
+        if inputs.len() == 7 {
+            let tz_expr = planner.plan_function_arg(&inputs[6])?.into_inner();
+            let tz_str = tz_expr
+                .as_literal()
+                .and_then(|l| l.as_str())
+                .ok_or_else(|| {
+                    crate::error::PlannerError::invalid_operation(
+                        "make_timestamp timezone argument must be a string literal",
+                    )
+                })?;
+            args.push(FunctionArg::named(
+                "timezone".to_string(),
+                lit(tz_str.to_string()),
+            ));
+        }
+
+        Ok(BuiltinScalarFn {
+            func: BuiltinScalarFnVariant::Sync(Arc::new(MakeTimestamp)),
+            inputs: FunctionArgs::new_unchecked(args),
+        }
+        .into())
+    }
+
+    fn docstrings(&self, _alias: &str) -> String {
+        "Creates a timestamp from year, month, day, hour, minute, second components.".to_string()
+    }
+
+    fn arg_names(&self) -> &'static [&'static str] {
+        &[
+            "year", "month", "day", "hour", "minute", "second", "timezone",
+        ]
+    }
+}
+
+pub struct SQLMakeTimestampLtz;
+
+impl SQLFunction for SQLMakeTimestampLtz {
+    fn to_expr(
+        &self,
+        inputs: &[ast::FunctionArg],
+        planner: &crate::planner::SQLPlanner,
+    ) -> SQLPlannerResult<ExprRef> {
+        match inputs.len() {
+            6 | 7 => {}
+            _ => invalid_operation_err!(
+                "make_timestamp_ltz expects 6 or 7 arguments (year, month, day, hour, minute, second[, timezone]), got {}",
+                inputs.len()
+            ),
+        }
+        let year = planner.plan_function_arg(&inputs[0])?.into_inner();
+        let month = planner.plan_function_arg(&inputs[1])?.into_inner();
+        let day = planner.plan_function_arg(&inputs[2])?.into_inner();
+        let hour = planner.plan_function_arg(&inputs[3])?.into_inner();
+        let minute = planner.plan_function_arg(&inputs[4])?.into_inner();
+        let second = planner.plan_function_arg(&inputs[5])?.into_inner();
+
+        let mut args = vec![
+            FunctionArg::unnamed(year),
+            FunctionArg::unnamed(month),
+            FunctionArg::unnamed(day),
+            FunctionArg::unnamed(hour),
+            FunctionArg::unnamed(minute),
+            FunctionArg::unnamed(second),
+        ];
+
+        if inputs.len() == 7 {
+            let tz_expr = planner.plan_function_arg(&inputs[6])?.into_inner();
+            let tz_str = tz_expr
+                .as_literal()
+                .and_then(|l| l.as_str())
+                .ok_or_else(|| {
+                    crate::error::PlannerError::invalid_operation(
+                        "make_timestamp_ltz timezone argument must be a string literal",
+                    )
+                })?;
+            args.push(FunctionArg::named(
+                "timezone".to_string(),
+                lit(tz_str.to_string()),
+            ));
+        }
+
+        Ok(BuiltinScalarFn {
+            func: BuiltinScalarFnVariant::Sync(Arc::new(MakeTimestampLtz)),
+            inputs: FunctionArgs::new_unchecked(args),
+        }
+        .into())
+    }
+
+    fn docstrings(&self, _alias: &str) -> String {
+        "Creates a UTC timestamp from components, optionally interpreting them in a source timezone."
+            .to_string()
+    }
+
+    fn arg_names(&self) -> &'static [&'static str] {
+        &[
+            "year", "month", "day", "hour", "minute", "second", "timezone",
+        ]
+    }
+}
+
+// --- Date navigation SQL functions ---
+
+pub struct SQLLastDay;
+
+impl SQLFunction for SQLLastDay {
+    fn to_expr(
+        &self,
+        inputs: &[ast::FunctionArg],
+        planner: &crate::planner::SQLPlanner,
+    ) -> SQLPlannerResult<ExprRef> {
+        if inputs.len() != 1 {
+            invalid_operation_err!("last_day expects 1 argument, got {}", inputs.len());
+        }
+        let input = planner.plan_function_arg(&inputs[0])?.into_inner();
+
+        let args = vec![FunctionArg::unnamed(input)];
+
+        Ok(BuiltinScalarFn {
+            func: BuiltinScalarFnVariant::Sync(Arc::new(LastDay)),
+            inputs: FunctionArgs::new_unchecked(args),
+        }
+        .into())
+    }
+
+    fn docstrings(&self, _alias: &str) -> String {
+        "Returns the last day of the month for the given date.".to_string()
+    }
+
+    fn arg_names(&self) -> &'static [&'static str] {
+        &["date"]
+    }
+}
+
+pub struct SQLNextDay;
+
+impl SQLFunction for SQLNextDay {
+    fn to_expr(
+        &self,
+        inputs: &[ast::FunctionArg],
+        planner: &crate::planner::SQLPlanner,
+    ) -> SQLPlannerResult<ExprRef> {
+        if inputs.len() != 2 {
+            invalid_operation_err!(
+                "next_day expects 2 arguments (date, day_of_week), got {}",
+                inputs.len()
+            );
+        }
+        let input = planner.plan_function_arg(&inputs[0])?.into_inner();
+        let dow_expr = planner.plan_function_arg(&inputs[1])?.into_inner();
+        let dow_str = dow_expr
+            .as_literal()
+            .and_then(|l| l.as_str())
+            .ok_or_else(|| {
+                crate::error::PlannerError::invalid_operation(
+                    "next_day day_of_week argument must be a string literal (e.g. 'Monday')",
+                )
+            })?;
+
+        let args = vec![
+            FunctionArg::unnamed(input),
+            FunctionArg::named("day_of_week".to_string(), lit(dow_str.to_string())),
+        ];
+
+        Ok(BuiltinScalarFn {
+            func: BuiltinScalarFnVariant::Sync(Arc::new(NextDay)),
+            inputs: FunctionArgs::new_unchecked(args),
+        }
+        .into())
+    }
+
+    fn docstrings(&self, _alias: &str) -> String {
+        "Returns the next occurrence of the specified day of the week after the given date."
+            .to_string()
+    }
+
+    fn arg_names(&self) -> &'static [&'static str] {
+        &["date", "day_of_week"]
     }
 }

--- a/tests/dataframe/test_temporals.py
+++ b/tests/dataframe/test_temporals.py
@@ -979,18 +979,14 @@ def test_make_date_invalid() -> None:
 
 
 def test_make_timestamp() -> None:
-    df = daft.from_pydict(
-        {"y": [2021], "m": [1], "d": [1], "h": [12], "mi": [30], "s": [45.0]}
-    )
+    df = daft.from_pydict({"y": [2021], "m": [1], "d": [1], "h": [12], "mi": [30], "s": [45.0]})
     df = df.with_column("ts", make_timestamp(col("y"), col("m"), col("d"), col("h"), col("mi"), col("s")))
     result = df.to_pydict()
     assert result["ts"] == [datetime(2021, 1, 1, 12, 30, 45)]
 
 
 def test_make_timestamp_with_timezone() -> None:
-    df = daft.from_pydict(
-        {"y": [2021], "m": [1], "d": [1], "h": [12], "mi": [0], "s": [0.0]}
-    )
+    df = daft.from_pydict({"y": [2021], "m": [1], "d": [1], "h": [12], "mi": [0], "s": [0.0]})
     df = df.with_column(
         "ts", make_timestamp(col("y"), col("m"), col("d"), col("h"), col("mi"), col("s"), timezone="UTC")
     )
@@ -1002,18 +998,14 @@ def test_make_timestamp_with_timezone() -> None:
 
 
 def test_make_timestamp_ltz() -> None:
-    df = daft.from_pydict(
-        {"y": [2021], "m": [1], "d": [1], "h": [12], "mi": [0], "s": [0.0]}
-    )
+    df = daft.from_pydict({"y": [2021], "m": [1], "d": [1], "h": [12], "mi": [0], "s": [0.0]})
     df = df.with_column("ts", make_timestamp_ltz(col("y"), col("m"), col("d"), col("h"), col("mi"), col("s")))
     result = df.to_pydict()
     assert result["ts"] == [datetime(2021, 1, 1, 12, 0, 0, tzinfo=timezone.utc)]
 
 
 def test_make_timestamp_ltz_with_timezone() -> None:
-    df = daft.from_pydict(
-        {"y": [2021], "m": [1], "d": [1], "h": [12], "mi": [0], "s": [0.0]}
-    )
+    df = daft.from_pydict({"y": [2021], "m": [1], "d": [1], "h": [12], "mi": [0], "s": [0.0]})
     df = df.with_column(
         "ts", make_timestamp_ltz(col("y"), col("m"), col("d"), col("h"), col("mi"), col("s"), timezone="US/Eastern")
     )
@@ -1026,9 +1018,7 @@ def test_make_timestamp_ltz_with_timezone() -> None:
 
 
 def test_last_day() -> None:
-    df = daft.from_pydict(
-        {"dt": [date(2021, 1, 15), date(2021, 2, 10), date(2020, 2, 10), date(2021, 4, 1)]}
-    )
+    df = daft.from_pydict({"dt": [date(2021, 1, 15), date(2021, 2, 10), date(2020, 2, 10), date(2021, 4, 1)]})
     df = df.with_column("last", last_day(col("dt")))
     result = df.to_pydict()
     assert result["last"] == [

--- a/tests/dataframe/test_temporals.py
+++ b/tests/dataframe/test_temporals.py
@@ -19,6 +19,11 @@ from daft.functions import (
     date_from_unix_date,
     date_sub,
     from_unixtime,
+    last_day,
+    make_date,
+    make_timestamp,
+    make_timestamp_ltz,
+    next_day,
     timestamp_micros,
     timestamp_millis,
     timestamp_seconds,
@@ -951,3 +956,114 @@ def test_temporal_batch2_sql() -> None:
     assert result["from_unix"] == [date(1970, 1, 11)]
     assert isinstance(result["ts_s"][0], datetime)
     assert result["fmt"] == ["2021-01-01 00:00:00"]
+
+
+# --- make_date ---
+
+
+def test_make_date() -> None:
+    df = daft.from_pydict({"y": [2021, 2020, 2000], "m": [1, 2, 12], "d": [15, 29, 31]})
+    df = df.with_column("dt", make_date(col("y"), col("m"), col("d")))
+    result = df.to_pydict()
+    assert result["dt"] == [date(2021, 1, 15), date(2020, 2, 29), date(2000, 12, 31)]
+
+
+def test_make_date_invalid() -> None:
+    df = daft.from_pydict({"y": [2021, 2021], "m": [2, 13], "d": [30, 1]})
+    df = df.with_column("dt", make_date(col("y"), col("m"), col("d")))
+    result = df.to_pydict()
+    assert result["dt"] == [None, None]
+
+
+# --- make_timestamp ---
+
+
+def test_make_timestamp() -> None:
+    df = daft.from_pydict(
+        {"y": [2021], "m": [1], "d": [1], "h": [12], "mi": [30], "s": [45.0]}
+    )
+    df = df.with_column("ts", make_timestamp(col("y"), col("m"), col("d"), col("h"), col("mi"), col("s")))
+    result = df.to_pydict()
+    assert result["ts"] == [datetime(2021, 1, 1, 12, 30, 45)]
+
+
+def test_make_timestamp_with_timezone() -> None:
+    df = daft.from_pydict(
+        {"y": [2021], "m": [1], "d": [1], "h": [12], "mi": [0], "s": [0.0]}
+    )
+    df = df.with_column(
+        "ts", make_timestamp(col("y"), col("m"), col("d"), col("h"), col("mi"), col("s"), timezone="UTC")
+    )
+    result = df.to_pydict()
+    assert result["ts"] == [datetime(2021, 1, 1, 12, 0, 0, tzinfo=timezone.utc)]
+
+
+# --- make_timestamp_ltz ---
+
+
+def test_make_timestamp_ltz() -> None:
+    df = daft.from_pydict(
+        {"y": [2021], "m": [1], "d": [1], "h": [12], "mi": [0], "s": [0.0]}
+    )
+    df = df.with_column("ts", make_timestamp_ltz(col("y"), col("m"), col("d"), col("h"), col("mi"), col("s")))
+    result = df.to_pydict()
+    assert result["ts"] == [datetime(2021, 1, 1, 12, 0, 0, tzinfo=timezone.utc)]
+
+
+def test_make_timestamp_ltz_with_timezone() -> None:
+    df = daft.from_pydict(
+        {"y": [2021], "m": [1], "d": [1], "h": [12], "mi": [0], "s": [0.0]}
+    )
+    df = df.with_column(
+        "ts", make_timestamp_ltz(col("y"), col("m"), col("d"), col("h"), col("mi"), col("s"), timezone="US/Eastern")
+    )
+    result = df.to_pydict()
+    # 12:00 EST = 17:00 UTC
+    assert result["ts"] == [datetime(2021, 1, 1, 17, 0, 0, tzinfo=timezone.utc)]
+
+
+# --- last_day ---
+
+
+def test_last_day() -> None:
+    df = daft.from_pydict(
+        {"dt": [date(2021, 1, 15), date(2021, 2, 10), date(2020, 2, 10), date(2021, 4, 1)]}
+    )
+    df = df.with_column("last", last_day(col("dt")))
+    result = df.to_pydict()
+    assert result["last"] == [
+        date(2021, 1, 31),
+        date(2021, 2, 28),
+        date(2020, 2, 29),
+        date(2021, 4, 30),
+    ]
+
+
+# --- next_day ---
+
+
+def test_next_day() -> None:
+    # 2021-01-01 is a Friday
+    df = daft.from_pydict({"dt": [date(2021, 1, 1), date(2021, 1, 1), date(2021, 1, 1)]})
+    results = {}
+    for dow in ["Monday", "Friday", "Sunday"]:
+        tmp = df.with_column("nd", next_day(col("dt"), dow))
+        results[dow] = tmp.to_pydict()["nd"]
+    assert results["Monday"] == [date(2021, 1, 4)] * 3  # next Mon
+    assert results["Friday"] == [date(2021, 1, 8)] * 3  # next Fri (not same day)
+    assert results["Sunday"] == [date(2021, 1, 3)] * 3  # next Sun
+
+
+# --- SQL integration ---
+
+
+def test_date_construction_sql() -> None:
+    df = daft.from_pydict({"y": [2021], "m": [1], "d": [15]})  # noqa: F841
+    result = daft.sql("SELECT make_date(y, m, d) as dt FROM df").to_pydict()
+    assert result["dt"] == [date(2021, 1, 15)]
+
+    result = daft.sql("SELECT last_day(make_date(y, m, d)) as ld FROM df").to_pydict()
+    assert result["ld"] == [date(2021, 1, 31)]
+
+    result = daft.sql("SELECT next_day(make_date(y, m, d), 'Monday') as nd FROM df").to_pydict()
+    assert result["nd"] == [date(2021, 1, 18)]

--- a/tests/dataframe/test_temporals.py
+++ b/tests/dataframe/test_temporals.py
@@ -994,6 +994,23 @@ def test_make_timestamp_with_timezone() -> None:
     assert result["ts"] == [datetime(2021, 1, 1, 12, 0, 0, tzinfo=timezone.utc)]
 
 
+def test_make_timestamp_with_non_utc_timezone() -> None:
+    df = daft.from_pydict({"y": [2021], "m": [1], "d": [1], "h": [12], "mi": [0], "s": [0.0]})
+    df = df.with_column(
+        "ts",
+        make_timestamp(col("y"), col("m"), col("d"), col("h"), col("mi"), col("s"), timezone="America/New_York"),
+    )
+    result = df.to_pydict()
+    ts = result["ts"][0]
+    # 12:00 EST = 17:00 UTC. Verify the underlying UTC value is correct
+    # by checking the UTC hour via astimezone.
+    assert ts.tzinfo is not None
+    utc_ts = ts.astimezone(timezone.utc)
+    assert utc_ts.hour == 17
+    # And the local representation should be 12:00 EST.
+    assert ts.hour == 12
+
+
 # --- make_timestamp_ltz ---
 
 
@@ -1036,12 +1053,12 @@ def test_next_day() -> None:
     # 2021-01-01 is a Friday
     df = daft.from_pydict({"dt": [date(2021, 1, 1), date(2021, 1, 1), date(2021, 1, 1)]})
     results = {}
-    for dow in ["Monday", "Friday", "Sunday"]:
+    for dow in ["Mon", "Fri", "Sun"]:
         tmp = df.with_column("next_d", next_day(col("dt"), dow))
         results[dow] = tmp.to_pydict()["next_d"]
-    assert results["Monday"] == [date(2021, 1, 4)] * 3  # next Mon
-    assert results["Friday"] == [date(2021, 1, 8)] * 3  # next Fri (not same day)
-    assert results["Sunday"] == [date(2021, 1, 3)] * 3  # next Sun
+    assert results["Mon"] == [date(2021, 1, 4)] * 3  # next Mon
+    assert results["Fri"] == [date(2021, 1, 8)] * 3  # next Fri (not same day)
+    assert results["Sun"] == [date(2021, 1, 3)] * 3  # next Sun
 
 
 # --- SQL integration ---

--- a/tests/dataframe/test_temporals.py
+++ b/tests/dataframe/test_temporals.py
@@ -1037,8 +1037,8 @@ def test_next_day() -> None:
     df = daft.from_pydict({"dt": [date(2021, 1, 1), date(2021, 1, 1), date(2021, 1, 1)]})
     results = {}
     for dow in ["Monday", "Friday", "Sunday"]:
-        tmp = df.with_column("nd", next_day(col("dt"), dow))
-        results[dow] = tmp.to_pydict()["nd"]
+        tmp = df.with_column("next_d", next_day(col("dt"), dow))
+        results[dow] = tmp.to_pydict()["next_d"]
     assert results["Monday"] == [date(2021, 1, 4)] * 3  # next Mon
     assert results["Friday"] == [date(2021, 1, 8)] * 3  # next Fri (not same day)
     assert results["Sunday"] == [date(2021, 1, 3)] * 3  # next Sun
@@ -1055,5 +1055,5 @@ def test_date_construction_sql() -> None:
     result = daft.sql("SELECT last_day(make_date(y, m, d)) as ld FROM df").to_pydict()
     assert result["ld"] == [date(2021, 1, 31)]
 
-    result = daft.sql("SELECT next_day(make_date(y, m, d), 'Monday') as nd FROM df").to_pydict()
-    assert result["nd"] == [date(2021, 1, 18)]
+    result = daft.sql("SELECT next_day(make_date(y, m, d), 'Monday') as next_d FROM df").to_pydict()
+    assert result["next_d"] == [date(2021, 1, 18)]


### PR DESCRIPTION
## Summary
Implements 5 new temporal functions for PySpark parity (issue #3798):

- **`make_date(year, month, day)`** : constructs a Date from integer components; invalid dates return null
- **`make_timestamp(year, month, day, hour, minute, second, [timezone])`** : constructs a Timestamp with optional timezone metadata; supports fractional seconds
- **`make_timestamp_ltz(year, month, day, hour, minute, second, [timezone])`** :  constructs a UTC Timestamp, optionally interpreting components in a source timezone and converting to UTC
- **`last_day(date)`** :  returns the last day of the month for the given date
- **`next_day(date, day_of_week)`** :  returns the next occurrence of the specified weekday after the given date

All functions have Rust UDFs, SQL wrappers, Python wrappers, and tests.

## Test plan
- [x] `test_make_date` : valid dates (2021-01-15, 2020-02-29 leap year, 2000-12-31)
- [x] `test_make_date_invalid` : invalid dates (Feb 30, month 13) return null
- [x] `test_make_timestamp` : basic timestamp construction
- [x] `test_make_timestamp_with_timezone` : verify timezone metadata on dtype
- [x] `test_make_timestamp_ltz` : verify UTC dtype output
- [x] `test_make_timestamp_ltz_with_timezone` : US/Eastern -> UTC conversion (12:00 EST = 17:00 UTC)
- [x] `test_last_day` : Jan 31, Feb 28 (non-leap), Feb 29 (leap), Apr 30
- [x] `test_next_day` : next Monday/Friday/Sunday from a Friday
- [x] `test_date_construction_sql` : SQL integration (make_date, last_day, next_day)


