### PR TITLE
feat: support read formatted json document

### DIFF
--- a/src/daft-json/src/read.rs
+++ b/src/daft-json/src/read.rs
@@ -527,6 +527,22 @@ async fn read_json_single_into_stream(
                 .context(super::JoinSnafu {});
             Ok((Box::pin(once(async move { Ok(inner) })), schema))
         }
+        b'{' if buf.len() > 1 && matches!(buf[1], b'\n' | b'\r') => {
+            let schema_clone = schema.clone();
+            let inner: Context<JoinHandle<Result<RecordBatch, DaftError>>, JoinSnafu, _> =
+                tokio::spawn(async move {
+                    let (send, recv) = tokio::sync::oneshot::channel();
+                    let mut buf = Vec::new();
+                    reader.read_to_end(&mut buf).await?;
+                    let daft_schema = Schema::try_from(schema_clone)?;
+                    let chunk = read_json_array_impl(&buf, daft_schema, None);
+                    let _ = send.send(chunk);
+
+                    recv.await.context(super::OneShotRecvSnafu {})?
+                })
+                .context(super::JoinSnafu {});
+            Ok((Box::pin(once(async move { Ok(inner) })), schema))
+        }
         b'{' => {
             let read_stream =
                 read_into_line_chunk_stream(reader, convert_options.limit, chunk_size);

--- a/src/daft-json/src/schema.rs
+++ b/src/daft-json/src/schema.rs
@@ -134,7 +134,6 @@ pub(crate) async fn read_json_schema_single(
         None => reader,
     };
 
-    // Defer skip-empty handling to infer_schema to avoid duplicate fill_buf.
     let arrow_schema =
         infer_schema(reader, None, max_bytes, parse_options.skip_empty_files).await?;
     let schema: Schema = arrow_schema.try_into()?;
@@ -150,8 +149,6 @@ async fn infer_schema<R>(
 where
     R: tokio::io::AsyncBufRead + Unpin + Send,
 {
-    let max_records = max_rows.unwrap_or(usize::MAX);
-    let mut total_bytes = 0;
     use tokio::io::AsyncReadExt;
     let buf = reader.fill_buf().await?;
 
@@ -179,7 +176,21 @@ where
             let inferred_schema = infer_records_schema(&parsed_record).context(ArrowSnafu);
             Ok(inferred_schema?)
         }
+        b'{' if buf.len() > 1 && matches!(buf[1], b'\n' | b'\r') => {
+            let mut buf = Vec::new();
+            reader.read_to_end(&mut buf).await?;
+
+            let parsed_record = crate::deserializer::to_value(&mut buf).map_err(|e| {
+                super::Error::JsonDeserializationError {
+                    string: e.to_string(),
+                }
+            })?;
+            let inferred_schema = infer_records_schema(&parsed_record).context(ArrowSnafu);
+            Ok(inferred_schema?)
+        }
         b'{' => {
+            let max_records = max_rows.unwrap_or(usize::MAX);
+            let mut total_bytes = 0;
             let max_bytes = max_bytes.unwrap_or(usize::MAX);
 
             // Stream of unparsed JSON string records.
@@ -479,6 +490,32 @@ mod tests {
                 Field::new("petalWidth", DataType::Float64),
                 Field::new("species", DataType::Utf8),
             ])
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_json_schema_local_formatted_json() -> DaftResult<()> {
+        let file = format!(
+            "{}/test/iris_tiny_formatted.json",
+            env!("CARGO_MANIFEST_DIR"),
+        );
+
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
+        let io_client = Arc::new(IOClient::new(io_config.into())?);
+
+        let schema = read_json_schema(file.as_ref(), None, None, io_client, None).await?;
+        assert_eq!(
+            schema,
+            Schema::new(vec![
+                Field::new("sepalLength", DataType::Float64),
+                Field::new("sepalWidth", DataType::Float64),
+                Field::new("petalLength", DataType::Float64),
+                Field::new("petalWidth", DataType::Float64),
+                Field::new("species", DataType::Utf8),
+            ]),
         );
 
         Ok(())

--- a/src/daft-json/test/iris_tiny_formatted.json
+++ b/src/daft-json/test/iris_tiny_formatted.json
@@ -1,0 +1,7 @@
+{
+  "sepalLength": 5.1,
+  "sepalWidth": 3.5,
+  "petalLength": 1.4,
+  "petalWidth": 0.2,
+  "species": "setosa"
+}

--- a/tests/io/test_json.py
+++ b/tests/io/test_json.py
@@ -93,3 +93,31 @@ def test_read_json_sparse_column_with_schema_hints(tmp_path):
     res = df_with_hint.where(daft.col("sound").not_null()).collect()
     assert len(res) == 1
     assert res.to_pydict()["sound"][0] == "hello"
+
+
+def test_read_formatted_json_document(tmp_path):
+    f = tmp_path / "record.json"
+    f.write_text('{\n  "a": 1,\n  "b": "hello"\n}\n', encoding="utf-8")
+
+    df = daft.read_json(str(f))
+    result = df.collect().to_pydict()
+    assert result == {"a": [1], "b": ["hello"]}
+
+
+def test_read_formatted_json_document_multiple_files(tmp_path):
+    for i in range(3):
+        f = tmp_path / f"record_{i}.json"
+        f.write_text(f'{{\n  "a": {i},\n  "b": "val_{i}"\n}}\n', encoding="utf-8")
+
+    df = daft.read_json(str(tmp_path))
+    result = df.collect()
+    assert result.count_rows() == 3
+
+
+def test_read_jsonl_dot_json_extension_still_works(tmp_path):
+    f = tmp_path / "data.json"
+    f.write_text('{"a": 1, "b": "x"}\n{"a": 2, "b": "y"}\n', encoding="utf-8")
+
+    df = daft.read_json(str(f))
+    result = df.collect().to_pydict()
+    assert result == {"a": [1, 2], "b": ["x", "y"]}


### PR DESCRIPTION
## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

Support reading formatted (pretty-printed) JSON files.


Problem:
The `daft.read_json() `API fails to parse JSON files that are formatted with indentation and line breaks (e.g., pretty-printed JSON).

Example of a failing JSON file:
```
{
  "sepalLength": 5.1,
  "sepalWidth": 3.5,
  "petalLength": 1.4,
  "petalWidth": 0.2,
  "species": "setosa"
}
```

Error message:
`DaftCoreException: DaftError::External JSON deserialization error: Syntax at character 0 ('{')
`

Expected behavior:
Daft should successfully read both minified and formatted JSON files.



## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

