### PR TITLE
docs(extensions): add community extensions subpage

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -56,7 +56,8 @@
         * [Turbopuffer](connectors/turbopuffer.md)
         * [Unity Catalog (Databricks)](connectors/unity_catalog.md)
     * Extensions
-        * [Extensions](extensions/index.md)
+        * [Community Extensions](extensions/community.md)
+        * [Authoring Guide](extensions/index.md)
     * Scaling Out and Deployment
         * [Distributed Execution](distributed/index.md)
         * [Running on Kubernetes](distributed/kubernetes.md)

--- a/docs/extensions/community.md
+++ b/docs/extensions/community.md
@@ -30,8 +30,8 @@ with sess:
     df = daft.from_pydict({"lat": [37.7749], "lng": [-122.4194]})
     df = df.select(
         daft_h3.h3_latlng_to_cell(col("lat"), col("lng"), 7).alias("cell"),
-    ).collect()
-    df = df.select(daft_h3.h3_cell_to_str(col("cell")).alias("hex")).collect()
+    )
+    df = df.select(daft_h3.h3_cell_to_str(col("cell")).alias("hex"))
     df.show()
 ```
 

--- a/docs/extensions/community.md
+++ b/docs/extensions/community.md
@@ -1,0 +1,41 @@
+# Community Extensions
+
+Community extensions are built by external contributors and maintained
+independently of Daft's release cadence. Extensions listed here have been
+reviewed by the Daft maintainers. Each is its own PyPI package, so install
+and version independently of Daft.
+
+| Name | Repository | Description |
+|---|---|---|
+| [daft-h3](#daft-h3) | [gweaverbiodev/daft-h3](https://github.com/gweaverbiodev/daft-h3) | Native [H3](https://h3geo.org/) geospatial indexing functions, maintained by [Garrett Weaver](https://github.com/gweaverbiodev). |
+
+To propose a new extension for this list, open a PR against this page.
+
+## daft-h3
+
+```bash
+pip install daft-h3
+```
+
+```python
+import daft
+import daft_h3
+from daft import col
+from daft.session import Session
+
+sess = Session()
+sess.load_extension(daft_h3)
+
+with sess:
+    df = daft.from_pydict({"lat": [37.7749], "lng": [-122.4194]})
+    df = df.select(
+        daft_h3.h3_latlng_to_cell(col("lat"), col("lng"), 7).alias("cell"),
+    ).collect()
+    df = df.select(daft_h3.h3_cell_to_str(col("cell")).alias("hex")).collect()
+    df.show()
+```
+
+Currently provides `h3_latlng_to_cell`, `h3_cell_to_lat`, `h3_cell_to_lng`,
+`h3_cell_to_str`, `h3_str_to_cell`, `h3_cell_resolution`, `h3_cell_is_valid`,
+`h3_cell_parent`, and `h3_grid_distance`. Cell-input functions accept both
+`UInt64` and `Utf8` (hex string) columns; output type matches input.

--- a/docs/extensions/community.md
+++ b/docs/extensions/community.md
@@ -35,7 +35,4 @@ with sess:
     df.show()
 ```
 
-Currently provides `h3_latlng_to_cell`, `h3_cell_to_lat`, `h3_cell_to_lng`,
-`h3_cell_to_str`, `h3_str_to_cell`, `h3_cell_resolution`, `h3_cell_is_valid`,
-`h3_cell_parent`, and `h3_grid_distance`. Cell-input functions accept both
-`UInt64` and `Utf8` (hex string) columns; output type matches input.
+See the [daft-h3 README](https://github.com/gweaverbiodev/daft-h3#readme) for the full list of functions and behavior details.

--- a/docs/extensions/community.md
+++ b/docs/extensions/community.md
@@ -21,18 +21,15 @@ pip install daft-h3
 import daft
 import daft_h3
 from daft import col
-from daft.session import Session
 
-sess = Session()
-sess.load_extension(daft_h3)
+daft.load_extension(daft_h3)
 
-with sess:
-    df = daft.from_pydict({"lat": [37.7749], "lng": [-122.4194]})
-    df = df.select(
-        daft_h3.h3_latlng_to_cell(col("lat"), col("lng"), 7).alias("cell"),
-    )
-    df = df.select(daft_h3.h3_cell_to_str(col("cell")).alias("hex"))
-    df.show()
+df = daft.from_pydict({"lat": [37.7749], "lng": [-122.4194]})
+df = df.select(
+    daft_h3.h3_latlng_to_cell(col("lat"), col("lng"), 7).alias("cell"),
+)
+df = df.select(daft_h3.h3_cell_to_str(col("cell")).alias("hex"))
+df.show()
 ```
 
 See the [daft-h3 README](https://github.com/gweaverbiodev/daft-h3#readme) for the full list of functions and behavior details.

--- a/docs/extensions/index.md
+++ b/docs/extensions/index.md
@@ -5,6 +5,7 @@
     Native extensions are experimental and may change in future releases.
 
 > Please see the [prompt](#prompt) if you want help generating an extension.
+> Looking for extensions you can install today? See [Community Extensions](community.md).
 
 This document is a guide for authoring Daft native extensions in Rust.
 Daft supports native Rust extensions by leveraging a stable C ABI based on the


### PR DESCRIPTION
Adds a Community Extensions subpage at `docs/extensions/community.md` with a table of vetted community-maintained extensions, modeled on DuckDB's separation of community-extension listings from the author-facing tutorial. First entry is [daft-h3](https://github.com/gweaverbiodev/daft-h3), Garrett Weaver's H3 geospatial extension.

The authoring guide at `docs/extensions/index.md` is unchanged apart from a blockquote link pointing readers at the new subpage. Nav under Extensions now lists Community Extensions above the Authoring Guide so the installable-today registry is one click away.