### PR TITLE
feat(subscribers): add optional origin_node_id to py operator events

### DIFF
--- a/daft/subscribers/event_log.py
+++ b/daft/subscribers/event_log.py
@@ -261,13 +261,16 @@ class EventLogSubscriber(Subscriber):
         query_id = event.query_id
         node_id = event.node_id
         self._operator_starts[(query_id, node_id)] = _mono_ms()
+
+        payload: dict[str, Any] = {"node_id": node_id, "name": event.name}
+        # if they are equal it's a distributed node or it's a native runner
+        if event.origin_node_id is not None and event.node_id != event.origin_node_id:
+            payload["origin_node_id"] = event.origin_node_id
+
         self._write_event(
             query_id,
             "operator_started",
-            {
-                "node_id": node_id,
-                "name": event.name,
-            },
+            payload,
         )
 
     def on_stats(self, event: Stats) -> None:
@@ -299,6 +302,10 @@ class EventLogSubscriber(Subscriber):
         payload: dict[str, Any] = {"node_id": node_id, "name": event.name}
         if duration_ms is not None:
             payload["duration_ms"] = duration_ms
+
+        # if they are equal it's a distributed node or it's a native runner
+        if event.origin_node_id is not None and event.node_id != event.origin_node_id:
+            payload["origin_node_id"] = event.origin_node_id
 
         self._write_event(query_id, "operator_ended", payload)
 

--- a/daft/subscribers/event_log.py
+++ b/daft/subscribers/event_log.py
@@ -263,8 +263,7 @@ class EventLogSubscriber(Subscriber):
         self._operator_starts[(query_id, node_id)] = _mono_ms()
 
         payload: dict[str, Any] = {"node_id": node_id, "name": event.name}
-        # if they are equal it's a distributed node or it's a native runner
-        if event.origin_node_id is not None and event.node_id != event.origin_node_id:
+        if event.origin_node_id is not None:
             payload["origin_node_id"] = event.origin_node_id
 
         self._write_event(
@@ -303,8 +302,7 @@ class EventLogSubscriber(Subscriber):
         if duration_ms is not None:
             payload["duration_ms"] = duration_ms
 
-        # if they are equal it's a distributed node or it's a native runner
-        if event.origin_node_id is not None and event.node_id != event.origin_node_id:
+        if event.origin_node_id is not None:
             payload["origin_node_id"] = event.origin_node_id
 
         self._write_event(query_id, "operator_ended", payload)

--- a/daft/subscribers/events.py
+++ b/daft/subscribers/events.py
@@ -58,6 +58,7 @@ class OperatorStarted(Event):
     query_id: str
     node_id: int
     name: str
+    origin_node_id: int | None = None
 
 
 @dataclass(frozen=True)
@@ -65,6 +66,7 @@ class OperatorFinished(Event):
     query_id: str
     node_id: int
     name: str
+    origin_node_id: int | None = None
 
 
 @dataclass(frozen=True)

--- a/src/daft-context/src/subscribers/python.rs
+++ b/src/daft-context/src/subscribers/python.rs
@@ -50,6 +50,7 @@ fn build_operator_started(py: Python<'_>, event: &OperatorStartEvent) -> PyResul
             event.header.query_id.to_string(),
             event.operator.node_id,
             event.operator.name.as_ref(),
+            event.operator.origin_node_id,
         ))
         .map(Into::into)
 }
@@ -60,6 +61,7 @@ fn build_operator_finished(py: Python<'_>, event: &OperatorEndEvent) -> PyResult
             event.header.query_id.to_string(),
             event.operator.node_id,
             event.operator.name.as_ref(),
+            event.operator.origin_node_id,
         ))
         .map(Into::into)
 }


### PR DESCRIPTION
## Changes Made
This adds an optional origin node id to the python events. This is useful in distributed settings to tie local operators back to the distributed operator.
