### PR TITLE
feat: remote EventLogSubscriber

### DIFF
--- a/daft/runners/flotilla.py
+++ b/daft/runners/flotilla.py
@@ -122,13 +122,20 @@ class RaySwordfishActor:
     It is a stateless, async actor, and can run multiple plans concurrently and is able to retry itself and it's tasks.
     """
 
-    def __init__(self, num_cpus: int, num_gpus: int, is_head: bool = False) -> None:
+    def __init__(
+        self,
+        num_cpus: int,
+        num_gpus: int,
+        is_head: bool = False,
+        event_log_dir: str | None = None,
+    ) -> None:
         os.environ["DAFT_FLOTILLA_WORKER"] = "1"  # TODO: Remove once fixed DashboardSubscriber
 
-        _attach_event_log_subscriber_if_configured(
-            component="swordfish_worker",
-            node_role="head" if is_head else "worker",
-        )
+        if event_log_dir:
+            _attach_remote_event_log_subscriber(
+                component="swordfish_worker",
+                node_role="head" if is_head else "worker",
+            )
 
         if num_gpus > 0:
             os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(str(i) for i in range(num_gpus))
@@ -403,14 +410,13 @@ def _get_worker_startup_timeout() -> int:
     return get_context().daft_execution_config.worker_startup_timeout
 
 
-def _attach_event_log_subscriber_if_configured(component: str, node_role: str) -> None:
-    """Attach a RemoteEventLogSubscriber to this process's context if the sink is reachable.
+def _attach_remote_event_log_subscriber(component: str, node_role: str) -> None:
+    """Attach a RemoteEventLogSubscriber to this process's context.
 
-    No-op unless ``DAFT_EVENT_LOG_DIR`` is set and the sink actor exists. Any
-    failure is swallowed so event-log setup cannot break actor initialization.
+    Looks up the per-job event log sink actor and wires a subscriber that
+    ships events to it. No-op if the sink does not exist. Failures are logged
+    (not raised) so event-log setup cannot break actor initialization.
     """
-    if not os.environ.get("DAFT_EVENT_LOG_DIR"):
-        return
     try:
         sink = get_sink(_get_ray_job_id_for_actor_naming())
         if sink is None:
@@ -419,11 +425,12 @@ def _attach_event_log_subscriber_if_configured(component: str, node_role: str) -
             "_daft_event_log_remote",
             RemoteEventLogSubscriber(sink, component=component, node_role=node_role),
         )
-    except Exception:
-        pass
+    except Exception as e:
+        logger.warning("Failed to attach remote event log subscriber: %s", e)
 
 
 def start_ray_workers(existing_worker_ids: list[str]) -> list[RaySwordfishWorker]:
+    event_log_dir = os.environ.get("DAFT_EVENT_LOG_DIR")
     actors = []
     for node in ray.nodes():
         if (
@@ -434,6 +441,8 @@ def start_ray_workers(existing_worker_ids: list[str]) -> list[RaySwordfishWorker
             and node["Resources"]["memory"] > 0
             and node["NodeID"] not in existing_worker_ids
         ):
+            # `node:__internal_head__` is Ray's internal resource key tagging the head node;
+            # not in public Ray docs but stable and relied on by Ray's own autoscaler/GCS code.
             is_head = node["Resources"].get("node:__internal_head__", 0) == 1
             actor = RaySwordfishActor.options(  # type: ignore
                 scheduling_strategy=ray.util.scheduling_strategies.NodeAffinitySchedulingStrategy(
@@ -444,6 +453,7 @@ def start_ray_workers(existing_worker_ids: list[str]) -> list[RaySwordfishWorker
                 num_cpus=int(node["Resources"]["CPU"]),
                 num_gpus=int(node["Resources"].get("GPU", 0)),
                 is_head=is_head,
+                event_log_dir=event_log_dir,
             )
             actors.append((node, actor))
 
@@ -484,7 +494,11 @@ def try_autoscale(bundles: list[dict[str, int]]) -> None:
 
 @ray.remote(num_cpus=0)
 class RemoteFlotillaRunner:
-    def __init__(self, dashboard_url: str | None = None) -> None:
+    def __init__(
+        self,
+        dashboard_url: str | None = None,
+        event_log_dir: str | None = None,
+    ) -> None:
         if dashboard_url:
             os.environ["DAFT_DASHBOARD_URL"] = dashboard_url
             try:
@@ -496,10 +510,11 @@ class RemoteFlotillaRunner:
             except Exception:
                 pass
 
-        _attach_event_log_subscriber_if_configured(
-            component="flotilla_runner",
-            node_role="head",
-        )
+        if event_log_dir:
+            _attach_remote_event_log_subscriber(
+                component="flotilla_runner",
+                node_role="head",
+            )
 
         self.curr_plans: dict[str, DistributedPhysicalPlan] = {}
         self.curr_result_gens: dict[str, AsyncIterator[RayPartitionRef]] = {}
@@ -626,8 +641,6 @@ class FlotillaRunner:
         runner_env_vars: dict[str, str] = {}
         if dashboard_url:
             runner_env_vars["DAFT_DASHBOARD_URL"] = dashboard_url
-        if event_log_dir:
-            runner_env_vars["DAFT_EVENT_LOG_DIR"] = event_log_dir
 
         self.runner = RemoteFlotillaRunner.options(  # type: ignore
             name=get_flotilla_runner_actor_name(),
@@ -642,7 +655,7 @@ class FlotillaRunner:
                 if head_node_id
                 else None
             ),
-        ).remote(dashboard_url=dashboard_url)
+        ).remote(dashboard_url=dashboard_url, event_log_dir=event_log_dir)
 
     def stream_plan(
         self,

--- a/daft/runners/flotilla.py
+++ b/daft/runners/flotilla.py
@@ -122,7 +122,7 @@ class RaySwordfishActor:
     It is a stateless, async actor, and can run multiple plans concurrently and is able to retry itself and it's tasks.
     """
 
-    def __init__(self, num_cpus: int, num_gpus: int) -> None:
+    def __init__(self, num_cpus: int, num_gpus: int, is_head: bool = False) -> None:
         os.environ["DAFT_FLOTILLA_WORKER"] = "1"  # TODO: Remove once fixed DashboardSubscriber
 
         if os.environ.get("DAFT_EVENT_LOG_DIR"):
@@ -130,7 +130,11 @@ class RaySwordfishActor:
             if sink is not None:
                 get_context().attach_subscriber(
                     "_daft_event_log_remote",
-                    RemoteEventLogSubscriber(sink, role="worker"),
+                    RemoteEventLogSubscriber(
+                        sink,
+                        component="swordfish_worker",
+                        node_role="head" if is_head else "worker",
+                    ),
                 )
 
         if num_gpus > 0:
@@ -417,6 +421,7 @@ def start_ray_workers(existing_worker_ids: list[str]) -> list[RaySwordfishWorker
             and node["Resources"]["memory"] > 0
             and node["NodeID"] not in existing_worker_ids
         ):
+            is_head = node["Resources"].get("node:__internal_head__", 0) == 1
             actor = RaySwordfishActor.options(  # type: ignore
                 scheduling_strategy=ray.util.scheduling_strategies.NodeAffinitySchedulingStrategy(
                     node_id=node["NodeID"],
@@ -425,6 +430,7 @@ def start_ray_workers(existing_worker_ids: list[str]) -> list[RaySwordfishWorker
             ).remote(
                 num_cpus=int(node["Resources"]["CPU"]),
                 num_gpus=int(node["Resources"].get("GPU", 0)),
+                is_head=is_head,
             )
             actors.append((node, actor))
 
@@ -476,6 +482,18 @@ class RemoteFlotillaRunner:
                 pass
             except Exception:
                 pass
+
+        if os.environ.get("DAFT_EVENT_LOG_DIR"):
+            sink = get_sink(_get_ray_job_id_for_actor_naming())
+            if sink is not None:
+                get_context().attach_subscriber(
+                    "_daft_event_log_remote",
+                    RemoteEventLogSubscriber(
+                        sink,
+                        component="flotilla_runner",
+                        node_role="head",
+                    ),
+                )
 
         self.curr_plans: dict[str, DistributedPhysicalPlan] = {}
         self.curr_result_gens: dict[str, AsyncIterator[RayPartitionRef]] = {}
@@ -599,11 +617,17 @@ class FlotillaRunner:
             create_or_get_sink(event_log_dir, sink_job_id, head_node_id)
             atexit.register(teardown_sink, sink_job_id)
 
+        runner_env_vars: dict[str, str] = {}
+        if dashboard_url:
+            runner_env_vars["DAFT_DASHBOARD_URL"] = dashboard_url
+        if event_log_dir:
+            runner_env_vars["DAFT_EVENT_LOG_DIR"] = event_log_dir
+
         self.runner = RemoteFlotillaRunner.options(  # type: ignore
             name=get_flotilla_runner_actor_name(),
             namespace=FLOTILLA_RUNNER_NAMESPACE,
             get_if_exists=True,
-            runtime_env=({"env_vars": {"DAFT_DASHBOARD_URL": dashboard_url}} if dashboard_url else None),
+            runtime_env=({"env_vars": runner_env_vars} if runner_env_vars else None),
             scheduling_strategy=(
                 ray.util.scheduling_strategies.NodeAffinitySchedulingStrategy(
                     node_id=head_node_id,

--- a/daft/runners/flotilla.py
+++ b/daft/runners/flotilla.py
@@ -33,6 +33,7 @@ from daft.runners.partitioning import (
     PartitionSet,
 )
 from daft.runners.profiler import profile
+from daft.subscribers.event_log import enable_event_log
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, AsyncIterator, Generator
@@ -117,6 +118,11 @@ class RaySwordfishActor:
 
     def __init__(self, num_cpus: int, num_gpus: int) -> None:
         os.environ["DAFT_FLOTILLA_WORKER"] = "1"  # TODO: Remove once fixed DashboardSubscriber
+
+        event_log_dir = os.environ.get("DAFT_EVENT_LOG_DIR")
+        if event_log_dir:
+            enable_event_log(event_log_dir)
+
         if num_gpus > 0:
             os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(str(i) for i in range(num_gpus))
         # Configure the number of worker threads for swordfish, according to the number of CPUs visible to ray.

--- a/daft/runners/flotilla.py
+++ b/daft/runners/flotilla.py
@@ -125,17 +125,10 @@ class RaySwordfishActor:
     def __init__(self, num_cpus: int, num_gpus: int, is_head: bool = False) -> None:
         os.environ["DAFT_FLOTILLA_WORKER"] = "1"  # TODO: Remove once fixed DashboardSubscriber
 
-        if os.environ.get("DAFT_EVENT_LOG_DIR"):
-            sink = get_sink(_get_ray_job_id_for_actor_naming())
-            if sink is not None:
-                get_context().attach_subscriber(
-                    "_daft_event_log_remote",
-                    RemoteEventLogSubscriber(
-                        sink,
-                        component="swordfish_worker",
-                        node_role="head" if is_head else "worker",
-                    ),
-                )
+        _attach_event_log_subscriber_if_configured(
+            component="swordfish_worker",
+            node_role="head" if is_head else "worker",
+        )
 
         if num_gpus > 0:
             os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(str(i) for i in range(num_gpus))
@@ -410,6 +403,22 @@ def _get_worker_startup_timeout() -> int:
     return get_context().daft_execution_config.worker_startup_timeout
 
 
+def _attach_event_log_subscriber_if_configured(component: str, node_role: str) -> None:
+    """Attach a RemoteEventLogSubscriber to this process's context if the sink is reachable.
+
+    No-op unless ``DAFT_EVENT_LOG_DIR`` is set and the sink actor exists.
+    """
+    if not os.environ.get("DAFT_EVENT_LOG_DIR"):
+        return
+    sink = get_sink(_get_ray_job_id_for_actor_naming())
+    if sink is None:
+        return
+    get_context().attach_subscriber(
+        "_daft_event_log_remote",
+        RemoteEventLogSubscriber(sink, component=component, node_role=node_role),
+    )
+
+
 def start_ray_workers(existing_worker_ids: list[str]) -> list[RaySwordfishWorker]:
     actors = []
     for node in ray.nodes():
@@ -483,17 +492,10 @@ class RemoteFlotillaRunner:
             except Exception:
                 pass
 
-        if os.environ.get("DAFT_EVENT_LOG_DIR"):
-            sink = get_sink(_get_ray_job_id_for_actor_naming())
-            if sink is not None:
-                get_context().attach_subscriber(
-                    "_daft_event_log_remote",
-                    RemoteEventLogSubscriber(
-                        sink,
-                        component="flotilla_runner",
-                        node_role="head",
-                    ),
-                )
+        _attach_event_log_subscriber_if_configured(
+            component="flotilla_runner",
+            node_role="head",
+        )
 
         self.curr_plans: dict[str, DistributedPhysicalPlan] = {}
         self.curr_result_gens: dict[str, AsyncIterator[RayPartitionRef]] = {}

--- a/daft/runners/flotilla.py
+++ b/daft/runners/flotilla.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import atexit
 import logging
 import os
 import shutil
@@ -34,7 +35,11 @@ from daft.runners.partitioning import (
 )
 from daft.runners.profiler import profile
 from daft.subscribers.event_log import RemoteEventLogSubscriber
-from daft.subscribers.event_log_sink import create_or_get_sink, get_sink
+from daft.subscribers.event_log_sink import (
+    create_or_get_sink,
+    get_sink,
+    teardown_sink,
+)
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, AsyncIterator, Generator
@@ -590,11 +595,9 @@ class FlotillaRunner:
 
         event_log_dir = os.environ.get("DAFT_EVENT_LOG_DIR")
         if event_log_dir:
-            create_or_get_sink(
-                event_log_dir,
-                _get_ray_job_id_for_actor_naming(),
-                head_node_id,
-            )
+            sink_job_id = _get_ray_job_id_for_actor_naming()
+            create_or_get_sink(event_log_dir, sink_job_id, head_node_id)
+            atexit.register(teardown_sink, sink_job_id)
 
         self.runner = RemoteFlotillaRunner.options(  # type: ignore
             name=get_flotilla_runner_actor_name(),

--- a/daft/runners/flotilla.py
+++ b/daft/runners/flotilla.py
@@ -406,17 +406,21 @@ def _get_worker_startup_timeout() -> int:
 def _attach_event_log_subscriber_if_configured(component: str, node_role: str) -> None:
     """Attach a RemoteEventLogSubscriber to this process's context if the sink is reachable.
 
-    No-op unless ``DAFT_EVENT_LOG_DIR`` is set and the sink actor exists.
+    No-op unless ``DAFT_EVENT_LOG_DIR`` is set and the sink actor exists. Any
+    failure is swallowed so event-log setup cannot break actor initialization.
     """
     if not os.environ.get("DAFT_EVENT_LOG_DIR"):
         return
-    sink = get_sink(_get_ray_job_id_for_actor_naming())
-    if sink is None:
-        return
-    get_context().attach_subscriber(
-        "_daft_event_log_remote",
-        RemoteEventLogSubscriber(sink, component=component, node_role=node_role),
-    )
+    try:
+        sink = get_sink(_get_ray_job_id_for_actor_naming())
+        if sink is None:
+            return
+        get_context().attach_subscriber(
+            "_daft_event_log_remote",
+            RemoteEventLogSubscriber(sink, component=component, node_role=node_role),
+        )
+    except Exception:
+        pass
 
 
 def start_ray_workers(existing_worker_ids: list[str]) -> list[RaySwordfishWorker]:

--- a/daft/runners/flotilla.py
+++ b/daft/runners/flotilla.py
@@ -33,7 +33,8 @@ from daft.runners.partitioning import (
     PartitionSet,
 )
 from daft.runners.profiler import profile
-from daft.subscribers.event_log import enable_event_log
+from daft.subscribers.event_log import RemoteEventLogSubscriber
+from daft.subscribers.event_log_sink import create_or_get_sink, get_sink
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, AsyncIterator, Generator
@@ -119,9 +120,13 @@ class RaySwordfishActor:
     def __init__(self, num_cpus: int, num_gpus: int) -> None:
         os.environ["DAFT_FLOTILLA_WORKER"] = "1"  # TODO: Remove once fixed DashboardSubscriber
 
-        event_log_dir = os.environ.get("DAFT_EVENT_LOG_DIR")
-        if event_log_dir:
-            enable_event_log(event_log_dir)
+        if os.environ.get("DAFT_EVENT_LOG_DIR"):
+            sink = get_sink(_get_ray_job_id_for_actor_naming())
+            if sink is not None:
+                get_context().attach_subscriber(
+                    "_daft_event_log_remote",
+                    RemoteEventLogSubscriber(sink, role="worker"),
+                )
 
         if num_gpus > 0:
             os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(str(i) for i in range(num_gpus))
@@ -582,6 +587,15 @@ class FlotillaRunner:
     def __init__(self) -> None:
         head_node_id = get_head_node_id()
         dashboard_url = os.environ.get("DAFT_DASHBOARD_URL")
+
+        event_log_dir = os.environ.get("DAFT_EVENT_LOG_DIR")
+        if event_log_dir:
+            create_or_get_sink(
+                event_log_dir,
+                _get_ray_job_id_for_actor_naming(),
+                head_node_id,
+            )
+
         self.runner = RemoteFlotillaRunner.options(  # type: ignore
             name=get_flotilla_runner_actor_name(),
             namespace=FLOTILLA_RUNNER_NAMESPACE,

--- a/daft/subscribers/event_log.py
+++ b/daft/subscribers/event_log.py
@@ -63,7 +63,12 @@ class EventLogSubscriber(Subscriber):
     one JSON object per line with ``event``, ``ts``, and event-specific fields.
     """
 
-    def __init__(self, log_dir: str | Path, role: str = "driver") -> None:
+    def __init__(
+        self,
+        log_dir: str | Path,
+        component: str = "driver",
+        node_role: str = "head",
+    ) -> None:
         self._log_dir = Path(log_dir).expanduser().resolve()
         self._log_dir.mkdir(parents=True, exist_ok=True)
         self._closed = False
@@ -77,7 +82,8 @@ class EventLogSubscriber(Subscriber):
 
         # Per-process identity tags. Attached to every record so consumers can
         # demultiplex interleaved output from driver + workers.
-        self._role = role
+        self._component = component
+        self._node_role = node_role
         self._hostname = socket.gethostname()
         self._pid = os.getpid()
 
@@ -136,7 +142,8 @@ class EventLogSubscriber(Subscriber):
             "event": event_name,
             "timestamp": _epoch_now(),
             "query_id": query_id,
-            "role": self._role,
+            "component": self._component,
+            "node_role": self._node_role,
             "hostname": self._hostname,
             "pid": self._pid,
         }
@@ -295,14 +302,15 @@ class EventLogSubscriber(Subscriber):
 
 
 class RemoteEventLogSubscriber(EventLogSubscriber):
-    """Event log subscriber that ships records to a centralized Ray actor sink
+    """Event log subscriber that ships records to a centralized Ray actor sink.
+
     instead of writing to a local file.
 
     Used on flotilla workers (and optionally the driver) to aggregate events
     from every process into a single per-query JSONL file on the head node.
     """
 
-    def __init__(self, sink_actor: Any, role: str) -> None:
+    def __init__(self, sink_actor: Any, component: str, node_role: str) -> None:
         # Intentionally bypass parent __init__ — this subscriber never touches
         # the local filesystem, so there is no log_dir to create.
         self._log_dir = None  # type: ignore[assignment]
@@ -312,7 +320,8 @@ class RemoteEventLogSubscriber(EventLogSubscriber):
         self._optimization_starts = {}
         self._exec_starts = {}
         self._operator_starts = {}
-        self._role = role
+        self._component = component
+        self._node_role = node_role
         self._hostname = socket.gethostname()
         self._pid = os.getpid()
         self._sink = sink_actor

--- a/daft/subscribers/event_log.py
+++ b/daft/subscribers/event_log.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 import atexit
 import json
+import logging
 import os
+import queue
 import socket
+import threading
 import time
 from datetime import timedelta
 from pathlib import Path
@@ -35,9 +38,13 @@ from daft.subscribers.abc import Subscriber
 if TYPE_CHECKING:
     from daft.daft import QueryEndState
 
+logger = logging.getLogger(__name__)
+
 _EVENT_LOG_ALIAS = "_daft_event_log"
 _DEFAULT_EVENT_LOG_DIR = Path("~/.daft/events").expanduser()
 _EVENT_LOG_ATEXIT_REGISTERED = False
+
+_REMOTE_DRAIN_TIMEOUT_SEC = 30.0
 
 
 def _json_default(obj: object) -> object:
@@ -66,14 +73,14 @@ class EventLogSubscriber(Subscriber):
     def __init__(
         self,
         log_dir: str | Path,
-        component: str = "driver",
-        node_role: str = "head",
+        component: str | None = None,
+        node_role: str | None = None,
     ) -> None:
         self._log_dir = Path(log_dir).expanduser().resolve()
         self._log_dir.mkdir(parents=True, exist_ok=True)
         self._init_subscriber_state(component=component, node_role=node_role)
 
-    def _init_subscriber_state(self, component: str, node_role: str) -> None:
+    def _init_subscriber_state(self, component: str | None, node_role: str | None) -> None:
         """Initialize all non-log-dir state shared by this class and subclasses."""
         self._closed = False
         self._query_files: dict[str, TextIOWrapper] = {}
@@ -84,8 +91,9 @@ class EventLogSubscriber(Subscriber):
         self._exec_starts: dict[str, float] = {}
         self._operator_starts: dict[tuple[str, int], float] = {}
 
-        # Per-process identity tags. Attached to every record so consumers can
-        # demultiplex interleaved output from driver + workers.
+        # Per-process identity tags. Only meaningful in distributed setups —
+        # when provided, attached to every record so consumers can demultiplex
+        # interleaved output from driver + workers.
         self._component = component
         self._node_role = node_role
         self._hostname = socket.gethostname()
@@ -146,11 +154,13 @@ class EventLogSubscriber(Subscriber):
             "event": event_name,
             "timestamp": _epoch_now(),
             "query_id": query_id,
-            "component": self._component,
-            "node_role": self._node_role,
             "hostname": self._hostname,
             "pid": self._pid,
         }
+        if self._component is not None:
+            record["component"] = self._component
+        if self._node_role is not None:
+            record["node_role"] = self._node_role
         record.update(payload)
         self._emit_record(query_id, record)
 
@@ -312,25 +322,52 @@ class RemoteEventLogSubscriber(EventLogSubscriber):
 
     Used on flotilla workers (and optionally the driver) to aggregate events
     from every process into a single per-query JSONL file on the head node.
+
+    The Subscriber framework is blocking/synchronous; this class offloads all
+    remote calls to a background thread via an unbounded queue so logging
+    never stalls query execution.
     """
 
-    def __init__(self, sink_actor: Any, component: str, node_role: str) -> None:
+    def __init__(
+        self,
+        sink_actor: Any,
+        component: str | None = None,
+        node_role: str | None = None,
+    ) -> None:
         # Skip parent __init__ — no log_dir to create — but reuse the shared
         # state init so future fields added there apply here automatically.
         self._log_dir = None  # type: ignore[assignment]
         self._init_subscriber_state(component=component, node_role=node_role)
         self._sink = sink_actor
+        self._queue: queue.Queue[dict[str, Any] | None] = queue.Queue()
+        self._worker = threading.Thread(
+            target=self._drain_loop,
+            name="daft-event-log-remote",
+            daemon=True,
+        )
+        self._worker.start()
 
     def _emit_record(self, query_id: str, record: dict[str, Any]) -> None:
         if self._closed:
             return
-        try:
-            self._sink.append.remote(record)
-        except Exception:
-            pass  # sink unreachable; drop event rather than failing the query
+        self._queue.put(record)
+
+    def _drain_loop(self) -> None:
+        while True:
+            record = self._queue.get()
+            if record is None:
+                return
+            try:
+                self._sink.append.remote(record)
+            except Exception as e:
+                logger.warning("RemoteEventLogSubscriber: failed to ship record: %s", e)
 
     def close(self) -> None:
+        if self._closed:
+            return
         self._closed = True
+        self._queue.put(None)
+        self._worker.join(timeout=_REMOTE_DRAIN_TIMEOUT_SEC)
 
 
 def query_state_str(state: QueryEndState) -> str:

--- a/daft/subscribers/event_log.py
+++ b/daft/subscribers/event_log.py
@@ -71,6 +71,10 @@ class EventLogSubscriber(Subscriber):
     ) -> None:
         self._log_dir = Path(log_dir).expanduser().resolve()
         self._log_dir.mkdir(parents=True, exist_ok=True)
+        self._init_subscriber_state(component=component, node_role=node_role)
+
+    def _init_subscriber_state(self, component: str, node_role: str) -> None:
+        """Initialize all non-log-dir state shared by this class and subclasses."""
         self._closed = False
         self._query_files: dict[str, TextIOWrapper] = {}
 
@@ -311,19 +315,10 @@ class RemoteEventLogSubscriber(EventLogSubscriber):
     """
 
     def __init__(self, sink_actor: Any, component: str, node_role: str) -> None:
-        # Intentionally bypass parent __init__ — this subscriber never touches
-        # the local filesystem, so there is no log_dir to create.
+        # Skip parent __init__ — no log_dir to create — but reuse the shared
+        # state init so future fields added there apply here automatically.
         self._log_dir = None  # type: ignore[assignment]
-        self._closed = False
-        self._query_files = {}
-        self._query_starts = {}
-        self._optimization_starts = {}
-        self._exec_starts = {}
-        self._operator_starts = {}
-        self._component = component
-        self._node_role = node_role
-        self._hostname = socket.gethostname()
-        self._pid = os.getpid()
+        self._init_subscriber_state(component=component, node_role=node_role)
         self._sink = sink_actor
 
     def _emit_record(self, query_id: str, record: dict[str, Any]) -> None:

--- a/daft/subscribers/event_log.py
+++ b/daft/subscribers/event_log.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import atexit
 import json
+import os
+import socket
 import time
 from datetime import timedelta
 from pathlib import Path
@@ -61,7 +63,7 @@ class EventLogSubscriber(Subscriber):
     one JSON object per line with ``event``, ``ts``, and event-specific fields.
     """
 
-    def __init__(self, log_dir: str | Path) -> None:
+    def __init__(self, log_dir: str | Path, role: str = "driver") -> None:
         self._log_dir = Path(log_dir).expanduser().resolve()
         self._log_dir.mkdir(parents=True, exist_ok=True)
         self._closed = False
@@ -72,6 +74,12 @@ class EventLogSubscriber(Subscriber):
         self._optimization_starts: dict[str, float] = {}
         self._exec_starts: dict[str, float] = {}
         self._operator_starts: dict[tuple[str, int], float] = {}
+
+        # Per-process identity tags. Attached to every record so consumers can
+        # demultiplex interleaved output from driver + workers.
+        self._role = role
+        self._hostname = socket.gethostname()
+        self._pid = os.getpid()
 
     def _clear_query_state(self, query_id: str) -> None:
         """Remove any leftover timing state for the given query."""
@@ -124,15 +132,22 @@ class EventLogSubscriber(Subscriber):
         )
 
     def _write_event(self, query_id: str, event_name: str, payload: dict[str, Any]) -> None:
-        query_file = self._get_query_file(query_id)
-        if query_file is None:
-            return
         record: dict[str, Any] = {
             "event": event_name,
             "timestamp": _epoch_now(),
             "query_id": query_id,
+            "role": self._role,
+            "hostname": self._hostname,
+            "pid": self._pid,
         }
         record.update(payload)
+        self._emit_record(query_id, record)
+
+    def _emit_record(self, query_id: str, record: dict[str, Any]) -> None:
+        """Write a record to its sink. Default: per-query JSONL file. Subclasses override."""
+        query_file = self._get_query_file(query_id)
+        if query_file is None:
+            return
         try:
             query_file.write(json.dumps(record, default=_json_default) + "\n")
         except OSError:
@@ -277,6 +292,41 @@ class EventLogSubscriber(Subscriber):
             payload["duration_ms"] = round(duration_ms)
 
         self._write_event(event.query_id, "execution_ended", payload)
+
+
+class RemoteEventLogSubscriber(EventLogSubscriber):
+    """Event log subscriber that ships records to a centralized Ray actor sink
+    instead of writing to a local file.
+
+    Used on flotilla workers (and optionally the driver) to aggregate events
+    from every process into a single per-query JSONL file on the head node.
+    """
+
+    def __init__(self, sink_actor: Any, role: str) -> None:
+        # Intentionally bypass parent __init__ — this subscriber never touches
+        # the local filesystem, so there is no log_dir to create.
+        self._log_dir = None  # type: ignore[assignment]
+        self._closed = False
+        self._query_files = {}
+        self._query_starts = {}
+        self._optimization_starts = {}
+        self._exec_starts = {}
+        self._operator_starts = {}
+        self._role = role
+        self._hostname = socket.gethostname()
+        self._pid = os.getpid()
+        self._sink = sink_actor
+
+    def _emit_record(self, query_id: str, record: dict[str, Any]) -> None:
+        if self._closed:
+            return
+        try:
+            self._sink.append.remote(record)
+        except Exception:
+            pass  # sink unreachable; drop event rather than failing the query
+
+    def close(self) -> None:
+        self._closed = True
 
 
 def query_state_str(state: QueryEndState) -> str:

--- a/daft/subscribers/event_log_sink.py
+++ b/daft/subscribers/event_log_sink.py
@@ -28,8 +28,7 @@ def _json_default(obj: object) -> object:
 
 @ray.remote(num_cpus=0)
 class EventLogSink:
-    """Ray actor that receives event records from driver and workers and writes
-    them to a merged per-query JSONL file on the head node's disk.
+    """Ray actor that writes received event records to per-query JSONL files.
 
     One file per query: ``<log_dir>/<query_id>/events.jsonl``. Records from
     multiple processes interleave but carry role/hostname/pid so consumers can
@@ -96,7 +95,7 @@ def create_or_get_sink(
             node_id=head_node_id,
             soft=False,
         )
-    return EventLogSink.options(**options).remote(log_dir)
+    return EventLogSink.options(**options).remote(log_dir)  # type: ignore[attr-defined]
 
 
 def get_sink(job_id: str | None) -> Any | None:
@@ -107,10 +106,30 @@ def get_sink(job_id: str | None) -> Any | None:
         return None
 
 
+def teardown_sink(job_id: str | None, timeout_sec: float = 5.0) -> None:
+    """Flush and kill the sink actor for the given job. Idempotent.
+
+    Safe to register via ``atexit``. Swallows errors because teardown is
+    best-effort; Ray cluster teardown may race with this.
+    """
+    sink = get_sink(job_id)
+    if sink is None:
+        return
+    try:
+        ray.get(sink.shutdown.remote(), timeout=timeout_sec)
+    except Exception:
+        pass
+    try:
+        ray.kill(sink)
+    except Exception:
+        pass
+
+
 __all__ = [
-    "EventLogSink",
     "SINK_ACTOR_NAMESPACE",
+    "EventLogSink",
     "create_or_get_sink",
     "get_sink",
     "get_sink_actor_name",
+    "teardown_sink",
 ]

--- a/daft/subscribers/event_log_sink.py
+++ b/daft/subscribers/event_log_sink.py
@@ -33,6 +33,20 @@ class EventLogSink:
     One file per query: ``<log_dir>/<query_id>/events.jsonl``. Records from
     multiple processes interleave but carry role/hostname/pid so consumers can
     demultiplex.
+
+    Lifecycle:
+      - Created (or fetched) by ``FlotillaRunner.__init__`` via
+        ``create_or_get_sink`` when ``DAFT_EVENT_LOG_DIR`` is set. The actor is
+        named per Ray job and scoped to the ``daft`` namespace, so every
+        process in the same job shares a single sink.
+      - Pinned to the head node (``NodeAffinitySchedulingStrategy``, soft=False)
+        so the JSONL files land on a well-known host.
+      - Declared ``lifetime="detached"`` so it survives the driver transiently
+        disconnecting; both the driver and remote flotilla/swordfish actors
+        look it up by name via ``get_sink``.
+      - Torn down via ``teardown_sink`` registered with ``atexit`` in
+        ``FlotillaRunner``: it flushes open files and ``ray.kill``s the actor.
+        Teardown is best-effort and idempotent; Ray cluster shutdown may race.
     """
 
     def __init__(self, log_dir: str) -> None:
@@ -48,9 +62,14 @@ class EventLogSink:
         if f is None:
             return
         try:
-            f.write(json.dumps(record, default=_json_default) + "\n")
-        except OSError:
-            pass
+            line = json.dumps(record, default=_json_default)
+        except (TypeError, ValueError) as e:
+            logger.warning("EventLogSink: failed to serialize record for query %s: %s", query_id, e)
+            return
+        try:
+            f.write(line + "\n")
+        except OSError as e:
+            logger.warning("EventLogSink: failed to write record for query %s: %s", query_id, e)
 
     def _get_file(self, query_id: str) -> TextIOWrapper | None:
         existing = self._files.get(query_id)

--- a/daft/subscribers/event_log_sink.py
+++ b/daft/subscribers/event_log_sink.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import json
+import logging
+from datetime import timedelta
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+try:
+    import ray
+except ImportError:
+    raise
+
+if TYPE_CHECKING:
+    from io import TextIOWrapper
+
+logger = logging.getLogger(__name__)
+
+SINK_ACTOR_NAME_PREFIX = "daft-event-log-sink"
+SINK_ACTOR_NAMESPACE = "daft"
+
+
+def _json_default(obj: object) -> object:
+    if isinstance(obj, timedelta):
+        return round(obj.total_seconds() * 1000)
+    return str(obj)
+
+
+@ray.remote(num_cpus=0)
+class EventLogSink:
+    """Ray actor that receives event records from driver and workers and writes
+    them to a merged per-query JSONL file on the head node's disk.
+
+    One file per query: ``<log_dir>/<query_id>/events.jsonl``. Records from
+    multiple processes interleave but carry role/hostname/pid so consumers can
+    demultiplex.
+    """
+
+    def __init__(self, log_dir: str) -> None:
+        self._log_dir = Path(log_dir).expanduser().resolve()
+        self._log_dir.mkdir(parents=True, exist_ok=True)
+        self._files: dict[str, TextIOWrapper] = {}
+
+    def append(self, record: dict[str, Any]) -> None:
+        query_id = record.get("query_id")
+        if not query_id:
+            return
+        f = self._get_file(query_id)
+        if f is None:
+            return
+        try:
+            f.write(json.dumps(record, default=_json_default) + "\n")
+        except OSError:
+            pass
+
+    def _get_file(self, query_id: str) -> TextIOWrapper | None:
+        existing = self._files.get(query_id)
+        if existing is not None:
+            return existing
+        query_dir = self._log_dir / query_id
+        try:
+            query_dir.mkdir(parents=True, exist_ok=True)
+            f = open(query_dir / "events.jsonl", "a", buffering=1)
+        except OSError:
+            return None
+        self._files[query_id] = f
+        return f
+
+    def shutdown(self) -> None:
+        for f in self._files.values():
+            try:
+                f.close()
+            except OSError:
+                pass
+        self._files.clear()
+
+
+def get_sink_actor_name(job_id: str | None) -> str:
+    return f"{SINK_ACTOR_NAME_PREFIX}-{job_id or 'default'}"
+
+
+def create_or_get_sink(
+    log_dir: str,
+    job_id: str | None,
+    head_node_id: str | None,
+) -> Any:
+    name = get_sink_actor_name(job_id)
+    options: dict[str, Any] = {
+        "name": name,
+        "namespace": SINK_ACTOR_NAMESPACE,
+        "get_if_exists": True,
+        "lifetime": "detached",
+    }
+    if head_node_id:
+        options["scheduling_strategy"] = ray.util.scheduling_strategies.NodeAffinitySchedulingStrategy(
+            node_id=head_node_id,
+            soft=False,
+        )
+    return EventLogSink.options(**options).remote(log_dir)
+
+
+def get_sink(job_id: str | None) -> Any | None:
+    name = get_sink_actor_name(job_id)
+    try:
+        return ray.get_actor(name, namespace=SINK_ACTOR_NAMESPACE)
+    except ValueError:
+        return None
+
+
+__all__ = [
+    "EventLogSink",
+    "SINK_ACTOR_NAMESPACE",
+    "create_or_get_sink",
+    "get_sink",
+    "get_sink_actor_name",
+]

--- a/daft/subscribers/event_log_sink.py
+++ b/daft/subscribers/event_log_sink.py
@@ -102,7 +102,7 @@ def get_sink(job_id: str | None) -> Any | None:
     name = get_sink_actor_name(job_id)
     try:
         return ray.get_actor(name, namespace=SINK_ACTOR_NAMESPACE)
-    except ValueError:
+    except Exception:
         return None
 
 

--- a/tests/ray/test_flotilla_runner_naming.py
+++ b/tests/ray/test_flotilla_runner_naming.py
@@ -46,8 +46,8 @@ def test_start_ray_workers_uses_configured_worker_startup_timeout(monkeypatch):
             self.get_address = _RemoteMethod(address)
 
     class _FakeActorOptions:
-        def remote(self, *, num_cpus: int, num_gpus: int) -> _FakeActor:
-            captured["remote_args"] = {"num_cpus": num_cpus, "num_gpus": num_gpus}
+        def remote(self, **kwargs: object) -> _FakeActor:
+            captured["remote_args"] = kwargs
             return _FakeActor("grpc://10.0.0.1:9999")
 
     class _FakeRaySwordfishActor:


### PR DESCRIPTION
## Changes Made

adds a ray based remote eventlog subscriber. 

instead of what i was doing in #6700 of just writing to the worker, this PR actually sets up a ray actor to sink the logs back to the head node and interleaves them in the same log as the rest of the EventLogSubscriber

this Matches Ray's own architecture. Ray captures stdout/stderr via its log_monitor and aggregates to the head. Named-actor aggregation is the same pattern users expect from Ray native components.

Validation: 
```
> ray job submit --runtime-env-json '{"env_vars":{"DAFT_PROCESS_MONITOR_ENABLED":"1","DAFT_EVENT_LOG_DIR":"/home/ec2-user/.daft/events"}}' \
    --working-dir . -- python pipeline.py

#  Then on the head:

> tail -f ~/.daft/events/fleet-lily-e73cf8/events.jsonl |  jq -r --unbuffered 'select(.event == "process_stats") |
    "\(.component // .role)@\(.hostname | split(".")[0]) rss=\((.metrics["process.memory.rss"]/1048576|floor))MB alloc=\((.metrics["process.memory.jemalloc.allocated"]/1048576|floor))MB cpu=\(.metrics["process.cpu.percent"]|floor)%"'
swordfish_worker@ip-172-31-27-207 rss=1082MB alloc=268MB cpu=775%
swordfish_worker@ip-172-31-20-52 rss=309MB alloc=36MB cpu=100%
swordfish_worker@ip-172-31-27-207 rss=1057MB alloc=242MB cpu=737%
swordfish_worker@ip-172-31-20-52 rss=309MB alloc=34MB cpu=190%
swordfish_worker@ip-172-31-27-207 rss=1066MB alloc=222MB cpu=791%

```

## Related Issues

Supersedes https://github.com/Eventual-Inc/Daft/pull/6700
