### PR TITLE
chore: Small changes from dedupe

### DIFF
--- a/daft/datasets/common_crawl.py
+++ b/daft/datasets/common_crawl.py
@@ -36,6 +36,9 @@ def _unique_cc_file_paths(paths_url: str, io_config: IOConfig | None) -> DataFra
     # *just* the unique parts of each file
     paths = paths.explode("url")
 
+    # filter out any text / metadata files
+    paths = paths.where(col("url").endswith(".txt"))
+
     return paths
 
 

--- a/daft/datasets/common_crawl.py
+++ b/daft/datasets/common_crawl.py
@@ -37,7 +37,7 @@ def _unique_cc_file_paths(paths_url: str, io_config: IOConfig | None) -> DataFra
     paths = paths.explode("url")
 
     # filter out any text / metadata files
-    paths = paths.where(col("url").endswith(".txt"))
+    paths = paths.where(~col("url").endswith(".txt"))
 
     return paths
 

--- a/daft/functions/list.py
+++ b/daft/functions/list.py
@@ -34,9 +34,11 @@ def value_counts(list_expr: Expression) -> Expression:
         │ ---          ┆ ---                 │
         │ List[String] ┆ Map[String: UInt64] │
         ╞══════════════╪═════════════════════╡
-        │ [a, b, a]    ┆ {"a": 2, "b": 1}    │
+        │ [a, b, a]    ┆ "a": 2              │
+        │              ┆ "b": 1              │
         ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
-        │ [b, c, b, c] ┆ {"b": 2, "c": 2}    │
+        │ [b, c, b, c] ┆ "b": 2              │
+        │              ┆ "c": 2              │
         ╰──────────────┴─────────────────────╯
         <BLANKLINE>
         (Showing first 2 of 2 rows)

--- a/daft/functions/misc.py
+++ b/daft/functions/misc.py
@@ -716,11 +716,11 @@ def map_get(expr: Expression, key: Expression) -> Expression:
         │ ---                ┆ ---   │
         │ Map[String: Int64] ┆ Int64 │
         ╞════════════════════╪═══════╡
-        │ {"a": 1}           ┆ 1     │
+        │ "a": 1             ┆ 1     │
         ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
         │ {}                 ┆ None  │
         ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
-        │ {"b": 2}           ┆ None  │
+        │ "b": 2             ┆ None  │
         ╰────────────────────┴───────╯
         <BLANKLINE>
         (Showing first 3 of 3 rows)

--- a/daft/functions/struct.py
+++ b/daft/functions/struct.py
@@ -56,17 +56,11 @@ def to_struct(*fields: Expression, **named_fields: Expression) -> Expression:
         │ ---                          │
         │ Struct[a: String, b2: Int64] │
         ╞══════════════════════════════╡
-        │ {a: a,                       │
-        │ b2: 2,                       │
-        │ }                            │
+        │ {a: a, b2: 2}                │
         ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
-        │ {a: b,                       │
-        │ b2: 4,                       │
-        │ }                            │
+        │ {a: b, b2: 4}                │
         ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
-        │ {a: c,                       │
-        │ b2: 6,                       │
-        │ }                            │
+        │ {a: c, b2: 6}                │
         ╰──────────────────────────────╯
         <BLANKLINE>
         (Showing first 3 of 3 rows)

--- a/src/daft-core/src/array/ops/cast.rs
+++ b/src/daft-core/src/array/ops/cast.rs
@@ -68,6 +68,13 @@ where
     pub fn cast(&self, dtype: &DataType) -> DaftResult<Series> {
         if self.data_type().is_null() || dtype.is_null() {
             return Ok(Series::full_null(self.name(), dtype, self.len()));
+        } else if dtype.is_uuid() {
+            let physical_series = self.cast(&DataType::FixedSizeBinary(16))?;
+            let physical = physical_series.fixed_size_binary()?;
+            return Ok(
+                UuidArray::new(Field::new(self.name(), DataType::Uuid), physical.clone())
+                    .into_series(),
+            );
         }
 
         match dtype {

--- a/src/daft-core/src/array/ops/list_agg.rs
+++ b/src/daft-core/src/array/ops/list_agg.rs
@@ -28,11 +28,19 @@ macro_rules! impl_daft_list_agg {
             for g in groups {
                 offsets.push(offsets.last().unwrap() + g.len() as i64);
             }
+            eprintln!(
+                "offsets memory usage: {} bytes",
+                offsets.len() * std::mem::size_of::<i64>()
+            );
 
             let idxs = groups
                 .iter()
                 .flat_map(|g| g.iter().copied())
                 .collect::<Vec<_>>();
+            eprintln!(
+                "idxs memory usage: {} bytes",
+                idxs.len() * std::mem::size_of::<u64>()
+            );
             let child_series = self.take(&UInt64Array::from_vec("", idxs))?;
             let list_field = self.field().to_list_field();
 

--- a/src/daft-core/src/array/ops/list_agg.rs
+++ b/src/daft-core/src/array/ops/list_agg.rs
@@ -4,11 +4,9 @@ use super::{DaftListAggable, GroupIndices};
 #[cfg(feature = "python")]
 use crate::prelude::PythonArray;
 use crate::{
-    array::{
-        DataArray, FixedSizeListArray, ListArray, StructArray,
-        growable::{Growable, GrowableArray},
-    },
+    array::{DataArray, FixedSizeListArray, ListArray, StructArray},
     datatypes::DaftArrowBackedType,
+    prelude::UInt64Array,
     series::IntoSeries,
 };
 
@@ -26,32 +24,21 @@ macro_rules! impl_daft_list_agg {
 
         fn grouped_list(&self, groups: &GroupIndices) -> Self::Output {
             let mut offsets = Vec::with_capacity(groups.len() + 1);
-
             offsets.push(0);
             for g in groups {
                 offsets.push(offsets.last().unwrap() + g.len() as i64);
             }
 
-            let total_capacity = *offsets.last().unwrap();
-
-            let mut growable: Box<dyn Growable> = Box::new(Self::make_growable(
-                self.name(),
-                self.data_type(),
-                vec![self],
-                self.null_count() > 0,
-                total_capacity as usize,
-            ));
-
-            for g in groups {
-                for idx in g {
-                    growable.extend(0, *idx as usize, 1);
-                }
-            }
+            let idxs = groups
+                .iter()
+                .flat_map(|g| g.iter().copied())
+                .collect::<Vec<_>>();
+            let child_series = self.take(&UInt64Array::from_vec("", idxs))?;
             let list_field = self.field().to_list_field();
 
             Ok(ListArray::new(
                 list_field,
-                growable.build()?,
+                child_series.into_series(),
                 arrow::buffer::OffsetBuffer::new(offsets.into()),
                 None,
             ))
@@ -63,7 +50,6 @@ impl<T> DaftListAggable for DataArray<T>
 where
     T: DaftArrowBackedType,
     Self: IntoSeries,
-    Self: GrowableArray,
 {
     impl_daft_list_agg!();
 }

--- a/src/daft-core/src/array/ops/repr.rs
+++ b/src/daft-core/src/array/ops/repr.rs
@@ -1,5 +1,6 @@
 use common_display::table_display::StrValue;
 use common_error::DaftResult;
+use itertools::Itertools as _;
 
 #[cfg(feature = "python")]
 use crate::prelude::PythonArray;
@@ -456,14 +457,9 @@ impl StructArray {
                     let fields_to_strs = fields
                         .iter()
                         .zip(self.children.iter())
-                        .map(|(f, s)| Ok(format!("{}: {}, ", f.name.as_ref(), s.str_value(idx))))
-                        .collect::<DaftResult<Vec<_>>>()?;
-                    let mut result = "{".to_string();
-                    for line in fields_to_strs {
-                        result += &line;
-                    }
-                    result += "}";
-                    Ok(result)
+                        .map(|(f, s)| format!("{}: {}", f.name.as_ref(), s.str_value(idx)))
+                        .join(", ");
+                    Ok(format!("{{{fields_to_strs}}}"))
                 }
                 dt => unreachable!("StructArray must have Struct dtype, but found: {}", dt),
             }

--- a/src/daft-core/src/array/ops/repr.rs
+++ b/src/daft-core/src/array/ops/repr.rs
@@ -299,7 +299,7 @@ impl MapArray {
                         format!("{}: {}", key_str, values.str_value(i))
                     })
                     .collect();
-                Ok(format!("{{{}}}", pairs.join(", ")))
+                Ok(pairs.join("\n"))
             }
         }
     }
@@ -456,7 +456,7 @@ impl StructArray {
                     let fields_to_strs = fields
                         .iter()
                         .zip(self.children.iter())
-                        .map(|(f, s)| Ok(format!("{}: {},\n", f.name.as_ref(), s.str_value(idx))))
+                        .map(|(f, s)| Ok(format!("{}: {}, ", f.name.as_ref(), s.str_value(idx))))
                         .collect::<DaftResult<Vec<_>>>()?;
                     let mut result = "{".to_string();
                     for line in fields_to_strs {

--- a/src/daft-distributed/src/pipeline_node/mod.rs
+++ b/src/daft-distributed/src/pipeline_node/mod.rs
@@ -479,7 +479,7 @@ impl TaskBuilderStream {
         materialize_all_pipeline_outputs(stream, scheduler_handle, None)
     }
 
-    pub fn task_outputs(
+    pub fn submit_to_scheduler(
         self,
         scheduler_handle: SchedulerHandle<SwordfishTask>,
         query_idx: QueryIdx,

--- a/src/daft-distributed/src/pipeline_node/random_shuffle.rs
+++ b/src/daft-distributed/src/pipeline_node/random_shuffle.rs
@@ -115,7 +115,7 @@ impl RandomShuffleNode {
     ) -> DaftResult<()> {
         let num_partitions = self.child.config().clustering_spec.num_partitions();
         let outputs = input_node
-            .task_outputs(
+            .submit_to_scheduler(
                 scheduler_handle.clone(),
                 self.context.query_idx,
                 task_id_counter.clone(),

--- a/src/daft-distributed/src/pipeline_node/shuffles/repartition.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/repartition.rs
@@ -38,11 +38,18 @@ pub(crate) struct RepartitionNode {
 }
 
 impl RepartitionNode {
-    fn node_name(repartition_spec: &RepartitionSpec, backend: &DistributedShuffleBackend) -> String {
-        format!("{} Repartition ({})", repartition_spec.var_name(), match backend {
-            DistributedShuffleBackend::Ray => "Ray",
-            DistributedShuffleBackend::Flight(_) => "Flight",
-        })
+    fn node_name(
+        repartition_spec: &RepartitionSpec,
+        backend: &DistributedShuffleBackend,
+    ) -> String {
+        format!(
+            "{} Repartition ({})",
+            repartition_spec.var_name(),
+            match backend {
+                DistributedShuffleBackend::Ray => "Ray",
+                DistributedShuffleBackend::Flight(_) => "Flight",
+            }
+        )
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -173,10 +180,13 @@ impl PipelineNodeImpl for RepartitionNode {
     }
 
     fn multiline_display(&self, _verbose: bool) -> Vec<String> {
-        let backend_name = Self::node_name(&self.repartition_spec, &self.shuffle_backend.backend());
+        let backend_name = Self::node_name(&self.repartition_spec, self.shuffle_backend.backend());
         let mut res = vec![format!("{}:", backend_name)];
         res.extend(self.repartition_spec.multiline_display());
-        res.push(format!("Actual Num Partitions = {}", self.shuffle_backend.num_partitions()));
+        res.push(format!(
+            "Actual Num Partitions = {}",
+            self.shuffle_backend.num_partitions()
+        ));
         res
     }
 }

--- a/src/daft-distributed/src/pipeline_node/shuffles/repartition.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/repartition.rs
@@ -38,7 +38,12 @@ pub(crate) struct RepartitionNode {
 }
 
 impl RepartitionNode {
-    const NODE_NAME: &'static str = "Repartition";
+    fn node_name(repartition_spec: &RepartitionSpec, backend: &DistributedShuffleBackend) -> String {
+        format!("{} Repartition ({})", repartition_spec.var_name(), match backend {
+            DistributedShuffleBackend::Ray => "Ray",
+            DistributedShuffleBackend::Flight(_) => "Flight",
+        })
+    }
 
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -54,7 +59,7 @@ impl RepartitionNode {
             plan_config.query_idx,
             plan_config.query_id.clone(),
             node_id,
-            Arc::from(Self::NODE_NAME),
+            Arc::from(Self::node_name(&repartition_spec, &backend)),
             NodeType::Repartition,
             NodeCategory::BlockingSink,
         );
@@ -83,7 +88,7 @@ impl RepartitionNode {
         scheduler_handle: SchedulerHandle<SwordfishTask>,
     ) -> DaftResult<()> {
         let outputs = local_shuffle_write_node
-            .task_outputs(
+            .submit_to_scheduler(
                 scheduler_handle.clone(),
                 self.context.query_idx,
                 task_id_counter,
@@ -168,15 +173,10 @@ impl PipelineNodeImpl for RepartitionNode {
     }
 
     fn multiline_display(&self, _verbose: bool) -> Vec<String> {
-        let backend_name = match self.shuffle_backend.backend() {
-            DistributedShuffleBackend::Ray => "RayShuffle",
-            DistributedShuffleBackend::Flight(_) => "FlightShuffle",
-        };
-        let mut res = vec![format!(
-            "{backend_name}: {}",
-            self.repartition_spec.var_name()
-        )];
+        let backend_name = Self::node_name(&self.repartition_spec, &self.shuffle_backend.backend());
+        let mut res = vec![format!("{}:", backend_name)];
         res.extend(self.repartition_spec.multiline_display());
+        res.push(format!("Actual Num Partitions = {}", self.shuffle_backend.num_partitions()));
         res
     }
 }

--- a/src/daft-functions-list/src/min.rs
+++ b/src/daft-functions-list/src/min.rs
@@ -34,7 +34,10 @@ impl ScalarUDF for ListMin {
         ensure!(inputs.len() == 1, SchemaMismatch: "Expected 1 input arg, got {}", inputs.len());
         let input = inputs.required((0, "input"))?;
         let field = input.to_field(schema)?.to_exploded_field()?;
-        ensure!(field.dtype.is_numeric() || field.dtype.is_boolean(), TypeError: "Expected input to be numeric or boolean, got {}", field.dtype);
+        ensure!(
+            field.dtype.is_numeric() || field.dtype.is_boolean() || field.dtype.is_uuid(),
+            TypeError: "Expected input to be numeric, boolean, or uuid, got {}", field.dtype
+        );
         Ok(field)
     }
 }

--- a/src/daft-groupby/src/arrays.rs
+++ b/src/daft-groupby/src/arrays.rs
@@ -66,6 +66,19 @@ where
         group_indices.push(group_index);
     }
 
+    eprintln!(
+        "sample_indices memory usage: {} bytes",
+        sample_indices.len() * std::mem::size_of::<u64>()
+    );
+
+    let mut contents = group_indices.len() * std::mem::size_of::<VecIndices>();
+    for group in &group_indices {
+        if group.spilled() {
+            contents += group.len() * std::mem::size_of::<u64>();
+        }
+    }
+    eprintln!("group_indices memory usage: {} bytes", contents);
+
     Ok((sample_indices, group_indices))
 }
 

--- a/src/daft-local-execution/src/sinks/grouped_aggregate.rs
+++ b/src/daft-local-execution/src/sinks/grouped_aggregate.rs
@@ -286,7 +286,11 @@ impl GroupedAggregateSink {
             // the data by the group keys and then run the original MapGroups
             // aggregation once per partition in `finalize`.
             Some(AggStrategy::PartitionOnly)
-        } else if partial_agg_exprs.is_empty() && !final_agg_exprs.is_empty() {
+        } else if aggregations.len() == 1
+            && matches!(aggregations[0].as_ref(), daft_dsl::AggExpr::List { .. })
+        {
+            // Optimization: Use partition-only for list-aggregations cause
+            // pre-agging doesn't help much since we're not reducing data
             Some(AggStrategy::PartitionOnly)
         } else {
             None

--- a/src/daft-local-execution/src/sinks/grouped_aggregate.rs
+++ b/src/daft-local-execution/src/sinks/grouped_aggregate.rs
@@ -413,7 +413,17 @@ impl BlockingSink for GroupedAggregateSink {
     }
 
     fn name(&self) -> NodeName {
-        "GroupedAggregate".into()
+        if self.grouped_aggregate_params.original_aggregations.len() == 1 {
+            format!(
+                "GroupBy-{}",
+                self.grouped_aggregate_params.original_aggregations[0]
+                    .as_ref()
+                    .agg_name()
+            )
+            .into()
+        } else {
+            "GroupBy-Agg".into()
+        }
     }
 
     fn op_type(&self) -> NodeType {
@@ -422,18 +432,19 @@ impl BlockingSink for GroupedAggregateSink {
 
     fn multiline_display(&self) -> Vec<String> {
         let mut display = vec![];
+        display.push("GroupBy Aggregate:".to_string());
         display.push(format!(
-            "GroupedAggregate: {}",
+            "Group By: {}",
             self.grouped_aggregate_params
-                .original_aggregations
+                .group_by
                 .iter()
                 .map(|e| e.to_string())
                 .join(", ")
         ));
         display.push(format!(
-            "Group by: {}",
+            "Aggregations: {}",
             self.grouped_aggregate_params
-                .group_by
+                .original_aggregations
                 .iter()
                 .map(|e| e.to_string())
                 .join(", ")

--- a/src/daft-local-plan/src/results.rs
+++ b/src/daft-local-plan/src/results.rs
@@ -96,7 +96,8 @@ impl ExecutionStats {
             types.append_value(node_info.node_type.to_string());
             categories.append_value(node_info.node_category.to_string());
             duration_values.append_value((stat_snapshot.duration_us() / 1000) as i64);
-            for (name, value) in stat_snapshot.to_stats() {
+            // Assume that the first value is the duration
+            for (name, value) in stat_snapshot.to_stats().into_iter().skip(1) {
                 stats.keys().append_value(name);
                 let values = stats.values();
                 let (value, unit) = value.into_f64_and_unit();

--- a/src/daft-logical-plan/src/ops/distinct.rs
+++ b/src/daft-logical-plan/src/ops/distinct.rs
@@ -41,17 +41,24 @@ impl Distinct {
     }
 
     pub(crate) fn with_materialized_stats(mut self) -> Self {
+        // Assume high cardinality, 90% of the values are distinct in every column.
+        const APPROX_COLUMN_NDV_SELECTIVITY: f64 = 0.8;
+        let num_columns = if let Some(columns) = &self.columns {
+            columns.len()
+        } else {
+            self.input.schema().len()
+        };
+        let approx_column_ndv = 1.0 - (1.0 - APPROX_COLUMN_NDV_SELECTIVITY) * (num_columns as f64);
+
         // TODO(desmond): We can simply use NDVs here. For now, do a naive estimation.
         let input_stats = self.input.materialized_stats();
         let est_bytes_per_row =
             input_stats.approx_stats.size_bytes / (input_stats.approx_stats.num_rows.max(1));
-        // Assume high cardinality, 80% of rows are distinct.
-        let est_distinct_values = input_stats.approx_stats.num_rows * 4 / 5;
+        let est_distinct_values = ((input_stats.approx_stats.num_rows as f64) * approx_column_ndv) as usize;
         let acc_selectivity = if input_stats.approx_stats.num_rows == 0 {
             0.0
         } else {
-            input_stats.approx_stats.acc_selectivity * est_distinct_values as f64
-                / input_stats.approx_stats.num_rows as f64
+            input_stats.approx_stats.acc_selectivity * approx_column_ndv
         };
         let approx_stats = ApproxStats {
             num_rows: est_distinct_values,

--- a/src/daft-logical-plan/src/ops/distinct.rs
+++ b/src/daft-logical-plan/src/ops/distinct.rs
@@ -48,13 +48,15 @@ impl Distinct {
         } else {
             self.input.schema().len()
         };
-        let approx_column_ndv = 1.0 - (1.0 - APPROX_COLUMN_NDV_SELECTIVITY) * (num_columns as f64);
+        let approx_column_ndv =
+            (1.0 - APPROX_COLUMN_NDV_SELECTIVITY).mul_add(-(num_columns as f64), 1.0);
 
         // TODO(desmond): We can simply use NDVs here. For now, do a naive estimation.
         let input_stats = self.input.materialized_stats();
         let est_bytes_per_row =
             input_stats.approx_stats.size_bytes / (input_stats.approx_stats.num_rows.max(1));
-        let est_distinct_values = ((input_stats.approx_stats.num_rows as f64) * approx_column_ndv) as usize;
+        let est_distinct_values =
+            ((input_stats.approx_stats.num_rows as f64) * approx_column_ndv) as usize;
         let acc_selectivity = if input_stats.approx_stats.num_rows == 0 {
             0.0
         } else {

--- a/src/daft-logical-plan/src/partitioning.rs
+++ b/src/daft-logical-plan/src/partitioning.rs
@@ -80,11 +80,11 @@ impl HashRepartitionConfig {
 
     pub fn multiline_display(&self) -> Vec<String> {
         let mut res = vec![];
-        res.push(format!("Num partitions = {:?}", self.num_partitions));
         res.push(format!(
             "By = {}",
             self.by.iter().map(|e| e.to_string()).join(", ")
         ));
+        res.push(format!("Num partitions = {:?}", self.num_partitions));
         res
     }
 }

--- a/src/daft-logical-plan/src/stats.rs
+++ b/src/daft-logical-plan/src/stats.rs
@@ -48,7 +48,7 @@ impl Display for PlanStats {
         use num_format::{Locale, ToFormattedString};
         write!(
             f,
-            "{{ Approx num rows = {}, Approx size bytes = {}, Accumulated selectivity = {:.2} }}",
+            "~{} rows out, ~{} out, Accumulated selectivity = {:.2}",
             self.approx_stats.num_rows.to_formatted_string(&Locale::en),
             bytes_to_human_readable(self.approx_stats.size_bytes),
             self.approx_stats.acc_selectivity,

--- a/src/daft-shuffles/src/shuffle_cache.rs
+++ b/src/daft-shuffles/src/shuffle_cache.rs
@@ -167,10 +167,7 @@ impl InProgressShuffleCache {
             return Err(DaftError::InternalError(error.clone()));
         }
 
-        let writer_senders = state
-            .writer_senders
-            .take()
-            .expect("writer_senders should be present");
+        let writer_senders = std::mem::take(&mut state.writer_senders);
         let writer_tasks = std::mem::take(&mut state.writer_tasks);
 
         // Close the writer tasks
@@ -218,11 +215,13 @@ impl InProgressShuffleCache {
     }
 
     async fn close_internal(
-        writer_senders: Vec<async_channel::Sender<MicroPartition>>,
+        writer_senders: Option<Vec<async_channel::Sender<MicroPartition>>>,
         writer_tasks: Vec<WriterTask>,
     ) -> DaftResult<Vec<WriterTaskResult>> {
         // Drop the writer senders so that the writer tasks can exit
-        drop(writer_senders);
+        if let Some(writer_senders) = writer_senders {
+            drop(writer_senders);
+        }
 
         // Wait for the writer tasks to exit
         let results = futures::future::try_join_all(writer_tasks)

--- a/src/daft-shuffles/src/shuffle_cache.rs
+++ b/src/daft-shuffles/src/shuffle_cache.rs
@@ -167,7 +167,10 @@ impl InProgressShuffleCache {
             return Err(DaftError::InternalError(error.clone()));
         }
 
-        let writer_senders = std::mem::take(&mut state.writer_senders);
+        let writer_senders = state
+            .writer_senders
+            .take()
+            .expect("writer_senders should be present");
         let writer_tasks = std::mem::take(&mut state.writer_tasks);
 
         // Close the writer tasks
@@ -215,13 +218,11 @@ impl InProgressShuffleCache {
     }
 
     async fn close_internal(
-        writer_senders: Option<Vec<async_channel::Sender<MicroPartition>>>,
+        writer_senders: Vec<async_channel::Sender<MicroPartition>>,
         writer_tasks: Vec<WriterTask>,
     ) -> DaftResult<Vec<WriterTaskResult>> {
         // Drop the writer senders so that the writer tasks can exit
-        if let Some(writer_senders) = writer_senders {
-            drop(writer_senders);
-        }
+        drop(writer_senders);
 
         // Wait for the writer tasks to exit
         let results = futures::future::try_join_all(writer_tasks)

--- a/tests/test_size_estimations.py
+++ b/tests/test_size_estimations.py
@@ -160,9 +160,9 @@ def test_canonical_files_in_s3(path):
 @pytest.mark.parametrize(
     "inflation_factor,expected_size_bytes",
     [
-        (1.0, "Approx size bytes = 174.70 K"),
-        (2.0, "Approx size bytes = 349.40 K"),
-        (3.0, "Approx size bytes = 524.11 K"),
+        (1.0, "~174.70 K"),
+        (2.0, "~349.40 K"),
+        (3.0, "~524.11 K"),
     ],
 )
 def test_csv_config_affects_estimations(tmpdir, inflation_factor, expected_size_bytes):
@@ -194,9 +194,9 @@ def test_csv_config_affects_estimations(tmpdir, inflation_factor, expected_size_
 @pytest.mark.parametrize(
     "inflation_factor,expected_size_bytes",
     [
-        (1.0, "Approx size bytes = 272.35 K"),
-        (2.0, "Approx size bytes = 544.71 K"),
-        (3.0, "Approx size bytes = 817.06 K"),
+        (1.0, "~272.35 K"),
+        (2.0, "~544.71 K"),
+        (3.0, "~817.06 K"),
     ],
 )
 def test_json_config_affects_estimations(tmpdir, inflation_factor, expected_size_bytes):


### PR DESCRIPTION
## Changes Made

A collection of mini changes I made while profiling dedupe:

* Filtered out non-WARC files from Common Crawl
* Added casting from primitives to UUID
* Cleaned up the formatting for map columns to look more like a list of key-value pairs
* Cleaned up the naming for some operators (Repartition, GroupBy)
* Modified the approximate stats for distinct to scale with # of columns. Was trying some sort of adaptive approach, but that fell through. This part was still useful though