### PR TITLE
fix: preserve identity partition predicates when combined with ScalarFn siblings during predicate pushdown

### DIFF
--- a/src/daft-scan/src/expr_rewriter.rs
+++ b/src/daft-scan/src/expr_rewriter.rs
@@ -139,6 +139,15 @@ pub fn rewrite_predicate_for_partitioning(
             needs_filter_op_preds.push(e.clone());
         } else if all_data_keys || all_part_keys && any_non_identity_part_keys {
             data_preds.push(e.clone());
+        } else if all_part_keys {
+            // Pure partition-column predicates with identity transforms: these will be
+            // extracted as partition-only filters in the second phase below, but we must
+            // also keep them in `data_preds` so they survive Filter-node reconstruction
+            // when other sibling predicates land in `needing_filter_op` (e.g. predicates
+            // containing ScalarFn). Without this, a subsequent optimizer pass would
+            // re-derive partition filters from the rebuilt Filter node and lose these
+            // predicates.
+            data_preds.push(e.clone());
         }
     }
     if pfields.is_empty() {

--- a/tests/io/test_partition_filter_pushdown.py
+++ b/tests/io/test_partition_filter_pushdown.py
@@ -278,3 +278,102 @@ def test_year_gt_is_relaxed_to_gteq():
     assert pushdowns.partition_filters is not None, "Expected a partition filter to be pushed down"
     result = extract_comparison(pushdowns.partition_filters)
     assert result["op"] == "greater_than_or_equal", f"Year Gt must be relaxed to GtEq, got op={result['op']}"
+
+
+# ---------------------------------------------------------------------------
+# Identity partition predicates must survive when combined with ScalarFn predicates
+# ---------------------------------------------------------------------------
+
+
+def _build_df_and_capture_multi_col(
+    columns: list[tuple[str, DataType]],
+    partition_fields: list[PartitionField],
+    filter_expr,
+) -> Pushdowns:
+    """Build a DataFrame with multiple columns, apply filter_expr, collect, and return captured pushdowns."""
+    source_schema = Schema._from_field_name_and_types(columns)
+    source = _CapturePushdownsDataSource(source_schema, partition_fields)
+    df = source.read().filter(filter_expr)
+    df.collect()
+    assert len(source.captured_pushdowns) == 1, "Expected exactly one call to get_tasks"
+    return source.captured_pushdowns[0]
+
+
+def _collect_ops(tree: dict, ops: list[str] | None = None) -> list[str]:
+    """Recursively collect all comparison operator names from an extracted predicate tree."""
+    if ops is None:
+        ops = []
+    op = tree.get("op")
+    if op in ("and", "or"):
+        _collect_ops(tree["left"], ops)
+        _collect_ops(tree["right"], ops)
+    elif op is not None:
+        ops.append(op)
+    return ops
+
+
+def test_identity_partition_pred_preserved_with_scalar_fn_sibling():
+    """Regression: identity partition predicates must not be dropped when a sibling predicate contains a ScalarFn.
+
+    Before the fix, `source_col < '5' AND source_col > cast(abs(1) as string)` would
+    only push down the ScalarFn predicate as a partition filter, losing the simple
+    `source_col < '5'` predicate entirely.
+    """
+    pfield = _make_identity_partition_field("source_col", "source_col", DataType.string())
+    pushdowns = _build_df_and_capture_multi_col(
+        columns=[("source_col", DataType.string()), ("user_id", DataType.int32())],
+        partition_fields=[pfield],
+        filter_expr="source_col < '5' and source_col > cast(abs(1) as string)",
+    )
+
+    assert pushdowns.partition_filters is not None, "Expected partition filters to be pushed down, but got None"
+    result = extract_comparison(pushdowns.partition_filters)
+    ops = _collect_ops(result)
+    assert len(ops) >= 2, f"Expected at least 2 comparison predicates in partition_filters, got {len(ops)}: {result}"
+
+
+def test_two_identity_lit_predicates_both_pushed_down():
+    """Two simple literal comparisons on an identity-partitioned column must both appear in partition_filters."""
+    pfield = _make_identity_partition_field("source_col", "source_col", DataType.string())
+    pushdowns = _build_df_and_capture_multi_col(
+        columns=[("source_col", DataType.string())],
+        partition_fields=[pfield],
+        filter_expr=(col("source_col") < lit("5")) & (col("source_col") > lit("1")),
+    )
+
+    assert pushdowns.partition_filters is not None, "Expected partition filters to be pushed down, but got None"
+    result = extract_comparison(pushdowns.partition_filters)
+    assert result["op"] == "and", f"Expected top-level 'and', got: {result['op']}"
+    ops = _collect_ops(result)
+    assert "less_than" in ops, f"Expected 'less_than' in partition filters, got ops: {ops}"
+    assert "greater_than" in ops, f"Expected 'greater_than' in partition filters, got ops: {ops}"
+
+
+def test_identity_pred_with_cast_sibling_both_pushed_down():
+    """An identity partition predicate combined with a cast-containing predicate must both survive."""
+    pfield = _make_identity_partition_field("source_col", "source_col", DataType.string())
+    pushdowns = _build_df_and_capture_multi_col(
+        columns=[("source_col", DataType.string())],
+        partition_fields=[pfield],
+        filter_expr="source_col < '5' and source_col > cast(1 as string)",
+    )
+
+    assert pushdowns.partition_filters is not None, "Expected partition filters to be pushed down, but got None"
+    result = extract_comparison(pushdowns.partition_filters)
+    ops = _collect_ops(result)
+    assert len(ops) >= 2, f"Expected at least 2 comparison predicates in partition_filters, got {len(ops)}: {result}"
+
+
+def test_identity_pred_with_scalar_fn_both_directions():
+    """Swapped order: ScalarFn predicate first, then simple lit predicate must both appear."""
+    pfield = _make_identity_partition_field("source_col", "source_col", DataType.string())
+    pushdowns = _build_df_and_capture_multi_col(
+        columns=[("source_col", DataType.string()), ("user_id", DataType.int32())],
+        partition_fields=[pfield],
+        filter_expr="source_col > cast(abs(1) as string) and source_col < '5'",
+    )
+
+    assert pushdowns.partition_filters is not None, "Expected partition filters to be pushed down, but got None"
+    result = extract_comparison(pushdowns.partition_filters)
+    ops = _collect_ops(result)
+    assert len(ops) >= 2, f"Expected at least 2 comparison predicates in partition_filters, got {len(ops)}: {result}"

--- a/tests/io/test_partition_filter_pushdown.py
+++ b/tests/io/test_partition_filter_pushdown.py
@@ -164,13 +164,12 @@ def _make_year_partition_field(partition_col: str, source_col: str) -> Partition
 
 
 def _build_df_and_capture(
-    source_col: str,
-    dtype: DataType,
+    columns: list[tuple[str, DataType]],
     partition_fields: list[PartitionField],
     filter_expr,
 ) -> Pushdowns:
     """Build a DataFrame via DataSource.read(), apply filter_expr, collect, and return captured pushdowns."""
-    source_schema = Schema._from_field_name_and_types([(source_col, dtype)])
+    source_schema = Schema._from_field_name_and_types(columns)
     source = _CapturePushdownsDataSource(source_schema, partition_fields)
     df = source.read().filter(filter_expr)
     df.collect()
@@ -187,8 +186,7 @@ def test_identity_lt_is_not_relaxed_to_lteq():
     """source_col < 5 with Identity transform -> partition_filter must be `p_col < 5`, not `p_col <= 5`."""
     pfield = _make_identity_partition_field("p_col", "source_col", DataType.int32())
     pushdowns = _build_df_and_capture(
-        source_col="source_col",
-        dtype=DataType.int32(),
+        columns=[("source_col", DataType.int32())],
         partition_fields=[pfield],
         filter_expr=col("source_col") < lit(5),
     )
@@ -203,8 +201,7 @@ def test_identity_gt_is_not_relaxed_to_gteq():
     """source_col > 5 with Identity transform -> partition_filter must be `p_col > 5`, not `p_col >= 5`."""
     pfield = _make_identity_partition_field("p_col", "source_col", DataType.int32())
     pushdowns = _build_df_and_capture(
-        source_col="source_col",
-        dtype=DataType.int32(),
+        columns=[("source_col", DataType.int32())],
         partition_fields=[pfield],
         filter_expr=col("source_col") > lit(5),
     )
@@ -219,8 +216,7 @@ def test_identity_lteq_stays_lteq():
     """source_col <= 5 with Identity transform -> partition_filter must be `p_col <= 5` (already inclusive)."""
     pfield = _make_identity_partition_field("p_col", "source_col", DataType.int32())
     pushdowns = _build_df_and_capture(
-        source_col="source_col",
-        dtype=DataType.int32(),
+        columns=[("source_col", DataType.int32())],
         partition_fields=[pfield],
         filter_expr=col("source_col") <= lit(5),
     )
@@ -234,8 +230,7 @@ def test_identity_gteq_stays_gteq():
     """source_col >= 5 with Identity transform -> partition_filter must be `p_col >= 5` (already inclusive)."""
     pfield = _make_identity_partition_field("p_col", "source_col", DataType.int32())
     pushdowns = _build_df_and_capture(
-        source_col="source_col",
-        dtype=DataType.int32(),
+        columns=[("source_col", DataType.int32())],
         partition_fields=[pfield],
         filter_expr=col("source_col") >= lit(5),
     )
@@ -254,8 +249,7 @@ def test_year_lt_is_relaxed_to_lteq():
     """ts_col < value with Year transform -> partition_filter must be `p_year <= value` (relaxed)."""
     pfield = _make_year_partition_field("p_year", "ts_col")
     pushdowns = _build_df_and_capture(
-        source_col="ts_col",
-        dtype=DataType.timestamp(timeunit=TimeUnit.from_str("us")),
+        columns=[("ts_col", DataType.timestamp(timeunit=TimeUnit.from_str("us")))],
         partition_fields=[pfield],
         filter_expr=col("ts_col") < lit("2024-01-01").cast(DataType.timestamp(timeunit=TimeUnit.from_str("us"))),
     )
@@ -269,8 +263,7 @@ def test_year_gt_is_relaxed_to_gteq():
     """ts_col > value with Year transform -> partition_filter must be `p_year >= value` (relaxed)."""
     pfield = _make_year_partition_field("p_year", "ts_col")
     pushdowns = _build_df_and_capture(
-        source_col="ts_col",
-        dtype=DataType.timestamp(timeunit=TimeUnit.from_str("us")),
+        columns=[("ts_col", DataType.timestamp(timeunit=TimeUnit.from_str("us")))],
         partition_fields=[pfield],
         filter_expr=col("ts_col") > lit("2024-01-01").cast(DataType.timestamp(timeunit=TimeUnit.from_str("us"))),
     )
@@ -285,18 +278,9 @@ def test_year_gt_is_relaxed_to_gteq():
 # ---------------------------------------------------------------------------
 
 
-def _build_df_and_capture_multi_col(
-    columns: list[tuple[str, DataType]],
-    partition_fields: list[PartitionField],
-    filter_expr,
-) -> Pushdowns:
-    """Build a DataFrame with multiple columns, apply filter_expr, collect, and return captured pushdowns."""
-    source_schema = Schema._from_field_name_and_types(columns)
-    source = _CapturePushdownsDataSource(source_schema, partition_fields)
-    df = source.read().filter(filter_expr)
-    df.collect()
-    assert len(source.captured_pushdowns) == 1, "Expected exactly one call to get_tasks"
-    return source.captured_pushdowns[0]
+_COMPARISON_OPS = frozenset(
+    ["less_than", "less_than_or_equal", "greater_than", "greater_than_or_equal", "equal", "not_equal"]
+)
 
 
 def _collect_ops(tree: dict, ops: list[str] | None = None) -> list[str]:
@@ -307,7 +291,7 @@ def _collect_ops(tree: dict, ops: list[str] | None = None) -> list[str]:
     if op in ("and", "or"):
         _collect_ops(tree["left"], ops)
         _collect_ops(tree["right"], ops)
-    elif op is not None:
+    elif op in _COMPARISON_OPS:
         ops.append(op)
     return ops
 
@@ -320,7 +304,7 @@ def test_identity_partition_pred_preserved_with_scalar_fn_sibling():
     `source_col < '5'` predicate entirely.
     """
     pfield = _make_identity_partition_field("source_col", "source_col", DataType.string())
-    pushdowns = _build_df_and_capture_multi_col(
+    pushdowns = _build_df_and_capture(
         columns=[("source_col", DataType.string()), ("user_id", DataType.int32())],
         partition_fields=[pfield],
         filter_expr="source_col < '5' and source_col > cast(abs(1) as string)",
@@ -335,7 +319,7 @@ def test_identity_partition_pred_preserved_with_scalar_fn_sibling():
 def test_two_identity_lit_predicates_both_pushed_down():
     """Two simple literal comparisons on an identity-partitioned column must both appear in partition_filters."""
     pfield = _make_identity_partition_field("source_col", "source_col", DataType.string())
-    pushdowns = _build_df_and_capture_multi_col(
+    pushdowns = _build_df_and_capture(
         columns=[("source_col", DataType.string())],
         partition_fields=[pfield],
         filter_expr=(col("source_col") < lit("5")) & (col("source_col") > lit("1")),
@@ -352,7 +336,7 @@ def test_two_identity_lit_predicates_both_pushed_down():
 def test_identity_pred_with_cast_sibling_both_pushed_down():
     """An identity partition predicate combined with a cast-containing predicate must both survive."""
     pfield = _make_identity_partition_field("source_col", "source_col", DataType.string())
-    pushdowns = _build_df_and_capture_multi_col(
+    pushdowns = _build_df_and_capture(
         columns=[("source_col", DataType.string())],
         partition_fields=[pfield],
         filter_expr="source_col < '5' and source_col > cast(1 as string)",
@@ -367,7 +351,7 @@ def test_identity_pred_with_cast_sibling_both_pushed_down():
 def test_identity_pred_with_scalar_fn_both_directions():
     """Swapped order: ScalarFn predicate first, then simple lit predicate must both appear."""
     pfield = _make_identity_partition_field("source_col", "source_col", DataType.string())
-    pushdowns = _build_df_and_capture_multi_col(
+    pushdowns = _build_df_and_capture(
         columns=[("source_col", DataType.string()), ("user_id", DataType.int32())],
         partition_fields=[pfield],
         filter_expr="source_col > cast(abs(1) as string) and source_col < '5'",


### PR DESCRIPTION

## Changes Made

### Problem

When a filter expression combines **identity-partitioned column predicates** (e.g. `source_col < '5'`) with **ScalarFn-containing predicates** (e.g. `source_col > cast(abs(1) as string)`), the simple identity partition predicate was silently dropped during predicate pushdown rewriting.

**Root cause**: In `rewrite_predicate_for_partitioning` (`src/daft-scan/src/expr_rewriter.rs`), the classification logic had three branches:

1. ScalarFn or mixed-key predicates → `needs_filter_op_preds`
2. All data keys, or all partition keys with non-identity transforms → `data_preds`
3. *(implicit fall-through)* — pure identity partition predicates were not pushed to any vec

When a ScalarFn sibling predicate landed in `needs_filter_op_preds`, the optimizer would reconstruct the Filter node from `data_preds` only. Since the pure identity partition predicate was never added to `data_preds`, it was lost entirely — the subsequent optimizer pass could not re-derive it from the rebuilt Filter node.

### Fix

Added an explicit `else if all_part_keys` branch that pushes pure identity-partition predicates into `data_preds`, ensuring they survive Filter-node reconstruction regardless of what sibling predicates do.

```rust
} else if all_part_keys {
    // Pure partition-column predicates with identity transforms: these will be
    // extracted as partition-only filters in the second phase below, but we must
    // also keep them in `data_preds` so they survive Filter-node reconstruction
    // when other sibling predicates land in `needing_filter_op` (e.g. predicates
    // containing ScalarFn).
    data_preds.push(e.clone());
}
```

### Tests

Added 4 regression tests in `tests/io/test_partition_filter_pushdown.py`:

| Test | Scenario |
|------|----------|
| `test_identity_partition_pred_preserved_with_scalar_fn_sibling` | Identity pred + `cast(abs(...))` ScalarFn pred — both must be pushed down |
| `test_two_identity_lit_predicates_both_pushed_down` | Two simple literal comparisons on identity-partitioned column |
| `test_identity_pred_with_cast_sibling_both_pushed_down` | Identity pred + `cast(...)` pred combination |
| `test_identity_pred_with_scalar_fn_both_directions` | Swapped order (ScalarFn first, then simple pred) to verify order-independence |

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
None