### PR TITLE
feat: better native execution for asof joins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3070,6 +3070,7 @@ dependencies = [
  "dashmap",
  "futures",
  "pyo3",
+ "rayon",
  "snafu",
  "tokio",
  "tracing",

--- a/src/daft-micropartition/Cargo.toml
+++ b/src/daft-micropartition/Cargo.toml
@@ -18,6 +18,7 @@ daft-warc = {path = "../daft-warc", default-features = false}
 dashmap = {workspace = true}
 futures = {workspace = true}
 pyo3 = {workspace = true, optional = true}
+rayon = {workspace = true}
 snafu = {workspace = true}
 tokio = {workspace = true}
 tracing = {workspace = true}

--- a/src/daft-micropartition/src/ops/join.rs
+++ b/src/daft-micropartition/src/ops/join.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use common_error::DaftResult;
 use daft_core::{
     array::ops::DaftCompare,
@@ -8,8 +10,9 @@ use daft_dsl::{
     expr::bound_expr::BoundExpr,
     join::{get_right_cols_to_drop, infer_asof_join_schema, infer_join_schema},
 };
-use daft_recordbatch::RecordBatch;
+use daft_recordbatch::{RecordBatch, build_left_to_right_map};
 use daft_stats::TruthValue;
+use rayon::prelude::*;
 
 use crate::micropartition::MicroPartition;
 
@@ -151,12 +154,30 @@ impl MicroPartition {
             None => RecordBatch::empty(Some(right.schema())),
         };
 
-        let joined_table = RecordBatch::asof_join(&lt, &rt, left_by, right_by, left_on, right_on)?;
-        Ok(Self::new_loaded(
-            join_schema,
-            vec![joined_table].into(),
-            None,
-        ))
+        if left_by.is_empty() {
+            let joined = RecordBatch::asof_join(&lt, &rt, right_by, left_on, right_on)?;
+            return Ok(Self::new_loaded(join_schema, Arc::new(vec![joined]), None));
+        }
+
+        let (left_groups, left_keys) = lt.partition_by_value(left_by)?;
+        let (right_groups, right_keys) = rt.partition_by_value(right_by)?;
+
+        let left_to_right = build_left_to_right_map(&left_keys, &right_keys)?;
+
+        let empty_right = RecordBatch::empty(Some(rt.schema));
+        let batches = left_groups
+            .par_iter()
+            .enumerate()
+            .map(|(i, left_group)| {
+                let right_group = match left_to_right[i] {
+                    Some(r_idx) => &right_groups[r_idx],
+                    None => &empty_right,
+                };
+                RecordBatch::asof_join(left_group, right_group, right_by, left_on, right_on)
+            })
+            .collect::<DaftResult<Vec<_>>>()?;
+
+        Ok(Self::new_loaded(join_schema, Arc::new(batches), None))
     }
 
     pub fn cross_join(&self, right: &Self, outer_loop_side: JoinSide) -> DaftResult<Self> {

--- a/src/daft-micropartition/src/ops/join.rs
+++ b/src/daft-micropartition/src/ops/join.rs
@@ -155,7 +155,7 @@ impl MicroPartition {
         };
 
         if left_by.is_empty() {
-            let joined = RecordBatch::asof_join(&lt, &rt, right_by, left_on, right_on)?;
+            let joined = RecordBatch::asof_join(&lt, &rt, &right_cols_to_drop, left_on, right_on)?;
             return Ok(Self::new_loaded(join_schema, Arc::new(vec![joined]), None));
         }
 
@@ -173,7 +173,13 @@ impl MicroPartition {
                     Some(r_idx) => &right_groups[r_idx],
                     None => &empty_right,
                 };
-                RecordBatch::asof_join(left_group, right_group, right_by, left_on, right_on)
+                RecordBatch::asof_join(
+                    left_group,
+                    right_group,
+                    &right_cols_to_drop,
+                    left_on,
+                    right_on,
+                )
             })
             .collect::<DaftResult<Vec<_>>>()?;
 

--- a/src/daft-recordbatch/src/lib.rs
+++ b/src/daft-recordbatch/src/lib.rs
@@ -47,7 +47,7 @@ mod probeable;
 mod repr_html;
 
 pub use growable::GrowableRecordBatch;
-pub use ops::{get_column_by_name, get_columns_by_name};
+pub use ops::{build_left_to_right_map, get_column_by_name, get_columns_by_name};
 pub use probeable::{ProbeState, Probeable, ProbeableBuilder, make_probeable_builder};
 
 #[cfg(feature = "python")]

--- a/src/daft-recordbatch/src/ops/joins/mod.rs
+++ b/src/daft-recordbatch/src/ops/joins/mod.rs
@@ -2,7 +2,10 @@ use std::{collections::HashSet, sync::Arc};
 
 use common_error::{DaftError, DaftResult};
 use daft_core::{
-    array::growable::make_growable, join::JoinSide, prelude::*, utils::supertype::try_get_supertype,
+    array::{growable::make_growable, ops::arrow::comparison::build_multi_array_is_equal},
+    join::JoinSide,
+    prelude::*,
+    utils::supertype::try_get_supertype,
 };
 use daft_dsl::{
     Expr,
@@ -81,51 +84,15 @@ impl RecordBatch {
     pub fn asof_join(
         &self,
         right: &Self,
-        left_by: &[BoundExpr],
         right_by: &[BoundExpr],
         left_on: &BoundExpr,
         right_on: &BoundExpr,
     ) -> DaftResult<Self> {
-        if left_by.len() != right_by.len() {
-            return Err(DaftError::ValueError(format!(
-                "Mismatch of asof by clauses: left: {:?} vs right: {:?}",
-                left_by.len(),
-                right_by.len()
-            )));
-        }
+        let left = self.sort(std::slice::from_ref(left_on), &[false], &[false])?;
+        let right = right.sort(std::slice::from_ref(right_on), &[false], &[false])?;
 
-        let left_sort_keys = left_by
-            .iter()
-            .cloned()
-            .chain(std::iter::once(left_on.clone()))
-            .collect::<Vec<_>>();
-        let right_sort_keys = right_by
-            .iter()
-            .cloned()
-            .chain(std::iter::once(right_on.clone()))
-            .collect::<Vec<_>>();
-
-        let left = self.sort(
-            left_sort_keys.as_slice(),
-            std::iter::repeat_n(false, left_sort_keys.len())
-                .collect::<Vec<_>>()
-                .as_slice(),
-            std::iter::repeat_n(false, left_sort_keys.len())
-                .collect::<Vec<_>>()
-                .as_slice(),
-        )?;
-        let right = right.sort(
-            right_sort_keys.as_slice(),
-            std::iter::repeat_n(false, right_sort_keys.len())
-                .collect::<Vec<_>>()
-                .as_slice(),
-            std::iter::repeat_n(false, right_sort_keys.len())
-                .collect::<Vec<_>>()
-                .as_slice(),
-        )?;
-
-        let left_key_table = left.eval_expression_list(left_sort_keys.as_slice())?;
-        let right_key_table = right.eval_expression_list(right_sort_keys.as_slice())?;
+        let left_key_table = left.eval_expression_list(std::slice::from_ref(left_on))?;
+        let right_key_table = right.eval_expression_list(std::slice::from_ref(right_on))?;
         let (left_key_table, right_key_table) =
             match_types_for_tables(&left_key_table, &right_key_table)?;
         let (lidx, ridx) = asof_join::asof_join_backward(&left_key_table, &right_key_table)?;
@@ -319,6 +286,51 @@ impl RecordBatch {
 
         Self::new_with_size(join_schema, join_columns, num_rows)
     }
+}
+
+pub fn build_left_to_right_map(
+    left_keys: &RecordBatch,
+    right_keys: &RecordBatch,
+) -> DaftResult<Vec<Option<usize>>> {
+    let n_left = left_keys.len();
+    if n_left == 0 {
+        return Ok(vec![]);
+    }
+    if right_keys.is_empty() {
+        return Ok(vec![None; n_left]);
+    }
+
+    let (left_keys, right_keys) = match_types_for_tables(left_keys, right_keys)?;
+
+    let probe_table = left_keys.to_probe_hash_table()?;
+    let r_hashes = right_keys.hash_rows()?;
+
+    let lcols: Vec<Series> = left_keys
+        .as_materialized_series()
+        .into_iter()
+        .cloned()
+        .collect();
+    let rcols: Vec<Series> = right_keys
+        .as_materialized_series()
+        .into_iter()
+        .cloned()
+        .collect();
+    let n_cols = lcols.len();
+
+    let is_equal =
+        build_multi_array_is_equal(&lcols, &rcols, &vec![false; n_cols], &vec![false; n_cols])?;
+
+    let mut left_to_right = vec![None; n_left];
+    for (r_idx, h) in r_hashes.values().iter().enumerate() {
+        if let Some((_, indices)) = probe_table.raw_entry().from_hash(*h, |other| {
+            *h == other.hash && is_equal(other.idx as usize, r_idx)
+        }) && let Some(&l_idx) = indices.first()
+        {
+            left_to_right[l_idx as usize] = Some(r_idx);
+        }
+    }
+
+    Ok(left_to_right)
 }
 
 #[deprecated(since = "TBD", note = "name-referenced columns")]

--- a/src/daft-recordbatch/src/ops/joins/mod.rs
+++ b/src/daft-recordbatch/src/ops/joins/mod.rs
@@ -288,6 +288,9 @@ impl RecordBatch {
     }
 }
 
+/// Builds a mapping from each left key index to its matching right key index.
+///
+/// Both `left_keys` and `right_keys` must contain **unique** rows (no duplicate key values).
 pub fn build_left_to_right_map(
     left_keys: &RecordBatch,
     right_keys: &RecordBatch,

--- a/src/daft-recordbatch/src/ops/joins/mod.rs
+++ b/src/daft-recordbatch/src/ops/joins/mod.rs
@@ -8,11 +8,8 @@ use daft_core::{
     utils::supertype::try_get_supertype,
 };
 use daft_dsl::{
-    Expr,
     expr::bound_expr::BoundExpr,
-    join::{
-        get_common_join_cols, get_right_cols_to_drop, infer_asof_join_schema, infer_join_schema,
-    },
+    join::{get_common_join_cols, infer_asof_join_schema, infer_join_schema},
 };
 use hash_join::hash_semi_anti_join;
 
@@ -84,7 +81,7 @@ impl RecordBatch {
     pub fn asof_join(
         &self,
         right: &Self,
-        right_by: &[BoundExpr],
+        right_cols_to_drop: &HashSet<String>,
         left_on: &BoundExpr,
         right_on: &BoundExpr,
     ) -> DaftResult<Self> {
@@ -97,13 +94,7 @@ impl RecordBatch {
             match_types_for_tables(&left_key_table, &right_key_table)?;
         let (lidx, ridx) = asof_join::asof_join_backward(&left_key_table, &right_key_table)?;
 
-        let right_cols_to_drop = get_right_cols_to_drop(right_by, left_on, right_on, |e| {
-            match e.inner().unwrap_alias().0.as_ref() {
-                Expr::Column(_) => Some(e.inner().unwrap_alias().0.name().to_string()),
-                _ => None,
-            }
-        });
-        let join_schema = infer_asof_join_schema(&left.schema, &right.schema, &right_cols_to_drop)?;
+        let join_schema = infer_asof_join_schema(&left.schema, &right.schema, right_cols_to_drop)?;
 
         let num_rows = lidx.len();
         let mut join_series = Vec::with_capacity(join_schema.len());

--- a/src/daft-recordbatch/src/ops/mod.rs
+++ b/src/daft-recordbatch/src/ops/mod.rs
@@ -13,4 +13,4 @@ mod unpivot;
 mod window;
 mod window_states;
 
-pub use joins::{get_column_by_name, get_columns_by_name};
+pub use joins::{build_left_to_right_map, get_column_by_name, get_columns_by_name};


### PR DESCRIPTION
instead of the original approach where we sort by the "by" + "on" keys, we now partition by the "by" keys first, then only sort by the "on" keys

```
Original === SUMMARY ===
system       scale    status   med_time_s  med_peak_gb
------------------------------------------------------
daft_native  small    ok             3.88         1.01

=== SUMMARY ===
system       scale    status   med_time_s  med_peak_gb
------------------------------------------------------
daft_native  medium   ok            60.79         9.87

After Hashing
=== SUMMARY ===
system       scale    status   med_time_s  med_peak_gb
------------------------------------------------------
daft_native  small    ok             0.61         0.97

=== SUMMARY ===
system       scale    status   med_time_s  med_peak_gb
------------------------------------------------------
daft_native  medium   ok             8.39        10.33
```

My implementation of the second optimization, which involves binary search instead of the two pointer approach, can be included in this PR / merged in after this one gets merged. 

With Binary Search
```
=== SUMMARY ===
system       scale    status   med_time_s  med_peak_gb
------------------------------------------------------
daft_native  small    ok             0.64         1.06

=== SUMMARY ===
system       scale    status   med_time_s  med_peak_gb
------------------------------------------------------
daft_native  medium   ok             8.17        10.38

```