### PR TITLE
feat: introduce AggFn trait and two-stage UDAF aggregation pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3149,6 +3149,7 @@ dependencies = [
  "num-traits",
  "pyo3",
  "rand 0.9.2",
+ "rayon",
  "serde",
  "serde_json",
  "smallvec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3150,6 +3150,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
+ "typetag",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2965,6 +2965,7 @@ dependencies = [
  "pyo3",
  "pyo3-async-runtimes",
  "rand 0.9.2",
+ "serde",
  "serde_json",
  "smallvec",
  "snafu",
@@ -2974,6 +2975,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tracing",
+ "typetag",
 ]
 
 [[package]]

--- a/src/daft-dsl/src/expr/agg.rs
+++ b/src/daft-dsl/src/expr/agg.rs
@@ -59,6 +59,19 @@ pub fn extract_agg_expr(expr: &ExprRef) -> DaftResult<AggExpr> {
                         .map(|input| input.alias(name.clone()))
                         .collect(),
                 },
+                AggExpr::AggFn { handle, inputs } => AggExpr::AggFn {
+                    handle,
+                    inputs: inputs
+                        .into_iter()
+                        .map(|input| input.alias(name.clone()))
+                        .collect(),
+                },
+                AggExpr::AggFnBlock { .. } | AggExpr::AggFnCombine { .. } => {
+                    unreachable!(
+                        "AggFnBlock / AggFnCombine are planner-internal expressions \
+                         and must not appear in a user-level alias context"
+                    )
+                }
             }
         }),
         _ => Err(DaftError::InternalError(format!(

--- a/src/daft-dsl/src/expr/agg.rs
+++ b/src/daft-dsl/src/expr/agg.rs
@@ -66,9 +66,9 @@ pub fn extract_agg_expr(expr: &ExprRef) -> DaftResult<AggExpr> {
                         .map(|input| input.alias(name.clone()))
                         .collect(),
                 },
-                AggExpr::AggFnBlock { .. } | AggExpr::AggFnCombine { .. } => {
+                AggExpr::AggFnMap { .. } | AggExpr::AggFnReduce { .. } => {
                     unreachable!(
-                        "AggFnBlock / AggFnCombine are planner-internal expressions \
+                        "AggFnMap / AggFnReduce are planner-internal expressions \
                          and must not appear in a user-level alias context"
                     )
                 }

--- a/src/daft-dsl/src/expr/mod.rs
+++ b/src/daft-dsl/src/expr/mod.rs
@@ -989,18 +989,21 @@ impl AggExpr {
                 handle.get_return_field(&input_fields, schema)
             }
             Self::AggFnMap { handle, inputs } => {
-                // Produces a Binary column of serialized accumulator bytes.
-                // Include input field names in the column name to avoid collisions
-                // when the same handle is used on different columns in one aggregation
-                // (e.g. `my_agg(a), my_agg(b)` would both produce "my_agg" otherwise).
-                let inputs_str = inputs
+                // Including input field names in the column name avoids collisions when
+                // the same handle is used on different columns (e.g. `my_agg(a), my_agg(b)`).
+                let input_fields: Vec<Field> = inputs
                     .iter()
-                    .map(|e| e.to_field(schema).map(|f| f.name.to_string()))
-                    .collect::<DaftResult<Vec<_>>>()?
+                    .map(|e| e.to_field(schema))
+                    .collect::<DaftResult<Vec<_>>>()?;
+                let inputs_str = input_fields
+                    .iter()
+                    .map(|f| f.name.as_ref())
+                    .collect::<Vec<_>>()
                     .join(", ");
+                let state_fields = handle.state_fields(&input_fields)?;
                 Ok(Field::new(
                     format!("{}({})", handle.name(), inputs_str),
-                    DataType::Binary,
+                    DataType::Struct(state_fields),
                 ))
             }
             Self::AggFnReduce { return_field, .. } => Ok(return_field.clone()),

--- a/src/daft-dsl/src/expr/mod.rs
+++ b/src/daft-dsl/src/expr/mod.rs
@@ -464,7 +464,7 @@ pub enum AggExpr {
         inputs: Vec<ExprRef>,
     },
 
-    /// Planner-internal step 1: produces a `Binary` column of serialized
+    /// Planner-internal step 1: produces a Struct column of typed
     /// accumulator states (one per group) from one input block.
     #[display("{handle}.__map({})", inputs.iter().map(|e| e.to_string()).collect::<Vec<_>>().join(", "))]
     AggFnMap {
@@ -472,7 +472,7 @@ pub enum AggExpr {
         inputs: Vec<ExprRef>,
     },
 
-    /// Planner-internal step 2: folds the `Binary` partial states from
+    /// Planner-internal step 2: folds the Struct partial states from
     /// `AggFnMap` per group and produces the final typed output.
     #[display("{handle}.__reduce({partial})")]
     AggFnReduce {
@@ -809,10 +809,7 @@ impl AggExpr {
                 return_field,
             } => Self::AggFnReduce {
                 handle: handle.clone(),
-                partial: children
-                    .into_iter()
-                    .next()
-                    .expect("AggFnReduce needs 1 child"),
+                partial: children.remove(0),
                 return_field: return_field.clone(),
             },
             Self::ApproxPercentile(ApproxPercentileParams {

--- a/src/daft-dsl/src/expr/mod.rs
+++ b/src/daft-dsl/src/expr/mod.rs
@@ -466,16 +466,16 @@ pub enum AggExpr {
 
     /// Planner-internal step 1: produces a `Binary` column of serialized
     /// accumulator states (one per group) from one input block.
-    #[display("{handle}.__block({})", inputs.iter().map(|e| e.to_string()).collect::<Vec<_>>().join(", "))]
-    AggFnBlock {
+    #[display("{handle}.__map({})", inputs.iter().map(|e| e.to_string()).collect::<Vec<_>>().join(", "))]
+    AggFnMap {
         handle: AggFnHandle,
         inputs: Vec<ExprRef>,
     },
 
     /// Planner-internal step 2: folds the `Binary` partial states from
-    /// `AggFnBlock` per group and produces the final typed output.
-    #[display("{handle}.__combine({partial})")]
-    AggFnCombine {
+    /// `AggFnMap` per group and produces the final typed output.
+    #[display("{handle}.__reduce({partial})")]
+    AggFnReduce {
         handle: AggFnHandle,
         partial: ExprRef,
         return_field: Field,
@@ -581,8 +581,8 @@ impl AggExpr {
             Self::Skew(_) => "Skew",
             Self::MapGroups { .. } => "Map Groups",
             Self::AggFn { .. } => "Extension Agg",
-            Self::AggFnBlock { .. } => "Extension Agg (Block)",
-            Self::AggFnCombine { .. } => "Extension Agg (Combine)",
+            Self::AggFnMap { .. } => "Extension Agg (Map)",
+            Self::AggFnReduce { .. } => "Extension Agg (Reduce)",
         }
     }
 
@@ -610,8 +610,8 @@ impl AggExpr {
             | Self::Skew(expr) => expr.name(),
             Self::MapGroups { func: _, inputs } => inputs.first().unwrap().name(),
             Self::AggFn { handle, .. }
-            | Self::AggFnBlock { handle, .. }
-            | Self::AggFnCombine { handle, .. } => handle.name(),
+            | Self::AggFnMap { handle, .. }
+            | Self::AggFnReduce { handle, .. } => handle.name(),
         }
     }
 
@@ -719,19 +719,19 @@ impl AggExpr {
                     .join(", ");
                 FieldID::new(format!("AggFn_{}({inputs_str})", handle.name()))
             }
-            Self::AggFnBlock { handle, inputs } => {
+            Self::AggFnMap { handle, inputs } => {
                 let inputs_str = inputs
                     .iter()
                     .map(|e| e.semantic_id(schema).id.to_string())
                     .collect::<Vec<_>>()
                     .join(", ");
-                FieldID::new(format!("AggFnBlock_{}({inputs_str})", handle.name()))
+                FieldID::new(format!("AggFnMap_{}({inputs_str})", handle.name()))
             }
-            Self::AggFnCombine {
+            Self::AggFnReduce {
                 handle, partial, ..
             } => {
                 let partial_id = partial.semantic_id(schema).id;
-                FieldID::new(format!("AggFnCombine_{}({partial_id})", handle.name()))
+                FieldID::new(format!("AggFnReduce_{}({partial_id})", handle.name()))
             }
         }
     }
@@ -759,15 +759,15 @@ impl AggExpr {
             | Self::Concat(expr, _)
             | Self::Skew(expr) => vec![expr.clone()],
             Self::MapGroups { func: _, inputs } => inputs.clone(),
-            Self::AggFn { inputs, .. } | Self::AggFnBlock { inputs, .. } => inputs.clone(),
-            Self::AggFnCombine { partial, .. } => vec![partial.clone()],
+            Self::AggFn { inputs, .. } | Self::AggFnMap { inputs, .. } => inputs.clone(),
+            Self::AggFnReduce { partial, .. } => vec![partial.clone()],
         }
     }
 
     pub fn with_new_children(&self, mut children: Vec<ExprRef>) -> Self {
         if let Self::MapGroups { func: _, inputs }
         | Self::AggFn { inputs, .. }
-        | Self::AggFnBlock { inputs, .. } = &self
+        | Self::AggFnMap { inputs, .. } = &self
         {
             assert_eq!(children.len(), inputs.len());
         } else {
@@ -799,20 +799,20 @@ impl AggExpr {
                 handle: handle.clone(),
                 inputs: children,
             },
-            Self::AggFnBlock { handle, inputs: _ } => Self::AggFnBlock {
+            Self::AggFnMap { handle, inputs: _ } => Self::AggFnMap {
                 handle: handle.clone(),
                 inputs: children,
             },
-            Self::AggFnCombine {
+            Self::AggFnReduce {
                 handle,
                 partial: _,
                 return_field,
-            } => Self::AggFnCombine {
+            } => Self::AggFnReduce {
                 handle: handle.clone(),
                 partial: children
                     .into_iter()
                     .next()
-                    .expect("AggFnCombine needs 1 child"),
+                    .expect("AggFnReduce needs 1 child"),
                 return_field: return_field.clone(),
             },
             Self::ApproxPercentile(ApproxPercentileParams {
@@ -988,7 +988,7 @@ impl AggExpr {
                     .collect::<DaftResult<_>>()?;
                 handle.get_return_field(&input_fields, schema)
             }
-            Self::AggFnBlock { handle, inputs } => {
+            Self::AggFnMap { handle, inputs } => {
                 // Produces a Binary column of serialized accumulator bytes.
                 // Include input field names in the column name to avoid collisions
                 // when the same handle is used on different columns in one aggregation
@@ -1003,7 +1003,7 @@ impl AggExpr {
                     DataType::Binary,
                 ))
             }
-            Self::AggFnCombine { return_field, .. } => Ok(return_field.clone()),
+            Self::AggFnReduce { return_field, .. } => Ok(return_field.clone()),
         }
     }
 }

--- a/src/daft-dsl/src/expr/mod.rs
+++ b/src/daft-dsl/src/expr/mod.rs
@@ -985,13 +985,8 @@ impl AggExpr {
                     .collect::<DaftResult<_>>()?;
                 let input_types: Vec<DataType> =
                     input_fields.iter().map(|f| f.dtype.clone()).collect();
-                let inputs_str = input_fields
-                    .iter()
-                    .map(|f| f.name.as_ref())
-                    .collect::<Vec<_>>()
-                    .join(", ");
                 Ok(Field::new(
-                    format!("{}({})", handle.name(), inputs_str),
+                    input_fields[0].name.clone(),
                     handle.return_dtype(&input_types)?,
                 ))
             }

--- a/src/daft-dsl/src/expr/mod.rs
+++ b/src/daft-dsl/src/expr/mod.rs
@@ -986,7 +986,17 @@ impl AggExpr {
                     .iter()
                     .map(|e| e.to_field(schema))
                     .collect::<DaftResult<_>>()?;
-                handle.get_return_field(&input_fields, schema)
+                let input_types: Vec<DataType> =
+                    input_fields.iter().map(|f| f.dtype.clone()).collect();
+                let inputs_str = input_fields
+                    .iter()
+                    .map(|f| f.name.as_ref())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                Ok(Field::new(
+                    format!("{}({})", handle.name(), inputs_str),
+                    handle.return_dtype(&input_types)?,
+                ))
             }
             Self::AggFnMap { handle, inputs } => {
                 // Including input field names in the column name avoids collisions when

--- a/src/daft-dsl/src/expr/mod.rs
+++ b/src/daft-dsl/src/expr/mod.rs
@@ -37,8 +37,8 @@ use super::functions::FunctionExpr;
 use crate::{
     expr::bound_expr::BoundExpr,
     functions::{
-        BuiltinScalarFn, FUNCTION_REGISTRY, FunctionArg, FunctionArgs, FunctionEvaluator,
-        function_display_without_formatter, function_semantic_id,
+        AggFnHandle, BuiltinScalarFn, FUNCTION_REGISTRY, FunctionArg, FunctionArgs,
+        FunctionEvaluator, function_display_without_formatter, function_semantic_id,
         python::{LegacyPythonUDF, RuntimePyObject},
         scalar::{ScalarFn, scalar_function_semantic_id},
         sketch::{HashableVecPercentiles, SketchExpr},
@@ -457,6 +457,29 @@ pub enum AggExpr {
         func: MapGroupsFn,
         inputs: Vec<ExprRef>,
     },
+
+    #[display("{handle}({})", inputs.iter().map(|e| e.to_string()).collect::<Vec<_>>().join(", "))]
+    AggFn {
+        handle: AggFnHandle,
+        inputs: Vec<ExprRef>,
+    },
+
+    /// Planner-internal step 1: produces a `Binary` column of serialized
+    /// accumulator states (one per group) from one input block.
+    #[display("{handle}.__block({})", inputs.iter().map(|e| e.to_string()).collect::<Vec<_>>().join(", "))]
+    AggFnBlock {
+        handle: AggFnHandle,
+        inputs: Vec<ExprRef>,
+    },
+
+    /// Planner-internal step 2: folds the `Binary` partial states from
+    /// `AggFnBlock` per group and produces the final typed output.
+    #[display("{handle}.__combine({partial})")]
+    AggFnCombine {
+        handle: AggFnHandle,
+        partial: ExprRef,
+        return_field: Field,
+    },
 }
 
 #[derive(Display, Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
@@ -557,6 +580,9 @@ impl AggExpr {
             Self::Concat(_, _) => "Concat",
             Self::Skew(_) => "Skew",
             Self::MapGroups { .. } => "Map Groups",
+            Self::AggFn { .. } => "Extension Agg",
+            Self::AggFnBlock { .. } => "Extension Agg (Block)",
+            Self::AggFnCombine { .. } => "Extension Agg (Combine)",
         }
     }
 
@@ -583,6 +609,9 @@ impl AggExpr {
             | Self::Concat(expr, _)
             | Self::Skew(expr) => expr.name(),
             Self::MapGroups { func: _, inputs } => inputs.first().unwrap().name(),
+            Self::AggFn { handle, .. }
+            | Self::AggFnBlock { handle, .. }
+            | Self::AggFnCombine { handle, .. } => handle.name(),
         }
     }
 
@@ -682,6 +711,28 @@ impl AggExpr {
                 FieldID::new(format!("{child_id}.local_skew()"))
             }
             Self::MapGroups { func, inputs } => func.semantic_id(inputs, schema),
+            Self::AggFn { handle, inputs } => {
+                let inputs_str = inputs
+                    .iter()
+                    .map(|e| e.semantic_id(schema).id.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                FieldID::new(format!("AggFn_{}({inputs_str})", handle.name()))
+            }
+            Self::AggFnBlock { handle, inputs } => {
+                let inputs_str = inputs
+                    .iter()
+                    .map(|e| e.semantic_id(schema).id.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                FieldID::new(format!("AggFnBlock_{}({inputs_str})", handle.name()))
+            }
+            Self::AggFnCombine {
+                handle, partial, ..
+            } => {
+                let partial_id = partial.semantic_id(schema).id;
+                FieldID::new(format!("AggFnCombine_{}({partial_id})", handle.name()))
+            }
         }
     }
 
@@ -708,11 +759,16 @@ impl AggExpr {
             | Self::Concat(expr, _)
             | Self::Skew(expr) => vec![expr.clone()],
             Self::MapGroups { func: _, inputs } => inputs.clone(),
+            Self::AggFn { inputs, .. } | Self::AggFnBlock { inputs, .. } => inputs.clone(),
+            Self::AggFnCombine { partial, .. } => vec![partial.clone()],
         }
     }
 
     pub fn with_new_children(&self, mut children: Vec<ExprRef>) -> Self {
-        if let Self::MapGroups { func: _, inputs } = &self {
+        if let Self::MapGroups { func: _, inputs }
+        | Self::AggFn { inputs, .. }
+        | Self::AggFnBlock { inputs, .. } = &self
+        {
             assert_eq!(children.len(), inputs.len());
         } else {
             assert_eq!(children.len(), 1);
@@ -738,6 +794,26 @@ impl AggExpr {
             Self::MapGroups { func, inputs: _ } => Self::MapGroups {
                 func: func.with_new_children(children.clone()),
                 inputs: children,
+            },
+            Self::AggFn { handle, inputs: _ } => Self::AggFn {
+                handle: handle.clone(),
+                inputs: children,
+            },
+            Self::AggFnBlock { handle, inputs: _ } => Self::AggFnBlock {
+                handle: handle.clone(),
+                inputs: children,
+            },
+            Self::AggFnCombine {
+                handle,
+                partial: _,
+                return_field,
+            } => Self::AggFnCombine {
+                handle: handle.clone(),
+                partial: children
+                    .into_iter()
+                    .next()
+                    .expect("AggFnCombine needs 1 child"),
+                return_field: return_field.clone(),
             },
             Self::ApproxPercentile(ApproxPercentileParams {
                 percentiles,
@@ -905,6 +981,29 @@ impl AggExpr {
             }
 
             Self::MapGroups { func, inputs } => func.to_field(inputs.as_slice(), schema),
+            Self::AggFn { handle, inputs } => {
+                let input_fields: Vec<Field> = inputs
+                    .iter()
+                    .map(|e| e.to_field(schema))
+                    .collect::<DaftResult<_>>()?;
+                handle.get_return_field(&input_fields, schema)
+            }
+            Self::AggFnBlock { handle, inputs } => {
+                // Produces a Binary column of serialized accumulator bytes.
+                // Include input field names in the column name to avoid collisions
+                // when the same handle is used on different columns in one aggregation
+                // (e.g. `my_agg(a), my_agg(b)` would both produce "my_agg" otherwise).
+                let inputs_str = inputs
+                    .iter()
+                    .map(|e| e.to_field(schema).map(|f| f.name.to_string()))
+                    .collect::<DaftResult<Vec<_>>>()?
+                    .join(", ");
+                Ok(Field::new(
+                    format!("{}({})", handle.name(), inputs_str),
+                    DataType::Binary,
+                ))
+            }
+            Self::AggFnCombine { return_field, .. } => Ok(return_field.clone()),
         }
     }
 }

--- a/src/daft-dsl/src/functions/agg_fn.rs
+++ b/src/daft-dsl/src/functions/agg_fn.rs
@@ -11,20 +11,19 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 ///
 /// Registered with `typetag::serde` so that plan serialization/deserialization works.
 ///
-/// Follows Ray's `AggregateFnV2` pattern with three mandatory stages:
+/// Three mandatory stages:
 ///
 /// ```text
-/// Block Aggregation:  call_agg_block(inputs, groups) → Binary Series
-///                         One serialized accumulator state per group,
-///                         produced independently per block.
-///                     ↓  [binary columns travel through Arrow pipeline]
-/// Combine:            call_agg_combine(&[u8], &[u8]) → Vec<u8>    (binary, associative)
-///                         Called by the framework N-1 times per group to fold
-///                         partial states into one.  Equivalent to Ray's `combine`.
-///                     ↓
-/// Finalize:           call_agg_finalize(states, return_field) → typed Series
-///                         Called once with the one-state-per-group Binary Series.
-///                         Equivalent to Ray's `finalize`.
+/// Map:     call_agg_block(inputs, groups) → Binary Series
+///              One serialized accumulator state per group,
+///              produced independently per block.
+///          ↓  [binary columns travel through Arrow pipeline]
+/// Combine: call_agg_combine(&[u8], &[u8]) → Vec<u8>    (binary, associative)
+///              Called by the framework N-1 times per group to fold
+///              partial states into one.
+///          ↓
+/// Reduce:  call_agg_finalize(states, return_field) → typed Series
+///              Called once with the one-state-per-group Binary Series.
 /// ```
 ///
 /// All three methods are required — there is no single-pass fallback.
@@ -33,8 +32,6 @@ pub trait AggFn: Send + Sync {
     fn name(&self) -> &'static str;
     fn get_return_field(&self, inputs: &[Field], schema: &Schema) -> DaftResult<Field>;
 
-    /// Block Aggregation (Ray's `aggregate_block`).
-    ///
     /// Process `inputs` for one block and return a `Binary`-typed [`Series`]
     /// containing one serialized accumulator state per group.
     fn call_agg_block(
@@ -43,9 +40,7 @@ pub trait AggFn: Send + Sync {
         groups: Option<&daft_core::array::ops::GroupIndices>,
     ) -> DaftResult<Series>;
 
-    /// Combine two accumulator states (Ray's `combine`).
-    ///
-    /// Merges exactly two serialized states into one.  Must be **associative**
+    /// Merge two serialized accumulator states into one.  Must be **associative**
     /// (and ideally commutative) so that the framework can fold partial states
     /// in any order or tree-reduce them in parallel.
     ///
@@ -53,8 +48,6 @@ pub trait AggFn: Send + Sync {
     /// partial states produced by `call_agg_block` across all blocks.
     fn call_agg_combine(&self, a: &[u8], b: &[u8]) -> DaftResult<Vec<u8>>;
 
-    /// Finalize (Ray's `finalize`).
-    ///
     /// Receives a `Binary`-typed [`Series`] with one combined accumulator per
     /// group and returns the final typed output column.
     ///

--- a/src/daft-dsl/src/functions/agg_fn.rs
+++ b/src/daft-dsl/src/functions/agg_fn.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use common_error::DaftResult;
-use daft_core::prelude::{Field, Schema, Series};
+use daft_core::prelude::{DataType, Field, Literal, Series};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// Trait for native extension aggregate UDFs.
@@ -14,14 +14,14 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 /// Three mandatory stages:
 ///
 /// ```text
-/// Map:     call_agg_block(inputs, groups) → Vec<Series>
-///              One typed Series per state field, one row per group.
-///          ↓  [typed state columns travel through the Arrow pipeline]
-/// Combine: call_agg_combine(states, groups) → Vec<Series>   (batched, associative)
-///              One call folds all partial states for all groups at once.
+/// Map:     call_agg_block(inputs) → Vec<Literal>
+///              One Literal per state field, for this group.
+///          ↓  [framework packs Literals into typed Struct columns]
+/// Combine: call_agg_combine(states) → Vec<Literal>   (associative)
+///              Folds all partial states for this group into one.
 ///          ↓
-/// Reduce:  call_agg_finalize(states, return_field) → typed Series
-///              Called once with one-row-per-group state to produce final output.
+/// Reduce:  call_agg_finalize(state) → Literal
+///              Called once per group to produce the final value.
 /// ```
 ///
 /// The intermediate state is declared via `state_fields` and flows as a Struct column
@@ -30,7 +30,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 #[typetag::serde(tag = "type")]
 pub trait AggFn: Send + Sync {
     fn name(&self) -> &'static str;
-    fn get_return_field(&self, inputs: &[Field], schema: &Schema) -> DaftResult<Field>;
+    fn return_dtype(&self, input_types: &[DataType]) -> DaftResult<DataType>;
 
     /// Declare the typed Arrow fields for the intermediate accumulator state.
     ///
@@ -39,34 +39,21 @@ pub trait AggFn: Send + Sync {
     /// the Map and Reduce stages.
     fn state_fields(&self, inputs: &[Field]) -> DaftResult<Vec<Field>>;
 
-    /// Process `inputs` for one block and return one typed [`Series`] per state field,
-    /// each containing one row per group.
-    fn call_agg_block(
-        &self,
-        inputs: Vec<Series>,
-        groups: Option<&daft_core::array::ops::GroupIndices>,
-    ) -> DaftResult<Vec<Series>>;
+    /// Process `inputs` for one group and return one [`Literal`] per state field.
+    fn call_agg_block(&self, inputs: Vec<Series>) -> DaftResult<Vec<Literal>>;
 
-    /// Merge all partial states in a single batched call.
+    /// Merge all partial states for one group into a single state.
     ///
     /// `states` contains one [`Series`] per state field (matching `state_fields`),
-    /// each with one row per partial result across all groups.
-    /// `groups` maps rows to output groups (same contract as `call_agg_block`).
-    ///
-    /// Must be **associative** so that the framework can fold partial states in any
-    /// order. Returns one [`Series`] per state field, with one row per output group.
-    fn call_agg_combine(
-        &self,
-        states: Vec<Series>,
-        groups: Option<&daft_core::array::ops::GroupIndices>,
-    ) -> DaftResult<Vec<Series>>;
+    /// where each row is one partial result. Must be **associative**.
+    /// Returns one [`Literal`] per state field.
+    fn call_agg_combine(&self, states: Vec<Series>) -> DaftResult<Vec<Literal>>;
 
-    /// Receives one [`Series`] per state field (one row per group) and returns the
-    /// final typed output column.
+    /// Receives one [`Literal`] per state field for this group and returns the
+    /// final value.
     ///
-    /// For simple accumulators (e.g. sum) this is just a rename/cast.
     /// For derived quantities (e.g. mean = sum/count) apply post-processing here.
-    fn call_agg_finalize(&self, states: Vec<Series>, return_field: &Field) -> DaftResult<Series>;
+    fn call_agg_finalize(&self, state: Vec<Literal>) -> DaftResult<Literal>;
 }
 
 /// A cloneable, hashable (by name) wrapper around `Arc<dyn AggFn>`.
@@ -85,32 +72,24 @@ impl AggFnHandle {
         self.0.name()
     }
 
-    pub fn get_return_field(&self, inputs: &[Field], schema: &Schema) -> DaftResult<Field> {
-        self.0.get_return_field(inputs, schema)
+    pub fn return_dtype(&self, input_types: &[DataType]) -> DaftResult<DataType> {
+        self.0.return_dtype(input_types)
     }
 
     pub fn state_fields(&self, inputs: &[Field]) -> DaftResult<Vec<Field>> {
         self.0.state_fields(inputs)
     }
 
-    pub fn call_agg_block(
-        &self,
-        inputs: Vec<Series>,
-        groups: Option<&daft_core::array::ops::GroupIndices>,
-    ) -> DaftResult<Vec<Series>> {
-        self.0.call_agg_block(inputs, groups)
+    pub fn call_agg_block(&self, inputs: Vec<Series>) -> DaftResult<Vec<Literal>> {
+        self.0.call_agg_block(inputs)
     }
 
-    pub fn call_agg_combine(
-        &self,
-        states: Vec<Series>,
-        groups: Option<&daft_core::array::ops::GroupIndices>,
-    ) -> DaftResult<Vec<Series>> {
-        self.0.call_agg_combine(states, groups)
+    pub fn call_agg_combine(&self, states: Vec<Series>) -> DaftResult<Vec<Literal>> {
+        self.0.call_agg_combine(states)
     }
 
-    pub fn call_agg_finalize(&self, states: Vec<Series>, return_field: &Field) -> DaftResult<Series> {
-        self.0.call_agg_finalize(states, return_field)
+    pub fn call_agg_finalize(&self, state: Vec<Literal>) -> DaftResult<Literal> {
+        self.0.call_agg_finalize(state)
     }
 }
 
@@ -162,7 +141,7 @@ mod tests {
     };
 
     use common_error::DaftResult;
-    use daft_core::{array::ops::GroupIndices, prelude::*};
+    use daft_core::prelude::*;
     use serde::{Deserialize, Serialize};
 
     use super::*;
@@ -177,31 +156,23 @@ mod tests {
             "noop_a"
         }
 
-        fn get_return_field(&self, inputs: &[Field], _schema: &Schema) -> DaftResult<Field> {
-            Ok(inputs[0].clone())
+        fn return_dtype(&self, input_types: &[DataType]) -> DaftResult<DataType> {
+            Ok(input_types[0].clone())
         }
 
         fn state_fields(&self, inputs: &[Field]) -> DaftResult<Vec<Field>> {
             Ok(vec![inputs[0].clone()])
         }
 
-        fn call_agg_block(
-            &self,
-            _inputs: Vec<Series>,
-            _groups: Option<&GroupIndices>,
-        ) -> DaftResult<Vec<Series>> {
+        fn call_agg_block(&self, _inputs: Vec<Series>) -> DaftResult<Vec<Literal>> {
             unimplemented!("only used for handle identity tests")
         }
 
-        fn call_agg_combine(
-            &self,
-            _states: Vec<Series>,
-            _groups: Option<&GroupIndices>,
-        ) -> DaftResult<Vec<Series>> {
+        fn call_agg_combine(&self, _states: Vec<Series>) -> DaftResult<Vec<Literal>> {
             unimplemented!("only used for handle identity tests")
         }
 
-        fn call_agg_finalize(&self, _states: Vec<Series>, _return_field: &Field) -> DaftResult<Series> {
+        fn call_agg_finalize(&self, _state: Vec<Literal>) -> DaftResult<Literal> {
             unimplemented!("only used for handle identity tests")
         }
     }
@@ -215,31 +186,23 @@ mod tests {
             "noop_b"
         }
 
-        fn get_return_field(&self, inputs: &[Field], _schema: &Schema) -> DaftResult<Field> {
-            Ok(inputs[0].clone())
+        fn return_dtype(&self, input_types: &[DataType]) -> DaftResult<DataType> {
+            Ok(input_types[0].clone())
         }
 
         fn state_fields(&self, inputs: &[Field]) -> DaftResult<Vec<Field>> {
             Ok(vec![inputs[0].clone()])
         }
 
-        fn call_agg_block(
-            &self,
-            _inputs: Vec<Series>,
-            _groups: Option<&GroupIndices>,
-        ) -> DaftResult<Vec<Series>> {
+        fn call_agg_block(&self, _inputs: Vec<Series>) -> DaftResult<Vec<Literal>> {
             unimplemented!("NoopB is only used for handle identity tests")
         }
 
-        fn call_agg_combine(
-            &self,
-            _states: Vec<Series>,
-            _groups: Option<&GroupIndices>,
-        ) -> DaftResult<Vec<Series>> {
+        fn call_agg_combine(&self, _states: Vec<Series>) -> DaftResult<Vec<Literal>> {
             unimplemented!("NoopB is only used for handle identity tests")
         }
 
-        fn call_agg_finalize(&self, _states: Vec<Series>, _return_field: &Field) -> DaftResult<Series> {
+        fn call_agg_finalize(&self, _state: Vec<Literal>) -> DaftResult<Literal> {
             unimplemented!("NoopB is only used for handle identity tests")
         }
     }

--- a/src/daft-dsl/src/functions/agg_fn.rs
+++ b/src/daft-dsl/src/functions/agg_fn.rs
@@ -1,0 +1,265 @@
+use std::{
+    hash::{Hash, Hasher},
+    sync::Arc,
+};
+
+use common_error::DaftResult;
+use daft_core::prelude::{Field, Schema, Series};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// Trait for native extension aggregate UDFs.
+///
+/// Registered with `typetag::serde` so that plan serialization/deserialization works.
+///
+/// Follows Ray's `AggregateFnV2` pattern with three mandatory stages:
+///
+/// ```text
+/// Block Aggregation:  call_agg_block(inputs, groups) → Binary Series
+///                         One serialized accumulator state per group,
+///                         produced independently per block.
+///                     ↓  [binary columns travel through Arrow pipeline]
+/// Combine:            call_agg_combine(&[u8], &[u8]) → Vec<u8>    (binary, associative)
+///                         Called by the framework N-1 times per group to fold
+///                         partial states into one.  Equivalent to Ray's `combine`.
+///                     ↓
+/// Finalize:           call_agg_finalize(states, return_field) → typed Series
+///                         Called once with the one-state-per-group Binary Series.
+///                         Equivalent to Ray's `finalize`.
+/// ```
+///
+/// All three methods are required — there is no single-pass fallback.
+#[typetag::serde(tag = "type")]
+pub trait AggFn: Send + Sync {
+    fn name(&self) -> &'static str;
+    fn get_return_field(&self, inputs: &[Field], schema: &Schema) -> DaftResult<Field>;
+
+    /// Block Aggregation (Ray's `aggregate_block`).
+    ///
+    /// Process `inputs` for one block and return a `Binary`-typed [`Series`]
+    /// containing one serialized accumulator state per group.
+    fn call_agg_block(
+        &self,
+        inputs: Vec<Series>,
+        groups: Option<&daft_core::array::ops::GroupIndices>,
+    ) -> DaftResult<Series>;
+
+    /// Combine two accumulator states (Ray's `combine`).
+    ///
+    /// Merges exactly two serialized states into one.  Must be **associative**
+    /// (and ideally commutative) so that the framework can fold partial states
+    /// in any order or tree-reduce them in parallel.
+    ///
+    /// The framework calls this N-1 times per group, where N is the number of
+    /// partial states produced by `call_agg_block` across all blocks.
+    fn call_agg_combine(&self, a: &[u8], b: &[u8]) -> DaftResult<Vec<u8>>;
+
+    /// Finalize (Ray's `finalize`).
+    ///
+    /// Receives a `Binary`-typed [`Series`] with one combined accumulator per
+    /// group and returns the final typed output column.
+    ///
+    /// For simple accumulators (e.g. sum, count) this is just deserialization.
+    /// For derived quantities (e.g. mean = sum/count) apply post-processing here.
+    fn call_agg_finalize(&self, states: Series, return_field: &Field) -> DaftResult<Series>;
+}
+
+/// A cloneable, hashable (by name) wrapper around `Arc<dyn AggFn>`.
+///
+/// `Hash` and `PartialEq` compare by function name only, matching the
+/// expression-identity semantics used elsewhere in the planner.
+///
+/// **Name uniqueness requirement**: Because equality and hashing are based
+/// solely on `AggFn::name()`, two handles with the same name are considered
+/// identical by the planner's expression deduplication (`IndexSet`).
+/// Registering two distinct `AggFn` implementations under the same name
+/// will cause one to silently shadow the other in intermediate aggregation
+/// stages.  Ensure that every `AggFn` implementation returns a globally
+/// unique name (e.g. include the crate/module prefix).
+#[derive(Clone)]
+pub struct AggFnHandle(pub Arc<dyn AggFn>);
+
+impl AggFnHandle {
+    pub fn new(udf: Arc<dyn AggFn>) -> Self {
+        Self(udf)
+    }
+
+    pub fn name(&self) -> &'static str {
+        self.0.name()
+    }
+
+    pub fn get_return_field(&self, inputs: &[Field], schema: &Schema) -> DaftResult<Field> {
+        self.0.get_return_field(inputs, schema)
+    }
+
+    pub fn call_agg_block(
+        &self,
+        inputs: Vec<Series>,
+        groups: Option<&daft_core::array::ops::GroupIndices>,
+    ) -> DaftResult<Series> {
+        self.0.call_agg_block(inputs, groups)
+    }
+
+    pub fn call_agg_combine(&self, a: &[u8], b: &[u8]) -> DaftResult<Vec<u8>> {
+        self.0.call_agg_combine(a, b)
+    }
+
+    pub fn call_agg_finalize(&self, states: Series, return_field: &Field) -> DaftResult<Series> {
+        self.0.call_agg_finalize(states, return_field)
+    }
+}
+
+impl Hash for AggFnHandle {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.name().hash(state);
+    }
+}
+
+impl PartialEq for AggFnHandle {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.name() == other.0.name()
+    }
+}
+
+impl Eq for AggFnHandle {}
+
+impl std::fmt::Debug for AggFnHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "AggFnHandle({})", self.0.name())
+    }
+}
+
+impl std::fmt::Display for AggFnHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0.name())
+    }
+}
+
+impl Serialize for AggFnHandle {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.0.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for AggFnHandle {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let udf = <Box<dyn AggFn>>::deserialize(deserializer)?;
+        Ok(Self(Arc::from(udf)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::hash_map::DefaultHasher,
+        hash::{Hash, Hasher},
+        sync::Arc,
+    };
+
+    use common_error::DaftResult;
+    use daft_core::{array::ops::GroupIndices, prelude::*};
+    use serde::{Deserialize, Serialize};
+
+    use super::*;
+
+    // Two distinct unit structs so we can test inequality without parameterized names.
+    #[derive(Serialize, Deserialize)]
+    struct NoopA;
+
+    #[typetag::serde(name = "NoopA")]
+    impl AggFn for NoopA {
+        fn name(&self) -> &'static str {
+            "noop_a"
+        }
+
+        fn get_return_field(&self, inputs: &[Field], _schema: &Schema) -> DaftResult<Field> {
+            Ok(inputs[0].clone())
+        }
+
+        fn call_agg_block(
+            &self,
+            _inputs: Vec<Series>,
+            _groups: Option<&GroupIndices>,
+        ) -> DaftResult<Series> {
+            unimplemented!("only used for handle identity tests")
+        }
+
+        fn call_agg_combine(&self, _a: &[u8], _b: &[u8]) -> DaftResult<Vec<u8>> {
+            unimplemented!("only used for handle identity tests")
+        }
+
+        fn call_agg_finalize(&self, _states: Series, _return_field: &Field) -> DaftResult<Series> {
+            unimplemented!("only used for handle identity tests")
+        }
+    }
+
+    #[derive(Serialize, Deserialize)]
+    struct NoopB;
+
+    #[typetag::serde(name = "NoopB")]
+    impl AggFn for NoopB {
+        fn name(&self) -> &'static str {
+            "noop_b"
+        }
+
+        fn get_return_field(&self, inputs: &[Field], _schema: &Schema) -> DaftResult<Field> {
+            Ok(inputs[0].clone())
+        }
+
+        fn call_agg_block(
+            &self,
+            _inputs: Vec<Series>,
+            _groups: Option<&GroupIndices>,
+        ) -> DaftResult<Series> {
+            unimplemented!("NoopB is only used for handle identity tests")
+        }
+
+        fn call_agg_combine(&self, _a: &[u8], _b: &[u8]) -> DaftResult<Vec<u8>> {
+            unimplemented!("NoopB is only used for handle identity tests")
+        }
+
+        fn call_agg_finalize(&self, _states: Series, _return_field: &Field) -> DaftResult<Series> {
+            unimplemented!("NoopB is only used for handle identity tests")
+        }
+    }
+
+    #[test]
+    fn test_name() {
+        let h = AggFnHandle::new(Arc::new(NoopA));
+        assert_eq!(h.name(), "noop_a");
+    }
+
+    #[test]
+    fn test_eq_by_name() {
+        let a1 = AggFnHandle::new(Arc::new(NoopA));
+        let a2 = AggFnHandle::new(Arc::new(NoopA));
+        let b = AggFnHandle::new(Arc::new(NoopB));
+        assert_eq!(a1, a2);
+        assert_ne!(a1, b);
+    }
+
+    #[test]
+    fn test_hash_consistent_with_eq() {
+        let hash_of = |x: &AggFnHandle| -> u64 {
+            let mut s = DefaultHasher::new();
+            x.hash(&mut s);
+            s.finish()
+        };
+        let a1 = AggFnHandle::new(Arc::new(NoopA));
+        let a2 = AggFnHandle::new(Arc::new(NoopA));
+        let b = AggFnHandle::new(Arc::new(NoopB));
+        assert_eq!(hash_of(&a1), hash_of(&a2));
+        assert_ne!(hash_of(&a1), hash_of(&b));
+    }
+
+    #[test]
+    fn test_display() {
+        let h = AggFnHandle::new(Arc::new(NoopA));
+        assert_eq!(format!("{h}"), "noop_a");
+    }
+
+    #[test]
+    fn test_debug() {
+        let h = AggFnHandle::new(Arc::new(NoopA));
+        assert_eq!(format!("{h:?}"), "AggFnHandle(noop_a)");
+    }
+}

--- a/src/daft-dsl/src/functions/agg_fn.rs
+++ b/src/daft-dsl/src/functions/agg_fn.rs
@@ -7,6 +7,8 @@ use common_error::DaftResult;
 use daft_core::prelude::{DataType, Field, Literal, Series};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
+pub type State = Literal;
+
 /// Trait for user-defined aggregate functions (UDAFs) that plug into the native execution engine.
 ///
 /// Registered with `typetag::serde` so implementations survive plan serialization across
@@ -15,11 +17,11 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 /// Execution follows a three-stage Map → Combine → Reduce pipeline:
 ///
 /// ```text
-/// Map:     call_agg_block(inputs) → Vec<Literal>          (one call per group per input block)
-///          ↓  [framework packs Literals into a typed Struct column]
-/// Combine: call_agg_combine(states) → Vec<Literal>        (one call per group, may be repeated)
+/// Map:     call_agg_block(inputs) → Vec<State>          (one call per group per input block)
+///          ↓  [framework packs States into a typed Struct column]
+/// Combine: call_agg_combine(states) → Vec<State>        (one call per group, may be repeated)
 ///          ↓
-/// Reduce:  call_agg_finalize(state) → Literal             (one call per group)
+/// Reduce:  call_agg_finalize(state) → State             (one call per group)
 /// ```
 ///
 /// Intermediate state is typed: `state_fields` declares one Arrow [`Field`] per state component,
@@ -49,25 +51,25 @@ pub trait AggFn: Send + Sync {
     fn state_fields(&self, inputs: &[Field]) -> DaftResult<Vec<Field>>;
 
     /// **Map stage.** Consume all rows of `inputs` for one group and emit the initial
-    /// accumulator state as one [`Literal`] per field declared by [`state_fields`].
+    /// accumulator state as one [`State`] per field declared by [`state_fields`].
     ///
     /// `inputs` contains one [`Series`] per input column; every Series has the same length
     /// (all rows belonging to this group). Nulls within a Series must be handled explicitly.
-    fn call_agg_block(&self, inputs: Vec<Series>) -> DaftResult<Vec<Literal>>;
+    fn call_agg_block(&self, inputs: Vec<Series>) -> DaftResult<Vec<State>>;
 
     /// **Combine stage.** Merge all partial states for one group into a single state.
     ///
     /// `states` contains one [`Series`] per state field declared by [`state_fields`];
     /// each row in a Series is one partial result from a prior Map or Combine call.
     /// Must be **associative and commutative** — the framework does not guarantee the
-    /// order in which partial states arrive. Returns one [`Literal`] per state field.
-    fn call_agg_combine(&self, states: Vec<Series>) -> DaftResult<Vec<Literal>>;
+    /// order in which partial states arrive. Returns one [`State`] per state field.
+    fn call_agg_combine(&self, states: Vec<Series>) -> DaftResult<Vec<State>>;
 
     /// **Reduce stage.** Produce the final output value from the fully-merged state.
     ///
-    /// Receives one [`Literal`] per state field. Called exactly once per group after all
+    /// Receives one [`State`] per state field. Called exactly once per group after all
     /// Combine passes are complete. Apply any post-processing here (e.g., `mean = sum / count`).
-    fn call_agg_finalize(&self, state: Vec<Literal>) -> DaftResult<Literal>;
+    fn call_agg_finalize(&self, state: Vec<State>) -> DaftResult<State>;
 }
 
 /// A cloneable, cheaply-shareable handle to an [`AggFn`] implementation.
@@ -95,15 +97,15 @@ impl AggFnHandle {
         self.0.state_fields(inputs)
     }
 
-    pub fn call_agg_block(&self, inputs: Vec<Series>) -> DaftResult<Vec<Literal>> {
+    pub fn call_agg_block(&self, inputs: Vec<Series>) -> DaftResult<Vec<State>> {
         self.0.call_agg_block(inputs)
     }
 
-    pub fn call_agg_combine(&self, states: Vec<Series>) -> DaftResult<Vec<Literal>> {
+    pub fn call_agg_combine(&self, states: Vec<Series>) -> DaftResult<Vec<State>> {
         self.0.call_agg_combine(states)
     }
 
-    pub fn call_agg_finalize(&self, state: Vec<Literal>) -> DaftResult<Literal> {
+    pub fn call_agg_finalize(&self, state: Vec<State>) -> DaftResult<State> {
         self.0.call_agg_finalize(state)
     }
 }
@@ -179,15 +181,15 @@ mod tests {
             Ok(vec![inputs[0].clone()])
         }
 
-        fn call_agg_block(&self, _inputs: Vec<Series>) -> DaftResult<Vec<Literal>> {
+        fn call_agg_block(&self, _inputs: Vec<Series>) -> DaftResult<Vec<State>> {
             unimplemented!("only used for handle identity tests")
         }
 
-        fn call_agg_combine(&self, _states: Vec<Series>) -> DaftResult<Vec<Literal>> {
+        fn call_agg_combine(&self, _states: Vec<Series>) -> DaftResult<Vec<State>> {
             unimplemented!("only used for handle identity tests")
         }
 
-        fn call_agg_finalize(&self, _state: Vec<Literal>) -> DaftResult<Literal> {
+        fn call_agg_finalize(&self, _state: Vec<State>) -> DaftResult<State> {
             unimplemented!("only used for handle identity tests")
         }
     }
@@ -209,15 +211,15 @@ mod tests {
             Ok(vec![inputs[0].clone()])
         }
 
-        fn call_agg_block(&self, _inputs: Vec<Series>) -> DaftResult<Vec<Literal>> {
+        fn call_agg_block(&self, _inputs: Vec<Series>) -> DaftResult<Vec<State>> {
             unimplemented!("NoopB is only used for handle identity tests")
         }
 
-        fn call_agg_combine(&self, _states: Vec<Series>) -> DaftResult<Vec<Literal>> {
+        fn call_agg_combine(&self, _states: Vec<Series>) -> DaftResult<Vec<State>> {
             unimplemented!("NoopB is only used for handle identity tests")
         }
 
-        fn call_agg_finalize(&self, _state: Vec<Literal>) -> DaftResult<Literal> {
+        fn call_agg_finalize(&self, _state: Vec<State>) -> DaftResult<State> {
             unimplemented!("NoopB is only used for handle identity tests")
         }
     }

--- a/src/daft-dsl/src/functions/agg_fn.rs
+++ b/src/daft-dsl/src/functions/agg_fn.rs
@@ -14,46 +14,59 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 /// Three mandatory stages:
 ///
 /// ```text
-/// Map:     call_agg_block(inputs, groups) → Binary Series
-///              One serialized accumulator state per group,
-///              produced independently per block.
-///          ↓  [binary columns travel through Arrow pipeline]
-/// Combine: call_agg_combine(&[u8], &[u8]) → Vec<u8>    (binary, associative)
-///              Called by the framework N-1 times per group to fold
-///              partial states into one.
+/// Map:     call_agg_block(inputs, groups) → Vec<Series>
+///              One typed Series per state field, one row per group.
+///          ↓  [typed state columns travel through the Arrow pipeline]
+/// Combine: call_agg_combine(states, groups) → Vec<Series>   (batched, associative)
+///              One call folds all partial states for all groups at once.
 ///          ↓
 /// Reduce:  call_agg_finalize(states, return_field) → typed Series
-///              Called once with the one-state-per-group Binary Series.
+///              Called once with one-row-per-group state to produce final output.
 /// ```
 ///
-/// All three methods are required — there is no single-pass fallback.
+/// The intermediate state is declared via `state_fields` and flows as a Struct column
+/// (one child field per state component). This avoids serialization overhead and lets
+/// the planner and Arrow pipeline work with properly typed data throughout.
 #[typetag::serde(tag = "type")]
 pub trait AggFn: Send + Sync {
     fn name(&self) -> &'static str;
     fn get_return_field(&self, inputs: &[Field], schema: &Schema) -> DaftResult<Field>;
 
-    /// Process `inputs` for one block and return a `Binary`-typed [`Series`]
-    /// containing one serialized accumulator state per group.
+    /// Declare the typed Arrow fields for the intermediate accumulator state.
+    ///
+    /// Returns one `Field` per state component. The names and types declared here
+    /// are used to build the Struct column that carries intermediate state between
+    /// the Map and Reduce stages.
+    fn state_fields(&self, inputs: &[Field]) -> DaftResult<Vec<Field>>;
+
+    /// Process `inputs` for one block and return one typed [`Series`] per state field,
+    /// each containing one row per group.
     fn call_agg_block(
         &self,
         inputs: Vec<Series>,
         groups: Option<&daft_core::array::ops::GroupIndices>,
-    ) -> DaftResult<Series>;
+    ) -> DaftResult<Vec<Series>>;
 
-    /// Merge two serialized accumulator states into one.  Must be **associative**
-    /// (and ideally commutative) so that the framework can fold partial states
-    /// in any order or tree-reduce them in parallel.
+    /// Merge all partial states in a single batched call.
     ///
-    /// The framework calls this N-1 times per group, where N is the number of
-    /// partial states produced by `call_agg_block` across all blocks.
-    fn call_agg_combine(&self, a: &[u8], b: &[u8]) -> DaftResult<Vec<u8>>;
+    /// `states` contains one [`Series`] per state field (matching `state_fields`),
+    /// each with one row per partial result across all groups.
+    /// `groups` maps rows to output groups (same contract as `call_agg_block`).
+    ///
+    /// Must be **associative** so that the framework can fold partial states in any
+    /// order. Returns one [`Series`] per state field, with one row per output group.
+    fn call_agg_combine(
+        &self,
+        states: Vec<Series>,
+        groups: Option<&daft_core::array::ops::GroupIndices>,
+    ) -> DaftResult<Vec<Series>>;
 
-    /// Receives a `Binary`-typed [`Series`] with one combined accumulator per
-    /// group and returns the final typed output column.
+    /// Receives one [`Series`] per state field (one row per group) and returns the
+    /// final typed output column.
     ///
-    /// For simple accumulators (e.g. sum, count) this is just deserialization.
+    /// For simple accumulators (e.g. sum) this is just a rename/cast.
     /// For derived quantities (e.g. mean = sum/count) apply post-processing here.
-    fn call_agg_finalize(&self, states: Series, return_field: &Field) -> DaftResult<Series>;
+    fn call_agg_finalize(&self, states: Vec<Series>, return_field: &Field) -> DaftResult<Series>;
 }
 
 /// A cloneable, hashable (by name) wrapper around `Arc<dyn AggFn>`.
@@ -76,19 +89,27 @@ impl AggFnHandle {
         self.0.get_return_field(inputs, schema)
     }
 
+    pub fn state_fields(&self, inputs: &[Field]) -> DaftResult<Vec<Field>> {
+        self.0.state_fields(inputs)
+    }
+
     pub fn call_agg_block(
         &self,
         inputs: Vec<Series>,
         groups: Option<&daft_core::array::ops::GroupIndices>,
-    ) -> DaftResult<Series> {
+    ) -> DaftResult<Vec<Series>> {
         self.0.call_agg_block(inputs, groups)
     }
 
-    pub fn call_agg_combine(&self, a: &[u8], b: &[u8]) -> DaftResult<Vec<u8>> {
-        self.0.call_agg_combine(a, b)
+    pub fn call_agg_combine(
+        &self,
+        states: Vec<Series>,
+        groups: Option<&daft_core::array::ops::GroupIndices>,
+    ) -> DaftResult<Vec<Series>> {
+        self.0.call_agg_combine(states, groups)
     }
 
-    pub fn call_agg_finalize(&self, states: Series, return_field: &Field) -> DaftResult<Series> {
+    pub fn call_agg_finalize(&self, states: Vec<Series>, return_field: &Field) -> DaftResult<Series> {
         self.0.call_agg_finalize(states, return_field)
     }
 }
@@ -160,19 +181,27 @@ mod tests {
             Ok(inputs[0].clone())
         }
 
+        fn state_fields(&self, inputs: &[Field]) -> DaftResult<Vec<Field>> {
+            Ok(vec![inputs[0].clone()])
+        }
+
         fn call_agg_block(
             &self,
             _inputs: Vec<Series>,
             _groups: Option<&GroupIndices>,
-        ) -> DaftResult<Series> {
+        ) -> DaftResult<Vec<Series>> {
             unimplemented!("only used for handle identity tests")
         }
 
-        fn call_agg_combine(&self, _a: &[u8], _b: &[u8]) -> DaftResult<Vec<u8>> {
+        fn call_agg_combine(
+            &self,
+            _states: Vec<Series>,
+            _groups: Option<&GroupIndices>,
+        ) -> DaftResult<Vec<Series>> {
             unimplemented!("only used for handle identity tests")
         }
 
-        fn call_agg_finalize(&self, _states: Series, _return_field: &Field) -> DaftResult<Series> {
+        fn call_agg_finalize(&self, _states: Vec<Series>, _return_field: &Field) -> DaftResult<Series> {
             unimplemented!("only used for handle identity tests")
         }
     }
@@ -190,19 +219,27 @@ mod tests {
             Ok(inputs[0].clone())
         }
 
+        fn state_fields(&self, inputs: &[Field]) -> DaftResult<Vec<Field>> {
+            Ok(vec![inputs[0].clone()])
+        }
+
         fn call_agg_block(
             &self,
             _inputs: Vec<Series>,
             _groups: Option<&GroupIndices>,
-        ) -> DaftResult<Series> {
+        ) -> DaftResult<Vec<Series>> {
             unimplemented!("NoopB is only used for handle identity tests")
         }
 
-        fn call_agg_combine(&self, _a: &[u8], _b: &[u8]) -> DaftResult<Vec<u8>> {
+        fn call_agg_combine(
+            &self,
+            _states: Vec<Series>,
+            _groups: Option<&GroupIndices>,
+        ) -> DaftResult<Vec<Series>> {
             unimplemented!("NoopB is only used for handle identity tests")
         }
 
-        fn call_agg_finalize(&self, _states: Series, _return_field: &Field) -> DaftResult<Series> {
+        fn call_agg_finalize(&self, _states: Vec<Series>, _return_field: &Field) -> DaftResult<Series> {
             unimplemented!("NoopB is only used for handle identity tests")
         }
     }

--- a/src/daft-dsl/src/functions/agg_fn.rs
+++ b/src/daft-dsl/src/functions/agg_fn.rs
@@ -60,14 +60,6 @@ pub trait AggFn: Send + Sync {
 ///
 /// `Hash` and `PartialEq` compare by function name only, matching the
 /// expression-identity semantics used elsewhere in the planner.
-///
-/// **Name uniqueness requirement**: Because equality and hashing are based
-/// solely on `AggFn::name()`, two handles with the same name are considered
-/// identical by the planner's expression deduplication (`IndexSet`).
-/// Registering two distinct `AggFn` implementations under the same name
-/// will cause one to silently shadow the other in intermediate aggregation
-/// stages.  Ensure that every `AggFn` implementation returns a globally
-/// unique name (e.g. include the crate/module prefix).
 #[derive(Clone)]
 pub struct AggFnHandle(pub Arc<dyn AggFn>);
 

--- a/src/daft-dsl/src/functions/agg_fn.rs
+++ b/src/daft-dsl/src/functions/agg_fn.rs
@@ -7,61 +7,76 @@ use common_error::DaftResult;
 use daft_core::prelude::{DataType, Field, Literal, Series};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-/// Trait for native extension aggregate UDFs.
+/// Trait for user-defined aggregate functions (UDAFs) that plug into the native execution engine.
 ///
-/// Registered with `typetag::serde` so that plan serialization/deserialization works.
+/// Registered with `typetag::serde` so implementations survive plan serialization across
+/// worker boundaries without extra registration steps.
 ///
-/// Three mandatory stages:
+/// Execution follows a three-stage Map → Combine → Reduce pipeline:
 ///
 /// ```text
-/// Map:     call_agg_block(inputs) → Vec<Literal>
-///              One Literal per state field, for this group.
-///          ↓  [framework packs Literals into typed Struct columns]
-/// Combine: call_agg_combine(states) → Vec<Literal>   (associative)
-///              Folds all partial states for this group into one.
+/// Map:     call_agg_block(inputs) → Vec<Literal>          (one call per group per input block)
+///          ↓  [framework packs Literals into a typed Struct column]
+/// Combine: call_agg_combine(states) → Vec<Literal>        (one call per group, may be repeated)
 ///          ↓
-/// Reduce:  call_agg_finalize(state) → Literal
-///              Called once per group to produce the final value.
+/// Reduce:  call_agg_finalize(state) → Literal             (one call per group)
 /// ```
 ///
-/// The intermediate state is declared via `state_fields` and flows as a Struct column
-/// (one child field per state component). This avoids serialization overhead and lets
-/// the planner and Arrow pipeline work with properly typed data throughout.
+/// Intermediate state is typed: `state_fields` declares one Arrow [`Field`] per state component,
+/// and the framework carries them as a Struct column between stages. This avoids binary
+/// serialization and lets Arrow and the query planner reason about state types.
 #[typetag::serde(tag = "type")]
 pub trait AggFn: Send + Sync {
+    /// Globally unique name for this function.
+    ///
+    /// Used as the serde discriminant (`typetag` tag value) and as the sole basis for
+    /// [`AggFnHandle`]'s `Hash` and `PartialEq`. Two handles with the same name are
+    /// considered the same function — choose a name that cannot collide across crates.
     fn name(&self) -> &'static str;
+
+    /// Infer the output [`DataType`] from the types of the input columns.
+    ///
+    /// Called once during planning. `input_types` is parallel to the `inputs` slice
+    /// passed at execution time.
     fn return_dtype(&self, input_types: &[DataType]) -> DaftResult<DataType>;
 
-    /// Declare the typed Arrow fields for the intermediate accumulator state.
+    /// Declare the schema of the intermediate accumulator state.
     ///
-    /// Returns one `Field` per state component. The names and types declared here
-    /// are used to build the Struct column that carries intermediate state between
-    /// the Map and Reduce stages.
+    /// Returns one [`Field`] per state component. The framework uses these fields to
+    /// build the Struct column that carries partial results between Map and Combine stages.
+    /// `inputs` are the input column fields, available here to derive state types that
+    /// depend on the input schema (e.g., keeping the same dtype as the input).
     fn state_fields(&self, inputs: &[Field]) -> DaftResult<Vec<Field>>;
 
-    /// Process `inputs` for one group and return one [`Literal`] per state field.
+    /// **Map stage.** Consume all rows of `inputs` for one group and emit the initial
+    /// accumulator state as one [`Literal`] per field declared by [`state_fields`].
+    ///
+    /// `inputs` contains one [`Series`] per input column; every Series has the same length
+    /// (all rows belonging to this group). Nulls within a Series must be handled explicitly.
     fn call_agg_block(&self, inputs: Vec<Series>) -> DaftResult<Vec<Literal>>;
 
-    /// Merge all partial states for one group into a single state.
+    /// **Combine stage.** Merge all partial states for one group into a single state.
     ///
-    /// `states` contains one [`Series`] per state field (matching `state_fields`),
-    /// where each row is one partial result. Must be **associative**.
-    /// Returns one [`Literal`] per state field.
+    /// `states` contains one [`Series`] per state field declared by [`state_fields`];
+    /// each row in a Series is one partial result from a prior Map or Combine call.
+    /// Must be **associative and commutative** — the framework does not guarantee the
+    /// order in which partial states arrive. Returns one [`Literal`] per state field.
     fn call_agg_combine(&self, states: Vec<Series>) -> DaftResult<Vec<Literal>>;
 
-    /// Receives one [`Literal`] per state field for this group and returns the
-    /// final value.
+    /// **Reduce stage.** Produce the final output value from the fully-merged state.
     ///
-    /// For derived quantities (e.g. mean = sum/count) apply post-processing here.
+    /// Receives one [`Literal`] per state field. Called exactly once per group after all
+    /// Combine passes are complete. Apply any post-processing here (e.g., `mean = sum / count`).
     fn call_agg_finalize(&self, state: Vec<Literal>) -> DaftResult<Literal>;
 }
 
-/// A cloneable, hashable (by name) wrapper around `Arc<dyn AggFn>`.
+/// A cloneable, cheaply-shareable handle to an [`AggFn`] implementation.
 ///
-/// `Hash` and `PartialEq` compare by function name only, matching the
-/// expression-identity semantics used elsewhere in the planner.
+/// Wraps `Arc<dyn AggFn>` so handles can be embedded in expression trees that require
+/// `Clone`. Identity comparisons (`Hash`, `PartialEq`) use the function name only,
+/// consistent with how the planner treats other expression kinds.
 #[derive(Clone)]
-pub struct AggFnHandle(pub Arc<dyn AggFn>);
+pub struct AggFnHandle(Arc<dyn AggFn>);
 
 impl AggFnHandle {
     pub fn new(udf: Arc<dyn AggFn>) -> Self {

--- a/src/daft-dsl/src/functions/mod.rs
+++ b/src/daft-dsl/src/functions/mod.rs
@@ -18,7 +18,7 @@ use std::{
     sync::{Arc, LazyLock, RwLock},
 };
 
-pub use agg_fn::{AggFn, AggFnHandle};
+pub use agg_fn::{AggFn, AggFnHandle, State};
 use common_error::DaftResult;
 use daft_core::prelude::*;
 pub use function_args::{FunctionArg, FunctionArgs, UnaryArg};

--- a/src/daft-dsl/src/functions/mod.rs
+++ b/src/daft-dsl/src/functions/mod.rs
@@ -1,4 +1,5 @@
 pub mod agg;
+pub mod agg_fn;
 pub mod function_args;
 #[cfg(test)]
 mod macro_tests;
@@ -17,6 +18,7 @@ use std::{
     sync::{Arc, LazyLock, RwLock},
 };
 
+pub use agg_fn::{AggFn, AggFnHandle};
 use common_error::DaftResult;
 use daft_core::prelude::*;
 pub use function_args::{FunctionArg, FunctionArgs, UnaryArg};

--- a/src/daft-local-execution/Cargo.toml
+++ b/src/daft-local-execution/Cargo.toml
@@ -81,6 +81,10 @@ python = [
   "daft-text/python"
 ]
 
+[dev-dependencies]
+serde = {workspace = true}
+typetag = {workspace = true}
+
 [lints]
 workspace = true
 

--- a/src/daft-local-execution/src/sinks/grouped_aggregate.rs
+++ b/src/daft-local-execution/src/sinks/grouped_aggregate.rs
@@ -61,6 +61,7 @@ impl AggStrategy {
         for (p, state) in partitioned.into_iter().zip(inner_states.iter_mut()) {
             let state = state.get_or_insert_default();
             state.partially_aggregated.push(p);
+            Self::try_eager_combine(state, params)?;
         }
         Ok(())
     }
@@ -84,6 +85,7 @@ impl AggStrategy {
                 )?;
                 state.partially_aggregated.push(aggregated);
                 state.unaggregated_size = 0;
+                Self::try_eager_combine(state, params)?;
             } else {
                 state.unaggregated_size += p.len();
                 state.unaggregated.push(p);
@@ -104,6 +106,27 @@ impl AggStrategy {
             state.unaggregated_size += p.len();
             state.unaggregated.push(p);
         }
+        Ok(())
+    }
+
+    /// Stage-1 map-side combine: mirrors Ray's `HashShuffleAggregator.compact`.
+    /// When enough partial partitions have accumulated per bucket, folds them
+    /// into one, reducing the binary-state volume shipped to stage 2.
+    fn try_eager_combine(
+        state: &mut SinglePartitionAggregateState,
+        params: &GroupedAggregateParams,
+    ) -> DaftResult<()> {
+        let needs_combine = params
+            .final_agg_exprs
+            .iter()
+            .any(|e| matches!(e.as_ref(), daft_dsl::AggExpr::AggFnCombine { .. }));
+        if !needs_combine || state.partially_aggregated.len() < PARTIAL_AGG_COMBINE_THRESHOLD {
+            return Ok(());
+        }
+        let partitions = std::mem::take(&mut state.partially_aggregated);
+        let concated = MicroPartition::concat(partitions)?;
+        let combined = concated.agg(&params.final_agg_exprs, &params.final_group_by)?;
+        state.partially_aggregated = vec![combined];
         Ok(())
     }
 }
@@ -227,6 +250,11 @@ impl GroupedAggregateState {
     }
 }
 
+/// How many accumulated partial-aggregate partitions (per hash-bucket) to allow
+/// before eagerly combining them with `call_agg_combine`.  Only active when
+/// `AggFn` expressions are present.  Mirrors Ray's `compact` threshold.
+const PARTIAL_AGG_COMBINE_THRESHOLD: usize = 4;
+
 struct GroupedAggregateParams {
     // The original aggregations and group by expressions
     original_aggregations: Vec<BoundAggExpr>,
@@ -260,13 +288,23 @@ impl GroupedAggregateSink {
                 group_by,
             )?;
 
-        // MapGroups aggregations cannot be decomposed into partial / final stages and
-        // must see the full group in a single pass. Detect this case so that we force
-        // a partition-only strategy and run the original aggregations during the
-        // final aggregation step.
+        // AggFn cannot be mixed with MapGroups: MapGroups forces the PartitionOnly strategy
+        // which runs `original_aggregations` in the finalize step.  Since AggFn no longer
+        // has a single-pass fallback, mixing the two would hit the "AggFn must be decomposed"
+        // error at runtime.  Reject the combination upfront with a clear message.
         let has_map_groups = aggregations
             .iter()
             .any(|agg| matches!(agg.as_ref(), daft_dsl::AggExpr::MapGroups { .. }));
+        let has_agg_fn = aggregations
+            .iter()
+            .any(|agg| matches!(agg.as_ref(), daft_dsl::AggExpr::AggFn { .. }));
+        if has_map_groups && has_agg_fn {
+            return Err(common_error::DaftError::ValueError(
+                "Cannot mix MapGroups (Python UDFs) and extension aggregations (AggFn) \
+                 in the same aggregation; split them into separate operations."
+                    .to_string(),
+            ));
+        }
 
         let final_group_by = if !partial_agg_exprs.is_empty() {
             group_by

--- a/src/daft-local-execution/src/sinks/grouped_aggregate.rs
+++ b/src/daft-local-execution/src/sinks/grouped_aggregate.rs
@@ -496,7 +496,7 @@ mod tests {
     use daft_dsl::{
         AggExpr,
         expr::bound_expr::BoundAggExpr,
-        functions::{AggFn, AggFnHandle},
+        functions::{AggFn, AggFnHandle, State},
         unresolved_col,
     };
     use daft_micropartition::MicroPartition;
@@ -521,17 +521,17 @@ mod tests {
             Ok(vec![Field::new("sum", DataType::Int64)])
         }
 
-        fn call_agg_block(&self, inputs: Vec<Series>) -> DaftResult<Vec<Literal>> {
+        fn call_agg_block(&self, inputs: Vec<Series>) -> DaftResult<Vec<State>> {
             let sum: i64 = inputs[0].i64()?.into_iter().map(|v| v.unwrap_or(0)).sum();
             Ok(vec![Literal::Int64(sum)])
         }
 
-        fn call_agg_combine(&self, states: Vec<Series>) -> DaftResult<Vec<Literal>> {
+        fn call_agg_combine(&self, states: Vec<Series>) -> DaftResult<Vec<State>> {
             let sum: i64 = states[0].i64()?.into_iter().map(|v| v.unwrap_or(0)).sum();
             Ok(vec![Literal::Int64(sum)])
         }
 
-        fn call_agg_finalize(&self, state: Vec<Literal>) -> DaftResult<Literal> {
+        fn call_agg_finalize(&self, state: Vec<State>) -> DaftResult<State> {
             Ok(state.into_iter().next().unwrap_or(Literal::Null))
         }
     }

--- a/src/daft-local-execution/src/sinks/grouped_aggregate.rs
+++ b/src/daft-local-execution/src/sinks/grouped_aggregate.rs
@@ -6,7 +6,7 @@ use std::{
 use common_daft_config::DaftExecutionConfig;
 use common_error::DaftResult;
 use common_metrics::ops::NodeType;
-use daft_core::prelude::SchemaRef;
+use daft_core::prelude::{Literal, SchemaRef};
 use daft_dsl::expr::{
     bound_col,
     bound_expr::{BoundAggExpr, BoundExpr},
@@ -515,37 +515,26 @@ mod tests {
             "test_sum_sink"
         }
 
-        fn get_return_field(&self, _inputs: &[Field], _schema: &Schema) -> DaftResult<Field> {
-            Ok(Field::new("x", DataType::Int64))
+        fn return_dtype(&self, _input_types: &[DataType]) -> DaftResult<DataType> {
+            Ok(DataType::Int64)
         }
 
         fn state_fields(&self, _inputs: &[Field]) -> DaftResult<Vec<Field>> {
             Ok(vec![Field::new("sum", DataType::Int64)])
         }
 
-        fn call_agg_block(
-            &self,
-            inputs: Vec<Series>,
-            groups: Option<&daft_core::array::ops::GroupIndices>,
-        ) -> DaftResult<Vec<Series>> {
-            let partial = inputs[0].sum(groups)?;
-            let sums: Vec<i64> = partial.i64()?.into_iter().map(|v| v.unwrap_or(0)).collect();
-            Ok(vec![Int64Array::from_vec("sum", sums).into_series()])
+        fn call_agg_block(&self, inputs: Vec<Series>) -> DaftResult<Vec<Literal>> {
+            let sum: i64 = inputs[0].i64()?.into_iter().map(|v| v.unwrap_or(0)).sum();
+            Ok(vec![Literal::Int64(sum)])
         }
 
-        fn call_agg_combine(
-            &self,
-            states: Vec<Series>,
-            groups: Option<&daft_core::array::ops::GroupIndices>,
-        ) -> DaftResult<Vec<Series>> {
-            let merged = states[0].sum(groups)?;
-            let sums: Vec<i64> = merged.i64()?.into_iter().map(|v| v.unwrap_or(0)).collect();
-            Ok(vec![Int64Array::from_vec("sum", sums).into_series()])
+        fn call_agg_combine(&self, states: Vec<Series>) -> DaftResult<Vec<Literal>> {
+            let sum: i64 = states[0].i64()?.into_iter().map(|v| v.unwrap_or(0)).sum();
+            Ok(vec![Literal::Int64(sum)])
         }
 
-        fn call_agg_finalize(&self, states: Vec<Series>, return_field: &Field) -> DaftResult<Series> {
-            let values: Vec<i64> = states[0].i64()?.into_iter().map(|v| v.unwrap_or(0)).collect();
-            Ok(Int64Array::from_vec(&return_field.name, values).into_series())
+        fn call_agg_finalize(&self, state: Vec<Literal>) -> DaftResult<Literal> {
+            Ok(state.into_iter().next().unwrap_or(Literal::Null))
         }
     }
 

--- a/src/daft-local-execution/src/sinks/grouped_aggregate.rs
+++ b/src/daft-local-execution/src/sinks/grouped_aggregate.rs
@@ -109,8 +109,8 @@ impl AggStrategy {
         Ok(())
     }
 
-    /// Map-side combine: when enough partial partitions have accumulated per
-    /// bucket, folds them into one to reduce binary-state volume before stage 2.
+    /// Map-side combine to keep memory bounded. Uses `agg_combine_only` (not `agg`) so
+    /// `AggFnReduce` columns stay in Binary format and remain valid input for the final `agg()`.
     fn try_eager_combine(
         state: &mut SinglePartitionAggregateState,
         params: &GroupedAggregateParams,
@@ -124,7 +124,8 @@ impl AggStrategy {
         }
         let partitions = std::mem::take(&mut state.partially_aggregated);
         let concated = MicroPartition::concat(partitions)?;
-        let combined = concated.agg(&params.final_agg_exprs, &params.final_group_by)?;
+        let combined =
+            concated.agg_combine_only(&params.final_agg_exprs, &params.final_group_by)?;
         state.partially_aggregated = vec![combined];
         Ok(())
     }
@@ -250,8 +251,7 @@ impl GroupedAggregateState {
 }
 
 /// How many partial-aggregate partitions may accumulate per hash-bucket before
-/// an eager map-side combine is triggered.  Only active when `AggFn` expressions
-/// are present.
+/// an eager map-side combine is triggered. Only active when `AggFn` expressions are present.
 const PARTIAL_AGG_COMBINE_THRESHOLD: usize = 4;
 
 struct GroupedAggregateParams {
@@ -483,5 +483,203 @@ impl BlockingSink for GroupedAggregateSink {
             self.partial_agg_threshold,
             self.high_cardinality_threshold_ratio,
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use common_error::DaftResult;
+    use daft_core::prelude::*;
+    use daft_dsl::{
+        AggExpr,
+        expr::bound_expr::BoundAggExpr,
+        functions::{AggFn, AggFnHandle},
+        unresolved_col,
+    };
+    use daft_micropartition::MicroPartition;
+    use daft_recordbatch::RecordBatch;
+
+    use super::{
+        AggStrategy, GroupedAggregateParams, PARTIAL_AGG_COMBINE_THRESHOLD,
+        SinglePartitionAggregateState,
+    };
+
+    #[derive(serde::Serialize, serde::Deserialize)]
+    struct TestSumAggSink;
+
+    #[typetag::serde(name = "TestSumAggSink")]
+    impl AggFn for TestSumAggSink {
+        fn name(&self) -> &'static str {
+            "test_sum_sink"
+        }
+
+        fn get_return_field(&self, _inputs: &[Field], _schema: &Schema) -> DaftResult<Field> {
+            Ok(Field::new("x", DataType::Int64))
+        }
+
+        fn call_agg_block(
+            &self,
+            inputs: Vec<Series>,
+            groups: Option<&daft_core::array::ops::GroupIndices>,
+        ) -> DaftResult<Series> {
+            let col = &inputs[0];
+            let col_name = format!("{}({})", self.name(), col.name());
+            match groups {
+                None => {
+                    let sum: i64 = col.i64()?.into_iter().map(|v| v.unwrap_or(0)).sum();
+                    let bytes = sum.to_le_bytes().to_vec();
+                    Ok(BinaryArray::from_iter(
+                        &col_name,
+                        std::iter::once(Some(bytes.as_slice())),
+                    )
+                    .into_series())
+                }
+                Some(groups) => {
+                    let sums: Vec<Option<Vec<u8>>> = groups
+                        .iter()
+                        .map(|group| {
+                            let sum: i64 = group
+                                .iter()
+                                .map(|&i| col.i64().unwrap().get(i as usize).unwrap_or(0))
+                                .sum();
+                            Some(sum.to_le_bytes().to_vec())
+                        })
+                        .collect();
+                    Ok(BinaryArray::from_iter(&col_name, sums.iter().map(|b| b.as_deref()))
+                        .into_series())
+                }
+            }
+        }
+
+        fn call_agg_combine(&self, a: &[u8], b: &[u8]) -> DaftResult<Vec<u8>> {
+            let av = i64::from_le_bytes(a.try_into().unwrap());
+            let bv = i64::from_le_bytes(b.try_into().unwrap());
+            Ok((av + bv).to_le_bytes().to_vec())
+        }
+
+        fn call_agg_finalize(&self, states: Series, return_field: &Field) -> DaftResult<Series> {
+            let binary = states.binary()?;
+            let values: Vec<i64> = binary
+                .into_iter()
+                .map(|b| b.map_or(0, |bytes| i64::from_le_bytes(bytes.try_into().unwrap())))
+                .collect();
+            Ok(Int64Array::from_vec(&return_field.name, values).into_series())
+        }
+    }
+
+    fn make_handle() -> AggFnHandle {
+        AggFnHandle::new(Arc::new(TestSumAggSink))
+    }
+
+    fn partial_col_name() -> String {
+        "test_sum_sink(x)".to_string()
+    }
+
+    fn make_binary_mp(value: i64) -> MicroPartition {
+        let col_name = partial_col_name();
+        let bytes = value.to_le_bytes().to_vec();
+        let series =
+            BinaryArray::from_iter(col_name.as_str(), std::iter::once(Some(bytes.as_slice())))
+                .into_series();
+        let rb = RecordBatch::from_nonempty_columns(vec![series]).unwrap();
+        MicroPartition::new_loaded(rb.schema.clone(), Arc::new(vec![rb]), None)
+    }
+
+    fn make_reduce_params() -> GroupedAggregateParams {
+        let col_name = partial_col_name();
+        let schema = Arc::new(Schema::new(std::iter::once(Field::new(
+            col_name.as_str(),
+            DataType::Binary,
+        ))));
+        let return_field = Field::new("x", DataType::Int64);
+        let final_agg = BoundAggExpr::try_new(
+            AggExpr::AggFnReduce {
+                handle: make_handle(),
+                partial: unresolved_col(col_name.as_str()),
+                return_field,
+            },
+            &schema,
+        )
+        .unwrap();
+        GroupedAggregateParams {
+            original_aggregations: vec![],
+            group_by: vec![],
+            partial_agg_exprs: vec![],
+            final_agg_exprs: vec![final_agg],
+            final_group_by: vec![],
+            final_projections: vec![],
+        }
+    }
+
+    fn make_empty_params() -> GroupedAggregateParams {
+        GroupedAggregateParams {
+            original_aggregations: vec![],
+            group_by: vec![],
+            partial_agg_exprs: vec![],
+            final_agg_exprs: vec![],
+            final_group_by: vec![],
+            final_projections: vec![],
+        }
+    }
+
+    #[test]
+    fn test_try_eager_combine_below_threshold() -> DaftResult<()> {
+        let params = make_reduce_params();
+        let mut state = SinglePartitionAggregateState::default();
+        for i in 1..(PARTIAL_AGG_COMBINE_THRESHOLD as i64) {
+            state.partially_aggregated.push(make_binary_mp(i));
+        }
+        let before = state.partially_aggregated.len();
+        AggStrategy::try_eager_combine(&mut state, &params)?;
+        assert_eq!(state.partially_aggregated.len(), before);
+        Ok(())
+    }
+
+    #[test]
+    fn test_try_eager_combine_no_agg_fn_reduce() -> DaftResult<()> {
+        let params = make_empty_params();
+        let mut state = SinglePartitionAggregateState::default();
+        for i in 0..(PARTIAL_AGG_COMBINE_THRESHOLD as i64 + 2) {
+            state.partially_aggregated.push(make_binary_mp(i));
+        }
+        let before = state.partially_aggregated.len();
+        AggStrategy::try_eager_combine(&mut state, &params)?;
+        assert_eq!(state.partially_aggregated.len(), before);
+        Ok(())
+    }
+
+    #[test]
+    fn test_try_eager_combine_triggers() -> DaftResult<()> {
+        let params = make_reduce_params();
+        let mut state = SinglePartitionAggregateState::default();
+        for i in 1..=(PARTIAL_AGG_COMBINE_THRESHOLD as i64) {
+            state.partially_aggregated.push(make_binary_mp(i));
+        }
+        AggStrategy::try_eager_combine(&mut state, &params)?;
+        assert_eq!(state.partially_aggregated.len(), 1);
+
+        // Finalize the combined binary state — should be 1+2+3+4 = 10.
+        let col_name = partial_col_name();
+        let schema = Arc::new(Schema::new(std::iter::once(Field::new(
+            col_name.as_str(),
+            DataType::Binary,
+        ))));
+        let return_field = Field::new("x", DataType::Int64);
+        let final_agg = BoundAggExpr::try_new(
+            AggExpr::AggFnReduce {
+                handle: make_handle(),
+                partial: unresolved_col(col_name.as_str()),
+                return_field,
+            },
+            &schema,
+        )
+        .unwrap();
+        let finalized = state.partially_aggregated[0].agg(&[final_agg], &[])?;
+        let rb = &finalized.record_batches()[0];
+        let col = daft_recordbatch::get_column_by_name(rb, "x")?;
+        assert_eq!(col.i64()?.get(0), Some(10i64));
+        Ok(())
     }
 }

--- a/src/daft-local-execution/src/sinks/grouped_aggregate.rs
+++ b/src/daft-local-execution/src/sinks/grouped_aggregate.rs
@@ -109,9 +109,8 @@ impl AggStrategy {
         Ok(())
     }
 
-    /// Stage-1 map-side combine: mirrors Ray's `HashShuffleAggregator.compact`.
-    /// When enough partial partitions have accumulated per bucket, folds them
-    /// into one, reducing the binary-state volume shipped to stage 2.
+    /// Map-side combine: when enough partial partitions have accumulated per
+    /// bucket, folds them into one to reduce binary-state volume before stage 2.
     fn try_eager_combine(
         state: &mut SinglePartitionAggregateState,
         params: &GroupedAggregateParams,
@@ -119,7 +118,7 @@ impl AggStrategy {
         let needs_combine = params
             .final_agg_exprs
             .iter()
-            .any(|e| matches!(e.as_ref(), daft_dsl::AggExpr::AggFnCombine { .. }));
+            .any(|e| matches!(e.as_ref(), daft_dsl::AggExpr::AggFnReduce { .. }));
         if !needs_combine || state.partially_aggregated.len() < PARTIAL_AGG_COMBINE_THRESHOLD {
             return Ok(());
         }
@@ -250,9 +249,9 @@ impl GroupedAggregateState {
     }
 }
 
-/// How many accumulated partial-aggregate partitions (per hash-bucket) to allow
-/// before eagerly combining them with `call_agg_combine`.  Only active when
-/// `AggFn` expressions are present.  Mirrors Ray's `compact` threshold.
+/// How many partial-aggregate partitions may accumulate per hash-bucket before
+/// an eager map-side combine is triggered.  Only active when `AggFn` expressions
+/// are present.
 const PARTIAL_AGG_COMBINE_THRESHOLD: usize = 4;
 
 struct GroupedAggregateParams {
@@ -288,10 +287,9 @@ impl GroupedAggregateSink {
                 group_by,
             )?;
 
-        // AggFn cannot be mixed with MapGroups: MapGroups forces the PartitionOnly strategy
-        // which runs `original_aggregations` in the finalize step.  Since AggFn no longer
-        // has a single-pass fallback, mixing the two would hit the "AggFn must be decomposed"
-        // error at runtime.  Reject the combination upfront with a clear message.
+        // MapGroups cannot be decomposed into partial/final stages — it must see the full
+        // group in one pass, so it always uses PartitionOnly.  AggFn has no single-pass
+        // path, so the two cannot coexist in the same aggregation.
         let has_map_groups = aggregations
             .iter()
             .any(|agg| matches!(agg.as_ref(), daft_dsl::AggExpr::MapGroups { .. }));

--- a/src/daft-local-execution/src/sinks/grouped_aggregate.rs
+++ b/src/daft-local-execution/src/sinks/grouped_aggregate.rs
@@ -110,7 +110,7 @@ impl AggStrategy {
     }
 
     /// Map-side combine to keep memory bounded. Uses `agg_combine_only` (not `agg`) so
-    /// `AggFnReduce` columns stay in Binary format and remain valid input for the final `agg()`.
+    /// `AggFnReduce` columns stay as Struct and remain valid input for the final `agg()`.
     fn try_eager_combine(
         state: &mut SinglePartitionAggregateState,
         params: &GroupedAggregateParams,
@@ -519,53 +519,32 @@ mod tests {
             Ok(Field::new("x", DataType::Int64))
         }
 
+        fn state_fields(&self, _inputs: &[Field]) -> DaftResult<Vec<Field>> {
+            Ok(vec![Field::new("sum", DataType::Int64)])
+        }
+
         fn call_agg_block(
             &self,
             inputs: Vec<Series>,
             groups: Option<&daft_core::array::ops::GroupIndices>,
-        ) -> DaftResult<Series> {
-            let col = &inputs[0];
-            let col_name = format!("{}({})", self.name(), col.name());
-            match groups {
-                None => {
-                    let sum: i64 = col.i64()?.into_iter().map(|v| v.unwrap_or(0)).sum();
-                    let bytes = sum.to_le_bytes().to_vec();
-                    Ok(
-                        BinaryArray::from_iter(&col_name, std::iter::once(Some(bytes.as_slice())))
-                            .into_series(),
-                    )
-                }
-                Some(groups) => {
-                    let sums: Vec<Option<Vec<u8>>> = groups
-                        .iter()
-                        .map(|group| {
-                            let sum: i64 = group
-                                .iter()
-                                .map(|&i| col.i64().unwrap().get(i as usize).unwrap_or(0))
-                                .sum();
-                            Some(sum.to_le_bytes().to_vec())
-                        })
-                        .collect();
-                    Ok(
-                        BinaryArray::from_iter(&col_name, sums.iter().map(|b| b.as_deref()))
-                            .into_series(),
-                    )
-                }
-            }
+        ) -> DaftResult<Vec<Series>> {
+            let partial = inputs[0].sum(groups)?;
+            let sums: Vec<i64> = partial.i64()?.into_iter().map(|v| v.unwrap_or(0)).collect();
+            Ok(vec![Int64Array::from_vec("sum", sums).into_series()])
         }
 
-        fn call_agg_combine(&self, a: &[u8], b: &[u8]) -> DaftResult<Vec<u8>> {
-            let av = i64::from_le_bytes(a.try_into().unwrap());
-            let bv = i64::from_le_bytes(b.try_into().unwrap());
-            Ok((av + bv).to_le_bytes().to_vec())
+        fn call_agg_combine(
+            &self,
+            states: Vec<Series>,
+            groups: Option<&daft_core::array::ops::GroupIndices>,
+        ) -> DaftResult<Vec<Series>> {
+            let merged = states[0].sum(groups)?;
+            let sums: Vec<i64> = merged.i64()?.into_iter().map(|v| v.unwrap_or(0)).collect();
+            Ok(vec![Int64Array::from_vec("sum", sums).into_series()])
         }
 
-        fn call_agg_finalize(&self, states: Series, return_field: &Field) -> DaftResult<Series> {
-            let binary = states.binary()?;
-            let values: Vec<i64> = binary
-                .into_iter()
-                .map(|b| b.map_or(0, |bytes| i64::from_le_bytes(bytes.try_into().unwrap())))
-                .collect();
+        fn call_agg_finalize(&self, states: Vec<Series>, return_field: &Field) -> DaftResult<Series> {
+            let values: Vec<i64> = states[0].i64()?.into_iter().map(|v| v.unwrap_or(0)).collect();
             Ok(Int64Array::from_vec(&return_field.name, values).into_series())
         }
     }
@@ -578,13 +557,16 @@ mod tests {
         "test_sum_sink(x)".to_string()
     }
 
-    fn make_binary_mp(value: i64) -> MicroPartition {
+    fn state_dtype() -> DataType {
+        DataType::Struct(vec![Field::new("sum", DataType::Int64)])
+    }
+
+    fn make_struct_mp(value: i64) -> MicroPartition {
         let col_name = partial_col_name();
-        let bytes = value.to_le_bytes().to_vec();
-        let series =
-            BinaryArray::from_iter(col_name.as_str(), std::iter::once(Some(bytes.as_slice())))
-                .into_series();
-        let rb = RecordBatch::from_nonempty_columns(vec![series]).unwrap();
+        let sum_series = Int64Array::from_vec("sum", vec![value]).into_series();
+        let struct_field = Field::new(col_name.as_str(), state_dtype());
+        let struct_series = StructArray::new(struct_field, vec![sum_series], None).into_series();
+        let rb = RecordBatch::from_nonempty_columns(vec![struct_series]).unwrap();
         MicroPartition::new_loaded(rb.schema.clone(), Arc::new(vec![rb]), None)
     }
 
@@ -592,7 +574,7 @@ mod tests {
         let col_name = partial_col_name();
         let schema = Arc::new(Schema::new(std::iter::once(Field::new(
             col_name.as_str(),
-            DataType::Binary,
+            state_dtype(),
         ))));
         let return_field = Field::new("x", DataType::Int64);
         let final_agg = BoundAggExpr::try_new(
@@ -630,7 +612,7 @@ mod tests {
         let params = make_reduce_params();
         let mut state = SinglePartitionAggregateState::default();
         for i in 1..(PARTIAL_AGG_COMBINE_THRESHOLD as i64) {
-            state.partially_aggregated.push(make_binary_mp(i));
+            state.partially_aggregated.push(make_struct_mp(i));
         }
         let before = state.partially_aggregated.len();
         AggStrategy::try_eager_combine(&mut state, &params)?;
@@ -643,7 +625,7 @@ mod tests {
         let params = make_empty_params();
         let mut state = SinglePartitionAggregateState::default();
         for i in 0..(PARTIAL_AGG_COMBINE_THRESHOLD as i64 + 2) {
-            state.partially_aggregated.push(make_binary_mp(i));
+            state.partially_aggregated.push(make_struct_mp(i));
         }
         let before = state.partially_aggregated.len();
         AggStrategy::try_eager_combine(&mut state, &params)?;
@@ -656,16 +638,16 @@ mod tests {
         let params = make_reduce_params();
         let mut state = SinglePartitionAggregateState::default();
         for i in 1..=(PARTIAL_AGG_COMBINE_THRESHOLD as i64) {
-            state.partially_aggregated.push(make_binary_mp(i));
+            state.partially_aggregated.push(make_struct_mp(i));
         }
         AggStrategy::try_eager_combine(&mut state, &params)?;
         assert_eq!(state.partially_aggregated.len(), 1);
 
-        // Finalize the combined binary state — should be 1+2+3+4 = 10.
+        // Finalize the combined struct state — should be 1+2+3+4 = 10.
         let col_name = partial_col_name();
         let schema = Arc::new(Schema::new(std::iter::once(Field::new(
             col_name.as_str(),
-            DataType::Binary,
+            state_dtype(),
         ))));
         let return_field = Field::new("x", DataType::Int64);
         let final_agg = BoundAggExpr::try_new(
@@ -681,6 +663,50 @@ mod tests {
         let rb = &finalized.record_batches()[0];
         let col = daft_recordbatch::get_column_by_name(rb, "x")?;
         assert_eq!(col.i64()?.get(0), Some(10i64));
+        Ok(())
+    }
+
+    // Verifies that the Struct output of one combine round is valid input for a
+    // subsequent round: the combined state must survive re-entry into call_agg_combine.
+    #[test]
+    fn test_try_eager_combine_multiple_rounds() -> DaftResult<()> {
+        let params = make_reduce_params();
+        let mut state = SinglePartitionAggregateState::default();
+
+        // Round 1: push exactly threshold MPs (1+2+3+4=10) → collapses to 1.
+        for i in 1..=(PARTIAL_AGG_COMBINE_THRESHOLD as i64) {
+            state.partially_aggregated.push(make_struct_mp(i));
+        }
+        AggStrategy::try_eager_combine(&mut state, &params)?;
+        assert_eq!(state.partially_aggregated.len(), 1);
+
+        // Round 2: add 3 more MPs (5+6+7) so total len=4 hits the threshold again.
+        for i in 5..=(PARTIAL_AGG_COMBINE_THRESHOLD as i64 + 3) {
+            state.partially_aggregated.push(make_struct_mp(i));
+        }
+        AggStrategy::try_eager_combine(&mut state, &params)?;
+        assert_eq!(state.partially_aggregated.len(), 1);
+
+        // Finalize — expected: 1+2+3+4+5+6+7 = 28.
+        let col_name = partial_col_name();
+        let schema = Arc::new(Schema::new(std::iter::once(Field::new(
+            col_name.as_str(),
+            state_dtype(),
+        ))));
+        let return_field = Field::new("x", DataType::Int64);
+        let final_agg = BoundAggExpr::try_new(
+            AggExpr::AggFnReduce {
+                handle: make_handle(),
+                partial: unresolved_col(col_name.as_str()),
+                return_field,
+            },
+            &schema,
+        )
+        .unwrap();
+        let finalized = state.partially_aggregated[0].agg(&[final_agg], &[])?;
+        let rb = &finalized.record_batches()[0];
+        let col = daft_recordbatch::get_column_by_name(rb, "x")?;
+        assert_eq!(col.i64()?.get(0), Some(28i64));
         Ok(())
     }
 }

--- a/src/daft-local-execution/src/sinks/grouped_aggregate.rs
+++ b/src/daft-local-execution/src/sinks/grouped_aggregate.rs
@@ -6,7 +6,7 @@ use std::{
 use common_daft_config::DaftExecutionConfig;
 use common_error::DaftResult;
 use common_metrics::ops::NodeType;
-use daft_core::prelude::{Literal, SchemaRef};
+use daft_core::prelude::SchemaRef;
 use daft_dsl::expr::{
     bound_col,
     bound_expr::{BoundAggExpr, BoundExpr},
@@ -109,6 +109,10 @@ impl AggStrategy {
         Ok(())
     }
 
+    /// How many partial-aggregate partitions may accumulate per hash-bucket before
+    /// an eager map-side combine is triggered. Only active when `AggFn` expressions are present.
+    const PARTIAL_AGG_COMBINE_THRESHOLD: usize = 4;
+
     /// Map-side combine to keep memory bounded. Uses `agg_combine_only` (not `agg`) so
     /// `AggFnReduce` columns stay as Struct and remain valid input for the final `agg()`.
     fn try_eager_combine(
@@ -119,7 +123,8 @@ impl AggStrategy {
             .final_agg_exprs
             .iter()
             .any(|e| matches!(e.as_ref(), daft_dsl::AggExpr::AggFnReduce { .. }));
-        if !needs_combine || state.partially_aggregated.len() < PARTIAL_AGG_COMBINE_THRESHOLD {
+        if !needs_combine || state.partially_aggregated.len() < Self::PARTIAL_AGG_COMBINE_THRESHOLD
+        {
             return Ok(());
         }
         let partitions = std::mem::take(&mut state.partially_aggregated);
@@ -249,10 +254,6 @@ impl GroupedAggregateState {
         res
     }
 }
-
-/// How many partial-aggregate partitions may accumulate per hash-bucket before
-/// an eager map-side combine is triggered. Only active when `AggFn` expressions are present.
-const PARTIAL_AGG_COMBINE_THRESHOLD: usize = 4;
 
 struct GroupedAggregateParams {
     // The original aggregations and group by expressions
@@ -501,10 +502,7 @@ mod tests {
     use daft_micropartition::MicroPartition;
     use daft_recordbatch::RecordBatch;
 
-    use super::{
-        AggStrategy, GroupedAggregateParams, PARTIAL_AGG_COMBINE_THRESHOLD,
-        SinglePartitionAggregateState,
-    };
+    use super::{AggStrategy, GroupedAggregateParams, SinglePartitionAggregateState};
 
     #[derive(serde::Serialize, serde::Deserialize)]
     struct TestSumAggSink;
@@ -600,7 +598,7 @@ mod tests {
     fn test_try_eager_combine_below_threshold() -> DaftResult<()> {
         let params = make_reduce_params();
         let mut state = SinglePartitionAggregateState::default();
-        for i in 1..(PARTIAL_AGG_COMBINE_THRESHOLD as i64) {
+        for i in 1..(AggStrategy::PARTIAL_AGG_COMBINE_THRESHOLD as i64) {
             state.partially_aggregated.push(make_struct_mp(i));
         }
         let before = state.partially_aggregated.len();
@@ -613,7 +611,7 @@ mod tests {
     fn test_try_eager_combine_no_agg_fn_reduce() -> DaftResult<()> {
         let params = make_empty_params();
         let mut state = SinglePartitionAggregateState::default();
-        for i in 0..(PARTIAL_AGG_COMBINE_THRESHOLD as i64 + 2) {
+        for i in 0..(AggStrategy::PARTIAL_AGG_COMBINE_THRESHOLD as i64 + 2) {
             state.partially_aggregated.push(make_struct_mp(i));
         }
         let before = state.partially_aggregated.len();
@@ -626,7 +624,7 @@ mod tests {
     fn test_try_eager_combine_triggers() -> DaftResult<()> {
         let params = make_reduce_params();
         let mut state = SinglePartitionAggregateState::default();
-        for i in 1..=(PARTIAL_AGG_COMBINE_THRESHOLD as i64) {
+        for i in 1..=(AggStrategy::PARTIAL_AGG_COMBINE_THRESHOLD as i64) {
             state.partially_aggregated.push(make_struct_mp(i));
         }
         AggStrategy::try_eager_combine(&mut state, &params)?;
@@ -663,14 +661,14 @@ mod tests {
         let mut state = SinglePartitionAggregateState::default();
 
         // Round 1: push exactly threshold MPs (1+2+3+4=10) → collapses to 1.
-        for i in 1..=(PARTIAL_AGG_COMBINE_THRESHOLD as i64) {
+        for i in 1..=(AggStrategy::PARTIAL_AGG_COMBINE_THRESHOLD as i64) {
             state.partially_aggregated.push(make_struct_mp(i));
         }
         AggStrategy::try_eager_combine(&mut state, &params)?;
         assert_eq!(state.partially_aggregated.len(), 1);
 
         // Round 2: add 3 more MPs (5+6+7) so total len=4 hits the threshold again.
-        for i in 5..=(PARTIAL_AGG_COMBINE_THRESHOLD as i64 + 3) {
+        for i in 5..=(AggStrategy::PARTIAL_AGG_COMBINE_THRESHOLD as i64 + 3) {
             state.partially_aggregated.push(make_struct_mp(i));
         }
         AggStrategy::try_eager_combine(&mut state, &params)?;

--- a/src/daft-local-execution/src/sinks/grouped_aggregate.rs
+++ b/src/daft-local-execution/src/sinks/grouped_aggregate.rs
@@ -530,11 +530,10 @@ mod tests {
                 None => {
                     let sum: i64 = col.i64()?.into_iter().map(|v| v.unwrap_or(0)).sum();
                     let bytes = sum.to_le_bytes().to_vec();
-                    Ok(BinaryArray::from_iter(
-                        &col_name,
-                        std::iter::once(Some(bytes.as_slice())),
+                    Ok(
+                        BinaryArray::from_iter(&col_name, std::iter::once(Some(bytes.as_slice())))
+                            .into_series(),
                     )
-                    .into_series())
                 }
                 Some(groups) => {
                     let sums: Vec<Option<Vec<u8>>> = groups
@@ -547,8 +546,10 @@ mod tests {
                             Some(sum.to_le_bytes().to_vec())
                         })
                         .collect();
-                    Ok(BinaryArray::from_iter(&col_name, sums.iter().map(|b| b.as_deref()))
-                        .into_series())
+                    Ok(
+                        BinaryArray::from_iter(&col_name, sums.iter().map(|b| b.as_deref()))
+                            .into_series(),
+                    )
                 }
             }
         }

--- a/src/daft-local-plan/src/agg.rs
+++ b/src/daft-local-plan/src/agg.rs
@@ -1,5 +1,5 @@
 use common_error::DaftResult;
-use daft_core::prelude::{CountMode, DataType, Schema};
+use daft_core::prelude::{CountMode, DataType, Field, Schema};
 use daft_dsl::{
     AggExpr, ApproxPercentileParams, ExprRef, SketchType, bound_col,
     expr::bound_expr::{BoundAggExpr, BoundExpr},
@@ -334,6 +334,30 @@ pub fn populate_aggregation_stages_bound_with_schema(
                 // or to the final projection list here. The grouped aggregate sinks
                 // will call `agg()` with the original MapGroups expression when
                 // `partial_agg_exprs` is empty.
+            }
+            AggExpr::AggFn { handle, inputs } => {
+                let input_fields: Vec<Field> = inputs
+                    .iter()
+                    .map(|e| e.to_field(schema))
+                    .collect::<DaftResult<Vec<_>>>()?;
+                let return_field = handle.get_return_field(&input_fields, schema)?;
+
+                let partial_col = first_stage!(AggExpr::AggFnBlock {
+                    handle: handle.clone(),
+                    inputs: inputs.clone(),
+                });
+                let final_col = second_stage!(AggExpr::AggFnCombine {
+                    handle: handle.clone(),
+                    partial: partial_col,
+                    return_field,
+                });
+                final_stage(final_col);
+            }
+            AggExpr::AggFnBlock { .. } | AggExpr::AggFnCombine { .. } => {
+                return Err(common_error::DaftError::InternalError(
+                    "AggFnBlock / AggFnCombine must not appear in the top-level aggregation list"
+                        .to_string(),
+                ));
             }
             // Only necessary for Flotilla
             AggExpr::ApproxSketch(expr, sketch_type) => {

--- a/src/daft-local-plan/src/agg.rs
+++ b/src/daft-local-plan/src/agg.rs
@@ -342,20 +342,20 @@ pub fn populate_aggregation_stages_bound_with_schema(
                     .collect::<DaftResult<Vec<_>>>()?;
                 let return_field = handle.get_return_field(&input_fields, schema)?;
 
-                let partial_col = first_stage!(AggExpr::AggFnBlock {
+                let partial_col = first_stage!(AggExpr::AggFnMap {
                     handle: handle.clone(),
                     inputs: inputs.clone(),
                 });
-                let final_col = second_stage!(AggExpr::AggFnCombine {
+                let final_col = second_stage!(AggExpr::AggFnReduce {
                     handle: handle.clone(),
                     partial: partial_col,
                     return_field,
                 });
                 final_stage(final_col);
             }
-            AggExpr::AggFnBlock { .. } | AggExpr::AggFnCombine { .. } => {
+            AggExpr::AggFnMap { .. } | AggExpr::AggFnReduce { .. } => {
                 return Err(common_error::DaftError::InternalError(
-                    "AggFnBlock / AggFnCombine must not appear in the top-level aggregation list"
+                    "AggFnMap / AggFnReduce must not appear in the top-level aggregation list"
                         .to_string(),
                 ));
             }

--- a/src/daft-local-plan/src/agg.rs
+++ b/src/daft-local-plan/src/agg.rs
@@ -340,7 +340,17 @@ pub fn populate_aggregation_stages_bound_with_schema(
                     .iter()
                     .map(|e| e.to_field(schema))
                     .collect::<DaftResult<Vec<_>>>()?;
-                let return_field = handle.get_return_field(&input_fields, schema)?;
+                let input_types: Vec<DataType> =
+                    input_fields.iter().map(|f| f.dtype.clone()).collect();
+                let inputs_str = input_fields
+                    .iter()
+                    .map(|f| f.name.as_ref())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                let return_field = Field::new(
+                    format!("{}({})", handle.name(), inputs_str),
+                    handle.return_dtype(&input_types)?,
+                );
 
                 let partial_col = first_stage!(AggExpr::AggFnMap {
                     handle: handle.clone(),

--- a/src/daft-local-plan/src/agg.rs
+++ b/src/daft-local-plan/src/agg.rs
@@ -342,13 +342,8 @@ pub fn populate_aggregation_stages_bound_with_schema(
                     .collect::<DaftResult<Vec<_>>>()?;
                 let input_types: Vec<DataType> =
                     input_fields.iter().map(|f| f.dtype.clone()).collect();
-                let inputs_str = input_fields
-                    .iter()
-                    .map(|f| f.name.as_ref())
-                    .collect::<Vec<_>>()
-                    .join(", ");
                 let return_field = Field::new(
-                    format!("{}({})", handle.name(), inputs_str),
+                    input_fields[0].name.clone(),
                     handle.return_dtype(&input_types)?,
                 );
 

--- a/src/daft-logical-plan/src/ops/project.rs
+++ b/src/daft-logical-plan/src/ops/project.rs
@@ -674,6 +674,54 @@ fn replace_column_with_semantic_id_aggexpr(
                 })
             }
         }
+        AggExpr::AggFn { handle, inputs } => {
+            let transforms = inputs
+                .iter()
+                .map(|e| replace_column_with_semantic_id(e.clone(), subexprs_to_replace, schema))
+                .collect::<Vec<_>>();
+            if transforms.iter().all(|e| !e.transformed) {
+                Transformed::no(AggExpr::AggFn { handle, inputs })
+            } else {
+                Transformed::yes(AggExpr::AggFn {
+                    handle,
+                    inputs: transforms.iter().map(|t| t.data.clone()).collect(),
+                })
+            }
+        }
+        AggExpr::AggFnBlock { handle, inputs } => {
+            let transforms = inputs
+                .iter()
+                .map(|e| replace_column_with_semantic_id(e.clone(), subexprs_to_replace, schema))
+                .collect::<Vec<_>>();
+            if transforms.iter().all(|e| !e.transformed) {
+                Transformed::no(AggExpr::AggFnBlock { handle, inputs })
+            } else {
+                Transformed::yes(AggExpr::AggFnBlock {
+                    handle,
+                    inputs: transforms.iter().map(|t| t.data.clone()).collect(),
+                })
+            }
+        }
+        AggExpr::AggFnCombine {
+            handle,
+            partial,
+            return_field,
+        } => {
+            let t = replace_column_with_semantic_id(partial.clone(), subexprs_to_replace, schema);
+            if !t.transformed {
+                Transformed::no(AggExpr::AggFnCombine {
+                    handle,
+                    partial,
+                    return_field,
+                })
+            } else {
+                Transformed::yes(AggExpr::AggFnCombine {
+                    handle,
+                    partial: t.data,
+                    return_field,
+                })
+            }
+        }
     }
 }
 

--- a/src/daft-logical-plan/src/ops/project.rs
+++ b/src/daft-logical-plan/src/ops/project.rs
@@ -688,34 +688,34 @@ fn replace_column_with_semantic_id_aggexpr(
                 })
             }
         }
-        AggExpr::AggFnBlock { handle, inputs } => {
+        AggExpr::AggFnMap { handle, inputs } => {
             let transforms = inputs
                 .iter()
                 .map(|e| replace_column_with_semantic_id(e.clone(), subexprs_to_replace, schema))
                 .collect::<Vec<_>>();
             if transforms.iter().all(|e| !e.transformed) {
-                Transformed::no(AggExpr::AggFnBlock { handle, inputs })
+                Transformed::no(AggExpr::AggFnMap { handle, inputs })
             } else {
-                Transformed::yes(AggExpr::AggFnBlock {
+                Transformed::yes(AggExpr::AggFnMap {
                     handle,
                     inputs: transforms.iter().map(|t| t.data.clone()).collect(),
                 })
             }
         }
-        AggExpr::AggFnCombine {
+        AggExpr::AggFnReduce {
             handle,
             partial,
             return_field,
         } => {
             let t = replace_column_with_semantic_id(partial.clone(), subexprs_to_replace, schema);
             if !t.transformed {
-                Transformed::no(AggExpr::AggFnCombine {
+                Transformed::no(AggExpr::AggFnReduce {
                     handle,
                     partial,
                     return_field,
                 })
             } else {
-                Transformed::yes(AggExpr::AggFnCombine {
+                Transformed::yes(AggExpr::AggFnReduce {
                     handle,
                     partial: t.data,
                     return_field,

--- a/src/daft-micropartition/src/ops/agg.rs
+++ b/src/daft-micropartition/src/ops/agg.rs
@@ -27,6 +27,24 @@ impl MicroPartition {
         }
     }
 
+    pub fn agg_combine_only(
+        &self,
+        to_agg: &[BoundAggExpr],
+        group_by: &[BoundExpr],
+    ) -> DaftResult<Self> {
+        match self.concat_or_get()? {
+            None => {
+                let empty_table = RecordBatch::empty(Some(self.schema.clone()));
+                let combined = empty_table.agg_combine_only(to_agg, group_by)?;
+                Ok(Self::new_loaded(combined.schema.clone(), vec![combined].into(), None))
+            }
+            Some(t) => {
+                let combined = t.agg_combine_only(to_agg, group_by)?;
+                Ok(Self::new_loaded(combined.schema.clone(), vec![combined].into(), None))
+            }
+        }
+    }
+
     pub fn dedup(&self, columns: &[BoundExpr]) -> DaftResult<Self> {
         if columns.is_empty() {
             return Err(DaftError::ValueError(

--- a/src/daft-micropartition/src/ops/agg.rs
+++ b/src/daft-micropartition/src/ops/agg.rs
@@ -36,11 +36,19 @@ impl MicroPartition {
             None => {
                 let empty_table = RecordBatch::empty(Some(self.schema.clone()));
                 let combined = empty_table.agg_combine_only(to_agg, group_by)?;
-                Ok(Self::new_loaded(combined.schema.clone(), vec![combined].into(), None))
+                Ok(Self::new_loaded(
+                    combined.schema.clone(),
+                    vec![combined].into(),
+                    None,
+                ))
             }
             Some(t) => {
                 let combined = t.agg_combine_only(to_agg, group_by)?;
-                Ok(Self::new_loaded(combined.schema.clone(), vec![combined].into(), None))
+                Ok(Self::new_loaded(
+                    combined.schema.clone(),
+                    vec![combined].into(),
+                    None,
+                ))
             }
         }
     }

--- a/src/daft-recordbatch/Cargo.toml
+++ b/src/daft-recordbatch/Cargo.toml
@@ -24,6 +24,7 @@ indexmap = {workspace = true}
 num-traits = {workspace = true}
 pyo3 = {workspace = true, optional = true}
 rand = {workspace = true}
+rayon = {workspace = true}
 serde = {workspace = true}
 serde_json = {workspace = true}
 

--- a/src/daft-recordbatch/Cargo.toml
+++ b/src/daft-recordbatch/Cargo.toml
@@ -41,6 +41,9 @@ python = [
   "daft-functions-list/python"
 ]
 
+[dev-dependencies]
+typetag = {workspace = true}
+
 [lints]
 workspace = true
 

--- a/src/daft-recordbatch/src/lib.rs
+++ b/src/daft-recordbatch/src/lib.rs
@@ -101,57 +101,21 @@ fn validate_schema(schema: &Schema, columns: &[Series]) -> DaftResult<()> {
     Ok(())
 }
 
-/// Framework-side fold for `AggFnReduce`: for each group, left-folds the
-/// partial `Binary` states produced by `call_agg_block` into a single state
-/// by calling `call_agg_combine` N-1 times.
-///
-/// Returns a `Binary`-typed [`Series`] with one combined state per group
-/// (or one state total for the ungrouped case).
-fn fold_agg_states(
-    handle: &daft_dsl::functions::AggFnHandle,
-    states: &Series,
-    groups: Option<&GroupIndices>,
-) -> DaftResult<Series> {
-    let binary = states.binary()?;
-    let name = states.name();
+fn unpack_struct_state(struct_series: &Series) -> DaftResult<Vec<Series>> {
+    let DataType::Struct(fields) = struct_series.data_type() else {
+        return Err(DaftError::InternalError(format!(
+            "Expected Struct series for AggFn state, got {}",
+            struct_series.data_type()
+        )));
+    };
+    fields
+        .iter()
+        .map(|f| struct_series.struct_get(&f.name))
+        .collect()
+}
 
-    match groups {
-        None => {
-            let mut acc: Option<Vec<u8>> = None;
-            for i in 0..binary.len() {
-                if let Some(state) = binary.get(i) {
-                    acc = Some(match acc {
-                        None => state.to_vec(),
-                        Some(a) => handle.call_agg_combine(&a, state)?,
-                    });
-                }
-            }
-            let result = acc.unwrap_or_default();
-            Ok(
-                BinaryArray::from_iter(name, std::iter::once(Some(result.as_slice())))
-                    .into_series(),
-            )
-        }
-        Some(groups) => {
-            let mut group_results: Vec<Option<Vec<u8>>> = Vec::with_capacity(groups.len());
-            for indices in groups {
-                let mut acc: Option<Vec<u8>> = None;
-                for &row_idx in indices {
-                    if let Some(state) = binary.get(row_idx as usize) {
-                        acc = Some(match acc {
-                            None => state.to_vec(),
-                            Some(a) => handle.call_agg_combine(&a, state)?,
-                        });
-                    }
-                }
-                group_results.push(acc);
-            }
-            Ok(
-                BinaryArray::from_iter(name, group_results.iter().map(|s| s.as_deref()))
-                    .into_series(),
-            )
-        }
-    }
+fn pack_struct_state(struct_field: Field, state_series: Vec<Series>) -> DaftResult<Series> {
+    Ok(StructArray::new(struct_field, state_series, None).into_series())
 }
 
 impl RecordBatch {
@@ -702,7 +666,7 @@ impl RecordBatch {
     }
 
     /// Like [`eval_agg_expression`] but stops before `call_agg_finalize` for
-    /// [`AggExpr::AggFnReduce`], keeping the `Binary` column type.  Output schema
+    /// [`AggExpr::AggFnReduce`], keeping the Struct column type.  Output schema
     /// matches stage-1 (`AggFnMap`) output — valid input for a subsequent full `agg()`.
     pub(crate) fn eval_agg_expression_combine_only(
         &self,
@@ -713,8 +677,11 @@ impl RecordBatch {
             handle, partial, ..
         } = agg_expr.as_ref()
         {
-            let evaled_partial = self.eval_agg_child(partial)?;
-            fold_agg_states(handle, &evaled_partial, groups)
+            let struct_series = self.eval_agg_child(partial)?;
+            let struct_field = struct_series.field().clone();
+            let state_series = unpack_struct_state(&struct_series)?;
+            let merged = handle.call_agg_combine(state_series, groups)?;
+            pack_struct_state(struct_field, merged)
         } else {
             self.eval_agg_expression(agg_expr, groups)
         }
@@ -802,24 +769,29 @@ impl RecordBatch {
                     .iter()
                     .map(|e| self.eval_agg_child(e))
                     .collect::<DaftResult<_>>()?;
-                let inputs_str = evaled_inputs
+                let input_fields: Vec<Field> =
+                    evaled_inputs.iter().map(|s| s.field().clone()).collect();
+                let inputs_str = input_fields
                     .iter()
-                    .map(|s| s.name())
+                    .map(|f| f.name.as_ref())
                     .collect::<Vec<_>>()
                     .join(", ");
                 let expected_name = format!("{}({})", handle.name(), inputs_str);
-                Ok(handle
-                    .call_agg_block(evaled_inputs, groups)?
-                    .rename(&expected_name))
+                let state_fields = handle.state_fields(&input_fields)?;
+                let state_series = handle.call_agg_block(evaled_inputs, groups)?;
+                let struct_field =
+                    Field::new(expected_name, DataType::Struct(state_fields));
+                Ok(StructArray::new(struct_field, state_series, None).into_series())
             }
             AggExpr::AggFnReduce {
                 handle,
                 partial,
                 return_field,
             } => {
-                let evaled_partial = self.eval_agg_child(partial)?;
-                let combined = fold_agg_states(handle, &evaled_partial, groups)?;
-                handle.call_agg_finalize(combined, return_field)
+                let struct_series = self.eval_agg_child(partial)?;
+                let state_series = unpack_struct_state(&struct_series)?;
+                let merged = handle.call_agg_combine(state_series, groups)?;
+                handle.call_agg_finalize(merged, return_field)
             }
         }
     }

--- a/src/daft-recordbatch/src/lib.rs
+++ b/src/daft-recordbatch/src/lib.rs
@@ -709,7 +709,10 @@ impl RecordBatch {
         agg_expr: &BoundAggExpr,
         groups: Option<&GroupIndices>,
     ) -> DaftResult<Series> {
-        if let AggExpr::AggFnReduce { handle, partial, .. } = agg_expr.as_ref() {
+        if let AggExpr::AggFnReduce {
+            handle, partial, ..
+        } = agg_expr.as_ref()
+        {
             let evaled_partial = self.eval_agg_child(partial)?;
             fold_agg_states(handle, &evaled_partial, groups)
         } else {

--- a/src/daft-recordbatch/src/lib.rs
+++ b/src/daft-recordbatch/src/lib.rs
@@ -783,7 +783,15 @@ impl RecordBatch {
                     .iter()
                     .map(|e| self.eval_agg_child(e))
                     .collect::<DaftResult<_>>()?;
-                handle.call_agg_block(evaled_inputs, groups)
+                let inputs_str = evaled_inputs
+                    .iter()
+                    .map(|s| s.name())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                let expected_name = format!("{}({})", handle.name(), inputs_str);
+                handle
+                    .call_agg_block(evaled_inputs, groups)?
+                    .rename(&expected_name)
             }
             AggExpr::AggFnReduce {
                 handle,

--- a/src/daft-recordbatch/src/lib.rs
+++ b/src/daft-recordbatch/src/lib.rs
@@ -701,6 +701,22 @@ impl RecordBatch {
         }
     }
 
+    /// Like [`eval_agg_expression`] but stops before `call_agg_finalize` for
+    /// [`AggExpr::AggFnReduce`], keeping the `Binary` column type.  Output schema
+    /// matches stage-1 (`AggFnMap`) output — valid input for a subsequent full `agg()`.
+    pub(crate) fn eval_agg_expression_combine_only(
+        &self,
+        agg_expr: &BoundAggExpr,
+        groups: Option<&GroupIndices>,
+    ) -> DaftResult<Series> {
+        if let AggExpr::AggFnReduce { handle, partial, .. } = agg_expr.as_ref() {
+            let evaled_partial = self.eval_agg_child(partial)?;
+            fold_agg_states(handle, &evaled_partial, groups)
+        } else {
+            self.eval_agg_expression(agg_expr, groups)
+        }
+    }
+
     fn eval_agg_expression(
         &self,
         agg_expr: &BoundAggExpr,
@@ -789,9 +805,9 @@ impl RecordBatch {
                     .collect::<Vec<_>>()
                     .join(", ");
                 let expected_name = format!("{}({})", handle.name(), inputs_str);
-                handle
+                Ok(handle
                     .call_agg_block(evaled_inputs, groups)?
-                    .rename(&expected_name)
+                    .rename(&expected_name))
             }
             AggExpr::AggFnReduce {
                 handle,

--- a/src/daft-recordbatch/src/lib.rs
+++ b/src/daft-recordbatch/src/lib.rs
@@ -121,14 +121,15 @@ fn pack_struct_state(struct_field: Field, state_series: Vec<Series>) -> DaftResu
 fn dispatch_per_group(
     inputs: Vec<Series>,
     groups: Option<&GroupIndices>,
-    f: impl Fn(Vec<Series>) -> DaftResult<Vec<Literal>>,
+    f: impl Fn(Vec<Series>) -> DaftResult<Vec<Literal>> + Sync,
 ) -> DaftResult<Vec<Series>> {
     use daft_core::series::from_lit::series_from_literals_iter;
+    use rayon::prelude::*;
 
     let group_lits: Vec<Vec<Literal>> = match groups {
         None => vec![f(inputs)?],
         Some(groups) => groups
-            .iter()
+            .par_iter()
             .map(|indices| {
                 let idx = UInt64Array::from_vec("", indices.iter().copied().collect());
                 let group_inputs: Vec<Series> = inputs

--- a/src/daft-recordbatch/src/lib.rs
+++ b/src/daft-recordbatch/src/lib.rs
@@ -130,7 +130,7 @@ fn dispatch_per_group(
         Some(groups) => groups
             .iter()
             .map(|indices| {
-                let idx = UInt64Array::from_vec("", indices.iter().map(|&i| i).collect());
+                let idx = UInt64Array::from_vec("", indices.iter().copied().collect());
                 let group_inputs: Vec<Series> = inputs
                     .iter()
                     .map(|s| s.take(&idx))
@@ -145,9 +145,7 @@ fn dispatch_per_group(
     }
     let num_fields = group_lits[0].len();
     (0..num_fields)
-        .map(|fi| {
-            series_from_literals_iter(group_lits.iter().map(|g| Ok(g[fi].clone())), None)
-        })
+        .map(|fi| series_from_literals_iter(group_lits.iter().map(|g| Ok(g[fi].clone())), None))
         .collect()
 }
 
@@ -713,9 +711,14 @@ impl RecordBatch {
             let struct_series = self.eval_agg_child(partial)?;
             let struct_field = struct_series.field().clone();
             let state_series = unpack_struct_state(&struct_series)?;
-            let field_names: Vec<String> = state_series.iter().map(|s| s.name().to_string()).collect();
+            let field_names: Vec<String> =
+                state_series.iter().map(|s| s.name().to_string()).collect();
             let merged = dispatch_per_group(state_series, groups, |s| handle.call_agg_combine(s))?;
-            let merged: Vec<Series> = merged.into_iter().zip(field_names.iter()).map(|(s, n)| s.rename(n)).collect();
+            let merged: Vec<Series> = merged
+                .into_iter()
+                .zip(field_names.iter())
+                .map(|(s, n)| s.rename(n))
+                .collect();
             pack_struct_state(struct_field, merged)
         } else {
             self.eval_agg_expression(agg_expr, groups)

--- a/src/daft-recordbatch/src/lib.rs
+++ b/src/daft-recordbatch/src/lib.rs
@@ -118,6 +118,39 @@ fn pack_struct_state(struct_field: Field, state_series: Vec<Series>) -> DaftResu
     Ok(StructArray::new(struct_field, state_series, None).into_series())
 }
 
+fn dispatch_per_group(
+    inputs: Vec<Series>,
+    groups: Option<&GroupIndices>,
+    f: impl Fn(Vec<Series>) -> DaftResult<Vec<Literal>>,
+) -> DaftResult<Vec<Series>> {
+    use daft_core::series::from_lit::series_from_literals_iter;
+
+    let group_lits: Vec<Vec<Literal>> = match groups {
+        None => vec![f(inputs)?],
+        Some(groups) => groups
+            .iter()
+            .map(|indices| {
+                let idx = UInt64Array::from_vec("", indices.iter().map(|&i| i).collect());
+                let group_inputs: Vec<Series> = inputs
+                    .iter()
+                    .map(|s| s.take(&idx))
+                    .collect::<DaftResult<_>>()?;
+                f(group_inputs)
+            })
+            .collect::<DaftResult<_>>()?,
+    };
+
+    if group_lits.is_empty() {
+        return Ok(vec![]);
+    }
+    let num_fields = group_lits[0].len();
+    (0..num_fields)
+        .map(|fi| {
+            series_from_literals_iter(group_lits.iter().map(|g| Ok(g[fi].clone())), None)
+        })
+        .collect()
+}
+
 impl RecordBatch {
     /// Create a new [`RecordBatch`] and handle broadcasting of any unit-length columns
     ///
@@ -680,7 +713,9 @@ impl RecordBatch {
             let struct_series = self.eval_agg_child(partial)?;
             let struct_field = struct_series.field().clone();
             let state_series = unpack_struct_state(&struct_series)?;
-            let merged = handle.call_agg_combine(state_series, groups)?;
+            let field_names: Vec<String> = state_series.iter().map(|s| s.name().to_string()).collect();
+            let merged = dispatch_per_group(state_series, groups, |s| handle.call_agg_combine(s))?;
+            let merged: Vec<Series> = merged.into_iter().zip(field_names.iter()).map(|(s, n)| s.rename(n)).collect();
             pack_struct_state(struct_field, merged)
         } else {
             self.eval_agg_expression(agg_expr, groups)
@@ -778,9 +813,14 @@ impl RecordBatch {
                     .join(", ");
                 let expected_name = format!("{}({})", handle.name(), inputs_str);
                 let state_fields = handle.state_fields(&input_fields)?;
-                let state_series = handle.call_agg_block(evaled_inputs, groups)?;
-                let struct_field =
-                    Field::new(expected_name, DataType::Struct(state_fields));
+                let state_series =
+                    dispatch_per_group(evaled_inputs, groups, |g| handle.call_agg_block(g))?;
+                let state_series: Vec<Series> = state_series
+                    .into_iter()
+                    .zip(state_fields.iter())
+                    .map(|(s, f)| s.rename(&f.name))
+                    .collect();
+                let struct_field = Field::new(expected_name, DataType::Struct(state_fields));
                 Ok(StructArray::new(struct_field, state_series, None).into_series())
             }
             AggExpr::AggFnReduce {
@@ -790,8 +830,28 @@ impl RecordBatch {
             } => {
                 let struct_series = self.eval_agg_child(partial)?;
                 let state_series = unpack_struct_state(&struct_series)?;
-                let merged = handle.call_agg_combine(state_series, groups)?;
-                handle.call_agg_finalize(merged, return_field)
+                let field_names: Vec<String> =
+                    state_series.iter().map(|s| s.name().to_string()).collect();
+                let merged =
+                    dispatch_per_group(state_series, groups, |s| handle.call_agg_combine(s))?;
+                let merged: Vec<Series> = merged
+                    .into_iter()
+                    .zip(field_names.iter())
+                    .map(|(s, n)| s.rename(n))
+                    .collect();
+                use daft_core::series::from_lit::series_from_literals_iter;
+                let n_groups = merged.first().map_or(0, Series::len);
+                let final_lits: Vec<Literal> = (0..n_groups)
+                    .map(|i| {
+                        let state: Vec<Literal> = merged.iter().map(|s| s.get_lit(i)).collect();
+                        handle.call_agg_finalize(state)
+                    })
+                    .collect::<DaftResult<_>>()?;
+                series_from_literals_iter(
+                    final_lits.into_iter().map(Ok),
+                    Some(return_field.dtype.clone()),
+                )
+                .map(|s| s.rename(&return_field.name))
             }
         }
     }

--- a/src/daft-recordbatch/src/lib.rs
+++ b/src/daft-recordbatch/src/lib.rs
@@ -101,6 +101,61 @@ fn validate_schema(schema: &Schema, columns: &[Series]) -> DaftResult<()> {
     Ok(())
 }
 
+/// Framework-side fold for `AggFnCombine`.
+///
+/// Mirrors Ray's `_combine_aggregated_blocks` loop: for each group, reduces
+/// the partial `Binary` states produced by `call_agg_block` into a single
+/// state by calling `call_agg_combine` N-1 times (left fold).
+///
+/// Returns a `Binary`-typed [`Series`] with one combined state per group
+/// (or one state total for the ungrouped case).
+fn fold_agg_states(
+    handle: &daft_dsl::functions::AggFnHandle,
+    states: &Series,
+    groups: Option<&GroupIndices>,
+) -> DaftResult<Series> {
+    let binary = states.binary()?;
+    let name = states.name();
+
+    match groups {
+        None => {
+            let mut acc: Option<Vec<u8>> = None;
+            for i in 0..binary.len() {
+                if let Some(state) = binary.get(i) {
+                    acc = Some(match acc {
+                        None => state.to_vec(),
+                        Some(a) => handle.call_agg_combine(&a, state)?,
+                    });
+                }
+            }
+            let result = acc.unwrap_or_default();
+            Ok(
+                BinaryArray::from_iter(name, std::iter::once(Some(result.as_slice())))
+                    .into_series(),
+            )
+        }
+        Some(groups) => {
+            let mut group_results: Vec<Option<Vec<u8>>> = Vec::with_capacity(groups.len());
+            for indices in groups {
+                let mut acc: Option<Vec<u8>> = None;
+                for &row_idx in indices {
+                    if let Some(state) = binary.get(row_idx as usize) {
+                        acc = Some(match acc {
+                            None => state.to_vec(),
+                            Some(a) => handle.call_agg_combine(&a, state)?,
+                        });
+                    }
+                }
+                group_results.push(acc);
+            }
+            Ok(
+                BinaryArray::from_iter(name, group_results.iter().map(|s| s.as_deref()))
+                    .into_series(),
+            )
+        }
+    }
+}
+
 impl RecordBatch {
     /// Create a new [`RecordBatch`] and handle broadcasting of any unit-length columns
     ///
@@ -720,6 +775,27 @@ impl RecordBatch {
             AggExpr::MapGroups { .. } => Err(DaftError::ValueError(
                 "MapGroups not supported via aggregation, use map_groups instead".to_string(),
             )),
+            AggExpr::AggFn { .. } => Err(DaftError::InternalError(
+                "AggFn must be decomposed into AggFnBlock + AggFnCombine by the planner \
+                 before execution; do not call eval_agg_expression with a raw AggFn"
+                    .to_string(),
+            )),
+            AggExpr::AggFnBlock { handle, inputs } => {
+                let evaled_inputs: Vec<Series> = inputs
+                    .iter()
+                    .map(|e| self.eval_agg_child(e))
+                    .collect::<DaftResult<_>>()?;
+                handle.call_agg_block(evaled_inputs, groups)
+            }
+            AggExpr::AggFnCombine {
+                handle,
+                partial,
+                return_field,
+            } => {
+                let evaled_partial = self.eval_agg_child(partial)?;
+                let combined = fold_agg_states(handle, &evaled_partial, groups)?;
+                handle.call_agg_finalize(combined, return_field)
+            }
         }
     }
 

--- a/src/daft-recordbatch/src/lib.rs
+++ b/src/daft-recordbatch/src/lib.rs
@@ -101,11 +101,9 @@ fn validate_schema(schema: &Schema, columns: &[Series]) -> DaftResult<()> {
     Ok(())
 }
 
-/// Framework-side fold for `AggFnCombine`.
-///
-/// Mirrors Ray's `_combine_aggregated_blocks` loop: for each group, reduces
-/// the partial `Binary` states produced by `call_agg_block` into a single
-/// state by calling `call_agg_combine` N-1 times (left fold).
+/// Framework-side fold for `AggFnReduce`: for each group, left-folds the
+/// partial `Binary` states produced by `call_agg_block` into a single state
+/// by calling `call_agg_combine` N-1 times.
 ///
 /// Returns a `Binary`-typed [`Series`] with one combined state per group
 /// (or one state total for the ungrouped case).
@@ -776,18 +774,18 @@ impl RecordBatch {
                 "MapGroups not supported via aggregation, use map_groups instead".to_string(),
             )),
             AggExpr::AggFn { .. } => Err(DaftError::InternalError(
-                "AggFn must be decomposed into AggFnBlock + AggFnCombine by the planner \
+                "AggFn must be decomposed into AggFnMap + AggFnReduce by the planner \
                  before execution; do not call eval_agg_expression with a raw AggFn"
                     .to_string(),
             )),
-            AggExpr::AggFnBlock { handle, inputs } => {
+            AggExpr::AggFnMap { handle, inputs } => {
                 let evaled_inputs: Vec<Series> = inputs
                     .iter()
                     .map(|e| self.eval_agg_child(e))
                     .collect::<DaftResult<_>>()?;
                 handle.call_agg_block(evaled_inputs, groups)
             }
-            AggExpr::AggFnCombine {
+            AggExpr::AggFnReduce {
                 handle,
                 partial,
                 return_field,

--- a/src/daft-recordbatch/src/ops/agg.rs
+++ b/src/daft-recordbatch/src/ops/agg.rs
@@ -87,6 +87,55 @@ impl RecordBatch {
         Self::from_nonempty_columns([groupkeys_series.as_slice(), &grouped_cols].concat())
     }
 
+    /// Runs a combine-only pass over `to_agg` on partially-aggregated data.
+    ///
+    /// - [`AggExpr::AggFnReduce`]: calls `call_agg_combine` N-1 times per group,
+    ///   returning a `Binary` column — identical schema to stage-1 (`AggFnMap`) output.
+    /// - All other expressions: evaluated normally (they are associative, so the result
+    ///   is a valid intermediate state for a subsequent [`Self::agg`] call).
+    ///
+    /// Intended for the map-side eager combine in `GroupedAggregateSink`.
+    pub fn agg_combine_only(
+        &self,
+        to_agg: &[BoundAggExpr],
+        group_by: &[BoundExpr],
+    ) -> DaftResult<Self> {
+        match group_by.len() {
+            0 => {
+                let cols = to_agg
+                    .iter()
+                    .map(|e| self.eval_agg_expression_combine_only(e, None))
+                    .collect::<DaftResult<Vec<_>>>()?;
+                Self::from_nonempty_columns(cols)
+            }
+            _ => {
+                let groupby_table = self.eval_expression_list(group_by)?;
+                let (groupkey_indices, groupvals_indices) = groupby_table.make_groups()?;
+                let groupkeys_table = {
+                    let indices_as_arr = UInt64Array::from_vec("", groupkey_indices);
+                    groupby_table.take(&indices_as_arr)?
+                };
+                let group_idx_input = if groupvals_indices.len() == 1 {
+                    None
+                } else {
+                    Some(&groupvals_indices)
+                };
+                let grouped_cols = to_agg
+                    .iter()
+                    .map(|e| self.eval_agg_expression_combine_only(e, group_idx_input))
+                    .collect::<DaftResult<Vec<_>>>()?;
+                let groupkeys_series: Vec<Series> = groupkeys_table
+                    .columns
+                    .iter()
+                    .map(|c| c.as_materialized_series().clone())
+                    .collect();
+                Self::from_nonempty_columns(
+                    [groupkeys_series.as_slice(), &grouped_cols].concat(),
+                )
+            }
+        }
+    }
+
     #[cfg(feature = "python")]
     pub fn map_groups(
         &self,
@@ -414,26 +463,33 @@ mod tests {
         .unwrap()
     }
 
-    // Global (no groups): block-agg then combine+finalize, result is 1+2+3 = 6.
+    // Global: two batches (one with a null). Null=0 per TestSumAgg, so 1+null+2+3 = 6.
     #[test]
     fn test_agg_fn_global() -> DaftResult<()> {
-        let rb = RecordBatch::from_nonempty_columns(vec![
-            Int64Array::from_vec("x", vec![1i64, 2, 3]).into_series(),
+        let rb1 = RecordBatch::from_nonempty_columns(vec![
+            Int64Array::from_iter(
+                Arc::new(Field::new("x", DataType::Int64)),
+                [Some(1i64), None, Some(2i64)],
+            )
+            .into_series(),
+        ])?;
+        let rb2 = RecordBatch::from_nonempty_columns(vec![
+            Int64Array::from_vec("x", vec![3i64]).into_series(),
         ])?;
 
-        // Stage 1: AggFnMap — one binary row (sum of all rows).
-        let intermediate = rb.agg_global(&[bound_block(&rb)])?;
-        assert_eq!(intermediate.len(), 1);
+        let partial1 = rb1.agg_global(&[bound_block(&rb1)])?;
+        let partial2 = rb2.agg_global(&[bound_block(&rb2)])?;
+        let merged = RecordBatch::concat(&[partial1, partial2])?;
+        assert_eq!(merged.len(), 2);
 
-        // Stage 2: AggFnReduce — combine (no-op, one group) + finalize.
-        let result = intermediate.agg_global(&[bound_combine(&intermediate.schema)])?;
+        let result = merged.agg_global(&[bound_combine(&merged.schema)])?;
         assert_eq!(result.len(), 1);
         let col = get_column_by_name(&result, "x")?;
         assert_eq!(col.i64()?.get(0), Some(6i64));
         Ok(())
     }
 
-    // Grouped: two groups summed across two simulated shards, then merged.
+    // Three shards (shard3 has null in group "a"). Null=0, so a=1+2+3+null=6, b=10+20+5=35.
     #[test]
     fn test_agg_fn_grouped() -> DaftResult<()> {
         let shard1 = RecordBatch::from_nonempty_columns(vec![
@@ -444,18 +500,26 @@ mod tests {
             Int64Array::from_vec("x", vec![3i64, 20]).into_series(),
             Utf8Array::from_slice("g", &["a", "b"]).into_series(),
         ])?;
+        let shard3 = RecordBatch::from_nonempty_columns(vec![
+            Int64Array::from_iter(
+                Arc::new(Field::new("x", DataType::Int64)),
+                [None::<i64>, Some(5i64)],
+            )
+            .into_series(),
+            Utf8Array::from_slice("g", &["a", "b"]).into_series(),
+        ])?;
 
         let bound_g_s1 = BoundExpr::try_new(unresolved_col("g"), &shard1.schema)?;
         let bound_g_s2 = BoundExpr::try_new(unresolved_col("g"), &shard2.schema)?;
+        let bound_g_s3 = BoundExpr::try_new(unresolved_col("g"), &shard3.schema)?;
 
-        // Stage 1: AggFnMap per shard.
         let partial1 = shard1.agg(&[bound_block(&shard1)], &[bound_g_s1])?;
         let partial2 = shard2.agg(&[bound_block(&shard2)], &[bound_g_s2])?;
+        let partial3 = shard3.agg(&[bound_block(&shard3)], &[bound_g_s3])?;
 
-        // Concat the two partial results (simulates shuffle merge).
-        let merged = RecordBatch::concat(&[partial1, partial2])?;
+        // Simulates shuffle merge: all partial states land in one reduce step.
+        let merged = RecordBatch::concat(&[partial1, partial2, partial3])?;
 
-        // Stage 2: AggFnReduce — combine partial states per group, then finalize.
         let bound_g_m = BoundExpr::try_new(unresolved_col("g"), &merged.schema)?;
         let result = merged.agg(&[bound_combine(&merged.schema)], &[bound_g_m])?;
         assert_eq!(result.len(), 2);
@@ -472,8 +536,111 @@ mod tests {
             .collect::<DaftResult<_>>()?;
         pairs.sort();
 
-        // a: 1+2+3=6, b: 10+20=30
-        assert_eq!(pairs, vec![("a".into(), 6i64), ("b".into(), 30i64)]);
+        assert_eq!(pairs, vec![("a".into(), 6i64), ("b".into(), 35i64)]);
+        Ok(())
+    }
+
+    // Verifies the deserialized handle produces the same pipeline results as the original.
+    #[test]
+    fn test_agg_fn_handle_serde_roundtrip() -> DaftResult<()> {
+        let original = make_handle();
+        let json = serde_json::to_string(&original).unwrap();
+        let restored: AggFnHandle = serde_json::from_str(&json).unwrap();
+        assert_eq!(original.name(), restored.name());
+
+        let rb = RecordBatch::from_nonempty_columns(vec![
+            Int64Array::from_vec("x", vec![4i64, 5, 6]).into_series(),
+        ])?;
+        let block_expr = BoundAggExpr::try_new(
+            AggExpr::AggFnMap {
+                handle: restored.clone(),
+                inputs: vec![unresolved_col("x")],
+            },
+            &rb.schema,
+        )
+        .unwrap();
+        let partial = rb.agg_global(&[block_expr])?;
+
+        let return_field = Field::new("x", DataType::Int64);
+        let reduce_expr = BoundAggExpr::try_new(
+            AggExpr::AggFnReduce {
+                handle: restored,
+                partial: unresolved_col(&*partial_col_name()),
+                return_field,
+            },
+            &partial.schema,
+        )
+        .unwrap();
+        let result = partial.agg_global(&[reduce_expr])?;
+        let col = get_column_by_name(&result, "x")?;
+        assert_eq!(col.i64()?.get(0), Some(15i64)); // 4+5+6
+        Ok(())
+    }
+
+    #[test]
+    fn test_agg_combine_only_preserves_binary() -> DaftResult<()> {
+        let rb1 = RecordBatch::from_nonempty_columns(vec![
+            Int64Array::from_vec("x", vec![1i64, 2]).into_series(),
+        ])?;
+        let rb2 = RecordBatch::from_nonempty_columns(vec![
+            Int64Array::from_vec("x", vec![3i64]).into_series(),
+        ])?;
+        let partial1 = rb1.agg_global(&[bound_block(&rb1)])?;
+        let partial2 = rb2.agg_global(&[bound_block(&rb2)])?;
+        let merged = RecordBatch::concat(&[partial1, partial2])?;
+        assert_eq!(merged.len(), 2);
+
+        let combined = merged.agg_combine_only(&[bound_combine(&merged.schema)], &[])?;
+        assert_eq!(combined.len(), 1);
+        let col = get_column_by_name(&combined, &partial_col_name())?;
+        assert_eq!(col.data_type(), &DataType::Binary, "should remain Binary after combine-only");
+
+        // Now finalize — result should be 1+2+3 = 6 typed as Int64.
+        let final_result = combined.agg_global(&[bound_combine(&combined.schema)])?;
+        let x = get_column_by_name(&final_result, "x")?;
+        assert_eq!(x.i64()?.get(0), Some(6i64));
+        Ok(())
+    }
+
+    #[test]
+    fn test_agg_combine_only_grouped() -> DaftResult<()> {
+        let shard1 = RecordBatch::from_nonempty_columns(vec![
+            Int64Array::from_vec("x", vec![10i64, 1]).into_series(),
+            Utf8Array::from_slice("g", &["a", "b"]).into_series(),
+        ])?;
+        let shard2 = RecordBatch::from_nonempty_columns(vec![
+            Int64Array::from_vec("x", vec![20i64, 2]).into_series(),
+            Utf8Array::from_slice("g", &["a", "b"]).into_series(),
+        ])?;
+
+        let bound_g = |rb: &RecordBatch| BoundExpr::try_new(unresolved_col("g"), &rb.schema);
+        let partial1 = shard1.agg(&[bound_block(&shard1)], &[bound_g(&shard1)?])?;
+        let partial2 = shard2.agg(&[bound_block(&shard2)], &[bound_g(&shard2)?])?;
+        let merged = RecordBatch::concat(&[partial1, partial2])?;
+
+        let bound_g_m = BoundExpr::try_new(unresolved_col("g"), &merged.schema)?;
+        let combined =
+            merged.agg_combine_only(&[bound_combine(&merged.schema)], &[bound_g_m.clone()])?;
+        assert_eq!(combined.len(), 2);
+        let partial_col = get_column_by_name(&combined, &partial_col_name())?;
+        assert_eq!(partial_col.data_type(), &DataType::Binary);
+
+        // Finalize the combined state — a: 10+20=30, b: 1+2=3.
+        let bound_g_c = BoundExpr::try_new(unresolved_col("g"), &combined.schema)?;
+        let final_result =
+            combined.agg(&[bound_combine(&combined.schema)], &[bound_g_c])?;
+        let g_col = get_column_by_name(&final_result, "g")?;
+        let x_col = get_column_by_name(&final_result, "x")?;
+        let mut pairs: Vec<(String, i64)> = (0..final_result.len())
+            .map(|i| {
+                Ok::<_, common_error::DaftError>((
+                    g_col.utf8()?.get(i).unwrap().to_string(),
+                    x_col.i64()?.get(i).unwrap(),
+                ))
+            })
+            .collect::<DaftResult<_>>()?;
+        pairs.sort();
+        assert_eq!(pairs, vec![("a".into(), 30i64), ("b".into(), 3i64)]);
         Ok(())
     }
 }

--- a/src/daft-recordbatch/src/ops/agg.rs
+++ b/src/daft-recordbatch/src/ops/agg.rs
@@ -89,8 +89,8 @@ impl RecordBatch {
 
     /// Runs a combine-only pass over `to_agg` on partially-aggregated data.
     ///
-    /// - [`AggExpr::AggFnReduce`]: calls `call_agg_combine` N-1 times per group,
-    ///   returning a `Binary` column — identical schema to stage-1 (`AggFnMap`) output.
+    /// - [`AggExpr::AggFnReduce`]: calls `call_agg_combine` in one batched call per group,
+    ///   returning a Struct column — identical schema to stage-1 (`AggFnMap`) output.
     /// - All other expressions: evaluated normally (they are associative, so the result
     ///   is a valid intermediate state for a subsequent [`Self::agg`] call).
     ///
@@ -369,29 +369,8 @@ mod tests {
     use crate::{GroupIndices, RecordBatch, ops::get_column_by_name};
 
     /// A sum UDAF that exercises the full three-stage pipeline.
-    ///
-    /// Accumulator encoding: one i64 serialized as 8 little-endian bytes.
     #[derive(serde::Serialize, serde::Deserialize)]
     struct TestSumAgg;
-
-    fn encode_i64s(name: &str, values: &[i64]) -> Series {
-        let byte_rows: Vec<Option<Vec<u8>>> = values
-            .iter()
-            .map(|v| Some(v.to_le_bytes().to_vec()))
-            .collect();
-        BinaryArray::from_iter(name, byte_rows.iter().map(|b| b.as_deref())).into_series()
-    }
-
-    fn decode_i64s(series: &Series) -> Vec<i64> {
-        let binary = series.binary().unwrap();
-        (0..binary.len())
-            .map(|i| {
-                binary
-                    .get(i)
-                    .map_or(0, |b| i64::from_le_bytes(b.try_into().unwrap()))
-            })
-            .collect()
-    }
 
     #[typetag::serde(name = "TestSumAgg")]
     impl AggFn for TestSumAgg {
@@ -403,28 +382,36 @@ mod tests {
             Ok(inputs[0].clone())
         }
 
+        fn state_fields(&self, _inputs: &[Field]) -> DaftResult<Vec<Field>> {
+            Ok(vec![Field::new("sum", DataType::Int64)])
+        }
+
         fn call_agg_block(
             &self,
             inputs: Vec<Series>,
             groups: Option<&GroupIndices>,
-        ) -> DaftResult<Series> {
+        ) -> DaftResult<Vec<Series>> {
             let partial = inputs[0].sum(groups)?;
-            let values = partial
+            let sums: Vec<i64> = partial
                 .i64()?
                 .into_iter()
                 .map(|v| v.unwrap_or(0))
-                .collect::<Vec<_>>();
-            Ok(encode_i64s(partial.name(), &values))
+                .collect();
+            Ok(vec![Int64Array::from_vec("sum", sums).into_series()])
         }
 
-        fn call_agg_combine(&self, a: &[u8], b: &[u8]) -> DaftResult<Vec<u8>> {
-            let sum_a = i64::from_le_bytes(a.try_into().unwrap());
-            let sum_b = i64::from_le_bytes(b.try_into().unwrap());
-            Ok((sum_a + sum_b).to_le_bytes().to_vec())
+        fn call_agg_combine(
+            &self,
+            states: Vec<Series>,
+            groups: Option<&GroupIndices>,
+        ) -> DaftResult<Vec<Series>> {
+            let merged = states[0].sum(groups)?;
+            let sums: Vec<i64> = merged.i64()?.into_iter().map(|v| v.unwrap_or(0)).collect();
+            Ok(vec![Int64Array::from_vec("sum", sums).into_series()])
         }
 
-        fn call_agg_finalize(&self, state: Series, return_field: &Field) -> DaftResult<Series> {
-            let values = decode_i64s(&state);
+        fn call_agg_finalize(&self, states: Vec<Series>, return_field: &Field) -> DaftResult<Series> {
+            let values: Vec<i64> = states[0].i64()?.into_iter().map(|v| v.unwrap_or(0)).collect();
             Ok(Int64Array::from_vec(&return_field.name, values).into_series())
         }
     }
@@ -576,7 +563,7 @@ mod tests {
     }
 
     #[test]
-    fn test_agg_combine_only_preserves_binary() -> DaftResult<()> {
+    fn test_agg_combine_only_preserves_struct() -> DaftResult<()> {
         let rb1 = RecordBatch::from_nonempty_columns(vec![
             Int64Array::from_vec("x", vec![1i64, 2]).into_series(),
         ])?;
@@ -591,10 +578,10 @@ mod tests {
         let combined = merged.agg_combine_only(&[bound_combine(&merged.schema)], &[])?;
         assert_eq!(combined.len(), 1);
         let col = get_column_by_name(&combined, &partial_col_name())?;
-        assert_eq!(
-            col.data_type(),
-            &DataType::Binary,
-            "should remain Binary after combine-only"
+        assert!(
+            matches!(col.data_type(), DataType::Struct(_)),
+            "should remain Struct after combine-only, got {}",
+            col.data_type()
         );
 
         // Now finalize — result should be 1+2+3 = 6 typed as Int64.
@@ -627,7 +614,7 @@ mod tests {
         )?;
         assert_eq!(combined.len(), 2);
         let partial_col = get_column_by_name(&combined, &partial_col_name())?;
-        assert_eq!(partial_col.data_type(), &DataType::Binary);
+        assert!(matches!(partial_col.data_type(), DataType::Struct(_)));
 
         // Finalize the combined state — a: 10+20=30, b: 1+2=3.
         let bound_g_c = BoundExpr::try_new(unresolved_col("g"), &combined.schema)?;

--- a/src/daft-recordbatch/src/ops/agg.rs
+++ b/src/daft-recordbatch/src/ops/agg.rs
@@ -366,7 +366,7 @@ mod tests {
         unresolved_col,
     };
 
-    use crate::{GroupIndices, RecordBatch, ops::get_column_by_name};
+    use crate::{RecordBatch, ops::get_column_by_name};
 
     /// A sum UDAF that exercises the full three-stage pipeline.
     #[derive(serde::Serialize, serde::Deserialize)]

--- a/src/daft-recordbatch/src/ops/agg.rs
+++ b/src/daft-recordbatch/src/ops/agg.rs
@@ -362,7 +362,7 @@ mod tests {
     use daft_dsl::{
         AggExpr,
         expr::bound_expr::{BoundAggExpr, BoundExpr},
-        functions::{AggFn, AggFnHandle},
+        functions::{AggFn, AggFnHandle, State},
         unresolved_col,
     };
 
@@ -386,17 +386,17 @@ mod tests {
             Ok(vec![Field::new("sum", DataType::Int64)])
         }
 
-        fn call_agg_block(&self, inputs: Vec<Series>) -> DaftResult<Vec<Literal>> {
+        fn call_agg_block(&self, inputs: Vec<Series>) -> DaftResult<Vec<State>> {
             let sum: i64 = inputs[0].i64()?.into_iter().map(|v| v.unwrap_or(0)).sum();
             Ok(vec![Literal::Int64(sum)])
         }
 
-        fn call_agg_combine(&self, states: Vec<Series>) -> DaftResult<Vec<Literal>> {
+        fn call_agg_combine(&self, states: Vec<Series>) -> DaftResult<Vec<State>> {
             let sum: i64 = states[0].i64()?.into_iter().map(|v| v.unwrap_or(0)).sum();
             Ok(vec![Literal::Int64(sum)])
         }
 
-        fn call_agg_finalize(&self, state: Vec<Literal>) -> DaftResult<Literal> {
+        fn call_agg_finalize(&self, state: Vec<State>) -> DaftResult<State> {
             Ok(state.into_iter().next().unwrap_or(Literal::Null))
         }
     }

--- a/src/daft-recordbatch/src/ops/agg.rs
+++ b/src/daft-recordbatch/src/ops/agg.rs
@@ -392,7 +392,7 @@ mod tests {
 
     fn bound_block(rb: &RecordBatch) -> BoundAggExpr {
         BoundAggExpr::try_new(
-            AggExpr::AggFnBlock {
+            AggExpr::AggFnMap {
                 handle: make_handle(),
                 inputs: vec![unresolved_col("x")],
             },
@@ -404,7 +404,7 @@ mod tests {
     fn bound_combine(schema: &daft_core::prelude::SchemaRef) -> BoundAggExpr {
         let return_field = Field::new("x", DataType::Int64);
         BoundAggExpr::try_new(
-            AggExpr::AggFnCombine {
+            AggExpr::AggFnReduce {
                 handle: make_handle(),
                 partial: unresolved_col(&*partial_col_name()),
                 return_field,
@@ -421,11 +421,11 @@ mod tests {
             Int64Array::from_vec("x", vec![1i64, 2, 3]).into_series(),
         ])?;
 
-        // Stage 1: AggFnBlock — one binary row (sum of all rows).
+        // Stage 1: AggFnMap — one binary row (sum of all rows).
         let intermediate = rb.agg_global(&[bound_block(&rb)])?;
         assert_eq!(intermediate.len(), 1);
 
-        // Stage 2: AggFnCombine — combine (no-op, one group) + finalize.
+        // Stage 2: AggFnReduce — combine (no-op, one group) + finalize.
         let result = intermediate.agg_global(&[bound_combine(&intermediate.schema)])?;
         assert_eq!(result.len(), 1);
         let col = get_column_by_name(&result, "x")?;
@@ -448,14 +448,14 @@ mod tests {
         let bound_g_s1 = BoundExpr::try_new(unresolved_col("g"), &shard1.schema)?;
         let bound_g_s2 = BoundExpr::try_new(unresolved_col("g"), &shard2.schema)?;
 
-        // Stage 1: AggFnBlock per shard.
+        // Stage 1: AggFnMap per shard.
         let partial1 = shard1.agg(&[bound_block(&shard1)], &[bound_g_s1])?;
         let partial2 = shard2.agg(&[bound_block(&shard2)], &[bound_g_s2])?;
 
         // Concat the two partial results (simulates shuffle merge).
         let merged = RecordBatch::concat(&[partial1, partial2])?;
 
-        // Stage 2: AggFnCombine — combine partial states per group, then finalize.
+        // Stage 2: AggFnReduce — combine partial states per group, then finalize.
         let bound_g_m = BoundExpr::try_new(unresolved_col("g"), &merged.schema)?;
         let result = merged.agg(&[bound_combine(&merged.schema)], &[bound_g_m])?;
         assert_eq!(result.len(), 2);

--- a/src/daft-recordbatch/src/ops/agg.rs
+++ b/src/daft-recordbatch/src/ops/agg.rs
@@ -129,9 +129,7 @@ impl RecordBatch {
                     .iter()
                     .map(|c| c.as_materialized_series().clone())
                     .collect();
-                Self::from_nonempty_columns(
-                    [groupkeys_series.as_slice(), &grouped_cols].concat(),
-                )
+                Self::from_nonempty_columns([groupkeys_series.as_slice(), &grouped_cols].concat())
             }
         }
     }
@@ -593,7 +591,11 @@ mod tests {
         let combined = merged.agg_combine_only(&[bound_combine(&merged.schema)], &[])?;
         assert_eq!(combined.len(), 1);
         let col = get_column_by_name(&combined, &partial_col_name())?;
-        assert_eq!(col.data_type(), &DataType::Binary, "should remain Binary after combine-only");
+        assert_eq!(
+            col.data_type(),
+            &DataType::Binary,
+            "should remain Binary after combine-only"
+        );
 
         // Now finalize — result should be 1+2+3 = 6 typed as Int64.
         let final_result = combined.agg_global(&[bound_combine(&combined.schema)])?;
@@ -619,16 +621,17 @@ mod tests {
         let merged = RecordBatch::concat(&[partial1, partial2])?;
 
         let bound_g_m = BoundExpr::try_new(unresolved_col("g"), &merged.schema)?;
-        let combined =
-            merged.agg_combine_only(&[bound_combine(&merged.schema)], &[bound_g_m.clone()])?;
+        let combined = merged.agg_combine_only(
+            &[bound_combine(&merged.schema)],
+            std::slice::from_ref(&bound_g_m),
+        )?;
         assert_eq!(combined.len(), 2);
         let partial_col = get_column_by_name(&combined, &partial_col_name())?;
         assert_eq!(partial_col.data_type(), &DataType::Binary);
 
         // Finalize the combined state — a: 10+20=30, b: 1+2=3.
         let bound_g_c = BoundExpr::try_new(unresolved_col("g"), &combined.schema)?;
-        let final_result =
-            combined.agg(&[bound_combine(&combined.schema)], &[bound_g_c])?;
+        let final_result = combined.agg(&[bound_combine(&combined.schema)], &[bound_g_c])?;
         let g_col = get_column_by_name(&final_result, "g")?;
         let x_col = get_column_by_name(&final_result, "x")?;
         let mut pairs: Vec<(String, i64)> = (0..final_result.len())

--- a/src/daft-recordbatch/src/ops/agg.rs
+++ b/src/daft-recordbatch/src/ops/agg.rs
@@ -378,41 +378,26 @@ mod tests {
             "test_sum"
         }
 
-        fn get_return_field(&self, inputs: &[Field], _schema: &Schema) -> DaftResult<Field> {
-            Ok(inputs[0].clone())
+        fn return_dtype(&self, input_types: &[DataType]) -> DaftResult<DataType> {
+            Ok(input_types[0].clone())
         }
 
         fn state_fields(&self, _inputs: &[Field]) -> DaftResult<Vec<Field>> {
             Ok(vec![Field::new("sum", DataType::Int64)])
         }
 
-        fn call_agg_block(
-            &self,
-            inputs: Vec<Series>,
-            groups: Option<&GroupIndices>,
-        ) -> DaftResult<Vec<Series>> {
-            let partial = inputs[0].sum(groups)?;
-            let sums: Vec<i64> = partial
-                .i64()?
-                .into_iter()
-                .map(|v| v.unwrap_or(0))
-                .collect();
-            Ok(vec![Int64Array::from_vec("sum", sums).into_series()])
+        fn call_agg_block(&self, inputs: Vec<Series>) -> DaftResult<Vec<Literal>> {
+            let sum: i64 = inputs[0].i64()?.into_iter().map(|v| v.unwrap_or(0)).sum();
+            Ok(vec![Literal::Int64(sum)])
         }
 
-        fn call_agg_combine(
-            &self,
-            states: Vec<Series>,
-            groups: Option<&GroupIndices>,
-        ) -> DaftResult<Vec<Series>> {
-            let merged = states[0].sum(groups)?;
-            let sums: Vec<i64> = merged.i64()?.into_iter().map(|v| v.unwrap_or(0)).collect();
-            Ok(vec![Int64Array::from_vec("sum", sums).into_series()])
+        fn call_agg_combine(&self, states: Vec<Series>) -> DaftResult<Vec<Literal>> {
+            let sum: i64 = states[0].i64()?.into_iter().map(|v| v.unwrap_or(0)).sum();
+            Ok(vec![Literal::Int64(sum)])
         }
 
-        fn call_agg_finalize(&self, states: Vec<Series>, return_field: &Field) -> DaftResult<Series> {
-            let values: Vec<i64> = states[0].i64()?.into_iter().map(|v| v.unwrap_or(0)).collect();
-            Ok(Int64Array::from_vec(&return_field.name, values).into_series())
+        fn call_agg_finalize(&self, state: Vec<Literal>) -> DaftResult<Literal> {
+            Ok(state.into_iter().next().unwrap_or(Literal::Null))
         }
     }
 

--- a/src/daft-recordbatch/src/ops/agg.rs
+++ b/src/daft-recordbatch/src/ops/agg.rs
@@ -305,3 +305,175 @@ impl RecordBatch {
         self.take(&indices_as_arr)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use common_error::DaftResult;
+    use daft_core::prelude::*;
+    use daft_dsl::{
+        AggExpr,
+        expr::bound_expr::{BoundAggExpr, BoundExpr},
+        functions::{AggFn, AggFnHandle},
+        unresolved_col,
+    };
+
+    use crate::{GroupIndices, RecordBatch, ops::get_column_by_name};
+
+    /// A sum UDAF that exercises the full three-stage pipeline.
+    ///
+    /// Accumulator encoding: one i64 serialized as 8 little-endian bytes.
+    #[derive(serde::Serialize, serde::Deserialize)]
+    struct TestSumAgg;
+
+    fn encode_i64s(name: &str, values: &[i64]) -> Series {
+        let byte_rows: Vec<Option<Vec<u8>>> = values
+            .iter()
+            .map(|v| Some(v.to_le_bytes().to_vec()))
+            .collect();
+        BinaryArray::from_iter(name, byte_rows.iter().map(|b| b.as_deref())).into_series()
+    }
+
+    fn decode_i64s(series: &Series) -> Vec<i64> {
+        let binary = series.binary().unwrap();
+        (0..binary.len())
+            .map(|i| {
+                binary
+                    .get(i)
+                    .map_or(0, |b| i64::from_le_bytes(b.try_into().unwrap()))
+            })
+            .collect()
+    }
+
+    #[typetag::serde(name = "TestSumAgg")]
+    impl AggFn for TestSumAgg {
+        fn name(&self) -> &'static str {
+            "test_sum"
+        }
+
+        fn get_return_field(&self, inputs: &[Field], _schema: &Schema) -> DaftResult<Field> {
+            Ok(inputs[0].clone())
+        }
+
+        fn call_agg_block(
+            &self,
+            inputs: Vec<Series>,
+            groups: Option<&GroupIndices>,
+        ) -> DaftResult<Series> {
+            let partial = inputs[0].sum(groups)?;
+            let values = partial
+                .i64()?
+                .into_iter()
+                .map(|v| v.unwrap_or(0))
+                .collect::<Vec<_>>();
+            Ok(encode_i64s(partial.name(), &values))
+        }
+
+        fn call_agg_combine(&self, a: &[u8], b: &[u8]) -> DaftResult<Vec<u8>> {
+            let sum_a = i64::from_le_bytes(a.try_into().unwrap());
+            let sum_b = i64::from_le_bytes(b.try_into().unwrap());
+            Ok((sum_a + sum_b).to_le_bytes().to_vec())
+        }
+
+        fn call_agg_finalize(&self, state: Series, return_field: &Field) -> DaftResult<Series> {
+            let values = decode_i64s(&state);
+            Ok(Int64Array::from_vec(&return_field.name, values).into_series())
+        }
+    }
+
+    fn make_handle() -> AggFnHandle {
+        AggFnHandle::new(Arc::new(TestSumAgg))
+    }
+
+    fn partial_col_name() -> String {
+        format!("{}({})", "test_sum", "x")
+    }
+
+    fn bound_block(rb: &RecordBatch) -> BoundAggExpr {
+        BoundAggExpr::try_new(
+            AggExpr::AggFnBlock {
+                handle: make_handle(),
+                inputs: vec![unresolved_col("x")],
+            },
+            &rb.schema,
+        )
+        .unwrap()
+    }
+
+    fn bound_combine(schema: &daft_core::prelude::SchemaRef) -> BoundAggExpr {
+        let return_field = Field::new("x", DataType::Int64);
+        BoundAggExpr::try_new(
+            AggExpr::AggFnCombine {
+                handle: make_handle(),
+                partial: unresolved_col(&*partial_col_name()),
+                return_field,
+            },
+            schema,
+        )
+        .unwrap()
+    }
+
+    // Global (no groups): block-agg then combine+finalize, result is 1+2+3 = 6.
+    #[test]
+    fn test_agg_fn_global() -> DaftResult<()> {
+        let rb = RecordBatch::from_nonempty_columns(vec![
+            Int64Array::from_vec("x", vec![1i64, 2, 3]).into_series(),
+        ])?;
+
+        // Stage 1: AggFnBlock — one binary row (sum of all rows).
+        let intermediate = rb.agg_global(&[bound_block(&rb)])?;
+        assert_eq!(intermediate.len(), 1);
+
+        // Stage 2: AggFnCombine — combine (no-op, one group) + finalize.
+        let result = intermediate.agg_global(&[bound_combine(&intermediate.schema)])?;
+        assert_eq!(result.len(), 1);
+        let col = get_column_by_name(&result, "x")?;
+        assert_eq!(col.i64()?.get(0), Some(6i64));
+        Ok(())
+    }
+
+    // Grouped: two groups summed across two simulated shards, then merged.
+    #[test]
+    fn test_agg_fn_grouped() -> DaftResult<()> {
+        let shard1 = RecordBatch::from_nonempty_columns(vec![
+            Int64Array::from_vec("x", vec![1i64, 2, 10]).into_series(),
+            Utf8Array::from_slice("g", &["a", "a", "b"]).into_series(),
+        ])?;
+        let shard2 = RecordBatch::from_nonempty_columns(vec![
+            Int64Array::from_vec("x", vec![3i64, 20]).into_series(),
+            Utf8Array::from_slice("g", &["a", "b"]).into_series(),
+        ])?;
+
+        let bound_g_s1 = BoundExpr::try_new(unresolved_col("g"), &shard1.schema)?;
+        let bound_g_s2 = BoundExpr::try_new(unresolved_col("g"), &shard2.schema)?;
+
+        // Stage 1: AggFnBlock per shard.
+        let partial1 = shard1.agg(&[bound_block(&shard1)], &[bound_g_s1])?;
+        let partial2 = shard2.agg(&[bound_block(&shard2)], &[bound_g_s2])?;
+
+        // Concat the two partial results (simulates shuffle merge).
+        let merged = RecordBatch::concat(&[partial1, partial2])?;
+
+        // Stage 2: AggFnCombine — combine partial states per group, then finalize.
+        let bound_g_m = BoundExpr::try_new(unresolved_col("g"), &merged.schema)?;
+        let result = merged.agg(&[bound_combine(&merged.schema)], &[bound_g_m])?;
+        assert_eq!(result.len(), 2);
+
+        let g_col = get_column_by_name(&result, "g")?;
+        let x_col = get_column_by_name(&result, "x")?;
+        let mut pairs: Vec<(String, i64)> = (0..result.len())
+            .map(|i| {
+                Ok::<_, common_error::DaftError>((
+                    g_col.utf8()?.get(i).unwrap().to_string(),
+                    x_col.i64()?.get(i).unwrap(),
+                ))
+            })
+            .collect::<DaftResult<_>>()?;
+        pairs.sort();
+
+        // a: 1+2+3=6, b: 10+20=30
+        assert_eq!(pairs, vec![("a".into(), 6i64), ("b".into(), 30i64)]);
+        Ok(())
+    }
+}

--- a/src/daft-recordbatch/src/ops/window.rs
+++ b/src/daft-recordbatch/src/ops/window.rs
@@ -28,10 +28,13 @@ impl RecordBatch {
         let agg_exprs = to_agg.to_vec();
 
         if let [agg_expr] = agg_exprs.as_slice()
-            && matches!(agg_expr.as_ref(), AggExpr::MapGroups { .. })
+            && matches!(
+                agg_expr.as_ref(),
+                AggExpr::MapGroups { .. } | AggExpr::AggFn { .. }
+            )
         {
             return Err(DaftError::ValueError(
-                "MapGroups not supported in window functions".into(),
+                "MapGroups and extension aggregations (AggFn) are not supported in window functions".into(),
             ));
         }
 
@@ -79,9 +82,12 @@ impl RecordBatch {
     }
 
     pub fn window_agg(&self, to_agg: &BoundAggExpr, name: String) -> DaftResult<Self> {
-        if matches!(to_agg.as_ref(), AggExpr::MapGroups { .. }) {
+        if matches!(
+            to_agg.as_ref(),
+            AggExpr::MapGroups { .. } | AggExpr::AggFn { .. }
+        ) {
             return Err(DaftError::ValueError(
-                "MapGroups not supported in window functions".into(),
+                "MapGroups and extension aggregations (AggFn) are not supported in window functions".into(),
             ));
         }
 

--- a/src/daft-sql/src/modules/aggs.rs
+++ b/src/daft-sql/src/modules/aggs.rs
@@ -207,8 +207,8 @@ fn to_expr(expr: &AggExpr, args: &[ExprRef]) -> SQLPlannerResult<ExprRef> {
         AggExpr::Set(_) => unsupported_sql_err!("set"),
         AggExpr::Skew(_) => unsupported_sql_err!("skew"),
         AggExpr::AggFn { .. } => unsupported_sql_err!("agg_fn"),
-        AggExpr::AggFnBlock { .. } => unsupported_sql_err!("agg_fn_block"),
-        AggExpr::AggFnCombine { .. } => unsupported_sql_err!("agg_fn_combine"),
+        AggExpr::AggFnMap { .. } => unsupported_sql_err!("agg_fn_block"),
+        AggExpr::AggFnReduce { .. } => unsupported_sql_err!("agg_fn_combine"),
     }
 }
 

--- a/src/daft-sql/src/modules/aggs.rs
+++ b/src/daft-sql/src/modules/aggs.rs
@@ -206,6 +206,9 @@ fn to_expr(expr: &AggExpr, args: &[ExprRef]) -> SQLPlannerResult<ExprRef> {
         AggExpr::MapGroups { .. } => unsupported_sql_err!("map_groups"),
         AggExpr::Set(_) => unsupported_sql_err!("set"),
         AggExpr::Skew(_) => unsupported_sql_err!("skew"),
+        AggExpr::AggFn { .. } => unsupported_sql_err!("agg_fn"),
+        AggExpr::AggFnBlock { .. } => unsupported_sql_err!("agg_fn_block"),
+        AggExpr::AggFnCombine { .. } => unsupported_sql_err!("agg_fn_combine"),
     }
 }
 

--- a/src/daft-sql/src/modules/aggs.rs
+++ b/src/daft-sql/src/modules/aggs.rs
@@ -207,8 +207,8 @@ fn to_expr(expr: &AggExpr, args: &[ExprRef]) -> SQLPlannerResult<ExprRef> {
         AggExpr::Set(_) => unsupported_sql_err!("set"),
         AggExpr::Skew(_) => unsupported_sql_err!("skew"),
         AggExpr::AggFn { .. } => unsupported_sql_err!("agg_fn"),
-        AggExpr::AggFnMap { .. } => unsupported_sql_err!("agg_fn_block"),
-        AggExpr::AggFnReduce { .. } => unsupported_sql_err!("agg_fn_combine"),
+        AggExpr::AggFnMap { .. } => unsupported_sql_err!("agg_fn_map"),
+        AggExpr::AggFnReduce { .. } => unsupported_sql_err!("agg_fn_reduce"),
     }
 }
 


### PR DESCRIPTION
## Changes Made

Introduces the `AggFn` trait for native extension UDAFs, following the accumulator-based API design of [Ray's AggregateFnV2](https://docs.ray.io/en/latest/data/api/doc/ray.data.aggregate.AggregateFnV2.html), decomposed by the planner into a two-stage `AggFnMap` → `AggFnReduce` pipeline that integrates with the existing grouped aggregation path. Adds a map-side eager combine step in `GroupedAggregateSink` to reduce partial-state volume before the reduce stage.

Note: This PR originally included `daft-ext` integration. That portion has been removed and will be delivered in a follow-up PR. The bot greptile-apps review comments reflect the earlier version of the diff and can be ignored.
<!-- Describe what changes were made and why. Include implementation details if necessary. -->

## Related Issues
#6698
#1981

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
