### PR TITLE
refactor(partition-refs): consolidate partition ref types and trim unused derives

### DIFF
--- a/src/daft-distributed/src/python/mod.rs
+++ b/src/daft-distributed/src/python/mod.rs
@@ -10,6 +10,7 @@ use common_partitioning::Partition;
 use common_py_serde::impl_bincode_py_state_serialization;
 use daft_local_plan::python::PyExecutionStats;
 use daft_logical_plan::PyLogicalPlanBuilder;
+use daft_partition_refs::RayPartitionRef;
 use dashboard::DashboardStatisticsSubscriber;
 use futures::StreamExt;
 use progress_bar::FlotillaProgressBar;
@@ -24,7 +25,7 @@ use crate::{
         viz_distributed_pipeline_mermaid,
     },
     plan::{DistributedPhysicalPlan, PlanConfig, PlanResultStream, PlanRunner},
-    python::ray::{RayPartitionRef, RayTaskResult},
+    python::ray::RayTaskResult,
     statistics::{StatisticsManager, StatisticsManagerRef, StatisticsSubscriber},
 };
 
@@ -270,7 +271,6 @@ impl PyDistributedPhysicalPlanRunner {
 pub fn register_modules(parent: &Bound<PyModule>) -> PyResult<()> {
     parent.add_class::<PyDistributedPhysicalPlan>()?;
     parent.add_class::<PyDistributedPhysicalPlanRunner>()?;
-    parent.add_class::<RayPartitionRef>()?;
     parent.add_class::<RaySwordfishTask>()?;
     parent.add_class::<RaySwordfishWorker>()?;
     parent.add_class::<RayTaskResult>()?;

--- a/src/daft-distributed/src/python/ray/mod.rs
+++ b/src/daft-distributed/src/python/ray/mod.rs
@@ -3,8 +3,9 @@ mod worker;
 mod worker_manager;
 
 use common_error::DaftResult;
+pub use daft_partition_refs::RayPartitionRef;
 use pyo3::prelude::*;
-pub(crate) use task::{RayPartitionRef, RaySwordfishTask, RayTaskResult};
+pub(crate) use task::{RaySwordfishTask, RayTaskResult};
 pub(crate) use worker::RaySwordfishWorker;
 pub(crate) use worker_manager::RayWorkerManager;
 

--- a/src/daft-distributed/src/python/ray/task.rs
+++ b/src/daft-distributed/src/python/ray/task.rs
@@ -1,9 +1,9 @@
-use std::{any::Any, collections::HashMap, future::Future, sync::Arc};
+use std::{collections::HashMap, future::Future, sync::Arc};
 
 use common_daft_config::PyDaftExecutionConfig;
 use common_partitioning::{Partition, PartitionRef};
 use daft_local_plan::{ExecutionStats, PyLocalPhysicalPlan, SourceId, python::PyInput};
-use daft_partition_refs::{FlightPartitionRef, PyFlightPartitionRef};
+use daft_partition_refs::{FlightPartitionRef, PyFlightPartitionRef, RayPartitionRef};
 use pyo3::{Py, PyAny, PyResult, Python, pyclass, pymethods};
 
 use crate::{
@@ -139,53 +139,6 @@ impl TaskResultHandle for RayTaskResultHandle {
                 .call_method0(py, "cancel")
                 .expect("Failed to cancel task");
         });
-    }
-}
-
-#[pyclass(module = "daft.daft", name = "RayPartitionRef", frozen, from_py_object)]
-#[derive(Debug, Clone)]
-pub(crate) struct RayPartitionRef {
-    pub object_ref: Arc<Py<PyAny>>,
-    pub num_rows: usize,
-    pub size_bytes: usize,
-}
-
-#[pymethods]
-impl RayPartitionRef {
-    #[new]
-    pub fn new(object_ref: Py<PyAny>, num_rows: usize, size_bytes: usize) -> Self {
-        Self {
-            object_ref: Arc::new(object_ref),
-            num_rows,
-            size_bytes,
-        }
-    }
-
-    #[getter]
-    pub fn get_object_ref(&self, py: Python) -> Py<PyAny> {
-        self.object_ref.clone_ref(py)
-    }
-
-    #[getter]
-    pub fn get_num_rows(&self) -> usize {
-        self.num_rows
-    }
-
-    #[getter]
-    pub fn get_size_bytes(&self) -> usize {
-        self.size_bytes
-    }
-}
-
-impl Partition for RayPartitionRef {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-    fn size_bytes(&self) -> usize {
-        self.size_bytes
-    }
-    fn num_rows(&self) -> usize {
-        self.num_rows
     }
 }
 

--- a/src/daft-partition-refs/src/flight.rs
+++ b/src/daft-partition-refs/src/flight.rs
@@ -3,7 +3,7 @@ use std::any::Any;
 use common_partitioning::Partition;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FlightPartitionRef {
     pub shuffle_id: u64,
     pub server_address: String,

--- a/src/daft-partition-refs/src/lib.rs
+++ b/src/daft-partition-refs/src/lib.rs
@@ -1,10 +1,16 @@
 mod flight;
+#[cfg(feature = "python")]
+mod ray;
+
 pub use flight::FlightPartitionRef;
 #[cfg(feature = "python")]
 pub use flight::PyFlightPartitionRef;
+#[cfg(feature = "python")]
+pub use ray::RayPartitionRef;
 
 #[cfg(feature = "python")]
 pub fn register_modules(parent: &pyo3::Bound<pyo3::types::PyModule>) -> pyo3::PyResult<()> {
     flight::register_modules(parent)?;
+    ray::register_modules(parent)?;
     Ok(())
 }

--- a/src/daft-partition-refs/src/ray.rs
+++ b/src/daft-partition-refs/src/ray.rs
@@ -1,0 +1,80 @@
+#[cfg(feature = "python")]
+mod python {
+    use std::{any::Any, sync::Arc};
+
+    use common_partitioning::Partition;
+    use pyo3::{
+        Bound, IntoPyObject, Py, PyAny, PyResult, PyTypeInfo, Python, pyclass, pymethods,
+        types::PyModuleMethods,
+    };
+
+    #[pyclass(module = "daft.daft", name = "RayPartitionRef", frozen, from_py_object)]
+    #[derive(Debug, Clone)]
+    pub struct RayPartitionRef {
+        pub object_ref: Arc<Py<PyAny>>,
+        pub num_rows: usize,
+        pub size_bytes: usize,
+    }
+
+    #[pymethods]
+    impl RayPartitionRef {
+        #[new]
+        pub fn new(object_ref: Py<PyAny>, num_rows: usize, size_bytes: usize) -> Self {
+            Self {
+                object_ref: Arc::new(object_ref),
+                num_rows,
+                size_bytes,
+            }
+        }
+
+        #[getter]
+        pub fn get_object_ref(&self, py: Python) -> Py<PyAny> {
+            self.object_ref.clone_ref(py)
+        }
+
+        #[getter]
+        pub fn get_num_rows(&self) -> usize {
+            self.num_rows
+        }
+
+        #[getter]
+        pub fn get_size_bytes(&self) -> usize {
+            self.size_bytes
+        }
+
+        fn __reduce__<'py>(&self, py: Python<'py>) -> PyResult<(Py<PyAny>, Bound<'py, PyAny>)> {
+            Ok((
+                Self::type_object(py).into(),
+                (
+                    self.object_ref.clone_ref(py),
+                    self.num_rows,
+                    self.size_bytes,
+                )
+                    .into_pyobject(py)?
+                    .into_any(),
+            ))
+        }
+    }
+
+    impl Partition for RayPartitionRef {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+
+        fn size_bytes(&self) -> usize {
+            self.size_bytes
+        }
+
+        fn num_rows(&self) -> usize {
+            self.num_rows
+        }
+    }
+
+    pub fn register_modules(parent: &Bound<pyo3::types::PyModule>) -> PyResult<()> {
+        parent.add_class::<RayPartitionRef>()?;
+        Ok(())
+    }
+}
+
+#[cfg(feature = "python")]
+pub use python::{RayPartitionRef, register_modules};


### PR DESCRIPTION
- Removes unused derives from FlightPartitionRef
- Move RayPartitionRef into shared `daft-partition-refs` crate