### PR TITLE
fix(stats): Track source execution time per message in pipeline stats

### DIFF
--- a/src/daft-local-execution/src/sources/source.rs
+++ b/src/daft-local-execution/src/sources/source.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::HashMap,
     sync::{Arc, atomic::Ordering},
+    time::Instant,
 };
 
 use async_trait::async_trait;
@@ -237,7 +238,13 @@ impl PipelineNode for SourceNode {
                 let mut per_input_stats: HashMap<InputId, Arc<SourceStats>> = HashMap::new();
                 stats_manager.activate_node(node_id);
 
-                while let Some(msg) = source_stream.next().await {
+                let mut source_started = Instant::now();
+                loop {
+                    let next = source_stream.next().await;
+                    let elapsed = source_started.elapsed().as_micros() as u64;
+                    let Some(msg) = next else {
+                        break;
+                    };
                     has_data = true;
                     let msg = msg?;
                     match &msg {
@@ -254,10 +261,14 @@ impl PipelineNode for SourceNode {
                                 &stats_manager,
                                 node_id,
                             );
+                            stats.add_duration_us(elapsed);
                             stats.add_rows_out(partition.len() as u64);
                             stats.add_bytes_out(partition.size_bytes() as u64);
                         }
                         PipelineMessage::Flush(input_id) => {
+                            if let Some(stats) = per_input_stats.get(input_id) {
+                                stats.add_duration_us(elapsed);
+                            }
                             per_input_stats.remove(input_id);
                         }
                         PipelineMessage::ShuffleMetadata { .. } => {
@@ -267,6 +278,7 @@ impl PipelineNode for SourceNode {
                     if destination_sender.send(msg).await.is_err() {
                         break;
                     }
+                    source_started = Instant::now();
                 }
 
                 if !has_data {


### PR DESCRIPTION
## Changes Made

Modified the source node execution loop to track and record the elapsed time between consecutive messages from the source stream. The changes include:

1. **Time tracking**: Added `Instant::now()` tracking to measure the time elapsed between receiving messages from the source stream
2. **Per-message stats**: Record the elapsed time for each message processed:
   - For `PipelineMessage::Partition` messages: Add the elapsed duration to the corresponding input's stats
   - For `PipelineMessage::Flush` messages: Add the elapsed duration before removing the input stats
3. **Loop refactoring**: Converted the `while let` loop to an explicit `loop` with pattern matching to enable time measurement between iterations

This enables better observability into source execution performance by tracking how long the source takes to produce each message, which can help identify bottlenecks in data ingestion.

## Related Issues

<!-- Link to related GitHub issues if applicable -->

https://claude.ai/code/session_01M6iswtHU21Epbwnk9QWdsn