### PR TITLE
chore: Simplify local Repartition operator

### DIFF
--- a/src/daft-local-execution/src/pipeline.rs
+++ b/src/daft-local-execution/src/pipeline.rs
@@ -1458,7 +1458,6 @@ fn physical_plan_to_pipeline(
         LocalPhysicalPlan::RepartitionWrite(RepartitionWrite {
             input,
             num_partitions,
-            schema,
             backend,
             repartition_spec,
             stats_state,
@@ -1471,7 +1470,6 @@ fn physical_plan_to_pipeline(
                     Arc::new(RepartitionSink::new_ray(
                         repartition_spec.clone(),
                         *num_partitions,
-                        schema.clone(),
                     )),
                     child_node,
                     stats_state.clone(),

--- a/src/daft-local-execution/src/sinks/repartition.rs
+++ b/src/daft-local-execution/src/sinks/repartition.rs
@@ -5,7 +5,6 @@ use std::{
 
 use common_error::DaftResult;
 use common_metrics::ops::NodeType;
-use daft_core::prelude::SchemaRef;
 use daft_dsl::expr::bound_expr::BoundExpr;
 use daft_logical_plan::partitioning::RepartitionSpec;
 use daft_micropartition::MicroPartition;
@@ -45,20 +44,39 @@ pub(crate) struct FlightRepartitionState {
     partitions: Arc<Vec<Arc<InProgressShuffleCache>>>,
 }
 
+impl FlightRepartitionState {
+    async fn push(&self, parts: Vec<MicroPartition>) -> DaftResult<()> {
+        let push_futures = self
+            .partitions
+            .iter()
+            .zip(parts)
+            .map(|(cache, partition)| cache.push_partition_data(partition));
+        futures::future::try_join_all(push_futures).await?;
+        Ok(())
+    }
+}
+
 pub(crate) enum RepartitionState {
     Ray(RayRepartitionState),
     Flight(FlightRepartitionState),
 }
 
+impl RepartitionState {
+    async fn push(&mut self, parts: Vec<MicroPartition>) -> DaftResult<()> {
+        match self {
+            Self::Ray(state) => {
+                state.push(parts);
+                Ok(())
+            }
+            Self::Flight(state) => state.push(parts).await,
+        }
+    }
+}
+
 enum RepartitionBackend {
-    Ray {
-        repartition_spec: RepartitionSpec,
-        schema: SchemaRef,
-    },
+    Ray,
     Flight {
-        num_partitions: usize,
         shuffle_id: u64,
-        repartition_spec: RepartitionSpec,
         shuffle_dirs: Vec<String>,
         compression: Option<String>,
         local_server: Arc<ShuffleFlightServer>,
@@ -69,22 +87,26 @@ enum RepartitionBackend {
     },
 }
 
+impl RepartitionBackend {
+    fn name(&self) -> &'static str {
+        match &self {
+            Self::Ray { .. } => "Ray",
+            Self::Flight { .. } => "Flight",
+        }
+    }
+}
+
 pub struct RepartitionSink {
     backend: RepartitionBackend,
+    repartition_spec: RepartitionSpec,
     num_partitions: usize,
 }
 
 impl RepartitionSink {
-    pub fn new_ray(
-        repartition_spec: RepartitionSpec,
-        num_partitions: usize,
-        schema: SchemaRef,
-    ) -> Self {
+    pub fn new_ray(repartition_spec: RepartitionSpec, num_partitions: usize) -> Self {
         Self {
-            backend: RepartitionBackend::Ray {
-                repartition_spec,
-                schema,
-            },
+            backend: RepartitionBackend::Ray,
+            repartition_spec,
             num_partitions,
         }
     }
@@ -102,9 +124,7 @@ impl RepartitionSink {
         const TARGET_TOTAL_IN_MEMORY_SIZE_BYTES: usize = 1024 * 1024 * 2000;
         Ok(Self {
             backend: RepartitionBackend::Flight {
-                num_partitions,
                 shuffle_id,
-                repartition_spec,
                 shuffle_dirs,
                 compression,
                 local_server,
@@ -114,6 +134,7 @@ impl RepartitionSink {
                     .clamp(1024 * 1024 * 8, 1024 * 1024 * 128),
                 partitions: Mutex::new(HashMap::new()),
             },
+            repartition_spec,
             num_partitions,
         })
     }
@@ -126,93 +147,37 @@ impl BlockingSink for RepartitionSink {
     fn sink(
         &self,
         input: MicroPartition,
-        state: Self::State,
+        mut state: Self::State,
         _runtime_stats: Arc<Self::Stats>,
         spawner: &ExecutionTaskSpawner,
     ) -> BlockingSinkSinkResult<Self> {
-        match (&self.backend, state) {
-            (
-                RepartitionBackend::Ray {
-                    repartition_spec,
-                    schema,
-                },
-                RepartitionState::Ray(mut state),
-            ) => {
-                let repartition_spec = repartition_spec.clone();
-                let num_partitions = self.num_partitions;
-                let schema = schema.clone();
-                spawner
-                    .spawn(
-                        async move {
-                            let partitioned = match repartition_spec {
-                                RepartitionSpec::Hash(config) => {
-                                    let bound_exprs = config
-                                        .by
-                                        .iter()
-                                        .map(|e| BoundExpr::try_new(e.clone(), &schema))
-                                        .collect::<DaftResult<Vec<_>>>()?;
-                                    input.partition_by_hash(&bound_exprs, num_partitions)?
-                                }
-                                RepartitionSpec::Random(config) => input.partition_by_random(
-                                    num_partitions,
-                                    config.seed.unwrap_or(0),
-                                )?,
-                                RepartitionSpec::Range(config) => input.partition_by_range(
-                                    &config.by,
-                                    &config.boundaries,
-                                    &config.descending,
-                                )?,
-                            };
-                            state.push(partitioned);
-                            Ok(RepartitionState::Ray(state))
-                        },
-                        Span::current(),
-                    )
-                    .into()
-            }
-            (
-                RepartitionBackend::Flight {
-                    repartition_spec,
-                    num_partitions,
-                    ..
-                },
-                RepartitionState::Flight(state),
-            ) => {
-                let num_partitions = *num_partitions;
-                let partition_by = match repartition_spec {
-                    RepartitionSpec::Hash(config) => Some(config.by.clone()),
-                    RepartitionSpec::Random(_) => None,
-                    RepartitionSpec::Range(_) => {
-                        unreachable!("Range repartition is not supported for flight shuffle")
-                    }
-                };
+        let repartition_spec = self.repartition_spec.clone();
+        let num_partitions = self.num_partitions;
 
-                spawner
-                    .spawn(
-                        async move {
-                            let partitioned = match &partition_by {
-                                Some(partition_by) => {
-                                    let partition_by =
-                                        BoundExpr::bind_all(partition_by, &input.schema())?;
-                                    input.partition_by_hash(&partition_by, num_partitions)?
-                                }
-                                None => input.partition_by_random(num_partitions, 0)?,
-                            };
-                            let mut push_futures = Vec::new();
-                            for (cache, partition) in
-                                state.partitions.iter().zip(partitioned.into_iter())
-                            {
-                                push_futures.push(cache.push_partition_data(partition));
-                            }
-                            futures::future::try_join_all(push_futures).await?;
-                            Ok(RepartitionState::Flight(state))
-                        },
-                        Span::current(),
-                    )
-                    .into()
-            }
-            _ => panic!("RepartitionSink state/backend mismatch"),
-        }
+        spawner
+            .spawn(
+                async move {
+                    let partitioned = match repartition_spec {
+                        RepartitionSpec::Hash(config) => {
+                            let bound_exprs = BoundExpr::bind_all(&config.by, &input.schema())?;
+                            input.partition_by_hash(&bound_exprs, num_partitions)?
+                        }
+                        RepartitionSpec::Random(config) => {
+                            input.partition_by_random(num_partitions, config.seed.unwrap_or(0))?
+                        }
+                        RepartitionSpec::Range(config) => input.partition_by_range(
+                            &config.by,
+                            &config.boundaries,
+                            &config.descending,
+                        )?,
+                    };
+
+                    state.push(partitioned).await?;
+                    Ok(state)
+                },
+                Span::current(),
+            )
+            .into()
     }
 
     #[instrument(skip_all, name = "RepartitionSink::finalize")]
@@ -222,9 +187,8 @@ impl BlockingSink for RepartitionSink {
         spawner: &ExecutionTaskSpawner,
     ) -> BlockingSinkFinalizeResult {
         match &self.backend {
-            RepartitionBackend::Ray { schema, .. } => {
+            RepartitionBackend::Ray => {
                 let num_partitions = self.num_partitions;
-                let schema = schema.clone();
 
                 let mut states = states
                     .into_iter()
@@ -247,9 +211,9 @@ impl BlockingSink for RepartitionSink {
                                     .iter_mut()
                                     .flat_map(|state| state.emit().unwrap())
                                     .collect::<Vec<_>>();
-                                let schema = schema.clone();
                                 let fut = tokio::spawn(async move {
                                     let together = MicroPartition::concat(data)?;
+                                    let schema = together.schema();
                                     let concated = together.concat_or_get()?;
                                     let mp = MicroPartition::new_loaded(
                                         schema,
@@ -330,7 +294,7 @@ impl BlockingSink for RepartitionSink {
     }
 
     fn name(&self) -> NodeName {
-        "Repartition".into()
+        format!("Repartition({})", self.backend.name()).into()
     }
 
     fn op_type(&self) -> NodeType {
@@ -338,60 +302,30 @@ impl BlockingSink for RepartitionSink {
     }
 
     fn multiline_display(&self) -> Vec<String> {
-        match &self.backend {
-            RepartitionBackend::Ray {
-                repartition_spec, ..
-            } => match repartition_spec {
-                RepartitionSpec::Hash(config) => vec![format!(
-                    "Repartition: By {} into {} partitions",
-                    config.by.iter().map(|e| e.to_string()).join(", "),
-                    self.num_partitions
-                )],
-                RepartitionSpec::Random(_) => vec![format!(
-                    "Repartition: Random into {} partitions",
-                    self.num_partitions
-                )],
-                RepartitionSpec::Range(config) => {
-                    let pairs = config
-                        .by
-                        .iter()
-                        .zip(config.descending.iter())
-                        .map(|(sb, d)| {
-                            format!("({}, {})", sb, if *d { "descending" } else { "ascending" })
-                        })
-                        .join(", ");
-                    vec![
-                        format!("Repartition: Range into {} partitions", self.num_partitions),
-                        format!("By: {:?}", pairs),
-                    ]
-                }
-            },
-            RepartitionBackend::Flight {
-                repartition_spec, ..
-            } => match repartition_spec {
-                RepartitionSpec::Hash(config) => vec![format!(
-                    "Repartition(Flight): By {} into {} partitions",
-                    config.by.iter().map(|e| e.to_string()).join(", "),
-                    self.num_partitions
-                )],
-                RepartitionSpec::Random(_) => vec![format!(
-                    "Repartition(Flight): Random into {} partitions",
-                    self.num_partitions
-                )],
-                RepartitionSpec::Range(_) => {
-                    unreachable!("Range repartition is not supported for flight shuffle")
-                }
-            },
+        let backend_name = self.backend.name();
+        match &self.repartition_spec {
+            RepartitionSpec::Hash(config) => vec![format!(
+                "Repartition({backend_name}): By {} into {} partitions",
+                config.by.iter().map(|e| e.to_string()).join(", "),
+                self.num_partitions
+            )],
+            RepartitionSpec::Random(_) => vec![format!(
+                "Repartition({backend_name}): Random into {} partitions",
+                self.num_partitions
+            )],
+            RepartitionSpec::Range(_) => vec![format!(
+                "Repartition({backend_name}): Range into {} partitions",
+                self.num_partitions
+            )],
         }
     }
 
     fn make_state(&self, input_id: InputId) -> DaftResult<Self::State> {
         match &self.backend {
-            RepartitionBackend::Ray { .. } => Ok(RepartitionState::Ray(RayRepartitionState {
+            RepartitionBackend::Ray => Ok(RepartitionState::Ray(RayRepartitionState {
                 states: (0..self.num_partitions).map(|_| vec![]).collect(),
             })),
             RepartitionBackend::Flight {
-                num_partitions,
                 shuffle_dirs,
                 shuffle_id,
                 target_in_memory_size_per_partition,
@@ -404,7 +338,7 @@ impl BlockingSink for RepartitionSink {
                     std::collections::hash_map::Entry::Occupied(e) => e.get().clone(),
                     std::collections::hash_map::Entry::Vacant(e) => {
                         let partition_set = Arc::new(
-                            (0..*num_partitions)
+                            (0..self.num_partitions)
                                 .map(|partition_idx| {
                                     Ok(Arc::new(InProgressShuffleCache::try_new(
                                         partition_ref_id(input_id, partition_idx),


### PR DESCRIPTION
## Changes Made

I'm going through and rewriting the repartition operator to handle some of the weird state management, but I was doing some other cleanup as well. 