### PR TITLE
refactor(daft-distributed): cleanup of statistics_manager

### DIFF
--- a/src/daft-distributed/src/plan/mod.rs
+++ b/src/daft-distributed/src/plan/mod.rs
@@ -14,7 +14,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     pipeline_node::MaterializedOutput,
-    statistics::StatisticsManagerRef,
     utils::{
         channel::{Receiver, ReceiverStream},
         stream::JoinableForwardingStream,
@@ -77,20 +76,11 @@ pub(crate) type PlanResultStream =
 pub(crate) struct PlanResult {
     joinset: JoinSet<DaftResult<()>>,
     rx: Receiver<MaterializedOutput>,
-    pub statistics_manager: StatisticsManagerRef,
 }
 
 impl PlanResult {
-    fn new(
-        joinset: JoinSet<DaftResult<()>>,
-        rx: Receiver<MaterializedOutput>,
-        statistics_manager: StatisticsManagerRef,
-    ) -> Self {
-        Self {
-            joinset,
-            rx,
-            statistics_manager,
-        }
+    fn new(joinset: JoinSet<DaftResult<()>>, rx: Receiver<MaterializedOutput>) -> Self {
+        Self { joinset, rx }
     }
 
     pub fn into_stream(self) -> PlanResultStream {

--- a/src/daft-distributed/src/plan/runner.rs
+++ b/src/daft-distributed/src/plan/runner.rs
@@ -15,6 +15,7 @@ use crate::{
         DistributedPipelineNode, MaterializedOutput, TaskBuilderStream,
         materialize::materialize_all_pipeline_outputs,
     },
+    plan::DistributedPhysicalPlan,
     scheduling::{
         scheduler::{SchedulerHandle, spawn_scheduler_actor},
         task::{SwordfishTask, TaskID},
@@ -87,6 +88,16 @@ pub(crate) struct PlanConfig {
     pub query_idx: QueryIdx,
     pub query_id: QueryID,
     pub config: Arc<DaftExecutionConfig>,
+}
+
+impl From<&DistributedPhysicalPlan> for PlanConfig {
+    fn from(plan: &DistributedPhysicalPlan) -> Self {
+        Self {
+            query_idx: plan.idx(),
+            query_id: plan.query_id(),
+            config: plan.execution_config().clone(),
+        }
+    }
 }
 
 impl PlanConfig {

--- a/src/daft-distributed/src/plan/runner.rs
+++ b/src/daft-distributed/src/plan/runner.rs
@@ -1,30 +1,26 @@
-use std::{
-    collections::HashMap,
-    sync::{
-        Arc,
-        atomic::{AtomicU32, Ordering},
-    },
+use std::sync::{
+    Arc,
+    atomic::{AtomicU32, Ordering},
 };
 
 use common_daft_config::DaftExecutionConfig;
 use common_error::DaftResult;
-use common_metrics::{Meter, QueryID};
-use common_partitioning::PartitionRef;
+use common_metrics::QueryID;
 use common_runtime::{JoinSet, create_join_set};
 use futures::{Stream, StreamExt};
 
-use super::{DistributedPhysicalPlan, PlanResult, QueryIdx};
+use super::{PlanResult, QueryIdx};
 use crate::{
     pipeline_node::{
         DistributedPipelineNode, MaterializedOutput, TaskBuilderStream,
-        logical_plan_to_pipeline_node, materialize::materialize_all_pipeline_outputs,
+        materialize::materialize_all_pipeline_outputs,
     },
     scheduling::{
         scheduler::{SchedulerHandle, spawn_scheduler_actor},
         task::{SwordfishTask, TaskID},
         worker::{Worker, WorkerManager},
     },
-    statistics::{StatisticsManager, StatisticsSubscriber},
+    statistics::StatisticsManagerRef,
     utils::{
         channel::{Sender, create_channel},
         runtime::get_or_init_runtime,
@@ -139,7 +135,33 @@ impl<W: Worker<Task = SwordfishTask>> PlanRunner<W> {
         Self { worker_manager }
     }
 
-    async fn execute_plan(
+    pub fn run_plan(
+        self: &Arc<Self>,
+        query_idx: QueryIdx,
+        pipeline_node: DistributedPipelineNode,
+        statistics_manager: StatisticsManagerRef,
+    ) -> DaftResult<PlanResult> {
+        let runtime = get_or_init_runtime();
+        let (result_sender, result_receiver) = create_channel(1);
+        let this = self.clone();
+        let joinset = runtime.block_on_current_thread(async move {
+            let mut joinset = create_join_set();
+            let scheduler_handle = spawn_scheduler_actor(
+                self.worker_manager.clone(),
+                &mut joinset,
+                statistics_manager,
+            );
+
+            joinset.spawn(async move {
+                this.run_plan_impl(pipeline_node, query_idx, scheduler_handle, result_sender)
+                    .await
+            });
+            joinset
+        });
+        Ok(PlanResult::new(joinset, result_receiver))
+    }
+
+    async fn run_plan_impl(
         &self,
         pipeline_node: DistributedPipelineNode,
         query_idx: QueryIdx,
@@ -168,48 +190,5 @@ impl<W: Worker<Task = SwordfishTask>> PlanRunner<W> {
         }
 
         Ok(())
-    }
-
-    pub fn run_plan(
-        self: &Arc<Self>,
-        plan: &DistributedPhysicalPlan,
-        psets: HashMap<String, Vec<PartitionRef>>,
-        subscribers: Vec<Box<dyn StatisticsSubscriber>>,
-    ) -> DaftResult<PlanResult> {
-        let query_idx = plan.idx();
-        let query_id = plan.query_id();
-        let config = plan.execution_config().clone();
-        let logical_plan = plan.logical_plan().clone();
-        let plan_config = PlanConfig::new(query_idx, query_id.clone(), config);
-
-        let meter = Meter::query_scope(query_id, "daft.execution.distributed");
-        let pipeline_node =
-            logical_plan_to_pipeline_node(plan_config, logical_plan, Arc::new(psets), &meter)?;
-        let statistics_manager =
-            StatisticsManager::from_pipeline_node(&pipeline_node, subscribers, &meter)?;
-
-        let runtime = get_or_init_runtime();
-        let (result_sender, result_receiver) = create_channel(1);
-        let this = self.clone();
-        let statistics_manager_clone = statistics_manager.clone();
-        let joinset = runtime.block_on_current_thread(async move {
-            let mut joinset = create_join_set();
-            let scheduler_handle = spawn_scheduler_actor(
-                self.worker_manager.clone(),
-                &mut joinset,
-                statistics_manager.clone(),
-            );
-
-            joinset.spawn(async move {
-                this.execute_plan(pipeline_node, query_idx, scheduler_handle, result_sender)
-                    .await
-            });
-            joinset
-        });
-        Ok(PlanResult::new(
-            joinset,
-            result_receiver,
-            statistics_manager_clone,
-        ))
     }
 }

--- a/src/daft-distributed/src/python/mod.rs
+++ b/src/daft-distributed/src/python/mod.rs
@@ -25,7 +25,7 @@ use crate::{
     },
     plan::{DistributedPhysicalPlan, PlanConfig, PlanResultStream, PlanRunner},
     python::ray::{RayPartitionRef, RayTaskResult},
-    statistics::{StatisticsManagerRef, StatisticsSubscriber},
+    statistics::{StatisticsManager, StatisticsManagerRef, StatisticsSubscriber},
 };
 
 #[pyclass(frozen)]
@@ -239,8 +239,23 @@ impl PyDistributedPhysicalPlanRunner {
             )));
         }
 
-        let plan_result = self.runner.run_plan(&plan.plan, psets, subscribers)?;
-        let statistics_manager = plan_result.statistics_manager.clone();
+        let query_idx = plan.plan.idx();
+        let query_id = plan.plan.query_id();
+        let config = plan.plan.execution_config().clone();
+        let logical_plan = plan.plan.logical_plan().clone();
+        let plan_config = PlanConfig::new(query_idx, query_id.clone(), config);
+
+        let meter = Meter::query_scope(query_id, "daft.execution.distributed");
+        let pipeline_node =
+            logical_plan_to_pipeline_node(plan_config, logical_plan, Arc::new(psets), &meter)?;
+
+        let statistics_manager =
+            StatisticsManager::from_pipeline_node(&pipeline_node, subscribers, &meter)?;
+
+        let plan_result =
+            self.runner
+                .run_plan(query_idx, pipeline_node, statistics_manager.clone())?;
+
         let part_stream = PythonPartitionRefStream {
             inner: Arc::new(Mutex::new(plan_result.into_stream())),
             statistics_manager,

--- a/src/daft-distributed/src/python/mod.rs
+++ b/src/daft-distributed/src/python/mod.rs
@@ -241,13 +241,16 @@ impl PyDistributedPhysicalPlanRunner {
 
         let query_idx = plan.plan.idx();
         let query_id = plan.plan.query_id();
-        let config = plan.plan.execution_config().clone();
         let logical_plan = plan.plan.logical_plan().clone();
-        let plan_config = PlanConfig::new(query_idx, query_id.clone(), config);
 
         let meter = Meter::query_scope(query_id, "daft.execution.distributed");
-        let pipeline_node =
-            logical_plan_to_pipeline_node(plan_config, logical_plan, Arc::new(psets), &meter)?;
+
+        let pipeline_node = logical_plan_to_pipeline_node(
+            (&plan.plan).into(),
+            logical_plan,
+            Arc::new(psets),
+            &meter,
+        )?;
 
         let statistics_manager =
             StatisticsManager::from_pipeline_node(&pipeline_node, subscribers, &meter)?;

--- a/src/daft-distributed/src/scheduling/dispatcher.rs
+++ b/src/daft-distributed/src/scheduling/dispatcher.rs
@@ -18,13 +18,15 @@ pub(super) struct Dispatcher<W: Worker> {
     // Mapping of joinset task id to the scheduled task
     // The scheduled task is kept here so that we can reschedule the task if it fails
     joinset_id_to_task: HashMap<JoinSetId, ScheduledTask<W::Task>>,
+    statistics_manager: StatisticsManagerRef,
 }
 
 impl<W: Worker> Dispatcher<W> {
-    pub fn new() -> Self {
+    pub fn new(statistics_manager: StatisticsManagerRef) -> Self {
         Self {
             task_result_joinset: JoinSet::new(),
             joinset_id_to_task: HashMap::new(),
+            statistics_manager,
         }
     }
 
@@ -69,7 +71,6 @@ impl<W: Worker> Dispatcher<W> {
     pub async fn await_completed_tasks(
         &mut self,
         worker_manager: &Arc<dyn WorkerManager<Worker = W>>,
-        statistics_manager: &StatisticsManagerRef,
     ) -> DaftResult<Vec<PendingTask<W::Task>>> {
         let mut failed_tasks = Vec::new();
         let mut task_results = Vec::new();
@@ -101,7 +102,8 @@ impl<W: Worker> Dispatcher<W> {
                 // Always mark the task as finished regardless of the result
                 worker_manager.mark_task_finished(task.task_context(), worker_id.clone());
                 // Send the event to the statistics manager
-                statistics_manager.handle_event((task.task_context(), &task_result).into())?;
+                self.statistics_manager
+                    .handle_event((task.task_context(), &task_result).into())?;
 
                 match task_result {
                     Ok(task_status) => match task_status {
@@ -201,7 +203,10 @@ mod tests {
         let workers = setup_workers(worker_configs);
         let worker_manager: Arc<dyn WorkerManager<Worker = MockWorker>> =
             Arc::new(MockWorkerManager::new(workers));
-        (Dispatcher::new(), worker_manager)
+        (
+            Dispatcher::new(StatisticsManagerRef::default()),
+            worker_manager,
+        )
     }
 
     fn unwrap_materialized(result: Option<TaskOutput>) -> crate::pipeline_node::MaterializedOutput {
@@ -227,9 +232,7 @@ mod tests {
         dispatcher.dispatch_tasks(scheduled_tasks, &worker_manager)?;
 
         // Wait for task completion
-        let failed_tasks = dispatcher
-            .await_completed_tasks(&worker_manager, &StatisticsManagerRef::default())
-            .await?;
+        let failed_tasks = dispatcher.await_completed_tasks(&worker_manager).await?;
         assert!(failed_tasks.is_empty());
 
         let result = submitted_task.await?;
@@ -269,9 +272,7 @@ mod tests {
 
         // Wait for all tasks to complete
         while dispatcher.has_running_tasks() {
-            let failed_tasks = dispatcher
-                .await_completed_tasks(&worker_manager, &StatisticsManagerRef::default())
-                .await?;
+            let failed_tasks = dispatcher.await_completed_tasks(&worker_manager).await?;
             assert!(failed_tasks.is_empty());
         }
 
@@ -326,9 +327,7 @@ mod tests {
         let scheduled_tasks = vec![ScheduledTask::new(schedulable_task, worker_id)];
         dispatcher.dispatch_tasks(scheduled_tasks, &worker_manager)?;
 
-        let failed_tasks = dispatcher
-            .await_completed_tasks(&worker_manager, &StatisticsManagerRef::default())
-            .await?;
+        let failed_tasks = dispatcher.await_completed_tasks(&worker_manager).await?;
         assert!(failed_tasks.is_empty());
 
         let result = submitted_task.await;
@@ -357,9 +356,7 @@ mod tests {
         let scheduled_tasks = vec![ScheduledTask::new(schedulable_task, worker_id)];
         dispatcher.dispatch_tasks(scheduled_tasks, &worker_manager)?;
 
-        let failed_tasks = dispatcher
-            .await_completed_tasks(&worker_manager, &StatisticsManagerRef::default())
-            .await?;
+        let failed_tasks = dispatcher.await_completed_tasks(&worker_manager).await?;
         assert!(failed_tasks.is_empty());
 
         let result = submitted_task.await;
@@ -390,9 +387,7 @@ mod tests {
         let scheduled_tasks = vec![ScheduledTask::new(schedulable_task, worker_id.clone())];
         dispatcher.dispatch_tasks(scheduled_tasks, &worker_manager)?;
 
-        let failed_tasks = dispatcher
-            .await_completed_tasks(&worker_manager, &StatisticsManagerRef::default())
-            .await?;
+        let failed_tasks = dispatcher.await_completed_tasks(&worker_manager).await?;
 
         // Task should be returned as a failed task that needs rescheduling
         assert_eq!(failed_tasks.len(), 1);
@@ -430,9 +425,7 @@ mod tests {
         let scheduled_tasks = vec![ScheduledTask::new(schedulable_task, worker_id.clone())];
         dispatcher.dispatch_tasks(scheduled_tasks, &worker_manager)?;
 
-        let failed_tasks = dispatcher
-            .await_completed_tasks(&worker_manager, &StatisticsManagerRef::default())
-            .await?;
+        let failed_tasks = dispatcher.await_completed_tasks(&worker_manager).await?;
 
         // Task should be returned as a failed task that needs rescheduling
         assert_eq!(failed_tasks.len(), 1);
@@ -514,9 +507,7 @@ mod tests {
         // Wait for all tasks to complete and collect failed tasks
         let mut all_failed_tasks = Vec::new();
         while dispatcher.has_running_tasks() {
-            let failed_tasks = dispatcher
-                .await_completed_tasks(&worker_manager, &StatisticsManagerRef::default())
-                .await?;
+            let failed_tasks = dispatcher.await_completed_tasks(&worker_manager).await?;
             all_failed_tasks.extend(failed_tasks);
         }
 

--- a/src/daft-distributed/src/scheduling/scheduler/scheduler_actor.rs
+++ b/src/daft-distributed/src/scheduling/scheduler/scheduler_actor.rs
@@ -33,159 +33,135 @@ pub(crate) type SchedulerReceiver<T> = UnboundedReceiver<PendingTask<T>>;
 const SCHEDULER_LOG_TARGET: &str = "DaftFlotillaScheduler";
 const SCHEDULER_TICK_INTERVAL: Duration = Duration::from_secs(1);
 
-struct SchedulerActor<W: Worker, S: Scheduler<W::Task>> {
-    worker_manager: Arc<dyn WorkerManager<Worker = W>>,
+/// Owned state for the scheduler event loop — one instance per plan run.
+/// Runs until `task_rx` closes and both scheduler + dispatcher are drained.
+struct SchedulerLoop<W: Worker, S: Scheduler<W::Task>> {
     scheduler: S,
+    task_rx: SchedulerReceiver<W::Task>,
+    dispatcher: Dispatcher<W>,
+    worker_manager: Arc<dyn WorkerManager<Worker = W>>,
+    statistics_manager: StatisticsManagerRef,
+    input_exhausted: bool,
 }
 
-impl<W: Worker> SchedulerActor<W, DefaultScheduler<W::Task>> {
-    fn default_scheduler(worker_manager: Arc<dyn WorkerManager<Worker = W>>) -> Self {
-        Self {
-            worker_manager,
-            scheduler: DefaultScheduler::default(),
-        }
-    }
-}
-
-impl<W: Worker> SchedulerActor<W, LinearScheduler<W::Task>> {
-    fn linear_scheduler(worker_manager: Arc<dyn WorkerManager<Worker = W>>) -> Self {
-        Self {
-            worker_manager,
-            scheduler: LinearScheduler::default(),
-        }
-    }
-}
-
-impl<W, S> SchedulerActor<W, S>
+impl<W, S> SchedulerLoop<W, S>
 where
     W: Worker,
     S: Scheduler<W::Task> + Send + 'static,
 {
-    fn spawn_scheduler_actor(
-        scheduler: Self,
-        joinset: &mut JoinSet<DaftResult<()>>,
+    fn new(
+        scheduler: S,
+        task_rx: SchedulerReceiver<W::Task>,
+        worker_manager: Arc<dyn WorkerManager<Worker = W>>,
         statistics_manager: StatisticsManagerRef,
-    ) -> SchedulerHandle<W::Task> {
-        tracing::info!(target: SCHEDULER_LOG_TARGET, "Spawning scheduler actor");
-
-        let (scheduler_sender, scheduler_receiver) = create_unbounded_channel();
-
-        // Create dispatcher directly instead of spawning it as an actor
-        let dispatcher = Dispatcher::new();
-
-        // Spawn the scheduler actor to schedule tasks and dispatch them directly via the dispatcher
-        joinset.spawn(Self::run_scheduler_loop(
-            scheduler.scheduler,
-            scheduler_receiver,
+    ) -> Self {
+        let dispatcher = Dispatcher::new(statistics_manager.clone());
+        Self {
+            scheduler,
+            task_rx,
             dispatcher,
-            scheduler.worker_manager,
+            worker_manager,
             statistics_manager,
-        ));
-
-        tracing::info!(target: SCHEDULER_LOG_TARGET, "Spawned scheduler actor");
-        SchedulerHandle::new(scheduler_sender)
+            input_exhausted: false,
+        }
     }
 
-    fn handle_new_tasks(
-        maybe_new_task: Option<PendingTask<W::Task>>,
-        task_rx: &mut SchedulerReceiver<W::Task>,
-        statistics_manager: &StatisticsManagerRef,
-        scheduler: &mut S,
-        input_exhausted: &mut bool,
-    ) -> DaftResult<()> {
-        // If there are any new tasks, enqueue them all
+    fn handle_new_tasks(&mut self, maybe_new_task: Option<PendingTask<W::Task>>) -> DaftResult<()> {
         if let Some(new_task) = maybe_new_task {
             let mut enqueueable_tasks = vec![new_task];
 
             // Drain all available tasks from the channel
-            while let Ok(task) = task_rx.try_recv() {
+            while let Ok(task) = self.task_rx.try_recv() {
                 enqueueable_tasks.push(task);
             }
 
             tracing::info!(target: SCHEDULER_LOG_TARGET, num_tasks = enqueueable_tasks.len(), "Enqueueing task batch");
             tracing::debug!(target: SCHEDULER_LOG_TARGET, enqueued_tasks = %format!("{:#?}", enqueueable_tasks));
 
-            // Register statistics for all tasks
             for task in &enqueueable_tasks {
-                let task_context = task.task_context();
-                statistics_manager.handle_event(TaskEvent::Submitted {
-                    context: task_context,
+                self.statistics_manager.handle_event(TaskEvent::Submitted {
+                    context: task.task_context(),
                     name: task.task.task_name().clone(),
                 })?;
             }
 
-            scheduler.enqueue_tasks(enqueueable_tasks);
-        } else if !*input_exhausted {
+            self.scheduler.enqueue_tasks(enqueueable_tasks);
+        } else if !self.input_exhausted {
             tracing::info!(target: SCHEDULER_LOG_TARGET, "Task input stream exhausted");
-            *input_exhausted = true;
+            self.input_exhausted = true;
         }
         Ok(())
     }
 
     #[instrument(name = "FlotillaScheduler", skip_all)]
-    async fn run_scheduler_loop(
-        mut scheduler: S,
-        mut task_rx: SchedulerReceiver<W::Task>,
-        mut dispatcher: Dispatcher<W>,
-        worker_manager: Arc<dyn WorkerManager<Worker = W>>,
-        statistics_manager: StatisticsManagerRef,
-    ) -> DaftResult<()> {
-        let mut input_exhausted = false;
+    async fn run(mut self) -> DaftResult<()> {
         let mut tick_interval = tokio::time::interval(SCHEDULER_TICK_INTERVAL);
-        // Keep running until the input is exhausted, i.e. no more new tasks, and there are no more pending tasks in the scheduler
-        while !input_exhausted
-            || scheduler.num_pending_tasks() > 0
-            || dispatcher.has_running_tasks()
+        while !self.input_exhausted
+            || self.scheduler.num_pending_tasks() > 0
+            || self.dispatcher.has_running_tasks()
         {
-            // Update worker snapshots at the start of each loop iteration
-            let worker_snapshots = worker_manager.worker_snapshots()?;
+            let worker_snapshots = self.worker_manager.worker_snapshots()?;
             tracing::info!(target: SCHEDULER_LOG_TARGET,
                 num_workers = worker_snapshots.len(),
-                pending_tasks = scheduler.num_pending_tasks(),
+                pending_tasks = self.scheduler.num_pending_tasks(),
                 "Received worker snapshots");
             tracing::debug!(target: SCHEDULER_LOG_TARGET, worker_snapshots = %format!("{:#?}", worker_snapshots));
 
-            scheduler.update_worker_state(&worker_snapshots);
+            self.scheduler.update_worker_state(&worker_snapshots);
 
             // 1: Get all tasks that are ready to be scheduled
-            let scheduled_tasks = scheduler.schedule_tasks();
+            let scheduled_tasks = self.scheduler.schedule_tasks();
             // 2: Dispatch tasks directly to the dispatcher
             if !scheduled_tasks.is_empty() {
                 tracing::info!(target: SCHEDULER_LOG_TARGET, num_tasks = scheduled_tasks.len(), "Scheduling tasks for dispatch");
                 tracing::debug!(target: SCHEDULER_LOG_TARGET, scheduled_tasks = %format!("{:#?}", scheduled_tasks));
 
-                // Report to statistics manager
                 for task in &scheduled_tasks {
-                    let task_context = task.task().task_context();
-                    statistics_manager.handle_event(TaskEvent::Scheduled {
-                        context: task_context,
+                    self.statistics_manager.handle_event(TaskEvent::Scheduled {
+                        context: task.task().task_context(),
                     })?;
                 }
 
-                dispatcher.dispatch_tasks(scheduled_tasks, &worker_manager)?;
+                self.dispatcher
+                    .dispatch_tasks(scheduled_tasks, &self.worker_manager)?;
             }
 
             // 3: Send autoscaling request if needed
-            let autoscaling_request = scheduler.get_autoscaling_request();
-            if let Some(request) = autoscaling_request {
+            if let Some(request) = self.scheduler.get_autoscaling_request() {
                 tracing::info!(target: SCHEDULER_LOG_TARGET, autoscaling_request = %format!("{:#?}", request), "Sending autoscaling request");
-                worker_manager.try_autoscale(request)?;
+                self.worker_manager.try_autoscale(request)?;
             }
 
-            // 4: Concurrently wait for new tasks, task completions, or periodic tick
-            tokio::select! {
-                maybe_new_task = task_rx.recv(), if !input_exhausted => {
-                    Self::handle_new_tasks(maybe_new_task, &mut task_rx, &statistics_manager, &mut scheduler, &mut input_exhausted)?;
+            // 4: Concurrently wait for new tasks, task completions, or periodic tick.
+            let Self {
+                task_rx,
+                dispatcher,
+                worker_manager,
+                input_exhausted,
+                ..
+            } = &mut self;
+            let worker_manager: &Arc<dyn WorkerManager<Worker = W>> = worker_manager;
+            let select_result = tokio::select! {
+                maybe_new_task = task_rx.recv(), if !*input_exhausted => {
+                    SelectOutcome::NewTask(maybe_new_task)
                 }
-                failed_tasks = dispatcher.await_completed_tasks(&worker_manager, &statistics_manager), if dispatcher.has_running_tasks() => {
-                    let failed_tasks = failed_tasks?;
-                    // Re-enqueue any failed tasks
+                failed_tasks = dispatcher.await_completed_tasks(worker_manager), if dispatcher.has_running_tasks() => {
+                    SelectOutcome::CompletedTasks(failed_tasks?)
+                }
+                _ = tick_interval.tick() => SelectOutcome::Tick,
+            };
+
+            match select_result {
+                SelectOutcome::NewTask(maybe_new_task) => {
+                    self.handle_new_tasks(maybe_new_task)?;
+                }
+                SelectOutcome::CompletedTasks(failed_tasks) => {
                     if !failed_tasks.is_empty() {
-                        scheduler.enqueue_tasks(failed_tasks);
+                        self.scheduler.enqueue_tasks(failed_tasks);
                     }
                 }
-                _ = tick_interval.tick() => {
-                    // Tick completed - worker snapshots will be updated at the top of the next loop iteration
+                SelectOutcome::Tick => {
+                    // Worker snapshots refreshed at top of next iteration.
                 }
             }
         }
@@ -195,12 +171,17 @@ where
     }
 }
 
+enum SelectOutcome<T: Task> {
+    NewTask(Option<PendingTask<T>>),
+    CompletedTasks(Vec<PendingTask<T>>),
+    Tick,
+}
+
 pub(crate) fn spawn_scheduler_actor<W: Worker>(
     worker_manager: Arc<dyn WorkerManager<Worker = W>>,
     joinset: &mut JoinSet<DaftResult<()>>,
     statistics_manager: StatisticsManagerRef,
 ) -> SchedulerHandle<W::Task> {
-    // Check for environment variable to use linear scheduler
     if std::env::var("DAFT_SCHEDULER_LINEAR")
         .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
         .unwrap_or(false)
@@ -211,15 +192,39 @@ pub(crate) fn spawn_scheduler_actor<W: Worker>(
     }
 }
 
+fn spawn_scheduler_loop<W, S>(
+    scheduler: S,
+    worker_manager: Arc<dyn WorkerManager<Worker = W>>,
+    joinset: &mut JoinSet<DaftResult<()>>,
+    statistics_manager: StatisticsManagerRef,
+) -> SchedulerHandle<W::Task>
+where
+    W: Worker,
+    S: Scheduler<W::Task> + Send + 'static,
+{
+    let (scheduler_sender, scheduler_receiver) = create_unbounded_channel();
+    let loop_state = SchedulerLoop::new(
+        scheduler,
+        scheduler_receiver,
+        worker_manager,
+        statistics_manager,
+    );
+    joinset.spawn(loop_state.run());
+    SchedulerHandle::new(scheduler_sender)
+}
+
 fn spawn_default_scheduler_actor<W: Worker>(
     worker_manager: Arc<dyn WorkerManager<Worker = W>>,
     joinset: &mut JoinSet<DaftResult<()>>,
     statistics_manager: StatisticsManagerRef,
 ) -> SchedulerHandle<W::Task> {
     tracing::info!(target: SCHEDULER_LOG_TARGET, "Spawning default scheduler actor");
-
-    let scheduler = SchedulerActor::default_scheduler(worker_manager);
-    SchedulerActor::spawn_scheduler_actor(scheduler, joinset, statistics_manager)
+    spawn_scheduler_loop(
+        DefaultScheduler::<W::Task>::default(),
+        worker_manager,
+        joinset,
+        statistics_manager,
+    )
 }
 
 fn spawn_linear_scheduler_actor<W: Worker>(
@@ -227,10 +232,13 @@ fn spawn_linear_scheduler_actor<W: Worker>(
     joinset: &mut JoinSet<DaftResult<()>>,
     statistics_manager: StatisticsManagerRef,
 ) -> SchedulerHandle<W::Task> {
-    tracing::info!(target: SCHEDULER_LOG_TARGET, "Creating linear scheduler");
-
-    let scheduler = SchedulerActor::linear_scheduler(worker_manager);
-    SchedulerActor::spawn_scheduler_actor(scheduler, joinset, statistics_manager)
+    tracing::info!(target: SCHEDULER_LOG_TARGET, "Spawning linear scheduler actor");
+    spawn_scheduler_loop(
+        LinearScheduler::<W::Task>::default(),
+        worker_manager,
+        joinset,
+        statistics_manager,
+    )
 }
 
 #[derive(Debug)]
@@ -420,10 +428,9 @@ mod tests {
     ) -> SchedulerActorTestContext {
         let workers = setup_workers(worker_configs);
         let worker_manager = Arc::new(MockWorkerManager::new(workers));
-        let scheduler = SchedulerActor::default_scheduler(worker_manager);
         let mut joinset = JoinSet::new();
-        let scheduler_handle = SchedulerActor::spawn_scheduler_actor(
-            scheduler,
+        let scheduler_handle = spawn_default_scheduler_actor(
+            worker_manager,
             &mut joinset,
             StatisticsManagerRef::default(),
         );


### PR DESCRIPTION
## Changes Made

### Untangle `StatisticsManager` threading in `daft-distributed`

`StatisticsManager` was being passed around ad-hoc — sometimes as a struct field, sometimes a function arg, sometimes borrowed, sometimes owned, which made it hard to reason about who was responsible for it. This PR cleans that up: `Dispatcher` now owns its own `StatisticsManagerRef` rather than accepting one per `await_completed_tasks` call, and the old `SchedulerActor` config-tuple is replaced with a `SchedulerLoop` struct that holds all of the event loop's state as fields (scheduler, task_rx, dispatcher, worker_manager, stats manager) instead of threading five owned params through a free function. `PlanRunner::run_plan` is refactored so the stats manager no longer rides along as an unrelated field on `PlanResult` . the Python layer now composes the stats manager and properly passes it to `PythonPartitionRefStream`

No behavior changes, just making the plumbing feel deliberate.


## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
