### PR TITLE
ci: Fix CI daft builds on Linux x86

### DIFF
--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -105,7 +105,7 @@ jobs:
       uses: PyO3/maturin-action@v1
       with:
         target: x86_64
-        args: --profile ${{ inputs.use_lto && 'release-lto' || 'release' }} --out dist
+        args: -i python${{ env.PYTHON_VERSION }} --profile ${{ inputs.use_lto && 'release-lto' || 'release' }} --out dist
       env:
         GITHUB_ACTIONS: true
 
@@ -116,7 +116,7 @@ jobs:
         target: x86_64
         manylinux: 2_24
         # only produce sdist for linux x86 to avoid multiple copies
-        args: --profile ${{ inputs.use_lto && 'release-lto' || 'release' }} --out dist --sdist
+        args: -i python${{ env.PYTHON_VERSION }} --profile ${{ inputs.use_lto && 'release-lto' || 'release' }} --out dist --sdist
       env:
         GITHUB_ACTIONS: true
 
@@ -127,7 +127,7 @@ jobs:
         target: aarch64-unknown-linux-gnu
         manylinux: 2_24
         # only produce sdist for linux x86 to avoid multiple copies
-        args: --profile ${{ inputs.use_lto && 'release-lto' || 'release' }} --out dist --sdist
+        args: -i python${{ env.PYTHON_VERSION }} --profile ${{ inputs.use_lto && 'release-lto' || 'release' }} --out dist --sdist
         before-script-linux: export JEMALLOC_SYS_WITH_LG_PAGE=16
       env:
         GITHUB_ACTIONS: true
@@ -137,7 +137,7 @@ jobs:
       uses: PyO3/maturin-action@v1
       with:
         target: aarch64
-        args: --profile ${{ inputs.use_lto && 'release-lto' || 'release' }} --out dist
+        args: -i python${{ env.PYTHON_VERSION }} --profile ${{ inputs.use_lto && 'release-lto' || 'release' }} --out dist
       env:
         RUSTFLAGS: -Ctarget-cpu=apple-m1
         CFLAGS: -mtune=apple-m1

--- a/.github/workflows/publish-dev-s3.yml
+++ b/.github/workflows/publish-dev-s3.yml
@@ -82,7 +82,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu]
+        os: [ubuntu, macos]
         arch: [x86_64, aarch64]
         lts: [false]
 

--- a/.github/workflows/publish-dev-s3.yml
+++ b/.github/workflows/publish-dev-s3.yml
@@ -82,7 +82,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu, macos]
+        os: [ubuntu]
         arch: [x86_64, aarch64]
         lts: [false]
 


### PR DESCRIPTION
## Changes Made

Fixes the issue when building Daft on CI. Should address the error from the last release attempt (https://github.com/Eventual-Inc/Daft/actions/runs/24369346877/job/71169070416).

Confirmed CI run: https://github.com/Eventual-Inc/Daft/actions/runs/24371093297
