### PR TITLE
feat: add paimon extra for pypaimon dep

### DIFF
--- a/daft/catalog/__init__.py
+++ b/daft/catalog/__init__.py
@@ -407,7 +407,7 @@ class Catalog(ABC):
 
             return PaimonCatalog._from_obj(catalog, name=name)
         except ImportError:
-            raise ImportError("pypaimon is required: pip install pypaimon")
+            raise ImportError("pypaimon is required: pip install daft[paimon]")
 
     @staticmethod
     def from_postgres(connection_string: str, extensions: list[str] | None = ["vector"]) -> Catalog:
@@ -985,7 +985,7 @@ class Table(ABC):
 
             return PaimonTable._from_obj(table)
         except ImportError:
-            raise ImportError("pypaimon is required: pip install pypaimon")
+            raise ImportError("pypaimon is required: pip install daft[paimon]")
 
     @staticmethod
     def from_gravitino(table: object) -> Table:

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -1405,7 +1405,7 @@ class DataFrame:
         try:
             import pypaimon  # noqa: F401
         except ImportError:
-            raise ImportError("pypaimon is required to use write_paimon. Install it with: `pip install pypaimon`")
+            raise ImportError("pypaimon is required to use write_paimon. Install it with: `pip install daft[paimon]`")
 
         from daft.io.paimon.paimon_data_sink import PaimonDataSink
 

--- a/daft/io/paimon/_paimon.py
+++ b/daft/io/paimon/_paimon.py
@@ -133,7 +133,7 @@ def read_paimon(
     try:
         import pypaimon  # noqa: F401
     except ImportError:
-        raise ImportError("pypaimon is required to use read_paimon. Install it with: `pip install pypaimon`")
+        raise ImportError("pypaimon is required to use read_paimon. Install it with: `pip install daft[paimon]`")
 
     from daft.io.paimon.paimon_scan import PaimonDataSource
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ homepage = "https://www.daft.ai"
 repository = "https://github.com/Eventual-Inc/Daft"
 
 [project.optional-dependencies]
-all = ["daft[aws, azure, clickhouse, deltalake, gcp, google, gravitino, hudi, huggingface, iceberg, lance, numpy, openai, paimon, pandas, postgres, ray, sentence-transformers, sql, transformers, turbopuffer, unity, video]"]
+all = ["daft[aws, azure, clickhouse, deltalake, gcp, google, gravitino, hudi, huggingface, iceberg, lance, numpy, openai, pandas, postgres, ray, sentence-transformers, sql, transformers, turbopuffer, unity, video]"]
 aws = ["boto3<1.43.0", "mypy-boto3-glue"]
 azure = []
 clickhouse = ["clickhouse_connect<0.12.0"]
@@ -44,7 +44,7 @@ iceberg = ["pyiceberg >= 0.7.0, <= 0.11.0, != 0.9.1, != 0.10.0"]
 lance = ["pylance<0.40.0"]
 numpy = ["numpy<2.4.0"]
 openai = ["openai<2.21.0", "numpy<2.4.0", "pillow==12.1.1"]
-paimon = ["pypaimon>=0.2.0,<1.4.0"]
+paimon = ["pypaimon>=1.3.1,<1.4.0"]
 pandas = ["pandas<2.4.0"]
 postgres = ["psycopg[binary]<3.4.0", "pgvector<0.5.0", "sqlglot<28.11.0", "connectorx>=0.4.4,<0.5.0"]
 ray = [
@@ -244,6 +244,11 @@ addopts = "-m 'not (integration or benchmark or hypothesis)'"
 minversion = "6.0"
 testpaths = [
   "tests"
+]
+
+[tool.uv]
+conflicts = [
+  [{extra = "paimon"}, {group = "dev"}],
 ]
 
 [tool.uv.sources.daft_dashboard]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ homepage = "https://www.daft.ai"
 repository = "https://github.com/Eventual-Inc/Daft"
 
 [project.optional-dependencies]
-all = ["daft[aws, azure, clickhouse, deltalake, gcp, google, gravitino, hudi, huggingface, iceberg, lance, numpy, openai, pandas, postgres, ray, sentence-transformers, sql, transformers, turbopuffer, unity, video]"]
+all = ["daft[aws, azure, clickhouse, deltalake, gcp, google, gravitino, hudi, huggingface, iceberg, lance, numpy, openai, paimon, pandas, postgres, ray, sentence-transformers, sql, transformers, turbopuffer, unity, video]"]
 aws = ["boto3<1.43.0", "mypy-boto3-glue"]
 azure = []
 clickhouse = ["clickhouse_connect<0.12.0"]
@@ -44,6 +44,7 @@ iceberg = ["pyiceberg >= 0.7.0, <= 0.11.0, != 0.9.1, != 0.10.0"]
 lance = ["pylance<0.40.0"]
 numpy = ["numpy<2.4.0"]
 openai = ["openai<2.21.0", "numpy<2.4.0", "pillow==12.1.1"]
+paimon = ["pypaimon>=0.2.0,<1.4.0"]
 pandas = ["pandas<2.4.0"]
 postgres = ["psycopg[binary]<3.4.0", "pgvector<0.5.0", "sqlglot<28.11.0", "connectorx>=0.4.4,<0.5.0"]
 ray = [

--- a/uv.lock
+++ b/uv.lock
@@ -1443,6 +1443,7 @@ all = [
     { name = "pyarrow" },
     { name = "pyiceberg" },
     { name = "pylance" },
+    { name = "pypaimon" },
     { name = "ray", extra = ["client", "data"] },
     { name = "requests" },
     { name = "sentence-transformers" },
@@ -1499,6 +1500,9 @@ openai = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
     { name = "openai" },
     { name = "pillow" },
+]
+paimon = [
+    { name = "pypaimon" },
 ]
 pandas = [
     { name = "pandas", version = "2.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
@@ -1640,7 +1644,7 @@ requires-dist = [
     { name = "clickhouse-connect", marker = "extra == 'clickhouse'", specifier = "<0.12.0" },
     { name = "connectorx", marker = "extra == 'postgres'", specifier = ">=0.4.4,<0.5.0" },
     { name = "connectorx", marker = "extra == 'sql'", specifier = ">=0.4.4,<0.5.0" },
-    { name = "daft", extras = ["aws", "azure", "clickhouse", "deltalake", "gcp", "google", "gravitino", "hudi", "huggingface", "iceberg", "lance", "numpy", "openai", "pandas", "postgres", "ray", "sentence-transformers", "sql", "transformers", "turbopuffer", "unity", "video"], marker = "extra == 'all'" },
+    { name = "daft", extras = ["aws", "azure", "clickhouse", "deltalake", "gcp", "google", "gravitino", "hudi", "huggingface", "iceberg", "lance", "numpy", "openai", "paimon", "pandas", "postgres", "ray", "sentence-transformers", "sql", "transformers", "turbopuffer", "unity", "video"], marker = "extra == 'all'" },
     { name = "datasets", marker = "extra == 'huggingface'", specifier = "<4.6.0" },
     { name = "deltalake", marker = "extra == 'deltalake'", specifier = ">=1.5.0,<1.6.0" },
     { name = "deltalake", marker = "extra == 'unity'", specifier = ">=1.5.0,<1.6.0" },
@@ -1665,6 +1669,7 @@ requires-dist = [
     { name = "pyarrow", marker = "extra == 'hudi'", specifier = ">=8.0.0,<22.1.0" },
     { name = "pyiceberg", marker = "extra == 'iceberg'", specifier = ">=0.7.0,!=0.9.1,!=0.10.0,<=0.11.0" },
     { name = "pylance", marker = "extra == 'lance'", specifier = "<0.40.0" },
+    { name = "pypaimon", marker = "extra == 'paimon'", specifier = ">=0.2.0,<1.4.0" },
     { name = "ray", extras = ["data", "client"], marker = "sys_platform == 'win32' and extra == 'ray'", specifier = ">=2.10.0,<2.54.0" },
     { name = "ray", extras = ["data", "client"], marker = "sys_platform != 'win32' and extra == 'ray'", specifier = ">=2.0.0,<2.54.0" },
     { name = "requests", marker = "extra == 'gravitino'", specifier = ">=2.28.0,<3.0.0" },
@@ -1681,7 +1686,7 @@ requires-dist = [
     { name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.0.0" },
     { name = "unitycatalog", marker = "extra == 'unity'", specifier = "<0.2.0" },
 ]
-provides-extras = ["all", "audio", "aws", "azure", "clickhouse", "deltalake", "gcp", "google", "gravitino", "hudi", "huggingface", "iceberg", "lance", "numpy", "openai", "pandas", "postgres", "ray", "sql", "transformers", "turbopuffer", "unity", "video", "viz"]
+provides-extras = ["all", "audio", "aws", "azure", "clickhouse", "deltalake", "gcp", "google", "gravitino", "hudi", "huggingface", "iceberg", "lance", "numpy", "openai", "paimon", "pandas", "postgres", "ray", "sql", "transformers", "turbopuffer", "unity", "video", "viz"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -6654,6 +6659,15 @@ wheels = [
 ]
 
 [[package]]
+name = "py4j"
+version = "0.10.9.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/f2/b34255180c72c36ff7097f7c2cdca02abcbd89f5eebf7c7c41262a9a0637/py4j-0.10.9.7.tar.gz", hash = "sha256:0b6e5315bb3ada5cf62ac651d107bb2ebc02def3dee9d9548e3baac644ea8dbb", size = 1508234, upload-time = "2022-08-12T22:49:09.792Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/30/a58b32568f1623aaad7db22aa9eafc4c6c194b429ff35bdc55ca2726da47/py4j-0.10.9.7-py2.py3-none-any.whl", hash = "sha256:85defdfd2b2376eb3abf5ca6474b51ab7e0de341c75a02f46dc9b5976f5a5c1b", size = 200481, upload-time = "2022-08-12T22:49:07.05Z" },
+]
+
+[[package]]
 name = "pyarrow"
 version = "22.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -7260,6 +7274,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/c7/ee98c62050de4aa8bafb6eb1e11b95e0b0c898bd5930137c6dc776e06a9b/pyodbc-5.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:bfeb3e34795d53b7d37e66dd54891d4f9c13a3889a8f5fe9640e56a82d770955", size = 79452, upload-time = "2025-10-17T18:03:54.664Z" },
     { url = "https://files.pythonhosted.org/packages/4b/8f/d8889efd96bbe8e5d43ff9701f6b1565a8e09c3e1f58c388d550724f777b/pyodbc-5.3.0-cp314-cp314t-win_arm64.whl", hash = "sha256:13656184faa3f2d5c6f19b701b8f247342ed581484f58bf39af7315c054e69db", size = 70142, upload-time = "2025-10-17T18:03:55.551Z" },
 ]
+
+[[package]]
+name = "pypaimon"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pandas", version = "2.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "py4j" },
+    { name = "pyarrow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/fd/397b04ac950a75ce71ecf613b9ee1a247e9da1b633b6ccf1847b513979d4/pypaimon-0.2.0.tar.gz", hash = "sha256:43ac684779841da17528b5f241ede6149bcdab4d16f3cd80f713262f6ed04720", size = 39469331, upload-time = "2024-12-19T07:37:07.501Z" }
 
 [[package]]
 name = "pyparsing"

--- a/uv.lock
+++ b/uv.lock
@@ -2,32 +2,61 @@ version = 1
 revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
-    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version >= '3.14' and sys_platform == 'darwin'",
-    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
-    "(python_full_version == '3.13.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
-    "(python_full_version == '3.12.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
-    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version < '3.11' and sys_platform == 'darwin'",
-    "(python_full_version < '3.11' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version >= '3.14' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'win32'",
-    "python_full_version < '3.11' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version == '3.13.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version < '3.11' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
 ]
+conflicts = [[
+    { package = "daft", extra = "paimon" },
+    { package = "daft", group = "dev" },
+]]
 
 [[package]]
 name = "adlfs"
@@ -39,7 +68,7 @@ dependencies = [
     { name = "azure-datalake-store" },
     { name = "azure-identity" },
     { name = "azure-storage-blob" },
-    { name = "fsspec" },
+    { name = "fsspec", version = "2024.9.0", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b4/1e/6d5146676044247af566fa5843b335b1a647e6446070cec9c8b61c31b369/adlfs-2024.7.0.tar.gz", hash = "sha256:106995b91f0eb5e775bcd5957d180d9a14faef3271a063b1f65c66fd5ab05ddf", size = 48588, upload-time = "2024-07-22T12:10:33.849Z" }
 wheels = [
@@ -54,7 +83,7 @@ dependencies = [
     { name = "aiohttp" },
     { name = "aioitertools" },
     { name = "botocore" },
-    { name = "jmespath" },
+    { name = "jmespath", version = "1.0.1", source = { registry = "https://pypi.org/simple" } },
     { name = "multidict" },
     { name = "python-dateutil" },
     { name = "urllib3" },
@@ -81,7 +110,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohappyeyeballs" },
     { name = "aiosignal" },
-    { name = "async-timeout", marker = "python_full_version < '3.11'" },
+    { name = "async-timeout", marker = "python_full_version < '3.11' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
     { name = "attrs" },
     { name = "frozenlist" },
     { name = "multidict" },
@@ -204,16 +233,51 @@ wheels = [
 ]
 
 [[package]]
+name = "aiooss2"
+version = "0.2.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "oss2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/99/81/63bc832d0ddf2ac5b61177343338ffb21d9ebd49964279a1bd83861b2844/aiooss2-0.2.10.tar.gz", hash = "sha256:65698a287386464e4a08fb862be85668df4d1e1acfe0620404617d88869630eb", size = 39955, upload-time = "2024-03-23T12:05:25.621Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/7d/26001e26c7e97e4e7a79f4b2e534fec79561c8dd9236775ab3b0862a0835/aiooss2-0.2.10-py3-none-any.whl", hash = "sha256:78a39a839752ef506d32dcfb83db718d9503fa69f7f9a80a1e2554d8e013daa9", size = 28503, upload-time = "2024-03-23T12:05:23.818Z" },
+]
+
+[[package]]
 name = "aiosignal"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "frozenlist" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl", hash = "sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e", size = 7490, upload-time = "2025-07-03T22:54:42.156Z" },
+]
+
+[[package]]
+name = "aliyun-python-sdk-core"
+version = "2.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "jmespath", version = "0.10.0", source = { registry = "https://pypi.org/simple" } },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3e/09/da9f58eb38b4fdb97ba6523274fbf445ef6a06be64b433693da8307b4bec/aliyun-python-sdk-core-2.16.0.tar.gz", hash = "sha256:651caad597eb39d4fad6cf85133dffe92837d53bdf62db9d8f37dab6508bb8f9", size = 449555, upload-time = "2024-10-09T06:01:01.762Z" }
+
+[[package]]
+name = "aliyun-python-sdk-kms"
+version = "2.16.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aliyun-python-sdk-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/2c/9877d0e6b18ecf246df671ac65a5d1d9fecbf85bdcb5d43efbde0d4662eb/aliyun-python-sdk-kms-2.16.5.tar.gz", hash = "sha256:f328a8a19d83ecbb965ffce0ec1e9930755216d104638cd95ecd362753b813b3", size = 12018, upload-time = "2024-08-30T09:01:20.104Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/5c/0132193d7da2c735669a1ed103b142fd63c9455984d48c5a88a1a516efaa/aliyun_python_sdk_kms-2.16.5-py2.py3-none-any.whl", hash = "sha256:24b6cdc4fd161d2942619479c8d050c63ea9cd22b044fe33b60bbb60153786f0", size = 99495, upload-time = "2024-08-30T09:01:18.462Z" },
 ]
 
 [[package]]
@@ -239,10 +303,10 @@ name = "anyio"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
     { name = "idna" },
     { name = "sniffio" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/95/7d/4c1bd541d4dffa1b52bd83fb8527089e097a106fc90b467a7313b105f840/anyio-4.9.0.tar.gz", hash = "sha256:673c0c244e15788651a4ff38710fea9675823028a6f08a5eda409e0c9840a028", size = 190949, upload-time = "2025-03-17T00:02:54.77Z" }
 wheels = [
@@ -263,7 +327,7 @@ name = "arro3-core"
 version = "0.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/eb/2a166478dfc951958bf4cd33891bfa346ab9c53c3a87f5ffe99dbe981577/arro3_core-0.5.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:a85c4d78fb4a3e3b216b01e44ac16121a06e80169555cd0f7b8fcf038a6c14b3", size = 2448695, upload-time = "2025-05-31T23:17:55.526Z" },
@@ -429,8 +493,8 @@ name = "audioread"
 version = "3.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "standard-aifc", marker = "python_full_version >= '3.13'" },
-    { name = "standard-sunau", marker = "python_full_version >= '3.13'" },
+    { name = "standard-aifc", marker = "python_full_version >= '3.13' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "standard-sunau", marker = "python_full_version >= '3.13' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a1/4a/874ecf9b472f998130c2b5e145dcdb9f6131e84786111489103b66772143/audioread-3.1.0.tar.gz", hash = "sha256:1c4ab2f2972764c896a8ac61ac53e261c8d29f0c6ccd652f84e18f08a4cab190", size = 20082, upload-time = "2025-10-26T19:44:13.484Z" }
 wheels = [
@@ -628,8 +692,8 @@ dependencies = [
     { name = "pathspec" },
     { name = "platformdirs" },
     { name = "pytokens" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "tomli", marker = "python_full_version < '3.11' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/13/88/560b11e521c522440af991d46848a2bde64b5f7202ec14e1f46f9509d328/black-26.1.0.tar.gz", hash = "sha256:d294ac3340eef9c9eb5d29288e96dc719ff269a88e27b396340459dd85da4c58", size = 658785, upload-time = "2026-01-18T04:50:11.993Z" }
 wheels = [
@@ -761,7 +825,8 @@ version = "1.36.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
-    { name = "jmespath" },
+    { name = "jmespath", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-4-daft-paimon'" },
+    { name = "jmespath", version = "1.0.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'group-4-daft-dev' or extra != 'extra-4-daft-paimon'" },
     { name = "s3transfer" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3a/e9/c0b2fa75efc4007ea1af21bc2fcbedf6e545c517fb90904d7f59850e02bf/boto3-1.36.2.tar.gz", hash = "sha256:fde1c29996b77274a60b7bc9f741525afa6267bb1716eb644a764fb7c124a0d2", size = 110998, upload-time = "2025-01-17T20:25:56.686Z" }
@@ -808,7 +873,8 @@ name = "botocore"
 version = "1.36.23"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jmespath" },
+    { name = "jmespath", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-4-daft-paimon'" },
+    { name = "jmespath", version = "1.0.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'group-4-daft-dev' or extra != 'extra-4-daft-paimon'" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
@@ -831,8 +897,71 @@ wheels = [
 
 [[package]]
 name = "cachetools"
+version = "5.3.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version < '3.11' and sys_platform == 'win32'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/4d/27a3e6dd09011649ad5210bdf963765bc8fa81a0827a4fc01bafd2705c5b/cachetools-5.3.3.tar.gz", hash = "sha256:ba29e2dfa0b8b556606f097407ed1aa62080ee108ab0dc5ec9d6a723a007d105", size = 26522, upload-time = "2024-02-26T20:33:23.386Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/2b/a64c2d25a37aeb921fddb929111413049fc5f8b9a4c1aefaffaafe768d54/cachetools-5.3.3-py3-none-any.whl", hash = "sha256:0abad1021d3f8325b2fc1d2e9c8b9c9d57b04c3932657a72465447332c24d945", size = 9325, upload-time = "2024-02-26T20:33:20.308Z" },
+]
+
+[[package]]
+name = "cachetools"
 version = "5.5.2"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version == '3.13.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version < '3.11' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+]
 sdist = { url = "https://files.pythonhosted.org/packages/6c/81/3747dad6b14fa2cf53fcf10548cf5aea6913e96fab41a3c198676f8948a5/cachetools-5.5.2.tar.gz", hash = "sha256:1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4", size = 28380, upload-time = "2025-02-20T21:01:19.524Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/72/76/20fa66124dbe6be5cafeb312ece67de6b61dd91a0247d1ea13db4ebb33c2/cachetools-5.5.2-py3-none-any.whl", hash = "sha256:d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a", size = 10080, upload-time = "2025-02-20T21:01:16.647Z" },
@@ -901,7 +1030,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -994,8 +1123,8 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aws-sam-translator" },
     { name = "jsonpatch" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "networkx", version = "3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "networkx", version = "3.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
     { name = "pyyaml" },
     { name = "regex" },
     { name = "sympy" },
@@ -1072,7 +1201,7 @@ name = "click"
 version = "8.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/60/6c/8ca2efa64cf75a977a0d7fac081354553ebe483345c734fb6b6515d96bbc/click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202", size = 286342, upload-time = "2025-05-20T23:19:49.832Z" }
 wheels = [
@@ -1081,16 +1210,131 @@ wheels = [
 
 [[package]]
 name = "clickhouse-connect"
+version = "0.9.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+]
+dependencies = [
+    { name = "certifi", marker = "(python_full_version >= '3.14' and extra == 'extra-4-daft-paimon') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "lz4", version = "4.4.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra == 'extra-4-daft-paimon') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "pytz", marker = "(python_full_version >= '3.14' and extra == 'extra-4-daft-paimon') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "urllib3", marker = "(python_full_version >= '3.14' and extra == 'extra-4-daft-paimon') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "zstandard", version = "0.24.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra == 'extra-4-daft-paimon') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/50/b98639b37d048f2d0ff31245eab7f116b0e5a0e9a4ee701d55e4c1ac2214/clickhouse_connect-0.9.2.tar.gz", hash = "sha256:d45f35c1734e1a8664edc31015fc490f53e6c912f359416fcd717b1815e28d56", size = 102064, upload-time = "2025-09-25T23:26:04.503Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/e1/c2f96d834942264875b7eba292298592aee6030d9e2721de844d6d565ac6/clickhouse_connect-0.9.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:1b4bd8f2864ebf1007ea59a2fbaa9fec8b5518030c1ad582645b8690db582305", size = 269393, upload-time = "2025-09-25T23:24:21.262Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/89/b98a8083bd1430dfda29b4dff8a24d4fcb88dd76f6827286e1cca739f5e8/clickhouse_connect-0.9.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:6d77bb17001cf5d88cbae3a579ab7bd76904058f8270bdd5ba3f09015f9efb55", size = 262705, upload-time = "2025-09-25T23:24:23.437Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/bb/324acd875fd6a32775e8f559bf5fa5b12ee20ba98348389d051e26c8d80a/clickhouse_connect-0.9.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c9a482eaf951aaf9aa9630fd33b832454a56e1612fd0780c50fbaf2d1e8b977", size = 975730, upload-time = "2025-09-25T23:24:24.605Z" },
+    { url = "https://files.pythonhosted.org/packages/69/30/eebb862e7326fc4e9793c4c2136be1d7ae9bdf29b8a24bb6563dd1e24668/clickhouse_connect-0.9.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:567f258de589b0930da43141397febd685acb3f4cf16f517c599bde4b63d35ad", size = 990832, upload-time = "2025-09-25T23:24:25.906Z" },
+    { url = "https://files.pythonhosted.org/packages/24/68/35bf56786ef044e92670dd4b01bc94726fb38d58a2b5425975edcff719a3/clickhouse_connect-0.9.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:07c0f5098e9e4c6fa19d7471bc225ca1cf3ace99f01e8dda8be48df947cf0ddf", size = 967196, upload-time = "2025-09-25T23:24:27.145Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/b3/fd000c961a6698f86ac7b27aad198a8b129836fa3803a7b420b0201ba492/clickhouse_connect-0.9.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:113abbc5fa6413322b806fa35455960cb09dd829f3eb951db66164b335daab60", size = 982156, upload-time = "2025-09-25T23:24:28.462Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/89/7db69621ecd56f765cf0f2c82774785d1f4d2f38e109b1fd156dda3a04ae/clickhouse_connect-0.9.2-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:f77444cb6e2d961c08fe2f1db130bfa587f3ad71ef09e46e083cf9f9dae90f00", size = 1004361, upload-time = "2025-09-25T23:24:29.855Z" },
+    { url = "https://files.pythonhosted.org/packages/29/84/be4e36d2c0ebcb9d9d20a8f58b91d7d1195d72291a0d8da7542f5a2ba1ff/clickhouse_connect-0.9.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:2c1bbe7d541fc776dc04fc0f416431e5245e4b872f5a8375a01094f336bcac57", size = 1015916, upload-time = "2025-09-25T23:24:31.798Z" },
+    { url = "https://files.pythonhosted.org/packages/44/39/4db440e56c07b1bb28914d15081157ad11edb58ef5314c82bffe35a8ddb0/clickhouse_connect-0.9.2-cp310-cp310-win32.whl", hash = "sha256:525e91c972f79dd40ae515b05894f2a2e8c9d0d26da3f1adff2656d1fde250f4", size = 241061, upload-time = "2025-09-25T23:24:33.079Z" },
+    { url = "https://files.pythonhosted.org/packages/06/38/b44464ef43b55293ce45c7b99088c7dea99af1e7330448615c66379aa77b/clickhouse_connect-0.9.2-cp310-cp310-win_amd64.whl", hash = "sha256:3bea1477347e93fb14e7bab63f3282ebd8bc23cc9ad76c128534ed9168e2256f", size = 258940, upload-time = "2025-09-25T23:24:34.352Z" },
+    { url = "https://files.pythonhosted.org/packages/00/8e/cd1dd33bb9e2a4c0b98e002337e7664158f90b768b750e916dab3623cf63/clickhouse_connect-0.9.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6c878f9eee3157455d623f1e5c233bb47e3f474f1ad8bc53358d7efb65ec199c", size = 269731, upload-time = "2025-09-25T23:24:35.518Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/9e/813ecaaf6a7560888c475de261837bf8b740bcb830eb44db3e2b10996f3d/clickhouse_connect-0.9.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7d735cd382cacac5bb846c9a7f97e4b2de806978eca726cb90599c173b15e925", size = 262761, upload-time = "2025-09-25T23:24:36.689Z" },
+    { url = "https://files.pythonhosted.org/packages/64/f5/287e9a9860ad33adb183d2f4a3efe2a9c6a3d36f27bbc0180c93db0cc671/clickhouse_connect-0.9.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4cf6d857ee4f2ccd2c008189e521d33e35b462bd3425e4b599fa33800e832e30", size = 1073232, upload-time = "2025-09-25T23:24:37.847Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/7a/ded19456bd4f73b16691550d928edaba00307f42182d71d7b52a14c2e5c6/clickhouse_connect-0.9.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9f2c5e89b78526796379b63c31c0170f0c7000c5321aaad68eb6a70084520eba", size = 1083805, upload-time = "2025-09-25T23:24:39.284Z" },
+    { url = "https://files.pythonhosted.org/packages/07/6c/a3ef627f21c75aaeab67fe6d7a1111f1f0fc46a0399cdab9cbce5f307f88/clickhouse_connect-0.9.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ef549994c63d20e0ba1c7af3dfcf64daa9578467a665925ed46aabe682de4fb8", size = 1045589, upload-time = "2025-09-25T23:24:41.189Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/2b/1bed54296265e9e4f85c9cbc1949cb47bd392ca2b8aab21c5faa429e7445/clickhouse_connect-0.9.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7ee21425c7f259641c82ed024d2c0d769ccb1e818bfaa4b63d34636521fda266", size = 1078042, upload-time = "2025-09-25T23:24:42.716Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/a7/f722a95ae54bace58ebc5a69227e1e3d0ded7168fd5966f06c9fe30c719f/clickhouse_connect-0.9.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:b909b56c4a5184245c7a414d0c4c154ba19fd6c147c6446e265c4c12923156a2", size = 1084070, upload-time = "2025-09-25T23:24:44.866Z" },
+    { url = "https://files.pythonhosted.org/packages/93/ca/d6e42c739a449f5ebccafce4cfd45526a30d4d076577fa30d32944af2cf0/clickhouse_connect-0.9.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f3816d1e07eed15a884bd81b827dccade4857e3ee4e9d81ea573e977e3cffc08", size = 1114990, upload-time = "2025-09-25T23:24:46.203Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/3d/a4f3aee7652590172d17c818e78d53af3b2a002d2421d45a4613581eb45d/clickhouse_connect-0.9.2-cp311-cp311-win32.whl", hash = "sha256:3364ca5e08986128d25a8926696d4f1bfb4ceb893b9b2cf93999287c1e98f92f", size = 240831, upload-time = "2025-09-25T23:24:47.432Z" },
+    { url = "https://files.pythonhosted.org/packages/48/0b/3ec3b235af26b6b83a51f0893edccac5709077213fe67be414f7c802e25d/clickhouse_connect-0.9.2-cp311-cp311-win_amd64.whl", hash = "sha256:8c0b3c2a9ca71bd78839a360a47a5df9b95c280a795f8aee083a3de01e9085fc", size = 259169, upload-time = "2025-09-25T23:24:48.57Z" },
+    { url = "https://files.pythonhosted.org/packages/77/23/8dec96b728692cfbb7fda45287bbb1a60d7d0ecc2091eb5d70e11e1d9c7e/clickhouse_connect-0.9.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8b666caa538732fadeae6b50ea5d5fd67583be9438c79bd1de9ae69ae6ec0c72", size = 273225, upload-time = "2025-09-25T23:24:50.147Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/a0/bbdec1e61f84830d4016c7176b14a60002d3474536caf0024126dc78ae15/clickhouse_connect-0.9.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:aead65896287f3322b92b2235e783ab6ea4d03724fc8adc8efc4eddd95ffe91f", size = 265018, upload-time = "2025-09-25T23:24:53.332Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/a2/b758903e2c9eebb7fcf24bdd83c0ba0233c4517203940f43e73496672d7b/clickhouse_connect-0.9.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:df25751bb5aa29e40b8b127500ea6a7f89031644c6b6bf9887c1dabe8df2bc36", size = 1069488, upload-time = "2025-09-25T23:24:54.704Z" },
+    { url = "https://files.pythonhosted.org/packages/04/f4/a8478d4672ad67d734e76820ebac33413d3531e656edfb19e1535b051a8f/clickhouse_connect-0.9.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9ab13be35a6c92489d68b6bd4b32afcbedaa9e7c4aacd15a2f1a4fba761a33d8", size = 1087995, upload-time = "2025-09-25T23:24:56.371Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/13/7e3052b3051e4b88bb9f9f99de48be99bd3ee61b481d97044d36754ff86d/clickhouse_connect-0.9.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:653dd934e545db2b5dda3c436ae68149ca6031149bf928cd7714921c45a66bb9", size = 1043122, upload-time = "2025-09-25T23:24:57.718Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d3/513a3b4f7d3397d98e69175a682eeb08edc758fa70f16fe43d8d788903bd/clickhouse_connect-0.9.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6461bf077736d990a7198c2f352dcc7919bebdf2952993d26d18b8f25f500f7e", size = 1069052, upload-time = "2025-09-25T23:24:59.619Z" },
+    { url = "https://files.pythonhosted.org/packages/26/e0/b1e370623f18b248bcdb86b7d5ac5bff8809da0640e1596d8bea090c0e3e/clickhouse_connect-0.9.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:9b7a09548d5542badcfdbe3d62fccc4148124e6da7f061dfbcbdf041b730d372", size = 1085444, upload-time = "2025-09-25T23:25:01.052Z" },
+    { url = "https://files.pythonhosted.org/packages/74/07/c7e4d34bf4636d86da26bde26a26626f4b68536e3e5faa1974724714b54d/clickhouse_connect-0.9.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2ab3fd64bbcf52a6a13ff3cf2a74d5c571e3c82d3c6a1d210562daec4ba2ba6b", size = 1110929, upload-time = "2025-09-25T23:25:02.819Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/78/b4feaad11398428dba2165d0b25dfac86f952f0bc960937d62f624338adc/clickhouse_connect-0.9.2-cp312-cp312-win32.whl", hash = "sha256:340e1353eddc2a5ea5ce073e4665d7ba10c2491254544ef802b592d8128a04e0", size = 240499, upload-time = "2025-09-25T23:25:04.26Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/b2/4fa0ce6fffff9e702f55cce6f48dbb51c8c7d70bf6e266c263a5c9337940/clickhouse_connect-0.9.2-cp312-cp312-win_amd64.whl", hash = "sha256:655d6670741ec87497b8b37b7eaada0ec50757b3816c500ec9b7d63775741c92", size = 259608, upload-time = "2025-09-25T23:25:05.689Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/ed/f2cfff4692deb5a3bbc11b7b103a5805a1d6db455cc3d133315dfc3d51aa/clickhouse_connect-0.9.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c114ace0c34956ef8d6f7a23a3fe7857bb7b7812e4f85ff04ad2eaffa23ee133", size = 270498, upload-time = "2025-09-25T23:25:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/71/5cc69ed7629b41d45a550264f51444430e649fe6f7328025ffb62bdeedc0/clickhouse_connect-0.9.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8521459ff9f7cc88d52f232ab006cd1d383a7b58f25022861f10770e6acde86e", size = 262167, upload-time = "2025-09-25T23:25:08.82Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/3e/56e100be63966c5a20a12edc02b4bf779c56055d32efd8f368ce4e5b3e96/clickhouse_connect-0.9.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4926616368b0a34173b1db5e567f06e855508ffc0db4d8ce5b3db4eb9bace5c1", size = 1052315, upload-time = "2025-09-25T23:25:10.228Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/51/3cfe007305f2febda5b67b8fa5a9b6da18e9a1c685a509c2eb58ffe9a766/clickhouse_connect-0.9.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5b9ce69c06109de2cf5827de7cdb12cf9688b5b4420463ebbfe959959f85e5c7", size = 1070988, upload-time = "2025-09-25T23:25:11.894Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/50/902cba1d35d087f56683a5975ac2c2d77e39ab7bfb81d3e7782c4008d60d/clickhouse_connect-0.9.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3bfcf901eb94a218298753980d130bef2d1fa2e9e5845b0385d405092d09661f", size = 1026518, upload-time = "2025-09-25T23:25:13.716Z" },
+    { url = "https://files.pythonhosted.org/packages/03/f3/b4bf7682950d62a721bc2fa5e2bdf0db5505276ace37f25843df1051cf00/clickhouse_connect-0.9.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0b43416e922c7efd8c636cba7c9dcbeed8e26125d1d0fdf2387e86f6457cbe51", size = 1053617, upload-time = "2025-09-25T23:25:15.167Z" },
+    { url = "https://files.pythonhosted.org/packages/97/2f/f4da8e296260519baccc8e45ad3fb1bb3c2c87effda338028bdd8e15d999/clickhouse_connect-0.9.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:4d2f9bb8fe9a3fe570057195a1d91f7a6ee8b8ca323e1b74a70c270179482516", size = 1068813, upload-time = "2025-09-25T23:25:17.036Z" },
+    { url = "https://files.pythonhosted.org/packages/94/50/9de26212bdc7ce10a2bc45be9bfdfa654624e0f16bd9ff6a8631af83687e/clickhouse_connect-0.9.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a147cf722d28f49ede19566b32d4e46cafd6a1854f78252d803d8a58fb825b64", size = 1096604, upload-time = "2025-09-25T23:25:21.023Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/2f/9cde7b2f0b1c2c17583d39fa4bbc32a6debf914a423b56dbb13acc898574/clickhouse_connect-0.9.2-cp313-cp313-win32.whl", hash = "sha256:bbfbfea214f314db92dcd403ee0b748082c712a65c285c390672ff5421d3cd2a", size = 239818, upload-time = "2025-09-25T23:25:22.522Z" },
+    { url = "https://files.pythonhosted.org/packages/94/d8/5df3209e05d9fde7e5133e6a7f6b59674435f524a513f461b9dfb0b37707/clickhouse_connect-0.9.2-cp313-cp313-win_amd64.whl", hash = "sha256:c5a78d95ba68e27e6acc768ea0f4f38ebe11b74ae9b00359ae005c6be793b012", size = 258664, upload-time = "2025-09-25T23:25:24.022Z" },
+    { url = "https://files.pythonhosted.org/packages/19/16/55e43a103b6d3e311ccb21460216eecc0f5da3d5ed7f3cdff500e4712fa2/clickhouse_connect-0.9.2-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:86510682f80d1c72c12b84cf272db670d963a2f005c26fdf8268fbd494b1e6f3", size = 241333, upload-time = "2025-09-25T23:25:43.928Z" },
+    { url = "https://files.pythonhosted.org/packages/13/39/a94a4152c0ff1b6a5febb5d537669a58c428314386fb2f9e66f71d20dca5/clickhouse_connect-0.9.2-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:169fb9d9cf191095d4d06622af856d3c38a5fd4dba3f53f203dd2ac9807858c4", size = 237509, upload-time = "2025-09-25T23:25:45.328Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/fc/be625a62bbf73371ae1033ce235351273696372ec0e5d320d038d6578199/clickhouse_connect-0.9.2-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ebc8517d00e94d3677382d01b9c4ff10e212183ec05a72e774dec78b75458fa0", size = 266215, upload-time = "2025-09-25T23:25:46.756Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/d8/31011bb0bd73e3d7a0a5de667ea669a53ffa12f5eef1253aebf147470a55/clickhouse_connect-0.9.2-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:19aa0bdfcb93117243a657df2d0f3c4dbf4849d6295afc199efbf680de43daf9", size = 273413, upload-time = "2025-09-25T23:25:48.37Z" },
+    { url = "https://files.pythonhosted.org/packages/91/be/7444016869001f0693a281c9e9e5a792711280d6e74470c04d2ad5e386fc/clickhouse_connect-0.9.2-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2b1cb1542c2e6d1ede32c3d7aed86c06bafe6b5a9d4bb645b5c04f48389f8a4a", size = 279541, upload-time = "2025-09-25T23:25:50.121Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/1b/3b3f775047f4ab15873d903501948508fa7dd245ec90a3a93409759ca269/clickhouse_connect-0.9.2-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:db2719ada3cf51aa94d98a4fb01778e795a26b1dbd5843d87d5f89120ef5bed6", size = 245155, upload-time = "2025-09-25T23:25:51.531Z" },
+]
+
+[[package]]
+name = "clickhouse-connect"
 version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version == '3.13.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version < '3.11' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+]
 dependencies = [
     { name = "certifi" },
-    { name = "lz4", version = "4.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "lz4", version = "4.4.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
+    { name = "lz4", version = "4.4.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and python_full_version < '3.14') or (python_full_version < '3.11' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version >= '3.14' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "lz4", version = "4.4.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (python_full_version >= '3.14' and extra != 'extra-4-daft-paimon') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
     { name = "pytz" },
     { name = "urllib3" },
-    { name = "zstandard", version = "0.24.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "zstandard", version = "0.25.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
+    { name = "zstandard", version = "0.24.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and python_full_version < '3.14') or (python_full_version < '3.11' and extra == 'extra-4-daft-paimon') or (python_full_version >= '3.14' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "zstandard", version = "0.25.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'group-4-daft-dev') or (python_full_version < '3.11' and extra != 'extra-4-daft-paimon') or (python_full_version >= '3.14' and extra == 'group-4-daft-dev') or (python_full_version >= '3.14' and extra != 'extra-4-daft-paimon') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/01/27/ed733561fe9ea78318900545671c33df5a44476e4ea35561b3a7b49662b0/clickhouse_connect-0.11.0.tar.gz", hash = "sha256:2dd49ac4d0d59a836ceda8b2c6b7f348accf2512f81d46543fc33f3b64c55152", size = 111237, upload-time = "2026-02-11T00:48:17.614Z" }
 wheels = [
@@ -1320,12 +1564,18 @@ toml = [
 ]
 
 [[package]]
+name = "crcmod"
+version = "1.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/b0/e595ce2a2527e169c3bcd6c33d2473c1918e0b7f6826a043ca1245dd4e5b/crcmod-1.7.tar.gz", hash = "sha256:dc7051a0db5f2bd48665a990d3ec1cc305a466a77358ca4492826f41f283601e", size = 89670, upload-time = "2010-06-27T14:35:29.538Z" }
+
+[[package]]
 name = "cryptography"
 version = "46.0.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/60/04/ee2a9e8542e4fa2773b81771ff8349ff19cdd56b7258a0cc442639052edb/cryptography-46.0.5.tar.gz", hash = "sha256:abace499247268e3757271b2f1e244b36b06f8515cf27c4d49468fc9eb16e93d", size = 750064, upload-time = "2026-02-10T19:18:38.255Z" }
 wheels = [
@@ -1391,8 +1641,8 @@ version = "13.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastrlock", marker = "sys_platform != 'darwin'" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13' and sys_platform != 'darwin'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' and sys_platform != 'darwin'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and sys_platform != 'darwin' and extra == 'group-4-daft-dev') or (python_full_version >= '3.13' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and sys_platform != 'darwin' and extra == 'group-4-daft-dev') or (python_full_version < '3.13' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/2e/db22c5148884e4e384f6ebbc7971fa3710f3ba67ca492798890a0fdebc45/cupy_cuda12x-13.6.0-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:9e37f60f27ff9625dfdccc4688a09852707ec613e32ea9404f425dd22a386d14", size = 126341714, upload-time = "2025-08-18T08:24:08.335Z" },
@@ -1413,37 +1663,43 @@ wheels = [
 name = "daft"
 source = { editable = "." }
 dependencies = [
-    { name = "fsspec" },
+    { name = "fsspec", version = "2024.3.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-4-daft-paimon'" },
+    { name = "fsspec", version = "2024.9.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'group-4-daft-dev' or extra != 'extra-4-daft-paimon'" },
     { name = "packaging" },
-    { name = "pyarrow" },
+    { name = "pyarrow", version = "16.0.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-4-daft-paimon'" },
+    { name = "pyarrow", version = "22.0.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'group-4-daft-dev' or extra != 'extra-4-daft-paimon'" },
     { name = "tqdm" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 
 [package.optional-dependencies]
 all = [
     { name = "av" },
     { name = "boto3" },
-    { name = "clickhouse-connect" },
+    { name = "clickhouse-connect", version = "0.9.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra == 'extra-4-daft-paimon') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "clickhouse-connect", version = "0.11.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or extra != 'extra-4-daft-paimon' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
     { name = "connectorx" },
-    { name = "datasets" },
+    { name = "datasets", version = "4.0.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-4-daft-paimon'" },
+    { name = "datasets", version = "4.5.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'group-4-daft-dev' or extra != 'extra-4-daft-paimon'" },
     { name = "deltalake" },
     { name = "google-genai" },
     { name = "httpx" },
     { name = "huggingface-hub" },
     { name = "mypy-boto3-glue" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'extra-4-daft-paimon') or (python_full_version < '3.13' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev')" },
     { name = "openai" },
-    { name = "pandas", version = "2.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "pandas", version = "2.2.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "pandas", version = "2.3.2", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-4-daft-paimon'" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra != 'extra-4-daft-paimon') or (extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
     { name = "pgvector" },
     { name = "pillow" },
     { name = "psycopg", extra = ["binary"] },
-    { name = "pyarrow" },
-    { name = "pyiceberg" },
+    { name = "pyarrow", version = "16.0.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-4-daft-paimon'" },
+    { name = "pyarrow", version = "22.0.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'group-4-daft-dev' or extra != 'extra-4-daft-paimon'" },
+    { name = "pyiceberg", version = "0.7.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-4-daft-paimon'" },
+    { name = "pyiceberg", version = "0.11.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'group-4-daft-dev' or extra != 'extra-4-daft-paimon'" },
     { name = "pylance" },
-    { name = "pypaimon" },
     { name = "ray", extra = ["client", "data"] },
     { name = "requests" },
     { name = "sentence-transformers" },
@@ -1464,40 +1720,44 @@ aws = [
     { name = "mypy-boto3-glue" },
 ]
 clickhouse = [
-    { name = "clickhouse-connect" },
+    { name = "clickhouse-connect", version = "0.9.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra == 'extra-4-daft-paimon') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "clickhouse-connect", version = "0.11.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or extra != 'extra-4-daft-paimon' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 deltalake = [
     { name = "deltalake" },
 ]
 google = [
     { name = "google-genai" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'extra-4-daft-paimon') or (python_full_version < '3.13' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev')" },
     { name = "pillow" },
 ]
 gravitino = [
     { name = "requests" },
 ]
 hudi = [
-    { name = "pyarrow" },
+    { name = "pyarrow", version = "16.0.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-4-daft-paimon'" },
+    { name = "pyarrow", version = "22.0.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'group-4-daft-dev' or extra != 'extra-4-daft-paimon'" },
 ]
 huggingface = [
-    { name = "datasets" },
+    { name = "datasets", version = "4.0.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-4-daft-paimon'" },
+    { name = "datasets", version = "4.5.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'group-4-daft-dev' or extra != 'extra-4-daft-paimon'" },
     { name = "huggingface-hub" },
 ]
 iceberg = [
-    { name = "pyiceberg" },
+    { name = "pyiceberg", version = "0.7.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-4-daft-paimon'" },
+    { name = "pyiceberg", version = "0.11.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'group-4-daft-dev' or extra != 'extra-4-daft-paimon'" },
 ]
 lance = [
     { name = "pylance" },
 ]
 numpy = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'extra-4-daft-paimon') or (python_full_version < '3.13' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev')" },
 ]
 openai = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'extra-4-daft-paimon') or (python_full_version < '3.13' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev')" },
     { name = "openai" },
     { name = "pillow" },
 ]
@@ -1505,8 +1765,9 @@ paimon = [
     { name = "pypaimon" },
 ]
 pandas = [
-    { name = "pandas", version = "2.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "pandas", version = "2.2.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "pandas", version = "2.3.2", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-4-daft-paimon'" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra != 'extra-4-daft-paimon') or (extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 postgres = [
     { name = "connectorx" },
@@ -1548,12 +1809,12 @@ dev = [
     { name = "av" },
     { name = "azure-storage-blob" },
     { name = "boto3" },
-    { name = "boto3-stubs", extra = ["essential", "glue", "s3", "s3tables"] },
-    { name = "clickhouse-connect" },
+    { name = "boto3-stubs", extra = ["essential", "glue", "s3", "s3tables"], marker = "extra == 'group-4-daft-dev'" },
+    { name = "clickhouse-connect", version = "0.11.0", source = { registry = "https://pypi.org/simple" } },
     { name = "connectorx" },
-    { name = "dask", extra = ["dataframe"] },
+    { name = "dask", extra = ["dataframe"], marker = "extra == 'group-4-daft-dev'" },
     { name = "databricks-sdk" },
-    { name = "datasets" },
+    { name = "datasets", version = "4.5.0", source = { registry = "https://pypi.org/simple" } },
     { name = "deltalake" },
     { name = "docker" },
     { name = "duckdb" },
@@ -1573,23 +1834,23 @@ dev = [
     { name = "mcap-protobuf-support" },
     { name = "mcap-ros2-support" },
     { name = "memray", marker = "sys_platform != 'win32'" },
-    { name = "moto", extra = ["glue", "s3", "server"] },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "moto", extra = ["glue", "s3", "server"], marker = "extra == 'group-4-daft-dev'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
     { name = "openai" },
     { name = "opencv-python" },
     { name = "orjson" },
-    { name = "pandas", version = "2.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "pandas", version = "2.2.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
     { name = "pandas-stubs" },
     { name = "pillow" },
     { name = "pre-commit" },
     { name = "psycopg2-binary" },
     { name = "py-spy" },
-    { name = "pyarrow" },
+    { name = "pyarrow", version = "22.0.0", source = { registry = "https://pypi.org/simple" } },
     { name = "pyarrow-stubs" },
     { name = "pydantic" },
-    { name = "pyiceberg" },
+    { name = "pyiceberg", version = "0.11.0", source = { registry = "https://pypi.org/simple" } },
     { name = "pylance" },
     { name = "pymysql" },
     { name = "pyodbc" },
@@ -1598,18 +1859,18 @@ dev = [
     { name = "pytest-codspeed" },
     { name = "pytest-cov" },
     { name = "pytest-profiling" },
-    { name = "pytest-xdist", extra = ["psutil"] },
-    { name = "ray", extra = ["client", "data"] },
+    { name = "pytest-xdist", extra = ["psutil"], marker = "extra == 'group-4-daft-dev'" },
+    { name = "ray", extra = ["client", "data"], marker = "extra == 'group-4-daft-dev'" },
     { name = "reportlab" },
     { name = "s3fs" },
     { name = "soundfile" },
     { name = "sqlalchemy" },
     { name = "sqlglot" },
-    { name = "tenacity" },
+    { name = "tenacity", version = "9.1.4", source = { registry = "https://pypi.org/simple" } },
     { name = "tiktoken" },
     { name = "torch" },
     { name = "torchvision" },
-    { name = "trino", extra = ["sqlalchemy"] },
+    { name = "trino", extra = ["sqlalchemy"], marker = "extra == 'group-4-daft-dev'" },
     { name = "unitycatalog" },
     { name = "viztracer" },
     { name = "vllm" },
@@ -1644,7 +1905,7 @@ requires-dist = [
     { name = "clickhouse-connect", marker = "extra == 'clickhouse'", specifier = "<0.12.0" },
     { name = "connectorx", marker = "extra == 'postgres'", specifier = ">=0.4.4,<0.5.0" },
     { name = "connectorx", marker = "extra == 'sql'", specifier = ">=0.4.4,<0.5.0" },
-    { name = "daft", extras = ["aws", "azure", "clickhouse", "deltalake", "gcp", "google", "gravitino", "hudi", "huggingface", "iceberg", "lance", "numpy", "openai", "paimon", "pandas", "postgres", "ray", "sentence-transformers", "sql", "transformers", "turbopuffer", "unity", "video"], marker = "extra == 'all'" },
+    { name = "daft", extras = ["aws", "azure", "clickhouse", "deltalake", "gcp", "google", "gravitino", "hudi", "huggingface", "iceberg", "lance", "numpy", "openai", "pandas", "postgres", "ray", "sentence-transformers", "sql", "transformers", "turbopuffer", "unity", "video"], marker = "extra == 'all'" },
     { name = "datasets", marker = "extra == 'huggingface'", specifier = "<4.6.0" },
     { name = "deltalake", marker = "extra == 'deltalake'", specifier = ">=1.5.0,<1.6.0" },
     { name = "deltalake", marker = "extra == 'unity'", specifier = ">=1.5.0,<1.6.0" },
@@ -1669,7 +1930,7 @@ requires-dist = [
     { name = "pyarrow", marker = "extra == 'hudi'", specifier = ">=8.0.0,<22.1.0" },
     { name = "pyiceberg", marker = "extra == 'iceberg'", specifier = ">=0.7.0,!=0.9.1,!=0.10.0,<=0.11.0" },
     { name = "pylance", marker = "extra == 'lance'", specifier = "<0.40.0" },
-    { name = "pypaimon", marker = "extra == 'paimon'", specifier = ">=0.2.0,<1.4.0" },
+    { name = "pypaimon", marker = "extra == 'paimon'", specifier = ">=1.3.1,<1.4.0" },
     { name = "ray", extras = ["data", "client"], marker = "sys_platform == 'win32' and extra == 'ray'", specifier = ">=2.10.0,<2.54.0" },
     { name = "ray", extras = ["data", "client"], marker = "sys_platform != 'win32' and extra == 'ray'", specifier = ">=2.0.0,<2.54.0" },
     { name = "requests", marker = "extra == 'gravitino'", specifier = ">=2.28.0,<3.0.0" },
@@ -1792,7 +2053,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "cloudpickle" },
-    { name = "fsspec" },
+    { name = "fsspec", version = "2024.9.0", source = { registry = "https://pypi.org/simple" } },
     { name = "importlib-metadata", marker = "python_full_version < '3.12'" },
     { name = "packaging" },
     { name = "partd" },
@@ -1806,11 +2067,11 @@ wheels = [
 
 [package.optional-dependencies]
 dataframe = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
-    { name = "pandas", version = "2.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
-    { name = "pyarrow" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "pandas", version = "2.2.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "pyarrow", version = "22.0.0", source = { registry = "https://pypi.org/simple" } },
 ]
 
 [[package]]
@@ -1819,8 +2080,8 @@ version = "0.88.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-auth" },
-    { name = "protobuf", version = "5.29.6", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "protobuf", version = "6.33.5", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'darwin'" },
+    { name = "protobuf", version = "5.29.6", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform == 'darwin' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "protobuf", version = "6.33.5", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'darwin' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
     { name = "requests" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d7/ef/4a970033e1ab97a1fea2d93d696bce646339fedf53641935f68573941bae/databricks_sdk-0.88.0.tar.gz", hash = "sha256:1d7d90656b418e488e7f72c872e85a1a1fe4d2d3c0305fd02d5b866f79b769a9", size = 848237, upload-time = "2026-02-12T08:22:04.717Z" }
@@ -1830,21 +2091,100 @@ wheels = [
 
 [[package]]
 name = "datasets"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version < '3.11' and sys_platform == 'win32'",
+]
+dependencies = [
+    { name = "dill", marker = "extra == 'extra-4-daft-paimon'" },
+    { name = "filelock", marker = "extra == 'extra-4-daft-paimon'" },
+    { name = "fsspec", version = "2024.3.1", source = { registry = "https://pypi.org/simple" }, extra = ["http"], marker = "extra == 'extra-4-daft-paimon'" },
+    { name = "huggingface-hub", marker = "extra == 'extra-4-daft-paimon'" },
+    { name = "multiprocess", marker = "extra == 'extra-4-daft-paimon'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'extra-4-daft-paimon') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra == 'extra-4-daft-paimon') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "packaging", marker = "extra == 'extra-4-daft-paimon'" },
+    { name = "pandas", version = "2.3.2", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-4-daft-paimon'" },
+    { name = "pyarrow", version = "16.0.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-4-daft-paimon'" },
+    { name = "pyyaml", marker = "extra == 'extra-4-daft-paimon'" },
+    { name = "requests", marker = "extra == 'extra-4-daft-paimon'" },
+    { name = "tqdm", marker = "extra == 'extra-4-daft-paimon'" },
+    { name = "xxhash", marker = "extra == 'extra-4-daft-paimon'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e3/9d/348ed92110ba5f9b70b51ca1078d4809767a835aa2b7ce7e74ad2b98323d/datasets-4.0.0.tar.gz", hash = "sha256:9657e7140a9050db13443ba21cb5de185af8af944479b00e7ff1e00a61c8dbf1", size = 569566, upload-time = "2025-07-09T14:35:52.431Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/62/eb8157afb21bd229c864521c1ab4fa8e9b4f1b06bafdd8c4668a7a31b5dd/datasets-4.0.0-py3-none-any.whl", hash = "sha256:7ef95e62025fd122882dbce6cb904c8cd3fbc829de6669a5eb939c77d50e203d", size = 494825, upload-time = "2025-07-09T14:35:50.658Z" },
+]
+
+[[package]]
+name = "datasets"
 version = "4.5.0"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version == '3.13.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version < '3.11' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+]
 dependencies = [
     { name = "dill" },
     { name = "filelock" },
-    { name = "fsspec", extra = ["http"] },
+    { name = "fsspec", version = "2024.9.0", source = { registry = "https://pypi.org/simple" }, extra = ["http"], marker = "extra == 'group-4-daft-dev' or extra != 'extra-4-daft-paimon'" },
     { name = "httpx" },
     { name = "huggingface-hub" },
     { name = "multiprocess" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra != 'extra-4-daft-paimon') or (extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
     { name = "packaging" },
-    { name = "pandas", version = "2.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
-    { name = "pyarrow" },
+    { name = "pandas", version = "2.2.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra != 'extra-4-daft-paimon') or (extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "pyarrow", version = "22.0.0", source = { registry = "https://pypi.org/simple" } },
     { name = "pyyaml" },
     { name = "requests" },
     { name = "tqdm" },
@@ -2069,7 +2409,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -2111,11 +2451,11 @@ wheels = [
 [package.optional-dependencies]
 standard = [
     { name = "email-validator" },
-    { name = "fastapi-cli", extra = ["standard"] },
+    { name = "fastapi-cli", extra = ["standard"], marker = "extra == 'group-4-daft-dev'" },
     { name = "httpx" },
     { name = "jinja2" },
     { name = "python-multipart" },
-    { name = "uvicorn", extra = ["standard"] },
+    { name = "uvicorn", extra = ["standard"], marker = "extra == 'group-4-daft-dev'" },
 ]
 
 [[package]]
@@ -2125,7 +2465,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "rich-toolkit" },
     { name = "typer" },
-    { name = "uvicorn", extra = ["standard"] },
+    { name = "uvicorn", extra = ["standard"], marker = "extra == 'group-4-daft-dev'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cc/13/11e43d630be84e51ba5510a6da6a11eb93b44b72caa796137c5dddda937b/fastapi_cli-0.0.14.tar.gz", hash = "sha256:ddfb5de0a67f77a8b3271af1460489bd4d7f4add73d11fbfac613827b0275274", size = 17994, upload-time = "2025-10-20T16:33:21.054Z" }
 wheels = [
@@ -2135,7 +2475,7 @@ wheels = [
 [package.optional-dependencies]
 standard = [
     { name = "fastapi-cloud-cli" },
-    { name = "uvicorn", extra = ["standard"] },
+    { name = "uvicorn", extra = ["standard"], marker = "extra == 'group-4-daft-dev'" },
 ]
 
 [[package]]
@@ -2144,16 +2484,53 @@ version = "0.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
-    { name = "pydantic", extra = ["email"] },
+    { name = "pydantic", extra = ["email"], marker = "extra == 'group-4-daft-dev'" },
     { name = "rich-toolkit" },
     { name = "rignore" },
     { name = "sentry-sdk" },
     { name = "typer" },
-    { name = "uvicorn", extra = ["standard"] },
+    { name = "uvicorn", extra = ["standard"], marker = "extra == 'group-4-daft-dev'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f9/48/0f14d8555b750dc8c04382804e4214f1d7f55298127f3a0237ba566e69dd/fastapi_cloud_cli-0.3.1.tar.gz", hash = "sha256:8c7226c36e92e92d0c89827e8f56dbf164ab2de4444bd33aa26b6c3f7675db69", size = 24080, upload-time = "2025-10-09T11:32:58.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/68/79/7f5a5e5513e6a737e5fb089d9c59c74d4d24dc24d581d3aa519b326bedda/fastapi_cloud_cli-0.3.1-py3-none-any.whl", hash = "sha256:7d1a98a77791a9d0757886b2ffbf11bcc6b3be93210dd15064be10b216bf7e00", size = 19711, upload-time = "2025-10-09T11:32:57.118Z" },
+]
+
+[[package]]
+name = "fastavro"
+version = "1.11.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/8f/32664a3245247b13702d13d2657ea534daf64e58a3f72a3a2d10598d6916/fastavro-1.11.1.tar.gz", hash = "sha256:bf6acde5ee633a29fb8dfd6dfea13b164722bc3adc05a0e055df080549c1c2f8", size = 1016250, upload-time = "2025-05-18T04:54:31.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/be/53df3fec7fdabc1848896a76afb0f01ab96b58abb29611aa68a994290167/fastavro-1.11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:603aa1c1d1be21fb4bcb63e1efb0711a9ddb337de81391c32dac95c6e0dacfcc", size = 944225, upload-time = "2025-05-18T04:54:34.586Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cc/c7c76a082fbf5aaaf82ab7da7b9ede6fc99eb8f008c084c67d230b29c446/fastavro-1.11.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:45653b312d4ce297e2bd802ea3ffd17ecbe718e5e8b6e2ae04cd72cb50bb99d5", size = 3105189, upload-time = "2025-05-18T04:54:36.855Z" },
+    { url = "https://files.pythonhosted.org/packages/48/ff/5f1f0b5e3835e788ba8121d6dd6426cd4c6e58ce1bff02cb7810278648b0/fastavro-1.11.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:998a53fc552e6bee9acda32af258f02557313c85fb5b48becba5b71ec82f421e", size = 3113124, upload-time = "2025-05-18T04:54:40.013Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/b8/1ac01433b55460dabeb6d3fbb05ba1c971d57137041e8f53b2e9f46cd033/fastavro-1.11.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:9f878c9ad819467120cb066f1c73496c42eb24ecdd7c992ec996f465ef4cedad", size = 3155196, upload-time = "2025-05-18T04:54:42.307Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/a8/66e599b946ead031a5caba12772e614a7802d95476e8732e2e9481369973/fastavro-1.11.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:da9e4c231ac4951092c2230ca423d8a3f2966718f072ac1e2c5d2d44c70b2a50", size = 3229028, upload-time = "2025-05-18T04:54:44.503Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/e7/17c35e2dfe8a9e4f3735eabdeec366b0edc4041bb1a84fcd528c8efd12af/fastavro-1.11.1-cp310-cp310-win_amd64.whl", hash = "sha256:7423bfad3199567eeee7ad6816402c7c0ee1658b959e8c10540cfbc60ce96c2a", size = 449177, upload-time = "2025-05-18T04:54:46.127Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/63/f33d6fd50d8711f305f07ad8c7b4a25f2092288f376f484c979dcf277b07/fastavro-1.11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:3573340e4564e8962e22f814ac937ffe0d4be5eabbd2250f77738dc47e3c8fe9", size = 957526, upload-time = "2025-05-18T04:54:47.701Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/09/a57ad9d8cb9b8affb2e43c29d8fb8cbdc0f1156f8496067a0712c944bacc/fastavro-1.11.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7291cf47735b8bd6ff5d9b33120e6e0974f52fd5dff90cd24151b22018e7fd29", size = 3322808, upload-time = "2025-05-18T04:54:50.419Z" },
+    { url = "https://files.pythonhosted.org/packages/86/70/d6df59309d3754d6d4b0c7beca45b9b1a957d6725aed8da3aca247db3475/fastavro-1.11.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bf3bb065d657d5bac8b2cb39945194aa086a9b3354f2da7f89c30e4dc20e08e2", size = 3330870, upload-time = "2025-05-18T04:54:52.406Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/ea/122315154d2a799a2787058435ef0d4d289c0e8e575245419436e9b702ca/fastavro-1.11.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8758317c85296b848698132efb13bc44a4fbd6017431cc0f26eaeb0d6fa13d35", size = 3343369, upload-time = "2025-05-18T04:54:54.652Z" },
+    { url = "https://files.pythonhosted.org/packages/62/12/7800de5fec36d55a818adf3db3b085b1a033c4edd60323cf6ca0754cf8cb/fastavro-1.11.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ad99d57228f83bf3e2214d183fbf6e2fda97fd649b2bdaf8e9110c36cbb02624", size = 3430629, upload-time = "2025-05-18T04:54:56.513Z" },
+    { url = "https://files.pythonhosted.org/packages/48/65/2b74ccfeba9dcc3f7dbe64907307386b4a0af3f71d2846f63254df0f1e1d/fastavro-1.11.1-cp311-cp311-win_amd64.whl", hash = "sha256:9134090178bdbf9eefd467717ced3dc151e27a7e7bfc728260ce512697efe5a4", size = 451621, upload-time = "2025-05-18T04:54:58.156Z" },
+    { url = "https://files.pythonhosted.org/packages/99/58/8e789b0a2f532b22e2d090c20d27c88f26a5faadcba4c445c6958ae566cf/fastavro-1.11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e8bc238f2637cd5d15238adbe8fb8c58d2e6f1870e0fb28d89508584670bae4b", size = 939583, upload-time = "2025-05-18T04:54:59.853Z" },
+    { url = "https://files.pythonhosted.org/packages/34/3f/02ed44742b1224fe23c9fc9b9b037fc61769df716c083cf80b59a02b9785/fastavro-1.11.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b403933081c83fc4d8a012ee64b86e560a024b1280e3711ee74f2abc904886e8", size = 3257734, upload-time = "2025-05-18T04:55:02.366Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/bc/9cc8b19eeee9039dd49719f8b4020771e805def262435f823fa8f27ddeea/fastavro-1.11.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3f6ecb4b5f77aa756d973b7dd1c2fb4e4c95b4832a3c98b059aa96c61870c709", size = 3318218, upload-time = "2025-05-18T04:55:04.352Z" },
+    { url = "https://files.pythonhosted.org/packages/39/77/3b73a986606494596b6d3032eadf813a05b59d1623f54384a23de4217d5f/fastavro-1.11.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:059893df63ef823b0231b485c9d43016c7e32850cae7bf69f4e9d46dd41c28f2", size = 3297296, upload-time = "2025-05-18T04:55:06.175Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/1c/b69ceef6494bd0df14752b5d8648b159ad52566127bfd575e9f5ecc0c092/fastavro-1.11.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5120ffc9a200699218e01777e695a2f08afb3547ba818184198c757dc39417bd", size = 3438056, upload-time = "2025-05-18T04:55:08.276Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/11/5c2d0db3bd0e6407546fabae9e267bb0824eacfeba79e7dd81ad88afa27d/fastavro-1.11.1-cp312-cp312-win_amd64.whl", hash = "sha256:7bb9d0d2233f33a52908b6ea9b376fe0baf1144bdfdfb3c6ad326e200a8b56b0", size = 442824, upload-time = "2025-05-18T04:55:10.385Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/08/8e25b9e87a98f8c96b25e64565fa1a1208c0095bb6a84a5c8a4b925688a5/fastavro-1.11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f963b8ddaf179660e814ab420850c1b4ea33e2ad2de8011549d958b21f77f20a", size = 931520, upload-time = "2025-05-18T04:55:11.614Z" },
+    { url = "https://files.pythonhosted.org/packages/02/ee/7cf5561ef94781ed6942cee6b394a5e698080f4247f00f158ee396ec244d/fastavro-1.11.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0253e5b6a3c9b62fae9fc3abd8184c5b64a833322b6af7d666d3db266ad879b5", size = 3195989, upload-time = "2025-05-18T04:55:13.732Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/31/f02f097d79f090e5c5aca8a743010c4e833a257c0efdeb289c68294f7928/fastavro-1.11.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca637b150e1f4c0e8e564fad40a16bd922bcb7ffd1a6e4836e6084f2c4f4e8db", size = 3239755, upload-time = "2025-05-18T04:55:16.463Z" },
+    { url = "https://files.pythonhosted.org/packages/09/4c/46626b4ee4eb8eb5aa7835973c6ba8890cf082ef2daface6071e788d2992/fastavro-1.11.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:76af1709031621828ca6ce7f027f7711fa33ac23e8269e7a5733996ff8d318da", size = 3243788, upload-time = "2025-05-18T04:55:18.544Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/6f/8ed42524e9e8dc0554f0f211dd1c6c7a9dde83b95388ddcf7c137e70796f/fastavro-1.11.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8224e6d8d9864d4e55dafbe88920d6a1b8c19cc3006acfac6aa4f494a6af3450", size = 3378330, upload-time = "2025-05-18T04:55:20.887Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/51/38cbe243d5facccab40fc43a4c17db264c261be955ce003803d25f0da2c3/fastavro-1.11.1-cp313-cp313-win_amd64.whl", hash = "sha256:cde7ed91b52ff21f0f9f157329760ba7251508ca3e9618af3ffdac986d9faaa2", size = 443115, upload-time = "2025-05-18T04:55:22.107Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/57/0d31ed1a49c65ad9f0f0128d9a928972878017781f9d4336f5f60982334c/fastavro-1.11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:e5ed1325c1c414dd954e7a2c5074daefe1eceb672b8c727aa030ba327aa00693", size = 1021401, upload-time = "2025-05-18T04:55:23.431Z" },
+    { url = "https://files.pythonhosted.org/packages/56/7a/a3f1a75fbfc16b3eff65dc0efcdb92364967923194312b3f8c8fc2cb95be/fastavro-1.11.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8cd3c95baeec37188899824faf44a5ee94dfc4d8667b05b2f867070c7eb174c4", size = 3384349, upload-time = "2025-05-18T04:55:25.575Z" },
+    { url = "https://files.pythonhosted.org/packages/be/84/02bceb7518867df84027232a75225db758b9b45f12017c9743f45b73101e/fastavro-1.11.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2e0babcd81acceb4c60110af9efa25d890dbb68f7de880f806dadeb1e70fe413", size = 3240658, upload-time = "2025-05-18T04:55:27.633Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/17/508c846c644d39bc432b027112068b8e96e7560468304d4c0757539dd73a/fastavro-1.11.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:b2c0cb8063c7208b53b6867983dc6ae7cc80b91116b51d435d2610a5db2fc52f", size = 3372809, upload-time = "2025-05-18T04:55:30.063Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/84/9c2917a70ed570ddbfd1d32ac23200c1d011e36c332e59950d2f6d204941/fastavro-1.11.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:1bc2824e9969c04ab6263d269a1e0e5d40b9bd16ade6b70c29d6ffbc4f3cc102", size = 3387171, upload-time = "2025-05-18T04:55:32.531Z" },
 ]
 
 [[package]]
@@ -2171,6 +2548,7 @@ version = "0.8.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/73/b1/1c3d635d955f2b4bf34d45abf8f35492e04dbd7804e94ce65d9f928ef3ec/fastrlock-0.8.3.tar.gz", hash = "sha256:4af6734d92eaa3ab4373e6c9a1dd0d5ad1304e172b1521733c6c3b3d73c8fa5d", size = 79327, upload-time = "2024-12-17T11:03:39.638Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/02/3f771177380d8690812d5b2b7736dc6b6c8cd1c317e4572e65f823eede08/fastrlock-0.8.3-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:cc5fa9166e05409f64a804d5b6d01af670979cdb12cd2594f555cb33cdc155bd", size = 55094, upload-time = "2024-12-17T11:01:49.721Z" },
     { url = "https://files.pythonhosted.org/packages/be/b4/aae7ed94b8122c325d89eb91336084596cebc505dc629b795fcc9629606d/fastrlock-0.8.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:7a77ebb0a24535ef4f167da2c5ee35d9be1e96ae192137e9dc3ff75b8dfc08a5", size = 48220, upload-time = "2024-12-17T11:01:51.071Z" },
     { url = "https://files.pythonhosted.org/packages/96/87/9807af47617fdd65c68b0fcd1e714542c1d4d3a1f1381f591f1aa7383a53/fastrlock-0.8.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_24_i686.whl", hash = "sha256:d51f7fb0db8dab341b7f03a39a3031678cf4a98b18533b176c533c122bfce47d", size = 49551, upload-time = "2024-12-17T11:01:52.316Z" },
     { url = "https://files.pythonhosted.org/packages/9d/12/e201634810ac9aee59f93e3953cb39f98157d17c3fc9d44900f1209054e9/fastrlock-0.8.3-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:767ec79b7f6ed9b9a00eb9ff62f2a51f56fdb221c5092ab2dadec34a9ccbfc6e", size = 49398, upload-time = "2024-12-17T11:01:53.514Z" },
@@ -2178,6 +2556,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b5/9e/1ae90829dd40559ab104e97ebe74217d9da794c4bb43016da8367ca7a596/fastrlock-0.8.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:92577ff82ef4a94c5667d6d2841f017820932bc59f31ffd83e4a2c56c1738f90", size = 52495, upload-time = "2024-12-17T11:01:57.76Z" },
     { url = "https://files.pythonhosted.org/packages/e5/8c/5e746ee6f3d7afbfbb0d794c16c71bfd5259a4e3fb1dda48baf31e46956c/fastrlock-0.8.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:3df8514086e16bb7c66169156a8066dc152f3be892c7817e85bf09a27fa2ada2", size = 51972, upload-time = "2024-12-17T11:02:01.384Z" },
     { url = "https://files.pythonhosted.org/packages/76/a7/8b91068f00400931da950f143fa0f9018bd447f8ed4e34bed3fe65ed55d2/fastrlock-0.8.3-cp310-cp310-win_amd64.whl", hash = "sha256:001fd86bcac78c79658bac496e8a17472d64d558cd2227fdc768aa77f877fe40", size = 30946, upload-time = "2024-12-17T11:02:03.491Z" },
+    { url = "https://files.pythonhosted.org/packages/90/9e/647951c579ef74b6541493d5ca786d21a0b2d330c9514ba2c39f0b0b0046/fastrlock-0.8.3-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:f68c551cf8a34b6460a3a0eba44bd7897ebfc820854e19970c52a76bf064a59f", size = 55233, upload-time = "2024-12-17T11:02:04.795Z" },
     { url = "https://files.pythonhosted.org/packages/be/91/5f3afba7d14b8b7d60ac651375f50fff9220d6ccc3bef233d2bd74b73ec7/fastrlock-0.8.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:55d42f6286b9d867370af4c27bc70d04ce2d342fe450c4a4fcce14440514e695", size = 48911, upload-time = "2024-12-17T11:02:06.173Z" },
     { url = "https://files.pythonhosted.org/packages/d5/7a/e37bd72d7d70a8a551b3b4610d028bd73ff5d6253201d5d3cf6296468bee/fastrlock-0.8.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_24_i686.whl", hash = "sha256:bbc3bf96dcbd68392366c477f78c9d5c47e5d9290cb115feea19f20a43ef6d05", size = 50357, upload-time = "2024-12-17T11:02:07.418Z" },
     { url = "https://files.pythonhosted.org/packages/0d/ef/a13b8bab8266840bf38831d7bf5970518c02603d00a548a678763322d5bf/fastrlock-0.8.3-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:77ab8a98417a1f467dafcd2226718f7ca0cf18d4b64732f838b8c2b3e4b55cb5", size = 50222, upload-time = "2024-12-17T11:02:08.745Z" },
@@ -2185,11 +2564,13 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c0/8f/65907405a8cdb2fc8beaf7d09a9a07bb58deff478ff391ca95be4f130b70/fastrlock-0.8.3-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:8c9d459ce344c21ff03268212a1845aa37feab634d242131bc16c2a2355d5f65", size = 53362, upload-time = "2024-12-17T11:02:12.476Z" },
     { url = "https://files.pythonhosted.org/packages/ec/b9/ae6511e52738ba4e3a6adb7c6a20158573fbc98aab448992ece25abb0b07/fastrlock-0.8.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:33e6fa4af4f3af3e9c747ec72d1eadc0b7ba2035456c2afb51c24d9e8a56f8fd", size = 52836, upload-time = "2024-12-17T11:02:13.74Z" },
     { url = "https://files.pythonhosted.org/packages/88/3e/c26f8192c93e8e43b426787cec04bb46ac36e72b1033b7fe5a9267155fdf/fastrlock-0.8.3-cp311-cp311-win_amd64.whl", hash = "sha256:5e5f1665d8e70f4c5b4a67f2db202f354abc80a321ce5a26ac1493f055e3ae2c", size = 31046, upload-time = "2024-12-17T11:02:15.033Z" },
+    { url = "https://files.pythonhosted.org/packages/00/df/56270f2e10c1428855c990e7a7e5baafa9e1262b8e789200bd1d047eb501/fastrlock-0.8.3-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:8cb2cf04352ea8575d496f31b3b88c42c7976e8e58cdd7d1550dfba80ca039da", size = 55727, upload-time = "2024-12-17T11:02:17.26Z" },
     { url = "https://files.pythonhosted.org/packages/57/21/ea1511b0ef0d5457efca3bf1823effb9c5cad4fc9dca86ce08e4d65330ce/fastrlock-0.8.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:85a49a1f1e020097d087e1963e42cea6f307897d5ebe2cb6daf4af47ffdd3eed", size = 52201, upload-time = "2024-12-17T11:02:19.512Z" },
     { url = "https://files.pythonhosted.org/packages/80/07/cdecb7aa976f34328372f1c4efd6c9dc1b039b3cc8d3f38787d640009a25/fastrlock-0.8.3-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5f13ec08f1adb1aa916c384b05ecb7dbebb8df9ea81abd045f60941c6283a670", size = 53924, upload-time = "2024-12-17T11:02:20.85Z" },
     { url = "https://files.pythonhosted.org/packages/88/6d/59c497f8db9a125066dd3a7442fab6aecbe90d6fec344c54645eaf311666/fastrlock-0.8.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:0ea4e53a04980d646def0f5e4b5e8bd8c7884288464acab0b37ca0c65c482bfe", size = 52140, upload-time = "2024-12-17T11:02:22.263Z" },
     { url = "https://files.pythonhosted.org/packages/62/04/9138943c2ee803d62a48a3c17b69de2f6fa27677a6896c300369e839a550/fastrlock-0.8.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:38340f6635bd4ee2a4fb02a3a725759fe921f2ca846cb9ca44531ba739cc17b4", size = 53261, upload-time = "2024-12-17T11:02:24.418Z" },
     { url = "https://files.pythonhosted.org/packages/e2/4b/db35a52589764c7745a613b6943bbd018f128d42177ab92ee7dde88444f6/fastrlock-0.8.3-cp312-cp312-win_amd64.whl", hash = "sha256:da06d43e1625e2ffddd303edcd6d2cd068e1c486f5fd0102b3f079c44eb13e2c", size = 31235, upload-time = "2024-12-17T11:02:25.708Z" },
+    { url = "https://files.pythonhosted.org/packages/92/74/7b13d836c3f221cff69d6f418f46c2a30c4b1fe09a8ce7db02eecb593185/fastrlock-0.8.3-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:5264088185ca8e6bc83181dff521eee94d078c269c7d557cc8d9ed5952b7be45", size = 54157, upload-time = "2024-12-17T11:02:29.196Z" },
     { url = "https://files.pythonhosted.org/packages/06/77/f06a907f9a07d26d0cca24a4385944cfe70d549a2c9f1c3e3217332f4f12/fastrlock-0.8.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a98ba46b3e14927550c4baa36b752d0d2f7387b8534864a8767f83cce75c160", size = 50954, upload-time = "2024-12-17T11:02:32.12Z" },
     { url = "https://files.pythonhosted.org/packages/f9/4e/94480fb3fd93991dd6f4e658b77698edc343f57caa2870d77b38c89c2e3b/fastrlock-0.8.3-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dbdea6deeccea1917c6017d353987231c4e46c93d5338ca3e66d6cd88fbce259", size = 52535, upload-time = "2024-12-17T11:02:33.402Z" },
     { url = "https://files.pythonhosted.org/packages/7d/a7/ee82bb55b6c0ca30286dac1e19ee9417a17d2d1de3b13bb0f20cefb86086/fastrlock-0.8.3-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:c6e5bfecbc0d72ff07e43fed81671747914d6794e0926700677ed26d894d4f4f", size = 50942, upload-time = "2024-12-17T11:02:34.688Z" },
@@ -2361,8 +2742,76 @@ wheels = [
 
 [[package]]
 name = "fsspec"
+version = "2024.3.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version < '3.11' and sys_platform == 'win32'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/b8/e3ba21f03c00c27adc9a8cd1cab8adfb37b6024757133924a9a4eab63a83/fsspec-2024.3.1.tar.gz", hash = "sha256:f39780e282d7d117ffb42bb96992f8a90795e4d0fb0f661a70ca39fe9c43ded9", size = 170742, upload-time = "2024-03-18T19:35:13.995Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/6d/66d48b03460768f523da62a57a7e14e5e95fdf339d79e996ce3cecda2cdb/fsspec-2024.3.1-py3-none-any.whl", hash = "sha256:918d18d41bf73f0e2b261824baeb1b124bcf771767e3a26425cd7dec3332f512", size = 171991, upload-time = "2024-03-18T19:35:11.259Z" },
+]
+
+[package.optional-dependencies]
+http = [
+    { name = "aiohttp", marker = "extra == 'extra-4-daft-paimon'" },
+]
+
+[[package]]
+name = "fsspec"
 version = "2024.9.0"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version == '3.13.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version < '3.11' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+]
 sdist = { url = "https://files.pythonhosted.org/packages/62/7c/12b0943011daaaa9c35c2a2e22e5eb929ac90002f08f1259d69aedad84de/fsspec-2024.9.0.tar.gz", hash = "sha256:4b0afb90c2f21832df142f292649035d80b421f60a9e1c027802e5a0da2b04e8", size = 286206, upload-time = "2024-09-04T15:06:57.91Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1d/a0/6aaea0c2fbea2f89bfd5db25fb1e3481896a423002ebe4e55288907a97a3/fsspec-2024.9.0-py3-none-any.whl", hash = "sha256:a0947d552d8a6efa72cc2c730b12c41d043509156966cca4fb157b0f2a0c574b", size = 179253, upload-time = "2024-09-04T15:06:55.908Z" },
@@ -2380,7 +2829,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "decorator" },
-    { name = "fsspec" },
+    { name = "fsspec", version = "2024.9.0", source = { registry = "https://pypi.org/simple" } },
     { name = "google-auth" },
     { name = "google-auth-oauthlib" },
     { name = "google-cloud-storage" },
@@ -2396,8 +2845,8 @@ name = "gguf"
 version = "0.17.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
     { name = "pyyaml" },
     { name = "tqdm" },
 ]
@@ -2426,8 +2875,8 @@ dependencies = [
     { name = "google-auth" },
     { name = "googleapis-common-protos" },
     { name = "proto-plus" },
-    { name = "protobuf", version = "5.29.6", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "protobuf", version = "6.33.5", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'darwin'" },
+    { name = "protobuf", version = "5.29.6", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform == 'darwin' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "protobuf", version = "6.33.5", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'darwin' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
     { name = "requests" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/dc/21/e9d043e88222317afdbdb567165fdbc3b0aad90064c7e0c9eb0ad9955ad8/google_api_core-2.25.1.tar.gz", hash = "sha256:d2aaa0b13c78c61cb3f4282c464c046e45fbd75755683c9c525e6e8f7ed0a5e8", size = 165443, upload-time = "2025-06-12T20:52:20.439Z" }
@@ -2437,10 +2886,10 @@ wheels = [
 
 [package.optional-dependencies]
 grpc = [
-    { name = "grpcio", version = "1.68.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "grpcio", version = "1.78.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'darwin'" },
-    { name = "grpcio-status", version = "1.67.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "grpcio-status", version = "1.78.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'darwin'" },
+    { name = "grpcio", version = "1.68.1", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform == 'darwin' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "grpcio", version = "1.78.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'darwin' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "grpcio-status", version = "1.67.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform == 'darwin' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "grpcio-status", version = "1.78.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'darwin' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 
 [[package]]
@@ -2480,14 +2929,14 @@ name = "google-cloud-bigtable"
 version = "2.35.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "google-api-core", extra = ["grpc"] },
+    { name = "google-api-core", extra = ["grpc"], marker = "extra == 'group-4-daft-dev'" },
     { name = "google-auth" },
     { name = "google-cloud-core" },
     { name = "google-crc32c" },
     { name = "grpc-google-iam-v1" },
     { name = "proto-plus" },
-    { name = "protobuf", version = "5.29.6", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "protobuf", version = "6.33.5", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'darwin'" },
+    { name = "protobuf", version = "5.29.6", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform == 'darwin' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "protobuf", version = "6.33.5", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'darwin' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/57/c9/aceae21411b1a77fb4d3cde6e6f461321ee33c65fb8dc53480d4e47e1a55/google_cloud_bigtable-2.35.0.tar.gz", hash = "sha256:f5699012c5fea4bd4bdf7e80e5e3a812a847eb8f41bf8dc2f43095d6d876b83b", size = 775613, upload-time = "2025-12-17T15:18:14.303Z" }
 wheels = [
@@ -2571,7 +3020,8 @@ dependencies = [
     { name = "pydantic" },
     { name = "requests" },
     { name = "sniffio" },
-    { name = "tenacity" },
+    { name = "tenacity", version = "8.5.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-4-daft-paimon'" },
+    { name = "tenacity", version = "9.1.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'group-4-daft-dev' or extra != 'extra-4-daft-paimon'" },
     { name = "typing-extensions" },
     { name = "websockets" },
 ]
@@ -2597,8 +3047,8 @@ name = "googleapis-common-protos"
 version = "1.70.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "protobuf", version = "5.29.6", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "protobuf", version = "6.33.5", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'darwin'" },
+    { name = "protobuf", version = "5.29.6", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform == 'darwin' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "protobuf", version = "6.33.5", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'darwin' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/39/24/33db22342cf4a2ea27c9955e6713140fedd51e8b141b5ce5260897020f1a/googleapis_common_protos-1.70.0.tar.gz", hash = "sha256:0e1b44e0ea153e6594f9f394fef15193a68aaaea2d843f83e2742717ca753257", size = 145903, upload-time = "2025-04-14T10:17:02.924Z" }
 wheels = [
@@ -2607,8 +3057,8 @@ wheels = [
 
 [package.optional-dependencies]
 grpc = [
-    { name = "grpcio", version = "1.68.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "grpcio", version = "1.78.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'darwin'" },
+    { name = "grpcio", version = "1.68.1", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform == 'darwin' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "grpcio", version = "1.78.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'darwin' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 
 [[package]]
@@ -2638,6 +3088,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/92/db/b4c12cff13ebac2786f4f217f06588bccd8b53d260453404ef22b121fc3a/greenlet-3.2.3-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:1afd685acd5597349ee6d7a88a8bec83ce13c106ac78c196ee9dde7c04fe87be", size = 268977, upload-time = "2025-06-05T16:10:24.001Z" },
     { url = "https://files.pythonhosted.org/packages/52/61/75b4abd8147f13f70986df2801bf93735c1bd87ea780d70e3b3ecda8c165/greenlet-3.2.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:761917cac215c61e9dc7324b2606107b3b292a8349bdebb31503ab4de3f559ac", size = 627351, upload-time = "2025-06-05T16:38:50.685Z" },
     { url = "https://files.pythonhosted.org/packages/35/aa/6894ae299d059d26254779a5088632874b80ee8cf89a88bca00b0709d22f/greenlet-3.2.3-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:a433dbc54e4a37e4fff90ef34f25a8c00aed99b06856f0119dcf09fbafa16392", size = 638599, upload-time = "2025-06-05T16:41:34.057Z" },
+    { url = "https://files.pythonhosted.org/packages/30/64/e01a8261d13c47f3c082519a5e9dbf9e143cc0498ed20c911d04e54d526c/greenlet-3.2.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:72e77ed69312bab0434d7292316d5afd6896192ac4327d44f3d613ecb85b037c", size = 634482, upload-time = "2025-06-05T16:48:16.26Z" },
     { url = "https://files.pythonhosted.org/packages/47/48/ff9ca8ba9772d083a4f5221f7b4f0ebe8978131a9ae0909cf202f94cd879/greenlet-3.2.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:68671180e3849b963649254a882cd544a3c75bfcd2c527346ad8bb53494444db", size = 633284, upload-time = "2025-06-05T16:13:01.599Z" },
     { url = "https://files.pythonhosted.org/packages/e9/45/626e974948713bc15775b696adb3eb0bd708bec267d6d2d5c47bb47a6119/greenlet-3.2.3-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:49c8cfb18fb419b3d08e011228ef8a25882397f3a859b9fe1436946140b6756b", size = 582206, upload-time = "2025-06-05T16:12:48.51Z" },
     { url = "https://files.pythonhosted.org/packages/b1/8e/8b6f42c67d5df7db35b8c55c9a850ea045219741bb14416255616808c690/greenlet-3.2.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:efc6dc8a792243c31f2f5674b670b3a95d46fa1c6a912b8e310d6f542e7b0712", size = 1111412, upload-time = "2025-06-05T16:36:45.479Z" },
@@ -2646,6 +3097,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fc/2e/d4fcb2978f826358b673f779f78fa8a32ee37df11920dc2bb5589cbeecef/greenlet-3.2.3-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:784ae58bba89fa1fa5733d170d42486580cab9decda3484779f4759345b29822", size = 270219, upload-time = "2025-06-05T16:10:10.414Z" },
     { url = "https://files.pythonhosted.org/packages/16/24/929f853e0202130e4fe163bc1d05a671ce8dcd604f790e14896adac43a52/greenlet-3.2.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0921ac4ea42a5315d3446120ad48f90c3a6b9bb93dd9b3cf4e4d84a66e42de83", size = 630383, upload-time = "2025-06-05T16:38:51.785Z" },
     { url = "https://files.pythonhosted.org/packages/d1/b2/0320715eb61ae70c25ceca2f1d5ae620477d246692d9cc284c13242ec31c/greenlet-3.2.3-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:d2971d93bb99e05f8c2c0c2f4aa9484a18d98c4c3bd3c62b65b7e6ae33dfcfaf", size = 642422, upload-time = "2025-06-05T16:41:35.259Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/49/445fd1a210f4747fedf77615d941444349c6a3a4a1135bba9701337cd966/greenlet-3.2.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c667c0bf9d406b77a15c924ef3285e1e05250948001220368e039b6aa5b5034b", size = 638375, upload-time = "2025-06-05T16:48:18.235Z" },
     { url = "https://files.pythonhosted.org/packages/7e/c8/ca19760cf6eae75fa8dc32b487e963d863b3ee04a7637da77b616703bc37/greenlet-3.2.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:592c12fb1165be74592f5de0d70f82bc5ba552ac44800d632214b76089945147", size = 637627, upload-time = "2025-06-05T16:13:02.858Z" },
     { url = "https://files.pythonhosted.org/packages/65/89/77acf9e3da38e9bcfca881e43b02ed467c1dedc387021fc4d9bd9928afb8/greenlet-3.2.3-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29e184536ba333003540790ba29829ac14bb645514fbd7e32af331e8202a62a5", size = 585502, upload-time = "2025-06-05T16:12:49.642Z" },
     { url = "https://files.pythonhosted.org/packages/97/c6/ae244d7c95b23b7130136e07a9cc5aadd60d59b5951180dc7dc7e8edaba7/greenlet-3.2.3-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:93c0bb79844a367782ec4f429d07589417052e621aa39a5ac1fb99c5aa308edc", size = 1114498, upload-time = "2025-06-05T16:36:46.598Z" },
@@ -2654,6 +3106,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/94/ad0d435f7c48debe960c53b8f60fb41c2026b1d0fa4a99a1cb17c3461e09/greenlet-3.2.3-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:25ad29caed5783d4bd7a85c9251c651696164622494c00802a139c00d639242d", size = 271992, upload-time = "2025-06-05T16:11:23.467Z" },
     { url = "https://files.pythonhosted.org/packages/93/5d/7c27cf4d003d6e77749d299c7c8f5fd50b4f251647b5c2e97e1f20da0ab5/greenlet-3.2.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88cd97bf37fe24a6710ec6a3a7799f3f81d9cd33317dcf565ff9950c83f55e0b", size = 638820, upload-time = "2025-06-05T16:38:52.882Z" },
     { url = "https://files.pythonhosted.org/packages/c6/7e/807e1e9be07a125bb4c169144937910bf59b9d2f6d931578e57f0bce0ae2/greenlet-3.2.3-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:baeedccca94880d2f5666b4fa16fc20ef50ba1ee353ee2d7092b383a243b0b0d", size = 653046, upload-time = "2025-06-05T16:41:36.343Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/ab/158c1a4ea1068bdbc78dba5a3de57e4c7aeb4e7fa034320ea94c688bfb61/greenlet-3.2.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:be52af4b6292baecfa0f397f3edb3c6092ce071b499dd6fe292c9ac9f2c8f264", size = 647701, upload-time = "2025-06-05T16:48:19.604Z" },
     { url = "https://files.pythonhosted.org/packages/cc/0d/93729068259b550d6a0288da4ff72b86ed05626eaf1eb7c0d3466a2571de/greenlet-3.2.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0cc73378150b8b78b0c9fe2ce56e166695e67478550769536a6742dca3651688", size = 649747, upload-time = "2025-06-05T16:13:04.628Z" },
     { url = "https://files.pythonhosted.org/packages/f6/f6/c82ac1851c60851302d8581680573245c8fc300253fc1ff741ae74a6c24d/greenlet-3.2.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:706d016a03e78df129f68c4c9b4c4f963f7d73534e48a24f5f5a7101ed13dbbb", size = 605461, upload-time = "2025-06-05T16:12:50.792Z" },
     { url = "https://files.pythonhosted.org/packages/98/82/d022cf25ca39cf1200650fc58c52af32c90f80479c25d1cbf57980ec3065/greenlet-3.2.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:419e60f80709510c343c57b4bb5a339d8767bf9aef9b8ce43f4f143240f88b7c", size = 1121190, upload-time = "2025-06-05T16:36:48.59Z" },
@@ -2662,6 +3115,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b1/cf/f5c0b23309070ae93de75c90d29300751a5aacefc0a3ed1b1d8edb28f08b/greenlet-3.2.3-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:500b8689aa9dd1ab26872a34084503aeddefcb438e2e7317b89b11eaea1901ad", size = 270732, upload-time = "2025-06-05T16:10:08.26Z" },
     { url = "https://files.pythonhosted.org/packages/48/ae/91a957ba60482d3fecf9be49bc3948f341d706b52ddb9d83a70d42abd498/greenlet-3.2.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a07d3472c2a93117af3b0136f246b2833fdc0b542d4a9799ae5f41c28323faef", size = 639033, upload-time = "2025-06-05T16:38:53.983Z" },
     { url = "https://files.pythonhosted.org/packages/6f/df/20ffa66dd5a7a7beffa6451bdb7400d66251374ab40b99981478c69a67a8/greenlet-3.2.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:8704b3768d2f51150626962f4b9a9e4a17d2e37c8a8d9867bbd9fa4eb938d3b3", size = 652999, upload-time = "2025-06-05T16:41:37.89Z" },
+    { url = "https://files.pythonhosted.org/packages/51/b4/ebb2c8cb41e521f1d72bf0465f2f9a2fd803f674a88db228887e6847077e/greenlet-3.2.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:5035d77a27b7c62db6cf41cf786cfe2242644a7a337a0e155c80960598baab95", size = 647368, upload-time = "2025-06-05T16:48:21.467Z" },
     { url = "https://files.pythonhosted.org/packages/8e/6a/1e1b5aa10dced4ae876a322155705257748108b7fd2e4fae3f2a091fe81a/greenlet-3.2.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2d8aa5423cd4a396792f6d4580f88bdc6efcb9205891c9d40d20f6e670992efb", size = 650037, upload-time = "2025-06-05T16:13:06.402Z" },
     { url = "https://files.pythonhosted.org/packages/26/f2/ad51331a157c7015c675702e2d5230c243695c788f8f75feba1af32b3617/greenlet-3.2.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2c724620a101f8170065d7dded3f962a2aea7a7dae133a009cada42847e04a7b", size = 608402, upload-time = "2025-06-05T16:12:51.91Z" },
     { url = "https://files.pythonhosted.org/packages/26/bc/862bd2083e6b3aff23300900a956f4ea9a4059de337f5c8734346b9b34fc/greenlet-3.2.3-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:873abe55f134c48e1f2a6f53f7d1419192a3d1a4e873bace00499a4e45ea6af0", size = 1119577, upload-time = "2025-06-05T16:36:49.787Z" },
@@ -2670,6 +3124,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d8/ca/accd7aa5280eb92b70ed9e8f7fd79dc50a2c21d8c73b9a0856f5b564e222/greenlet-3.2.3-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:3d04332dddb10b4a211b68111dabaee2e1a073663d117dc10247b5b1642bac86", size = 271479, upload-time = "2025-06-05T16:10:47.525Z" },
     { url = "https://files.pythonhosted.org/packages/55/71/01ed9895d9eb49223280ecc98a557585edfa56b3d0e965b9fa9f7f06b6d9/greenlet-3.2.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8186162dffde068a465deab08fc72c767196895c39db26ab1c17c0b77a6d8b97", size = 683952, upload-time = "2025-06-05T16:38:55.125Z" },
     { url = "https://files.pythonhosted.org/packages/ea/61/638c4bdf460c3c678a0a1ef4c200f347dff80719597e53b5edb2fb27ab54/greenlet-3.2.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f4bfbaa6096b1b7a200024784217defedf46a07c2eee1a498e94a1b5f8ec5728", size = 696917, upload-time = "2025-06-05T16:41:38.959Z" },
+    { url = "https://files.pythonhosted.org/packages/22/cc/0bd1a7eb759d1f3e3cc2d1bc0f0b487ad3cc9f34d74da4b80f226fde4ec3/greenlet-3.2.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:ed6cfa9200484d234d8394c70f5492f144b20d4533f69262d530a1a082f6ee9a", size = 692443, upload-time = "2025-06-05T16:48:23.113Z" },
     { url = "https://files.pythonhosted.org/packages/67/10/b2a4b63d3f08362662e89c103f7fe28894a51ae0bc890fabf37d1d780e52/greenlet-3.2.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:02b0df6f63cd15012bed5401b47829cfd2e97052dc89da3cfaf2c779124eb892", size = 692995, upload-time = "2025-06-05T16:13:07.972Z" },
     { url = "https://files.pythonhosted.org/packages/5a/c6/ad82f148a4e3ce9564056453a71529732baf5448ad53fc323e37efe34f66/greenlet-3.2.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:86c2d68e87107c1792e2e8d5399acec2487a4e993ab76c792408e59394d52141", size = 655320, upload-time = "2025-06-05T16:12:53.453Z" },
     { url = "https://files.pythonhosted.org/packages/5c/4f/aab73ecaa6b3086a4c89863d94cf26fa84cbff63f52ce9bc4342b3087a06/greenlet-3.2.3-cp314-cp314-win_amd64.whl", hash = "sha256:8c47aae8fbbfcf82cc13327ae802ba13c9c36753b67e760023fd116bc124a62a", size = 301236, upload-time = "2025-06-05T16:15:20.111Z" },
@@ -2715,11 +3170,11 @@ name = "grpc-google-iam-v1"
 version = "0.14.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "googleapis-common-protos", extra = ["grpc"] },
-    { name = "grpcio", version = "1.68.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "grpcio", version = "1.78.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'darwin'" },
-    { name = "protobuf", version = "5.29.6", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "protobuf", version = "6.33.5", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'darwin'" },
+    { name = "googleapis-common-protos", extra = ["grpc"], marker = "extra == 'group-4-daft-dev'" },
+    { name = "grpcio", version = "1.68.1", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform == 'darwin' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "grpcio", version = "1.78.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'darwin' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "protobuf", version = "5.29.6", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform == 'darwin' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "protobuf", version = "6.33.5", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'darwin' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/1e/1011451679a983f2f5c6771a1682542ecb027776762ad031fd0d7129164b/grpc_google_iam_v1-0.14.3.tar.gz", hash = "sha256:879ac4ef33136c5491a6300e27575a9ec760f6cdf9a2518798c1b8977a5dc389", size = 23745, upload-time = "2025-10-15T21:14:53.318Z" }
 wheels = [
@@ -2739,10 +3194,42 @@ resolution-markers = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/91/ec/b76ff6d86bdfd1737a5ec889394b54c18b1ec3832d91041e25023fbcb67d/grpcio-1.68.1.tar.gz", hash = "sha256:44a8502dd5de653ae6a73e2de50a401d84184f0331d0ac3daeb044e66d5c5054", size = 12694654, upload-time = "2024-12-02T05:26:03.953Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/88/d1ac9676a0809e3efec154d45246474ec12a4941686da71ffb3d34190294/grpcio-1.68.1-cp310-cp310-linux_armv7l.whl", hash = "sha256:d35740e3f45f60f3c37b1e6f2f4702c23867b9ce21c6410254c9c682237da68d", size = 5171054, upload-time = "2024-12-02T05:19:21.787Z" },
     { url = "https://files.pythonhosted.org/packages/ec/cb/94ca41e100201fee8876a4b44d64e43ac7405929909afe1fa943d65b25ef/grpcio-1.68.1-cp310-cp310-macosx_12_0_universal2.whl", hash = "sha256:d99abcd61760ebb34bdff37e5a3ba333c5cc09feda8c1ad42547bea0416ada78", size = 11078566, upload-time = "2024-12-02T05:19:24.981Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/b0/ad4c66f2e3181b4eab99885686c960c403ae2300bacfe427526282facc07/grpcio-1.68.1-cp310-cp310-manylinux_2_17_aarch64.whl", hash = "sha256:f8261fa2a5f679abeb2a0a93ad056d765cdca1c47745eda3f2d87f874ff4b8c9", size = 5690039, upload-time = "2024-12-02T05:19:28.78Z" },
+    { url = "https://files.pythonhosted.org/packages/67/1e/f5d3410674d021831c9fef2d1d7ca2357b08d09c840ad4e054ea8ffc302e/grpcio-1.68.1-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0feb02205a27caca128627bd1df4ee7212db051019a9afa76f4bb6a1a80ca95e", size = 6317470, upload-time = "2024-12-02T05:19:31.631Z" },
+    { url = "https://files.pythonhosted.org/packages/91/93/701d5f33b163a621c8f2d4453f9e22f6c14e996baed54118d0dea93fc8c7/grpcio-1.68.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:919d7f18f63bcad3a0f81146188e90274fde800a94e35d42ffe9eadf6a9a6330", size = 5941884, upload-time = "2024-12-02T05:19:34.694Z" },
+    { url = "https://files.pythonhosted.org/packages/67/44/06917ffaa35ca463b93dde60f324015fe4192312b0f4dd0faec061e7ca7f/grpcio-1.68.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:963cc8d7d79b12c56008aabd8b457f400952dbea8997dd185f155e2f228db079", size = 6646332, upload-time = "2024-12-02T05:19:37.619Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/94/074db039532687ec8ef07ebbcc747c46547c94329016e22b97d97b9e5f3b/grpcio-1.68.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:ccf2ebd2de2d6661e2520dae293298a3803a98ebfc099275f113ce1f6c2a80f1", size = 6212515, upload-time = "2024-12-02T05:19:40.759Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/f2/0c939264c36c6038fae1732a2a3e01a7075ba171a2154d86842ee0ac9b0a/grpcio-1.68.1-cp310-cp310-win32.whl", hash = "sha256:2cc1fd04af8399971bcd4f43bd98c22d01029ea2e56e69c34daf2bf8470e47f5", size = 3650459, upload-time = "2024-12-02T05:19:44.038Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/90/b0e9278e88f747879d13b79fb893c9acb381fb90541ad9e416c7816c5eaf/grpcio-1.68.1-cp310-cp310-win_amd64.whl", hash = "sha256:ee2e743e51cb964b4975de572aa8fb95b633f496f9fcb5e257893df3be854746", size = 4399144, upload-time = "2024-12-02T05:19:47.337Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/0d/fde5a5777d65696c39bb3e622fe1239dd0a878589bf6c5066980e7d19154/grpcio-1.68.1-cp311-cp311-linux_armv7l.whl", hash = "sha256:55857c71641064f01ff0541a1776bfe04a59db5558e82897d35a7793e525774c", size = 5180919, upload-time = "2024-12-02T05:19:49.456Z" },
     { url = "https://files.pythonhosted.org/packages/07/fd/e5fa75b5ddf5d9f16606196973f9c2b4b1adf5a1735117eb7129fc33d2ec/grpcio-1.68.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:4b177f5547f1b995826ef529d2eef89cca2f830dd8b2c99ffd5fde4da734ba73", size = 11150922, upload-time = "2024-12-02T05:19:52.029Z" },
+    { url = "https://files.pythonhosted.org/packages/86/1e/aaf5a1dae87fe47f277c5a1be72b31d2c209d095bebb0ce1d2df5cb8779c/grpcio-1.68.1-cp311-cp311-manylinux_2_17_aarch64.whl", hash = "sha256:3522c77d7e6606d6665ec8d50e867f13f946a4e00c7df46768f1c85089eae515", size = 5685685, upload-time = "2024-12-02T05:19:54.757Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/69/c4fdf87d5c5696207e2ed232e4bdde656d8c99ba91f361927f3f06aa41ca/grpcio-1.68.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9d1fae6bbf0816415b81db1e82fb3bf56f7857273c84dcbe68cbe046e58e1ccd", size = 6316535, upload-time = "2024-12-02T05:19:56.999Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c6/539660516ea7db7bc3d39e07154512ae807961b14ec6b5b0c58d15657ff1/grpcio-1.68.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:298ee7f80e26f9483f0b6f94cc0a046caf54400a11b644713bb5b3d8eb387600", size = 5939920, upload-time = "2024-12-02T05:19:59.583Z" },
+    { url = "https://files.pythonhosted.org/packages/38/f3/97a74dc4dd95bf195168d6da2ca4731ab7d3d0b03078f2833b4ff9c4f48f/grpcio-1.68.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:cbb5780e2e740b6b4f2d208e90453591036ff80c02cc605fea1af8e6fc6b1bbe", size = 6644770, upload-time = "2024-12-02T05:20:03.579Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/36/79a5e04073e58106aff442509a0c459151fa4f43202395db3eb8f77b78e9/grpcio-1.68.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:ddda1aa22495d8acd9dfbafff2866438d12faec4d024ebc2e656784d96328ad0", size = 6211743, upload-time = "2024-12-02T05:20:06.134Z" },
+    { url = "https://files.pythonhosted.org/packages/73/0f/2250f4a0de1a0bec0726c47a021cbf71af6105f512ecaf67703e2eb1ad2f/grpcio-1.68.1-cp311-cp311-win32.whl", hash = "sha256:b33bd114fa5a83f03ec6b7b262ef9f5cac549d4126f1dc702078767b10c46ed9", size = 3650734, upload-time = "2024-12-02T05:20:08.493Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/29/061c93a35f498238dc35eb8fb039ce168aa99cac2f0f1ce0c8a0a4bdb274/grpcio-1.68.1-cp311-cp311-win_amd64.whl", hash = "sha256:7f20ebec257af55694d8f993e162ddf0d36bd82d4e57f74b31c67b3c6d63d8b2", size = 4400816, upload-time = "2024-12-02T05:20:11.035Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/15/674a1468fef234fa996989509bbdfc0d695878cbb385b9271f5d690d5cd3/grpcio-1.68.1-cp312-cp312-linux_armv7l.whl", hash = "sha256:8829924fffb25386995a31998ccbbeaa7367223e647e0122043dfc485a87c666", size = 5148351, upload-time = "2024-12-02T05:20:15.009Z" },
     { url = "https://files.pythonhosted.org/packages/62/f5/edce368682d6d0b3573b883b134df022a44b1c888ea416dd7d78d480ab24/grpcio-1.68.1-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:3aed6544e4d523cd6b3119b0916cef3d15ef2da51e088211e4d1eb91a6c7f4f1", size = 11127559, upload-time = "2024-12-02T05:20:18.124Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/14/a6fde3114eafd9e4e345d1ebd0291c544d83b22f0554b1678a2968ae39e1/grpcio-1.68.1-cp312-cp312-manylinux_2_17_aarch64.whl", hash = "sha256:4efac5481c696d5cb124ff1c119a78bddbfdd13fc499e3bc0ca81e95fc573684", size = 5645221, upload-time = "2024-12-02T05:20:22.592Z" },
+    { url = "https://files.pythonhosted.org/packages/21/21/d1865bd6a22f9a26217e4e1b35f9105f7a0cdfb7a5fffe8be48e1a1afafc/grpcio-1.68.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6ab2d912ca39c51f46baf2a0d92aa265aa96b2443266fc50d234fa88bf877d8e", size = 6292270, upload-time = "2024-12-02T05:20:26.199Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/f6/19798be6c3515a7b1fb9570198c91710472e2eb21f1900109a76834829e3/grpcio-1.68.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95c87ce2a97434dffe7327a4071839ab8e8bffd0054cc74cbe971fba98aedd60", size = 5905978, upload-time = "2024-12-02T05:20:28.825Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/43/c3670a657445cd55be1246f64dbc3a6a33cab0f0141c5836df2e04f794c8/grpcio-1.68.1-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:e4842e4872ae4ae0f5497bf60a0498fa778c192cc7a9e87877abd2814aca9475", size = 6630444, upload-time = "2024-12-02T05:20:32.898Z" },
+    { url = "https://files.pythonhosted.org/packages/80/69/fbbebccffd266bea4268b685f3e8e03613405caba69e93125dc783036465/grpcio-1.68.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:255b1635b0ed81e9f91da4fcc8d43b7ea5520090b9a9ad9340d147066d1d3613", size = 6200324, upload-time = "2024-12-02T05:20:35.476Z" },
+    { url = "https://files.pythonhosted.org/packages/65/5c/27a26c21916f94f0c1585111974a5d5a41d8420dcb42c2717ee514c97a97/grpcio-1.68.1-cp312-cp312-win32.whl", hash = "sha256:7dfc914cc31c906297b30463dde0b9be48e36939575eaf2a0a22a8096e69afe5", size = 3638381, upload-time = "2024-12-02T05:20:37.875Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ba/ba6b65ccc93c7df1031c6b41e45b79a5a37e46b81d816bb3ea68ba476d77/grpcio-1.68.1-cp312-cp312-win_amd64.whl", hash = "sha256:a0c8ddabef9c8f41617f213e527254c41e8b96ea9d387c632af878d05db9229c", size = 4389959, upload-time = "2024-12-02T05:20:40.646Z" },
+    { url = "https://files.pythonhosted.org/packages/37/1a/15ccc08da339a5536690e6f877963422a5abf3f6dfeed96b3175f5c816b9/grpcio-1.68.1-cp313-cp313-linux_armv7l.whl", hash = "sha256:a47faedc9ea2e7a3b6569795c040aae5895a19dde0c728a48d3c5d7995fda385", size = 5149822, upload-time = "2024-12-02T05:20:43.252Z" },
     { url = "https://files.pythonhosted.org/packages/bc/fe/91bb4b160cd251d5b5ee722e6342355f76d1ffe176c50a6ef0e8256fbb47/grpcio-1.68.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:390eee4225a661c5cd133c09f5da1ee3c84498dc265fd292a6912b65c421c78c", size = 11085016, upload-time = "2024-12-02T05:20:46.245Z" },
+    { url = "https://files.pythonhosted.org/packages/55/2d/0bb2478410f5896da1090b9f43c2979dd72e7e97d10bc223bfbdddcf8eca/grpcio-1.68.1-cp313-cp313-manylinux_2_17_aarch64.whl", hash = "sha256:66a24f3d45c33550703f0abb8b656515b0ab777970fa275693a2f6dc8e35f1c1", size = 5645634, upload-time = "2024-12-02T05:20:50.102Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/6c/e2d22d963b695f87a09965246beb1c3224b09ffc666fc0b285820926499a/grpcio-1.68.1-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c08079b4934b0bf0a8847f42c197b1d12cba6495a3d43febd7e99ecd1cdc8d54", size = 6291096, upload-time = "2024-12-02T05:20:53.582Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/f6/21d9204e2c4c0804ad72be8c830c44f0e1355e649c173f87508b7f0e5488/grpcio-1.68.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8720c25cd9ac25dd04ee02b69256d0ce35bf8a0f29e20577427355272230965a", size = 5906528, upload-time = "2024-12-02T05:20:57.445Z" },
+    { url = "https://files.pythonhosted.org/packages/39/2a/bf6ae4fef13755ca236d587d630b82207cfad43cf956870adead97fd1ef1/grpcio-1.68.1-cp313-cp313-musllinux_1_1_i686.whl", hash = "sha256:04cfd68bf4f38f5bb959ee2361a7546916bd9a50f78617a346b3aeb2b42e2161", size = 6634215, upload-time = "2024-12-02T05:21:00.975Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/83/9c96a6adfbea5e8a9ed408410c0259942713be64173b8816c7bf6ac2d830/grpcio-1.68.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:c28848761a6520c5c6071d2904a18d339a796ebe6b800adc8b3f474c5ce3c3ad", size = 6200750, upload-time = "2024-12-02T05:21:03.567Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/3e/af42f87759c6301c4fed894b3dd801b13162ba1d8e2942412e788ac749eb/grpcio-1.68.1-cp313-cp313-win32.whl", hash = "sha256:77d65165fc35cff6e954e7fd4229e05ec76102d4406d4576528d3a3635fc6172", size = 3637594, upload-time = "2024-12-02T05:21:06.082Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/d1/3bef33a3d5d26d4ea9284e1b464f481d6d21ed8ae1c3da381b05f62c701d/grpcio-1.68.1-cp313-cp313-win_amd64.whl", hash = "sha256:a8040f85dcb9830d8bbb033ae66d272614cec6faceee88d37a88a9bd1a7a704e", size = 4391184, upload-time = "2024-12-02T05:21:08.772Z" },
 ]
 
 [[package]]
@@ -2750,33 +3237,49 @@ name = "grpcio"
 version = "1.78.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "(python_full_version == '3.13.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "(python_full_version == '3.12.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "(python_full_version < '3.11' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version >= '3.14' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'win32'",
-    "python_full_version < '3.11' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "(python_full_version == '3.13.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "(python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
 ]
 dependencies = [
-    { name = "typing-extensions", marker = "sys_platform != 'darwin'" },
+    { name = "typing-extensions", marker = "sys_platform != 'darwin' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/06/8a/3d098f35c143a89520e568e6539cc098fcd294495910e359889ce8741c84/grpcio-1.78.0.tar.gz", hash = "sha256:7382b95189546f375c174f53a5fa873cef91c4b8005faa05cc5b3beea9c4f1c5", size = 12852416, upload-time = "2026-02-06T09:57:18.093Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/a8/690a085b4d1fe066130de97a87de32c45062cf2ecd218df9675add895550/grpcio-1.78.0-cp310-cp310-linux_armv7l.whl", hash = "sha256:7cc47943d524ee0096f973e1081cb8f4f17a4615f2116882a5f1416e4cfe92b5", size = 5946986, upload-time = "2026-02-06T09:54:34.043Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/1b/e5213c5c0ced9d2d92778d30529ad5bb2dcfb6c48c4e2d01b1f302d33d64/grpcio-1.78.0-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:c3f293fdc675ccba4db5a561048cca627b5e7bd1c8a6973ffedabe7d116e22e2", size = 11816533, upload-time = "2026-02-06T09:54:37.04Z" },
     { url = "https://files.pythonhosted.org/packages/18/37/1ba32dccf0a324cc5ace744c44331e300b000a924bf14840f948c559ede7/grpcio-1.78.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:10a9a644b5dd5aec3b82b5b0b90d41c0fa94c85ef42cb42cf78a23291ddb5e7d", size = 6519964, upload-time = "2026-02-06T09:54:40.268Z" },
     { url = "https://files.pythonhosted.org/packages/ed/f5/c0e178721b818072f2e8b6fde13faaba942406c634009caf065121ce246b/grpcio-1.78.0-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:4c5533d03a6cbd7f56acfc9cfb44ea64f63d29091e40e44010d34178d392d7eb", size = 7198058, upload-time = "2026-02-06T09:54:42.389Z" },
     { url = "https://files.pythonhosted.org/packages/5b/b2/40d43c91ae9cd667edc960135f9f08e58faa1576dc95af29f66ec912985f/grpcio-1.78.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ff870aebe9a93a85283837801d35cd5f8814fe2ad01e606861a7fb47c762a2b7", size = 6727212, upload-time = "2026-02-06T09:54:44.91Z" },
@@ -2786,6 +3289,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/41/09/f16e487d4cc65ccaf670f6ebdd1a17566b965c74fc3d93999d3b2821e052/grpcio-1.78.0-cp310-cp310-win32.whl", hash = "sha256:f8dff3d9777e5d2703a962ee5c286c239bf0ba173877cc68dc02c17d042e29de", size = 4076715, upload-time = "2026-02-06T09:54:55.549Z" },
     { url = "https://files.pythonhosted.org/packages/2a/32/4ce60d94e242725fd3bcc5673c04502c82a8e87b21ea411a63992dc39f8f/grpcio-1.78.0-cp310-cp310-win_amd64.whl", hash = "sha256:94f95cf5d532d0e717eed4fc1810e8e6eded04621342ec54c89a7c2f14b581bf", size = 4799157, upload-time = "2026-02-06T09:54:59.838Z" },
     { url = "https://files.pythonhosted.org/packages/86/c7/d0b780a29b0837bf4ca9580904dfb275c1fc321ded7897d620af7047ec57/grpcio-1.78.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:2777b783f6c13b92bd7b716667452c329eefd646bfb3f2e9dabea2e05dbd34f6", size = 5951525, upload-time = "2026-02-06T09:55:01.989Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b1/96920bf2ee61df85a9503cb6f733fe711c0ff321a5a697d791b075673281/grpcio-1.78.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:9dca934f24c732750389ce49d638069c3892ad065df86cb465b3fa3012b70c9e", size = 11830418, upload-time = "2026-02-06T09:55:04.462Z" },
     { url = "https://files.pythonhosted.org/packages/83/0c/7c1528f098aeb75a97de2bae18c530f56959fb7ad6c882db45d9884d6edc/grpcio-1.78.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:459ab414b35f4496138d0ecd735fed26f1318af5e52cb1efbc82a09f0d5aa911", size = 6524477, upload-time = "2026-02-06T09:55:07.111Z" },
     { url = "https://files.pythonhosted.org/packages/8d/52/e7c1f3688f949058e19a011c4e0dec973da3d0ae5e033909677f967ae1f4/grpcio-1.78.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:082653eecbdf290e6e3e2c276ab2c54b9e7c299e07f4221872380312d8cf395e", size = 7198266, upload-time = "2026-02-06T09:55:10.016Z" },
     { url = "https://files.pythonhosted.org/packages/e5/61/8ac32517c1e856677282c34f2e7812d6c328fa02b8f4067ab80e77fdc9c9/grpcio-1.78.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:85f93781028ec63f383f6bc90db785a016319c561cc11151fbb7b34e0d012303", size = 6730552, upload-time = "2026-02-06T09:55:12.207Z" },
@@ -2795,6 +3299,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b5/6e/8052e3a28eb6a820c372b2eb4b5e32d195c661e137d3eca94d534a4cfd8a/grpcio-1.78.0-cp311-cp311-win32.whl", hash = "sha256:6092beabe1966a3229f599d7088b38dfc8ffa1608b5b5cdda31e591e6500f856", size = 4076503, upload-time = "2026-02-06T09:55:21.521Z" },
     { url = "https://files.pythonhosted.org/packages/08/62/f22c98c5265dfad327251fa2f840b591b1df5f5e15d88b19c18c86965b27/grpcio-1.78.0-cp311-cp311-win_amd64.whl", hash = "sha256:1afa62af6e23f88629f2b29ec9e52ec7c65a7176c1e0a83292b93c76ca882558", size = 4799767, upload-time = "2026-02-06T09:55:24.107Z" },
     { url = "https://files.pythonhosted.org/packages/4e/f4/7384ed0178203d6074446b3c4f46c90a22ddf7ae0b3aee521627f54cfc2a/grpcio-1.78.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:f9ab915a267fc47c7e88c387a3a28325b58c898e23d4995f765728f4e3dedb97", size = 5913985, upload-time = "2026-02-06T09:55:26.832Z" },
+    { url = "https://files.pythonhosted.org/packages/81/ed/be1caa25f06594463f685b3790b320f18aea49b33166f4141bfdc2bfb236/grpcio-1.78.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3f8904a8165ab21e07e58bf3e30a73f4dffc7a1e0dbc32d51c61b5360d26f43e", size = 11811853, upload-time = "2026-02-06T09:55:29.224Z" },
     { url = "https://files.pythonhosted.org/packages/24/a7/f06d151afc4e64b7e3cc3e872d331d011c279aaab02831e40a81c691fb65/grpcio-1.78.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:859b13906ce098c0b493af92142ad051bf64c7870fa58a123911c88606714996", size = 6475766, upload-time = "2026-02-06T09:55:31.825Z" },
     { url = "https://files.pythonhosted.org/packages/8a/a8/4482922da832ec0082d0f2cc3a10976d84a7424707f25780b82814aafc0a/grpcio-1.78.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:b2342d87af32790f934a79c3112641e7b27d63c261b8b4395350dad43eff1dc7", size = 7170027, upload-time = "2026-02-06T09:55:34.7Z" },
     { url = "https://files.pythonhosted.org/packages/54/bf/f4a3b9693e35d25b24b0b39fa46d7d8a3c439e0a3036c3451764678fec20/grpcio-1.78.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:12a771591ae40bc65ba67048fa52ef4f0e6db8279e595fd349f9dfddeef571f9", size = 6690766, upload-time = "2026-02-06T09:55:36.902Z" },
@@ -2804,6 +3309,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/47/7f05f81e4bb6b831e93271fb12fd52ba7b319b5402cbc101d588f435df00/grpcio-1.78.0-cp312-cp312-win32.whl", hash = "sha256:94309f498bcc07e5a7d16089ab984d42ad96af1d94b5a4eb966a266d9fcabf68", size = 4066123, upload-time = "2026-02-06T09:55:47.644Z" },
     { url = "https://files.pythonhosted.org/packages/ad/e7/d6914822c88aa2974dbbd10903d801a28a19ce9cd8bad7e694cbbcf61528/grpcio-1.78.0-cp312-cp312-win_amd64.whl", hash = "sha256:9566fe4ababbb2610c39190791e5b829869351d14369603702e890ef3ad2d06e", size = 4797657, upload-time = "2026-02-06T09:55:49.86Z" },
     { url = "https://files.pythonhosted.org/packages/05/a9/8f75894993895f361ed8636cd9237f4ab39ef87fd30db17467235ed1c045/grpcio-1.78.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:ce3a90455492bf8bfa38e56fbbe1dbd4f872a3d8eeaf7337dc3b1c8aa28c271b", size = 5920143, upload-time = "2026-02-06T09:55:52.035Z" },
+    { url = "https://files.pythonhosted.org/packages/55/06/0b78408e938ac424100100fd081189451b472236e8a3a1f6500390dc4954/grpcio-1.78.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:2bf5e2e163b356978b23652c4818ce4759d40f4712ee9ec5a83c4be6f8c23a3a", size = 11803926, upload-time = "2026-02-06T09:55:55.494Z" },
     { url = "https://files.pythonhosted.org/packages/88/93/b59fe7832ff6ae3c78b813ea43dac60e295fa03606d14d89d2e0ec29f4f3/grpcio-1.78.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8f2ac84905d12918e4e55a16da17939eb63e433dc11b677267c35568aa63fc84", size = 6478628, upload-time = "2026-02-06T09:55:58.533Z" },
     { url = "https://files.pythonhosted.org/packages/ed/df/e67e3734527f9926b7d9c0dde6cd998d1d26850c3ed8eeec81297967ac67/grpcio-1.78.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:b58f37edab4a3881bc6c9bca52670610e0c9ca14e2ea3cf9debf185b870457fb", size = 7173574, upload-time = "2026-02-06T09:56:01.786Z" },
     { url = "https://files.pythonhosted.org/packages/a6/62/cc03fffb07bfba982a9ec097b164e8835546980aec25ecfa5f9c1a47e022/grpcio-1.78.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:735e38e176a88ce41840c21bb49098ab66177c64c82426e24e0082500cc68af5", size = 6692639, upload-time = "2026-02-06T09:56:04.529Z" },
@@ -2813,6 +3319,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1c/9f/1e233fe697ecc82845942c2822ed06bb522e70d6771c28d5528e4c50f6a4/grpcio-1.78.0-cp313-cp313-win32.whl", hash = "sha256:271c73e6e5676afe4fc52907686670c7cea22ab2310b76a59b678403ed40d670", size = 4064899, upload-time = "2026-02-06T09:56:15.601Z" },
     { url = "https://files.pythonhosted.org/packages/4d/27/d86b89e36de8a951501fb06a0f38df19853210f341d0b28f83f4aa0ffa08/grpcio-1.78.0-cp313-cp313-win_amd64.whl", hash = "sha256:f2d4e43ee362adfc05994ed479334d5a451ab7bc3f3fee1b796b8ca66895acb4", size = 4797393, upload-time = "2026-02-06T09:56:17.882Z" },
     { url = "https://files.pythonhosted.org/packages/29/f2/b56e43e3c968bfe822fa6ce5bca10d5c723aa40875b48791ce1029bb78c7/grpcio-1.78.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:e87cbc002b6f440482b3519e36e1313eb5443e9e9e73d6a52d43bd2004fcfd8e", size = 5920591, upload-time = "2026-02-06T09:56:20.758Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/81/1f3b65bd30c334167bfa8b0d23300a44e2725ce39bba5b76a2460d85f745/grpcio-1.78.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:c41bc64626db62e72afec66b0c8a0da76491510015417c127bfc53b2fe6d7f7f", size = 11813685, upload-time = "2026-02-06T09:56:24.315Z" },
     { url = "https://files.pythonhosted.org/packages/0e/1c/bbe2f8216a5bd3036119c544d63c2e592bdf4a8ec6e4a1867592f4586b26/grpcio-1.78.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8dfffba826efcf366b1e3ccc37e67afe676f290e13a3b48d31a46739f80a8724", size = 6487803, upload-time = "2026-02-06T09:56:27.367Z" },
     { url = "https://files.pythonhosted.org/packages/16/5c/a6b2419723ea7ddce6308259a55e8e7593d88464ce8db9f4aa857aba96fa/grpcio-1.78.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:74be1268d1439eaaf552c698cdb11cd594f0c49295ae6bb72c34ee31abbe611b", size = 7173206, upload-time = "2026-02-06T09:56:29.876Z" },
     { url = "https://files.pythonhosted.org/packages/df/1e/b8801345629a415ea7e26c83d75eb5dbe91b07ffe5210cc517348a8d4218/grpcio-1.78.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:be63c88b32e6c0f1429f1398ca5c09bc64b0d80950c8bb7807d7d7fb36fb84c7", size = 6693826, upload-time = "2026-02-06T09:56:32.305Z" },
@@ -2851,19 +3358,14 @@ source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "(python_full_version == '3.13.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
+    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
+    "(python_full_version == '3.13.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
     "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "(python_full_version == '3.12.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "(python_full_version < '3.11' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "(python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
+    "(python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
     "python_full_version == '3.12.*' and sys_platform == 'win32'",
@@ -2991,8 +3493,9 @@ version = "0.36.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
-    { name = "fsspec" },
-    { name = "hf-xet", marker = "platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "fsspec", version = "2024.3.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-4-daft-paimon'" },
+    { name = "fsspec", version = "2024.9.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'group-4-daft-dev' or extra != 'extra-4-daft-paimon'" },
+    { name = "hf-xet", marker = "platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
     { name = "packaging" },
     { name = "pyyaml" },
     { name = "requests" },
@@ -3071,8 +3574,8 @@ version = "0.13.13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "decorator" },
-    { name = "ipython", version = "8.37.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "ipython", version = "9.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "ipython", version = "8.37.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "ipython", version = "9.4.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3d/1b/7e07e7b752017f7693a0f4d41c13e5ca29ce8cbcfdcc1fd6c4ad8c0a27a0/ipdb-0.13.13.tar.gz", hash = "sha256:e3ac6018ef05126d442af680aad863006ec19d02290561ac88b8b1c0b0cfc726", size = 17042, upload-time = "2023-03-09T15:40:57.487Z" }
@@ -3085,11 +3588,11 @@ name = "ipykernel"
 version = "6.30.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "appnope", marker = "sys_platform == 'darwin'" },
+    { name = "appnope", marker = "sys_platform == 'darwin' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
     { name = "comm" },
     { name = "debugpy" },
-    { name = "ipython", version = "8.37.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "ipython", version = "9.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "ipython", version = "8.37.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "ipython", version = "9.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
     { name = "jupyter-client" },
     { name = "jupyter-core" },
     { name = "matplotlib-inline" },
@@ -3110,24 +3613,29 @@ name = "ipython"
 version = "8.37.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version < '3.11' and sys_platform == 'darwin'",
-    "(python_full_version < '3.11' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version < '3.11' and sys_platform == 'win32'",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version < '3.11' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version < '3.11'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "jedi", marker = "python_full_version < '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.11'" },
-    { name = "pexpect", marker = "python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.11'" },
-    { name = "pygments", marker = "python_full_version < '3.11'" },
-    { name = "stack-data", marker = "python_full_version < '3.11'" },
-    { name = "traitlets", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (python_full_version >= '3.11' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "decorator", marker = "python_full_version < '3.11' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "jedi", marker = "python_full_version < '3.11' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "matplotlib-inline", marker = "python_full_version < '3.11' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "pexpect", marker = "(python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32') or (python_full_version >= '3.11' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (sys_platform == 'emscripten' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "prompt-toolkit", marker = "python_full_version < '3.11' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "pygments", marker = "python_full_version < '3.11' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "stack-data", marker = "python_full_version < '3.11' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "traitlets", marker = "python_full_version < '3.11' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/85/31/10ac88f3357fc276dc8a64e8880c82e80e7459326ae1d0a211b40abf6665/ipython-8.37.0.tar.gz", hash = "sha256:ca815841e1a41a1e6b73a0b08f3038af9b2252564d01fc405356d34033012216", size = 5606088, upload-time = "2025-05-31T16:39:09.613Z" }
 wheels = [
@@ -3139,39 +3647,59 @@ name = "ipython"
 version = "9.4.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version >= '3.14' and sys_platform == 'darwin'",
-    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
-    "(python_full_version == '3.13.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
-    "(python_full_version == '3.12.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
-    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version >= '3.14' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version == '3.13.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version >= '3.11'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11'" },
-    { name = "jedi", marker = "python_full_version >= '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version >= '3.11'" },
-    { name = "pexpect", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version >= '3.11'" },
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
-    { name = "stack-data", marker = "python_full_version >= '3.11'" },
-    { name = "traitlets", marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
+    { name = "colorama", marker = "(python_full_version >= '3.11' and sys_platform == 'win32') or (python_full_version < '3.11' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "decorator", marker = "python_full_version >= '3.11' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "jedi", marker = "python_full_version >= '3.11' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "matplotlib-inline", marker = "python_full_version >= '3.11' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "pexpect", marker = "(python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32') or (python_full_version < '3.11' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (sys_platform == 'emscripten' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "prompt-toolkit", marker = "python_full_version >= '3.11' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "pygments", marker = "python_full_version >= '3.11' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "stack-data", marker = "python_full_version >= '3.11' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "traitlets", marker = "python_full_version >= '3.11' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "typing-extensions", marker = "python_full_version == '3.11.*' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/54/80/406f9e3bde1c1fd9bf5a0be9d090f8ae623e401b7670d8f6fdf2ab679891/ipython-9.4.0.tar.gz", hash = "sha256:c033c6d4e7914c3d9768aabe76bbe87ba1dc66a92a05db6bfa1125d81f2ee270", size = 4385338, upload-time = "2025-07-01T11:11:30.606Z" }
 wheels = [
@@ -3183,7 +3711,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "pygments", marker = "python_full_version >= '3.11' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
@@ -3224,11 +3752,11 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jaxlib" },
     { name = "ml-dtypes" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
     { name = "opt-einsum" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "scipy", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cf/1e/267f59c8fb7f143c3f778c76cb7ef1389db3fd7e4540f04b9f42ca90764d/jax-0.6.2.tar.gz", hash = "sha256:a437d29038cbc8300334119692744704ca7941490867b9665406b7f90665cd96", size = 2334091, upload-time = "2025-06-17T23:10:27.186Z" }
 wheels = [
@@ -3241,10 +3769,10 @@ version = "0.6.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ml-dtypes" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "scipy", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/15/c5/41598634c99cbebba46e6777286fb76abc449d33d50aeae5d36128ca8803/jaxlib-0.6.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:da4601b2b5dc8c23d6afb293eacfb9aec4e1d1871cb2f29c5a151d103e73b0f8", size = 54298019, upload-time = "2025-06-17T23:10:36.916Z" },
@@ -3377,8 +3905,71 @@ wheels = [
 
 [[package]]
 name = "jmespath"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version < '3.11' and sys_platform == 'win32'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3c/56/3f325b1eef9791759784aa5046a8f6a1aff8f7c898a2e34506771d3b99d8/jmespath-0.10.0.tar.gz", hash = "sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9", size = 21607, upload-time = "2020-05-12T22:03:47.267Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/cb/5f001272b6faeb23c1c9e0acc04d48eaaf5c862c17709d20e3469c6e0139/jmespath-0.10.0-py2.py3-none-any.whl", hash = "sha256:cdf6525904cc597730141d61b36f2e4b8ecc257c420fa2f4549bac2c2d0cb72f", size = 24489, upload-time = "2020-05-12T22:03:45.643Z" },
+]
+
+[[package]]
+name = "jmespath"
 version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version == '3.13.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version < '3.11' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+]
 sdist = { url = "https://files.pythonhosted.org/packages/00/2a/e867e8531cf3e36b41201936b7fa7ba7b5702dbef42922193f05c8976cd6/jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe", size = 25843, upload-time = "2022-06-17T18:00:12.224Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980", size = 20256, upload-time = "2022-06-17T18:00:10.251Z" },
@@ -3508,7 +4099,7 @@ version = "5.8.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "platformdirs" },
-    { name = "pywin32", marker = "platform_python_implementation != 'PyPy' and sys_platform == 'win32'" },
+    { name = "pywin32", marker = "(platform_python_implementation != 'PyPy' and sys_platform == 'win32') or (platform_python_implementation == 'PyPy' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
     { name = "traitlets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/99/1b/72906d554acfeb588332eaaa6f61577705e9ec752ddb486f302dafa292d9/jupyter_core-5.8.1.tar.gz", hash = "sha256:0a5f9706f70e64786b75acba995988915ebd4601c8a52e534a40b51c95f59941", size = 88923, upload-time = "2025-05-27T07:38:16.655Z" }
@@ -3535,7 +4126,7 @@ dependencies = [
     { name = "nbformat" },
     { name = "packaging" },
     { name = "pyyaml" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "tomli", marker = "python_full_version < '3.11' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/30/ce/0bd5290ca4978777154e2683413dca761781aacf57f7dc0146f5210df8b1/jupytext-1.17.2.tar.gz", hash = "sha256:772d92898ac1f2ded69106f897b34af48ce4a85c985fa043a378ff5a65455f02", size = 3748577, upload-time = "2025-06-01T21:31:48.231Z" }
 wheels = [
@@ -3548,7 +4139,8 @@ version = "0.0.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "lance-namespace-urllib3-client" },
-    { name = "pyarrow" },
+    { name = "pyarrow", version = "16.0.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-4-daft-paimon'" },
+    { name = "pyarrow", version = "22.0.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'group-4-daft-dev' or extra != 'extra-4-daft-paimon'" },
     { name = "pylance" },
     { name = "typing-extensions" },
 ]
@@ -3649,16 +4241,16 @@ dependencies = [
     { name = "lazy-loader" },
     { name = "msgpack" },
     { name = "numba" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'extra-4-daft-paimon') or (python_full_version < '3.13' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev')" },
     { name = "pooch" },
     { name = "scikit-learn" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "scipy", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
     { name = "soundfile" },
     { name = "soxr" },
-    { name = "standard-aifc", marker = "python_full_version >= '3.13'" },
-    { name = "standard-sunau", marker = "python_full_version >= '3.13'" },
+    { name = "standard-aifc", marker = "python_full_version >= '3.13' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "standard-sunau", marker = "python_full_version >= '3.13' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/64/36/360b5aafa0238e29758729e9486c6ed92a6f37fa403b7875e06c115cdf4a/librosa-0.11.0.tar.gz", hash = "sha256:f5ed951ca189b375bbe2e33b2abd7e040ceeee302b9bbaeeffdfddb8d0ace908", size = 327001, upload-time = "2025-03-11T15:09:54.884Z" }
@@ -3760,7 +4352,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/e1/694c89986fcae7777184fc8b22baa0976eba15a6847221763f6ad211fc1f/llguidance-0.7.30-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c80af02c118d2b0526bcecaab389af2ed094537a069b0fc724cd2a2f2ba3990f", size = 3327974, upload-time = "2025-06-23T00:23:47.556Z" },
     { url = "https://files.pythonhosted.org/packages/fd/77/ab7a548ae189dc23900fdd37803c115c2339b1223af9e8eb1f4329b5935a/llguidance-0.7.30-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:00a256d532911d2cf5ba4ef63e182944e767dd2402f38d63002016bc37755958", size = 3210709, upload-time = "2025-06-23T00:23:45.872Z" },
     { url = "https://files.pythonhosted.org/packages/9c/5b/6a166564b14f9f805f0ea01ec233a84f55789cb7eeffe1d6224ccd0e6cdd/llguidance-0.7.30-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:af8741c867e4bc7e42f7cdc68350c076b4edd0ca10ecefbde75f15a9f6bc25d0", size = 14867038, upload-time = "2025-06-23T00:23:39.571Z" },
+    { url = "https://files.pythonhosted.org/packages/17/ec/69507bdb36767f9b6ff2e290660a9b5afdda0fb8a7903faa37f37c6c2a72/llguidance-0.7.30-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f4a327a30dd37d86dd6347861ac8de3521fc1dbef9475296c06744e5b40ffc54", size = 15142936, upload-time = "2025-06-23T00:23:41.944Z" },
     { url = "https://files.pythonhosted.org/packages/af/80/5a40b9689f17612434b820854cba9b8cabd5142072c491b5280fe5f7a35e/llguidance-0.7.30-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9edc409b9decd6cffba5f5bf3b4fbd7541f95daa8cbc9510cbf96c6ab1ffc153", size = 15004926, upload-time = "2025-06-23T00:23:43.965Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/bc/2d2f9b446bb3e51e4dd4db290590afee03ae29163f417168569f0361204c/llguidance-0.7.30-cp39-abi3-win32.whl", hash = "sha256:a0d52b8d1b2d3b0e661e3f953ecccfa16644f302026b3067a4815c1baa2ae643", size = 2585627, upload-time = "2025-06-23T00:23:52.39Z" },
     { url = "https://files.pythonhosted.org/packages/99/47/58e49a118b514855b245f8a962c6aaf9a5cc95a0f61eac7e230e691c7b7e/llguidance-0.7.30-cp39-abi3-win_amd64.whl", hash = "sha256:05234ecceea7c9c6ff13b9739112043173a3bcb88cae860249b20335a07b3075", size = 2796878, upload-time = "2025-06-23T00:23:51Z" },
 ]
 
@@ -3945,21 +4539,36 @@ name = "lz4"
 version = "4.4.4"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
-    "(python_full_version == '3.13.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
-    "(python_full_version == '3.12.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
-    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version == '3.13.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c6/5a/945f5086326d569f14c84ac6f7fcc3229f0b9b1e8cc536b951fd53dfb9e1/lz4-4.4.4.tar.gz", hash = "sha256:070fd0627ec4393011251a094e08ed9fdcc78cb4e7ab28f507638eee4e39abda", size = 171884, upload-time = "2025-04-01T22:55:58.62Z" }
 wheels = [
@@ -4002,16 +4611,26 @@ name = "lz4"
 version = "4.4.5"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version >= '3.14' and sys_platform == 'darwin'",
-    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version < '3.11' and sys_platform == 'darwin'",
-    "(python_full_version < '3.11' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version >= '3.14' and sys_platform == 'win32'",
-    "python_full_version < '3.11' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/57/51/f1b86d93029f418033dddf9b9f79c8d2641e7454080478ee2aab5123173e/lz4-4.4.5.tar.gz", hash = "sha256:5f0b9e53c1e82e88c10d7c180069363980136b9d7a8306c4dca4f760d60c39f0", size = 172886, upload-time = "2025-11-03T13:02:36.061Z" }
 wheels = [
@@ -4205,10 +4824,10 @@ name = "mcap"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "lz4", version = "4.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "lz4", version = "4.4.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
-    { name = "zstandard", version = "0.24.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "zstandard", version = "0.25.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
+    { name = "lz4", version = "4.4.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and python_full_version < '3.14' and extra == 'group-4-daft-dev') or (python_full_version < '3.11' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version >= '3.14' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "lz4", version = "4.4.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'group-4-daft-dev') or (python_full_version >= '3.14' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "zstandard", version = "0.24.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and python_full_version < '3.14' and extra == 'group-4-daft-dev') or (python_full_version < '3.11' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version >= '3.14' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "zstandard", version = "0.25.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'group-4-daft-dev') or (python_full_version >= '3.14' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8b/38/8bd73953b9c37dd7a2c590e72ab4fa4682a43864fe1d55f7209f2536fa64/mcap-1.3.1.tar.gz", hash = "sha256:2878879a786021aa7f7f36319276396a778717ccd013b2191fe94d37572d7551", size = 21676, upload-time = "2025-12-24T21:31:35.476Z" }
 wheels = [
@@ -4221,8 +4840,8 @@ version = "0.5.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mcap" },
-    { name = "protobuf", version = "5.29.6", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "protobuf", version = "6.33.5", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'darwin'" },
+    { name = "protobuf", version = "5.29.6", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform == 'darwin' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "protobuf", version = "6.33.5", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'darwin' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cc/8e/98af824adce25082f1c7fb8e8aab48b1678a370f97633a55bfb06c40e3fd/mcap_protobuf_support-0.5.4.tar.gz", hash = "sha256:3af2de2c2dbda9d1dbb1a526d2ad0cf3604ab44947dd1c99a52a2f990b1eb308", size = 7059, upload-time = "2025-12-24T21:22:57.716Z" }
 wheels = [
@@ -4326,11 +4945,11 @@ version = "1.8.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonschema" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
     { name = "pillow" },
     { name = "pydantic" },
-    { name = "pydantic-extra-types", extra = ["pycountry"] },
+    { name = "pydantic-extra-types", extra = ["pycountry"], marker = "extra == 'group-4-daft-dev'" },
     { name = "requests" },
     { name = "tiktoken" },
     { name = "typing-extensions" },
@@ -4354,7 +4973,7 @@ name = "mistune"
 version = "3.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c4/79/bda47f7dd7c3c55770478d6d02c9960c430b0cf1773b72366ff89126ea31/mistune-3.1.3.tar.gz", hash = "sha256:a7035c21782b2becb6be62f8f25d3df81ccb4d6fa477a6525b15af06539f02a0", size = 94347, upload-time = "2025-03-19T14:27:24.955Z" }
 wheels = [
@@ -4367,7 +4986,7 @@ version = "1.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
     { name = "ghp-import" },
     { name = "jinja2" },
     { name = "markdown" },
@@ -4570,7 +5189,7 @@ dependencies = [
     { name = "griffe" },
     { name = "mkdocs-autorefs" },
     { name = "mkdocstrings" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/25/84/78243847ad9d5c21d30a2842720425b17e880d99dfe824dee11d6b2149b4/mkdocstrings_python-2.0.2.tar.gz", hash = "sha256:4a32ccfc4b8d29639864698e81cfeb04137bce76bb9f3c251040f55d4b6e1ad8", size = 199124, upload-time = "2026-02-09T15:12:01.543Z" }
 wheels = [
@@ -4582,8 +5201,8 @@ name = "ml-dtypes"
 version = "0.5.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/78/a7/aad060393123cfb383956dca68402aff3db1e1caffd5764887ed5153f41b/ml_dtypes-0.5.3.tar.gz", hash = "sha256:95ce33057ba4d05df50b1f3cfefab22e351868a843b3b15a46c65836283670c9", size = 692316, upload-time = "2025-07-29T18:39:19.454Z" }
 wheels = [
@@ -4630,18 +5249,28 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/21/2f95936bdffeed3a5769b1677be0d17fa4c6131d76cad40b4d60ab5c2f22/mlx-0.30.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:f861392df1ee0ee216188060a8ff2cd2ed4d2b34d4366102863d01d02acf2a7e", size = 554578, upload-time = "2025-11-20T06:42:23.059Z" },
     { url = "https://files.pythonhosted.org/packages/e3/11/85f679159f58770a02e4e61bd418c4a441b2a5df7efee1003e6301be5211/mlx-0.30.0-cp310-cp310-macosx_15_0_arm64.whl", hash = "sha256:7f4a0c37cc3eee051ee5efade3200cb49bc7e9973b38e53db2dddacdb3896a71", size = 554576, upload-time = "2025-11-20T01:16:34.564Z" },
     { url = "https://files.pythonhosted.org/packages/49/18/e11f5b6f617b69b5b4ad8b83489e920adbabde90a8453f561edd774416af/mlx-0.30.0-cp310-cp310-macosx_26_0_arm64.whl", hash = "sha256:df9a48d181ba52da86b524b5e21f8c4eebd73393649127cde19ace75b26daa2c", size = 554517, upload-time = "2025-11-20T05:33:22.645Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/51/9c9a408d63494a9353cfbf1717a679a0fef4a603acee22c6d67c6bc1c69e/mlx-0.30.0-cp310-cp310-manylinux_2_35_aarch64.whl", hash = "sha256:8a83c09b6fa44c089b6ea2fc813e5dc1f134d32298b303da368fed82de9a1a92", size = 625906, upload-time = "2025-12-01T15:22:33.051Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/a7/e18ebe7c9572106e1e1fe7bf9cd91d446c2a9b828c4a062ccfbaa4e5f3dd/mlx-0.30.0-cp310-cp310-manylinux_2_35_x86_64.whl", hash = "sha256:3e2488ec30a1b17138050f0a33d9202c3cbdf67307b411d4ba3e116bd14484d0", size = 659670, upload-time = "2025-11-20T01:16:36.291Z" },
     { url = "https://files.pythonhosted.org/packages/4a/e8/69ebac29536c026489ded1ad58a6f5163b8fc10ab5eac21228f57ea9e83f/mlx-0.30.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:d5871a5f1ce5cba2f690d2c630a6672cc65a62326bcaa6db258185957a1f073f", size = 554825, upload-time = "2025-11-20T16:45:11.135Z" },
     { url = "https://files.pythonhosted.org/packages/2b/c7/db80b1e9f613baf99745e9920a3a7fe7b6c61398420ed308f24f60877a15/mlx-0.30.0-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:302c3d52b4f68b80a8ee259489369524a3381fcc9aed12b17c1c537870c81fce", size = 554821, upload-time = "2025-11-20T01:16:38.53Z" },
     { url = "https://files.pythonhosted.org/packages/8a/68/55cd5cab5a9b8b958ea995295aa3428ad65b3e893f04c27e2cdfcdc176af/mlx-0.30.0-cp311-cp311-macosx_26_0_arm64.whl", hash = "sha256:d72443a461f2e92329edf344ded8460df53fd7ec3c04ddd2353ee4ceb34c0ff2", size = 554791, upload-time = "2025-11-20T05:33:23.851Z" },
+    { url = "https://files.pythonhosted.org/packages/16/91/5b79b6febcbb7e1051ecf408a8c30226ebfdf19a6e304b4cfa32309059ab/mlx-0.30.0-cp311-cp311-manylinux_2_35_aarch64.whl", hash = "sha256:9de2ab05cc9721c99a0802721aa1f0d6c305e97acd2f8ec4c05af3449ee7700d", size = 625176, upload-time = "2025-12-01T15:23:40.991Z" },
+    { url = "https://files.pythonhosted.org/packages/80/17/16868ac1ea36ea3baf61f84721b4dfd98dd247a230b951ddd715981db79b/mlx-0.30.0-cp311-cp311-manylinux_2_35_x86_64.whl", hash = "sha256:0beb015a6afef2f86dfbefe65c9022dce91dbe1651e1b4330ef32434602323e0", size = 659735, upload-time = "2025-11-20T01:16:40.594Z" },
     { url = "https://files.pythonhosted.org/packages/94/a3/32c4c05d8967591e2a1a1e7e3fc9cece8821f5aea8ac8f3bcfdb203f4722/mlx-0.30.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:11fbae58b1e992afdec6709d5e281932871a0138582a794cdcc82ff895a28670", size = 554567, upload-time = "2025-11-20T16:45:12.73Z" },
     { url = "https://files.pythonhosted.org/packages/aa/b3/b6143f1c078fbc873e40e624dc428a3ada240721001414955f584afa866d/mlx-0.30.0-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:fc1994a4c9e60ccfe2ab9211c846be2ef7abc6fc3e53e1addb2cdf7468f61e7b", size = 554566, upload-time = "2025-11-20T01:16:41.877Z" },
     { url = "https://files.pythonhosted.org/packages/96/cb/aec36297ef76b4b190cc6d4cea1ed995b458bbc21cb91c58b0862f8cae7d/mlx-0.30.0-cp312-cp312-macosx_26_0_arm64.whl", hash = "sha256:a9f30c5c94b30b65f026162e91256473187e1de57c13dcc2aedb2fc33c07f2c1", size = 554593, upload-time = "2025-11-20T05:33:25.312Z" },
+    { url = "https://files.pythonhosted.org/packages/40/d3/575eee4ef4b5f3dad9076a78f287affe046fd32b3bdba7a2e0af31f0d9d3/mlx-0.30.0-cp312-cp312-manylinux_2_35_aarch64.whl", hash = "sha256:f88d11e2719fdab08dbe68c9666003c8644ccd01dff973bc86e949cc16195eac", size = 612086, upload-time = "2025-12-01T15:23:42.317Z" },
+    { url = "https://files.pythonhosted.org/packages/23/37/b5dd68da0e79e258f5d6a0e9f5fd4f9e5452e92c20b13b64948a965ea429/mlx-0.30.0-cp312-cp312-manylinux_2_35_x86_64.whl", hash = "sha256:1c4a2f5285bdd585aa6485a4fb5759ebc2721ba9381404ff867c136e84764e9b", size = 653994, upload-time = "2025-11-20T01:16:43.492Z" },
     { url = "https://files.pythonhosted.org/packages/33/a5/e171b2caa69b346bc1abc1bfd0b139f631f68a0ff602862dd255e7dd95ec/mlx-0.30.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:f46aaa6c562ba183e2a64a0e6ba15ed54f9027d9b7b1822e9eec7f59b13d610c", size = 554595, upload-time = "2025-11-20T16:45:13.919Z" },
     { url = "https://files.pythonhosted.org/packages/3e/f4/aeb8980bbef08fc031ab1a2d043a1d76e60d49bf46728bef66cf25b26dfa/mlx-0.30.0-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:5edee9f1452703c0804e067f212c61d488b3ad7419b9fcacf337ffd35842f576", size = 554593, upload-time = "2025-11-20T01:16:45.033Z" },
     { url = "https://files.pythonhosted.org/packages/0b/b3/904235e11610c7cf2ba39eb39f32587d34048f7293d386f19d42d1e3dabc/mlx-0.30.0-cp313-cp313-macosx_26_0_arm64.whl", hash = "sha256:b8ae92b61353d756bbd0668b065a4ee5ee35867b03d63c0c61134d656ed236fe", size = 554330, upload-time = "2025-11-20T05:33:26.653Z" },
+    { url = "https://files.pythonhosted.org/packages/de/0f/bb956ec9926596fe771ec67677c049e358c43f0506699b59dbed7ba9fedc/mlx-0.30.0-cp313-cp313-manylinux_2_35_aarch64.whl", hash = "sha256:f3ae4c99308ff4c006c3062ff73108b6f39414bcd90416930b917160070f759b", size = 612083, upload-time = "2025-12-01T15:23:43.369Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/87/3f3505d3fbf0f977b2930b3596f590f0079c3a2a253d01349f936c40985a/mlx-0.30.0-cp313-cp313-manylinux_2_35_x86_64.whl", hash = "sha256:431009c531f8bdbf56f46b85d458d5526b40ea43178dbc85f37ed55e03e716be", size = 653971, upload-time = "2025-11-20T01:16:46.292Z" },
     { url = "https://files.pythonhosted.org/packages/43/25/6fa174632f5beb583eda80902af80dc39a63e5b4b6e66c7831301751d82e/mlx-0.30.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:384819dccfd551aa1444acacedb9ed2619724b0e67fc361ab80d73b8a8a7618f", size = 558834, upload-time = "2025-11-20T16:45:15.303Z" },
     { url = "https://files.pythonhosted.org/packages/b9/00/8c93f6ba5dc37a459b378bd22d2303824aa341595ed6c4958c6a48870677/mlx-0.30.0-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:8982a7d7fd078988c12c3fc53da1670aa910dd8a7df1fc0b9fee7303394ac8ff", size = 558833, upload-time = "2025-11-20T01:16:48.748Z" },
     { url = "https://files.pythonhosted.org/packages/58/65/0ecb3a858142d7b250b46d1e5c2bb4ebff9f57b735643626b7d4653b0f11/mlx-0.30.0-cp314-cp314-macosx_26_0_arm64.whl", hash = "sha256:392af721cb0bcf600162d7258923c15d39e197a64e23b6abd171e1aea79771c5", size = 558510, upload-time = "2025-11-20T05:33:28.286Z" },
+    { url = "https://files.pythonhosted.org/packages/27/a2/df61dc58caf6238d90cfa2535018fa2c52745e76421dd3ff11c034aae26f/mlx-0.30.0-cp314-cp314-manylinux_2_35_aarch64.whl", hash = "sha256:a4dae4c0404560d3df9832ee709e502022a9e5f89c4d432c576af8405d9a45ef", size = 614193, upload-time = "2025-12-01T15:23:44.688Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/dd/38f465477f996bb24ab133aaf79a3eb0fa13a9bd9d19504aad30c3be7ffc/mlx-0.30.0-cp314-cp314-manylinux_2_35_x86_64.whl", hash = "sha256:cf688c9dda18f2521d48f712515a47b145b37d5d0ab245eaf1a68f286af7ae66", size = 654400, upload-time = "2025-11-20T01:16:50.018Z" },
 ]
 
 [[package]]
@@ -4651,8 +5280,8 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jinja2", marker = "sys_platform == 'darwin'" },
     { name = "mlx", marker = "sys_platform == 'darwin'" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13' and sys_platform == 'darwin'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' and sys_platform == 'darwin'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and sys_platform == 'darwin' and extra == 'group-4-daft-dev') or (python_full_version >= '3.13' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (sys_platform != 'darwin' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and sys_platform == 'darwin' and extra == 'group-4-daft-dev') or (python_full_version < '3.13' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (sys_platform != 'darwin' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
     { name = "protobuf", version = "5.29.6", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
     { name = "pyyaml", marker = "sys_platform == 'darwin'" },
     { name = "transformers", marker = "sys_platform == 'darwin'" },
@@ -4772,8 +5401,8 @@ server = [
     { name = "pydantic" },
     { name = "pyparsing" },
     { name = "pyyaml" },
-    { name = "setuptools", version = "79.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "setuptools", version = "80.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "setuptools", version = "79.0.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "setuptools", version = "80.9.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.12' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 
 [[package]]
@@ -4791,7 +5420,7 @@ version = "1.33.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
-    { name = "pyjwt", extra = ["crypto"] },
+    { name = "pyjwt", extra = ["crypto"], marker = "extra == 'group-4-daft-dev'" },
     { name = "requests" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d5/da/81acbe0c1fd7e9e4ec35f55dadeba9833a847b9a6ba2e2d1e4432da901dd/msal-1.33.0.tar.gz", hash = "sha256:836ad80faa3e25a7d71015c990ce61f704a87328b1e73bcbb0623a18cbf17510", size = 153801, upload-time = "2025-07-22T19:36:33.693Z" }
@@ -4900,7 +5529,7 @@ name = "multidict"
 version = "6.6.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/69/7f/0652e6ed47ab288e3756ea9c0df8b14950781184d4bd7883f4d87dd41245/multidict-6.6.4.tar.gz", hash = "sha256:d2d4e4787672911b48350df02ed3fa3fffdc2f2e8ca06dd6afdf34189b76a9dd", size = 101843, upload-time = "2025-08-11T12:08:48.217Z" }
 wheels = [
@@ -5020,10 +5649,10 @@ name = "mypy"
 version = "1.19.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
     { name = "mypy-extensions" },
     { name = "pathspec" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "tomli", marker = "python_full_version < '3.11' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f5/db/4efed9504bc01309ab9c2da7e352cc223569f05478012b5d9ece38fd44d2/mypy-1.19.1.tar.gz", hash = "sha256:19d88bb05303fe63f71dd2c6270daca27cb9401c4ca8255fe50d1d920e0eb9ba", size = 3582404, upload-time = "2025-12-15T05:03:48.42Z" }
@@ -5102,7 +5731,7 @@ name = "mypy-boto3-glue"
 version = "1.38.46"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fe/61/0e1211c533f8bc1862ba32e43f240b139b4015fcdcde4201b11129bdbf72/mypy_boto3_glue-1.38.46.tar.gz", hash = "sha256:f0fc53c9d40cd2cd7b05ff2113e9c3542e5d6bb4be15cef6eddeabb165b915af", size = 123755, upload-time = "2025-06-27T20:33:43.476Z" }
 wheels = [
@@ -5247,11 +5876,16 @@ name = "networkx"
 version = "3.4.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version < '3.11' and sys_platform == 'darwin'",
-    "(python_full_version < '3.11' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version < '3.11' and sys_platform == 'win32'",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version < '3.11' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fd/1d/06475e1cd5264c0b870ea2cc6fdb3e37177c1e565c43f56ff17a10e3937f/networkx-3.4.2.tar.gz", hash = "sha256:307c3669428c5362aab27c8a1260aa8f47c4e91d3891f48be0141738d8d053e1", size = 2151368, upload-time = "2024-10-21T12:39:38.695Z" }
 wheels = [
@@ -5263,26 +5897,46 @@ name = "networkx"
 version = "3.5"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version >= '3.14' and sys_platform == 'darwin'",
-    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
-    "(python_full_version == '3.13.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
-    "(python_full_version == '3.12.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
-    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version >= '3.14' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version == '3.13.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6c/4f/ccdb8ad3a38e583f214547fd2f7ff1fc160c43a75af88e6aec213404b96a/networkx-3.5.tar.gz", hash = "sha256:d4c6f9cf81f52d69230866796b82afbccdec3db7ae4fbd1b65ea750feed50037", size = 2471065, upload-time = "2025-05-29T11:35:07.804Z" }
 wheels = [
@@ -5330,8 +5984,8 @@ version = "0.61.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "llvmlite" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'extra-4-daft-paimon') or (python_full_version < '3.13' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/a0/e21f57604304aa03ebb8e098429222722ad99176a4f979d34af1d1ee80da/numba-0.61.2.tar.gz", hash = "sha256:8750ee147940a6637b80ecf7f95062185ad8726c8c28a2295b8ec1160a196f7d", size = 2820615, upload-time = "2025-04-09T02:58:07.659Z" }
 wheels = [
@@ -5362,21 +6016,27 @@ name = "numpy"
 version = "1.26.4"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
-    "(python_full_version == '3.12.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
-    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version < '3.11' and sys_platform == 'darwin'",
-    "(python_full_version < '3.11' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'win32'",
-    "python_full_version < '3.11' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version < '3.11' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/65/6e/09db70a523a96d25e115e71cc56a6f9031e7b8cd166c1ac8438307c14058/numpy-1.26.4.tar.gz", hash = "sha256:2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010", size = 15786129, upload-time = "2024-02-06T00:26:44.495Z" }
 wheels = [
@@ -5411,16 +6071,35 @@ name = "numpy"
 version = "2.2.6"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version >= '3.14' and sys_platform == 'darwin'",
-    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
-    "(python_full_version == '3.13.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version >= '3.14' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version == '3.13.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/21/7d2a95e4bba9dc13d043ee156a356c0a8f0c6309dff6b21b4d71a073b8a8/numpy-2.2.6.tar.gz", hash = "sha256:e29554e2bef54a90aa5cc07da6ce955accb83f21ab5de01a62c8478897b264fd", size = 20276440, upload-time = "2025-05-17T22:38:04.611Z" }
 wheels = [
@@ -5485,7 +6164,9 @@ name = "nvidia-cublas-cu12"
 version = "12.8.4.1"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/99/db44d685f0e257ff0e213ade1964fc459b4a690a73293220e98feb3307cf/nvidia_cublas_cu12-12.8.4.1-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b86f6dd8935884615a0683b663891d43781b819ac4f2ba2b0c9604676af346d0", size = 590537124, upload-time = "2025-03-07T01:43:53.556Z" },
     { url = "https://files.pythonhosted.org/packages/dc/61/e24b560ab2e2eaeb3c839129175fb330dfcfc29e5203196e5541a4c44682/nvidia_cublas_cu12-12.8.4.1-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:8ac4e771d5a348c551b2a426eda6193c19aa630236b418086020df5ba9667142", size = 594346921, upload-time = "2025-03-07T01:44:31.254Z" },
+    { url = "https://files.pythonhosted.org/packages/70/61/7d7b3c70186fb651d0fbd35b01dbfc8e755f69fd58f817f3d0f642df20c3/nvidia_cublas_cu12-12.8.4.1-py3-none-win_amd64.whl", hash = "sha256:47e9b82132fa8d2b4944e708049229601448aaad7e6f296f630f2d1a32de35af", size = 567544208, upload-time = "2025-03-07T01:53:30.535Z" },
 ]
 
 [[package]]
@@ -5493,7 +6174,9 @@ name = "nvidia-cuda-cupti-cu12"
 version = "12.8.90"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/1f/b3bd73445e5cb342727fd24fe1f7b748f690b460acadc27ea22f904502c8/nvidia_cuda_cupti_cu12-12.8.90-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4412396548808ddfed3f17a467b104ba7751e6b58678a4b840675c56d21cf7ed", size = 9533318, upload-time = "2025-03-07T01:40:10.421Z" },
     { url = "https://files.pythonhosted.org/packages/f8/02/2adcaa145158bf1a8295d83591d22e4103dbfd821bcaf6f3f53151ca4ffa/nvidia_cuda_cupti_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ea0cb07ebda26bb9b29ba82cda34849e73c166c18162d3913575b0c9db9a6182", size = 10248621, upload-time = "2025-03-07T01:40:21.213Z" },
+    { url = "https://files.pythonhosted.org/packages/41/bc/83f5426095d93694ae39fe1311431b5d5a9bb82e48bf0dd8e19be2765942/nvidia_cuda_cupti_cu12-12.8.90-py3-none-win_amd64.whl", hash = "sha256:bb479dcdf7e6d4f8b0b01b115260399bf34154a1a2e9fe11c85c517d87efd98e", size = 7015759, upload-time = "2025-03-07T01:51:11.355Z" },
 ]
 
 [[package]]
@@ -5502,6 +6185,8 @@ version = "12.8.93"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/05/6b/32f747947df2da6994e999492ab306a903659555dddc0fbdeb9d71f75e52/nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:a7756528852ef889772a84c6cd89d41dfa74667e24cca16bb31f8f061e3e9994", size = 88040029, upload-time = "2025-03-07T01:42:13.562Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d1/e50d0acaab360482034b84b6e27ee83c6738f7d32182b987f9c7a4e32962/nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fc1fec1e1637854b4c0a65fb9a8346b51dd9ee69e61ebaccc82058441f15bce8", size = 43106076, upload-time = "2025-03-07T01:41:59.817Z" },
+    { url = "https://files.pythonhosted.org/packages/45/51/52a3d84baa2136cc8df15500ad731d74d3a1114d4c123e043cb608d4a32b/nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-win_amd64.whl", hash = "sha256:7a4b6b2904850fe78e0bd179c4b655c404d4bb799ef03ddc60804247099ae909", size = 73586838, upload-time = "2025-03-07T01:52:13.483Z" },
 ]
 
 [[package]]
@@ -5509,7 +6194,9 @@ name = "nvidia-cuda-runtime-cu12"
 version = "12.8.90"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/75/f865a3b236e4647605ea34cc450900854ba123834a5f1598e160b9530c3a/nvidia_cuda_runtime_cu12-12.8.90-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:52bf7bbee900262ffefe5e9d5a2a69a30d97e2bc5bb6cc866688caa976966e3d", size = 965265, upload-time = "2025-03-07T01:39:43.533Z" },
     { url = "https://files.pythonhosted.org/packages/0d/9b/a997b638fcd068ad6e4d53b8551a7d30fe8b404d6f1804abf1df69838932/nvidia_cuda_runtime_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:adade8dcbd0edf427b7204d480d6066d33902cab2a4707dcfc48a2d0fd44ab90", size = 954765, upload-time = "2025-03-07T01:40:01.615Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a5/a515b7600ad361ea14bfa13fb4d6687abf500adc270f19e89849c0590492/nvidia_cuda_runtime_cu12-12.8.90-py3-none-win_amd64.whl", hash = "sha256:c0c6027f01505bfed6c3b21ec546f69c687689aad5f1a377554bc6ca4aa993a8", size = 944318, upload-time = "2025-03-07T01:51:01.794Z" },
 ]
 
 [[package]]
@@ -5517,10 +6204,12 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cublas-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-4-daft-paimon') or (sys_platform == 'linux' and extra != 'group-4-daft-dev') or (sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/41/e79269ce215c857c935fd86bcfe91a451a584dfc27f1e068f568b9ad1ab7/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:c9132cc3f8958447b4910a1720036d9eff5928cc3179b0a51fb6d167c6cc87d8", size = 705026878, upload-time = "2025-06-06T21:52:51.348Z" },
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/90/0bd6e586701b3a890fd38aa71c387dab4883d619d6e5ad912ccbd05bfd67/nvidia_cudnn_cu12-9.10.2.21-py3-none-win_amd64.whl", hash = "sha256:c6288de7d63e6cf62988f0923f96dc339cea362decb1bf5b3141883392a7d65e", size = 692992268, upload-time = "2025-06-06T21:55:18.114Z" },
 ]
 
 [[package]]
@@ -5528,10 +6217,12 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-4-daft-paimon') or (sys_platform == 'linux' and extra != 'group-4-daft-dev') or (sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/bc/7771846d3a0272026c416fbb7e5f4c1f146d6d80704534d0b187dd6f4800/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:848ef7224d6305cdb2a4df928759dca7b1201874787083b6e7550dd6765ce69a", size = 193109211, upload-time = "2025-03-07T01:44:56.873Z" },
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/ec/ce1629f1e478bb5ccd208986b5f9e0316a78538dd6ab1d0484f012f8e2a1/nvidia_cufft_cu12-11.3.3.83-py3-none-win_amd64.whl", hash = "sha256:7a64a98ef2a7c47f905aaf8931b69a3a43f27c55530c698bb2ed7c75c0b42cb7", size = 192216559, upload-time = "2025-03-07T01:53:57.106Z" },
 ]
 
 [[package]]
@@ -5540,6 +6231,7 @@ version = "1.13.1.3"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bb/fe/1bcba1dfbfb8d01be8d93f07bfc502c93fa23afa6fd5ab3fc7c1df71038a/nvidia_cufile_cu12-1.13.1.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1d069003be650e131b21c932ec3d8969c1715379251f8d23a1860554b1cb24fc", size = 1197834, upload-time = "2025-03-07T01:45:50.723Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/f5/5607710447a6fe9fd9b3283956fceeee8a06cda1d2f56ce31371f595db2a/nvidia_cufile_cu12-1.13.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:4beb6d4cce47c1a0f1013d72e02b0994730359e17801d395bdcbf20cfb3bb00a", size = 1120705, upload-time = "2025-03-07T01:45:41.434Z" },
 ]
 
 [[package]]
@@ -5547,7 +6239,9 @@ name = "nvidia-curand-cu12"
 version = "10.3.9.90"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/5e/92aa15eca622a388b80fbf8375d4760738df6285b1e92c43d37390a33a9a/nvidia_curand_cu12-10.3.9.90-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:dfab99248034673b779bc6decafdc3404a8a6f502462201f2f31f11354204acd", size = 63625754, upload-time = "2025-03-07T01:46:10.735Z" },
     { url = "https://files.pythonhosted.org/packages/fb/aa/6584b56dc84ebe9cf93226a5cde4d99080c8e90ab40f0c27bda7a0f29aa1/nvidia_curand_cu12-10.3.9.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:b32331d4f4df5d6eefa0554c565b626c7216f87a06a4f56fab27c3b68a830ec9", size = 63619976, upload-time = "2025-03-07T01:46:23.323Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/75/70c05b2f3ed5be3bb30b7102b6eb78e100da4bbf6944fd6725c012831cab/nvidia_curand_cu12-10.3.9.90-py3-none-win_amd64.whl", hash = "sha256:f149a8ca457277da854f89cf282d6ef43176861926c7ac85b2a0fbd237c587ec", size = 62765309, upload-time = "2025-03-07T01:54:20.478Z" },
 ]
 
 [[package]]
@@ -5555,12 +6249,14 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cublas-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-4-daft-paimon') or (sys_platform == 'linux' and extra != 'group-4-daft-dev') or (sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "nvidia-cusparse-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-4-daft-paimon') or (sys_platform == 'linux' and extra != 'group-4-daft-dev') or (sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-4-daft-paimon') or (sys_platform == 'linux' and extra != 'group-4-daft-dev') or (sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/32/f7cd6ce8a7690544d084ea21c26e910a97e077c9b7f07bf5de623ee19981/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:db9ed69dbef9715071232caa9b69c52ac7de3a95773c2db65bdba85916e4e5c0", size = 267229841, upload-time = "2025-03-07T01:46:54.356Z" },
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
+    { url = "https://files.pythonhosted.org/packages/13/c0/76ca8551b8a84146ffa189fec81c26d04adba4bc0dbe09cd6e6fd9b7de04/nvidia_cusolver_cu12-11.7.3.90-py3-none-win_amd64.whl", hash = "sha256:4a550db115fcabc4d495eb7d39ac8b58d4ab5d8e63274d3754df1c0ad6a22d34", size = 256720438, upload-time = "2025-03-07T01:54:39.898Z" },
 ]
 
 [[package]]
@@ -5568,10 +6264,12 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-4-daft-paimon') or (sys_platform == 'linux' and extra != 'group-4-daft-dev') or (sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/f7/cd777c4109681367721b00a106f491e0d0d15cfa1fd59672ce580ce42a97/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9b6c161cb130be1a07a27ea6923df8141f3c295852f4b260c65f18f3e0a091dc", size = 288117129, upload-time = "2025-03-07T01:47:40.407Z" },
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
+    { url = "https://files.pythonhosted.org/packages/62/07/f3b2ad63f8e3d257a599f422ae34eb565e70c41031aecefa3d18b62cabd1/nvidia_cusparse_cu12-12.5.8.93-py3-none-win_amd64.whl", hash = "sha256:9a33604331cb2cac199f2e7f5104dfbb8a5a898c367a53dfda9ff2acb6b6b4dd", size = 284937404, upload-time = "2025-03-07T01:55:07.742Z" },
 ]
 
 [[package]]
@@ -5579,7 +6277,9 @@ name = "nvidia-cusparselt-cu12"
 version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/b9/598f6ff36faaece4b3c50d26f50e38661499ff34346f00e057760b35cc9d/nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:8878dce784d0fac90131b6817b607e803c36e629ba34dc5b433471382196b6a5", size = 283835557, upload-time = "2025-02-26T00:16:54.265Z" },
     { url = "https://files.pythonhosted.org/packages/56/79/12978b96bd44274fe38b5dde5cfb660b1d114f70a65ef962bcbbed99b549/nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f1bb701d6b930d5a7cea44c19ceb973311500847f81b634d802b7b539dc55623", size = 287193691, upload-time = "2025-02-26T00:15:44.104Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/d8/a6b0d0d0c2435e9310f3e2bb0d9c9dd4c33daef86aa5f30b3681defd37ea/nvidia_cusparselt_cu12-0.7.1-py3-none-win_amd64.whl", hash = "sha256:f67fbb5831940ec829c9117b7f33807db9f9678dc2a617fbe781cac17b4e1075", size = 271020911, upload-time = "2025-02-26T00:14:47.204Z" },
 ]
 
 [[package]]
@@ -5587,6 +6287,7 @@ name = "nvidia-nccl-cu12"
 version = "2.27.3"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/7b/8354b784cf73b0ba51e566b4baba3ddd44fe8288a3d39ef1e06cd5417226/nvidia_nccl_cu12-2.27.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9ddf1a245abc36c550870f26d537a9b6087fb2e2e3d6e0ef03374c6fd19d984f", size = 322397768, upload-time = "2025-06-03T21:57:30.234Z" },
     { url = "https://files.pythonhosted.org/packages/5c/5b/4e4fff7bad39adf89f735f2bc87248c81db71205b62bcc0d5ca5b606b3c3/nvidia_nccl_cu12-2.27.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:adf27ccf4238253e0b826bce3ff5fa532d65fc42322c8bfdfaf28024c0fbe039", size = 322364134, upload-time = "2025-06-03T21:58:04.013Z" },
 ]
 
@@ -5596,6 +6297,8 @@ version = "12.8.93"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f6/74/86a07f1d0f42998ca31312f998bd3b9a7eff7f52378f4f270c8679c77fb9/nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:81ff63371a7ebd6e6451970684f916be2eab07321b73c9d244dc2b4da7f73b88", size = 39254836, upload-time = "2025-03-07T01:49:55.661Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/a2/8cee5da30d13430e87bf99bb33455d2724d0a4a9cb5d7926d80ccb96d008/nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:adccd7161ace7261e01bb91e44e88da350895c270d23f744f0820c818b7229e7", size = 38386204, upload-time = "2025-03-07T01:49:43.612Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/d7/34f02dad2e30c31b10a51f6b04e025e5dd60e5f936af9045a9b858a05383/nvidia_nvjitlink_cu12-12.8.93-py3-none-win_amd64.whl", hash = "sha256:bd93fbeeee850917903583587f4fc3a4eafa022e34572251368238ab5e6bd67f", size = 268553710, upload-time = "2025-03-07T01:56:24.13Z" },
 ]
 
 [[package]]
@@ -5603,7 +6306,9 @@ name = "nvidia-nvtx-cu12"
 version = "12.8.90"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/c0/1b303feea90d296f6176f32a2a70b5ef230f9bdeb3a72bddb0dc922dc137/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d7ad891da111ebafbf7e015d34879f7112832fc239ff0d7d776b6cb685274615", size = 91161, upload-time = "2025-03-07T01:42:23.922Z" },
     { url = "https://files.pythonhosted.org/packages/a2/eb/86626c1bbc2edb86323022371c39aa48df6fd8b0a1647bc274577f72e90b/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5b17e2001cc0d751a5bc2c6ec6d26ad95913324a4adb86788c944f8ce9ba441f", size = 89954, upload-time = "2025-03-07T01:42:44.131Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/99/4c9c0c329bf9fc125008c3b54c7c94c0023518d06fc025ae36431375e1fe/nvidia_nvtx_cu12-12.8.90-py3-none-win_amd64.whl", hash = "sha256:619c8304aedc69f02ea82dd244541a83c3d9d40993381b3b590f1adaed3db41e", size = 56492, upload-time = "2025-03-07T01:52:24.69Z" },
 ]
 
 [[package]]
@@ -5701,8 +6406,8 @@ name = "opencv-python"
 version = "4.10.0.84"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4a/e7/b70a2d9ab205110d715906fc8ec83fbb00404aeb3a37a0654fdb68eb0c8c/opencv-python-4.10.0.84.tar.gz", hash = "sha256:72d234e4582e9658ffea8e9cae5b63d488ad06994ef12d81dc303b17472f3526", size = 95103981, upload-time = "2024-06-17T18:29:56.757Z" }
 wheels = [
@@ -5719,8 +6424,8 @@ name = "opencv-python-headless"
 version = "4.11.0.86"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/36/2f/5b2b3ba52c864848885ba988f24b7f105052f68da9ab0e693cc7c25b0b30/opencv-python-headless-4.11.0.86.tar.gz", hash = "sha256:996eb282ca4b43ec6a3972414de0e2331f5d9cda2b41091a49739c19fb843798", size = 95177929, upload-time = "2025-01-16T13:53:40.22Z" }
 wheels = [
@@ -5823,6 +6528,34 @@ wheels = [
 ]
 
 [[package]]
+name = "oss2"
+version = "2.18.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aliyun-python-sdk-core" },
+    { name = "aliyun-python-sdk-kms" },
+    { name = "crcmod" },
+    { name = "pycryptodome" },
+    { name = "requests" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4a/e7/08b90651a435acde68c537eebff970011422f61c465f6d1c88c4b3af6774/oss2-2.18.1.tar.gz", hash = "sha256:5a901f6c0f3ac42f792e16a1e1c04e60f34e6cc9eb2bc4c0c3ce6e7bda2da4cc", size = 274272, upload-time = "2023-07-18T13:04:48.784Z" }
+
+[[package]]
+name = "ossfs"
+version = "2023.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiooss2" },
+    { name = "fsspec", version = "2024.3.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "oss2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d2/42/4cdce6e1ff4ce53c33cdc0dc1d212207181af3037d0a3a789367da42a266/ossfs-2023.12.0.tar.gz", hash = "sha256:f99eb2d74717d22551b1f32ec9434587962627a816a64536dc47d68470536110", size = 41625, upload-time = "2023-12-05T16:37:52.692Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/c0/121c6ae711376258a3e786d6afc991d022e3a74884ef4e6caa80b9c141a0/ossfs-2023.12.0-py3-none-any.whl", hash = "sha256:d1c5bbd24e7c0b3badd47d9c659bfdfac96d148b7e5d1f88ccdaf26403e893ab", size = 25028, upload-time = "2023-12-05T16:37:51.364Z" },
+]
+
+[[package]]
 name = "outlines-core"
 version = "0.2.11"
 source = { registry = "https://pypi.org/simple" }
@@ -5889,23 +6622,20 @@ resolution-markers = [
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version == '3.12.*' and sys_platform == 'darwin'",
-    "(python_full_version == '3.12.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
+    "(python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
     "python_full_version == '3.11.*' and sys_platform == 'darwin'",
-    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
     "python_full_version < '3.11' and sys_platform == 'darwin'",
-    "(python_full_version < '3.11' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "(python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
     "python_full_version == '3.12.*' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'win32'",
     "python_full_version < '3.11' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "python-dateutil", marker = "python_full_version < '3.13'" },
-    { name = "pytz", marker = "python_full_version < '3.13'" },
-    { name = "tzdata", marker = "python_full_version < '3.13'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "python-dateutil", marker = "(python_full_version < '3.13' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "pytz", marker = "(python_full_version < '3.13' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "tzdata", marker = "(python_full_version < '3.13' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9c/d6/9f8431bacc2e19dca897724cd097b1bb224a6ad5433784a44b587c7c13af/pandas-2.2.3.tar.gz", hash = "sha256:4f18ba62b61d7e192368b84517265a99b4d7ee8912f8708660fb4a366cc82667", size = 4399213, upload-time = "2024-09-20T13:10:04.827Z" }
 wheels = [
@@ -5947,25 +6677,104 @@ wheels = [
 
 [[package]]
 name = "pandas"
+version = "2.3.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version < '3.11' and sys_platform == 'win32'",
+]
+dependencies = [
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'extra-4-daft-paimon') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra == 'extra-4-daft-paimon') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "python-dateutil", marker = "extra == 'extra-4-daft-paimon'" },
+    { name = "pytz", marker = "extra == 'extra-4-daft-paimon'" },
+    { name = "tzdata", marker = "extra == 'extra-4-daft-paimon'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/8e/0e90233ac205ad182bd6b422532695d2b9414944a280488105d598c70023/pandas-2.3.2.tar.gz", hash = "sha256:ab7b58f8f82706890924ccdfb5f48002b83d2b5a3845976a9fb705d36c34dcdb", size = 4488684, upload-time = "2025-08-21T10:28:29.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/16/a8eeb70aad84ccbf14076793f90e0031eded63c1899aeae9fdfbf37881f4/pandas-2.3.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:52bc29a946304c360561974c6542d1dd628ddafa69134a7131fdfd6a5d7a1a35", size = 11539648, upload-time = "2025-08-21T10:26:36.236Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f1/c5bdaea13bf3708554d93e948b7ea74121ce6e0d59537ca4c4f77731072b/pandas-2.3.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:220cc5c35ffaa764dd5bb17cf42df283b5cb7fdf49e10a7b053a06c9cb48ee2b", size = 10786923, upload-time = "2025-08-21T10:26:40.518Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/10/811fa01476d29ffed692e735825516ad0e56d925961819e6126b4ba32147/pandas-2.3.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42c05e15111221384019897df20c6fe893b2f697d03c811ee67ec9e0bb5a3424", size = 11726241, upload-time = "2025-08-21T10:26:43.175Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/6a/40b043b06e08df1ea1b6d20f0e0c2f2c4ec8c4f07d1c92948273d943a50b/pandas-2.3.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cc03acc273c5515ab69f898df99d9d4f12c4d70dbfc24c3acc6203751d0804cf", size = 12349533, upload-time = "2025-08-21T10:26:46.611Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ea/2e081a2302e41a9bca7056659fdd2b85ef94923723e41665b42d65afd347/pandas-2.3.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:d25c20a03e8870f6339bcf67281b946bd20b86f1a544ebbebb87e66a8d642cba", size = 13202407, upload-time = "2025-08-21T10:26:49.068Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/12/7ff9f6a79e2ee8869dcf70741ef998b97ea20050fe25f83dc759764c1e32/pandas-2.3.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:21bb612d148bb5860b7eb2c10faacf1a810799245afd342cf297d7551513fbb6", size = 13837212, upload-time = "2025-08-21T10:26:51.832Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/df/5ab92fcd76455a632b3db34a746e1074d432c0cdbbd28d7cd1daba46a75d/pandas-2.3.2-cp310-cp310-win_amd64.whl", hash = "sha256:b62d586eb25cb8cb70a5746a378fc3194cb7f11ea77170d59f889f5dfe3cec7a", size = 11338099, upload-time = "2025-08-21T10:26:54.382Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/59/f3e010879f118c2d400902d2d871c2226cef29b08c09fb8dc41111730400/pandas-2.3.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1333e9c299adcbb68ee89a9bb568fc3f20f9cbb419f1dd5225071e6cddb2a743", size = 11563308, upload-time = "2025-08-21T10:26:56.656Z" },
+    { url = "https://files.pythonhosted.org/packages/38/18/48f10f1cc5c397af59571d638d211f494dba481f449c19adbd282aa8f4ca/pandas-2.3.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:76972bcbd7de8e91ad5f0ca884a9f2c477a2125354af624e022c49e5bd0dfff4", size = 10820319, upload-time = "2025-08-21T10:26:59.162Z" },
+    { url = "https://files.pythonhosted.org/packages/95/3b/1e9b69632898b048e223834cd9702052bcf06b15e1ae716eda3196fb972e/pandas-2.3.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b98bdd7c456a05eef7cd21fd6b29e3ca243591fe531c62be94a2cc987efb5ac2", size = 11790097, upload-time = "2025-08-21T10:27:02.204Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/ef/0e2ffb30b1f7fbc9a588bd01e3c14a0d96854d09a887e15e30cc19961227/pandas-2.3.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1d81573b3f7db40d020983f78721e9bfc425f411e616ef019a10ebf597aedb2e", size = 12397958, upload-time = "2025-08-21T10:27:05.409Z" },
+    { url = "https://files.pythonhosted.org/packages/23/82/e6b85f0d92e9afb0e7f705a51d1399b79c7380c19687bfbf3d2837743249/pandas-2.3.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e190b738675a73b581736cc8ec71ae113d6c3768d0bd18bffa5b9a0927b0b6ea", size = 13225600, upload-time = "2025-08-21T10:27:07.791Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/f1/f682015893d9ed51611948bd83683670842286a8edd4f68c2c1c3b231eef/pandas-2.3.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:c253828cb08f47488d60f43c5fc95114c771bbfff085da54bfc79cb4f9e3a372", size = 13879433, upload-time = "2025-08-21T10:27:10.347Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/e7/ae86261695b6c8a36d6a4c8d5f9b9ede8248510d689a2f379a18354b37d7/pandas-2.3.2-cp311-cp311-win_amd64.whl", hash = "sha256:9467697b8083f9667b212633ad6aa4ab32436dcbaf4cd57325debb0ddef2012f", size = 11336557, upload-time = "2025-08-21T10:27:12.983Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/db/614c20fb7a85a14828edd23f1c02db58a30abf3ce76f38806155d160313c/pandas-2.3.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3fbb977f802156e7a3f829e9d1d5398f6192375a3e2d1a9ee0803e35fe70a2b9", size = 11587652, upload-time = "2025-08-21T10:27:15.888Z" },
+    { url = "https://files.pythonhosted.org/packages/99/b0/756e52f6582cade5e746f19bad0517ff27ba9c73404607c0306585c201b3/pandas-2.3.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1b9b52693123dd234b7c985c68b709b0b009f4521000d0525f2b95c22f15944b", size = 10717686, upload-time = "2025-08-21T10:27:18.486Z" },
+    { url = "https://files.pythonhosted.org/packages/37/4c/dd5ccc1e357abfeee8353123282de17997f90ff67855f86154e5a13b81e5/pandas-2.3.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0bd281310d4f412733f319a5bc552f86d62cddc5f51d2e392c8787335c994175", size = 11278722, upload-time = "2025-08-21T10:27:21.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/a4/f7edcfa47e0a88cda0be8b068a5bae710bf264f867edfdf7b71584ace362/pandas-2.3.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:96d31a6b4354e3b9b8a2c848af75d31da390657e3ac6f30c05c82068b9ed79b9", size = 11987803, upload-time = "2025-08-21T10:27:23.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/61/1bce4129f93ab66f1c68b7ed1c12bac6a70b1b56c5dab359c6bbcd480b52/pandas-2.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:df4df0b9d02bb873a106971bb85d448378ef14b86ba96f035f50bbd3688456b4", size = 12766345, upload-time = "2025-08-21T10:27:26.6Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/46/80d53de70fee835531da3a1dae827a1e76e77a43ad22a8cd0f8142b61587/pandas-2.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:213a5adf93d020b74327cb2c1b842884dbdd37f895f42dcc2f09d451d949f811", size = 13439314, upload-time = "2025-08-21T10:27:29.213Z" },
+    { url = "https://files.pythonhosted.org/packages/28/30/8114832daff7489f179971dbc1d854109b7f4365a546e3ea75b6516cea95/pandas-2.3.2-cp312-cp312-win_amd64.whl", hash = "sha256:8c13b81a9347eb8c7548f53fd9a4f08d4dfe996836543f805c987bafa03317ae", size = 10983326, upload-time = "2025-08-21T10:27:31.901Z" },
+    { url = "https://files.pythonhosted.org/packages/27/64/a2f7bf678af502e16b472527735d168b22b7824e45a4d7e96a4fbb634b59/pandas-2.3.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0c6ecbac99a354a051ef21c5307601093cb9e0f4b1855984a084bfec9302699e", size = 11531061, upload-time = "2025-08-21T10:27:34.647Z" },
+    { url = "https://files.pythonhosted.org/packages/54/4c/c3d21b2b7769ef2f4c2b9299fcadd601efa6729f1357a8dbce8dd949ed70/pandas-2.3.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c6f048aa0fd080d6a06cc7e7537c09b53be6642d330ac6f54a600c3ace857ee9", size = 10668666, upload-time = "2025-08-21T10:27:37.203Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e2/f775ba76ecfb3424d7f5862620841cf0edb592e9abd2d2a5387d305fe7a8/pandas-2.3.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0064187b80a5be6f2f9c9d6bdde29372468751dfa89f4211a3c5871854cfbf7a", size = 11332835, upload-time = "2025-08-21T10:27:40.188Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/52/0634adaace9be2d8cac9ef78f05c47f3a675882e068438b9d7ec7ef0c13f/pandas-2.3.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4ac8c320bded4718b298281339c1a50fb00a6ba78cb2a63521c39bec95b0209b", size = 12057211, upload-time = "2025-08-21T10:27:43.117Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/9d/2df913f14b2deb9c748975fdb2491da1a78773debb25abbc7cbc67c6b549/pandas-2.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:114c2fe4f4328cf98ce5716d1532f3ab79c5919f95a9cfee81d9140064a2e4d6", size = 12749277, upload-time = "2025-08-21T10:27:45.474Z" },
+    { url = "https://files.pythonhosted.org/packages/87/af/da1a2417026bd14d98c236dba88e39837182459d29dcfcea510b2ac9e8a1/pandas-2.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:48fa91c4dfb3b2b9bfdb5c24cd3567575f4e13f9636810462ffed8925352be5a", size = 13415256, upload-time = "2025-08-21T10:27:49.885Z" },
+    { url = "https://files.pythonhosted.org/packages/22/3c/f2af1ce8840ef648584a6156489636b5692c162771918aa95707c165ad2b/pandas-2.3.2-cp313-cp313-win_amd64.whl", hash = "sha256:12d039facec710f7ba305786837d0225a3444af7bbd9c15c32ca2d40d157ed8b", size = 10982579, upload-time = "2025-08-21T10:28:08.435Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/98/8df69c4097a6719e357dc249bf437b8efbde808038268e584421696cbddf/pandas-2.3.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:c624b615ce97864eb588779ed4046186f967374185c047070545253a52ab2d57", size = 12028163, upload-time = "2025-08-21T10:27:52.232Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/23/f95cbcbea319f349e10ff90db488b905c6883f03cbabd34f6b03cbc3c044/pandas-2.3.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:0cee69d583b9b128823d9514171cabb6861e09409af805b54459bd0c821a35c2", size = 11391860, upload-time = "2025-08-21T10:27:54.673Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1b/6a984e98c4abee22058aa75bfb8eb90dce58cf8d7296f8bc56c14bc330b0/pandas-2.3.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2319656ed81124982900b4c37f0e0c58c015af9a7bbc62342ba5ad07ace82ba9", size = 11309830, upload-time = "2025-08-21T10:27:56.957Z" },
+    { url = "https://files.pythonhosted.org/packages/15/d5/f0486090eb18dd8710bf60afeaf638ba6817047c0c8ae5c6a25598665609/pandas-2.3.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b37205ad6f00d52f16b6d09f406434ba928c1a1966e2771006a9033c736d30d2", size = 11883216, upload-time = "2025-08-21T10:27:59.302Z" },
+    { url = "https://files.pythonhosted.org/packages/10/86/692050c119696da19e20245bbd650d8dfca6ceb577da027c3a73c62a047e/pandas-2.3.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:837248b4fc3a9b83b9c6214699a13f069dc13510a6a6d7f9ba33145d2841a012", size = 12699743, upload-time = "2025-08-21T10:28:02.447Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/d7/612123674d7b17cf345aad0a10289b2a384bff404e0463a83c4a3a59d205/pandas-2.3.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:d2c3554bd31b731cd6490d94a28f3abb8dd770634a9e06eb6d2911b9827db370", size = 13186141, upload-time = "2025-08-21T10:28:05.377Z" },
+]
+
+[[package]]
+name = "pandas"
 version = "2.3.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version >= '3.14' and sys_platform == 'darwin'",
-    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
-    "(python_full_version == '3.13.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version >= '3.14' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version == '3.13.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.13'" },
-    { name = "pytz", marker = "python_full_version >= '3.13'" },
-    { name = "tzdata", marker = "python_full_version >= '3.13'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra != 'extra-4-daft-paimon') or (extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "python-dateutil", marker = "(python_full_version >= '3.13' and extra != 'extra-4-daft-paimon') or (extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "pytz", marker = "(python_full_version >= '3.13' and extra != 'extra-4-daft-paimon') or (extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "tzdata", marker = "(python_full_version >= '3.13' and extra != 'extra-4-daft-paimon') or (extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -6023,8 +6832,8 @@ name = "pandas-stubs"
 version = "2.3.3.260113"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
     { name = "types-pytz" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/92/5d/be23854a73fda69f1dbdda7bc10fbd6f930bd1fa87aaec389f00c901c1e8/pandas_stubs-2.3.3.260113.tar.gz", hash = "sha256:076e3724bcaa73de78932b012ec64b3010463d377fa63116f4e6850643d93800", size = 116131, upload-time = "2026-01-13T22:30:16.704Z" }
@@ -6095,7 +6904,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "sys_platform != 'win32'" },
+    { name = "ptyprocess", marker = "sys_platform != 'win32' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -6107,8 +6916,8 @@ name = "pgvector"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'extra-4-daft-paimon') or (python_full_version < '3.13' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/44/43/9a0fb552ab4fd980680c2037962e331820f67585df740bedc4a2b50faf20/pgvector-0.4.1.tar.gz", hash = "sha256:83d3a1c044ff0c2f1e95d13dfb625beb0b65506cfec0941bfe81fd0ad44f4003", size = 30646, upload-time = "2025-04-26T18:56:37.151Z" }
 wheels = [
@@ -6238,6 +7047,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e5/69/882ee5c9d017149285cab114ebeab373308ef0f874fcdac9beb90e0ac4da/ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3", size = 159130, upload-time = "2018-02-15T19:01:31.097Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a3/58/35da89ee790598a0700ea49b2a66594140f44dec458c07e8e3d4979137fc/ply-3.11-py2.py3-none-any.whl", hash = "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce", size = 49567, upload-time = "2018-02-15T19:01:27.172Z" },
+]
+
+[[package]]
+name = "polars"
+version = "1.32.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/67/23/6a5f151981f3ac409bed6dc48a3eaecd0592a03eb382693d4c7e749eda8b/polars-1.32.0.tar.gz", hash = "sha256:b01045981c0f23eeccfbfc870b782f93e73b74b29212fdfc8aae0be9024bc1fb", size = 4761045, upload-time = "2025-08-01T01:43:22.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/40/5b27067d10b5a77ab4094932118e16629ffb20ea9ae5f7d1178e04087891/polars-1.32.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:94f7c6a3b30bc99bc6b682ea42bb1ae983e33a302ca21aacbac50ae19e34fcf2", size = 37479518, upload-time = "2025-08-01T01:42:18.603Z" },
+    { url = "https://files.pythonhosted.org/packages/08/b7/ca28ac10d340fb91bffb2751efd52aebc9799ae161b867214c6299c8f75b/polars-1.32.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:8bf14c16164839e62c741a863942a94a9a463db21e797452fca996c8afaf8827", size = 34214196, upload-time = "2025-08-01T01:42:22.667Z" },
+    { url = "https://files.pythonhosted.org/packages/61/97/fe3797e8e1d4f9eadab32ffe218a841b8874585b6c9bd0f1a26469fb2992/polars-1.32.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f4c15adb97d44766d30c759f5cebbdb64d361e8349ef10b5afc7413f71bf4b72", size = 37985353, upload-time = "2025-08-01T01:42:26.033Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/7e/2baa2858556e970cc6a35c0d8ad34b2f9d982f1766c0a1fec20ca529a947/polars-1.32.0-cp39-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:13af55890734f89b76016a395fb2e7460e7d9feecf50ed2f55cf0f05a1c0c991", size = 35183912, upload-time = "2025-08-01T01:42:30.446Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/41/0e6821dccc5871186a9b95af3990404aa283318263918d33ac974b35cb37/polars-1.32.0-cp39-abi3-win_amd64.whl", hash = "sha256:0397fc2501a5d5f1bb3fe8d27e0c26c7a5349b4110157c0fb7833cd3f5921c9e", size = 37747905, upload-time = "2025-08-01T01:42:33.975Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/93/d06df0817da93f922a67e27e9e0f407856991374daa62687e2a45a18935c/polars-1.32.0-cp39-abi3-win_arm64.whl", hash = "sha256:dd84e24422509e1ec9be46f67f758d0bd9944d1ae4eacecee4f53adaa8ecd822", size = 33978543, upload-time = "2025-08-01T01:42:36.779Z" },
 ]
 
 [[package]]
@@ -6398,8 +7221,8 @@ name = "proto-plus"
 version = "1.26.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "protobuf", version = "5.29.6", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "protobuf", version = "6.33.5", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'darwin'" },
+    { name = "protobuf", version = "5.29.6", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform == 'darwin' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "protobuf", version = "6.33.5", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'darwin' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f4/ac/87285f15f7cce6d4a008f33f1757fb5a13611ea8914eb58c3d0d26243468/proto_plus-1.26.1.tar.gz", hash = "sha256:21a515a4c4c0088a773899e23c7bbade3d18f9c66c73edd4c7ee3816bc96a012", size = 56142, upload-time = "2025-03-10T15:54:38.843Z" }
 wheels = [
@@ -6419,7 +7242,11 @@ resolution-markers = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7e/57/394a763c103e0edf87f0938dafcd918d53b4c011dfc5c8ae80f3b0452dbb/protobuf-5.29.6.tar.gz", hash = "sha256:da9ee6a5424b6b30fd5e45c5ea663aef540ca95f9ad99d1e887e819cdf9b8723", size = 425623, upload-time = "2026-02-04T22:54:40.584Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/88/9ee58ff7863c479d6f8346686d4636dd4c415b0cbeed7a6a7d0617639c2a/protobuf-5.29.6-cp310-abi3-win32.whl", hash = "sha256:62e8a3114992c7c647bce37dcc93647575fc52d50e48de30c6fcb28a6a291eb1", size = 423357, upload-time = "2026-02-04T22:54:25.805Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/66/2dc736a4d576847134fb6d80bd995c569b13cdc7b815d669050bf0ce2d2c/protobuf-5.29.6-cp310-abi3-win_amd64.whl", hash = "sha256:7e6ad413275be172f67fdee0f43484b6de5a904cc1c3ea9804cb6fe2ff366eda", size = 435175, upload-time = "2026-02-04T22:54:28.592Z" },
     { url = "https://files.pythonhosted.org/packages/06/db/49b05966fd208ae3f44dcd33837b6243b4915c57561d730a43f881f24dea/protobuf-5.29.6-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:b5a169e664b4057183a34bdc424540e86eea47560f3c123a0d64de4e137f9269", size = 418619, upload-time = "2026-02-04T22:54:30.266Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/d7/48cbf6b0c3c39761e47a99cb483405f0fde2be22cf00d71ef316ce52b458/protobuf-5.29.6-cp38-abi3-manylinux2014_aarch64.whl", hash = "sha256:a8866b2cff111f0f863c1b3b9e7572dc7eaea23a7fae27f6fc613304046483e6", size = 320284, upload-time = "2026-02-04T22:54:31.782Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/dd/cadd6ec43069247d91f6345fa7a0d2858bef6af366dbd7ba8f05d2c77d3b/protobuf-5.29.6-cp38-abi3-manylinux2014_x86_64.whl", hash = "sha256:e3387f44798ac1106af0233c04fb8abf543772ff241169946f698b3a9a3d3ab9", size = 320478, upload-time = "2026-02-04T22:54:32.909Z" },
     { url = "https://files.pythonhosted.org/packages/5a/cb/e3065b447186cb70aa65acc70c86baf482d82bf75625bf5a2c4f6919c6a3/protobuf-5.29.6-py3-none-any.whl", hash = "sha256:6b9edb641441b2da9fa8f428760fc136a49cf97a52076010cf22a2ff73438a86", size = 173126, upload-time = "2026-02-04T22:54:39.462Z" },
 ]
 
@@ -6428,31 +7255,47 @@ name = "protobuf"
 version = "6.33.5"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "(python_full_version == '3.13.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "(python_full_version == '3.12.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "(python_full_version < '3.11' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version >= '3.14' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'win32'",
-    "python_full_version < '3.11' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "(python_full_version == '3.13.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "(python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ba/25/7c72c307aafc96fa87062aa6291d9f7c94836e43214d43722e86037aac02/protobuf-6.33.5.tar.gz", hash = "sha256:6ddcac2a081f8b7b9642c09406bc6a4290128fce5f471cddd165960bb9119e5c", size = 444465, upload-time = "2026-01-29T21:51:33.494Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b1/79/af92d0a8369732b027e6d6084251dd8e782c685c72da161bd4a2e00fbabb/protobuf-6.33.5-cp310-abi3-win32.whl", hash = "sha256:d71b040839446bac0f4d162e758bea99c8251161dae9d0983a3b88dee345153b", size = 425769, upload-time = "2026-01-29T21:51:21.751Z" },
     { url = "https://files.pythonhosted.org/packages/55/75/bb9bc917d10e9ee13dee8607eb9ab963b7cf8be607c46e7862c748aa2af7/protobuf-6.33.5-cp310-abi3-win_amd64.whl", hash = "sha256:3093804752167bcab3998bec9f1048baae6e29505adaf1afd14a37bddede533c", size = 437118, upload-time = "2026-01-29T21:51:24.022Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/6b/e48dfc1191bc5b52950246275bf4089773e91cb5ba3592621723cdddca62/protobuf-6.33.5-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:a5cb85982d95d906df1e2210e58f8e4f1e3cdc088e52c921a041f9c9a0386de5", size = 427766, upload-time = "2026-01-29T21:51:25.413Z" },
     { url = "https://files.pythonhosted.org/packages/4e/b1/c79468184310de09d75095ed1314b839eb2f72df71097db9d1404a1b2717/protobuf-6.33.5-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:9b71e0281f36f179d00cbcb119cb19dec4d14a81393e5ea220f64b286173e190", size = 324638, upload-time = "2026-01-29T21:51:26.423Z" },
     { url = "https://files.pythonhosted.org/packages/c5/f5/65d838092fd01c44d16037953fd4c2cc851e783de9b8f02b27ec4ffd906f/protobuf-6.33.5-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:8afa18e1d6d20af15b417e728e9f60f3aa108ee76f23c3b2c07a2c3b546d3afd", size = 339411, upload-time = "2026-01-29T21:51:27.446Z" },
     { url = "https://files.pythonhosted.org/packages/9b/53/a9443aa3ca9ba8724fdfa02dd1887c1bcd8e89556b715cfbacca6b63dbec/protobuf-6.33.5-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:cbf16ba3350fb7b889fca858fb215967792dc125b35c7976ca4818bee3521cf0", size = 323465, upload-time = "2026-01-29T21:51:28.925Z" },
@@ -6479,8 +7322,8 @@ name = "psycopg"
 version = "3.2.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-    { name = "tzdata", marker = "sys_platform == 'win32'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "tzdata", marker = "sys_platform == 'win32' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a8/77/c72d10262b872617e509a0c60445afcc4ce2cd5cd6bc1c97700246d69c85/psycopg-3.2.12.tar.gz", hash = "sha256:85c08d6f6e2a897b16280e0ff6406bef29b1327c045db06d21f364d7cd5da90b", size = 160642, upload-time = "2025-10-26T00:46:03.045Z" }
 wheels = [
@@ -6489,7 +7332,7 @@ wheels = [
 
 [package.optional-dependencies]
 binary = [
-    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 
 [[package]]
@@ -6659,18 +7502,96 @@ wheels = [
 ]
 
 [[package]]
-name = "py4j"
-version = "0.10.9.7"
+name = "pyarrow"
+version = "16.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1e/f2/b34255180c72c36ff7097f7c2cdca02abcbd89f5eebf7c7c41262a9a0637/py4j-0.10.9.7.tar.gz", hash = "sha256:0b6e5315bb3ada5cf62ac651d107bb2ebc02def3dee9d9548e3baac644ea8dbb", size = 1508234, upload-time = "2022-08-12T22:49:09.792Z" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version < '3.11' and sys_platform == 'win32'",
+]
+dependencies = [
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'extra-4-daft-paimon') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra == 'extra-4-daft-paimon') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b8/c3/61781b3a0d754807f5662fc0cb459f2bb5e76db1b18a1cfbb3efd770fdcc/pyarrow-16.0.0.tar.gz", hash = "sha256:59bb1f1edbbf4114c72415f039f1359f1a57d166a331c3229788ccbfbb31689a", size = 1080222, upload-time = "2024-04-20T21:47:47.654Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/30/a58b32568f1623aaad7db22aa9eafc4c6c194b429ff35bdc55ca2726da47/py4j-0.10.9.7-py2.py3-none-any.whl", hash = "sha256:85defdfd2b2376eb3abf5ca6474b51ab7e0de341c75a02f46dc9b5976f5a5c1b", size = 200481, upload-time = "2022-08-12T22:49:07.05Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/5c/a4349f50b36382d3f40b304b91a3587ac433baceed9bec2434d663393a51/pyarrow-16.0.0-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:22a1fdb1254e5095d629e29cd1ea98ed04b4bbfd8e42cc670a6b639ccc208b60", size = 29115166, upload-time = "2024-04-20T21:43:53.94Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/04/c2a6f3ae840d96a00de2e07d68a3d30591b413b15b4385242e47e2ae0e97/pyarrow-16.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:574a00260a4ed9d118a14770edbd440b848fcae5a3024128be9d0274dbcaf858", size = 25963651, upload-time = "2024-04-20T21:44:02.459Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/84/a891dd617c5b7c8746765c383c8bced035f7aed38062b89e50b5ba4e79d7/pyarrow-16.0.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c0815d0ddb733b8c1b53a05827a91f1b8bde6240f3b20bf9ba5d650eb9b89cdf", size = 38572478, upload-time = "2024-04-20T21:44:08.735Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/75/9bf5522ac1dae815bc0c31ae0ebdb191e15f7a7cb3f1b0d3ed38191bb614/pyarrow-16.0.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:df0080339387b5d30de31e0a149c0c11a827a10c82f0c67d9afae3981d1aabb7", size = 40840534, upload-time = "2024-04-20T21:44:14.916Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/99/3e3d6c5d761f8331ffe5e656a6a57531b5f6ed80297ae15056dd8e598f88/pyarrow-16.0.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:edf38cce0bf0dcf726e074159c60516447e4474904c0033f018c1f33d7dac6c5", size = 38014964, upload-time = "2024-04-20T21:44:21.713Z" },
+    { url = "https://files.pythonhosted.org/packages/83/b7/77b5a755560329ebe12b16a7a15074fb003685e1cbcfef8dcab0a05fdd58/pyarrow-16.0.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:91d28f9a40f1264eab2af7905a4d95320ac2f287891e9c8b0035f264fe3c3a4b", size = 40752466, upload-time = "2024-04-20T21:44:27.853Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7a/36243efd5a9c1a0ac1146fa69044f4676eac13a162c8fb388869262330fe/pyarrow-16.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:99af421ee451a78884d7faea23816c429e263bd3618b22d38e7992c9ce2a7ad9", size = 25867611, upload-time = "2024-04-20T21:44:35.327Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/22/bb83bd005cb8245bd9f247c5a805860c04e1f51f05a4ad790c14fdd048ab/pyarrow-16.0.0-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:d22d0941e6c7bafddf5f4c0662e46f2075850f1c044bf1a03150dd9e189427ce", size = 29152966, upload-time = "2024-04-20T21:44:41.598Z" },
+    { url = "https://files.pythonhosted.org/packages/75/97/5c1e0169ea1ee22f675801956682ef44731c0ccf1c0361a37e9701f46107/pyarrow-16.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:266ddb7e823f03733c15adc8b5078db2df6980f9aa93d6bb57ece615df4e0ba7", size = 25991316, upload-time = "2024-04-20T21:44:47.583Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/d2/8ec169aa9b7b6c71309b1fa03f6f5f2c7337b4d4cb47d2c09a0117dc9f7e/pyarrow-16.0.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5cc23090224b6594f5a92d26ad47465af47c1d9c079dd4a0061ae39551889efe", size = 38574861, upload-time = "2024-04-20T21:44:54.441Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/42/722431397a4c705fcd7d145e1ba445defa8d2327269310f13c9980314057/pyarrow-16.0.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:56850a0afe9ef37249d5387355449c0f94d12ff7994af88f16803a26d38f2016", size = 40841151, upload-time = "2024-04-20T21:45:01.529Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/e4/1e1825f0c1dc0aecfe86e4aac320b0f9d32103417899eb89896ba0eb177f/pyarrow-16.0.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:705db70d3e2293c2f6f8e84874b5b775f690465798f66e94bb2c07bab0a6bb55", size = 38032331, upload-time = "2024-04-20T21:45:08.699Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/73/d5588e2bd671aabe02e1e11b12966fa1a066767b20340885964f5d4e1862/pyarrow-16.0.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:5448564754c154997bc09e95a44b81b9e31ae918a86c0fcb35c4aa4922756f55", size = 40766741, upload-time = "2024-04-20T21:45:16.218Z" },
+    { url = "https://files.pythonhosted.org/packages/51/e6/83d51c9822ea0232548f73e39bc25e9a4b658422100d5b23d7abc9e871b0/pyarrow-16.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:729f7b262aa620c9df8b9967db96c1575e4cfc8c25d078a06968e527b8d6ec05", size = 25875894, upload-time = "2024-04-20T21:45:23.116Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/64/7a94bec6658873c7d82f743a92653bcc961eda95480827bd46d2d33003be/pyarrow-16.0.0-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:fb8065dbc0d051bf2ae2453af0484d99a43135cadabacf0af588a3be81fbbb9b", size = 29061857, upload-time = "2024-04-20T21:45:28.306Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/5a/d538f1ef43432bbd15b1fe70a2efe4a5681a9502263b88554d2dc5b648a3/pyarrow-16.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:20ce707d9aa390593ea93218b19d0eadab56390311cb87aad32c9a869b0e958c", size = 25954853, upload-time = "2024-04-20T21:45:35.919Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/4d/102736461f88f6cc9b693023f5a52322d6e9be728ca033c39892680bc00f/pyarrow-16.0.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5823275c8addbbb50cd4e6a6839952682a33255b447277e37a6f518d6972f4e1", size = 38570048, upload-time = "2024-04-20T21:45:42.798Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/b2/508775722a370c92c52d11f0fdbf4167397841982ad03aa43ea9a1713cef/pyarrow-16.0.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1ab8b9050752b16a8b53fcd9853bf07d8daf19093533e990085168f40c64d978", size = 40853417, upload-time = "2024-04-20T21:45:50.159Z" },
+    { url = "https://files.pythonhosted.org/packages/59/a5/02fcff287ca45e8e95d414475f2dbad5bb9f762fa6f3c5e02def855ccfcc/pyarrow-16.0.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:42e56557bc7c5c10d3e42c3b32f6cff649a29d637e8f4e8b311d334cc4326730", size = 38015031, upload-time = "2024-04-20T21:45:56.817Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/1c/2c196290d83a680d381e25c4072bf49120f8b7fc5c7c633638575811a0b5/pyarrow-16.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:2a7abdee4a4a7cfa239e2e8d721224c4b34ffe69a0ca7981354fe03c1328789b", size = 40772701, upload-time = "2024-04-20T21:46:03.303Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e3/0879dfa4e1de2bcf06a22c9450af7755b4c9237588203b52df5927930b28/pyarrow-16.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:ef2f309b68396bcc5a354106741d333494d6a0d3e1951271849787109f0229a6", size = 25821876, upload-time = "2024-04-20T21:46:08.891Z" },
 ]
 
 [[package]]
 name = "pyarrow"
 version = "22.0.0"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version == '3.13.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version < '3.11' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+]
 sdist = { url = "https://files.pythonhosted.org/packages/30/53/04a7fdc63e6056116c9ddc8b43bc28c12cdd181b85cbeadb79278475f3ae/pyarrow-22.0.0.tar.gz", hash = "sha256:3d600dc583260d845c7d8a6db540339dd883081925da2bd1c5cb808f720b3cd9", size = 1151151, upload-time = "2025-10-24T12:30:00.762Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/9b/cb3f7e0a345353def531ca879053e9ef6b9f38ed91aebcf68b09ba54dec0/pyarrow-22.0.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:77718810bd3066158db1e95a63c160ad7ce08c6b0710bc656055033e39cdad88", size = 34223968, upload-time = "2025-10-24T10:03:31.21Z" },
@@ -6729,7 +7650,7 @@ name = "pyarrow-stubs"
 version = "20.0.0.20251215"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyarrow" },
+    { name = "pyarrow", version = "22.0.0", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/30/16/ca991ada0416dc02c246e4b3c853f35053676eb704c63720ef24547d2d68/pyarrow_stubs-20.0.0.20251215.tar.gz", hash = "sha256:92c1fda4998f0c13e608d8abc7e4b8537e3ef108f6bf42c58e5af97e7d143e75", size = 236578, upload-time = "2025-12-15T06:47:46.187Z" }
 wheels = [
@@ -6942,6 +7863,41 @@ wheels = [
 ]
 
 [[package]]
+name = "pycryptodome"
+version = "3.23.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/a6/8452177684d5e906854776276ddd34eca30d1b1e15aa1ee9cefc289a33f5/pycryptodome-3.23.0.tar.gz", hash = "sha256:447700a657182d60338bab09fdb27518f8856aecd80ae4c6bdddb67ff5da44ef", size = 4921276, upload-time = "2025-05-17T17:21:45.242Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/5d/bdb09489b63cd34a976cc9e2a8d938114f7a53a74d3dd4f125ffa49dce82/pycryptodome-3.23.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:0011f7f00cdb74879142011f95133274741778abba114ceca229adbf8e62c3e4", size = 2495152, upload-time = "2025-05-17T17:20:20.833Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/ce/7840250ed4cc0039c433cd41715536f926d6e86ce84e904068eb3244b6a6/pycryptodome-3.23.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:90460fc9e088ce095f9ee8356722d4f10f86e5be06e2354230a9880b9c549aae", size = 1639348, upload-time = "2025-05-17T17:20:23.171Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f0/991da24c55c1f688d6a3b5a11940567353f74590734ee4a64294834ae472/pycryptodome-3.23.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4764e64b269fc83b00f682c47443c2e6e85b18273712b98aa43bcb77f8570477", size = 2184033, upload-time = "2025-05-17T17:20:25.424Z" },
+    { url = "https://files.pythonhosted.org/packages/54/16/0e11882deddf00f68b68dd4e8e442ddc30641f31afeb2bc25588124ac8de/pycryptodome-3.23.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eb8f24adb74984aa0e5d07a2368ad95276cf38051fe2dc6605cbcf482e04f2a7", size = 2270142, upload-time = "2025-05-17T17:20:27.808Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/fc/4347fea23a3f95ffb931f383ff28b3f7b1fe868739182cb76718c0da86a1/pycryptodome-3.23.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d97618c9c6684a97ef7637ba43bdf6663a2e2e77efe0f863cce97a76af396446", size = 2309384, upload-time = "2025-05-17T17:20:30.765Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/d9/c5261780b69ce66d8cfab25d2797bd6e82ba0241804694cd48be41add5eb/pycryptodome-3.23.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9a53a4fe5cb075075d515797d6ce2f56772ea7e6a1e5e4b96cf78a14bac3d265", size = 2183237, upload-time = "2025-05-17T17:20:33.736Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/6f/3af2ffedd5cfa08c631f89452c6648c4d779e7772dfc388c77c920ca6bbf/pycryptodome-3.23.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:763d1d74f56f031788e5d307029caef067febf890cd1f8bf61183ae142f1a77b", size = 2343898, upload-time = "2025-05-17T17:20:36.086Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/dc/9060d807039ee5de6e2f260f72f3d70ac213993a804f5e67e0a73a56dd2f/pycryptodome-3.23.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:954af0e2bd7cea83ce72243b14e4fb518b18f0c1649b576d114973e2073b273d", size = 2269197, upload-time = "2025-05-17T17:20:38.414Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/34/e6c8ca177cb29dcc4967fef73f5de445912f93bd0343c9c33c8e5bf8cde8/pycryptodome-3.23.0-cp313-cp313t-win32.whl", hash = "sha256:257bb3572c63ad8ba40b89f6fc9d63a2a628e9f9708d31ee26560925ebe0210a", size = 1768600, upload-time = "2025-05-17T17:20:40.688Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/1d/89756b8d7ff623ad0160f4539da571d1f594d21ee6d68be130a6eccb39a4/pycryptodome-3.23.0-cp313-cp313t-win_amd64.whl", hash = "sha256:6501790c5b62a29fcb227bd6b62012181d886a767ce9ed03b303d1f22eb5c625", size = 1799740, upload-time = "2025-05-17T17:20:42.413Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/61/35a64f0feaea9fd07f0d91209e7be91726eb48c0f1bfc6720647194071e4/pycryptodome-3.23.0-cp313-cp313t-win_arm64.whl", hash = "sha256:9a77627a330ab23ca43b48b130e202582e91cc69619947840ea4d2d1be21eb39", size = 1703685, upload-time = "2025-05-17T17:20:44.388Z" },
+    { url = "https://files.pythonhosted.org/packages/db/6c/a1f71542c969912bb0e106f64f60a56cc1f0fabecf9396f45accbe63fa68/pycryptodome-3.23.0-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:187058ab80b3281b1de11c2e6842a357a1f71b42cb1e15bce373f3d238135c27", size = 2495627, upload-time = "2025-05-17T17:20:47.139Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/4e/a066527e079fc5002390c8acdd3aca431e6ea0a50ffd7201551175b47323/pycryptodome-3.23.0-cp37-abi3-macosx_10_9_x86_64.whl", hash = "sha256:cfb5cd445280c5b0a4e6187a7ce8de5a07b5f3f897f235caa11f1f435f182843", size = 1640362, upload-time = "2025-05-17T17:20:50.392Z" },
+    { url = "https://files.pythonhosted.org/packages/50/52/adaf4c8c100a8c49d2bd058e5b551f73dfd8cb89eb4911e25a0c469b6b4e/pycryptodome-3.23.0-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:67bd81fcbe34f43ad9422ee8fd4843c8e7198dd88dd3d40e6de42ee65fbe1490", size = 2182625, upload-time = "2025-05-17T17:20:52.866Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/e9/a09476d436d0ff1402ac3867d933c61805ec2326c6ea557aeeac3825604e/pycryptodome-3.23.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c8987bd3307a39bc03df5c8e0e3d8be0c4c3518b7f044b0f4c15d1aa78f52575", size = 2268954, upload-time = "2025-05-17T17:20:55.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/c5/ffe6474e0c551d54cab931918127c46d70cab8f114e0c2b5a3c071c2f484/pycryptodome-3.23.0-cp37-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:aa0698f65e5b570426fc31b8162ed4603b0c2841cbb9088e2b01641e3065915b", size = 2308534, upload-time = "2025-05-17T17:20:57.279Z" },
+    { url = "https://files.pythonhosted.org/packages/18/28/e199677fc15ecf43010f2463fde4c1a53015d1fe95fb03bca2890836603a/pycryptodome-3.23.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:53ecbafc2b55353edcebd64bf5da94a2a2cdf5090a6915bcca6eca6cc452585a", size = 2181853, upload-time = "2025-05-17T17:20:59.322Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/ea/4fdb09f2165ce1365c9eaefef36625583371ee514db58dc9b65d3a255c4c/pycryptodome-3.23.0-cp37-abi3-musllinux_1_2_i686.whl", hash = "sha256:156df9667ad9f2ad26255926524e1c136d6664b741547deb0a86a9acf5ea631f", size = 2342465, upload-time = "2025-05-17T17:21:03.83Z" },
+    { url = "https://files.pythonhosted.org/packages/22/82/6edc3fc42fe9284aead511394bac167693fb2b0e0395b28b8bedaa07ef04/pycryptodome-3.23.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:dea827b4d55ee390dc89b2afe5927d4308a8b538ae91d9c6f7a5090f397af1aa", size = 2267414, upload-time = "2025-05-17T17:21:06.72Z" },
+    { url = "https://files.pythonhosted.org/packages/59/fe/aae679b64363eb78326c7fdc9d06ec3de18bac68be4b612fc1fe8902693c/pycryptodome-3.23.0-cp37-abi3-win32.whl", hash = "sha256:507dbead45474b62b2bbe318eb1c4c8ee641077532067fec9c1aa82c31f84886", size = 1768484, upload-time = "2025-05-17T17:21:08.535Z" },
+    { url = "https://files.pythonhosted.org/packages/54/2f/e97a1b8294db0daaa87012c24a7bb714147c7ade7656973fd6c736b484ff/pycryptodome-3.23.0-cp37-abi3-win_amd64.whl", hash = "sha256:c75b52aacc6c0c260f204cbdd834f76edc9fb0d8e0da9fbf8352ef58202564e2", size = 1799636, upload-time = "2025-05-17T17:21:10.393Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3d/f9441a0d798bf2b1e645adc3265e55706aead1255ccdad3856dbdcffec14/pycryptodome-3.23.0-cp37-abi3-win_arm64.whl", hash = "sha256:11eeeb6917903876f134b56ba11abe95c0b0fd5e3330def218083c7d98bbcb3c", size = 1703675, upload-time = "2025-05-17T17:21:13.146Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/12/e33935a0709c07de084d7d58d330ec3f4daf7910a18e77937affdb728452/pycryptodome-3.23.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:ddb95b49df036ddd264a0ad246d1be5b672000f12d6961ea2c267083a5e19379", size = 1623886, upload-time = "2025-05-17T17:21:20.614Z" },
+    { url = "https://files.pythonhosted.org/packages/22/0b/aa8f9419f25870889bebf0b26b223c6986652bdf071f000623df11212c90/pycryptodome-3.23.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d8e95564beb8782abfd9e431c974e14563a794a4944c29d6d3b7b5ea042110b4", size = 1672151, upload-time = "2025-05-17T17:21:22.666Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/5e/63f5cbde2342b7f70a39e591dbe75d9809d6338ce0b07c10406f1a140cdc/pycryptodome-3.23.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:14e15c081e912c4b0d75632acd8382dfce45b258667aa3c67caf7a4d4c13f630", size = 1664461, upload-time = "2025-05-17T17:21:25.225Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/92/608fbdad566ebe499297a86aae5f2a5263818ceeecd16733006f1600403c/pycryptodome-3.23.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a7fc76bf273353dc7e5207d172b83f569540fc9a28d63171061c42e361d22353", size = 1702440, upload-time = "2025-05-17T17:21:27.991Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/92/2eadd1341abd2989cce2e2740b4423608ee2014acb8110438244ee97d7ff/pycryptodome-3.23.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:45c69ad715ca1a94f778215a11e66b7ff989d792a4d63b68dc586a1da1392ff5", size = 1803005, upload-time = "2025-05-17T17:21:31.37Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.12.4"
 source = { registry = "https://pypi.org/simple" }
@@ -7108,12 +8064,103 @@ wheels = [
 
 [[package]]
 name = "pyiceberg"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version < '3.11' and sys_platform == 'win32'",
+]
+dependencies = [
+    { name = "click", marker = "extra == 'extra-4-daft-paimon'" },
+    { name = "fsspec", version = "2024.3.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-4-daft-paimon'" },
+    { name = "mmh3", marker = "extra == 'extra-4-daft-paimon'" },
+    { name = "pydantic", marker = "extra == 'extra-4-daft-paimon'" },
+    { name = "pyparsing", marker = "extra == 'extra-4-daft-paimon'" },
+    { name = "requests", marker = "extra == 'extra-4-daft-paimon'" },
+    { name = "rich", marker = "extra == 'extra-4-daft-paimon'" },
+    { name = "sortedcontainers", marker = "extra == 'extra-4-daft-paimon'" },
+    { name = "strictyaml", marker = "extra == 'extra-4-daft-paimon'" },
+    { name = "tenacity", version = "8.5.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-4-daft-paimon'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/a0/7e371eafe0f1f757fc4f9e071caf4fd5c1dbf195bd3523fd1b63da1a78ee/pyiceberg-0.7.1.tar.gz", hash = "sha256:2fd8f9717b02673cb9cabe7aed82fc38933241b2bd15cbdc1ff7371e70317a47", size = 568827, upload-time = "2024-08-18T19:58:29.489Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/df/f4c4b507845b74d333235d13dd086994e83507dab8ee79cf5092f2a06a7e/pyiceberg-0.7.1-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:9e0cc837d41e100df81f1f5e580a89668aade694d8c616941d6e11c3a27e49cb", size = 534974, upload-time = "2024-08-18T19:57:28.749Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/80/cd8f215f09c1b1d9a57c39ba873f58b226a36e960ba3df86588e495ac043/pyiceberg-0.7.1-cp310-cp310-macosx_13_0_x86_64.whl", hash = "sha256:71c053c2d484505d1beabd7d5167fe2e835ca865f52ad91ef4852f0d91fa4a25", size = 536578, upload-time = "2024-08-18T19:57:30.521Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/78/3fd8bea871e20710c859ebc998ba42fc028d6e773c329cbb34e567c7e8ba/pyiceberg-0.7.1-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:0549ab1843bc07037a7d212c2db527ff1755f5d8f80420907952b5b080eb3663", size = 530698, upload-time = "2024-08-18T19:57:32.109Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/a6/821dcd2e4ce67aea7ff6e845d934ed8f6df90726c1bbffae2879cda26bfc/pyiceberg-0.7.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ec4a8000f0bb6ce6ec47f3368ca99f3191e9105662eeef7be2fbb493363cba96", size = 1003347, upload-time = "2024-08-18T19:57:33.984Z" },
+    { url = "https://files.pythonhosted.org/packages/78/cf/9f67f202a6e84444b25254350042d524dc3fd96598af36524eb1b308f58e/pyiceberg-0.7.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:0ef6636d3cf370b796529f9a8dbd84e892a2151f0310a8015b9a1e702647ad90", size = 1002989, upload-time = "2024-08-18T19:57:35.936Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/f2/4b6208b84dfbfb1943aa91d14be3db8be7fd22d7f0317e56e3d669658bab/pyiceberg-0.7.1-cp310-cp310-win_amd64.whl", hash = "sha256:9b49320f3e9624075879a4ddb4fa5ddff7d4a03f6561ad6fd73d514c63095367", size = 529640, upload-time = "2024-08-18T19:57:37.53Z" },
+    { url = "https://files.pythonhosted.org/packages/47/3a/dd56ae4fcb1550d6a6c8c869a02e9300e65f2e4a52d425610f388fd0cc18/pyiceberg-0.7.1-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:27e9b4033691411ef7c49d93df7b3b7f3ed85fe8019cbf0dab5a5ba888b27f34", size = 573861, upload-time = "2024-08-18T19:57:39.045Z" },
+    { url = "https://files.pythonhosted.org/packages/95/d2/8edeedbfc7f5e3baf266f3b6310c7d4e05038346cc7a5edeb40798adc76b/pyiceberg-0.7.1-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:7262ba4f95e05a1421567e24c0db57288dc59974c94676aba34afef121544694", size = 575756, upload-time = "2024-08-18T19:57:40.667Z" },
+    { url = "https://files.pythonhosted.org/packages/92/d3/eb080a2fd8dc7f4793cdc6c95daa7669e04ddd880fd99cb73f630eeb7e46/pyiceberg-0.7.1-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:3eb1fc1d47085b16973999c2111d252fab2a394625c0f25da6515b8c3233c853", size = 567588, upload-time = "2024-08-18T19:57:42.209Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/71/1ec3ca0537112546f2896b40142102881634e0599f04ceeade26f3bb0d76/pyiceberg-0.7.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1856c5d64197c9335817b8cf7081e490b601385623e5178cb094ee645d4fb24c", size = 1217034, upload-time = "2024-08-18T19:57:43.825Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/9f/2f3200d6294068802bbd3cfce8cad68d3b684d0acce673f08aa9155cf82b/pyiceberg-0.7.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b6b64006c361220ce103b5bb2f50381a3f851452668adf5a6c61d39f5611e832", size = 1212220, upload-time = "2024-08-18T19:57:45.508Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/a4/8623938d21386ce04de37db69ac703572acef843c7edf624cff22a28bf24/pyiceberg-0.7.1-cp311-cp311-win_amd64.whl", hash = "sha256:57a0b1fb390d26a5b7155de011300300058343e5c2561f4839d69c1775df1d7e", size = 565493, upload-time = "2024-08-18T19:57:47.165Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/90/5718ebc67c4992200dc63a5b8c20f3c2398096b9f4a974ed19723195c1ca/pyiceberg-0.7.1-pp310-pypy310_pp73-macosx_12_0_x86_64.whl", hash = "sha256:9ae56197db8570553491173adfd2e01a03ae116a1f9fa78ba5a1a1c4e2ad3dbf", size = 669140, upload-time = "2024-08-18T19:58:06.56Z" },
+    { url = "https://files.pythonhosted.org/packages/87/d7/711dcbeef3b997cd516bdb9025fe12aed802066ca09470171a43aa9d473c/pyiceberg-0.7.1-pp310-pypy310_pp73-macosx_13_0_x86_64.whl", hash = "sha256:e28adc58500ca72e45a07ee4dcd90b63699a8875f178001bd12ace37294c5814", size = 668770, upload-time = "2024-08-18T19:58:07.804Z" },
+    { url = "https://files.pythonhosted.org/packages/37/cf/b1a99eb222574c92eb149a558c4d29641d10dbc73783db9b2068e8c15f71/pyiceberg-0.7.1-pp310-pypy310_pp73-macosx_14_0_arm64.whl", hash = "sha256:1ae47f2d0e87dccd158ae8dafc47125f9739858068fc3add8940f5585ea40ead", size = 657202, upload-time = "2024-08-18T19:58:09.503Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/65/244d68f414f93b5f8732a4bdfffacdacdbef07bf556ffe9816064a020d56/pyiceberg-0.7.1-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fb94c3e11354f85daafb2b2f3e13a245bcb35848135b5ed4e8c83e61393c36ea", size = 1329793, upload-time = "2024-08-18T19:58:10.857Z" },
+    { url = "https://files.pythonhosted.org/packages/83/cb/82b141dbea405c640335c5df330a437617cb0ef23669b86503ee5f905101/pyiceberg-0.7.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:4fe212b0594128d183711c6efb1a40ea5f17372e11595a84f4565eb9fe97c703", size = 657765, upload-time = "2024-08-18T19:58:12.519Z" },
+]
+
+[[package]]
+name = "pyiceberg"
 version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version == '3.13.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version < '3.11' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+]
 dependencies = [
-    { name = "cachetools" },
+    { name = "cachetools", version = "5.5.2", source = { registry = "https://pypi.org/simple" } },
     { name = "click" },
-    { name = "fsspec" },
+    { name = "fsspec", version = "2024.9.0", source = { registry = "https://pypi.org/simple" } },
     { name = "mmh3" },
     { name = "pydantic" },
     { name = "pyparsing" },
@@ -7121,9 +8168,9 @@ dependencies = [
     { name = "requests" },
     { name = "rich" },
     { name = "strictyaml" },
-    { name = "tenacity" },
-    { name = "zstandard", version = "0.24.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "zstandard", version = "0.25.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
+    { name = "tenacity", version = "9.1.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "zstandard", version = "0.24.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and python_full_version < '3.14' and extra != 'extra-4-daft-paimon') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "zstandard", version = "0.25.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'group-4-daft-dev') or (python_full_version < '3.11' and extra != 'extra-4-daft-paimon') or (python_full_version >= '3.14' and extra == 'group-4-daft-dev') or (python_full_version >= '3.14' and extra != 'extra-4-daft-paimon') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/bd/22/3d02ad39710bf51834d108e6d548cee9c1916850460ccba80db47a982567/pyiceberg-0.11.0.tar.gz", hash = "sha256:095bbafc87d204cf8d3ffc1c434e07cf9a67a709192ac0b11dcb0f8251f7ad4e", size = 1074873, upload-time = "2026-02-10T02:28:20.762Z" }
 wheels = [
@@ -7177,9 +8224,10 @@ version = "0.39.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "lance-namespace" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
-    { name = "pyarrow" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'extra-4-daft-paimon') or (python_full_version < '3.13' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev')" },
+    { name = "pyarrow", version = "16.0.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-4-daft-paimon'" },
+    { name = "pyarrow", version = "22.0.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'group-4-daft-dev' or extra != 'extra-4-daft-paimon'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/99/a8a610ca0dd5ece26ccbfdb15803a9df1c2ae3a5d97918434c2e43aa25fc/pylance-0.39.0-cp39-abi3-macosx_10_15_x86_64.whl", hash = "sha256:faa6fbf45c345e430f4be75da86071fdab56550e94e657a749b7407b4add3a8f", size = 47094423, upload-time = "2025-11-04T05:35:47.689Z" },
@@ -7277,15 +8325,21 @@ wheels = [
 
 [[package]]
 name = "pypaimon"
-version = "0.2.0"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pandas", version = "2.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
-    { name = "py4j" },
-    { name = "pyarrow" },
+    { name = "cachetools", version = "5.3.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "fastavro" },
+    { name = "fsspec", version = "2024.3.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "ossfs" },
+    { name = "packaging" },
+    { name = "pandas", version = "2.3.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "polars" },
+    { name = "pyarrow", version = "16.0.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "readerwriterlock" },
+    { name = "zstandard", version = "0.24.0", source = { registry = "https://pypi.org/simple" } },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1d/fd/397b04ac950a75ce71ecf613b9ee1a247e9da1b633b6ccf1847b513979d4/pypaimon-0.2.0.tar.gz", hash = "sha256:43ac684779841da17528b5f241ede6149bcdab4d16f3cd80f713262f6ed04720", size = 39469331, upload-time = "2024-12-19T07:37:07.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/fb/7bff5e40e863a7af27d99290b9bb2c7ee53fdae3ee6bb55045ad3aae000e/pypaimon-1.3.1.tar.gz", hash = "sha256:7029d777efab7898bce3bbbd09b1e2bb0cd088807f370117f84b1d5c654043d8", size = 189204, upload-time = "2025-11-20T02:43:23.698Z" }
 
 [[package]]
 name = "pyparsing"
@@ -7422,7 +8476,7 @@ name = "pytest-cov"
 version = "7.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "coverage", extra = ["toml"] },
+    { name = "coverage", extra = ["toml"], marker = "extra == 'group-4-daft-dev'" },
     { name = "pluggy" },
     { name = "pytest" },
 ]
@@ -7603,7 +8657,7 @@ name = "pyzmq"
 version = "27.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "implementation_name == 'pypy'" },
+    { name = "cffi", marker = "implementation_name == 'pypy' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f8/66/159f38d184f08b5f971b467f87b1ab142ab1320d5200825c824b32b84b66/pyzmq-27.0.2.tar.gz", hash = "sha256:b398dd713b18de89730447347e96a0240225e154db56e35b6bb8447ffdb07798", size = 281440, upload-time = "2025-08-21T04:23:26.334Z" }
 wheels = [
@@ -7681,8 +8735,8 @@ dependencies = [
     { name = "jsonschema" },
     { name = "msgpack" },
     { name = "packaging" },
-    { name = "protobuf", version = "5.29.6", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "protobuf", version = "6.33.5", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'darwin'" },
+    { name = "protobuf", version = "5.29.6", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "protobuf", version = "6.33.5", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'darwin' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
     { name = "pyyaml" },
     { name = "requests" },
 ]
@@ -7709,16 +8763,31 @@ cgraph = [
     { name = "cupy-cuda12x", marker = "sys_platform != 'darwin'" },
 ]
 client = [
-    { name = "grpcio", version = "1.68.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "grpcio", version = "1.78.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'darwin'" },
+    { name = "grpcio", version = "1.68.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "grpcio", version = "1.78.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'darwin' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 data = [
-    { name = "fsspec" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
-    { name = "pandas", version = "2.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
-    { name = "pyarrow" },
+    { name = "fsspec", version = "2024.3.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-4-daft-paimon'" },
+    { name = "fsspec", version = "2024.9.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'group-4-daft-dev' or extra != 'extra-4-daft-paimon'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'extra-4-daft-paimon') or (python_full_version < '3.13' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev')" },
+    { name = "pandas", version = "2.2.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "pandas", version = "2.3.2", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-4-daft-paimon'" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra != 'extra-4-daft-paimon') or (extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "pyarrow", version = "16.0.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-4-daft-paimon'" },
+    { name = "pyarrow", version = "22.0.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'group-4-daft-dev' or extra != 'extra-4-daft-paimon'" },
+]
+
+[[package]]
+name = "readerwriterlock"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a4/b9/6b7c390440ec23bf5fdf33e76d6c3b697a788b983c11cb2739d6541835d6/readerwriterlock-1.0.9.tar.gz", hash = "sha256:b7c4cc003435d7a8ff15b312b0a62a88d9800ba6164af88991f87f8b748f9bea", size = 16595, upload-time = "2021-09-06T03:41:21.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/5a/2f2e7fc026d5e64b5408aa3fbe0296a6407b8481196cae4daacacb3a3ae0/readerwriterlock-1.0.9-py3-none-any.whl", hash = "sha256:8c4b704e60d15991462081a27ef46762fea49b478aa4426644f2146754759ca7", size = 9999, upload-time = "2021-09-06T03:41:19.435Z" },
 ]
 
 [[package]]
@@ -7728,7 +8797,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
     { name = "rpds-py" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2f/db/98b5c277be99dd18bfd91dd04e1b759cad18d1a338188c936e92f921c7e2/referencing-0.36.2.tar.gz", hash = "sha256:df2e89862cd09deabbdba16944cc3f10feb6b3e6f18e902f7cc25609a34775aa", size = 74744, upload-time = "2025-01-25T08:48:16.138Z" }
 wheels = [
@@ -7888,7 +8957,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py" },
     { name = "pygments" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ab/3a/0316b28d0761c6734d6bc14e770d85506c986c85ffb239e688eeaab2c2bc/rich-13.9.4.tar.gz", hash = "sha256:439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098", size = 223149, upload-time = "2024-11-01T16:43:57.873Z" }
 wheels = [
@@ -8178,7 +9247,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiobotocore" },
     { name = "aiohttp" },
-    { name = "fsspec" },
+    { name = "fsspec", version = "2024.9.0", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e3/de/1dbadd86b81a587d9d6cce18512ab130062d386edf0e368a1ff7c2e2f462/s3fs-2024.9.0.tar.gz", hash = "sha256:6493705abb50374d6b7994f9616d27adbdd8a219c8635100bdc286382efd91f5", size = 74925, upload-time = "2024-09-04T15:14:23.106Z" }
 wheels = [
@@ -8225,10 +9294,10 @@ version = "1.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "joblib" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'extra-4-daft-paimon') or (python_full_version < '3.13' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev')" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "scipy", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
     { name = "threadpoolctl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/41/84/5f4af978fff619706b8961accac84780a6d298d82a8873446f72edb4ead0/scikit_learn-1.7.1.tar.gz", hash = "sha256:24b3f1e976a4665aa74ee0fcaac2b8fccc6ae77c8e07ab25da3ba6d3292b9802", size = 7190445, upload-time = "2025-07-18T08:01:54.5Z" }
@@ -8265,14 +9334,20 @@ name = "scipy"
 version = "1.15.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version < '3.11' and sys_platform == 'darwin'",
-    "(python_full_version < '3.11' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version < '3.11' and sys_platform == 'win32'",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version < '3.11' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
 ]
 dependencies = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-4-daft-paimon') or (python_full_version < '3.11' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -8328,30 +9403,50 @@ name = "scipy"
 version = "1.16.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version >= '3.14' and sys_platform == 'darwin'",
-    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
-    "(python_full_version == '3.13.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
-    "(python_full_version == '3.12.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
-    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version >= '3.14' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version == '3.13.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
 ]
 dependencies = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and python_full_version < '3.13' and extra == 'extra-4-daft-paimon') or (python_full_version >= '3.11' and python_full_version < '3.13' and extra == 'group-4-daft-dev') or (python_full_version < '3.11' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version >= '3.13' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' or (python_full_version >= '3.11' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f5/4a/b927028464795439faec8eaf0b03b011005c487bb2d07409f28bf30879c4/scipy-1.16.1.tar.gz", hash = "sha256:44c76f9e8b6e8e488a586190ab38016e4ed2f8a038af7cd3defa903c0a2238b3", size = 30580861, upload-time = "2025-07-27T16:33:30.834Z" }
 wheels = [
@@ -8419,8 +9514,8 @@ dependencies = [
     { name = "huggingface-hub" },
     { name = "pillow" },
     { name = "scikit-learn" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "scipy", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
     { name = "torch" },
     { name = "tqdm" },
     { name = "transformers" },
@@ -8597,21 +9692,36 @@ name = "setuptools"
 version = "79.0.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version >= '3.14' and sys_platform == 'darwin'",
-    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
-    "(python_full_version == '3.13.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
-    "(python_full_version == '3.12.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version >= '3.14' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version == '3.13.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/bb/71/b6365e6325b3290e14957b2c3a804a529968c77a049b2ed40c095f749707/setuptools-79.0.1.tar.gz", hash = "sha256:128ce7b8f33c3079fd1b067ecbb4051a66e8526e7b65f6cec075dfc650ddfa88", size = 1367909, upload-time = "2025-04-23T22:20:59.241Z" }
 wheels = [
@@ -8623,16 +9733,18 @@ name = "setuptools"
 version = "80.9.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
-    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version < '3.11' and sys_platform == 'darwin'",
-    "(python_full_version < '3.11' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version == '3.11.*' and sys_platform == 'win32'",
-    "python_full_version < '3.11' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version < '3.11' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/18/5d/3bf57dcd21979b887f014ea83c24ae194cfcd12b9e0fda66b957c69d1fca/setuptools-80.9.0.tar.gz", hash = "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c", size = 1319958, upload-time = "2025-05-27T00:56:51.443Z" }
 wheels = [
@@ -8681,8 +9793,8 @@ version = "0.13.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'extra-4-daft-paimon') or (python_full_version < '3.13' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e1/41/9b873a8c055582859b239be17902a85339bec6a30ad162f98c9b0288a2cc/soundfile-0.13.1.tar.gz", hash = "sha256:b2c68dab1e30297317080a5b43df57e302584c49e2942defdde0acccc53f0e5b", size = 46156, upload-time = "2025-01-25T09:17:04.831Z" }
 wheels = [
@@ -8709,8 +9821,8 @@ name = "soxr"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'extra-4-daft-paimon') or (python_full_version < '3.13' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/7e/f4b461944662ad75036df65277d6130f9411002bfb79e9df7dff40a31db9/soxr-1.0.0.tar.gz", hash = "sha256:e07ee6c1d659bc6957034f4800c60cb8b98de798823e34d2a2bba1caa85a4509", size = 171415, upload-time = "2025-09-07T13:22:21.317Z" }
 wheels = [
@@ -8741,7 +9853,7 @@ name = "sqlalchemy"
 version = "2.0.46"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
+    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/06/aa/9ce0f3e7a9829ead5c8ce549392f33a12c4555a6c0609bb27d882e9c7ddf/sqlalchemy-2.0.46.tar.gz", hash = "sha256:cf36851ee7219c170bb0793dbc3da3e80c582e04a5437bc601bfe8c85c9216d7", size = 9865393, upload-time = "2026-01-21T18:03:45.119Z" }
@@ -8820,8 +9932,8 @@ name = "standard-aifc"
 version = "3.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "audioop-lts", marker = "python_full_version >= '3.13'" },
-    { name = "standard-chunk", marker = "python_full_version >= '3.13'" },
+    { name = "audioop-lts", marker = "python_full_version >= '3.13' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "standard-chunk", marker = "python_full_version >= '3.13' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c4/53/6050dc3dde1671eb3db592c13b55a8005e5040131f7509cef0215212cb84/standard_aifc-3.13.0.tar.gz", hash = "sha256:64e249c7cb4b3daf2fdba4e95721f811bde8bdfc43ad9f936589b7bb2fae2e43", size = 15240, upload-time = "2024-10-30T16:01:31.772Z" }
 wheels = [
@@ -8842,7 +9954,7 @@ name = "standard-sunau"
 version = "3.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "audioop-lts", marker = "python_full_version >= '3.13'" },
+    { name = "audioop-lts", marker = "python_full_version >= '3.13' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/e3/ce8d38cb2d70e05ffeddc28bb09bad77cfef979eb0a299c9117f7ed4e6a9/standard_sunau-3.13.0.tar.gz", hash = "sha256:b319a1ac95a09a2378a8442f403c66f4fd4b36616d6df6ae82b8e536ee790908", size = 9368, upload-time = "2024-10-30T16:01:41.626Z" }
 wheels = [
@@ -8900,8 +10012,71 @@ wheels = [
 
 [[package]]
 name = "tenacity"
+version = "8.5.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version < '3.11' and sys_platform == 'win32'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/4d/6a19536c50b849338fcbe9290d562b52cbdcf30d8963d3588a68a4107df1/tenacity-8.5.0.tar.gz", hash = "sha256:8bc6c0c8a09b31e6cad13c47afbed1a567518250a9a171418582ed8d9c20ca78", size = 47309, upload-time = "2024-07-05T07:25:31.836Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/3f/8ba87d9e287b9d385a02a7114ddcef61b26f86411e121c9003eb509a1773/tenacity-8.5.0-py3-none-any.whl", hash = "sha256:b594c2a5945830c267ce6b79a166228323ed52718f30302c1359836112346687", size = 28165, upload-time = "2024-07-05T07:25:29.591Z" },
+]
+
+[[package]]
+name = "tenacity"
 version = "9.1.4"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version == '3.13.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version < '3.11' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+]
 sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
@@ -8921,7 +10096,7 @@ name = "textual"
 version = "5.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markdown-it-py", extra = ["linkify", "plugins"], marker = "sys_platform != 'win32'" },
+    { name = "markdown-it-py", extra = ["linkify", "plugins"], marker = "(sys_platform != 'win32' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
     { name = "platformdirs", marker = "sys_platform != 'win32'" },
     { name = "pygments", marker = "sys_platform != 'win32'" },
     { name = "rich", marker = "sys_platform != 'win32'" },
@@ -9093,27 +10268,28 @@ version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
-    { name = "fsspec" },
+    { name = "fsspec", version = "2024.3.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-4-daft-paimon'" },
+    { name = "fsspec", version = "2024.9.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'group-4-daft-dev' or extra != 'extra-4-daft-paimon'" },
     { name = "jinja2" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "networkx", version = "3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-cupti-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-nvrtc-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-runtime-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cudnn-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cufft-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cufile-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-curand-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusolver-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparselt-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nccl-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvtx-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "setuptools", version = "79.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "networkx", version = "3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "nvidia-cublas-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (sys_platform != 'linux' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "nvidia-cuda-cupti-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (sys_platform != 'linux' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (sys_platform != 'linux' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (sys_platform != 'linux' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "nvidia-cudnn-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (sys_platform != 'linux' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "nvidia-cufft-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (sys_platform != 'linux' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "nvidia-cufile-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (sys_platform != 'linux' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "nvidia-curand-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (sys_platform != 'linux' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "nvidia-cusolver-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (sys_platform != 'linux' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "nvidia-cusparse-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (sys_platform != 'linux' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "nvidia-cusparselt-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (sys_platform != 'linux' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "nvidia-nccl-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (sys_platform != 'linux' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (sys_platform != 'linux' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "nvidia-nvtx-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (sys_platform != 'linux' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "setuptools", version = "79.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
     { name = "sympy" },
-    { name = "triton", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "triton", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (sys_platform != 'linux' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
     { name = "typing-extensions" },
 ]
 wheels = [
@@ -9174,8 +10350,8 @@ name = "torchvision"
 version = "0.23.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'extra-4-daft-paimon') or (python_full_version < '3.13' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev')" },
     { name = "pillow" },
     { name = "torch" },
 ]
@@ -9226,7 +10402,7 @@ name = "tqdm"
 version = "4.67.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737, upload-time = "2024-11-24T20:12:22.481Z" }
 wheels = [
@@ -9249,8 +10425,8 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "huggingface-hub" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'extra-4-daft-paimon') or (python_full_version < '3.13' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev')" },
     { name = "packaging" },
     { name = "pyyaml" },
     { name = "regex" },
@@ -9269,15 +10445,15 @@ name = "trino"
 version = "0.336.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "lz4", version = "4.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "lz4", version = "4.4.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
+    { name = "lz4", version = "4.4.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and python_full_version < '3.14' and extra == 'group-4-daft-dev') or (python_full_version < '3.11' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version >= '3.14' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "lz4", version = "4.4.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'group-4-daft-dev') or (python_full_version >= '3.14' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
     { name = "orjson", marker = "platform_python_implementation != 'PyPy'" },
     { name = "python-dateutil" },
     { name = "pytz" },
     { name = "requests" },
     { name = "tzlocal" },
-    { name = "zstandard", version = "0.24.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "zstandard", version = "0.25.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
+    { name = "zstandard", version = "0.24.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and python_full_version < '3.14' and extra == 'group-4-daft-dev') or (python_full_version < '3.11' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version >= '3.14' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "zstandard", version = "0.25.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'group-4-daft-dev') or (python_full_version >= '3.14' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/63/bc/1559f7eaf8501e5205be18f18acb13c2e91604c5eae5a9299963b24e62df/trino-0.336.0.tar.gz", hash = "sha256:389150841446949119c3c2c13c1a51bb4be1a27818e40ae40dd3701f36c02550", size = 55505, upload-time = "2025-08-14T11:09:16.315Z" }
 wheels = [
@@ -9294,8 +10470,8 @@ name = "triton"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "setuptools", version = "79.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "setuptools", version = "80.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "setuptools", version = "79.0.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32') or (python_full_version >= '3.12' and sys_platform == 'linux' and extra == 'extra-4-daft-paimon') or (python_full_version >= '3.12' and sys_platform == 'linux' and extra != 'group-4-daft-dev') or (python_full_version < '3.12' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "setuptools", version = "80.9.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32') or (python_full_version < '3.12' and sys_platform == 'linux' and extra == 'extra-4-daft-paimon') or (python_full_version < '3.12' and sys_platform == 'linux' and extra != 'group-4-daft-dev') or (python_full_version >= '3.12' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/ee/0ee5f64a87eeda19bbad9bc54ae5ca5b98186ed00055281fd40fb4beb10e/triton-3.4.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7ff2785de9bc02f500e085420273bb5cc9c9bb767584a4aa28d6e360cec70128", size = 155430069, upload-time = "2025-07-30T19:58:21.715Z" },
@@ -9575,25 +10751,25 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "blake3" },
-    { name = "cachetools" },
+    { name = "cachetools", version = "5.5.2", source = { registry = "https://pypi.org/simple" } },
     { name = "cbor2" },
     { name = "cloudpickle" },
     { name = "compressed-tensors" },
     { name = "depyf" },
     { name = "diskcache" },
     { name = "einops" },
-    { name = "fastapi", extra = ["standard"] },
+    { name = "fastapi", extra = ["standard"], marker = "extra == 'group-4-daft-dev'" },
     { name = "filelock" },
     { name = "gguf" },
     { name = "lark" },
     { name = "llguidance", marker = "platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
     { name = "lm-format-enforcer" },
-    { name = "mistral-common", extra = ["audio", "image"] },
+    { name = "mistral-common", extra = ["audio", "image"], marker = "extra == 'group-4-daft-dev'" },
     { name = "msgspec" },
     { name = "ninja" },
     { name = "numba" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
     { name = "openai" },
     { name = "openai-harmony" },
     { name = "opencv-python-headless" },
@@ -9602,8 +10778,8 @@ dependencies = [
     { name = "pillow" },
     { name = "prometheus-client" },
     { name = "prometheus-fastapi-instrumentator" },
-    { name = "protobuf", version = "5.29.6", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "protobuf", version = "6.33.5", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'darwin'" },
+    { name = "protobuf", version = "5.29.6", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform == 'darwin' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "protobuf", version = "6.33.5", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'darwin' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
     { name = "psutil" },
     { name = "py-cpuinfo" },
     { name = "pybase64" },
@@ -9611,11 +10787,11 @@ dependencies = [
     { name = "python-json-logger" },
     { name = "pyyaml" },
     { name = "pyzmq" },
-    { name = "ray", extra = ["cgraph"] },
+    { name = "ray", extra = ["cgraph"], marker = "extra == 'group-4-daft-dev'" },
     { name = "regex" },
     { name = "requests" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "scipy", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
     { name = "sentencepiece" },
     { name = "setproctitle" },
     { name = "setuptools", version = "79.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
@@ -9937,13 +11113,14 @@ name = "xformers"
 version = "0.0.32.post1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "torch", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'group-4-daft-dev') or (python_full_version >= '3.13' and platform_machine != 'aarch64' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'group-4-daft-dev') or (python_full_version >= '3.13' and sys_platform != 'linux' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'group-4-daft-dev') or (python_full_version < '3.13' and platform_machine != 'aarch64' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'group-4-daft-dev') or (python_full_version < '3.13' and sys_platform != 'linux' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "torch", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6f/33/3b9c4d3d5b2da453d27de891df4ad653ac5795324961aa3a5c15b0353fe6/xformers-0.0.32.post1.tar.gz", hash = "sha256:1de84a45c497c8d92326986508d81f4b0a8c6be4d3d62a29b8ad6048a6ab51e1", size = 12106196, upload-time = "2025-08-14T18:07:45.486Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6b/df/6817346f1a77278315d5fe1fc9f239ba3282ba36e8ab3256babd448dde62/xformers-0.0.32.post1-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:5f245b5555188da112070d8fefb6b7ae1ae47422856521d66c837e9d2352fbe4", size = 117199943, upload-time = "2025-08-14T18:07:34.78Z" },
+    { url = "https://files.pythonhosted.org/packages/91/70/7dee5a786d77a63cf20dac60c38086bd2202d59ae89c8acef0ef6331c374/xformers-0.0.32.post1-cp39-abi3-win_amd64.whl", hash = "sha256:feb452bc2c8731da1c5d0e2e4536ba95bb214f77b41e91f24443c74d6f98a126", size = 100221531, upload-time = "2025-08-14T18:07:41.112Z" },
 ]
 
 [[package]]
@@ -9953,8 +11130,8 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mlx-lm", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'" },
     { name = "ninja" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra == 'group-4-daft-dev') or (extra == 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')" },
     { name = "pydantic" },
     { name = "torch" },
     { name = "transformers" },
@@ -10223,21 +11400,42 @@ name = "zstandard"
 version = "0.24.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
-    "(python_full_version == '3.13.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
-    "(python_full_version == '3.12.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
-    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version == '3.13.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'darwin' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'win32' and extra == 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/09/1b/c20b2ef1d987627765dcd5bf1dadb8ef6564f00a87972635099bb76b7a05/zstandard-0.24.0.tar.gz", hash = "sha256:fe3198b81c00032326342d973e526803f183f97aa9e9a98e3f897ebafe21178f", size = 905681, upload-time = "2025-08-17T18:36:36.352Z" }
 wheels = [
@@ -10330,16 +11528,20 @@ name = "zstandard"
 version = "0.25.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version >= '3.14' and sys_platform == 'darwin'",
-    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version < '3.11' and sys_platform == 'darwin'",
-    "(python_full_version < '3.11' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
-    "python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version >= '3.14' and sys_platform == 'win32'",
-    "python_full_version < '3.11' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "(python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev')",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra == 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'darwin' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
+    "python_full_version < '3.11' and sys_platform == 'win32' and extra != 'extra-4-daft-paimon' and extra != 'group-4-daft-dev'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fd/aa/3e0508d5a5dd96529cdc5a97011299056e14c6505b678fd58938792794b1/zstandard-0.25.0.tar.gz", hash = "sha256:7713e1179d162cf5c7906da876ec2ccb9c3a9dcbdffef0cc7f70c3667a205f0b", size = 711513, upload-time = "2025-09-14T22:15:54.002Z" }
 wheels = [


### PR DESCRIPTION
## Summary
- Adds `paimon = [\"pypaimon>=0.2.0,<1.4.0\"]` to `[project.optional-dependencies]`.
- Includes it in the `all` extra.

`pypaimon` is already referenced in `daft/io/paimon/` under `TYPE_CHECKING` and raises `ImportError` at runtime, but was never surfaced through `pip install daft[paimon]`. This aligns it with other optional backends (deltalake, iceberg, hudi, etc).

## Test plan
- [ ] `pip install .[paimon]` resolves pypaimon
- [ ] `pip install .[all]` now pulls pypaimon alongside other extras
- [ ] `daft.read_paimon` no longer raises the install-hint `ImportError` after install