### PR TITLE
feat: range-partitioned asof joins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3001,6 +3001,7 @@ dependencies = [
  "log",
  "pyo3",
  "serde",
+ "serde_bytes",
  "serde_json",
  "strum",
 ]
@@ -7142,6 +7143,16 @@ dependencies = [
  "half",
  "marrow",
  "serde",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2533,6 +2533,7 @@ dependencies = [
  "common-treenode",
  "daft-checkpoint",
  "daft-context",
+ "daft-core",
  "daft-dsl",
  "daft-functions",
  "daft-io",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -336,6 +336,7 @@ rayon = "1.11.0"
 regex = "1.12.2"
 rstest = "0.26.1"
 reqwest = {version = "0.12.19", default-features = false, features = ["json"]}
+serde_bytes = "0.11"
 serde_json = "1.0.145"
 sha1 = "0.10.6"
 simdutf8 = "0.1.5"

--- a/daft/daft/__init__.pyi
+++ b/daft/daft/__init__.pyi
@@ -2273,6 +2273,10 @@ class RayTaskResult:
     @staticmethod
     def ray_shuffle_success(shuffle_part_refs: list[RayPartitionRef], stats: bytes) -> RayTaskResult: ...
     @staticmethod
+    def ray_shuffle_with_sentinel_success(
+        shuffle_part_refs: list[RayPartitionRef], sentinels: bytes, stats: bytes
+    ) -> RayTaskResult: ...
+    @staticmethod
     def flight_shuffle_success(shuffle_part_refs: list[FlightShufflePartitionRef], stats: bytes) -> RayTaskResult: ...
     @staticmethod
     def worker_died() -> RayTaskResult: ...
@@ -2305,6 +2309,9 @@ class PyResultReceiver:
     async def try_finish_with_shuffle_metadata(
         self,
     ) -> tuple[PyExecutionStats, list[tuple[object | None, int, int]] | None]: ...
+    async def try_finish_with_shuffle_metadata_and_sentinels(
+        self,
+    ) -> tuple[PyExecutionStats, list[tuple[object | None, int, int]] | None, bytes | None]: ...
 
 class ShuffleWriteInfo:
     @property

--- a/daft/runners/flotilla.py
+++ b/daft/runners/flotilla.py
@@ -55,7 +55,7 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 ShufflePlanMetadata = list[tuple[object | None, int, int]]
-ShufflePlanResult = tuple[str, ShufflePlanMetadata, bytes]
+ShufflePlanResult = tuple[str, ShufflePlanMetadata, bytes | None, bytes]
 ShuffleWriteInfoLike: TypeAlias = "ShuffleWriteInfo | tuple[str, int, int]"
 
 
@@ -237,13 +237,22 @@ class RaySwordfishActor:
                 context,
                 False,
             )
-            stats, shuffle_metadata = await result_handle.try_finish_with_shuffle_metadata()
+            if backend == "ray_with_sentinel":
+                (
+                    stats,
+                    shuffle_metadata,
+                    sentinel_bytes,
+                ) = await result_handle.try_finish_with_shuffle_metadata_and_sentinels()
+            else:
+                stats, shuffle_metadata = await result_handle.try_finish_with_shuffle_metadata()
+                sentinel_bytes = None
             if shuffle_metadata is None:
                 raise ValueError("Shuffle plan did not return shuffle metadata")
 
             return (
                 backend,
                 [(object_ref, int(num_rows), int(size_bytes)) for object_ref, num_rows, size_bytes in shuffle_metadata],
+                sentinel_bytes,
                 stats.encode(),
             )
 
@@ -296,13 +305,19 @@ class RaySwordfishTaskHandle:
     async def _get_result(self) -> RayTaskResult:
         try:
             if self.shuffle_write_info is not None:
-                backend, refs, stats = await self.result_handle
-                if backend == "ray":
+                backend, refs, sentinel_bytes, stats = await self.result_handle
+                if backend in ("ray", "ray_with_sentinel"):
                     ray_refs: list[RayPartitionRef] = []
                     for object_ref, num_rows, size_bytes in refs:
                         if object_ref is None:
                             raise ValueError("Expected Ray shuffle metadata to include object refs")
                         ray_refs.append(RayPartitionRef(object_ref, num_rows, size_bytes))
+                    if sentinel_bytes is not None:
+                        return RayTaskResult.ray_shuffle_with_sentinel_success(
+                            ray_refs,
+                            sentinel_bytes,
+                            stats,
+                        )
                     return RayTaskResult.ray_shuffle_success(
                         ray_refs,
                         stats,

--- a/src/daft-distributed/Cargo.toml
+++ b/src/daft-distributed/Cargo.toml
@@ -10,6 +10,7 @@ common-py-serde = {path = "../common/py-serde", default-features = false}
 common-resource-request = {path = "../common/resource-request", default-features = false}
 common-runtime = {path = "../common/runtime", default-features = false}
 common-treenode = {path = "../common/treenode", default-features = false}
+daft-core = {path = "../daft-core", default-features = false}
 daft-checkpoint = {path = "../daft-checkpoint", default-features = false}
 daft-context = {path = "../daft-context", default-features = false}
 daft-dsl = {path = "../daft-dsl", default-features = false}

--- a/src/daft-distributed/src/pipeline_node/join/asof_join.rs
+++ b/src/daft-distributed/src/pipeline_node/join/asof_join.rs
@@ -1,24 +1,38 @@
-use std::sync::Arc;
+use std::{cmp::Ordering, future, sync::Arc};
 
+use common_error::DaftResult;
 use common_metrics::{
     Meter,
     ops::{NodeCategory, NodeType},
 };
+use common_partitioning::PartitionRef;
+use daft_core::{array::ops::build_multi_array_compare, prelude::UInt64Array};
 use daft_dsl::expr::bound_expr::BoundExpr;
-use daft_local_plan::{LocalNodeContext, LocalPhysicalPlan};
+use daft_local_plan::{LocalNodeContext, LocalPhysicalPlan, ShuffleReadBackend};
 use daft_logical_plan::{partitioning::HashClusteringConfig, stats::StatsState};
+use daft_recordbatch::RecordBatch;
 use daft_schema::schema::SchemaRef;
-use futures::StreamExt;
+use futures::{TryStreamExt, future::try_join_all};
 
-use super::stats::BasicJoinStats;
 use crate::{
     pipeline_node::{
-        DistributedPipelineNode, NodeID, PipelineNodeConfig, PipelineNodeContext, PipelineNodeImpl,
-        TaskBuilderStream,
+        DistributedPipelineNode, MaterializedOutput, NodeID, PipelineNodeConfig,
+        PipelineNodeContext, PipelineNodeImpl, TaskBuilderStream, TaskOutput,
+        shuffles::partition_groups::{
+            ray_partition_groups_and_sentinels_from_outputs, ray_partition_groups_from_outputs,
+        },
+        sort::{
+            create_range_repartition_tasks, create_range_repartition_tasks_with_sentinels,
+            create_sample_tasks, get_partition_boundaries_from_samples,
+        },
     },
-    plan::{PlanConfig, PlanExecutionContext},
-    scheduling::task::SwordfishTaskBuilder,
+    plan::{PlanConfig, PlanExecutionContext, TaskIDCounter},
+    scheduling::{
+        scheduler::SchedulerHandle,
+        task::{SwordfishTask, SwordfishTaskBuilder},
+    },
     statistics::stats::RuntimeStatsRef,
+    utils::channel::{Sender, create_channel},
 };
 
 pub(crate) struct AsofJoinNode {
@@ -29,6 +43,7 @@ pub(crate) struct AsofJoinNode {
     right_by: Vec<BoundExpr>,
     left_on: BoundExpr,
     right_on: BoundExpr,
+    num_partitions: usize,
 
     left: DistributedPipelineNode,
     right: DistributedPipelineNode,
@@ -75,9 +90,314 @@ impl AsofJoinNode {
             right_by,
             left_on,
             right_on,
+            num_partitions,
             left,
             right,
         }
+    }
+
+    fn multiline_display(&self) -> Vec<String> {
+        use itertools::Itertools;
+        let mut res = vec!["AsofJoin".to_string()];
+        res.push(format!(
+            "Left by: [{}]",
+            self.left_by.iter().map(|e| e.to_string()).join(", ")
+        ));
+        res.push(format!(
+            "Right by: [{}]",
+            self.right_by.iter().map(|e| e.to_string()).join(", ")
+        ));
+        res.push(format!("Left on: {}", self.left_on));
+        res.push(format!("Right on: {}", self.right_on));
+        res.push(format!("Num partitions: {}", self.num_partitions));
+        res
+    }
+
+    /// Creates and submits an asof join task for a partition pair, embedding the sentinel
+    /// row (if any) directly into the plan payload.
+    async fn create_and_submit_join_task(
+        self: &Arc<Self>,
+        left_partition_group: Vec<PartitionRef>,
+        right_partition_group: Vec<PartitionRef>,
+        right_sentinel: Option<RecordBatch>,
+        result_tx: &Sender<SwordfishTaskBuilder>,
+    ) -> DaftResult<()> {
+        let left_shuffle_read_plan = LocalPhysicalPlan::shuffle_read(
+            self.left.node_id(),
+            self.left.config().schema.clone(),
+            ShuffleReadBackend::Ray,
+            StatsState::NotMaterialized,
+            LocalNodeContext::new(Some(self.left.node_id() as usize)),
+        );
+
+        let right_shuffle_read_plan = LocalPhysicalPlan::shuffle_read(
+            self.right.node_id(),
+            self.right.config().schema.clone(),
+            ShuffleReadBackend::Ray,
+            StatsState::NotMaterialized,
+            LocalNodeContext::new(Some(self.right.node_id() as usize)),
+        );
+
+        let plan = LocalPhysicalPlan::asof_join(
+            left_shuffle_read_plan,
+            right_shuffle_read_plan,
+            self.left_by.clone(),
+            self.right_by.clone(),
+            self.left_on.clone(),
+            self.right_on.clone(),
+            right_sentinel,
+            self.config.schema.clone(),
+            StatsState::NotMaterialized,
+            LocalNodeContext::new(Some(self.node_id() as usize)),
+        );
+
+        let builder = SwordfishTaskBuilder::new(plan, self.as_ref(), self.node_id())
+            .with_psets(self.left.node_id(), left_partition_group)
+            .with_psets(self.right.node_id(), right_partition_group);
+
+        result_tx.send(builder).await.ok();
+        Ok(())
+    }
+
+    /// Handles the multi-partition join case.
+    /// Samples both sides with the composite (by, on) key, computes range boundaries,
+    /// repartitions left normally and right with sentinel tracking, merges sentinel
+    /// candidates per partition, forward-fills, then dispatches join tasks.
+    async fn range_shuffle_and_join(
+        self: Arc<Self>,
+        left_materialized: Vec<MaterializedOutput>,
+        right_materialized: Vec<MaterializedOutput>,
+        task_id_counter: &TaskIDCounter,
+        result_tx: &Sender<SwordfishTaskBuilder>,
+        scheduler_handle: &SchedulerHandle<SwordfishTask>,
+    ) -> DaftResult<()> {
+        let num_partitions = self.num_partitions;
+
+        let left_composite_key: Vec<BoundExpr> = self
+            .left_by
+            .iter()
+            .chain(std::iter::once(&self.left_on))
+            .cloned()
+            .collect();
+        let right_composite_key: Vec<BoundExpr> = self
+            .right_by
+            .iter()
+            .chain(std::iter::once(&self.right_on))
+            .cloned()
+            .collect();
+
+        let descending = vec![false; left_composite_key.len()];
+        let nulls_first = vec![false; left_composite_key.len()];
+
+        let left_sample_tasks = create_sample_tasks(
+            left_materialized.clone(),
+            self.left.config().schema.clone(),
+            left_composite_key.clone(),
+            self.as_ref(),
+            task_id_counter,
+            scheduler_handle,
+            Some(0),
+        )?;
+
+        let left_boundary_key_names = left_composite_key
+            .iter()
+            .map(|expr| {
+                expr.inner()
+                    .to_field(&self.left.config().schema)
+                    .map(|f| f.name)
+            })
+            .collect::<DaftResult<Vec<_>>>()?;
+
+        let right_sample_by_aliased = right_composite_key
+            .iter()
+            .zip(left_boundary_key_names.into_iter())
+            .map(|(expr, key_name)| BoundExpr::new_unchecked(expr.inner().alias(key_name)))
+            .collect::<Vec<_>>();
+
+        let right_sample_tasks = create_sample_tasks(
+            right_materialized.clone(),
+            self.right.config().schema.clone(),
+            right_sample_by_aliased,
+            self.as_ref(),
+            task_id_counter,
+            scheduler_handle,
+            Some(1),
+        )?;
+
+        let combined_sampled_outputs = try_join_all(
+            left_sample_tasks
+                .into_iter()
+                .chain(right_sample_tasks.into_iter()),
+        )
+        .await?
+        .into_iter()
+        .flatten()
+        .map(TaskOutput::into_materialized)
+        .collect::<DaftResult<Vec<_>>>()?;
+
+        let left_partition_boundaries = get_partition_boundaries_from_samples(
+            combined_sampled_outputs,
+            &left_composite_key,
+            descending.clone(),
+            nulls_first,
+            num_partitions,
+        )
+        .await?;
+
+        // Range repartition left side (no sentinel tracking needed)
+        let left_partition_tasks = create_range_repartition_tasks(
+            left_materialized,
+            self.left.config().schema.clone(),
+            left_composite_key,
+            descending.clone(),
+            left_partition_boundaries.clone(),
+            num_partitions,
+            self.as_ref(),
+            task_id_counter,
+            scheduler_handle,
+            Some(0),
+        )?;
+
+        let right_boundary_names = right_composite_key
+            .iter()
+            .map(|expr| {
+                expr.inner()
+                    .to_field(&self.right.config().schema)
+                    .map(|f| f.name)
+            })
+            .collect::<DaftResult<Vec<_>>>()?;
+
+        let right_partition_boundaries = RecordBatch::from_nonempty_columns(
+            left_partition_boundaries
+                .columns()
+                .iter()
+                .zip(right_boundary_names)
+                .map(|(col, name)| col.as_materialized_series().rename(&name))
+                .collect::<Vec<_>>(),
+        )?;
+
+        // Range repartition right side with sentinel tracking
+        let right_partition_tasks = create_range_repartition_tasks_with_sentinels(
+            right_materialized,
+            self.right.config().schema.clone(),
+            right_composite_key.clone(),
+            descending,
+            right_partition_boundaries,
+            num_partitions,
+            right_composite_key.clone(),
+            self.as_ref(),
+            task_id_counter,
+            scheduler_handle,
+            Some(1),
+        )?;
+
+        let (left_partitioned_outputs, right_partitioned_outputs) = futures::try_join!(
+            try_join_all(left_partition_tasks),
+            try_join_all(right_partition_tasks)
+        )?;
+
+        let left_partitioned_outputs = left_partitioned_outputs
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
+        let right_partitioned_outputs = right_partitioned_outputs
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
+
+        let left_partition_groups =
+            ray_partition_groups_from_outputs(left_partitioned_outputs, num_partitions)?;
+        let (right_partition_groups, sentinel_candidates_per_partition) =
+            ray_partition_groups_and_sentinels_from_outputs(
+                right_partitioned_outputs,
+                num_partitions,
+            )?;
+
+        // Merge sentinels: for each partition j, pick the max row across all worker candidates,
+        // then forward-fill Nones from the previous partition.
+        let mut global_sentinels: Vec<Option<RecordBatch>> = Vec::with_capacity(num_partitions);
+        for candidates in sentinel_candidates_per_partition {
+            let valid: Vec<RecordBatch> = candidates.into_iter().flatten().collect();
+            let global_sentinel = if valid.is_empty() {
+                None
+            } else {
+                let combined = RecordBatch::concat(&valid)?;
+                record_batch_max(&combined, &right_composite_key)?
+            };
+            global_sentinels.push(global_sentinel);
+        }
+
+        // Forward-fill: partition j with no sentinel inherits the sentinel of partition j-1.
+        // Partition 0 always gets None (no previous partition).
+        for j in 1..num_partitions {
+            if global_sentinels[j].is_none() {
+                let prev = global_sentinels[j - 1].clone();
+                global_sentinels[j] = prev;
+            }
+        }
+
+        // Dispatch one join task per partition, embedding global_sentinels[i-1] in the plan
+        for (i, (left_partition_group, right_partition_group)) in left_partition_groups
+            .into_iter()
+            .zip(right_partition_groups)
+            .enumerate()
+        {
+            let sentinel = if i == 0 {
+                None
+            } else {
+                global_sentinels[i - 1].clone()
+            };
+            self.create_and_submit_join_task(
+                left_partition_group,
+                right_partition_group,
+                sentinel,
+                result_tx,
+            )
+            .await?;
+        }
+
+        Ok(())
+    }
+
+    async fn execution_loop(
+        self: Arc<Self>,
+        left_inputs: TaskBuilderStream,
+        right_inputs: TaskBuilderStream,
+        task_id_counter: TaskIDCounter,
+        result_tx: Sender<SwordfishTaskBuilder>,
+        scheduler_handle: SchedulerHandle<SwordfishTask>,
+    ) -> DaftResult<()> {
+        let left_materialized = left_inputs
+            .materialize(
+                scheduler_handle.clone(),
+                self.context.query_idx,
+                task_id_counter.clone(),
+            )
+            .try_filter(|output| future::ready(output.num_rows() > 0))
+            .try_collect::<Vec<_>>()
+            .await?;
+
+        let right_materialized = right_inputs
+            .materialize(
+                scheduler_handle.clone(),
+                self.context.query_idx,
+                task_id_counter.clone(),
+            )
+            .try_filter(|output| future::ready(output.num_rows() > 0))
+            .try_collect::<Vec<_>>()
+            .await?;
+
+        if left_materialized.is_empty() || right_materialized.is_empty() {
+            return Ok(());
+        }
+        self.range_shuffle_and_join(
+            left_materialized,
+            right_materialized,
+            &task_id_counter,
+            &result_tx,
+            &scheduler_handle,
+        )
+        .await
     }
 }
 
@@ -94,24 +414,12 @@ impl PipelineNodeImpl for AsofJoinNode {
         vec![self.left.clone(), self.right.clone()]
     }
 
-    fn make_runtime_stats(&self, meter: &Meter) -> RuntimeStatsRef {
-        Arc::new(BasicJoinStats::new(meter, self.context()))
+    fn multiline_display(&self, _verbose: bool) -> Vec<String> {
+        self.multiline_display()
     }
 
-    fn multiline_display(&self, _verbose: bool) -> Vec<String> {
-        use itertools::Itertools;
-        let mut res = vec!["AsofJoin".to_string()];
-        res.push(format!(
-            "Left by: [{}]",
-            self.left_by.iter().map(|e| e.to_string()).join(", ")
-        ));
-        res.push(format!(
-            "Right by: [{}]",
-            self.right_by.iter().map(|e| e.to_string()).join(", ")
-        ));
-        res.push(format!("Left on: {}", self.left_on));
-        res.push(format!("Right on: {}", self.right_on));
-        res
+    fn make_runtime_stats(&self, meter: &Meter) -> RuntimeStatsRef {
+        Arc::new(super::stats::BasicJoinStats::new(meter, self.context()))
     }
 
     fn produce_tasks(
@@ -120,32 +428,42 @@ impl PipelineNodeImpl for AsofJoinNode {
     ) -> TaskBuilderStream {
         let left_input = self.left.clone().produce_tasks(plan_context);
         let right_input = self.right.clone().produce_tasks(plan_context);
-
-        TaskBuilderStream::new(
-            left_input
-                .zip(right_input)
-                .map(move |(left_task, right_task)| {
-                    SwordfishTaskBuilder::combine_with(
-                        &left_task,
-                        &right_task,
-                        self.as_ref(),
-                        |left_plan, right_plan| {
-                            LocalPhysicalPlan::asof_join(
-                                left_plan,
-                                right_plan,
-                                self.left_by.clone(),
-                                self.right_by.clone(),
-                                self.left_on.clone(),
-                                self.right_on.clone(),
-                                None,
-                                self.config.schema.clone(),
-                                StatsState::NotMaterialized,
-                                LocalNodeContext::new(Some(self.node_id() as usize)),
-                            )
-                        },
-                    )
-                })
-                .boxed(),
-        )
+        let (result_tx, result_rx) = create_channel(1);
+        plan_context.spawn(self.execution_loop(
+            left_input,
+            right_input,
+            plan_context.task_id_counter(),
+            result_tx,
+            plan_context.scheduler_handle(),
+        ));
+        TaskBuilderStream::from(result_rx)
     }
+}
+
+/// Find the row with the maximum value of `sort_keys` in `batch` using a linear O(n) scan.
+/// Returns `None` if `batch` is empty.
+fn record_batch_max(
+    batch: &RecordBatch,
+    sort_keys: &[BoundExpr],
+) -> DaftResult<Option<RecordBatch>> {
+    let len = batch.len();
+    if len == 0 {
+        return Ok(None);
+    }
+    let evaluated: Vec<_> = sort_keys
+        .iter()
+        .map(|k| batch.eval_expression(k))
+        .collect::<DaftResult<_>>()?;
+    let descending = vec![true; sort_keys.len()];
+    let nulls_first = vec![false; sort_keys.len()];
+    let cmp = build_multi_array_compare(&evaluated, &descending, &nulls_first)?;
+    let max_idx = (1..len).fold(0usize, |best, i| {
+        if cmp(i, best) == Ordering::Greater {
+            i
+        } else {
+            best
+        }
+    });
+    let idx = UInt64Array::from_vec("idx", vec![max_idx as u64]);
+    Ok(Some(batch.take(&idx)?))
 }

--- a/src/daft-distributed/src/pipeline_node/join/asof_join.rs
+++ b/src/daft-distributed/src/pipeline_node/join/asof_join.rs
@@ -173,6 +173,23 @@ impl AsofJoinNode {
     ) -> DaftResult<()> {
         let num_partitions = self.num_partitions;
 
+        // When num_partitions == 1, skip range shuffle entirely.
+        // get_partition_boundaries_from_samples returns empty boundaries for n=1
+        // (no splits needed), which would error with "No boundaries found".
+        if num_partitions == 1 {
+            let left_refs = left_materialized
+                .into_iter()
+                .flat_map(|mo| mo.into_inner().0)
+                .collect::<Vec<_>>();
+            let right_refs = right_materialized
+                .into_iter()
+                .flat_map(|mo| mo.into_inner().0)
+                .collect::<Vec<_>>();
+            return self
+                .create_and_submit_join_task(left_refs, right_refs, None, result_tx)
+                .await;
+        }
+
         let left_composite_key: Vec<BoundExpr> = self
             .left_by
             .iter()

--- a/src/daft-distributed/src/pipeline_node/join/asof_join.rs
+++ b/src/daft-distributed/src/pipeline_node/join/asof_join.rs
@@ -117,6 +117,7 @@ impl AsofJoinNode {
     /// row (if any) directly into the plan payload.
     async fn create_and_submit_join_task(
         self: &Arc<Self>,
+        partition_idx: u32,
         left_partition_group: Vec<PartitionRef>,
         right_partition_group: Vec<PartitionRef>,
         right_sentinel: Option<RecordBatch>,
@@ -152,6 +153,7 @@ impl AsofJoinNode {
         );
 
         let builder = SwordfishTaskBuilder::new(plan, self.as_ref(), self.node_id())
+            .extend_fingerprint(partition_idx)
             .with_psets(self.left.node_id(), left_partition_group)
             .with_psets(self.right.node_id(), right_partition_group);
 
@@ -186,7 +188,7 @@ impl AsofJoinNode {
                 .flat_map(|mo| mo.into_inner().0)
                 .collect::<Vec<_>>();
             return self
-                .create_and_submit_join_task(left_refs, right_refs, None, result_tx)
+                .create_and_submit_join_task(0, left_refs, right_refs, None, result_tx)
                 .await;
         }
 
@@ -365,6 +367,7 @@ impl AsofJoinNode {
                 global_sentinels[i - 1].clone()
             };
             self.create_and_submit_join_task(
+                i as u32,
                 left_partition_group,
                 right_partition_group,
                 sentinel,
@@ -414,7 +417,7 @@ impl AsofJoinNode {
                 .flat_map(|o| o.partitions().iter().cloned())
                 .collect();
             return self
-                .create_and_submit_join_task(all_left, vec![], None, &result_tx)
+                .create_and_submit_join_task(0, all_left, vec![], None, &result_tx)
                 .await;
         }
 

--- a/src/daft-distributed/src/pipeline_node/join/asof_join.rs
+++ b/src/daft-distributed/src/pipeline_node/join/asof_join.rs
@@ -137,6 +137,7 @@ impl PipelineNodeImpl for AsofJoinNode {
                                 self.right_by.clone(),
                                 self.left_on.clone(),
                                 self.right_on.clone(),
+                                None,
                                 self.config.schema.clone(),
                                 StatsState::NotMaterialized,
                                 LocalNodeContext::new(Some(self.node_id() as usize)),

--- a/src/daft-distributed/src/pipeline_node/join/asof_join.rs
+++ b/src/daft-distributed/src/pipeline_node/join/asof_join.rs
@@ -161,7 +161,6 @@ impl AsofJoinNode {
         Ok(())
     }
 
-    /// Handles the multi-partition join case.
     /// Samples both sides with the composite (by, on) key, computes range boundaries,
     /// repartitions left normally and right with sentinel tracking, merges sentinel
     /// candidates per partition, forward-fills, then dispatches join tasks.
@@ -176,8 +175,6 @@ impl AsofJoinNode {
         let num_partitions = self.num_partitions;
 
         // When num_partitions == 1, skip range shuffle entirely.
-        // get_partition_boundaries_from_samples returns empty boundaries for n=1
-        // (no splits needed), which would error with "No boundaries found".
         if num_partitions == 1 {
             let left_refs = left_materialized
                 .into_iter()
@@ -413,8 +410,8 @@ impl AsofJoinNode {
 
         if right_materialized.is_empty() {
             let all_left: Vec<PartitionRef> = left_materialized
-                .iter()
-                .flat_map(|o| o.partitions().iter().cloned())
+                .into_iter()
+                .flat_map(|o| o.into_inner().0)
                 .collect();
             return self
                 .create_and_submit_join_task(0, all_left, vec![], None, &result_tx)
@@ -473,9 +470,6 @@ impl PipelineNodeImpl for AsofJoinNode {
 
 /// Find the single row with the lexicographically maximum composite key `(by..., on)` in
 /// `batch`. Returns `None` if `batch` is empty.
-///
-/// `composite_keys` is `[by_keys..., on_key]` sorted ascending — the max row is the one
-/// that sorts last under `(by ASC..., on ASC)`.
 fn record_batch_max_composite(
     batch: &RecordBatch,
     composite_keys: &[BoundExpr],

--- a/src/daft-distributed/src/pipeline_node/join/asof_join.rs
+++ b/src/daft-distributed/src/pipeline_node/join/asof_join.rs
@@ -332,8 +332,8 @@ impl AsofJoinNode {
                 num_partitions,
             )?;
 
-        // Merge sentinels: for each partition j, pick the max row across all worker candidates,
-        // then forward-fill Nones from the previous partition.
+        // Merge sentinels: for each partition j, pick the single globally max (by..., on)
+        // row across all worker candidates, then forward-fill Nones from the previous partition.
         let mut global_sentinels: Vec<Option<RecordBatch>> = Vec::with_capacity(num_partitions);
         for candidates in sentinel_candidates_per_partition {
             let valid: Vec<RecordBatch> = candidates.into_iter().flatten().collect();
@@ -341,7 +341,7 @@ impl AsofJoinNode {
                 None
             } else {
                 let combined = RecordBatch::concat(&valid)?;
-                record_batch_max(&combined, &right_composite_key)?
+                record_batch_max_composite(&combined, &right_composite_key)?
             };
             global_sentinels.push(global_sentinel);
         }
@@ -471,24 +471,27 @@ impl PipelineNodeImpl for AsofJoinNode {
     }
 }
 
-/// Find the row with the maximum value of `sort_keys` in `batch` using a linear O(n) scan.
-/// Returns `None` if `batch` is empty.
-fn record_batch_max(
+/// Find the single row with the lexicographically maximum composite key `(by..., on)` in
+/// `batch`. Returns `None` if `batch` is empty.
+///
+/// `composite_keys` is `[by_keys..., on_key]` sorted ascending — the max row is the one
+/// that sorts last under `(by ASC..., on ASC)`.
+fn record_batch_max_composite(
     batch: &RecordBatch,
-    sort_keys: &[BoundExpr],
+    composite_keys: &[BoundExpr],
 ) -> DaftResult<Option<RecordBatch>> {
-    let len = batch.len();
-    if len == 0 {
+    if batch.is_empty() {
         return Ok(None);
     }
-    let evaluated: Vec<_> = sort_keys
+
+    let cols: Vec<_> = composite_keys
         .iter()
         .map(|k| batch.eval_expression(k))
         .collect::<DaftResult<_>>()?;
-    let descending = vec![true; sort_keys.len()];
-    let nulls_first = vec![false; sort_keys.len()];
-    let cmp = build_multi_array_compare(&evaluated, &descending, &nulls_first)?;
-    let max_idx = (1..len).fold(0usize, |best, i| {
+    let descending = vec![false; composite_keys.len()];
+    let nulls_first = vec![false; composite_keys.len()];
+    let cmp = build_multi_array_compare(&cols, &descending, &nulls_first)?;
+    let max_idx = (1..batch.len()).fold(0usize, |best, i| {
         if cmp(i, best) == Ordering::Greater {
             i
         } else {

--- a/src/daft-distributed/src/pipeline_node/join/asof_join.rs
+++ b/src/daft-distributed/src/pipeline_node/join/asof_join.rs
@@ -404,9 +404,20 @@ impl AsofJoinNode {
             .try_collect::<Vec<_>>()
             .await?;
 
-        if left_materialized.is_empty() || right_materialized.is_empty() {
+        if left_materialized.is_empty() {
             return Ok(());
         }
+
+        if right_materialized.is_empty() {
+            let all_left: Vec<PartitionRef> = left_materialized
+                .iter()
+                .flat_map(|o| o.partitions().iter().cloned())
+                .collect();
+            return self
+                .create_and_submit_join_task(all_left, vec![], None, &result_tx)
+                .await;
+        }
+
         self.range_shuffle_and_join(
             left_materialized,
             right_materialized,

--- a/src/daft-distributed/src/pipeline_node/join/translate_asof_join.rs
+++ b/src/daft-distributed/src/pipeline_node/join/translate_asof_join.rs
@@ -1,12 +1,8 @@
 use std::{cmp::max, sync::Arc};
 
 use common_error::DaftResult;
-use daft_dsl::{expr::bound_expr::BoundExpr, is_partition_compatible};
-use daft_logical_plan::{
-    ClusteringSpec,
-    ops::AsofJoin,
-    partitioning::{HashRepartitionConfig, RepartitionSpec},
-};
+use daft_dsl::expr::bound_expr::BoundExpr;
+use daft_logical_plan::ops::AsofJoin;
 use daft_schema::schema::SchemaRef;
 
 use crate::pipeline_node::{
@@ -25,88 +21,18 @@ impl LogicalPlanToPipelineNodeTranslator {
         right_on: BoundExpr,
         output_schema: SchemaRef,
     ) -> DaftResult<DistributedPipelineNode> {
-        let left_spec = left.config().clustering_spec.as_ref();
-        let right_spec = right.config().clustering_spec.as_ref();
+        let num_left_partitions = left.config().clustering_spec.num_partitions();
+        let num_right_partitions = right.config().clustering_spec.num_partitions();
 
-        let is_left_hash_partitioned = !left_by.is_empty()
-            && matches!(left_spec, ClusteringSpec::Hash(..))
-            && is_partition_compatible(
-                &left_spec.partition_by(),
-                left_by.iter().map(|e| e.inner()),
-            );
-        let is_right_hash_partitioned = !right_by.is_empty()
-            && matches!(right_spec, ClusteringSpec::Hash(..))
-            && is_partition_compatible(
-                &right_spec.partition_by(),
-                right_by.iter().map(|e| e.inner()),
-            );
-        let num_left_partitions = left_spec.num_partitions();
-        let num_right_partitions = right_spec.num_partitions();
-
-        let num_partitions = if left_by.is_empty() {
-            // No by keys: 1 partition only
-            1
-        } else {
-            match (
-                is_left_hash_partitioned,
-                is_right_hash_partitioned,
-                num_left_partitions,
-                num_right_partitions,
-            ) {
-                (true, true, a, b) | (false, false, a, b) => max(a, b),
-                (_, _, 1, x) | (_, _, x, 1) => x,
-                (true, false, a, b)
-                    if (a as f64)
-                        >= (b as f64)
-                            * self.plan_config.config.hash_join_partition_size_leniency =>
-                {
-                    a
-                }
-                (false, true, a, b)
-                    if (b as f64)
-                        >= (a as f64)
-                            * self.plan_config.config.hash_join_partition_size_leniency =>
-                {
-                    b
-                }
-                (_, _, a, b) => max(a, b),
-            }
-        };
-
-        let left = if left_by.is_empty() {
+        let (num_partitions, left, right) = if left_by.is_empty() {
             // No by keys: gather everything into a single partition
-            self.gen_gather_node(left)
-        } else if num_left_partitions != num_partitions
-            || (num_partitions > 1 && !is_left_hash_partitioned)
-        {
-            self.gen_repartition_node(
-                RepartitionSpec::Hash(HashRepartitionConfig::new(
-                    Some(num_partitions),
-                    left_by.iter().map(|e| e.clone().into()).collect(),
-                )),
-                left.config().schema.clone(),
-                left,
-            )?
+            let left = self.gen_gather_node(left);
+            let right = self.gen_gather_node(right);
+            (1, left, right)
         } else {
-            left
-        };
-
-        let right = if right_by.is_empty() {
-            // No by keys: gather everything into a single partition
-            self.gen_gather_node(right)
-        } else if num_right_partitions != num_partitions
-            || (num_partitions > 1 && !is_right_hash_partitioned)
-        {
-            self.gen_repartition_node(
-                RepartitionSpec::Hash(HashRepartitionConfig::new(
-                    Some(num_partitions),
-                    right_by.iter().map(|e| e.clone().into()).collect(),
-                )),
-                right.config().schema.clone(),
-                right,
-            )?
-        } else {
-            right
+            // AsofJoinNode handles all repartitioning internally via range partitioning
+            let num_partitions = max(num_left_partitions, num_right_partitions);
+            (num_partitions, left, right)
         };
 
         let node_id = self.get_next_pipeline_node_id();

--- a/src/daft-distributed/src/pipeline_node/join/translate_asof_join.rs
+++ b/src/daft-distributed/src/pipeline_node/join/translate_asof_join.rs
@@ -24,16 +24,7 @@ impl LogicalPlanToPipelineNodeTranslator {
         let num_left_partitions = left.config().clustering_spec.num_partitions();
         let num_right_partitions = right.config().clustering_spec.num_partitions();
 
-        let (num_partitions, left, right) = if left_by.is_empty() {
-            // No by keys: gather everything into a single partition
-            let left = self.gen_gather_node(left);
-            let right = self.gen_gather_node(right);
-            (1, left, right)
-        } else {
-            // AsofJoinNode handles all repartitioning internally via range partitioning
-            let num_partitions = max(num_left_partitions, num_right_partitions);
-            (num_partitions, left, right)
-        };
+        let num_partitions = max(num_left_partitions, num_right_partitions);
 
         let node_id = self.get_next_pipeline_node_id();
         Ok(DistributedPipelineNode::new(

--- a/src/daft-distributed/src/pipeline_node/mod.rs
+++ b/src/daft-distributed/src/pipeline_node/mod.rs
@@ -19,7 +19,7 @@ use common_metrics::{
 };
 use common_partitioning::PartitionRef;
 use common_treenode::ConcreteTreeNode;
-use daft_local_plan::{LocalNodeContext, LocalPhysicalPlan, LocalPhysicalPlanRef};
+use daft_local_plan::{LocalNodeContext, LocalPhysicalPlan, LocalPhysicalPlanRef, Sentinels};
 use daft_logical_plan::{partitioning::ClusteringSpecRef, stats::StatsState};
 use daft_schema::schema::SchemaRef;
 use futures::{Stream, StreamExt, stream::BoxStream};
@@ -233,9 +233,32 @@ impl ShuffleWriteOutput {
 }
 
 #[derive(Clone, Debug)]
+#[allow(dead_code)]
+pub(crate) struct ShuffleWriteWithSentinelOutput {
+    pub partitions: Vec<ShufflePartitionRef>,
+    pub sentinels: Sentinels,
+}
+
+impl ShuffleWriteWithSentinelOutput {
+    pub fn new(
+        partitions: Vec<ShufflePartitionRef>,
+        sentinels: Sentinels,
+        _worker_id: WorkerId,
+        _task_id: TaskID,
+    ) -> Self {
+        Self {
+            partitions,
+            sentinels,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+#[allow(dead_code)]
 pub(crate) enum TaskOutput {
     Materialized(MaterializedOutput),
     ShuffleWrite(ShuffleWriteOutput),
+    ShuffleWriteWithSentinel(ShuffleWriteWithSentinelOutput),
 }
 
 impl TaskOutput {
@@ -244,6 +267,10 @@ impl TaskOutput {
             Self::Materialized(materialized_output) => Ok(materialized_output),
             Self::ShuffleWrite(_) => Err(common_error::DaftError::InternalError(
                 "Expected materialized task output but received shuffle write output".to_string(),
+            )),
+            Self::ShuffleWriteWithSentinel(_) => Err(common_error::DaftError::InternalError(
+                "Expected materialized task output but received shuffle write with sentinel output"
+                    .to_string(),
             )),
         }
     }

--- a/src/daft-distributed/src/pipeline_node/mod.rs
+++ b/src/daft-distributed/src/pipeline_node/mod.rs
@@ -233,7 +233,6 @@ impl ShuffleWriteOutput {
 }
 
 #[derive(Clone, Debug)]
-#[allow(dead_code)]
 pub(crate) struct ShuffleWriteWithSentinelOutput {
     pub partitions: Vec<ShufflePartitionRef>,
     pub sentinels: Sentinels,
@@ -254,7 +253,6 @@ impl ShuffleWriteWithSentinelOutput {
 }
 
 #[derive(Clone, Debug)]
-#[allow(dead_code)]
 pub(crate) enum TaskOutput {
     Materialized(MaterializedOutput),
     ShuffleWrite(ShuffleWriteOutput),

--- a/src/daft-distributed/src/pipeline_node/shuffles/partition_groups.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/partition_groups.rs
@@ -46,7 +46,7 @@ pub(crate) fn ray_partition_groups_from_outputs(
     Ok(partition_groups)
 }
 
-#[allow(dead_code, clippy::type_complexity)]
+#[allow(clippy::type_complexity)]
 pub(crate) fn ray_partition_groups_and_sentinels_from_outputs(
     outputs: Vec<TaskOutput>,
     num_partitions: usize,

--- a/src/daft-distributed/src/pipeline_node/shuffles/partition_groups.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/partition_groups.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use common_error::{DaftError, DaftResult};
 use common_partitioning::PartitionRef;
+use daft_recordbatch::RecordBatch;
 
 use crate::pipeline_node::{ShufflePartitionRef, TaskOutput};
 
@@ -43,6 +44,61 @@ pub(crate) fn ray_partition_groups_from_outputs(
     }
 
     Ok(partition_groups)
+}
+
+#[allow(dead_code, clippy::type_complexity)]
+pub(crate) fn ray_partition_groups_and_sentinels_from_outputs(
+    outputs: Vec<TaskOutput>,
+    num_partitions: usize,
+) -> DaftResult<(Vec<Vec<PartitionRef>>, Vec<Vec<Option<RecordBatch>>>)> {
+    let mut partition_groups = (0..num_partitions).map(|_| Vec::new()).collect::<Vec<_>>();
+    let mut sentinel_candidates = (0..num_partitions).map(|_| Vec::new()).collect::<Vec<_>>();
+
+    for output in outputs {
+        let TaskOutput::ShuffleWriteWithSentinel(output) = output else {
+            return Err(DaftError::InternalError(
+                "Expected Ray shuffle write with sentinel task output".to_string(),
+            ));
+        };
+
+        if output.partitions.len() != num_partitions {
+            return Err(DaftError::InternalError(format!(
+                "Expected {} Ray shuffle partitions, got {}",
+                num_partitions,
+                output.partitions.len()
+            )));
+        }
+
+        let sentinels = output.sentinels.into_record_batches();
+        if sentinels.len() != num_partitions {
+            return Err(DaftError::InternalError(format!(
+                "Expected {} sentinels, got {}",
+                num_partitions,
+                sentinels.len()
+            )));
+        }
+
+        for (partition_idx, partition) in output.partitions.into_iter().enumerate() {
+            match partition {
+                ShufflePartitionRef::Ray(partition) => {
+                    if partition.num_rows() > 0 {
+                        partition_groups[partition_idx].push(partition);
+                    }
+                }
+                ShufflePartitionRef::Flight(_) => {
+                    return Err(DaftError::InternalError(
+                        "Expected Ray shuffle partition ref but received Flight".to_string(),
+                    ));
+                }
+            }
+        }
+
+        for (partition_idx, sentinel) in sentinels.into_iter().enumerate() {
+            sentinel_candidates[partition_idx].push(sentinel);
+        }
+    }
+
+    Ok((partition_groups, sentinel_candidates))
 }
 
 pub(crate) fn flight_server_cache_mapping_from_outputs(

--- a/src/daft-distributed/src/pipeline_node/sort.rs
+++ b/src/daft-distributed/src/pipeline_node/sort.rs
@@ -213,6 +213,60 @@ pub(crate) fn create_sample_tasks(
         .collect::<DaftResult<Vec<_>>>()
 }
 
+#[allow(clippy::too_many_arguments, dead_code)]
+pub(crate) fn create_range_repartition_tasks_with_sentinels(
+    materialized_outputs: Vec<MaterializedOutput>,
+    input_schema: SchemaRef,
+    partition_by: Vec<BoundExpr>,
+    descending: Vec<bool>,
+    boundaries: RecordBatch,
+    num_partitions: usize,
+    sentinel_sort_keys: Vec<BoundExpr>,
+    pipeline_node: &dyn PipelineNodeImpl,
+    task_id_counter: &TaskIDCounter,
+    scheduler_handle: &SchedulerHandle<SwordfishTask>,
+    fingerprint_salt: Option<u32>,
+) -> DaftResult<Vec<SubmittedTask>> {
+    let context = pipeline_node.context();
+    let node_id = pipeline_node.node_id();
+    materialized_outputs
+        .into_iter()
+        .map(|mo| {
+            let (in_memory_source_plan, psets) =
+                MaterializedOutput::into_in_memory_scan_with_psets_and_phase(
+                    vec![mo],
+                    input_schema.clone(),
+                    node_id,
+                    REPARTITION_PHASE,
+                );
+            let plan = LocalPhysicalPlan::repartition_write_with_sentinel(
+                in_memory_source_plan,
+                num_partitions,
+                input_schema.clone(),
+                RepartitionWriteBackend::Ray,
+                RepartitionSpec::Range(RangeRepartitionConfig::new(
+                    Some(num_partitions),
+                    boundaries.clone(),
+                    partition_by.clone(),
+                    descending.clone(),
+                )),
+                sentinel_sort_keys.clone(),
+                StatsState::NotMaterialized,
+                LocalNodeContext::new(Some(node_id as usize)).with_phase(REPARTITION_PHASE),
+            );
+            let mut builder =
+                SwordfishTaskBuilder::new(plan, pipeline_node, pipeline_node.node_id())
+                    .with_psets(node_id, psets);
+            if let Some(salt) = fingerprint_salt {
+                builder = builder.extend_fingerprint(salt);
+            }
+            let submittable_task = builder.build(context.query_idx, task_id_counter);
+            let submitted_task = submittable_task.submit(scheduler_handle)?;
+            Ok(submitted_task)
+        })
+        .collect::<DaftResult<Vec<_>>>()
+}
+
 /// Creates range repartition tasks from materialized outputs using the provided boundaries.
 /// This is used to repartition data after computing partition boundaries from samples.
 #[allow(clippy::too_many_arguments)]

--- a/src/daft-distributed/src/pipeline_node/sort.rs
+++ b/src/daft-distributed/src/pipeline_node/sort.rs
@@ -213,7 +213,7 @@ pub(crate) fn create_sample_tasks(
         .collect::<DaftResult<Vec<_>>>()
 }
 
-#[allow(clippy::too_many_arguments, dead_code)]
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn create_range_repartition_tasks_with_sentinels(
     materialized_outputs: Vec<MaterializedOutput>,
     input_schema: SchemaRef,

--- a/src/daft-distributed/src/python/ray/task.rs
+++ b/src/daft-distributed/src/python/ray/task.rs
@@ -2,13 +2,13 @@ use std::{any::Any, collections::HashMap, future::Future, sync::Arc};
 
 use common_daft_config::PyDaftExecutionConfig;
 use common_partitioning::{Partition, PartitionRef};
-use daft_local_plan::{ExecutionStats, PyLocalPhysicalPlan, SourceId, python::PyInput};
+use daft_local_plan::{ExecutionStats, PyLocalPhysicalPlan, Sentinels, SourceId, python::PyInput};
 use pyo3::{Py, PyAny, PyResult, Python, pyclass, pymethods};
 
 use crate::{
     pipeline_node::{
         FlightShufflePartitionRef as RustFlightShufflePartitionRef, MaterializedOutput,
-        ShufflePartitionRef, ShuffleWriteOutput, TaskOutput,
+        ShufflePartitionRef, ShuffleWriteOutput, ShuffleWriteWithSentinelOutput, TaskOutput,
     },
     scheduling::{
         task::{SwordfishTask, Task, TaskContext, TaskResultHandle, TaskStatus},
@@ -21,6 +21,7 @@ use crate::{
 pub(crate) enum RayTaskResult {
     Success(Vec<RayPartitionRef>, Vec<u8>),
     RayShuffleSuccess(Vec<RayPartitionRef>, Vec<u8>),
+    RayShuffleWithSentinelSuccess(Vec<RayPartitionRef>, Vec<u8>, Vec<u8>), // refs, sentinels_serialized, stats_serialized
     FlightShuffleSuccess(Vec<FlightShufflePartitionRef>, Vec<u8>),
     WorkerDied(),
     WorkerUnavailable(),
@@ -39,6 +40,19 @@ impl RayTaskResult {
         stats_serialized: Vec<u8>,
     ) -> Self {
         Self::RayShuffleSuccess(shuffle_part_refs, stats_serialized)
+    }
+
+    #[staticmethod]
+    fn ray_shuffle_with_sentinel_success(
+        shuffle_part_refs: Vec<RayPartitionRef>,
+        sentinels_serialized: Vec<u8>,
+        stats_serialized: Vec<u8>,
+    ) -> Self {
+        Self::RayShuffleWithSentinelSuccess(
+            shuffle_part_refs,
+            sentinels_serialized,
+            stats_serialized,
+        )
     }
 
     #[staticmethod]
@@ -145,6 +159,30 @@ impl TaskResultHandle for RayTaskResultHandle {
 
                     TaskStatus::Success {
                         result: TaskOutput::ShuffleWrite(shuffle_output),
+                        stats,
+                    }
+                }
+                Ok(RayTaskResult::RayShuffleWithSentinelSuccess(
+                    ray_part_refs,
+                    sentinels_serialized,
+                    stats_serialized,
+                )) => {
+                    let stats: ExecutionStats = ExecutionStats::decode(&stats_serialized);
+                    let sentinels = Sentinels::decode(&sentinels_serialized);
+                    let shuffle_output = ShuffleWriteWithSentinelOutput::new(
+                        ray_part_refs
+                            .into_iter()
+                            .map(|ray_part_ref| {
+                                ShufflePartitionRef::Ray(Arc::new(ray_part_ref) as PartitionRef)
+                            })
+                            .collect(),
+                        sentinels,
+                        worker_id.clone(),
+                        task_id,
+                    );
+
+                    TaskStatus::Success {
+                        result: TaskOutput::ShuffleWriteWithSentinel(shuffle_output),
                         stats,
                     }
                 }

--- a/src/daft-distributed/src/scheduling/dispatcher.rs
+++ b/src/daft-distributed/src/scheduling/dispatcher.rs
@@ -213,6 +213,7 @@ mod tests {
         match result.expect("expected task output") {
             TaskOutput::Materialized(materialized_output) => materialized_output,
             TaskOutput::ShuffleWrite(_) => panic!("expected materialized output"),
+            TaskOutput::ShuffleWriteWithSentinel(_) => panic!("expected materialized output"),
         }
     }
 

--- a/src/daft-distributed/src/scheduling/scheduler/scheduler_actor.rs
+++ b/src/daft-distributed/src/scheduling/scheduler/scheduler_actor.rs
@@ -444,6 +444,7 @@ mod tests {
         match result.expect("expected task output") {
             TaskOutput::Materialized(materialized_output) => materialized_output,
             TaskOutput::ShuffleWrite(_) => panic!("expected materialized output"),
+            TaskOutput::ShuffleWriteWithSentinel(_) => panic!("expected materialized output"),
         }
     }
 

--- a/src/daft-local-execution/src/join/asof_join.rs
+++ b/src/daft-local-execution/src/join/asof_join.rs
@@ -3,6 +3,7 @@ use common_metrics::ops::NodeType;
 use daft_core::prelude::SchemaRef;
 use daft_dsl::expr::bound_expr::BoundExpr;
 use daft_micropartition::MicroPartition;
+use daft_recordbatch::RecordBatch;
 use tracing::Span;
 
 use crate::{
@@ -28,6 +29,7 @@ pub struct AsofJoinOperator {
     right_by: Vec<BoundExpr>,
     left_on: BoundExpr,
     right_on: BoundExpr,
+    right_sentinel: Option<RecordBatch>,
     left_schema: SchemaRef,
     right_schema: SchemaRef,
 }
@@ -38,6 +40,7 @@ impl AsofJoinOperator {
         right_by: Vec<BoundExpr>,
         left_on: BoundExpr,
         right_on: BoundExpr,
+        right_sentinel: Option<RecordBatch>,
         left_schema: SchemaRef,
         right_schema: SchemaRef,
     ) -> Self {
@@ -46,6 +49,7 @@ impl AsofJoinOperator {
             right_by,
             left_on,
             right_on,
+            right_sentinel,
             left_schema,
             right_schema,
         }
@@ -112,6 +116,7 @@ impl JoinOperator for AsofJoinOperator {
         let right_by = self.right_by.clone();
         let left_on = self.left_on.clone();
         let right_on = self.right_on.clone();
+        let right_sentinel = self.right_sentinel.clone();
         let left_schema = self.left_schema.clone();
         let right_schema = self.right_schema.clone();
 
@@ -120,8 +125,21 @@ impl JoinOperator for AsofJoinOperator {
                 async move {
                     let left_mp =
                         MicroPartition::concat_or_empty(state.build_contents, left_schema)?;
-                    let right_mp =
-                        MicroPartition::concat_or_empty(state.probe_contents, right_schema)?;
+                    let right_mp = MicroPartition::concat_or_empty(
+                        state.probe_contents,
+                        right_schema.clone(),
+                    )?;
+
+                    let right_mp = if let Some(sentinel) = right_sentinel {
+                        let sentinel_mp = MicroPartition::new_loaded(
+                            right_schema,
+                            std::sync::Arc::new(vec![sentinel]),
+                            None,
+                        );
+                        MicroPartition::concat(vec![sentinel_mp, right_mp])?
+                    } else {
+                        right_mp
+                    };
 
                     let joined =
                         left_mp.asof_join(&right_mp, &left_by, &right_by, &left_on, &right_on)?;

--- a/src/daft-local-execution/src/pipeline.rs
+++ b/src/daft-local-execution/src/pipeline.rs
@@ -1248,6 +1248,7 @@ fn physical_plan_to_pipeline(
             right_by,
             left_on,
             right_on,
+            right_sentinel,
             stats_state,
             context,
             ..
@@ -1260,6 +1261,7 @@ fn physical_plan_to_pipeline(
                 right_by.clone(),
                 left_on.clone(),
                 right_on.clone(),
+                right_sentinel.clone(),
                 left.schema().clone(),
                 right.schema().clone(),
             );

--- a/src/daft-local-execution/src/pipeline.rs
+++ b/src/daft-local-execution/src/pipeline.rs
@@ -20,9 +20,10 @@ use daft_local_plan::{
     AsofJoin, CommitWrite, Concat, CrossJoin, Dedup, Explode, Filter, FlightShuffleReadInput,
     GlobScan, HashAggregate, HashJoin, InMemoryScan, IntoBatches, Limit, LocalNodeContext,
     LocalPhysicalPlan, MonotonicallyIncreasingId, PhysicalScan, PhysicalWrite, Pivot, Project,
-    RepartitionWrite, RepartitionWriteBackend, Sample, ShuffleReadBackend, Sort, SortMergeJoin,
-    SourceId, TopN, UDFProject, UnGroupedAggregate, Unpivot, VLLMProject, WindowOrderByOnly,
-    WindowPartitionAndDynamicFrame, WindowPartitionAndOrderBy, WindowPartitionOnly,
+    RepartitionWrite, RepartitionWriteBackend, RepartitionWriteWithSentinel, Sample,
+    ShuffleReadBackend, Sort, SortMergeJoin, SourceId, TopN, UDFProject, UnGroupedAggregate,
+    Unpivot, VLLMProject, WindowOrderByOnly, WindowPartitionAndDynamicFrame,
+    WindowPartitionAndOrderBy, WindowPartitionOnly,
 };
 use daft_logical_plan::{JoinType, stats::StatsState};
 use daft_micropartition::{MicroPartition, MicroPartitionRef};
@@ -56,6 +57,7 @@ use crate::{
         into_partitions::IntoPartitionsSink,
         pivot::PivotSink,
         repartition::RepartitionSink,
+        repartition_with_sentinel::RepartitionWithSentinelSink,
         sort::SortSink,
         top_n::TopNSink,
         window_order_by_only::WindowOrderByOnlySink,
@@ -1512,8 +1514,42 @@ fn physical_plan_to_pipeline(
                 }
             }
         }
-        LocalPhysicalPlan::RepartitionWriteWithSentinel(_) => {
-            unimplemented!("RepartitionWriteWithSentinel pipeline node is not yet implemented")
+        LocalPhysicalPlan::RepartitionWriteWithSentinel(RepartitionWriteWithSentinel {
+            input,
+            num_partitions,
+            schema,
+            backend,
+            repartition_spec,
+            sentinel_sort_keys,
+            stats_state,
+            context,
+            ..
+        }) => {
+            let child_node = physical_plan_to_pipeline(input, cfg, ctx, input_senders)?;
+            match backend {
+                RepartitionWriteBackend::Ray => {
+                    let sink = RepartitionWithSentinelSink::new_ray(
+                        repartition_spec.clone(),
+                        *num_partitions,
+                        schema.clone(),
+                        sentinel_sort_keys.clone(),
+                    );
+                    BlockingSinkNode::new(
+                        Arc::new(sink),
+                        child_node,
+                        stats_state.clone(),
+                        ctx,
+                        context,
+                    )
+                    .boxed()
+                }
+                RepartitionWriteBackend::Flight { .. } => {
+                    unimplemented!(
+                        "RepartitionWriteWithSentinel does not support Flight backend: \
+                         sentinel tracking is only used in the Ray distributed execution path"
+                    )
+                }
+            }
         }
         LocalPhysicalPlan::ShuffleRead(daft_local_plan::ShuffleRead {
             source_id,

--- a/src/daft-local-execution/src/pipeline.rs
+++ b/src/daft-local-execution/src/pipeline.rs
@@ -1512,6 +1512,9 @@ fn physical_plan_to_pipeline(
                 }
             }
         }
+        LocalPhysicalPlan::RepartitionWriteWithSentinel(_) => {
+            unimplemented!("RepartitionWriteWithSentinel pipeline node is not yet implemented")
+        }
         LocalPhysicalPlan::ShuffleRead(daft_local_plan::ShuffleRead {
             source_id,
             backend,

--- a/src/daft-local-execution/src/run.rs
+++ b/src/daft-local-execution/src/run.rs
@@ -11,7 +11,9 @@ use common_metrics::{QueryEndState, QueryID};
 use common_runtime::RuntimeTask;
 use common_tracing::flush_opentelemetry_providers;
 use daft_context::{DaftContext, Subscriber};
-use daft_local_plan::{ExecutionStats, Input, InputId, LocalPhysicalPlanRef, SourceId, translate};
+use daft_local_plan::{
+    ExecutionStats, Input, InputId, LocalPhysicalPlanRef, Sentinels, SourceId, translate,
+};
 use daft_logical_plan::LogicalPlanBuilder;
 use daft_micropartition::MicroPartition;
 use daft_shuffles::server::flight_server::{
@@ -602,6 +604,21 @@ impl ExecutionEngineResult {
         }
         self.shuffle_metadata
     }
+
+    async fn into_shuffle_metadata_and_sentinels(
+        mut self,
+    ) -> (Option<ShuffleMetadata>, Option<Sentinels>) {
+        while let Some(item) = self.receiver.recv().await {
+            if let ExecutionEngineResultItem::ShuffleMetadata(metadata) = item {
+                self.shuffle_metadata = Some(metadata);
+            }
+        }
+        let sentinels = self
+            .shuffle_metadata
+            .as_mut()
+            .and_then(|m| m.sentinels.take());
+        (self.shuffle_metadata, sentinels)
+    }
 }
 
 #[cfg_attr(
@@ -679,6 +696,38 @@ impl PyResultReceiver {
                     .map(|metadata| metadata.to_pyobject(py))
                     .transpose()?;
                 Ok((PyExecutionStats::from(stats), py_metadata)
+                    .into_pyobject(py)?
+                    .unbind())
+            })
+        })
+    }
+
+    fn try_finish_with_shuffle_metadata_and_sentinels<'py>(
+        &self,
+        py: Python<'py>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let result = self.result.clone();
+        let executor = self.executor.clone();
+        let fingerprint = self.fingerprint;
+        let input_id = self.input_id;
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let mut result_guard = result.lock().await;
+            let execution_result = result_guard
+                .take()
+                .expect("PyResultReceiver.try_finish_with_shuffle_metadata_and_sentinels() should not be called more than once.");
+            drop(result_guard);
+
+            let (shuffle_metadata, sentinels) =
+                execution_result.into_shuffle_metadata_and_sentinels().await;
+            let finish_future = executor.lock().unwrap().try_finish(fingerprint, input_id)?;
+            let stats = finish_future.await?;
+            Python::attach(|py| {
+                let py_metadata = shuffle_metadata
+                    .as_ref()
+                    .map(|metadata| metadata.to_pyobject(py))
+                    .transpose()?;
+                let sentinel_bytes = sentinels.map(|s| s.encode());
+                Ok((PyExecutionStats::from(stats), py_metadata, sentinel_bytes)
                     .into_pyobject(py)?
                     .unbind())
             })

--- a/src/daft-local-execution/src/shuffle_metadata.rs
+++ b/src/daft-local-execution/src/shuffle_metadata.rs
@@ -1,9 +1,12 @@
+use daft_recordbatch::RecordBatch;
 #[cfg(feature = "python")]
 use pyo3::{IntoPyObjectExt, Py, PyAny, PyResult, Python};
 
 #[derive(Debug)]
 pub(crate) struct ShuffleMetadata {
     pub partitions: Vec<ShufflePartitionMetadata>,
+    #[allow(dead_code)]
+    pub sentinels: Option<Vec<Option<RecordBatch>>>,
 }
 
 #[derive(Debug)]

--- a/src/daft-local-execution/src/shuffle_metadata.rs
+++ b/src/daft-local-execution/src/shuffle_metadata.rs
@@ -5,7 +5,6 @@ use pyo3::{IntoPyObjectExt, Py, PyAny, PyResult, Python};
 #[derive(Debug)]
 pub(crate) struct ShuffleMetadata {
     pub partitions: Vec<ShufflePartitionMetadata>,
-    #[allow(dead_code)]
     pub sentinels: Option<Sentinels>,
 }
 

--- a/src/daft-local-execution/src/shuffle_metadata.rs
+++ b/src/daft-local-execution/src/shuffle_metadata.rs
@@ -1,4 +1,4 @@
-use daft_recordbatch::RecordBatch;
+use daft_local_plan::Sentinels;
 #[cfg(feature = "python")]
 use pyo3::{IntoPyObjectExt, Py, PyAny, PyResult, Python};
 
@@ -6,7 +6,7 @@ use pyo3::{IntoPyObjectExt, Py, PyAny, PyResult, Python};
 pub(crate) struct ShuffleMetadata {
     pub partitions: Vec<ShufflePartitionMetadata>,
     #[allow(dead_code)]
-    pub sentinels: Option<Vec<Option<RecordBatch>>>,
+    pub sentinels: Option<Sentinels>,
 }
 
 #[derive(Debug)]

--- a/src/daft-local-execution/src/sinks/mod.rs
+++ b/src/daft-local-execution/src/sinks/mod.rs
@@ -6,6 +6,7 @@ pub mod grouped_aggregate;
 pub mod into_partitions;
 pub mod pivot;
 pub mod repartition;
+pub mod repartition_with_sentinel;
 pub mod sort;
 pub mod top_n;
 pub mod window_base;

--- a/src/daft-local-execution/src/sinks/repartition.rs
+++ b/src/daft-local-execution/src/sinks/repartition.rs
@@ -285,6 +285,7 @@ impl BlockingSink for RepartitionSink {
                                 })?;
                                 Ok(BlockingSinkOutput::ShuffleMetadata(ShuffleMetadata {
                                     partitions: metadata,
+                                    sentinels: None,
                                 }))
                             }
                             #[cfg(not(feature = "python"))]
@@ -331,6 +332,7 @@ impl BlockingSink for RepartitionSink {
                                         ShufflePartitionMetadata::new(num_rows, size_bytes)
                                     })
                                     .collect(),
+                                sentinels: None,
                             }))
                         },
                         Span::current(),

--- a/src/daft-local-execution/src/sinks/repartition_with_sentinel.rs
+++ b/src/daft-local-execution/src/sinks/repartition_with_sentinel.rs
@@ -54,24 +54,24 @@ enum RepartitionWithSentinelBackend {
     },
 }
 
-/// Find the row with the maximum value of `sort_keys` in `batch` using a linear scan.
-/// Returns `None` if `batch` is empty.
-fn record_batch_max(
+/// Find the single row with the lexicographically maximum composite key `(by..., on)` in
+/// `batch`.
+fn record_batch_max_composite(
     batch: &RecordBatch,
-    sort_keys: &[BoundExpr],
+    composite_keys: &[BoundExpr],
 ) -> DaftResult<Option<RecordBatch>> {
-    let len = batch.len();
-    if len == 0 {
+    if batch.is_empty() {
         return Ok(None);
     }
-    let evaluated: Vec<_> = sort_keys
+
+    let cols: Vec<_> = composite_keys
         .iter()
         .map(|k| batch.eval_expression(k))
         .collect::<DaftResult<_>>()?;
-    let descending = vec![true; sort_keys.len()];
-    let nulls_first = vec![false; sort_keys.len()];
-    let cmp = build_multi_array_compare(&evaluated, &descending, &nulls_first)?;
-    let max_idx = (1..len).fold(0usize, |best, i| {
+    let descending = vec![false; composite_keys.len()];
+    let nulls_first = vec![false; composite_keys.len()];
+    let cmp = build_multi_array_compare(&cols, &descending, &nulls_first)?;
+    let max_idx = (1..batch.len()).fold(0usize, |best, i| {
         if cmp(i, best) == Ordering::Greater {
             i
         } else {
@@ -82,16 +82,16 @@ fn record_batch_max(
     Ok(Some(batch.take(&idx)?))
 }
 
-/// Find the row with the maximum value of `sort_keys` across all record batches in `partition`.
-/// Returns `None` if the partition is empty.
+/// Find the single globally maximum composite-key row across all record batches in
+/// `partition`. Returns `None` if the partition is empty.
 fn compute_partition_max(
     partition: &MicroPartition,
-    sort_keys: &[BoundExpr],
+    composite_keys: &[BoundExpr],
 ) -> DaftResult<Option<RecordBatch>> {
     let batches = partition.record_batches();
     let candidates: Vec<RecordBatch> = batches
         .iter()
-        .filter_map(|b| record_batch_max(b, sort_keys).transpose())
+        .filter_map(|b| record_batch_max_composite(b, composite_keys).transpose())
         .collect::<DaftResult<_>>()?;
     if candidates.is_empty() {
         return Ok(None);
@@ -99,9 +99,8 @@ fn compute_partition_max(
     if candidates.len() == 1 {
         return Ok(Some(candidates.into_iter().next().unwrap()));
     }
-    // Find the max among per-batch candidates (at most `batches.len()` rows).
     let combined = RecordBatch::concat(&candidates.iter().collect::<Vec<_>>())?;
-    record_batch_max(&combined, sort_keys)
+    record_batch_max_composite(&combined, composite_keys)
 }
 
 pub struct RepartitionWithSentinelSink {

--- a/src/daft-local-execution/src/sinks/repartition_with_sentinel.rs
+++ b/src/daft-local-execution/src/sinks/repartition_with_sentinel.rs
@@ -1,0 +1,318 @@
+use std::{cmp::Ordering, collections::VecDeque, sync::Arc};
+
+use common_error::DaftResult;
+use common_metrics::ops::NodeType;
+use daft_core::{
+    array::ops::build_multi_array_compare,
+    prelude::{SchemaRef, UInt64Array},
+};
+use daft_dsl::expr::bound_expr::BoundExpr;
+use daft_logical_plan::partitioning::RepartitionSpec;
+use daft_micropartition::MicroPartition;
+use daft_recordbatch::RecordBatch;
+use tracing::{Span, instrument};
+
+use super::blocking_sink::{
+    BlockingSink, BlockingSinkFinalizeResult, BlockingSinkOutput, BlockingSinkSinkResult,
+};
+use crate::{
+    ExecutionTaskSpawner,
+    pipeline::{InputId, NodeName},
+    shuffle_metadata::{ShuffleMetadata, ShufflePartitionMetadata},
+};
+
+pub(crate) struct RayRepartitionWithSentinelState {
+    states: VecDeque<Vec<MicroPartition>>,
+}
+
+impl RayRepartitionWithSentinelState {
+    fn new(num_partitions: usize) -> Self {
+        Self {
+            states: (0..num_partitions).map(|_| vec![]).collect(),
+        }
+    }
+
+    fn push(&mut self, parts: Vec<MicroPartition>) {
+        for (vec, part) in self.states.iter_mut().zip(parts) {
+            vec.push(part);
+        }
+    }
+
+    fn emit(&mut self) -> Option<Vec<MicroPartition>> {
+        self.states.pop_front()
+    }
+}
+
+pub(crate) enum RepartitionWithSentinelState {
+    Ray(RayRepartitionWithSentinelState),
+}
+
+enum RepartitionWithSentinelBackend {
+    Ray {
+        repartition_spec: RepartitionSpec,
+        schema: SchemaRef,
+    },
+}
+
+/// Find the row with the maximum value of `sort_keys` in `batch` using a linear scan.
+/// Returns `None` if `batch` is empty.
+fn record_batch_max(
+    batch: &RecordBatch,
+    sort_keys: &[BoundExpr],
+) -> DaftResult<Option<RecordBatch>> {
+    let len = batch.len();
+    if len == 0 {
+        return Ok(None);
+    }
+    let evaluated: Vec<_> = sort_keys
+        .iter()
+        .map(|k| batch.eval_expression(k))
+        .collect::<DaftResult<_>>()?;
+    let descending = vec![true; sort_keys.len()];
+    let nulls_first = vec![false; sort_keys.len()];
+    let cmp = build_multi_array_compare(&evaluated, &descending, &nulls_first)?;
+    let max_idx = (1..len).fold(0usize, |best, i| {
+        if cmp(i, best) == Ordering::Greater {
+            i
+        } else {
+            best
+        }
+    });
+    let idx = UInt64Array::from_vec("idx", vec![max_idx as u64]);
+    Ok(Some(batch.take(&idx)?))
+}
+
+/// Find the row with the maximum value of `sort_keys` across all record batches in `partition`.
+/// Returns `None` if the partition is empty.
+fn compute_partition_max(
+    partition: &MicroPartition,
+    sort_keys: &[BoundExpr],
+) -> DaftResult<Option<RecordBatch>> {
+    let batches = partition.record_batches();
+    let candidates: Vec<RecordBatch> = batches
+        .iter()
+        .filter_map(|b| record_batch_max(b, sort_keys).transpose())
+        .collect::<DaftResult<_>>()?;
+    if candidates.is_empty() {
+        return Ok(None);
+    }
+    if candidates.len() == 1 {
+        return Ok(Some(candidates.into_iter().next().unwrap()));
+    }
+    // Find the max among per-batch candidates (at most `batches.len()` rows).
+    let combined = RecordBatch::concat(&candidates.iter().collect::<Vec<_>>())?;
+    record_batch_max(&combined, sort_keys)
+}
+
+pub struct RepartitionWithSentinelSink {
+    backend: RepartitionWithSentinelBackend,
+    num_partitions: usize,
+    sentinel_sort_keys: Vec<BoundExpr>,
+}
+
+impl RepartitionWithSentinelSink {
+    pub fn new_ray(
+        repartition_spec: RepartitionSpec,
+        num_partitions: usize,
+        schema: SchemaRef,
+        sentinel_sort_keys: Vec<BoundExpr>,
+    ) -> Self {
+        Self {
+            backend: RepartitionWithSentinelBackend::Ray {
+                repartition_spec,
+                schema,
+            },
+            num_partitions,
+            sentinel_sort_keys,
+        }
+    }
+}
+
+impl BlockingSink for RepartitionWithSentinelSink {
+    type State = RepartitionWithSentinelState;
+
+    #[instrument(skip_all, name = "RepartitionWithSentinelSink::sink")]
+    fn sink(
+        &self,
+        input: MicroPartition,
+        state: Self::State,
+        _runtime_stats: Arc<Self::Stats>,
+        spawner: &ExecutionTaskSpawner,
+    ) -> BlockingSinkSinkResult<Self> {
+        match (&self.backend, state) {
+            (
+                RepartitionWithSentinelBackend::Ray {
+                    repartition_spec, ..
+                },
+                RepartitionWithSentinelState::Ray(mut state),
+            ) => {
+                let repartition_spec = repartition_spec.clone();
+
+                spawner
+                    .spawn(
+                        async move {
+                            let partitioned = if let RepartitionSpec::Range(config) =
+                                &repartition_spec
+                            {
+                                input.partition_by_range(
+                                    &config.by,
+                                    &config.boundaries,
+                                    &config.descending,
+                                )?
+                            } else {
+                                unreachable!(
+                                    "RepartitionWithSentinelSink only supports Range repartition"
+                                )
+                            };
+
+                            state.push(partitioned);
+                            Ok(RepartitionWithSentinelState::Ray(state))
+                        },
+                        Span::current(),
+                    )
+                    .into()
+            }
+        }
+    }
+
+    #[instrument(skip_all, name = "RepartitionWithSentinelSink::finalize")]
+    fn finalize(
+        &self,
+        states: Vec<Self::State>,
+        spawner: &ExecutionTaskSpawner,
+    ) -> BlockingSinkFinalizeResult {
+        match &self.backend {
+            RepartitionWithSentinelBackend::Ray { schema, .. } => {
+                let num_partitions = self.num_partitions;
+                let schema = schema.clone();
+                let sentinel_sort_keys = self.sentinel_sort_keys.clone();
+
+                let mut states = states
+                    .into_iter()
+                    .map(|state| match state {
+                        RepartitionWithSentinelState::Ray(state) => state,
+                    })
+                    .collect::<Vec<_>>();
+
+                spawner
+                    .spawn(
+                        async move {
+                            let mut repart_states = states.iter_mut().collect::<Vec<_>>();
+                            let mut outputs = Vec::new();
+                            for _ in 0..num_partitions {
+                                let data = repart_states
+                                    .iter_mut()
+                                    .flat_map(|state| state.emit().unwrap())
+                                    .collect::<Vec<_>>();
+                                let schema = schema.clone();
+                                let sentinel_sort_keys = sentinel_sort_keys.clone();
+                                let fut = tokio::spawn(async move {
+                                    let together = MicroPartition::concat(data)?;
+                                    let sentinel =
+                                        compute_partition_max(&together, &sentinel_sort_keys)?;
+                                    let concated = together.concat_or_get()?;
+                                    let mp = MicroPartition::new_loaded(
+                                        schema,
+                                        Arc::new(if let Some(t) = concated {
+                                            vec![t]
+                                        } else {
+                                            vec![]
+                                        }),
+                                        None,
+                                    );
+                                    Ok::<_, common_error::DaftError>((mp, sentinel))
+                                });
+                                outputs.push(fut);
+                            }
+                            let results = futures::future::try_join_all(outputs)
+                                .await
+                                .unwrap()
+                                .into_iter()
+                                .collect::<DaftResult<Vec<_>>>()?;
+                            let (partitions, sentinels): (Vec<_>, Vec<_>) =
+                                results.into_iter().unzip();
+
+                            #[cfg(feature = "python")]
+                            {
+                                use pyo3::{Python, types::PyAnyMethods};
+
+                                let mut metadata = Vec::with_capacity(partitions.len());
+                                Python::attach(|py| -> DaftResult<()> {
+                                    let ray = py.import("ray")?;
+                                    for partition in partitions {
+                                        let py_partition =
+                                            daft_micropartition::python::PyMicroPartition::from(
+                                                partition.clone(),
+                                            );
+                                        let object_ref =
+                                            ray.call_method1("put", (py_partition,))?.unbind();
+                                        metadata.push(ShufflePartitionMetadata::with_object_ref(
+                                            object_ref,
+                                            partition.len(),
+                                            partition.size_bytes(),
+                                        ));
+                                    }
+                                    Ok(())
+                                })?;
+                                Ok(BlockingSinkOutput::ShuffleMetadata(ShuffleMetadata {
+                                    partitions: metadata,
+                                    sentinels: Some(sentinels),
+                                }))
+                            }
+                            #[cfg(not(feature = "python"))]
+                            {
+                                unreachable!("RepartitionWithSentinelSink requires python feature")
+                            }
+                        },
+                        Span::current(),
+                    )
+                    .into()
+            }
+        }
+    }
+
+    fn name(&self) -> NodeName {
+        "RepartitionWithSentinel".into()
+    }
+
+    fn op_type(&self) -> NodeType {
+        NodeType::Repartition
+    }
+
+    fn multiline_display(&self) -> Vec<String> {
+        match &self.backend {
+            RepartitionWithSentinelBackend::Ray {
+                repartition_spec, ..
+            } => {
+                if let RepartitionSpec::Range(config) = repartition_spec {
+                    let pairs = config
+                        .by
+                        .iter()
+                        .zip(config.descending.iter())
+                        .map(|(sb, d)| {
+                            format!("({}, {})", sb, if *d { "descending" } else { "ascending" })
+                        })
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    vec![
+                        format!(
+                            "RepartitionWithSentinel: Range into {} partitions",
+                            self.num_partitions
+                        ),
+                        format!("By: {:?}", pairs),
+                    ]
+                } else {
+                    unreachable!("RepartitionWithSentinelSink only supports Range repartition")
+                }
+            }
+        }
+    }
+
+    fn make_state(&self, _input_id: InputId) -> DaftResult<Self::State> {
+        match &self.backend {
+            RepartitionWithSentinelBackend::Ray { .. } => Ok(RepartitionWithSentinelState::Ray(
+                RayRepartitionWithSentinelState::new(self.num_partitions),
+            )),
+        }
+    }
+}

--- a/src/daft-local-execution/src/sinks/repartition_with_sentinel.rs
+++ b/src/daft-local-execution/src/sinks/repartition_with_sentinel.rs
@@ -256,7 +256,7 @@ impl BlockingSink for RepartitionWithSentinelSink {
                                 })?;
                                 Ok(BlockingSinkOutput::ShuffleMetadata(ShuffleMetadata {
                                     partitions: metadata,
-                                    sentinels: Some(sentinels),
+                                    sentinels: Some(daft_local_plan::Sentinels::from(sentinels)),
                                 }))
                             }
                             #[cfg(not(feature = "python"))]

--- a/src/daft-local-plan/Cargo.toml
+++ b/src/daft-local-plan/Cargo.toml
@@ -12,6 +12,7 @@ daft-micropartition = {path = "../daft-micropartition", default-features = false
 daft-scan = {path = "../daft-scan", default-features = false}
 daft-recordbatch = {path = "../daft-recordbatch", default-features = false}
 bincode = {workspace = true}
+serde_bytes = {workspace = true}
 arrow-schema = {workspace = true}
 arrow-array = {workspace = true}
 log = {workspace = true}

--- a/src/daft-local-plan/src/lib.rs
+++ b/src/daft-local-plan/src/lib.rs
@@ -12,9 +12,10 @@ pub use plan::{
     GlobScan, HashAggregate, HashJoin, InMemoryScan, IntoBatches, IntoPartitions, Limit,
     LocalNodeContext, LocalPhysicalPlan, LocalPhysicalPlanRef, MonotonicallyIncreasingId,
     PhysicalScan, PhysicalWrite, Pivot, PlaceholderScan, Project, RepartitionWrite,
-    RepartitionWriteBackend, Sample, SamplingMethod, ShuffleRead, ShuffleReadBackend, Sort,
-    SortMergeJoin, TopN, UDFProject, UnGroupedAggregate, Unpivot, VLLMProject, WindowOrderByOnly,
-    WindowPartitionAndDynamicFrame, WindowPartitionAndOrderBy, WindowPartitionOnly,
+    RepartitionWriteBackend, RepartitionWriteWithSentinel, Sample, SamplingMethod, ShuffleRead,
+    ShuffleReadBackend, Sort, SortMergeJoin, TopN, UDFProject, UnGroupedAggregate, Unpivot,
+    VLLMProject, WindowOrderByOnly, WindowPartitionAndDynamicFrame, WindowPartitionAndOrderBy,
+    WindowPartitionOnly,
 };
 #[cfg(feature = "python")]
 pub use plan::{CatalogWrite, DataSink, DistributedActorPoolProject, LanceWrite};

--- a/src/daft-local-plan/src/lib.rs
+++ b/src/daft-local-plan/src/lib.rs
@@ -21,7 +21,7 @@ pub use plan::{
 pub use plan::{CatalogWrite, DataSink, DistributedActorPoolProject, LanceWrite};
 #[cfg(feature = "python")]
 pub use python::{PyLocalPhysicalPlan, PyShuffleWriteInfo, register_modules};
-pub use results::ExecutionStats;
+pub use results::{ExecutionStats, Sentinels};
 use serde::{Deserialize, Serialize};
 pub use translate::translate;
 

--- a/src/daft-local-plan/src/plan.rs
+++ b/src/daft-local-plan/src/plan.rs
@@ -108,6 +108,7 @@ pub enum LocalPhysicalPlan {
     // Flotilla Only Nodes
     IntoPartitions(IntoPartitions),
     RepartitionWrite(RepartitionWrite),
+    RepartitionWriteWithSentinel(RepartitionWriteWithSentinel),
     ShuffleRead(ShuffleRead),
     SortMergeJoin(SortMergeJoin),
     AsofJoin(AsofJoin),
@@ -164,6 +165,10 @@ impl LocalPhysicalPlan {
             | Self::CommitWrite(CommitWrite { stats_state, .. })
             | Self::IntoPartitions(IntoPartitions { stats_state, .. })
             | Self::RepartitionWrite(RepartitionWrite { stats_state, .. })
+            | Self::RepartitionWriteWithSentinel(RepartitionWriteWithSentinel {
+                stats_state,
+                ..
+            })
             | Self::ShuffleRead(ShuffleRead { stats_state, .. })
             | Self::WindowPartitionOnly(WindowPartitionOnly { stats_state, .. })
             | Self::WindowPartitionAndOrderBy(WindowPartitionAndOrderBy { stats_state, .. })
@@ -214,6 +219,9 @@ impl LocalPhysicalPlan {
             | Self::CommitWrite(CommitWrite { context, .. })
             | Self::IntoPartitions(IntoPartitions { context, .. })
             | Self::RepartitionWrite(RepartitionWrite { context, .. })
+            | Self::RepartitionWriteWithSentinel(RepartitionWriteWithSentinel {
+                context, ..
+            })
             | Self::ShuffleRead(ShuffleRead { context, .. })
             | Self::WindowPartitionOnly(WindowPartitionOnly { context, .. })
             | Self::WindowPartitionAndOrderBy(WindowPartitionAndOrderBy { context, .. })
@@ -1008,6 +1016,30 @@ impl LocalPhysicalPlan {
         .arced()
     }
 
+    #[allow(clippy::too_many_arguments)]
+    pub fn repartition_write_with_sentinel(
+        input: LocalPhysicalPlanRef,
+        num_partitions: usize,
+        schema: SchemaRef,
+        backend: RepartitionWriteBackend,
+        repartition_spec: RepartitionSpec,
+        sentinel_sort_keys: Vec<BoundExpr>,
+        stats_state: StatsState,
+        context: LocalNodeContext,
+    ) -> LocalPhysicalPlanRef {
+        Self::RepartitionWriteWithSentinel(RepartitionWriteWithSentinel {
+            input,
+            num_partitions,
+            schema,
+            backend,
+            repartition_spec,
+            sentinel_sort_keys,
+            stats_state,
+            context,
+        })
+        .arced()
+    }
+
     pub fn shuffle_read(
         source_id: SourceId,
         schema: SchemaRef,
@@ -1069,6 +1101,9 @@ impl LocalPhysicalPlan {
             Self::DistributedActorPoolProject(DistributedActorPoolProject { schema, .. }) => schema,
             Self::IntoPartitions(IntoPartitions { schema, .. }) => schema,
             Self::RepartitionWrite(RepartitionWrite { schema, .. }) => schema,
+            Self::RepartitionWriteWithSentinel(RepartitionWriteWithSentinel { schema, .. }) => {
+                schema
+            }
             Self::ShuffleRead(ShuffleRead { schema, .. }) => schema,
             Self::WindowPartitionOnly(WindowPartitionOnly { schema, .. }) => schema,
             Self::WindowPartitionAndOrderBy(WindowPartitionAndOrderBy { schema, .. }) => schema,
@@ -1152,6 +1187,9 @@ impl LocalPhysicalPlan {
             }
             Self::IntoPartitions(IntoPartitions { input, .. }) => vec![input.clone()],
             Self::RepartitionWrite(RepartitionWrite { input, .. }) => vec![input.clone()],
+            Self::RepartitionWriteWithSentinel(RepartitionWriteWithSentinel { input, .. }) => {
+                vec![input.clone()]
+            }
             Self::ShuffleRead(ShuffleRead { .. }) => vec![], // No input children
             Self::TopN(TopN { input, .. }) => vec![input.clone()],
             Self::WindowOrderByOnly(WindowOrderByOnly { input, .. }) => vec![input.clone()],
@@ -1620,6 +1658,24 @@ impl LocalPhysicalPlan {
                     schema.clone(),
                     backend.clone(),
                     repartition_spec.clone(),
+                    StatsState::NotMaterialized,
+                    context.clone(),
+                ),
+                Self::RepartitionWriteWithSentinel(RepartitionWriteWithSentinel {
+                    num_partitions,
+                    schema,
+                    backend,
+                    repartition_spec,
+                    sentinel_sort_keys,
+                    context,
+                    ..
+                }) => Self::repartition_write_with_sentinel(
+                    new_child.clone(),
+                    *num_partitions,
+                    schema.clone(),
+                    backend.clone(),
+                    repartition_spec.clone(),
+                    sentinel_sort_keys.clone(),
                     StatsState::NotMaterialized,
                     context.clone(),
                 ),
@@ -2234,6 +2290,18 @@ pub struct RepartitionWrite {
     pub schema: SchemaRef,
     pub backend: RepartitionWriteBackend,
     pub repartition_spec: RepartitionSpec,
+    pub stats_state: StatsState,
+    pub context: LocalNodeContext,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RepartitionWriteWithSentinel {
+    pub input: LocalPhysicalPlanRef,
+    pub num_partitions: usize,
+    pub schema: SchemaRef,
+    pub backend: RepartitionWriteBackend,
+    pub repartition_spec: RepartitionSpec,
+    pub sentinel_sort_keys: Vec<BoundExpr>,
     pub stats_state: StatsState,
     pub context: LocalNodeContext,
 }

--- a/src/daft-local-plan/src/plan.rs
+++ b/src/daft-local-plan/src/plan.rs
@@ -23,6 +23,7 @@ use daft_logical_plan::{
     partitioning::RepartitionSpec,
     stats::{PlanStats, StatsState},
 };
+use daft_recordbatch::RecordBatch;
 use daft_scan::{Pushdowns, SourceConfig};
 use serde::{Deserialize, Serialize};
 
@@ -814,6 +815,7 @@ impl LocalPhysicalPlan {
         right_by: Vec<BoundExpr>,
         left_on: BoundExpr,
         right_on: BoundExpr,
+        right_sentinel: Option<RecordBatch>,
         schema: SchemaRef,
         stats_state: StatsState,
         context: LocalNodeContext,
@@ -825,6 +827,7 @@ impl LocalPhysicalPlan {
             right_by,
             left_on,
             right_on,
+            right_sentinel,
             schema,
             stats_state,
             context,
@@ -1702,6 +1705,7 @@ impl LocalPhysicalPlan {
                     right_by,
                     left_on,
                     right_on,
+                    right_sentinel,
                     schema,
                     stats_state,
                     context,
@@ -1713,6 +1717,7 @@ impl LocalPhysicalPlan {
                     right_by.clone(),
                     left_on.clone(),
                     right_on.clone(),
+                    right_sentinel.clone(),
                     schema.clone(),
                     stats_state.clone(),
                     context.clone(),
@@ -2050,6 +2055,7 @@ pub struct AsofJoin {
     pub right_by: Vec<BoundExpr>,
     pub left_on: BoundExpr,
     pub right_on: BoundExpr,
+    pub right_sentinel: Option<RecordBatch>,
     pub schema: SchemaRef,
     pub stats_state: StatsState,
     pub context: LocalNodeContext,

--- a/src/daft-local-plan/src/python.rs
+++ b/src/daft-local-plan/src/python.rs
@@ -91,6 +91,16 @@ impl PyLocalPhysicalPlan {
                     }
                 }
             }
+            LocalPhysicalPlan::RepartitionWriteWithSentinel(repartition_write) => {
+                match &repartition_write.backend {
+                    RepartitionWriteBackend::Ray => Some(PyShuffleWriteInfo {
+                        backend: "ray_with_sentinel".to_string(),
+                        shuffle_id: 0,
+                        num_partitions: repartition_write.num_partitions,
+                    }),
+                    _ => None,
+                }
+            }
             _ => None,
         }
     }

--- a/src/daft-local-plan/src/results.rs
+++ b/src/daft-local-plan/src/results.rs
@@ -14,6 +14,56 @@ use daft_recordbatch::RecordBatch;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+struct SentinelRecord(#[serde(with = "serde_bytes")] Vec<u8>);
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Sentinels(Vec<Option<SentinelRecord>>);
+
+impl From<Vec<Option<RecordBatch>>> for Sentinels {
+    fn from(batches: Vec<Option<RecordBatch>>) -> Self {
+        Self(
+            batches
+                .into_iter()
+                .map(|rb| {
+                    rb.map(|r| {
+                        SentinelRecord(
+                            r.to_ipc_stream()
+                                .expect("Failed to encode sentinel RecordBatch to IPC stream"),
+                        )
+                    })
+                })
+                .collect(),
+        )
+    }
+}
+
+impl Sentinels {
+    pub fn into_record_batches(self) -> Vec<Option<RecordBatch>> {
+        self.0
+            .into_iter()
+            .map(|s| {
+                s.map(|sr| {
+                    RecordBatch::from_ipc_stream(&sr.0)
+                        .expect("Failed to decode sentinel RecordBatch from IPC stream")
+                })
+            })
+            .collect()
+    }
+
+    pub fn encode(&self) -> Vec<u8> {
+        bincode::serde::encode_to_vec(self, bincode::config::legacy())
+            .expect("Failed to encode Sentinels")
+    }
+
+    pub fn decode(bytes: &[u8]) -> Self {
+        let (sentinels, _): (Self, usize) =
+            bincode::serde::decode_from_slice(bytes, bincode::config::legacy())
+                .expect("Failed to decode Sentinels");
+        sentinels
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExecutionStats {
     pub query_id: QueryID,
     pub query_plan: Option<serde_json::Value>,

--- a/src/daft-local-plan/src/translate.rs
+++ b/src/daft-local-plan/src/translate.rs
@@ -506,6 +506,7 @@ fn translate_helper(
                     right_by,
                     left_on,
                     right_on,
+                    None,
                     asof_join.output_schema.clone(),
                     asof_join.stats_state.clone(),
                     LocalNodeContext::default(),

--- a/tests/ray/test_flotilla_shuffle_backends.py
+++ b/tests/ray/test_flotilla_shuffle_backends.py
@@ -54,7 +54,7 @@ def test_task_handle_converts_ray_shuffle_results(monkeypatch):
 
     object_ref = object()
     handle = flotilla.RaySwordfishTaskHandle(
-        result_handle=_AwaitableResultHandle(("ray", [(object_ref, 3, 24)], b"stats")),
+        result_handle=_AwaitableResultHandle(("ray", [(object_ref, 3, 24)], None, b"stats")),
         actor_handle=_FakeActorHandle("grpc://unused"),
         shuffle_write_info=("ray", 0, 1),
     )
@@ -84,7 +84,7 @@ def test_task_handle_converts_flight_shuffle_results(monkeypatch):
     monkeypatch.setattr(flotilla, "FlightShufflePartitionRef", _FlightPartitionRef)
 
     handle = flotilla.RaySwordfishTaskHandle(
-        result_handle=_AwaitableResultHandle(("flight", [(None, 4, 40), (None, 5, 50)], b"stats")),
+        result_handle=_AwaitableResultHandle(("flight", [(None, 4, 40), (None, 5, 50)], None, b"stats")),
         actor_handle=_FakeActorHandle("grpc://127.0.0.1:9000"),
         shuffle_write_info=("flight", 17, 2),
         cache_id=9,


### PR DESCRIPTION
Step 1: Sample & Compute Boundaries

Sample the composite (by, on) key from the left table. Compute N-1 quantile split points to define range partition boundaries.

Step 2: Range Repartition with Sentinel Tracking

Shuffle both tables using the same boundaries. During the right-side shuffle, track the max (by, on) row (all columns) per output partition.

Step 3: Coordinator Merges Sentinels

The coordinator collects max rows from all input partitions. For each output partition, pick the global max across all contributors.

Step 4: Forward-Fill & Dispatch Sentinels

The coordinator scans left to right across partitions. If a partition had no right-side data, it
inherits the previous partition's max. This produces one sentinel per partition. The coordinator then sends sentinel[i-1] to worker i alongside its sort/join task.

Step 5: Local Sort

Each worker sorts its local left and right data by (by, on).

Step 6: Local AsOf Join

Each worker prepends its sentinel to the right-side data and runs the two-pointer merge.
