### PR TITLE
fix: fix column not found when using count_rows() for sparse data

### DIFF
--- a/src/daft-json/src/local.rs
+++ b/src/daft-json/src/local.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, collections::HashSet, num::NonZeroUsize, sync::Arc};
 use arrow::array::builder::ArrayBuilder;
 use common_error::{DaftError, DaftResult};
 use daft_core::prelude::*;
-use daft_dsl::{Expr, ExprRef, expr::bound_expr::BoundExpr};
+use daft_dsl::{Expr, ExprRef, expr::bound_expr::BoundExpr, optimization::get_required_columns};
 use daft_recordbatch::RecordBatch;
 use indexmap::IndexMap;
 use num_traits::Pow;
@@ -256,7 +256,16 @@ impl<'a> JsonReader<'a> {
         .context(RayonThreadPoolSnafu)?;
 
         let projected_schema = match convert_options.and_then(|options| options.include_columns) {
-            Some(projected_columns) => Arc::new(schema.project(&projected_columns)?),
+            Some(mut projected_columns) => {
+                if let Some(ref predicate) = predicate {
+                    for rc in get_required_columns(predicate) {
+                        if projected_columns.iter().all(|c| c.as_str() != rc.as_str()) {
+                            projected_columns.push(rc);
+                        }
+                    }
+                }
+                Arc::new(schema.project(&projected_columns)?)
+            }
             None => schema,
         };
 

--- a/tests/io/test_json.py
+++ b/tests/io/test_json.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 import pytest
 
 import daft
@@ -64,8 +66,6 @@ def test_read_json_skip_multiple_empty_files_in_dir(tmp_path):
 
 
 def test_read_json_sparse_column_with_schema_hints(tmp_path):
-    import json
-
     file_path = tmp_path / "sparse_data.jsonl"
     with file_path.open("w") as f:
         for i in range(50000):
@@ -93,3 +93,38 @@ def test_read_json_sparse_column_with_schema_hints(tmp_path):
     res = df_with_hint.where(daft.col("sound").not_null()).collect()
     assert len(res) == 1
     assert res.to_pydict()["sound"][0] == "hello"
+
+
+def test_read_json_schema_hint_filter_with_count_rows(tmp_path):
+    file_path = tmp_path / "sparse_count.jsonl"
+    with file_path.open("w") as f:
+        for i in range(50000):
+            f.write(json.dumps({"name": f"Person{i}", "id": i}) + "\n")
+        f.write(json.dumps({"name": "Alice", "id": 50000, "sound": "hello"}) + "\n")
+        f.write(json.dumps({"name": "Bob", "id": 50001, "sound": "world"}) + "\n")
+
+    df_no_hint = daft.read_json(str(file_path))
+    assert "sound" not in df_no_hint.column_names
+
+    schema_hints = {"sound": daft.DataType.string()}
+    df = daft.read_json(str(file_path), schema=schema_hints)
+    assert "sound" in df.column_names
+
+    assert df.where(daft.col("sound").not_null()).count_rows() == 2
+    assert df.where(daft.col("sound").is_null()).count_rows() == 50000
+
+    res = df.where(daft.col("sound").not_null()).collect()
+    assert res.to_pydict()["sound"] == ["hello", "world"]
+
+    res = df.where(daft.col("sound").not_null()).select("name", "id").collect()
+    assert res.column_names == ["name", "id"]
+    assert res.to_pydict()["name"] == ["Alice", "Bob"]
+
+    res = df.select("name", "id").where(daft.col("id") > 50000).collect()
+    assert res.column_names == ["name", "id"]
+    assert res.to_pydict()["name"] == ["Bob"]
+
+    with pytest.raises(ValueError, match="FieldNotFound.*sound"):
+        # select() drops "sound" from the schema, so a subsequent filter
+        # referencing it must fail at plan construction time, not at execution.
+        df.select("name", "id").where(daft.col("sound").not_null()).collect()


### PR DESCRIPTION
## Changes Made

followup  https://github.com/Eventual-Inc/Daft/pull/5681

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

Previously, the issue of missing fields in sparse data was resolved at the plan level for APIs such as collect() and show(). However, the count_rows() API still suffered from the same problem during the physical execution path for local files. Specifically, when calling count_rows() on a DataFrame that includes a filter on a missing field (e.g., where("sound is null")), the operation failed with a FieldNotFound error because the schema did not contain the required column.

```
daft.read_json('/mnt/test/vedio.audio-00002.jsonl')
.where("sound is null")
.count_rows()
```

```
DaftError::FieldNotFound Column "sound" not found in schema: [Field { name: "video_meta", dtype: Struct(...), metadata: {} }]
```

The current modification extends the field completion logic to the physical execution path of count_rows(), ensuring that missing fields are properly filled before counting rows. This aligns the behavior of count_rows() with that of collect() and show().


## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
