### PR TITLE
fix(docs): fix syntax errors in connectors documentation

### DIFF
--- a/docs/connectors/custom.md
+++ b/docs/connectors/custom.md
@@ -295,7 +295,7 @@ class LocalFileDataSink(DataSink[dict]):
         """
         return micropartition.to_pylist()
 
-    def _write_data_to_files(self, data: list[Any]) -> dict::
+    def _write_data_to_files(self, data: list[Any]) -> dict:
         """Write data to one or more files based on size limits.
 
         Args:

--- a/docs/connectors/glue.md
+++ b/docs/connectors/glue.md
@@ -94,6 +94,6 @@ class GlueTestTable(GlueTable):
     def write(self, df: DataFrame, mode: Literal['append'] | Literal['overwrite'] = "append", **options) -> None:
         raise NotImplementedError
 
-gc = load_glue("my_glue_catalog", region="us-west-2")
+gc = load_glue("my_glue_catalog", region_name="us-west-2")
 gc._table_impls.append(GlueTestTable) # !! REGISTER GLUE TEST TABLE !!
 ```


### PR DESCRIPTION
- Remove extra colon in custom.md `-> dict::` to `-> dict:`
- Fix parameter name in glue.md `region=` to `region_name=`

https://claude.ai/code/session_0114DocrUEyGW9h38LwgtAXx

## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
