### PR TITLE
fix(docs): correct from_glob_paths to from_glob_path in audio-transcription workload

### DIFF
--- a/docs/examples/audio-transcription.md
+++ b/docs/examples/audio-transcription.md
@@ -152,7 +152,7 @@ def transcribe(file: daft.File) -> str:
     return result['text']
 
 # Create dataframe from all flac files in directory
-df = daft.from_glob_paths("./LibriSpeech/dev-clean/**/*.flac")
+df = daft.from_glob_path("./LibriSpeech/dev-clean/**/*.flac")
 
 # Process all files
 df = df.select(


### PR DESCRIPTION
The function `daft.from_glob_paths()` does not exist. The correct API is `daft.from_glob_path()` (singular). This was causing AttributeError at runtime.

https://claude.ai/code/session_01PF6UY5PDCCJvWXrtTyqF4q

## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
