### PR TITLE
refactor(flight): implement distributed gather for flight shuffle

### DIFF
--- a/src/common/metrics/src/ops.rs
+++ b/src/common/metrics/src/ops.rs
@@ -38,6 +38,7 @@ pub enum NodeType {
     IntoPartitions,
     Pivot,
     Repartition,
+    Gather,
     RandomShuffle,
     Sort,
     TopN,

--- a/src/daft-distributed/src/pipeline_node/shuffles/backends/mod.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/backends/mod.rs
@@ -1,7 +1,9 @@
 use std::sync::Arc;
 
 use common_error::DaftResult;
-use daft_local_plan::{LocalNodeContext, LocalPhysicalPlan, RepartitionWriteBackend};
+use daft_local_plan::{
+    GatherWriteBackend, LocalNodeContext, LocalPhysicalPlan, RepartitionWriteBackend,
+};
 use daft_logical_plan::{partitioning::RepartitionSpec, stats::StatsState};
 use daft_schema::schema::SchemaRef;
 
@@ -70,7 +72,7 @@ impl ShuffleBackend {
         }
     }
 
-    pub(crate) fn build_write_stage(
+    pub(crate) fn build_repartition_write_stage(
         &self,
         producer: Arc<dyn PipelineNodeImpl>,
         input_node: TaskBuilderStream,
@@ -94,6 +96,32 @@ impl ShuffleBackend {
                 schema.clone(),
                 repartition_backend.clone(),
                 repartition_spec.clone(),
+                StatsState::NotMaterialized,
+                LocalNodeContext::new(Some(node_id as usize)),
+            )
+        })
+    }
+
+    pub(crate) fn build_gather_write_stage(
+        &self,
+        producer: Arc<dyn PipelineNodeImpl>,
+        input_node: TaskBuilderStream,
+    ) -> TaskBuilderStream {
+        let schema = self.schema.clone();
+        let node_id = self.node_id;
+        let gather_backend = match self.backend.clone() {
+            DistributedShuffleBackend::Ray => GatherWriteBackend::Ray,
+            DistributedShuffleBackend::Flight(backend) => GatherWriteBackend::Flight {
+                shuffle_id: backend.shuffle_id,
+                shuffle_dirs: backend.shuffle_dirs.clone(),
+                compression: backend.compression,
+            },
+        };
+        input_node.pipeline_instruction(producer, move |input| {
+            LocalPhysicalPlan::gather_write(
+                input,
+                schema.clone(),
+                gather_backend.clone(),
                 StatsState::NotMaterialized,
                 LocalNodeContext::new(Some(node_id as usize)),
             )

--- a/src/daft-distributed/src/pipeline_node/shuffles/gather.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/gather.rs
@@ -10,6 +10,7 @@ use crate::{
     pipeline_node::{
         DistributedPipelineNode, MaterializedOutput, NodeID, PipelineNodeConfig,
         PipelineNodeContext, PipelineNodeImpl, TaskBuilderStream,
+        shuffles::backends::{DistributedShuffleBackend, ShuffleBackend},
     },
     plan::{PlanConfig, PlanExecutionContext, TaskIDCounter},
     scheduling::{
@@ -22,17 +23,18 @@ use crate::{
 pub(crate) struct GatherNode {
     config: PipelineNodeConfig,
     context: PipelineNodeContext,
+    shuffle_backend: ShuffleBackend,
     child: DistributedPipelineNode,
 }
 
 impl GatherNode {
     const NODE_NAME: &'static str = "Gather";
 
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
         node_id: NodeID,
         plan_config: &PlanConfig,
         schema: SchemaRef,
+        backend: DistributedShuffleBackend,
         child: DistributedPipelineNode,
     ) -> Self {
         let context = PipelineNodeContext::new(
@@ -44,45 +46,40 @@ impl GatherNode {
             NodeCategory::BlockingSink,
         );
         let config = PipelineNodeConfig::new(
-            schema,
+            schema.clone(),
             plan_config.config.clone(),
             Arc::new(UnknownClusteringConfig::new(1).into()),
         );
+        let shuffle_backend = ShuffleBackend::new(&context, schema, backend);
         Self {
             config,
             context,
+            shuffle_backend,
             child,
         }
     }
 
-    // Async execution to get all partitions out
     async fn execution_loop(
         self: Arc<Self>,
-        input_node: TaskBuilderStream,
+        local_gather_write_node: TaskBuilderStream,
         task_id_counter: TaskIDCounter,
         result_tx: Sender<SwordfishTaskBuilder>,
         scheduler_handle: SchedulerHandle<SwordfishTask>,
     ) -> DaftResult<()> {
-        // Trigger materialization of all inputs
-        let materialized = input_node
+        // Drive all upstream gather-write tasks to completion and collect their outputs.
+        let materialized = local_gather_write_node
             .materialize(
                 scheduler_handle.clone(),
                 self.context.query_idx,
-                task_id_counter.clone(),
+                task_id_counter,
             )
-            .try_collect::<Vec<_>>()
+            .try_collect::<Vec<MaterializedOutput>>()
             .await?;
 
-        let (plan, psets) = MaterializedOutput::into_in_memory_scan_with_psets(
-            materialized,
-            self.config.schema.clone(),
-            self.node_id(),
-        );
-        let builder = SwordfishTaskBuilder::new(plan, self.as_ref(), self.node_id())
-            .with_psets(self.node_id(), psets);
-
-        let _ = result_tx.send(builder).await;
-        Ok(())
+        // Gather = single read task that consumes every ref from every worker.
+        self.shuffle_backend
+            .emit_read_tasks(vec![materialized], self.as_ref(), result_tx)
+            .await
     }
 }
 
@@ -100,7 +97,11 @@ impl PipelineNodeImpl for GatherNode {
     }
 
     fn multiline_display(&self, _verbose: bool) -> Vec<String> {
-        vec!["Gather".to_string()]
+        let backend_name = match self.shuffle_backend.backend() {
+            DistributedShuffleBackend::Ray => "RayGather",
+            DistributedShuffleBackend::Flight(_) => "FlightGather",
+        };
+        vec![backend_name.to_string()]
     }
 
     fn produce_tasks(
@@ -108,17 +109,29 @@ impl PipelineNodeImpl for GatherNode {
         plan_context: &mut PlanExecutionContext,
     ) -> TaskBuilderStream {
         let input_node = self.child.clone().produce_tasks(plan_context);
+        self.shuffle_backend.register_cleanup(plan_context);
+        let local_gather_write_node = self
+            .shuffle_backend
+            .build_gather_write_stage(self.clone(), input_node);
 
-        // Materialize and gather all partitions to a single node
         let (result_tx, result_rx) = create_channel(1);
-        let execution_loop = self.execution_loop(
-            input_node,
-            plan_context.task_id_counter(),
-            result_tx,
-            plan_context.scheduler_handle(),
-        );
-        plan_context.spawn(execution_loop);
 
+        let self_arc = self.clone();
+        let task_id_counter = plan_context.task_id_counter();
+        let scheduler_handle = plan_context.scheduler_handle();
+
+        let execution = async move {
+            self_arc
+                .execution_loop(
+                    local_gather_write_node,
+                    task_id_counter,
+                    result_tx,
+                    scheduler_handle,
+                )
+                .await
+        };
+
+        plan_context.spawn(execution);
         TaskBuilderStream::from(result_rx)
     }
 }

--- a/src/daft-distributed/src/pipeline_node/shuffles/gather.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/gather.rs
@@ -42,7 +42,7 @@ impl GatherNode {
             plan_config.query_id.clone(),
             node_id,
             Arc::from(Self::NODE_NAME),
-            NodeType::Repartition,
+            NodeType::Gather,
             NodeCategory::BlockingSink,
         );
         let config = PipelineNodeConfig::new(

--- a/src/daft-distributed/src/pipeline_node/shuffles/repartition.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/repartition.rs
@@ -112,7 +112,7 @@ impl PipelineNodeImpl for RepartitionNode {
         let input_node = self.child.clone().produce_tasks(plan_context);
         let self_arc = self.clone();
         self.shuffle_backend.register_cleanup(plan_context);
-        let local_shuffle_write_node = self.shuffle_backend.build_write_stage(
+        let local_shuffle_write_node = self.shuffle_backend.build_repartition_write_stage(
             self.clone(),
             input_node,
             self.num_partitions,

--- a/src/daft-distributed/src/pipeline_node/shuffles/translate_shuffle.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/translate_shuffle.rs
@@ -117,12 +117,22 @@ impl LogicalPlanToPipelineNodeTranslator {
             return input_node;
         }
 
+        let backend = if self.plan_config.config.shuffle_algorithm.as_str() == "flight_shuffle" {
+            DistributedShuffleBackend::Flight(FlightShuffleBackendConfig {
+                shuffle_dirs: self.plan_config.config.flight_shuffle_dirs.clone(),
+                ..Default::default()
+            })
+        } else {
+            DistributedShuffleBackend::Ray
+        };
+
         let node_id = self.get_next_pipeline_node_id();
         DistributedPipelineNode::new(
             Arc::new(GatherNode::new(
                 node_id,
                 &self.plan_config,
                 input_node.config().schema.clone(),
+                backend,
                 input_node,
             )),
             &self.meter,

--- a/src/daft-distributed/src/pipeline_node/shuffles/translate_shuffle.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/translate_shuffle.rs
@@ -16,20 +16,25 @@ use crate::pipeline_node::{
 };
 
 impl LogicalPlanToPipelineNodeTranslator {
-    pub fn gen_repartition_node(
-        &mut self,
-        repartition_spec: RepartitionSpec,
-        schema: SchemaRef,
-        child: DistributedPipelineNode,
-    ) -> DaftResult<DistributedPipelineNode> {
-        let backend = if self.plan_config.config.shuffle_algorithm.as_str() == "flight_shuffle" {
+    /// Pick the shuffle backend implied by the current execution config.
+    fn select_backend(&self) -> DistributedShuffleBackend {
+        if self.plan_config.config.shuffle_algorithm.as_str() == "flight_shuffle" {
             DistributedShuffleBackend::Flight(FlightShuffleBackendConfig {
                 shuffle_dirs: self.plan_config.config.flight_shuffle_dirs.clone(),
                 ..Default::default()
             })
         } else {
             DistributedShuffleBackend::Ray
-        };
+        }
+    }
+
+    pub fn gen_repartition_node(
+        &mut self,
+        repartition_spec: RepartitionSpec,
+        schema: SchemaRef,
+        child: DistributedPipelineNode,
+    ) -> DaftResult<DistributedPipelineNode> {
+        let backend = self.select_backend();
         self.gen_repartition_node_with_backend(repartition_spec, schema, child, backend)
     }
 
@@ -117,14 +122,7 @@ impl LogicalPlanToPipelineNodeTranslator {
             return input_node;
         }
 
-        let backend = if self.plan_config.config.shuffle_algorithm.as_str() == "flight_shuffle" {
-            DistributedShuffleBackend::Flight(FlightShuffleBackendConfig {
-                shuffle_dirs: self.plan_config.config.flight_shuffle_dirs.clone(),
-                ..Default::default()
-            })
-        } else {
-            DistributedShuffleBackend::Ray
-        };
+        let backend = self.select_backend();
 
         let node_id = self.get_next_pipeline_node_id();
         DistributedPipelineNode::new(

--- a/src/daft-local-execution/src/pipeline.rs
+++ b/src/daft-local-execution/src/pipeline.rs
@@ -18,11 +18,12 @@ use daft_dsl::{common_treenode::ConcreteTreeNode, join::get_common_join_cols};
 pub use daft_local_plan::InputId;
 use daft_local_plan::{
     AsofJoin, CommitWrite, Concat, CrossJoin, Dedup, Explode, Filter, FlightShuffleReadInput,
-    GlobScan, HashAggregate, HashJoin, InMemoryScan, IntoBatches, Limit, LocalNodeContext,
-    LocalPhysicalPlan, MonotonicallyIncreasingId, PhysicalScan, PhysicalWrite, Pivot, Project,
-    RepartitionWrite, RepartitionWriteBackend, Sample, ShuffleReadBackend, Sort, SortMergeJoin,
-    SourceId, TopN, UDFProject, UnGroupedAggregate, Unpivot, VLLMProject, WindowOrderByOnly,
-    WindowPartitionAndDynamicFrame, WindowPartitionAndOrderBy, WindowPartitionOnly,
+    GatherWrite, GatherWriteBackend, GlobScan, HashAggregate, HashJoin, InMemoryScan, IntoBatches,
+    Limit, LocalNodeContext, LocalPhysicalPlan, MonotonicallyIncreasingId, PhysicalScan,
+    PhysicalWrite, Pivot, Project, RepartitionWrite, RepartitionWriteBackend, Sample,
+    ShuffleReadBackend, Sort, SortMergeJoin, SourceId, TopN, UDFProject, UnGroupedAggregate,
+    Unpivot, VLLMProject, WindowOrderByOnly, WindowPartitionAndDynamicFrame,
+    WindowPartitionAndOrderBy, WindowPartitionOnly,
 };
 use daft_logical_plan::{JoinType, stats::StatsState};
 use daft_micropartition::{MicroPartition, MicroPartitionRef};
@@ -52,6 +53,7 @@ use crate::{
         blocking_sink::BlockingSinkNode,
         commit_write::CommitWriteSink,
         dedup::DedupSink,
+        gather::GatherSink,
         grouped_aggregate::GroupedAggregateSink,
         into_partitions::IntoPartitionsSink,
         pivot::PivotSink,
@@ -1500,6 +1502,53 @@ fn physical_plan_to_pipeline(
 
                     BlockingSinkNode::new(
                         Arc::new(repartition_sink),
+                        child_node,
+                        stats_state.clone(),
+                        ctx,
+                        context,
+                    )
+                    .boxed()
+                }
+            }
+        }
+        LocalPhysicalPlan::GatherWrite(GatherWrite {
+            input,
+            backend,
+            stats_state,
+            context,
+            ..
+        }) => {
+            let child_node = physical_plan_to_pipeline(input, cfg, ctx, input_senders)?;
+            match backend {
+                GatherWriteBackend::Ray => BlockingSinkNode::new(
+                    Arc::new(GatherSink::new_ray()),
+                    child_node,
+                    stats_state.clone(),
+                    ctx,
+                    context,
+                )
+                .boxed(),
+                GatherWriteBackend::Flight {
+                    shuffle_id,
+                    shuffle_dirs,
+                    compression,
+                } => {
+                    let (shuffle_server, shuffle_address) = ctx
+                        .shuffle_server()
+                        .expect("Flight shuffle server must be initialized for Flight gather plans when using flight_shuffle algorithm");
+                    let gather_sink = GatherSink::try_new_flight(
+                        *shuffle_id,
+                        shuffle_dirs.clone(),
+                        compression.clone(),
+                        shuffle_server,
+                        shuffle_address,
+                    )
+                    .with_context(|_| PipelineCreationSnafu {
+                        plan_name: physical_plan.name(),
+                    })?;
+
+                    BlockingSinkNode::new(
+                        Arc::new(gather_sink),
                         child_node,
                         stats_state.clone(),
                         ctx,

--- a/src/daft-local-execution/src/sinks/gather.rs
+++ b/src/daft-local-execution/src/sinks/gather.rs
@@ -1,7 +1,4 @@
-use std::sync::{
-    Arc,
-    atomic::{AtomicU32, Ordering},
-};
+use std::sync::Arc;
 
 use common_error::DaftResult;
 use common_metrics::ops::NodeType;
@@ -39,7 +36,6 @@ struct FlightShared {
     local_server: Arc<ShuffleFlightServer>,
     shuffle_address: String,
     target_in_memory_size_per_partition: usize,
-    next_partition_ref_id: AtomicU32,
 }
 
 pub(crate) struct FlightGatherState {
@@ -51,8 +47,7 @@ pub(crate) struct FlightGatherState {
 impl FlightGatherState {
     async fn push(&mut self, input: MicroPartition) -> DaftResult<()> {
         let shared = &self.shared;
-        let idx = shared.next_partition_ref_id.fetch_add(1, Ordering::Relaxed);
-        let partition_ref_id = partition_ref_id(self.input_id, idx as usize);
+        let partition_ref_id = partition_ref_id(self.input_id, self.refs.len());
         let cache = InProgressShuffleCache::try_new(
             partition_ref_id,
             &shared.shuffle_dirs,
@@ -85,6 +80,9 @@ pub(crate) enum GatherState {
 
 impl GatherState {
     async fn push(&mut self, input: MicroPartition) -> DaftResult<()> {
+        if input.is_empty() {
+            return Ok(());
+        }
         match self {
             Self::Ray(state) => {
                 state.push(input);
@@ -164,7 +162,6 @@ impl GatherSink {
                 local_server,
                 shuffle_address,
                 target_in_memory_size_per_partition: TARGET_IN_MEMORY_SIZE_BYTES,
-                next_partition_ref_id: AtomicU32::new(0),
             })),
         })
     }

--- a/src/daft-local-execution/src/sinks/gather.rs
+++ b/src/daft-local-execution/src/sinks/gather.rs
@@ -1,0 +1,231 @@
+use std::sync::{
+    Arc,
+    atomic::{AtomicU32, Ordering},
+};
+
+use common_error::DaftResult;
+use common_metrics::ops::NodeType;
+use daft_micropartition::MicroPartition;
+use daft_partition_refs::FlightPartitionRef;
+use daft_shuffles::{
+    server::flight_server::ShuffleFlightServer,
+    shuffle_cache::{InProgressShuffleCache, partition_ref_id},
+};
+use tracing::{Span, instrument};
+
+use super::blocking_sink::{
+    BlockingSink, BlockingSinkFinalizeResult, BlockingSinkOutput, BlockingSinkSinkResult,
+};
+use crate::{
+    ExecutionTaskSpawner,
+    pipeline::{InputId, NodeName},
+};
+
+pub(crate) struct RayGatherState {
+    partitions: Vec<MicroPartition>,
+}
+
+impl RayGatherState {
+    fn push(&mut self, input: MicroPartition) {
+        self.partitions.push(input);
+    }
+}
+
+/// Shared config for all Flight gather states produced by a single GatherSink.
+struct FlightShared {
+    shuffle_id: u64,
+    shuffle_dirs: Vec<String>,
+    compression: Option<String>,
+    local_server: Arc<ShuffleFlightServer>,
+    shuffle_address: String,
+    target_in_memory_size_per_partition: usize,
+    next_partition_ref_id: AtomicU32,
+}
+
+pub(crate) struct FlightGatherState {
+    shared: Arc<FlightShared>,
+    input_id: InputId,
+    refs: Vec<FlightPartitionRef>,
+}
+
+impl FlightGatherState {
+    async fn push(&mut self, input: MicroPartition) -> DaftResult<()> {
+        let shared = &self.shared;
+        let idx = shared.next_partition_ref_id.fetch_add(1, Ordering::Relaxed);
+        let partition_ref_id = partition_ref_id(self.input_id, idx as usize);
+        let cache = InProgressShuffleCache::try_new(
+            partition_ref_id,
+            &shared.shuffle_dirs,
+            shared.shuffle_id,
+            shared.target_in_memory_size_per_partition,
+            shared.compression.as_deref(),
+        )?;
+        cache.push_partition_data(input).await?;
+        let closed = cache.close().await?;
+        let flight_ref = FlightPartitionRef {
+            shuffle_id: shared.shuffle_id,
+            server_address: shared.shuffle_address.clone(),
+            partition_ref_id: closed.partition_ref_id,
+            num_rows: closed.num_rows,
+            size_bytes: closed.size_bytes,
+        };
+        shared
+            .local_server
+            .register_shuffle_partitions(shared.shuffle_id, vec![closed])
+            .await?;
+        self.refs.push(flight_ref);
+        Ok(())
+    }
+}
+
+pub(crate) enum GatherState {
+    Ray(RayGatherState),
+    Flight(FlightGatherState),
+}
+
+impl GatherState {
+    async fn push(&mut self, input: MicroPartition) -> DaftResult<()> {
+        match self {
+            Self::Ray(state) => {
+                state.push(input);
+                Ok(())
+            }
+            Self::Flight(state) => state.push(input).await,
+        }
+    }
+}
+
+// TODO: unify shuffle backends in all local operations
+#[derive(Clone)]
+enum GatherBackend {
+    Ray,
+    Flight(Arc<FlightShared>),
+}
+
+impl GatherBackend {
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Ray => "Ray",
+            Self::Flight(_) => "Flight",
+        }
+    }
+
+    fn collect_output(&self, states: Vec<GatherState>) -> BlockingSinkOutput {
+        match self {
+            Self::Ray => BlockingSinkOutput::Partitions(
+                states
+                    .into_iter()
+                    .flat_map(|s| match s {
+                        GatherState::Ray(s) => s.partitions,
+                        GatherState::Flight(_) => unreachable!("GatherSink state/backend mismatch"),
+                    })
+                    .collect(),
+            ),
+            Self::Flight(_) => BlockingSinkOutput::FlightPartitionRefs(
+                states
+                    .into_iter()
+                    .flat_map(|s| match s {
+                        GatherState::Flight(s) => s.refs,
+                        GatherState::Ray(_) => unreachable!("GatherSink state/backend mismatch"),
+                    })
+                    .collect(),
+            ),
+        }
+    }
+}
+
+pub struct GatherSink {
+    backend: GatherBackend,
+}
+
+impl GatherSink {
+    pub fn new_ray() -> Self {
+        Self {
+            backend: GatherBackend::Ray,
+        }
+    }
+
+    pub fn try_new_flight(
+        shuffle_id: u64,
+        shuffle_dirs: Vec<String>,
+        compression: Option<String>,
+        local_server: Arc<ShuffleFlightServer>,
+        shuffle_address: String,
+    ) -> DaftResult<Self> {
+        const TARGET_IN_MEMORY_SIZE_BYTES: usize = 1024 * 1024 * 64;
+        Ok(Self {
+            backend: GatherBackend::Flight(Arc::new(FlightShared {
+                shuffle_id,
+                shuffle_dirs,
+                compression,
+                local_server,
+                shuffle_address,
+                target_in_memory_size_per_partition: TARGET_IN_MEMORY_SIZE_BYTES,
+                next_partition_ref_id: AtomicU32::new(0),
+            })),
+        })
+    }
+}
+
+impl BlockingSink for GatherSink {
+    type State = GatherState;
+
+    #[instrument(skip_all, name = "GatherSink::sink")]
+    fn sink(
+        &self,
+        input: MicroPartition,
+        mut state: Self::State,
+        _runtime_stats: Arc<Self::Stats>,
+        spawner: &ExecutionTaskSpawner,
+    ) -> BlockingSinkSinkResult<Self> {
+        spawner
+            .spawn(
+                async move {
+                    state.push(input).await?;
+                    Ok(state)
+                },
+                Span::current(),
+            )
+            .into()
+    }
+
+    #[instrument(skip_all, name = "GatherSink::finalize")]
+    fn finalize(
+        &self,
+        states: Vec<Self::State>,
+        spawner: &ExecutionTaskSpawner,
+    ) -> BlockingSinkFinalizeResult {
+        let backend = self.backend.clone();
+        spawner
+            .spawn(
+                async move { Ok(backend.collect_output(states)) },
+                Span::current(),
+            )
+            .into()
+    }
+
+    fn name(&self) -> NodeName {
+        format!("Gather({})", self.backend.name()).into()
+    }
+
+    fn op_type(&self) -> NodeType {
+        NodeType::Repartition
+    }
+
+    fn multiline_display(&self) -> Vec<String> {
+        vec![format!("Gather({})", self.backend.name())]
+    }
+
+    fn make_state(&self, input_id: InputId) -> DaftResult<Self::State> {
+        match &self.backend {
+            GatherBackend::Ray => Ok(GatherState::Ray(RayGatherState {
+                partitions: Vec::new(),
+            })),
+            GatherBackend::Flight(shared) => Ok(GatherState::Flight(FlightGatherState {
+                shared: shared.clone(),
+                input_id,
+                refs: Vec::new(),
+            })),
+        }
+    }
+}

--- a/src/daft-local-execution/src/sinks/gather.rs
+++ b/src/daft-local-execution/src/sinks/gather.rs
@@ -152,7 +152,10 @@ impl GatherSink {
         local_server: Arc<ShuffleFlightServer>,
         shuffle_address: String,
     ) -> DaftResult<Self> {
-        const TARGET_IN_MEMORY_SIZE_BYTES: usize = 1024 * 1024 * 64;
+        // Each input MP gets its own cache (unlike repartition, which keeps N open caches per
+        // input and divides a global budget by `num_partitions`). Matches the upper end of
+        // `RepartitionSink`'s per-partition clamp so the two sinks spill at similar sizes.
+        const TARGET_IN_MEMORY_SIZE_BYTES: usize = 1024 * 1024 * 128;
         Ok(Self {
             backend: GatherBackend::Flight(Arc::new(FlightShared {
                 shuffle_id,
@@ -209,7 +212,7 @@ impl BlockingSink for GatherSink {
     }
 
     fn op_type(&self) -> NodeType {
-        NodeType::Repartition
+        NodeType::Gather
     }
 
     fn multiline_display(&self) -> Vec<String> {

--- a/src/daft-local-execution/src/sinks/mod.rs
+++ b/src/daft-local-execution/src/sinks/mod.rs
@@ -2,6 +2,7 @@ pub mod aggregate;
 pub mod blocking_sink;
 pub mod commit_write;
 pub mod dedup;
+pub mod gather;
 pub mod grouped_aggregate;
 pub mod into_partitions;
 pub mod pivot;

--- a/src/daft-local-execution/src/sinks/repartition.rs
+++ b/src/daft-local-execution/src/sinks/repartition.rs
@@ -73,6 +73,7 @@ impl RepartitionState {
     }
 }
 
+// TODO: unify shuffle backends in all local operations
 enum RepartitionBackend {
     Ray,
     Flight {

--- a/src/daft-local-plan/src/lib.rs
+++ b/src/daft-local-plan/src/lib.rs
@@ -9,12 +9,13 @@ use daft_micropartition::MicroPartitionRef;
 use daft_scan::ScanTaskRef;
 pub use plan::{
     AsofJoin, CommitWrite, Concat, CrossJoin, Dedup, Explode, Filter, FlightShuffleReadInput,
-    GlobScan, HashAggregate, HashJoin, InMemoryScan, IntoBatches, IntoPartitions, Limit,
-    LocalNodeContext, LocalPhysicalPlan, LocalPhysicalPlanRef, MonotonicallyIncreasingId,
-    PhysicalScan, PhysicalWrite, Pivot, PlaceholderScan, Project, RepartitionWrite,
-    RepartitionWriteBackend, Sample, SamplingMethod, ShuffleRead, ShuffleReadBackend, Sort,
-    SortMergeJoin, TopN, UDFProject, UnGroupedAggregate, Unpivot, VLLMProject, WindowOrderByOnly,
-    WindowPartitionAndDynamicFrame, WindowPartitionAndOrderBy, WindowPartitionOnly,
+    GatherWrite, GatherWriteBackend, GlobScan, HashAggregate, HashJoin, InMemoryScan, IntoBatches,
+    IntoPartitions, Limit, LocalNodeContext, LocalPhysicalPlan, LocalPhysicalPlanRef,
+    MonotonicallyIncreasingId, PhysicalScan, PhysicalWrite, Pivot, PlaceholderScan, Project,
+    RepartitionWrite, RepartitionWriteBackend, Sample, SamplingMethod, ShuffleRead,
+    ShuffleReadBackend, Sort, SortMergeJoin, TopN, UDFProject, UnGroupedAggregate, Unpivot,
+    VLLMProject, WindowOrderByOnly, WindowPartitionAndDynamicFrame, WindowPartitionAndOrderBy,
+    WindowPartitionOnly,
 };
 #[cfg(feature = "python")]
 pub use plan::{CatalogWrite, DataSink, DistributedActorPoolProject, LanceWrite};

--- a/src/daft-local-plan/src/plan.rs
+++ b/src/daft-local-plan/src/plan.rs
@@ -108,6 +108,7 @@ pub enum LocalPhysicalPlan {
     // Flotilla Only Nodes
     IntoPartitions(IntoPartitions),
     RepartitionWrite(RepartitionWrite),
+    GatherWrite(GatherWrite),
     ShuffleRead(ShuffleRead),
     SortMergeJoin(SortMergeJoin),
     AsofJoin(AsofJoin),
@@ -164,6 +165,7 @@ impl LocalPhysicalPlan {
             | Self::CommitWrite(CommitWrite { stats_state, .. })
             | Self::IntoPartitions(IntoPartitions { stats_state, .. })
             | Self::RepartitionWrite(RepartitionWrite { stats_state, .. })
+            | Self::GatherWrite(GatherWrite { stats_state, .. })
             | Self::ShuffleRead(ShuffleRead { stats_state, .. })
             | Self::WindowPartitionOnly(WindowPartitionOnly { stats_state, .. })
             | Self::WindowPartitionAndOrderBy(WindowPartitionAndOrderBy { stats_state, .. })
@@ -214,6 +216,7 @@ impl LocalPhysicalPlan {
             | Self::CommitWrite(CommitWrite { context, .. })
             | Self::IntoPartitions(IntoPartitions { context, .. })
             | Self::RepartitionWrite(RepartitionWrite { context, .. })
+            | Self::GatherWrite(GatherWrite { context, .. })
             | Self::ShuffleRead(ShuffleRead { context, .. })
             | Self::WindowPartitionOnly(WindowPartitionOnly { context, .. })
             | Self::WindowPartitionAndOrderBy(WindowPartitionAndOrderBy { context, .. })
@@ -1006,6 +1009,23 @@ impl LocalPhysicalPlan {
         .arced()
     }
 
+    pub fn gather_write(
+        input: LocalPhysicalPlanRef,
+        schema: SchemaRef,
+        backend: GatherWriteBackend,
+        stats_state: StatsState,
+        context: LocalNodeContext,
+    ) -> LocalPhysicalPlanRef {
+        Self::GatherWrite(GatherWrite {
+            input,
+            schema,
+            backend,
+            stats_state,
+            context,
+        })
+        .arced()
+    }
+
     pub fn shuffle_read(
         source_id: SourceId,
         schema: SchemaRef,
@@ -1067,6 +1087,7 @@ impl LocalPhysicalPlan {
             Self::DistributedActorPoolProject(DistributedActorPoolProject { schema, .. }) => schema,
             Self::IntoPartitions(IntoPartitions { schema, .. }) => schema,
             Self::RepartitionWrite(RepartitionWrite { schema, .. }) => schema,
+            Self::GatherWrite(GatherWrite { schema, .. }) => schema,
             Self::ShuffleRead(ShuffleRead { schema, .. }) => schema,
             Self::WindowPartitionOnly(WindowPartitionOnly { schema, .. }) => schema,
             Self::WindowPartitionAndOrderBy(WindowPartitionAndOrderBy { schema, .. }) => schema,
@@ -1150,6 +1171,7 @@ impl LocalPhysicalPlan {
             }
             Self::IntoPartitions(IntoPartitions { input, .. }) => vec![input.clone()],
             Self::RepartitionWrite(RepartitionWrite { input, .. }) => vec![input.clone()],
+            Self::GatherWrite(GatherWrite { input, .. }) => vec![input.clone()],
             Self::ShuffleRead(ShuffleRead { .. }) => vec![], // No input children
             Self::TopN(TopN { input, .. }) => vec![input.clone()],
             Self::WindowOrderByOnly(WindowOrderByOnly { input, .. }) => vec![input.clone()],
@@ -1618,6 +1640,18 @@ impl LocalPhysicalPlan {
                     schema.clone(),
                     backend.clone(),
                     repartition_spec.clone(),
+                    StatsState::NotMaterialized,
+                    context.clone(),
+                ),
+                Self::GatherWrite(GatherWrite {
+                    schema,
+                    backend,
+                    context,
+                    ..
+                }) => Self::gather_write(
+                    new_child.clone(),
+                    schema.clone(),
+                    backend.clone(),
                     StatsState::NotMaterialized,
                     context.clone(),
                 ),
@@ -2226,6 +2260,25 @@ pub struct RepartitionWrite {
     pub schema: SchemaRef,
     pub backend: RepartitionWriteBackend,
     pub repartition_spec: RepartitionSpec,
+    pub stats_state: StatsState,
+    pub context: LocalNodeContext,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum GatherWriteBackend {
+    Ray,
+    Flight {
+        shuffle_id: u64,
+        shuffle_dirs: Vec<String>,
+        compression: Option<String>,
+    },
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GatherWrite {
+    pub input: LocalPhysicalPlanRef,
+    pub schema: SchemaRef,
+    pub backend: GatherWriteBackend,
     pub stats_state: StatsState,
     pub context: LocalNodeContext,
 }

--- a/tests/dataframe/test_shuffles.py
+++ b/tests/dataframe/test_shuffles.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import io
 import random
 import tempfile
 from collections.abc import Callable
@@ -239,10 +240,91 @@ def test_flight_gather(flight_shuffle_ctx, input_partitions):
     with flight_shuffle_ctx():
         df = daft.from_pydict({"x": list(range(rows))}).into_partitions(input_partitions)
 
+        agg_df = df.sum("x")
+        top_df = df.sort("x", desc=True).limit(5)
+
+        # Plan-shape assertion: a regression that routes around GatherNode (or
+        # trips the num_partitions==1 short-circuit when it shouldn't) would
+        # still produce correct values, so verify the plan explicitly.
+        for plan_df in (agg_df, top_df):
+            buf = io.StringIO()
+            plan_df.explain(show_all=True, file=buf)
+            plan = buf.getvalue()
+            if input_partitions > 1:
+                assert "FlightGather" in plan, f"expected FlightGather in plan:\n{plan}"
+            else:
+                assert "Gather" not in plan, f"unexpected Gather for single-partition input:\n{plan}"
+
         # UnGroupedAggregate → gather
-        total = df.sum("x").collect().to_pydict()["x"]
+        total = agg_df.collect().to_pydict()["x"]
         assert total == [sum(range(rows))]
 
         # TopN → gather
-        top = df.sort("x", desc=True).limit(5).collect().to_pydict()["x"]
+        top = top_df.collect().to_pydict()["x"]
         assert top == [rows - 1, rows - 2, rows - 3, rows - 4, rows - 5]
+
+
+@pytest.mark.skipif(
+    get_tests_daft_runner_name() != "ray",
+    reason="distributed gather tests require the ray runner",
+)
+@pytest.mark.parametrize("input_partitions", [1, 8, 32])
+def test_ray_gather(input_partitions):
+    """Gather over the Ray backend (no flight_shuffle_ctx).
+
+    Mirrors test_flight_gather but exercises GatherSink::Ray → emit_read_tasks.
+    """
+    rows = 1000
+    df = daft.from_pydict({"x": list(range(rows))}).into_partitions(input_partitions)
+
+    agg_df = df.sum("x")
+    top_df = df.sort("x", desc=True).limit(5)
+
+    for plan_df in (agg_df, top_df):
+        buf = io.StringIO()
+        plan_df.explain(show_all=True, file=buf)
+        plan = buf.getvalue()
+        if input_partitions > 1:
+            assert "Gather" in plan, f"expected Gather in plan:\n{plan}"
+            assert "FlightGather" not in plan, f"expected Ray gather, got Flight:\n{plan}"
+        else:
+            assert "Gather" not in plan, f"unexpected Gather for single-partition input:\n{plan}"
+
+    total = agg_df.collect().to_pydict()["x"]
+    assert total == [sum(range(rows))]
+
+    top = top_df.collect().to_pydict()["x"]
+    assert top == [rows - 1, rows - 2, rows - 3, rows - 4, rows - 5]
+
+
+@pytest.mark.skipif(
+    get_tests_daft_runner_name() != "ray",
+    reason="shuffle tests are meant for the ray runner",
+)
+def test_flight_gather_mixed_empty_inputs(flight_shuffle_ctx):
+    """Gather handles a mix of empty and non-empty input partitions.
+
+    Exercises the FlightGatherState empty-input short-circuit: some input
+    partitions have rows after the filter, others don't. Regressions in
+    the short-circuit would either miscount refs or skip data.
+
+    Note: the all-empty case (every partition filtered away) hangs in the
+    downstream ShuffleRead today and is intentionally not covered here.
+    """
+    rows = 1000
+    input_partitions = 8
+    filter_threshold = 500  # roughly half the data survives
+    with flight_shuffle_ctx():
+        df = (
+            daft.from_pydict({"x": list(range(rows))})
+            .into_partitions(input_partitions)
+            .filter(daft.col("x") < filter_threshold)
+        )
+
+        expected_rows = [v for v in range(rows) if v < filter_threshold]
+
+        total = df.sum("x").collect().to_pydict()["x"]
+        assert total == [sum(expected_rows)]
+
+        top = df.sort("x", desc=True).limit(5).collect().to_pydict()["x"]
+        assert top == sorted(expected_rows, reverse=True)[:5]

--- a/tests/dataframe/test_shuffles.py
+++ b/tests/dataframe/test_shuffles.py
@@ -222,3 +222,27 @@ def test_flight_shuffle(flight_shuffle_ctx, input_partitions, output_partitions)
 
         assert base_df.to_arrow().sort_by("ids") == df.to_arrow().sort_by("ids")
         assert len(df) == input_partitions * output_partitions
+
+
+@pytest.mark.skipif(
+    get_tests_daft_runner_name() != "ray",
+    reason="shuffle tests are meant for the ray runner",
+)
+@pytest.mark.parametrize("input_partitions", [1, 8, 32])
+def test_flight_gather(flight_shuffle_ctx, input_partitions):
+    """Gather is triggered by top_n and ungrouped agg on multi-partition inputs.
+
+    Under `shuffle_algorithm="flight_shuffle"` this exercises the GatherWrite
+    blocking sink → ShuffleRead path (rather than the in-memory-scan shortcut).
+    """
+    rows = 1000
+    with flight_shuffle_ctx():
+        df = daft.from_pydict({"x": list(range(rows))}).into_partitions(input_partitions)
+
+        # UnGroupedAggregate → gather
+        total = df.sum("x").collect().to_pydict()["x"]
+        assert total == [sum(range(rows))]
+
+        # TopN → gather
+        top = df.sort("x", desc=True).limit(5).collect().to_pydict()["x"]
+        assert top == [rows - 1, rows - 2, rows - 3, rows - 4, rows - 5]


### PR DESCRIPTION
## Summary

Implements a distributed gather path for flight shuffle. 

Previously `GatherNode` collected all upstream `PartitionRef`s into a single `in_memory_scan` task — correct for Ray (partition refs are Ray object refs) but wrong for Flight, where partitions live on remote shuffle servers and must be fetched through `ShuffleRead`. As a result, gather was effectively Ray-only.

  ## Changes

  - **New local-plan variant** `LocalPhysicalPlan::GatherWrite` + `GatherWriteBackend::{Ray, Flight}` — sibling of `RepartitionWrite`, no
  `num_partitions`/`RepartitionSpec`.
  - **New blocking sink** `GatherSink` (`sinks/gather.rs`):
    - Ray: accumulates input `MicroPartition`s as-is (no bucketing).
    - Flight: for each input MP, opens a fresh `InProgressShuffleCache`, pushes, closes, and registers the resulting `FlightPartitionRef`
  inline — so the write task completes incrementally and `finalize()` does no I/O.
    - Returns N refs per task, one per input partition the task saw (gather ≠ `repartition(1)`).
  - **Distributed `GatherNode`** now owns a `ShuffleBackend` (mirrors `RepartitionNode`): materializes all child outputs, flattens them into
  one partition group, and calls the existing `emit_read_tasks` to produce a single `ShuffleRead` task. Removes the old
  `into_in_memory_scan_with_psets` shortcut.
  - **`gen_gather_node`** picks Ray vs Flight backend from `shuffle_algorithm` config, mirroring `gen_repartition_node`.
  - **`ShuffleBackend::build_gather_write_stage`** added alongside `build_repartition_write_stage`.

