### PR TITLE
test: add round-trip read-back coverage for write_csv with header=False

### DIFF
--- a/tests/io/test_csv.py
+++ b/tests/io/test_csv.py
@@ -146,6 +146,14 @@ def test_write_csv_parametrized(tmp_path, delimiter, header, quote, escape_char,
         }
         read_back = daft.read_csv(str(tmp_path), **read_kwargs)
         assert df.to_arrow() == read_back.to_arrow()
+    else:
+        # When writing without a header row, verify the headerless CSV can be
+        # read back correctly using has_headers=False. Column names are auto-assigned
+        # (e.g. "column_0", "column_1") since there is no header row in the file.
+        read_back = daft.read_csv(str(tmp_path), delimiter=delimiter, has_headers=False)
+        # Compare data values column-by-column (ignoring auto-assigned column names)
+        for orig_vals, read_vals in zip(df.to_pydict().values(), read_back.to_pydict().values()):
+            assert orig_vals == read_vals
 
 
 def test_write_csv_custom_date_format(tmp_path):


### PR DESCRIPTION
## Summary

Fixes #3775 — Support writing CSV without headers

The existing `test_write_csv_parametrized` already has a `header=False` parametrize case that verifies the raw text of the written CSV contains no header row. However, it was missing a read-back assertion for that case: the `if header:` block only performed the round-trip read under `has_headers=True`.

This PR adds an `else` branch that:
1. Reads the headerless CSV back using `daft.read_csv(..., has_headers=False)`
2. Verifies the data values match column-by-column (columns are auto-named e.g. `column_0`, `column_1` since there is no header row)

This ensures the full write→read round-trip is covered for the no-header case, closing the gap identified in #3775.

## Changes

- `tests/io/test_csv.py`: Added `else` branch to `test_write_csv_parametrized` for the `header=False` case

## Test plan

- [ ] `pytest tests/io/test_csv.py::test_write_csv_parametrized` — all parametrize cases pass including `header=False`
- [ ] Verify the new else-branch exercises `daft.read_csv` with `has_headers=False`