### PR TITLE
fix: Fix document example, unnest is not a param on prompt

### DIFF
--- a/docs/modalities/documents.md
+++ b/docs/modalities/documents.md
@@ -42,9 +42,9 @@ df = (
             tools=[{"type": "web_search"}],
             return_format=SearchResults,
             provider="openai",
-            unnest=True,
         ),
     )
+    .select(daft.col("path"), unnest(daft.col("results")))
 )
 results = df.to_pydict()
 print(results)

--- a/docs/modalities/documents.md
+++ b/docs/modalities/documents.md
@@ -30,15 +30,15 @@ class SearchResults(BaseModel):
 
 
 df = (
-    daft.from_glob_path("hf://datasets/Eventual-Inc/sample-files/papers/*.pdf").limit(1)
+    daft.from_glob_path("hf://datasets/Eventual-Inc/sample-files/papers/*.pdf")
+    .limit(1)
     .with_column(
         "results",
         prompt(
             messages=[
-                daft.lit("Find 5 closely related papers to the one attached"),
+                "Find 5 closely related papers to the one attached",
                 file(daft.col("path")),
             ],
-            model="gpt-4-turbo",
             tools=[{"type": "web_search"}],
             return_format=SearchResults,
             provider="openai",


### PR DESCRIPTION
## Changes Made

btw, i removed the model name, because gpt 4 turbo is like 8 years ago at this point.

I'm also in favor of removing all hard coded model names in our docs unless we are explicitly showcasing a specific model, because i don't want to 1. overcomplicate 2. show outdated models in our examples

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
