### PR TITLE
fix: respect proxy env vars (HTTP_PROXY, HTTPS_PROXY, etc.) in S3 client

### DIFF
--- a/src/daft-io/src/s3_like.rs
+++ b/src/daft-io/src/s3_like.rs
@@ -563,12 +563,30 @@ async fn build_s3_conf(config: &S3Config) -> super::Result<s3::Config> {
 
         fn default_client() -> SharedHttpClient {
             use aws_smithy_http_client::{
-                Builder,
+                Connector,
+                proxy::ProxyConfig,
                 tls::{Provider, rustls_provider::CryptoMode},
             };
-            Builder::new()
-                .tls_provider(Provider::Rustls(CryptoMode::AwsLc))
-                .build_https()
+            use aws_smithy_runtime_api::client::http::{
+                HttpConnectorSettings, SharedHttpConnector, http_client_fn,
+            };
+            use std::sync::OnceLock;
+
+            let proxy_config = ProxyConfig::from_env();
+            let cached: OnceLock<SharedHttpConnector> = OnceLock::new();
+
+            http_client_fn(move |settings: &HttpConnectorSettings, _components| {
+                cached
+                    .get_or_init(|| {
+                        let connector = Connector::builder()
+                            .tls_provider(Provider::Rustls(CryptoMode::AwsLc))
+                            .proxy_config(proxy_config.clone())
+                            .connector_settings(settings.clone())
+                            .build();
+                        SharedHttpConnector::new(connector)
+                    })
+                    .clone()
+            })
         }
 
         fn no_verify_hostname_client() -> SharedHttpClient {

--- a/src/daft-io/src/s3_like.rs
+++ b/src/daft-io/src/s3_like.rs
@@ -562,8 +562,6 @@ async fn build_s3_conf(config: &S3Config) -> super::Result<s3::Config> {
         use aws_smithy_runtime_api::client::http::SharedHttpClient;
 
         fn default_client() -> SharedHttpClient {
-            use std::sync::OnceLock;
-
             use aws_smithy_http_client::{
                 Connector,
                 proxy::ProxyConfig,
@@ -574,19 +572,14 @@ async fn build_s3_conf(config: &S3Config) -> super::Result<s3::Config> {
             };
 
             let proxy_config = ProxyConfig::from_env();
-            let cached: OnceLock<SharedHttpConnector> = OnceLock::new();
 
             http_client_fn(move |settings: &HttpConnectorSettings, _components| {
-                cached
-                    .get_or_init(|| {
-                        let connector = Connector::builder()
-                            .tls_provider(Provider::Rustls(CryptoMode::AwsLc))
-                            .proxy_config(proxy_config.clone())
-                            .connector_settings(settings.clone())
-                            .build();
-                        SharedHttpConnector::new(connector)
-                    })
-                    .clone()
+                let connector = Connector::builder()
+                    .tls_provider(Provider::Rustls(CryptoMode::AwsLc))
+                    .proxy_config(proxy_config.clone())
+                    .connector_settings(settings.clone())
+                    .build();
+                SharedHttpConnector::new(connector)
             })
         }
 

--- a/src/daft-io/src/s3_like.rs
+++ b/src/daft-io/src/s3_like.rs
@@ -562,6 +562,8 @@ async fn build_s3_conf(config: &S3Config) -> super::Result<s3::Config> {
         use aws_smithy_runtime_api::client::http::SharedHttpClient;
 
         fn default_client() -> SharedHttpClient {
+            use std::sync::OnceLock;
+
             use aws_smithy_http_client::{
                 Connector,
                 proxy::ProxyConfig,
@@ -570,7 +572,6 @@ async fn build_s3_conf(config: &S3Config) -> super::Result<s3::Config> {
             use aws_smithy_runtime_api::client::http::{
                 HttpConnectorSettings, SharedHttpConnector, http_client_fn,
             };
-            use std::sync::OnceLock;
 
             let proxy_config = ProxyConfig::from_env();
             let cached: OnceLock<SharedHttpConnector> = OnceLock::new();


### PR DESCRIPTION
## Summary
- Fix S3 HTTP client silently ignoring standard proxy environment variables
  (HTTP_PROXY, HTTPS_PROXY, ALL_PROXY, NO_PROXY)
- Replace high-level `Builder::build_https()` with lower-level
  `Connector::builder()` + `ProxyConfig::from_env()`
- No new crate dependencies - > use existing `aws-smithy-http-client` and
  `aws-smithy-runtime-api` APIs

Closes #6638

## Test plan
- When no proxy env vars are set, behavior is identical to before
  (`ProxyConfig::from_env()` returns disabled config)
- When HTTP_PROXY/HTTPS_PROXY are set, S3 traffic routes through the proxy
