### PR TITLE
docs(extensions): move authoring guide to dedicated page

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -58,7 +58,7 @@
         * [Unity Catalog (Databricks)](connectors/unity_catalog.md)
     * Extensions
         * [Community Extensions](extensions/community.md)
-        * [Authoring Guide](extensions/index.md)
+        * [Authoring Guide](extensions/authoring.md)
     * Scaling Out and Deployment
         * [Distributed Execution](distributed/index.md)
         * [Running on Kubernetes](distributed/kubernetes.md)

--- a/docs/extensions/authoring.md
+++ b/docs/extensions/authoring.md
@@ -1,4 +1,4 @@
-# Daft Extensions
+# Authoring Guide
 
 !!! warning "Experimental"
 
@@ -391,7 +391,7 @@ Create a Daft native extension called `<extension_name>` with the following scal
 
 <describe each function: name, arguments with types, return type, and behavior>
 
-Follow the Daft extension authoring guide at docs/extensions/index.md. Here is a summary of the key conventions:
+Follow the Daft extension authoring guide at docs/extensions/authoring.md. Here is a summary of the key conventions:
 
 ## Project structure
 

--- a/docs/extensions/community.md
+++ b/docs/extensions/community.md
@@ -1,5 +1,9 @@
 # Community Extensions
 
+!!! tip "Want to build your own extension?"
+
+    See the [Authoring Guide](authoring.md) to learn how to write a native Daft extension in Rust.
+
 Community extensions are built by external contributors and maintained
 independently of Daft's release cadence. Extensions listed here have been
 reviewed by the Daft maintainers. Each is its own PyPI package, so install


### PR DESCRIPTION
## Summary

- Moves the extension authoring guide from `extensions/index.md` to a dedicated `extensions/authoring.md`
- Adds a tip callout at the top of `extensions/community.md` pointing readers to the authoring guide
- Updates `SUMMARY.md` nav entry to reference the new page

## Test Plan

- [ ] Verify docs build renders `extensions/authoring.md` correctly
- [ ] Verify tip callout appears at top of community extensions page
- [ ] Verify nav link "Authoring Guide" navigates to the new page

🤖 Generated with [Claude Code](https://claude.com/claude-code)