### PR TITLE
feat: Add support for writing Extension and Duration types to Parquet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3362,6 +3362,7 @@ dependencies = [
  "arrow-json",
  "arrow-schema 57.3.0",
  "async-trait",
+ "bytes",
  "chrono",
  "chrono-tz",
  "common-daft-config",

--- a/src/daft-writers/Cargo.toml
+++ b/src/daft-writers/Cargo.toml
@@ -28,6 +28,10 @@ uuid = {workspace = true, features = ["v4"]}
 [features]
 python = ["dep:pyo3", "common-file-formats/python", "common-error/python", "daft-dsl/python", "daft-io/python", "daft-logical-plan/python", "daft-micropartition/python"]
 
+[dev-dependencies]
+arrow-array = {workspace = true}
+bytes = {workspace = true}
+
 [lints]
 workspace = true
 

--- a/src/daft-writers/src/parquet_writer.rs
+++ b/src/daft-writers/src/parquet_writer.rs
@@ -29,8 +29,7 @@ use crate::{
 
 type ColumnWriterFuture = dyn Future<Output = DaftResult<ArrowColumnChunk>> + Send;
 
-/// Writer properties for the native Parquet path: physical Parquet encoding plus
-/// [`ARROW:schema`](parquet::arrow::ARROW_SCHEMA_META_KEY) so Arrow extension metadata round-trips.
+/// Construct writer properties for the native Parquet writer
 fn native_parquet_writer_properties(arrow_schema: &arrow_schema::Schema) -> WriterProperties {
     let mut props = WriterProperties::builder()
         .set_writer_version(WriterVersion::PARQUET_1_0)
@@ -40,25 +39,7 @@ fn native_parquet_writer_properties(arrow_schema: &arrow_schema::Schema) -> Writ
     props
 }
 
-/// Helper function to check if we support writing a specific data type to Parquet
-fn native_parquet_field_supported(field: &arrow_schema::Field) -> bool {
-    // TODO: Newer versions of parquet support Duration, but we don't write
-    // the arrow schema metadata to Parquet, so we can't support it yet.
-    // Similarly, we don't support TimestampTz or Extension
-    match field.data_type() {
-        arrow_schema::DataType::Duration(_) => false,
-        arrow_schema::DataType::Timestamp(_, tz) => tz.is_none(),
-        arrow_schema::DataType::List(field)
-        | arrow_schema::DataType::FixedSizeList(field, _)
-        | arrow_schema::DataType::Map(field, _) => native_parquet_field_supported(field.as_ref()),
-        arrow_schema::DataType::Struct(fields) => fields
-            .iter()
-            .all(|field| native_parquet_field_supported(field.as_ref())),
-        _ => true,
-    }
-}
-
-/// Helper function that checks if we support native writes given the file format, root directory, and schema.
+/// Helper function that checks if we support native writes given the file format, path, and schema.
 pub(crate) fn native_parquet_writer_supported(
     root_dir: &str,
     file_schema: &SchemaRef,
@@ -71,14 +52,6 @@ pub(crate) fn native_parquet_writer_supported(
     let Ok(arrow_schema) = file_schema.to_arrow() else {
         return Ok(false);
     };
-
-    if arrow_schema
-        .fields()
-        .iter()
-        .any(|field| !native_parquet_field_supported(field.as_ref()))
-    {
-        return Ok(false);
-    }
 
     let writer_properties = native_parquet_writer_properties(&arrow_schema);
     Ok(ArrowSchemaConverter::new()

--- a/src/daft-writers/src/parquet_writer.rs
+++ b/src/daft-writers/src/parquet_writer.rs
@@ -10,7 +10,7 @@ use daft_recordbatch::RecordBatch;
 #[allow(deprecated)]
 use parquet::{
     arrow::{
-        ArrowSchemaConverter,
+        ArrowSchemaConverter, add_encoded_arrow_schema_to_metadata,
         arrow_writer::{ArrowColumnChunk, ArrowLeafColumn, compute_leaves, get_column_writers},
     },
     basic::Compression,
@@ -29,13 +29,19 @@ use crate::{
 
 type ColumnWriterFuture = dyn Future<Output = DaftResult<ArrowColumnChunk>> + Send;
 
-/// Helper function to check if we support writing a specific data type to Parquet.
-fn native_parquet_field_supported(field: &arrow_schema::Field) -> bool {
-    // TODO: Include extension info in parquet metadata
-    if field.extension_type_name().is_some() {
-        return false;
-    }
+/// Writer properties for the native Parquet path: physical Parquet encoding plus
+/// [`ARROW:schema`](parquet::arrow::ARROW_SCHEMA_META_KEY) so Arrow extension metadata round-trips.
+fn native_parquet_writer_properties(arrow_schema: &arrow_schema::Schema) -> WriterProperties {
+    let mut props = WriterProperties::builder()
+        .set_writer_version(WriterVersion::PARQUET_1_0)
+        .set_compression(Compression::SNAPPY)
+        .build();
+    add_encoded_arrow_schema_to_metadata(arrow_schema, &mut props);
+    props
+}
 
+/// Helper function to check if we support writing a specific data type to Parquet
+fn native_parquet_field_supported(field: &arrow_schema::Field) -> bool {
     // TODO: Newer versions of parquet support Duration, but we don't write
     // the arrow schema metadata to Parquet, so we can't support it yet.
     // Similarly, we don't support TimestampTz or Extension
@@ -74,12 +80,7 @@ pub(crate) fn native_parquet_writer_supported(
         return Ok(false);
     }
 
-    let writer_properties = Arc::new(
-        WriterProperties::builder()
-            .set_writer_version(WriterVersion::PARQUET_1_0)
-            .set_compression(Compression::SNAPPY)
-            .build(),
-    );
+    let writer_properties = native_parquet_writer_properties(&arrow_schema);
     Ok(ArrowSchemaConverter::new()
         .with_coerce_types(writer_properties.coerce_types())
         .convert(&arrow_schema)
@@ -105,14 +106,8 @@ pub(crate) fn create_native_parquet_writer(
 
     // TODO(desmond): Explore configurations such data page size limit, writer version, etc. Parquet format v2
     // could be interesting but has much less support in the ecosystem (including ourselves).
-    let writer_properties = Arc::new(
-        WriterProperties::builder()
-            .set_writer_version(WriterVersion::PARQUET_1_0)
-            .set_compression(Compression::SNAPPY)
-            .build(),
-    );
-
     let arrow_schema = Arc::new(schema.to_arrow()?.into());
+    let writer_properties = native_parquet_writer_properties(&arrow_schema);
 
     let parquet_schema = ArrowSchemaConverter::new()
         .with_coerce_types(writer_properties.coerce_types())
@@ -124,7 +119,7 @@ pub(crate) fn create_native_parquet_writer(
             let storage_backend = FileStorageBackend {};
             Ok(Box::new(ParquetWriter::new(
                 filename,
-                writer_properties,
+                Arc::new(writer_properties),
                 arrow_schema,
                 parquet_schema,
                 partition_values.cloned(),
@@ -139,7 +134,7 @@ pub(crate) fn create_native_parquet_writer(
             let storage_backend = ObjectStorageBackend::new(scheme, io_config);
             Ok(Box::new(ParquetWriter::new(
                 filename,
-                writer_properties,
+                Arc::new(writer_properties),
                 arrow_schema,
                 parquet_schema,
                 partition_values.cloned(),
@@ -414,5 +409,70 @@ impl<B: StorageBackend> AsyncFileWriter for ParquetWriter<B> {
 
     fn bytes_per_file(&self) -> Vec<usize> {
         vec![self.total_bytes_written]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use arrow_array::RecordBatch;
+    use bytes::Bytes;
+    use parquet::{
+        arrow::{ARROW_SCHEMA_META_KEY, ArrowWriter, parquet_to_arrow_schema},
+        file::reader::{FileReader, SerializedFileReader},
+    };
+
+    use super::*;
+
+    #[test]
+    fn native_parquet_writer_properties_embeds_arrow_schema_metadata() {
+        let daft_schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Uuid)]));
+        assert!(native_parquet_writer_supported("file:///tmp", &daft_schema).unwrap());
+
+        let arrow_schema = daft_schema.to_arrow().expect("Conversion should pass");
+        assert!(
+            arrow_schema
+                .field(0)
+                .extension_type_name()
+                .is_some_and(|n| n == "arrow.uuid")
+        );
+
+        let props = native_parquet_writer_properties(&arrow_schema);
+        let kv = props
+            .key_value_metadata()
+            .expect("expected key_value_metadata");
+        assert!(kv.iter().any(|entry| entry.key == ARROW_SCHEMA_META_KEY));
+    }
+
+    #[test]
+    fn parquet_file_round_trips_extension_metadata() {
+        let daft_schema = Schema::new(vec![Field::new("id", DataType::Uuid)]);
+        let arrow_schema = Arc::new(daft_schema.to_arrow().unwrap());
+        let expected_ext = arrow_schema
+            .field(0)
+            .extension_type_name()
+            .map(str::to_string);
+
+        let props = native_parquet_writer_properties(&arrow_schema);
+        let mut buffer = Vec::new();
+        {
+            let mut writer = ArrowWriter::try_new(&mut buffer, arrow_schema.clone(), Some(props))
+                .expect("ArrowWriter::try_new");
+            let batch = RecordBatch::new_empty(arrow_schema);
+            writer.write(&batch).expect("write empty batch");
+            writer.close().expect("close writer");
+        }
+
+        let reader = SerializedFileReader::new(Bytes::from(buffer)).expect("read parquet");
+        let file_meta = reader.metadata().file_metadata();
+        let inferred =
+            parquet_to_arrow_schema(file_meta.schema_descr(), file_meta.key_value_metadata())
+                .expect("parquet_to_arrow_schema");
+
+        assert_eq!(
+            inferred.field(0).extension_type_name().map(str::to_string),
+            expected_ext
+        );
     }
 }

--- a/tests/io/test_parquet.py
+++ b/tests/io/test_parquet.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import datetime
+import io
 import os
 import tempfile
 import uuid
@@ -435,7 +436,7 @@ def test_parquet_read_databricks_generated_file():
     assert table.to_arrow() == expected.to_arrow(), f"Expected:\n{expected}\n\nReceived:\n{table}"
 
 
-def test_parquet_count(tmp_path_factory, capsys):
+def test_parquet_count(tmp_path_factory):
     path = str(tmp_path_factory.mktemp("parquet_count"))
     data = {
         "string_content": ["a"] * 10,
@@ -445,11 +446,9 @@ def test_parquet_count(tmp_path_factory, capsys):
     df.write_parquet(path, write_mode="overwrite")
 
     df = daft.read_parquet(path).count(1)
-    _ = capsys.readouterr()
-    df.explain(True)
-    actual = capsys.readouterr()
-
-    assert "Project: col(int_id) as count" in actual.out
+    actual = io.StringIO()
+    df.explain(True, file=actual)
+    assert "Project: col(int_id) as count" in actual.getvalue()
 
     result = df.to_pydict()
     assert result == {"count": [10]}

--- a/tests/io/test_parquet_roundtrip.py
+++ b/tests/io/test_parquet_roundtrip.py
@@ -13,6 +13,7 @@ import pytest
 import daft
 from daft import DataType, Series, TimeUnit
 from daft.context import execution_config_ctx
+from tests.conftest import get_tests_daft_runner_name
 
 
 @pytest.mark.parametrize(
@@ -195,6 +196,10 @@ def test_roundtrip_uuid_type(tmp_path, native_parquet_writer: bool) -> None:
     assert before.to_arrow() == after.to_arrow()
 
 
+@pytest.mark.skipif(
+    get_tests_daft_runner_name() == "ray",
+    reason="pyarrow extension types aren't supported on Ray clusters.",
+)
 @pytest.mark.parametrize("native_parquet_writer", [True, False])
 def test_roundtrip_arrow_extension_type(tmp_path, uuid_ext_type, native_parquet_writer: bool) -> None:
     """Parquet write/read preserves a registered Arrow extension column (storage + extension name)."""

--- a/tests/io/test_parquet_roundtrip.py
+++ b/tests/io/test_parquet_roundtrip.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import datetime
 import decimal
 import random
+import uuid
 
 import numpy as np
 import pyarrow as pa
@@ -11,6 +12,7 @@ import pytest
 
 import daft
 from daft import DataType, Series, TimeUnit
+from daft.context import execution_config_ctx
 
 
 @pytest.mark.parametrize(
@@ -162,7 +164,54 @@ def test_roundtrip_boolean_rle(tmp_path, has_none):
     assert pa_original == df_roundtrip.to_arrow()
 
 
+@pytest.mark.skipif(
+    not hasattr(pa, "uuid"),
+    reason="PyArrow version doesn't support the canonical uuid extension type.",
+)
+@pytest.mark.parametrize("native_parquet_writer", [True, False])
+def test_roundtrip_uuid_type(tmp_path, native_parquet_writer: bool) -> None:
+    """Parquet write/read preserves Arrow uuid (logical) and Daft DataType.uuid()."""
+    pydict = {"uuid_col": [uuid.uuid4().bytes for _ in range(3)]}
+    pa_schema = pa.schema([pa.field("uuid_col", pa.uuid())])
+    t = pa.Table.from_pydict(pydict, schema=pa_schema)
+    before = daft.from_arrow(t)
+    before = before.concat(before)
+
+    with execution_config_ctx(native_parquet_writer=native_parquet_writer):
+        before.write_parquet(str(tmp_path))
+        after = daft.read_parquet(str(tmp_path))
+
+    assert before.schema()["uuid_col"].dtype == DataType.uuid()
+    assert after.schema()["uuid_col"].dtype == DataType.uuid()
+    assert before.to_arrow() == after.to_arrow()
+
+
+@pytest.mark.parametrize("native_parquet_writer", [True, False])
+def test_roundtrip_arrow_extension_type(tmp_path, uuid_ext_type, native_parquet_writer: bool) -> None:
+    """Parquet write/read preserves a registered Arrow extension column (storage + extension name)."""
+    n = 3
+    pydict = {
+        "id": list(range(n)),
+        "ext_col": pa.ExtensionArray.from_storage(uuid_ext_type, pa.array([f"{i}".encode() for i in range(n)])),
+    }
+    t = pa.Table.from_pydict(pydict)
+    before = daft.from_arrow(t)
+    expected_dtype = before.schema()["ext_col"].dtype
+    assert expected_dtype == DataType.extension(
+        uuid_ext_type.NAME, DataType.from_arrow_type(uuid_ext_type.storage_type), ""
+    )
+
+    with execution_config_ctx(native_parquet_writer=native_parquet_writer):
+        before.write_parquet(str(tmp_path))
+        after = daft.read_parquet(str(tmp_path))
+
+    assert before.schema()["ext_col"].dtype == expected_dtype
+    assert after.schema()["ext_col"].dtype == expected_dtype
+    ba = before.to_arrow()
+    aa = after.to_arrow()
+    assert ba.equals(aa, check_metadata=False)
+
+
 # TODO: reading/writing:
 # 1. Embedding type
 # 2. Image type
-# 3. Extension type?

--- a/tests/io/test_parquet_roundtrip.py
+++ b/tests/io/test_parquet_roundtrip.py
@@ -57,11 +57,15 @@ from daft.context import execution_config_ctx
         ),
     ],
 )
-def test_roundtrip_simple_arrow_types(tmp_path, data, pa_type, expected_dtype):
+@pytest.mark.parametrize("native_parquet_writer", [True, False])
+def test_roundtrip_simple_arrow_types(tmp_path, data, pa_type, expected_dtype, native_parquet_writer):
     before = daft.from_arrow(pa.table({"foo": pa.array(data, type=pa_type)}))
     before = before.concat(before)
-    before.write_parquet(str(tmp_path))
-    after = daft.read_parquet(str(tmp_path))
+
+    with execution_config_ctx(native_parquet_writer=native_parquet_writer):
+        before.write_parquet(str(tmp_path))
+        after = daft.read_parquet(str(tmp_path))
+
     assert before.schema()["foo"].dtype == expected_dtype
     assert after.schema()["foo"].dtype == expected_dtype
     assert before.to_arrow() == after.to_arrow()
@@ -92,11 +96,16 @@ def test_roundtrip_simple_arrow_types(tmp_path, data, pa_type, expected_dtype):
         ),
     ],
 )
-def test_roundtrip_temporal_arrow_types(tmp_path, data, pa_type, expected_dtype):
+@pytest.mark.parametrize("native_parquet_writer", [True, False])
+def test_roundtrip_temporal_arrow_types(tmp_path, data, pa_type, expected_dtype, native_parquet_writer: bool):
+    """Includes naive and zoned timestamps; native writer preserves tz via ARROW:schema."""
     before = daft.from_arrow(pa.table({"foo": pa.array(data, type=pa_type)}))
     before = before.concat(before)
-    before.write_parquet(str(tmp_path))
-    after = daft.read_parquet(str(tmp_path))
+
+    with execution_config_ctx(native_parquet_writer=native_parquet_writer):
+        before.write_parquet(str(tmp_path))
+        after = daft.read_parquet(str(tmp_path))
+
     assert before.schema()["foo"].dtype == expected_dtype
     assert after.schema()["foo"].dtype == expected_dtype
     assert before.to_arrow() == after.to_arrow()


### PR DESCRIPTION
## Changes Made

Added support for writing duration columns and Arrow extension-based columns (like UUID) to Parquet files. Useful for saving intermediates of MinHash dedupe runs.