### PR TITLE
feat: support version-hint.text for resolving iceberg table locations

### DIFF
--- a/daft/io/iceberg/_iceberg.py
+++ b/daft/io/iceberg/_iceberg.py
@@ -1,6 +1,7 @@
 # ruff: noqa: I002
 # isort: dont-add-import: from __future__ import annotations
 
+import posixpath
 from typing import TYPE_CHECKING, Any, Union
 
 from daft import context, runners
@@ -27,12 +28,10 @@ def _resolve_metadata_location(location: str) -> str:
     if location.endswith(".metadata.json"):
         return location
 
-    import os
-
     from pyiceberg.io import load_file_io
 
     # Try version-hint.text (Iceberg spec standard)
-    version_hint_path = os.path.join(location, "metadata", "version-hint.text")
+    version_hint_path = posixpath.join(location, "metadata", "version-hint.text")
     io = load_file_io(properties={}, location=version_hint_path)
     try:
         input_file = io.new_input(version_hint_path)
@@ -43,12 +42,14 @@ def _resolve_metadata_location(location: str) -> str:
         # pyiceberg handle it (it may raise its own error).
         return location
 
+    if not content:
+        return location
     if content.endswith(".metadata.json"):
-        return os.path.join(location, "metadata", content)
+        return posixpath.join(location, "metadata", content)
     elif content.isnumeric():
-        return os.path.join(location, "metadata", f"v{content}.metadata.json")
+        return posixpath.join(location, "metadata", f"v{content}.metadata.json")
     else:
-        return os.path.join(location, "metadata", f"{content}.metadata.json")
+        return posixpath.join(location, "metadata", f"{content}.metadata.json")
 
 
 def _convert_iceberg_file_io_properties_to_io_config(props: dict[str, Any]) -> IOConfig | None:

--- a/daft/io/iceberg/_iceberg.py
+++ b/daft/io/iceberg/_iceberg.py
@@ -13,6 +13,44 @@ if TYPE_CHECKING:
     from pyiceberg.table import Table as PyIcebergTable
 
 
+def _resolve_metadata_location(location: str) -> str:
+    """Resolve an Iceberg table location to a metadata file path.
+
+    If the location already points to a ``.metadata.json`` file, it is returned
+    as-is.  Otherwise, we treat it as a table root directory and attempt to read
+    ``<location>/metadata/version-hint.text`` (the standard Iceberg version-hint
+    file) to derive the metadata file path.
+
+    This provides built-in support for ``version-hint.text`` regardless of which
+    PyIceberg version is installed.
+    """
+    if location.endswith(".metadata.json"):
+        return location
+
+    import os
+
+    from pyiceberg.io import load_file_io
+
+    # Try version-hint.text (Iceberg spec standard)
+    version_hint_path = os.path.join(location, "metadata", "version-hint.text")
+    io = load_file_io(properties={}, location=version_hint_path)
+    try:
+        input_file = io.new_input(version_hint_path)
+        with input_file.open() as f:
+            content = f.read().decode("utf-8").strip()
+    except FileNotFoundError:
+        # No version-hint file found; return the original location and let
+        # pyiceberg handle it (it may raise its own error).
+        return location
+
+    if content.endswith(".metadata.json"):
+        return os.path.join(location, "metadata", content)
+    elif content.isnumeric():
+        return os.path.join(location, "metadata", f"v{content}.metadata.json")
+    else:
+        return os.path.join(location, "metadata", f"{content}.metadata.json")
+
+
 def _convert_iceberg_file_io_properties_to_io_config(props: dict[str, Any]) -> IOConfig | None:
     """Property keys defined here: https://github.com/apache/iceberg-python/blob/main/pyiceberg/io/__init__.py."""
     from daft.io import AzureConfig, GCSConfig, IOConfig, S3Config
@@ -61,9 +99,11 @@ def read_iceberg(
     """Create a DataFrame from an Iceberg table.
 
     Args:
-        table (str or pyiceberg.table.Table): A path to an Iceberg metadata file (supports remote URLs to object stores
-            such as ``s3://`` or ``gs://``) or a [PyIceberg Table](https://py.iceberg.apache.org/reference/pyiceberg/table/#pyiceberg.table.Table)
-            created using the PyIceberg library.
+        table (str or pyiceberg.table.Table): A path to an Iceberg metadata file, an Iceberg table location
+            (directory), or a [PyIceberg Table](https://py.iceberg.apache.org/reference/pyiceberg/table/#pyiceberg.table.Table)
+            created using the PyIceberg library. Supports remote URLs to object stores such as ``s3://`` or ``gs://``.
+            When a table location is provided (i.e. a path that does not end in ``.metadata.json``), the metadata
+            is resolved via ``<location>/metadata/version-hint.text``.
         snapshot_id (int, optional): Snapshot ID of the table to query
         io_config (IOConfig, optional): A custom IOConfig to use when accessing Iceberg object storage data. If provided, configurations set in `table` are ignored.
 
@@ -90,14 +130,18 @@ def read_iceberg(
         >>> io_config = IOConfig(s3=S3Config(region="us-west-2", anonymous=True))
         >>> df = daft.read_iceberg("s3://bucket/path/to/iceberg/metadata.json", io_config=io_config)
         >>> df.show()
+
+        Read an Iceberg table from a table location (uses version-hint.text):
+        >>> df = daft.read_iceberg("/path/to/iceberg/table")
+        >>> df.show()
     """
     from pyiceberg.table import StaticTable
 
     from daft.io.iceberg.iceberg_scan import IcebergScanOperator
 
-    # support for read_iceberg('path/to/metadata.json')
+    # support for read_iceberg('path/to/table') and read_iceberg('path/to/metadata.json')
     if isinstance(table, str):
-        table = StaticTable.from_metadata(metadata_location=table)
+        table = StaticTable.from_metadata(metadata_location=_resolve_metadata_location(table))
 
     io_config = (
         _convert_iceberg_file_io_properties_to_io_config(table.io.properties) if io_config is None else io_config

--- a/src/daft-logical-plan/src/scan_builder.rs
+++ b/src/daft-logical-plan/src/scan_builder.rs
@@ -404,10 +404,15 @@ pub fn iceberg_scan<T: AsRef<str>>(
     use pyo3::IntoPyObjectExt;
     let storage_config: StorageConfig = io_config.unwrap_or_default().into();
     let scan_operator = Python::attach(|py| -> DaftResult<ScanOperatorHandle> {
+        // Resolve table location to metadata file path via version-hint.text
+        let iceberg_module = PyModule::import(py, "daft.io.iceberg._iceberg")?;
+        let resolve_fn = iceberg_module.getattr("_resolve_metadata_location")?;
+        let resolved_location = resolve_fn.call1((metadata_location.as_ref(),))?;
+
         let iceberg_table_module = PyModule::import(py, "pyiceberg.table")?;
         let iceberg_static_table = iceberg_table_module.getattr("StaticTable")?;
         let iceberg_table =
-            iceberg_static_table.call_method1("from_metadata", (metadata_location.as_ref(),))?;
+            iceberg_static_table.call_method1("from_metadata", (resolved_location,))?;
         let iceberg_scan_module = PyModule::import(py, "daft.io.iceberg.iceberg_scan")?;
         let iceberg_scan_class = iceberg_scan_module.getattr("IcebergScanOperator")?;
         let iceberg_scan = iceberg_scan_class

--- a/tests/io/iceberg/test_iceberg_version_hint.py
+++ b/tests/io/iceberg/test_iceberg_version_hint.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+pyiceberg = pytest.importorskip("pyiceberg")
+
+import daft
+from daft.io.iceberg._iceberg import _resolve_metadata_location
+
+
+def _create_iceberg_table(tmpdir, version=1, schema_fields=None):
+    """Helper to create a minimal Iceberg table directory structure."""
+    metadata_dir = os.path.join(str(tmpdir), "metadata")
+    os.makedirs(metadata_dir, exist_ok=True)
+
+    if schema_fields is None:
+        schema_fields = [{"id": 1, "name": "x", "required": False, "type": "long"}]
+
+    metadata = {
+        "format-version": 2,
+        "table-uuid": "00000000-0000-0000-0000-000000000000",
+        "location": str(tmpdir),
+        "last-sequence-number": 0,
+        "last-updated-ms": 0,
+        "last-column-id": max(f["id"] for f in schema_fields),
+        "current-schema-id": 0,
+        "schemas": [{"type": "struct", "schema-id": 0, "fields": schema_fields}],
+        "default-spec-id": 0,
+        "partition-specs": [{"spec-id": 0, "fields": []}],
+        "last-partition-id": 0,
+        "default-sort-order-id": 0,
+        "sort-orders": [{"order-id": 0, "fields": []}],
+        "properties": {},
+        "snapshots": [],
+        "snapshot-log": [],
+        "metadata-log": [],
+    }
+
+    metadata_file = os.path.join(metadata_dir, f"v{version}.metadata.json")
+    with open(metadata_file, "w") as f:
+        json.dump(metadata, f)
+
+    return metadata_dir, metadata_file
+
+
+class TestResolveMetadataLocation:
+    def test_direct_metadata_path_returned_as_is(self):
+        path = "/path/to/v1.metadata.json"
+        assert _resolve_metadata_location(path) == path
+
+    def test_direct_metadata_path_with_scheme(self):
+        path = "s3://bucket/path/to/v1.metadata.json"
+        assert _resolve_metadata_location(path) == path
+
+    def test_resolves_numeric_version_hint(self, tmp_path):
+        metadata_dir, _ = _create_iceberg_table(tmp_path, version=3)
+        with open(os.path.join(metadata_dir, "version-hint.text"), "w") as f:
+            f.write("3")
+
+        result = _resolve_metadata_location(str(tmp_path))
+        assert result == os.path.join(metadata_dir, "v3.metadata.json")
+
+    def test_resolves_full_filename_version_hint(self, tmp_path):
+        metadata_dir, _ = _create_iceberg_table(tmp_path, version=2)
+        with open(os.path.join(metadata_dir, "version-hint.text"), "w") as f:
+            f.write("v2.metadata.json")
+
+        result = _resolve_metadata_location(str(tmp_path))
+        assert result == os.path.join(metadata_dir, "v2.metadata.json")
+
+    def test_resolves_version_hint_with_whitespace(self, tmp_path):
+        metadata_dir, _ = _create_iceberg_table(tmp_path, version=1)
+        with open(os.path.join(metadata_dir, "version-hint.text"), "w") as f:
+            f.write("1\n")
+
+        result = _resolve_metadata_location(str(tmp_path))
+        assert result == os.path.join(metadata_dir, "v1.metadata.json")
+
+    def test_missing_version_hint_returns_original(self, tmp_path):
+        # No version-hint.text file — should return original location
+        result = _resolve_metadata_location(str(tmp_path))
+        assert result == str(tmp_path)
+
+
+class TestReadIcebergVersionHint:
+    def test_read_iceberg_with_table_location(self, tmp_path):
+        metadata_dir, _ = _create_iceberg_table(tmp_path)
+        with open(os.path.join(metadata_dir, "version-hint.text"), "w") as f:
+            f.write("1")
+
+        df = daft.read_iceberg(str(tmp_path))
+        assert "x" in df.schema().column_names()
+        result = df.collect()
+        assert len(result) == 0  # empty table, no snapshots
+
+    def test_read_iceberg_with_direct_metadata_path(self, tmp_path):
+        _, metadata_file = _create_iceberg_table(tmp_path)
+
+        df = daft.read_iceberg(metadata_file)
+        assert "x" in df.schema().column_names()
+
+    def test_read_iceberg_sql_with_table_location(self, tmp_path):
+        metadata_dir, _ = _create_iceberg_table(tmp_path)
+        with open(os.path.join(metadata_dir, "version-hint.text"), "w") as f:
+            f.write("1")
+
+        df = daft.sql(f"SELECT * FROM read_iceberg('{tmp_path}')")
+        assert "x" in df.schema().column_names()

--- a/tests/io/iceberg/test_iceberg_version_hint.py
+++ b/tests/io/iceberg/test_iceberg_version_hint.py
@@ -84,6 +84,14 @@ class TestResolveMetadataLocation:
         result = _resolve_metadata_location(str(tmp_path))
         assert result == str(tmp_path)
 
+    def test_empty_version_hint_returns_original(self, tmp_path):
+        metadata_dir, _ = _create_iceberg_table(tmp_path)
+        with open(os.path.join(metadata_dir, "version-hint.text"), "w") as f:
+            f.write("   \n")
+
+        result = _resolve_metadata_location(str(tmp_path))
+        assert result == str(tmp_path)
+
 
 class TestReadIcebergVersionHint:
     def test_read_iceberg_with_table_location(self, tmp_path):


### PR DESCRIPTION
## Summary
- When `read_iceberg` receives a table location (directory) instead of an exact `.metadata.json` path, it now reads `<location>/metadata/version-hint.text` to derive the metadata file path
- Supports numeric hints (`3` → `v3.metadata.json`), full filenames, and bare names
- Works across storage backends (local, S3, GCS) via pyiceberg's `load_file_io`
- Falls back gracefully if `version-hint.text` is missing
- Both the Python API and SQL path (`read_iceberg('path/to/table')`) are supported

Resolves #3698

## Test plan
- [x] 6 unit tests for `_resolve_metadata_location` (direct paths, numeric hints, full filenames, whitespace, missing file)
- [x] 3 integration tests for `read_iceberg` (table location, direct metadata path, SQL path)
- [x] All 88 existing iceberg tests pass with no regressions