### PR TITLE
feat: introduce richer source stats

### DIFF
--- a/src/daft-logical-plan/src/ops/source.rs
+++ b/src/daft-logical-plan/src/ops/source.rs
@@ -79,12 +79,12 @@ impl Source {
         if let Some(stats) = &scan_stats
             && let Precision::Exact(num_rows) = &stats.num_rows
         {
-            let num_rows = *num_rows as usize;
+            let acc_selectivity = scan_pushdowns.estimated_selectivity(self.output_schema.as_ref());
+            let num_rows = (*num_rows as f64 * acc_selectivity) as usize;
             let size_bytes = match stats.size_bytes {
                 Precision::Exact(n) | Precision::Inexact(n) => n as usize,
-                Precision::Absent => 0,
+                Precision::Absent => 0, // unknown size; treated as 0 like ApproxStats::empty()
             };
-            let acc_selectivity = scan_pushdowns.estimated_selectivity(self.output_schema.as_ref());
             let approx_stats = ApproxStats {
                 num_rows,
                 size_bytes,

--- a/src/daft-logical-plan/src/ops/source.rs
+++ b/src/daft-logical-plan/src/ops/source.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use common_daft_config::DaftExecutionConfig;
 use common_error::DaftResult;
-use daft_scan::{PhysicalScanInfo, ScanState};
+use daft_scan::{PhysicalScanInfo, Precision, ScanState};
 use daft_schema::schema::SchemaRef;
 use serde::{Deserialize, Serialize};
 
@@ -50,22 +50,50 @@ impl Source {
     // should also hold a ScanState::Operator and not a ScanState::Tasks (which would indicate that we're
     // materializing this physical scan node multiple times).
     pub(crate) fn build_materialized_scan_source(mut self) -> DaftResult<Self> {
-        let new_physical_scan_info = match Arc::unwrap_or_clone(self.source_info) {
-            SourceInfo::Physical(mut physical_scan_info) => {
-                let scan_tasks = match &physical_scan_info.scan_state {
-                    ScanState::Operator(scan_op) => scan_op
-                        .0
-                        .to_scan_tasks(physical_scan_info.pushdowns.clone())?,
-                    ScanState::Tasks(_) => {
-                        panic!("Physical scan nodes are being materialized more than once");
-                    }
-                };
-                physical_scan_info.scan_state = ScanState::Tasks(Arc::new(scan_tasks));
-                physical_scan_info
-            }
-            _ => panic!("Only unmaterialized physical scan nodes can be materialized"),
+        // Extract the scan_info from the source_info.
+        let mut scan_info = match Arc::unwrap_or_clone(self.source_info) {
+            SourceInfo::Physical(scan_info) => scan_info,
+            _ => panic!("Only physical scan nodes can be materialized"),
         };
-        self.source_info = Arc::new(SourceInfo::Physical(new_physical_scan_info));
+
+        // Extract the scan operator from the scan_info, it's just an arc clone
+        let scan_operator = match &mut scan_info.scan_state {
+            ScanState::Operator(op) => op.clone().0,
+            ScanState::Tasks(_) => {
+                panic!("Physical scan nodes are being materialized more than once")
+            }
+        };
+
+        // Now we can materialize the scan tasks then patch the state.
+        let scan_pushdowns = scan_info.pushdowns.clone();
+        let scan_stats = scan_operator.statistics();
+        let scan_tasks = scan_operator.to_scan_tasks(scan_pushdowns.clone())?;
+
+        // !! SCAN TASK MATERIALIZATION !!
+        // Mutable update to the scan_info to hold the materialized scan tasks
+        scan_info.scan_state = ScanState::Tasks(Arc::new(scan_tasks));
+        self.source_info = Arc::new(SourceInfo::Physical(scan_info));
+
+        // If the source reports Exact num_rows, short-circuit the per-task stats
+        // aggregation, since there's no need to sum up task stats.
+        if let Some(stats) = &scan_stats
+            && let Precision::Exact(num_rows) = &stats.num_rows
+        {
+            let num_rows = *num_rows as usize;
+            let size_bytes = match stats.size_bytes {
+                Precision::Exact(n) | Precision::Inexact(n) => n as usize,
+                Precision::Absent => 0,
+            };
+            let acc_selectivity = scan_pushdowns.estimated_selectivity(self.output_schema.as_ref());
+            let approx_stats = ApproxStats {
+                num_rows,
+                size_bytes,
+                acc_selectivity,
+            };
+            // Update the stats state to hold the materialized plan stats.
+            self.stats_state = StatsState::Materialized(PlanStats::new(approx_stats).into());
+        }
+
         Ok(self)
     }
 

--- a/src/daft-logical-plan/src/optimization/rules/materialize_scans.rs
+++ b/src/daft-logical-plan/src/optimization/rules/materialize_scans.rs
@@ -49,3 +49,85 @@ impl MaterializeScans {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use common_treenode::TransformedResult;
+    use daft_scan::{
+        Precision, Pushdowns, ScanOperatorRef, Statistics, test_utils::DummyScanOperator,
+    };
+    use daft_schema::{dtype::DataType, field::Field, schema::Schema};
+
+    use super::*;
+    use crate::{
+        stats::StatsState,
+        test::{dummy_scan_node_with_pushdowns, dummy_scan_operator},
+    };
+
+    fn scan_op_with_stats(stats: Option<Statistics>) -> ScanOperatorRef {
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int64)]));
+        ScanOperatorRef(Arc::new(DummyScanOperator {
+            schema,
+            num_scan_tasks: 1,
+            num_rows_per_task: None,
+            supports_count_pushdown_flag: false,
+            stats,
+        }))
+    }
+
+    fn run_materialize(scan_op: ScanOperatorRef) -> Arc<LogicalPlan> {
+        let plan = dummy_scan_node_with_pushdowns(scan_op, Pushdowns::default()).build();
+        MaterializeScans::new()
+            .try_optimize(plan)
+            .data()
+            .expect("materialize_scans succeeds")
+    }
+
+    #[test]
+    fn exact_num_rows_short_circuits_stats() {
+        let scan_op = scan_op_with_stats(Some(Statistics {
+            num_rows: Precision::Exact(42),
+            size_bytes: Precision::Exact(1024),
+            column_statistics: vec![],
+        }));
+        let plan = run_materialize(scan_op);
+        let LogicalPlan::Source(source) = &*plan else {
+            panic!("expected Source at root")
+        };
+        let stats = match &source.stats_state {
+            StatsState::Materialized(s) => s,
+            StatsState::NotMaterialized => {
+                panic!("Exact source stats should materialize PlanStats during MaterializeScans")
+            }
+        };
+        assert_eq!(stats.approx_stats.num_rows, 42);
+        assert_eq!(stats.approx_stats.size_bytes, 1024);
+    }
+
+    #[test]
+    fn inexact_num_rows_falls_back_to_task_iteration() {
+        let scan_op = scan_op_with_stats(Some(Statistics {
+            num_rows: Precision::Inexact(42),
+            size_bytes: Precision::Absent,
+            column_statistics: vec![],
+        }));
+        let plan = run_materialize(scan_op);
+        let LogicalPlan::Source(source) = &*plan else {
+            panic!("expected Source at root")
+        };
+        assert!(
+            matches!(source.stats_state, StatsState::NotMaterialized),
+            "Inexact stats should not short-circuit — EnrichWithStats runs next"
+        );
+    }
+
+    #[test]
+    fn no_source_stats_preserves_existing_behavior() {
+        let scan_op = dummy_scan_operator(vec![Field::new("a", DataType::Int64)]);
+        let plan = run_materialize(scan_op);
+        let LogicalPlan::Source(source) = &*plan else {
+            panic!("expected Source at root")
+        };
+        assert!(matches!(source.stats_state, StatsState::NotMaterialized));
+    }
+}

--- a/src/daft-logical-plan/src/optimization/rules/shard_scans.rs
+++ b/src/daft-logical-plan/src/optimization/rules/shard_scans.rs
@@ -75,6 +75,7 @@ mod tests {
             num_scan_tasks,
             num_rows_per_task: Some(1000),
             supports_count_pushdown_flag: false,
+            stats: None,
         });
 
         let scan_tasks = scan_operator.to_scan_tasks(Pushdowns::default())?;

--- a/src/daft-logical-plan/src/test/mod.rs
+++ b/src/daft-logical-plan/src/test/mod.rs
@@ -22,6 +22,7 @@ pub fn dummy_scan_operator_with_size(
         num_scan_tasks: 1,
         num_rows_per_task,
         supports_count_pushdown_flag: false,
+        stats: None,
     }))
 }
 
@@ -49,5 +50,6 @@ pub fn dummy_scan_operator_for_aggregation(
         num_scan_tasks: 1,
         num_rows_per_task: None,
         supports_count_pushdown_flag,
+        stats: None,
     }))
 }

--- a/src/daft-scan/src/lib.rs
+++ b/src/daft-scan/src/lib.rs
@@ -53,7 +53,7 @@ pub use source::{
     DataSource, DataSourceRef, DataSourceTask, DataSourceTaskRef, DataSourceTaskStream,
     ReadOptions, RecordBatchStream, ShimSourceTask,
 };
-pub use statistics::{Precision, Statistics};
+pub use statistics::{ColumnStatistics, Precision, Statistics};
 
 #[cfg(feature = "python")]
 pub mod python;

--- a/src/daft-scan/src/lib.rs
+++ b/src/daft-scan/src/lib.rs
@@ -38,6 +38,7 @@ pub mod scan_state;
 pub mod scan_task_iters;
 mod sharder;
 mod source_config;
+pub mod statistics;
 pub use expr_rewriter::{PredicateGroups, rewrite_predicate_for_partitioning};
 pub use partitioning::{PartitionField, PartitionTransform};
 pub use pushdowns::{Pushdowns, SupportsPushdownFilters};
@@ -49,9 +50,10 @@ pub mod test_utils;
 
 // Re-export source module for DataSource and DataSourceTask traits.
 pub use source::{
-    DataSource, DataSourceRef, DataSourceStatistics, DataSourceTask, DataSourceTaskRef,
-    DataSourceTaskStream, Precision, ReadOptions, RecordBatchStream, ShimSourceTask,
+    DataSource, DataSourceRef, DataSourceTask, DataSourceTaskRef, DataSourceTaskStream,
+    ReadOptions, RecordBatchStream, ShimSourceTask,
 };
+pub use statistics::{Precision, Statistics};
 
 #[cfg(feature = "python")]
 pub mod python;

--- a/src/daft-scan/src/scan_operator.rs
+++ b/src/daft-scan/src/scan_operator.rs
@@ -7,7 +7,7 @@ use std::{
 use common_error::DaftResult;
 use daft_schema::schema::SchemaRef;
 
-use crate::{PartitionField, Pushdowns, ScanTaskRef, SupportsPushdownFilters};
+use crate::{PartitionField, Pushdowns, ScanTaskRef, Statistics, SupportsPushdownFilters};
 
 pub trait ScanOperator: Send + Sync + Debug {
     fn name(&self) -> &str;
@@ -35,6 +35,14 @@ pub trait ScanOperator: Send + Sync + Debug {
 
     fn supports_count_pushdown(&self) -> bool {
         false
+    }
+
+    /// Pre-computed statistics for this source, if known cheaply (e.g. from
+    /// manifest metadata). The optimizer populates `PlanStats` from this when
+    /// available, skipping per-scan-task aggregation. Returning `None` (the
+    /// default) preserves today's behavior of summing stats from scan tasks.
+    fn statistics(&self) -> Option<Statistics> {
+        None
     }
 
     fn supported_count_modes(&self) -> Vec<daft_core::count_mode::CountMode> {

--- a/src/daft-scan/src/source.rs
+++ b/src/daft-scan/src/source.rs
@@ -7,7 +7,12 @@ use daft_schema::schema::SchemaRef;
 use daft_stats::{PartitionSpec, TableStatistics};
 use futures::stream::BoxStream;
 
-use crate::{ScanTaskRef, partitioning::PartitionField, pushdowns::Pushdowns};
+use crate::{
+    ScanTaskRef,
+    partitioning::PartitionField,
+    pushdowns::Pushdowns,
+    statistics::{Precision, Statistics},
+};
 
 /// Reference to a [`DataSource`].
 pub type DataSourceRef = Arc<dyn DataSource>;
@@ -41,7 +46,7 @@ pub trait DataSource: Send + Sync + Debug {
     /// from metadata alone (e.g. `COUNT(*)` when `num_rows` is `Exact`), without
     /// reading any data. Returning `None` disables all statistics-based rewrites
     /// for this source.
-    fn statistics(&self) -> Option<DataSourceStatistics> {
+    fn statistics(&self) -> Option<Statistics> {
         None
     }
 
@@ -50,34 +55,6 @@ pub trait DataSource: Send + Sync + Debug {
     /// The outer `DaftResult` captures setup errors (e.g. metadata lookup failures)
     /// before any tasks are produced. Per-task errors appear as items in the stream.
     async fn get_tasks(&self, pushdowns: &Pushdowns) -> DaftResult<DataSourceTaskStream>;
-}
-
-/// Pre-computed statistics exposed by a [`DataSource`] for query optimization.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct DataSourceStatistics {
-    /// Total number of rows across all tasks produced by this source.
-    pub num_rows: Precision<u64>,
-}
-
-/// Exactness annotation for a statistic.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Precision<T> {
-    /// The value is exact. Safe to substitute for a full scan.
-    Exact(T),
-    /// The value is an estimate. Not safe to substitute; usable for heuristics only.
-    Inexact(T),
-    /// No value is available.
-    Absent,
-}
-
-impl<T> Precision<T> {
-    /// Returns a reference to the inner value regardless of exactness, or `None` if absent.
-    pub fn get(&self) -> Option<&T> {
-        match self {
-            Self::Exact(v) | Self::Inexact(v) => Some(v),
-            Self::Absent => None,
-        }
-    }
 }
 
 /// Metadata about a [`DataSourceTask`] used for planning and optimization.

--- a/src/daft-scan/src/statistics.rs
+++ b/src/daft-scan/src/statistics.rs
@@ -1,0 +1,77 @@
+use daft_core::lit::Literal;
+
+/// Pre-computed statistics exposed by a scan source for query optimization.
+///
+/// The optimizer uses these to populate `PlanStats` and make selectivity-aware
+/// decisions without iterating scan tasks. Sources that know their totals cheaply
+/// (manifest-backed formats like Iceberg/Delta, sized in-memory tables)
+/// should return `Some` here.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Statistics {
+    /// Total rows across the source.
+    pub num_rows: Precision<u64>,
+    /// On-disk size of the source in bytes.
+    pub size_bytes: Precision<u64>,
+    /// Per-column statistics, indexed by column position in the source schema.
+    /// Empty when no column-level stats are available.
+    pub column_statistics: Vec<ColumnStatistics>,
+}
+
+/// Per-column statistics. All fields are independently `Precision`-wrapped so
+/// a source can report e.g. an exact `null_count` while leaving `distinct_count`
+/// absent.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ColumnStatistics {
+    /// Number of nulls in the column.
+    pub null_count: Precision<u64>,
+    /// Minimum value in the column.
+    pub min_value: Precision<Literal>,
+    /// Maximum value in the column.
+    pub max_value: Precision<Literal>,
+    /// Number of distinct values in the column.
+    pub distinct_count: Precision<u64>,
+    /// Average or total on-disk byte size of the column; units are source-defined.
+    pub size_bytes: Precision<u64>,
+}
+
+impl ColumnStatistics {
+    /// Returns a `ColumnStatistics` with every field `Absent`.
+    pub fn unknown() -> Self {
+        Self {
+            null_count: Precision::Absent,
+            min_value: Precision::Absent,
+            max_value: Precision::Absent,
+            distinct_count: Precision::Absent,
+            size_bytes: Precision::Absent,
+        }
+    }
+}
+
+/// Exactness annotation for a statistic.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Precision<T> {
+    /// The value is exact. Safe to substitute for a full scan.
+    Exact(T),
+    /// The value is an estimate. Usable for heuristics, not substitution.
+    Inexact(T),
+    /// No value available.
+    Absent,
+}
+
+impl<T> Precision<T> {
+    /// Returns a reference to the inner value regardless of exactness, or `None` if absent.
+    pub fn get(&self) -> Option<&T> {
+        match self {
+            Self::Exact(v) | Self::Inexact(v) => Some(v),
+            Self::Absent => None,
+        }
+    }
+
+    /// Returns the exact value, or `None` if inexact or absent.
+    pub fn exact(&self) -> Option<&T> {
+        match self {
+            Self::Exact(v) => Some(v),
+            _ => None,
+        }
+    }
+}

--- a/src/daft-scan/src/test_utils.rs
+++ b/src/daft-scan/src/test_utils.rs
@@ -7,15 +7,17 @@ use daft_stats::TableMetadata;
 
 use crate::{
     FileFormatConfig, PartitionField, Pushdowns, ScanOperator, ScanSource, ScanSourceKind,
-    ScanTask, ScanTaskRef, SourceConfig, SupportsPushdownFilters, storage_config::StorageConfig,
+    ScanTask, ScanTaskRef, SourceConfig, Statistics, SupportsPushdownFilters,
+    storage_config::StorageConfig,
 };
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct DummyScanOperator {
     pub schema: SchemaRef,
     pub num_scan_tasks: u32,
     pub num_rows_per_task: Option<usize>,
     pub supports_count_pushdown_flag: bool,
+    pub stats: Option<Statistics>,
 }
 
 impl ScanOperator for DummyScanOperator {
@@ -94,6 +96,10 @@ impl ScanOperator for DummyScanOperator {
 
     fn as_pushdown_filter(&self) -> Option<&dyn SupportsPushdownFilters> {
         Some(self)
+    }
+
+    fn statistics(&self) -> Option<Statistics> {
+        self.stats.clone()
     }
 }
 


### PR DESCRIPTION
## Changes Made

This adds a datafusion-inspired source statistics which allows us to not materialize tasks for compute stats. Todays implementation always materiazlies tasks, then computes table stats, but with Iceberg (and others) we don't need to do any scan-planning to get this info.

## Related Issues

It's part 6 of N on cleaning up sources
