### PR TITLE
ci: fix dependency check on external prs

### DIFF
--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -1455,6 +1455,7 @@ jobs:
           --max-new 25 \
           --markdown-summary | tee rust_dep_report.md >> "$GITHUB_STEP_SUMMARY"
     - name: Post sticky PR comment
+      if: github.event.pull_request.head.repo.full_name == github.repository
       uses: marocchino/sticky-pull-request-comment@v2
       with:
         header: rust-dependency-budget


### PR DESCRIPTION
## Changes Made

External PRs are not allowed to post sticky comments are they require write permissions. So we disable it for those
