### PR TITLE
feat: support catalog-qualified identifiers in create_table, drop_table

### DIFF
--- a/daft/session.py
+++ b/daft/session.py
@@ -320,12 +320,17 @@ class Session:
         Returns:
             Table: the newly created table instance.
         """
+        if isinstance(identifier, str):
+            identifier = Identifier.from_str(identifier)
+
+        if len(identifier) >= 2 and self.has_catalog(identifier[0]):
+            catalog = self.get_catalog(identifier[0])
+            identifier = identifier.drop(1)
+            return catalog.create_table(identifier, source, properties)
+
         if not (catalog := self.current_catalog()):
             # TODO relax this constraint by joining with the catalog name
             raise ValueError("Cannot create a table without a current catalog")
-
-        if isinstance(identifier, str):
-            identifier = Identifier.from_str(identifier)
 
         if len(identifier) == 1:
             if ns := self.current_namespace():
@@ -346,12 +351,17 @@ class Session:
         Returns:
             Table: the newly created instance, or the existing table instance.
         """
+        if isinstance(identifier, str):
+            identifier = Identifier.from_str(identifier)
+
+        if len(identifier) >= 2 and self.has_catalog(identifier[0]):
+            catalog = self.get_catalog(identifier[0])
+            identifier = identifier.drop(1)
+            return catalog.create_table_if_not_exists(identifier, source, properties)
+
         if not (catalog := self.current_catalog()):
             # TODO relax this constraint by joining with the catalog name
             raise ValueError("Cannot create a table without a current catalog")
-
-        if isinstance(identifier, str):
-            identifier = Identifier.from_str(identifier)
 
         if len(identifier) == 1:
             if ns := self.current_namespace():
@@ -415,6 +425,14 @@ class Session:
         Args:
             identifier (Identifier|str): table identifier
         """
+        if isinstance(identifier, str):
+            identifier = Identifier.from_str(identifier)
+
+        if len(identifier) >= 2 and self.has_catalog(identifier[0]):
+            catalog = self.get_catalog(identifier[0])
+            identifier = identifier.drop(1)
+            return catalog.drop_table(identifier)
+
         if not (catalog := self.current_catalog()):
             raise ValueError("Cannot drop a table without a current catalog")
         # TODO join the identifier with the current namespace

--- a/daft/session.py
+++ b/daft/session.py
@@ -312,6 +312,12 @@ class Session:
             raise ValueError("Cannot create a namespace without a current catalog")
         return catalog.create_namespace_if_not_exists(identifier)
 
+    def _resolve_catalog(self, identifier: Identifier) -> tuple[Catalog, Identifier] | None:
+        """If the identifier is catalog-qualified, return (catalog, remainder)."""
+        if len(identifier) >= 2 and self.has_catalog(identifier[0]):
+            return self.get_catalog(identifier[0]), identifier.drop(1)
+        return None
+
     def create_table(self, identifier: Identifier | str, source: Schema | DataFrame, **properties: Any) -> Table:
         """Creates a table in the current catalog.
 
@@ -323,9 +329,8 @@ class Session:
         if isinstance(identifier, str):
             identifier = Identifier.from_str(identifier)
 
-        if len(identifier) >= 2 and self.has_catalog(identifier[0]):
-            cat = self.get_catalog(identifier[0])
-            identifier = identifier.drop(1)
+        if resolved := self._resolve_catalog(identifier):
+            cat, identifier = resolved
             return cat.create_table(identifier, source, properties)
 
         if not (catalog := self.current_catalog()):
@@ -354,9 +359,8 @@ class Session:
         if isinstance(identifier, str):
             identifier = Identifier.from_str(identifier)
 
-        if len(identifier) >= 2 and self.has_catalog(identifier[0]):
-            cat = self.get_catalog(identifier[0])
-            identifier = identifier.drop(1)
+        if resolved := self._resolve_catalog(identifier):
+            cat, identifier = resolved
             return cat.create_table_if_not_exists(identifier, source, properties)
 
         if not (catalog := self.current_catalog()):
@@ -428,9 +432,8 @@ class Session:
         if isinstance(identifier, str):
             identifier = Identifier.from_str(identifier)
 
-        if len(identifier) >= 2 and self.has_catalog(identifier[0]):
-            cat = self.get_catalog(identifier[0])
-            identifier = identifier.drop(1)
+        if resolved := self._resolve_catalog(identifier):
+            cat, identifier = resolved
             return cat.drop_table(identifier)
 
         if not (catalog := self.current_catalog()):

--- a/daft/session.py
+++ b/daft/session.py
@@ -324,9 +324,9 @@ class Session:
             identifier = Identifier.from_str(identifier)
 
         if len(identifier) >= 2 and self.has_catalog(identifier[0]):
-            catalog = self.get_catalog(identifier[0])
+            cat = self.get_catalog(identifier[0])
             identifier = identifier.drop(1)
-            return catalog.create_table(identifier, source, properties)
+            return cat.create_table(identifier, source, properties)
 
         if not (catalog := self.current_catalog()):
             # TODO relax this constraint by joining with the catalog name
@@ -355,9 +355,9 @@ class Session:
             identifier = Identifier.from_str(identifier)
 
         if len(identifier) >= 2 and self.has_catalog(identifier[0]):
-            catalog = self.get_catalog(identifier[0])
+            cat = self.get_catalog(identifier[0])
             identifier = identifier.drop(1)
-            return catalog.create_table_if_not_exists(identifier, source, properties)
+            return cat.create_table_if_not_exists(identifier, source, properties)
 
         if not (catalog := self.current_catalog()):
             # TODO relax this constraint by joining with the catalog name
@@ -429,9 +429,9 @@ class Session:
             identifier = Identifier.from_str(identifier)
 
         if len(identifier) >= 2 and self.has_catalog(identifier[0]):
-            catalog = self.get_catalog(identifier[0])
+            cat = self.get_catalog(identifier[0])
             identifier = identifier.drop(1)
-            return catalog.drop_table(identifier)
+            return cat.drop_table(identifier)
 
         if not (catalog := self.current_catalog()):
             raise ValueError("Cannot drop a table without a current catalog")

--- a/tests/catalog/test_catalog.py
+++ b/tests/catalog/test_catalog.py
@@ -290,3 +290,53 @@ def test_catalog_create_and_get_function():
 
     func = _function_catalog.get_function("double_fn")
     assert func is not None
+
+
+def test_create_table_catalog_qualified():
+    """Test that create_table routes to the correct catalog when using a catalog-qualified identifier."""
+    from daft.session import Session
+
+    catalog = MockCatalog()
+    sess = Session()
+    sess.attach_catalog(catalog, alias="my_cat")
+
+    schema = Schema.from_pydict({"a": dt.int64()})
+    sess.create_table("my_cat.my_schema.my_table", schema)
+
+    # The table should exist in the catalog with the catalog prefix stripped
+    t = catalog.get_table("my_schema.my_table")
+    assert t is not None
+    assert t.name == "my_schema.my_table"
+
+
+def test_create_table_if_not_exists_catalog_qualified():
+    """Test that create_table_if_not_exists routes to the correct catalog when using a catalog-qualified identifier."""
+    from daft.session import Session
+
+    catalog = MockCatalog()
+    sess = Session()
+    sess.attach_catalog(catalog, alias="my_cat")
+
+    schema = Schema.from_pydict({"a": dt.int64()})
+    t1 = sess.create_table_if_not_exists("my_cat.my_schema.my_table", schema)
+    t2 = sess.create_table_if_not_exists("my_cat.my_schema.my_table", schema)
+
+    assert t1 is not None
+    assert t2 is not None
+    assert t1.name == t2.name
+
+
+def test_drop_table_catalog_qualified():
+    """Test that drop_table routes to the correct catalog when using a catalog-qualified identifier."""
+    from daft.session import Session
+
+    catalog = MockCatalog()
+    sess = Session()
+    sess.attach_catalog(catalog, alias="my_cat")
+
+    schema = Schema.from_pydict({"a": dt.int64()})
+    sess.create_table("my_cat.my_schema.my_table", schema)
+    assert catalog.has_table("my_schema.my_table")
+
+    sess.drop_table("my_cat.my_schema.my_table")
+    assert not catalog.has_table("my_schema.my_table")


### PR DESCRIPTION
## Summary
- `create_table`, `create_table_if_not_exists`, and `drop_table` now resolve catalog-qualified identifiers (e.g. `my_cat.my_schema.my_table`) by routing to the matched catalog with the prefix stripped
- Replicates the existing resolution pattern from `get_table` (Rule 3: if `identifier[0]` matches an attached catalog, strip it and route there)
- Python-only change (no Rust changes)

Resolves #4566

## Test plan
- [x] 3 new tests in `tests/catalog/test_catalog.py` covering `create_table`, `create_table_if_not_exists`, and `drop_table` with catalog-qualified identifiers
- [x] Full `tests/catalog/` suite passes with no regressions