### PR TITLE
refactor(distributed): Remove node_origin_id self-ref in distributed

### DIFF
--- a/src/common/metrics/src/ops.rs
+++ b/src/common/metrics/src/ops.rs
@@ -103,7 +103,9 @@ impl NodeInfo {
             KeyValue::new(ATTR_NODE_TYPE, self.node_type.to_string()),
         ];
         // Add node_origin_id if present. This is used by distributed
-        // pipeline nodes that have multiple execution phases.
+        // pipeline nodes, which create one or more local plan nodes
+        // for local execution, to associate those local nodes back to the
+        // distributed node that created them.
         if let Some(node_origin_id) = &self.node_origin_id {
             kvs.push(KeyValue::new(
                 ATTR_NODE_ORIGIN_ID,

--- a/src/common/metrics/src/ops.rs
+++ b/src/common/metrics/src/ops.rs
@@ -88,7 +88,7 @@ impl Display for NodeCategory {
 pub struct NodeInfo {
     pub name: Arc<str>,
     pub id: NodeID,
-    pub node_origin_id: NodeID,
+    pub node_origin_id: Option<NodeID>,
     #[allow(dead_code)]
     pub node_type: NodeType,
     pub node_category: NodeCategory,
@@ -99,10 +99,17 @@ pub struct NodeInfo {
 impl NodeInfo {
     pub fn to_key_values(&self) -> Vec<KeyValue> {
         let mut kvs = vec![
-            KeyValue::new(ATTR_NODE_ORIGIN_ID, self.node_origin_id.to_string()),
             KeyValue::new(ATTR_NODE_ID, self.id.to_string()),
             KeyValue::new(ATTR_NODE_TYPE, self.node_type.to_string()),
         ];
+        // Add node_origin_id if present. This is used by distributed
+        // pipeline nodes that have multiple execution phases.
+        if let Some(node_origin_id) = &self.node_origin_id {
+            kvs.push(KeyValue::new(
+                ATTR_NODE_ORIGIN_ID,
+                node_origin_id.to_string(),
+            ));
+        }
         // Add node phase if present. This is used by distributed
         // pipeline nodes that have multiple execution phases.
         if let Some(phase) = self.node_phase.as_ref() {

--- a/src/daft-context/src/subscribers/debug.rs
+++ b/src/daft-context/src/subscribers/debug.rs
@@ -95,21 +95,21 @@ impl DebugSubscriber {
     }
 
     fn handle_operator_start(&self, event: &OperatorStartEvent) -> DaftResult<()> {
-        if event.operator.origin_node_id == event.operator.node_id {
+        if let Some(origin_node_id) = event.operator.origin_node_id {
             eprintln!(
-                "operator_start query_id={} node_id={} name=\"{}\" type={:?} category={:?}",
+                "operator_start query_id={} node_id={} origin_node_id={} name=\"{}\" type={:?} category={:?}",
                 event.header.query_id,
                 event.operator.node_id,
+                origin_node_id,
                 event.operator.name,
                 event.operator.node_type,
                 event.operator.node_category,
             );
         } else {
             eprintln!(
-                "operator_start query_id={} node_id={} origin_node_id={} name=\"{}\" type={:?} category={:?}",
+                "operator_start query_id={} node_id={} name=\"{}\" type={:?} category={:?}",
                 event.header.query_id,
                 event.operator.node_id,
-                event.operator.origin_node_id,
                 event.operator.name,
                 event.operator.node_type,
                 event.operator.node_category,
@@ -119,18 +119,15 @@ impl DebugSubscriber {
     }
 
     fn handle_operator_end(&self, event: &OperatorEndEvent) -> DaftResult<()> {
-        if event.operator.origin_node_id == event.operator.node_id {
+        if let Some(origin_node_id) = event.operator.origin_node_id {
             eprintln!(
-                "operator_end query_id={} node_id={} name=\"{}\"",
-                event.header.query_id, event.operator.node_id, event.operator.name,
+                "operator_end query_id={} node_id={} origin_node_id={} name=\"{}\"",
+                event.header.query_id, event.operator.node_id, origin_node_id, event.operator.name,
             );
         } else {
             eprintln!(
-                "operator_end query_id={} node_id={} origin_node_id={} name=\"{}\"",
-                event.header.query_id,
-                event.operator.node_id,
-                event.operator.origin_node_id,
-                event.operator.name,
+                "operator_end query_id={} node_id={} name=\"{}\"",
+                event.header.query_id, event.operator.node_id, event.operator.name,
             );
         }
         Ok(())

--- a/src/daft-context/src/subscribers/events.rs
+++ b/src/daft-context/src/subscribers/events.rs
@@ -36,7 +36,7 @@ pub struct OperatorMeta {
     pub name: Arc<str>,
     pub node_type: NodeType,
     pub node_category: NodeCategory,
-    pub origin_node_id: NodeID,
+    pub origin_node_id: Option<NodeID>,
     pub node_phase: Option<String>,
     pub context: HashMap<String, String>,
 }
@@ -50,7 +50,7 @@ impl OperatorMeta {
             name: Arc::from("unknown"),
             node_type: NodeType::default(),
             node_category: NodeCategory::default(),
-            origin_node_id: node_id,
+            origin_node_id: None,
             node_phase: None,
             context: HashMap::new(),
         }

--- a/src/daft-distributed/src/python/dashboard.rs
+++ b/src/daft-distributed/src/python/dashboard.rs
@@ -101,11 +101,11 @@ impl StatisticsSubscriber for DashboardStatisticsSubscriber {
                         .values()
                         .map(|mgr| {
                             let (info, snapshot) = mgr.export_snapshot();
-                            (info.node_origin_id, snapshot.to_stats())
+                            // use `id` here because it's a distributed node
+                            // these nodes do not have an `origin_node_id`
+                            (info.id, snapshot.to_stats())
                         })
-                        .filter(|(node_origin_id, _)| {
-                            task_ctx.node_ids.contains(&(*node_origin_id as u32))
-                        })
+                        .filter(|(node_id, _)| task_ctx.node_ids.contains(&(*node_id as u32)))
                         .collect::<Vec<_>>();
 
                     if !relevant_stats.is_empty()

--- a/src/daft-distributed/src/statistics/mod.rs
+++ b/src/daft-distributed/src/statistics/mod.rs
@@ -113,7 +113,7 @@ impl StatisticsManager {
             let node_info = Arc::new(NodeInfo {
                 name: node.name(),
                 id: node.node_id() as usize,
-                node_origin_id: node.node_id() as usize,
+                node_origin_id: None,
                 node_type: node.context().node_type.clone(),
                 node_category: node.context().node_category.clone(),
                 node_phase: None,

--- a/src/daft-distributed/src/statistics/stats.rs
+++ b/src/daft-distributed/src/statistics/stats.rs
@@ -77,9 +77,13 @@ impl RuntimeNodeManager {
 
                 for (node_info, snapshot) in &stats.nodes {
                     // Local nodes are associated to this node through the node_origin_id
-                    if self.node_info.node_origin_id == node_info.node_origin_id {
-                        self.runtime_stats
-                            .handle_worker_node_stats(node_info, snapshot);
+                    if let Some(node_origin_id) = node_info.node_origin_id {
+                        if self.node_info.id == node_origin_id {
+                            self.runtime_stats
+                                .handle_worker_node_stats(node_info, snapshot);
+                        }
+                    } else {
+                        tracing::debug!("expected `origin_node_id` for node_info: {:?}", node_info);
                     }
                 }
             }
@@ -178,5 +182,130 @@ impl RuntimeStats for DefaultRuntimeStats {
 
     fn export_snapshot(&self) -> StatSnapshot {
         self.base.export_default_snapshot()
+    }
+}
+
+#[cfg(test)]
+pub(super) mod tests {
+
+    use std::{collections::HashMap, sync::Arc};
+
+    use common_metrics::{
+        Meter, NodeID, StatSnapshot,
+        ops::{NodeCategory, NodeInfo, NodeType},
+        snapshot::DefaultSnapshot,
+    };
+    use daft_local_plan::ExecutionStats;
+
+    use super::{DefaultRuntimeStats, RuntimeNodeManager};
+    use crate::{
+        pipeline_node::PipelineNodeContext, scheduling::task::TaskContext, statistics::TaskEvent,
+    };
+
+    #[test]
+    fn test_runtime_stats_origin_node_id() {
+        struct Case {
+            name: &'static str,
+            node_id: usize,
+            origin_node_id: usize,
+            expected_cpu_us: u64,
+            expected_rows_in: u64,
+            expected_rows_out: u64,
+            expected_bytes_in: u64,
+            expected_bytes_out: u64,
+        }
+
+        let distributed_node_id: NodeID = 42;
+
+        let cases = [
+            Case {
+                name: "matching",
+                node_id: distributed_node_id,
+                origin_node_id: distributed_node_id,
+                expected_cpu_us: 100,
+                expected_rows_in: 10,
+                expected_rows_out: 5,
+                expected_bytes_in: 1000,
+                expected_bytes_out: 500,
+            },
+            Case {
+                name: "non_matching",
+                node_id: distributed_node_id,
+                origin_node_id: 99,
+                expected_cpu_us: 0,
+                expected_rows_in: 0,
+                expected_rows_out: 0,
+                expected_bytes_in: 0,
+                expected_bytes_out: 0,
+            },
+        ];
+
+        for case in cases {
+            let distributed_node_info = Arc::new(NodeInfo {
+                id: case.node_id,
+                name: "parent".into(),
+                node_origin_id: None,
+                node_type: NodeType::Filter,
+                node_category: NodeCategory::Intermediate,
+                node_phase: None,
+                context: HashMap::new(),
+            });
+
+            let distributed_ctx = PipelineNodeContext::new(
+                0,
+                "q".into(),
+                case.node_id as u32,
+                "distributed-filter".into(),
+                NodeType::Filter,
+                NodeCategory::Intermediate,
+            );
+
+            let meter = Meter::test_scope("runtime-stats-test");
+            let runtime_stats = Arc::new(DefaultRuntimeStats::new(&meter, &distributed_ctx));
+            let manager = RuntimeNodeManager::new(&meter, runtime_stats, distributed_node_info);
+
+            let local_node_info = Arc::new(NodeInfo {
+                id: 7,
+                node_origin_id: Some(case.origin_node_id),
+                ..Default::default()
+            });
+
+            let local_snapshot = StatSnapshot::Default(DefaultSnapshot {
+                cpu_us: 100,
+                rows_in: 10,
+                rows_out: 5,
+                bytes_in: 1000,
+                bytes_out: 500,
+            });
+
+            let event = TaskEvent::Completed {
+                context: TaskContext::new(0, 42, 1, vec![42], 0),
+                stats: ExecutionStats::new("".into(), vec![(local_node_info, local_snapshot)]),
+            };
+
+            manager.handle_task_event(&event);
+
+            let (_info, actual) = manager.export_snapshot();
+            let StatSnapshot::Default(got) = &actual else {
+                panic!("{}: expected StatSnapshot::Default", case.name);
+            };
+            assert_eq!(got.cpu_us, case.expected_cpu_us, "{}: cpu_us", case.name);
+            assert_eq!(got.rows_in, case.expected_rows_in, "{}: rows_in", case.name);
+            assert_eq!(
+                got.rows_out, case.expected_rows_out,
+                "{}: rows_out",
+                case.name
+            );
+            assert_eq!(
+                got.bytes_in, case.expected_bytes_in,
+                "{}: bytes_in",
+                case.name
+            );
+            assert_eq!(
+                got.bytes_out, case.expected_bytes_out,
+                "{}: bytes_out",
+                case.name
+            );
+        }
     }
 }

--- a/src/daft-distributed/src/statistics/stats.rs
+++ b/src/daft-distributed/src/statistics/stats.rs
@@ -83,7 +83,10 @@ impl RuntimeNodeManager {
                                 .handle_worker_node_stats(node_info, snapshot);
                         }
                     } else {
-                        tracing::debug!("expected `origin_node_id` for node_info: {:?}", node_info);
+                        tracing::debug!(
+                            "local node stats missing `origin_node_id`, skipping attribution: {:?}",
+                            node_info
+                        );
                     }
                 }
             }

--- a/src/daft-local-execution/src/pipeline.rs
+++ b/src/daft-local-execution/src/pipeline.rs
@@ -319,7 +319,7 @@ impl BuilderContext {
         // Keep a unique local runtime node id (`id`), but preserve the originating
         // distributed plan node id (`node_origin_id`) when available so metrics/stats
         // from local execution can be attributed back to the distributed node.
-        let node_origin_id = node_context.origin_node_id.unwrap_or(id);
+        let node_origin_id = node_context.origin_node_id;
 
         NodeInfo {
             name,


### PR DESCRIPTION
## Changes Made

Make NodeInfo.node_origin_id an Option<NodeID> so distributed plan nodes (which are themselves the origin) carry None instead of self-referencing via node.node_id(). Local-execution nodes still set Some(distributed_id) when attributing stats back to a distributed node.
