### PR TITLE
ci: instrument integration-test-ray for codecov

### DIFF
--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -1149,22 +1149,42 @@ jobs:
 
   integration-test-ray:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
-    needs: [skipcheck, integration-test-build]
+    timeout-minutes: 60
+    needs: [skipcheck]
     if: ${{ needs.skipcheck.outputs.skip == 'false' }}
     env:
       package-name: daft
     steps:
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@v1.3.1
+      with:
+        tool-cache: false
+        android: true
+        dotnet: true
+        haskell: true
+        large-packages: false
+        docker-images: true
+        swap-storage: true
     - uses: actions/checkout@v6
       with:
         submodules: true
         fetch-depth: 0
-    - name: Download built wheels
-      uses: actions/download-artifact@v8
+    - uses: moonrepo/setup-rust@v1
       with:
-        pattern: wheels-*
-        merge-multiple: true
-        path: dist
+        cache: false
+    - uses: Swatinem/rust-cache@v2
+      with:
+        shared-key: "ubuntu-coverage"
+        cache-all-crates: "true"
+        cache-workspace-crates: "true"
+        save-if: ${{ github.ref == 'refs/heads/main' }}
+    - uses: ./.github/actions/restore-mtime
+    - name: Install cargo-llvm-cov
+      uses: taiki-e/install-action@cargo-llvm-cov
+      with:
+        tool: cargo-llvm-cov@0.7.1
+    - name: Install llvm tools
+      run: rustup component add llvm-tools-preview
     - name: Setup Python and uv
       uses: astral-sh/setup-uv@v7
       with:
@@ -1175,7 +1195,7 @@ jobs:
       run: |
         uv venv --seed .venv
         echo "$GITHUB_WORKSPACE/.venv/bin" >> $GITHUB_PATH
-    - name: Install Daft and dev dependencies
+    - name: Install dev dependencies
       uses: nick-fields/retry@v4
       with:
         timeout_minutes: 10
@@ -1184,13 +1204,13 @@ jobs:
         command: |
           source .venv/bin/activate
           uv sync --no-install-project --all-extras --all-groups
-          uv pip install dist/${{ env.package-name }}-*x86_64*.whl --force-reinstall
-          rm -rf daft
 
-    - name: Run Ray Integration Tests
+    - name: Build instrumented library and run Ray Integration Tests
       run: |
         set -o pipefail
         source .venv/bin/activate
+        cargo llvm-cov clean --workspace
+        maturin develop --uv
         # Note: These tests are run sequentially (one at a time) to avoid Ray cluster conflicts
         # Each test spins up its own Ray cluster, so parallel execution may cause issues
         test_names=$(pytest --collect-only -q -m integration tests/integration/ray | grep "::test_")
@@ -1198,8 +1218,23 @@ jobs:
           echo "Running $test..."
           pytest -m integration $test --durations=0
         done
+        mkdir -p report-output
+        cargo llvm-cov report --lcov --output-path report-output/rust-coverage-integration-ray.lcov
       env:
+        # Mirror the unit-test coverage env block.
+        RUSTFLAGS: -C instrument-coverage --cfg=coverage --cfg=coverage_nightly --cfg=trybuild_no_target
+        LLVM_PROFILE_FILE: ./target/daft-coverage-%p-%m.profraw
+        CARGO_LLVM_COV: 1
+        CARGO_LLVM_COV_SHOW_ENV: 1
+        CARGO_LLVM_COV_TARGET_DIR: ./target
+        CARGO_TARGET_DIR: ./target
         DAFT_RUNNER: ray
+
+    - name: Upload coverage report
+      uses: actions/upload-artifact@v7
+      with:
+        name: coverage-reports-integration-ray
+        path: ./report-output
 
     - name: Send Slack notification on failure
       uses: slackapi/slack-github-action@v3.0.1
@@ -1527,6 +1562,7 @@ jobs:
     needs:
     - unit-test
     - rust-tests-platform
+    - integration-test-ray
     steps:
     - uses: actions/checkout@v6
     - uses: actions/download-artifact@v8

--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -347,22 +347,42 @@ jobs:
 
   integration-test-tpch:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
-    needs: [skipcheck, integration-test-build]
+    timeout-minutes: 75
+    needs: [skipcheck]
     if: ${{ needs.skipcheck.outputs.skip == 'false' }}
     env:
       package-name: daft
     steps:
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@v1.3.1
+      with:
+        tool-cache: false
+        android: true
+        dotnet: true
+        haskell: true
+        large-packages: false
+        docker-images: true
+        swap-storage: true
     - uses: actions/checkout@v6
       with:
         submodules: true
         fetch-depth: 0
-    - name: Download built wheels
-      uses: actions/download-artifact@v8
+    - uses: moonrepo/setup-rust@v1
       with:
-        pattern: wheels-*
-        merge-multiple: true
-        path: dist
+        cache: false
+    - uses: Swatinem/rust-cache@v2
+      with:
+        shared-key: "ubuntu-coverage"
+        cache-all-crates: "true"
+        cache-workspace-crates: "true"
+        save-if: ${{ github.ref == 'refs/heads/main' }}
+    - uses: ./.github/actions/restore-mtime
+    - name: Install cargo-llvm-cov
+      uses: taiki-e/install-action@cargo-llvm-cov
+      with:
+        tool: cargo-llvm-cov@0.7.1
+    - name: Install llvm tools
+      run: rustup component add llvm-tools-preview
     - name: Setup Python and uv
       uses: astral-sh/setup-uv@v7
       with:
@@ -373,7 +393,7 @@ jobs:
       run: |
         uv venv --seed .venv
         echo "$GITHUB_WORKSPACE/.venv/bin" >> $GITHUB_PATH
-    - name: Install Daft and dev dependencies
+    - name: Install dev dependencies
       uses: nick-fields/retry@v4
       with:
         timeout_minutes: 15
@@ -382,14 +402,26 @@ jobs:
         command: |
           source .venv/bin/activate
           uv sync --no-install-project --all-extras --all-groups
-          uv pip install dist/${{ env.package-name }}-*x86_64*.whl --force-reinstall
-          rm -rf daft
     - uses: actions/cache@v5
       env:
         cache-name: cache-tpch-data
       with:
         path: data/tpch-dbgen
         key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('tests/integration/test_tpch.py', 'benchmarking/tpch/**') }}
+
+    - name: Build instrumented library
+      run: |
+        set -o pipefail
+        source .venv/bin/activate
+        cargo llvm-cov clean --workspace
+        maturin develop --uv
+      env:
+        RUSTFLAGS: -C instrument-coverage --cfg=coverage --cfg=coverage_nightly --cfg=trybuild_no_target
+        LLVM_PROFILE_FILE: ./target/daft-coverage-%p-%m.profraw
+        CARGO_LLVM_COV: 1
+        CARGO_LLVM_COV_SHOW_ENV: 1
+        CARGO_LLVM_COV_TARGET_DIR: ./target
+        CARGO_TARGET_DIR: ./target
 
     - name: Run TPCH integration tests (native)
       run: |
@@ -399,6 +431,12 @@ jobs:
         python ./tools/aggregate_test_durations.py tpch_pytest_output.txt
       env:
         DAFT_RUNNER: native
+        RUSTFLAGS: -C instrument-coverage --cfg=coverage --cfg=coverage_nightly --cfg=trybuild_no_target
+        LLVM_PROFILE_FILE: ./target/daft-coverage-%p-%m.profraw
+        CARGO_LLVM_COV: 1
+        CARGO_LLVM_COV_SHOW_ENV: 1
+        CARGO_LLVM_COV_TARGET_DIR: ./target
+        CARGO_TARGET_DIR: ./target
     - name: Run TPCH integration tests (ray)
       run: |
         set -o pipefail
@@ -407,6 +445,31 @@ jobs:
         python ./tools/aggregate_test_durations.py tpch_pytest_output.txt
       env:
         DAFT_RUNNER: ray
+        RUSTFLAGS: -C instrument-coverage --cfg=coverage --cfg=coverage_nightly --cfg=trybuild_no_target
+        LLVM_PROFILE_FILE: ./target/daft-coverage-%p-%m.profraw
+        CARGO_LLVM_COV: 1
+        CARGO_LLVM_COV_SHOW_ENV: 1
+        CARGO_LLVM_COV_TARGET_DIR: ./target
+        CARGO_TARGET_DIR: ./target
+
+    - name: Generate coverage report
+      run: |
+        source .venv/bin/activate
+        mkdir -p report-output
+        cargo llvm-cov report --lcov --output-path report-output/rust-coverage-integration-tpch.lcov
+      env:
+        RUSTFLAGS: -C instrument-coverage --cfg=coverage --cfg=coverage_nightly --cfg=trybuild_no_target
+        LLVM_PROFILE_FILE: ./target/daft-coverage-%p-%m.profraw
+        CARGO_LLVM_COV: 1
+        CARGO_LLVM_COV_SHOW_ENV: 1
+        CARGO_LLVM_COV_TARGET_DIR: ./target
+        CARGO_TARGET_DIR: ./target
+
+    - name: Upload coverage report
+      uses: actions/upload-artifact@v7
+      with:
+        name: coverage-reports-integration-tpch
+        path: ./report-output
 
     - name: Send Slack notification on failure
       uses: slackapi/slack-github-action@v3.0.1
@@ -1563,6 +1626,7 @@ jobs:
     - unit-test
     - rust-tests-platform
     - integration-test-ray
+    - integration-test-tpch
     steps:
     - uses: actions/checkout@v6
     - uses: actions/download-artifact@v8

--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -215,7 +215,7 @@ jobs:
       env:
           # output of `cargo llvm-cov show-env --export-prefix`
         RUSTFLAGS: -C instrument-coverage --cfg=coverage --cfg=coverage_nightly --cfg=trybuild_no_target
-        LLVM_PROFILE_FILE: ./target/daft-coverage-%p-%m.profraw
+        LLVM_PROFILE_FILE: ${{ github.workspace }}/target/daft-coverage-%p-%m.profraw
         CARGO_LLVM_COV: 1
         CARGO_LLVM_COV_SHOW_ENV: 1
         CARGO_LLVM_COV_TARGET_DIR: ./target
@@ -417,7 +417,7 @@ jobs:
         maturin develop --uv
       env:
         RUSTFLAGS: -C instrument-coverage --cfg=coverage --cfg=coverage_nightly --cfg=trybuild_no_target
-        LLVM_PROFILE_FILE: ./target/daft-coverage-%p-%m.profraw
+        LLVM_PROFILE_FILE: ${{ github.workspace }}/target/daft-coverage-%p-%m.profraw
         CARGO_LLVM_COV: 1
         CARGO_LLVM_COV_SHOW_ENV: 1
         CARGO_LLVM_COV_TARGET_DIR: ./target
@@ -432,7 +432,7 @@ jobs:
       env:
         DAFT_RUNNER: native
         RUSTFLAGS: -C instrument-coverage --cfg=coverage --cfg=coverage_nightly --cfg=trybuild_no_target
-        LLVM_PROFILE_FILE: ./target/daft-coverage-%p-%m.profraw
+        LLVM_PROFILE_FILE: ${{ github.workspace }}/target/daft-coverage-%p-%m.profraw
         CARGO_LLVM_COV: 1
         CARGO_LLVM_COV_SHOW_ENV: 1
         CARGO_LLVM_COV_TARGET_DIR: ./target
@@ -446,7 +446,7 @@ jobs:
       env:
         DAFT_RUNNER: ray
         RUSTFLAGS: -C instrument-coverage --cfg=coverage --cfg=coverage_nightly --cfg=trybuild_no_target
-        LLVM_PROFILE_FILE: ./target/daft-coverage-%p-%m.profraw
+        LLVM_PROFILE_FILE: ${{ github.workspace }}/target/daft-coverage-%p-%m.profraw
         CARGO_LLVM_COV: 1
         CARGO_LLVM_COV_SHOW_ENV: 1
         CARGO_LLVM_COV_TARGET_DIR: ./target
@@ -459,7 +459,7 @@ jobs:
         cargo llvm-cov report --lcov --output-path report-output/rust-coverage-integration-tpch.lcov
       env:
         RUSTFLAGS: -C instrument-coverage --cfg=coverage --cfg=coverage_nightly --cfg=trybuild_no_target
-        LLVM_PROFILE_FILE: ./target/daft-coverage-%p-%m.profraw
+        LLVM_PROFILE_FILE: ${{ github.workspace }}/target/daft-coverage-%p-%m.profraw
         CARGO_LLVM_COV: 1
         CARGO_LLVM_COV_SHOW_ENV: 1
         CARGO_LLVM_COV_TARGET_DIR: ./target
@@ -1286,7 +1286,7 @@ jobs:
       env:
         # Mirror the unit-test coverage env block.
         RUSTFLAGS: -C instrument-coverage --cfg=coverage --cfg=coverage_nightly --cfg=trybuild_no_target
-        LLVM_PROFILE_FILE: ./target/daft-coverage-%p-%m.profraw
+        LLVM_PROFILE_FILE: ${{ github.workspace }}/target/daft-coverage-%p-%m.profraw
         CARGO_LLVM_COV: 1
         CARGO_LLVM_COV_SHOW_ENV: 1
         CARGO_LLVM_COV_TARGET_DIR: ./target

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -403,6 +403,13 @@ version = "0.13"
 features = ["derive", "rc"]
 version = "1.0.228"
 
+[workspace.lints.rust]
+unexpected_cfgs = {level = "warn", check-cfg = [
+  "cfg(coverage)",
+  "cfg(coverage_nightly)",
+  "cfg(trybuild_no_target)"
+]}
+
 [workspace.lints.clippy]
 as_conversions = "allow"
 cast-sign-loss = "allow"

--- a/daft/runners/flotilla.py
+++ b/daft/runners/flotilla.py
@@ -96,6 +96,40 @@ async def clear_flight_shuffle_dirs_on_all_nodes(shuffle_dirs: list[str]) -> Non
     )
 
 
+def _install_coverage_flush() -> None:
+    """Ensure LLVM profile counters are written before a Ray actor is torn down.
+
+    In coverage-instrumented builds this calls `__llvm_profile_write_file` on clean
+    interpreter exit and on SIGTERM (Ray's pre-SIGKILL signal), so per-actor profraw
+    files actually hit disk. In non-coverage builds `flush_llvm_profile` is a no-op,
+    so installing the handlers is essentially free.
+    """
+    import signal
+
+    try:
+        from daft.daft import flush_llvm_profile  # type: ignore[attr-defined]
+    except ImportError:
+        return
+
+    def _flush() -> None:
+        try:
+            flush_llvm_profile()
+        except Exception:
+            pass
+
+    atexit.register(_flush)
+
+    def _sigterm(signum: int, _frame: object) -> None:
+        _flush()
+        signal.signal(signum, signal.SIG_DFL)
+        os.kill(os.getpid(), signum)
+
+    try:
+        signal.signal(signal.SIGTERM, _sigterm)
+    except (ValueError, OSError):
+        pass
+
+
 @ray.remote
 class RaySwordfishActor:
     """RaySwordfishActor is a ray actor that runs local physical plans on swordfish.
@@ -110,6 +144,7 @@ class RaySwordfishActor:
         is_head: bool = False,
         event_log_dir: str | None = None,
     ) -> None:
+        _install_coverage_flush()
         os.environ["DAFT_FLOTILLA_WORKER"] = "1"  # TODO: Remove once fixed DashboardSubscriber
 
         if event_log_dir:
@@ -402,6 +437,7 @@ class RemoteFlotillaRunner:
         dashboard_url: str | None = None,
         event_log_dir: str | None = None,
     ) -> None:
+        _install_coverage_flush()
         if dashboard_url:
             os.environ["DAFT_DASHBOARD_URL"] = dashboard_url
             try:

--- a/daft/runners/flotilla.py
+++ b/daft/runners/flotilla.py
@@ -130,6 +130,21 @@ def _install_coverage_flush() -> None:
         pass
 
 
+def _coverage_runtime_env_vars() -> dict[str, str]:
+    """Return env vars that must propagate to Ray actor processes under coverage.
+
+    Ray actors start fresh subprocesses and do not inherit arbitrary env vars from
+    the driver. The LLVM profile runtime reads `LLVM_PROFILE_FILE` at .so load time
+    to decide where to write profraw; without it, actors write to `default.profraw`
+    in their cwd (typically /tmp/ray/session_*) where cargo-llvm-cov never looks.
+    Forwarding the driver's value via Ray `runtime_env` pins actor profraw into the
+    workspace target dir so the merge step picks them up.
+    """
+    keys = ("LLVM_PROFILE_FILE",)
+    env = {k: os.environ[k] for k in keys if k in os.environ}
+    return env
+
+
 @ray.remote
 class RaySwordfishActor:
     """RaySwordfishActor is a ray actor that runs local physical plans on swordfish.
@@ -382,11 +397,13 @@ def start_ray_workers(existing_worker_ids: list[str]) -> list[RaySwordfishWorker
             # `node:__internal_head__` is Ray's internal resource key tagging the head node;
             # not in public Ray docs but stable and relied on by Ray's own autoscaler/GCS code.
             is_head = node["Resources"].get("node:__internal_head__", 0) == 1
+            worker_env_vars = _coverage_runtime_env_vars()
             actor = RaySwordfishActor.options(  # type: ignore
                 scheduling_strategy=ray.util.scheduling_strategies.NodeAffinitySchedulingStrategy(
                     node_id=node["NodeID"],
                     soft=False,
                 ),
+                runtime_env=({"env_vars": worker_env_vars} if worker_env_vars else None),
             ).remote(
                 num_cpus=int(node["Resources"]["CPU"]),
                 num_gpus=int(node["Resources"].get("GPU", 0)),
@@ -577,7 +594,7 @@ class FlotillaRunner:
             create_or_get_sink(event_log_dir, sink_job_id, head_node_id)
             atexit.register(teardown_sink, sink_job_id)
 
-        runner_env_vars: dict[str, str] = {}
+        runner_env_vars: dict[str, str] = _coverage_runtime_env_vars()
         if dashboard_url:
             runner_env_vars["DAFT_DASHBOARD_URL"] = dashboard_url
 

--- a/src/daft-distributed/src/python/mod.rs
+++ b/src/daft-distributed/src/python/mod.rs
@@ -267,6 +267,23 @@ impl PyDistributedPhysicalPlanRunner {
     }
 }
 
+// Coverage-only hook for flushing LLVM profile counters from Ray actor processes
+// before Ray's SIGKILL teardown loses them. No-op in non-coverage builds so there
+// is no runtime overhead outside of coverage-instrumented CI.
+#[cfg(coverage)]
+unsafe extern "C" {
+    fn __llvm_profile_write_file() -> i32;
+}
+
+#[pyfunction]
+fn flush_llvm_profile() -> PyResult<()> {
+    #[cfg(coverage)]
+    unsafe {
+        __llvm_profile_write_file();
+    }
+    Ok(())
+}
+
 pub fn register_modules(parent: &Bound<PyModule>) -> PyResult<()> {
     parent.add_class::<PyDistributedPhysicalPlan>()?;
     parent.add_class::<PyDistributedPhysicalPlanRunner>()?;
@@ -274,5 +291,6 @@ pub fn register_modules(parent: &Bound<PyModule>) -> PyResult<()> {
     parent.add_class::<RaySwordfishTask>()?;
     parent.add_class::<RaySwordfishWorker>()?;
     parent.add_class::<RayTaskResult>()?;
+    parent.add_function(wrap_pyfunction!(flush_llvm_profile, parent)?)?;
     Ok(())
 }


### PR DESCRIPTION
Experiment to see whether daft-distributed's reported coverage is artificially low because the Ray integration test job runs uninstrumented.

`integration-test-ray` currently downloads the release wheel from `integration-test-build` (`maturin build --release`, no `-C instrument-coverage`) and never uploads a coverage artifact, so every driver-side code path those tests exercise is invisible to Codecov. Meanwhile Codecov reports `src/daft-distributed/src` at 54.84%, with `plan/runner.rs` at 5.98% and `python/ray/worker_manager.rs` / `python/ray/worker.rs` at 0% - numbers that can't be right if ray-runner tests ever materialize a plan. The gap is mostly collection, not missing tests.

This PR flips that one job to build `maturin develop` in place with `RUSTFLAGS="-C instrument-coverage --cfg=coverage ..."` and `LLVM_PROFILE_FILE=./target/daft-coverage-%p-%m.profraw` (mirroring the `unit-test` coverage block), runs the existing serial ray integration loop, generates `rust-coverage-integration-ray.lcov`, and uploads it as `coverage-reports-integration-ray` so `publish-coverage-reports` merges it into the existing Codecov upload. The job also gets its own `ubuntu-coverage` rust-cache key so the instrumented target dir doesn't thrash the unit-test `dev-build` cache.

As a note, I deliberately kept the blast radius small:

- Only `integration-test-ray` is instrumented. The other five integration jobs (`tpch`, `io`, `sql`, `catalogs`, `ai`) still consume the uninstrumented release wheel. If driver-side coverage moves the needle here, I'll extend.
- No Ray actor-side profraw flush hook yet. Actors terminate via SIGKILL on teardown, so actor-process profraw is lost. Driver-side code (which is most of `daft-distributed`) doesn't need the hook; if actor-executed code in `daft-local-execution` still looks low after this experiment lands, that's the next step.

Downsides to watch: instrumented builds are slower, instrumented tests run slower (timeout bumped 45 to 60 min to absorb this), and profraw can balloon to multi-GB with many worker processes. If this is too expensive to run per-PR, the followup is to gate it on `push` to `main` only so Codecov updates daily instead of per-PR.