### PR TITLE
chore(parquet): lower opt-level for daft-parquet release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,6 +151,11 @@ inherits = "release"
 lto = 'thin'
 strip = "none"  # dont strip
 
+# LLVM's SLP vectorizer takes 75+ min on this crate at opt-level=3.
+# opt-level=2 disables it, bringing compile time down to ~15s.
+[profile.release.package.daft-parquet]
+opt-level = 2
+
 [profile.release-lto]
 codegen-units = 1
 inherits = "release"


### PR DESCRIPTION
LLVM's SLP vectorizer exhibits pathological super-linear compile time on daft-parquet. At `opt-level=3` (the release default), compiling daft-parquet alone takes **75+ minutes** pegged at 100% CPU on a single core - and still doesn't finish.

Passing `-C no-vectorize-slp` to rustc confirmed SLP vectorization as the root cause, dropping compile time to 15.6s. Since Cargo's per-package profile overrides don't support `rustflags`, the fix sets `opt-level=2` for daft-parquet specifically, which disables the SLP pass.

| Configuration | daft-parquet compile time |
|---|---|
| O3 (default) | **75+ min** (killed, still running) |
| O3 + `-C no-vectorize-slp` | 15.6s |
| O3 + `codegen-units=256` | 19.2s |
| **O2 (this PR)** | **15.0s** |

daft-parquet is I/O orchestration code that delegates compute-heavy work to the `arrow` and `parquet` crates, so disabling SLP vectorization here should have little runtime impact.