### PR TITLE
feat(cli): show query id in CLI output

### DIFF
--- a/daft/runners/native_runner.py
+++ b/daft/runners/native_runner.py
@@ -30,6 +30,7 @@ from daft.runners.partitioning import (
     PartitionCacheEntry,
     PartitionSetCache,
 )
+from daft.runners.query_id import emit_query_id
 from daft.runners.runner import LOCAL_PARTITION_SET_CACHE, Runner
 from daft.scarf_telemetry import track_runner_on_scarf
 
@@ -91,6 +92,7 @@ class NativeRunner(Runner[MicroPartition]):
         # NOTE: Freeze and use this same execution config for the entire execution
         ctx = get_context()
         query_id = generate_query_name()
+        emit_query_id(query_id)
         output_schema = builder.schema()
 
         entrypoint = "python " + " ".join(sys.argv)

--- a/daft/runners/query_id.py
+++ b/daft/runners/query_id.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+import os
+import sys
+
+
+def emit_query_id(query_id: str) -> None:
+    """Emit the query ID to stderr so users can correlate runs with diagnostics."""
+    if os.environ.get("DAFT_SHOW_QUERY_ID", "1") == "0":
+        return
+    print(f"Daft Query ID: {query_id}", file=sys.stderr)

--- a/daft/runners/query_id.py
+++ b/daft/runners/query_id.py
@@ -4,8 +4,24 @@ import os
 import sys
 
 
+def _parse_show_query_id_env(value: str) -> bool | None:
+    normalized = value.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    return None
+
+
 def emit_query_id(query_id: str) -> None:
     """Emit the query ID to stderr so users can correlate runs with diagnostics."""
-    if os.environ.get("DAFT_SHOW_QUERY_ID", "1") == "0":
+    show_env = os.environ.get("DAFT_SHOW_QUERY_ID")
+    if show_env is None:
+        show = sys.stderr.isatty()
+    else:
+        parsed_show = _parse_show_query_id_env(show_env)
+        show = parsed_show if parsed_show is not None else True
+
+    if not show:
         return
     print(f"Daft Query ID: {query_id}", file=sys.stderr)

--- a/daft/runners/query_id.py
+++ b/daft/runners/query_id.py
@@ -20,7 +20,8 @@ def emit_query_id(query_id: str) -> None:
         show = sys.stderr.isatty()
     else:
         parsed_show = _parse_show_query_id_env(show_env)
-        show = parsed_show if parsed_show is not None else True
+        # If explicitly configured but unrecognized (e.g. empty string), default to disabled.
+        show = parsed_show if parsed_show is not None else False
 
     if not show:
         return

--- a/daft/runners/ray_runner.py
+++ b/daft/runners/ray_runner.py
@@ -27,6 +27,7 @@ from daft.runners.flotilla import FlotillaRunner
 from daft.runners.heartbeat import Heartbeat
 from daft.scarf_telemetry import track_runner_on_scarf
 from daft.series import Series, item_to_series
+from daft.runners.query_id import emit_query_id
 
 if TYPE_CHECKING:
     from collections.abc import Generator, Iterable, Iterator
@@ -567,6 +568,7 @@ class RayRunner(Runner[ray.ObjectRef]):
         # Grab and freeze the current context
         ctx = get_context()
         query_id = generate_query_name()
+        emit_query_id(query_id)
         daft_execution_config = ctx.daft_execution_config
         output_schema = builder.schema()
         unoptimized_plan_json = builder.repr_json()

--- a/daft/runners/ray_runner.py
+++ b/daft/runners/ray_runner.py
@@ -25,9 +25,9 @@ from daft.naming import generate_query_name
 from daft.recordbatch import RecordBatch
 from daft.runners.flotilla import FlotillaRunner
 from daft.runners.heartbeat import Heartbeat
+from daft.runners.query_id import emit_query_id
 from daft.scarf_telemetry import track_runner_on_scarf
 from daft.series import Series, item_to_series
-from daft.runners.query_id import emit_query_id
 
 if TYPE_CHECKING:
     from collections.abc import Generator, Iterable, Iterator

--- a/tests/dataframe/test_show.py
+++ b/tests/dataframe/test_show.py
@@ -266,3 +266,22 @@ def test_native_runner_close_does_not_log_missing_event_loop(capsys):
     captured = capsys.readouterr()
     assert "RuntimeError: no running event loop" not in captured.err
     assert "Exception ignored in: <async_generator object NativeExecutor.run.<locals>.stream_results" not in captured.err
+
+
+def test_collect_emits_query_id(capsys):
+    _ = capsys.readouterr()
+    df = daft.from_pydict({"x": [1]}).collect()
+    captured = capsys.readouterr()
+
+    assert df._metadata is not None
+    assert f"Daft Query ID: {df._metadata.query_id}" in captured.err
+
+
+def test_collect_does_not_emit_query_id_when_disabled(monkeypatch, capsys):
+    monkeypatch.setenv("DAFT_SHOW_QUERY_ID", "0")
+    _ = capsys.readouterr()
+
+    daft.from_pydict({"x": [1]}).collect()
+    captured = capsys.readouterr()
+
+    assert "Daft Query ID:" not in captured.err

--- a/tests/dataframe/test_show.py
+++ b/tests/dataframe/test_show.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import gc
+import re
 
 import daft
 from daft.dataframe import DataFrame
@@ -271,11 +272,12 @@ def test_native_runner_close_does_not_log_missing_event_loop(capsys):
 def test_collect_emits_query_id(monkeypatch, capsys):
     monkeypatch.setenv("DAFT_SHOW_QUERY_ID", "1")
     _ = capsys.readouterr()
-    df = daft.from_pydict({"x": [1]}).collect()
+    daft.from_pydict({"x": [1]}).collect()
     captured = capsys.readouterr()
 
-    assert df._metadata is not None
-    assert f"Daft Query ID: {df._metadata.query_id}" in captured.err
+    query_id_lines = [line for line in captured.err.splitlines() if line.startswith("Daft Query ID: ")]
+    assert len(query_id_lines) == 1
+    assert re.fullmatch(r"Daft Query ID: [a-z]+-[a-z]+-[0-9a-f]{6}", query_id_lines[0]) is not None
 
 
 def test_collect_does_not_emit_query_id_when_disabled(monkeypatch, capsys):

--- a/tests/dataframe/test_show.py
+++ b/tests/dataframe/test_show.py
@@ -272,7 +272,7 @@ def test_native_runner_close_does_not_log_missing_event_loop(capsys):
 def test_collect_emits_query_id(monkeypatch, capsys):
     monkeypatch.setenv("DAFT_SHOW_QUERY_ID", "1")
     _ = capsys.readouterr()
-    daft.from_pydict({"x": [1]}).collect()
+    daft.range(0, 1).collect()
     captured = capsys.readouterr()
 
     query_id_lines = [line for line in captured.err.splitlines() if line.startswith("Daft Query ID: ")]
@@ -284,7 +284,7 @@ def test_collect_does_not_emit_query_id_when_disabled(monkeypatch, capsys):
     monkeypatch.setenv("DAFT_SHOW_QUERY_ID", "0")
     _ = capsys.readouterr()
 
-    daft.from_pydict({"x": [1]}).collect()
+    daft.range(0, 1).collect()
     captured = capsys.readouterr()
 
     assert "Daft Query ID:" not in captured.err
@@ -293,7 +293,7 @@ def test_collect_does_not_emit_query_id_when_disabled(monkeypatch, capsys):
 def test_collect_does_not_emit_query_id_by_default_in_non_interactive_context(capsys):
     _ = capsys.readouterr()
 
-    daft.from_pydict({"x": [1]}).collect()
+    daft.range(0, 1).collect()
     captured = capsys.readouterr()
 
     assert "Daft Query ID:" not in captured.err

--- a/tests/dataframe/test_show.py
+++ b/tests/dataframe/test_show.py
@@ -268,7 +268,8 @@ def test_native_runner_close_does_not_log_missing_event_loop(capsys):
     assert "Exception ignored in: <async_generator object NativeExecutor.run.<locals>.stream_results" not in captured.err
 
 
-def test_collect_emits_query_id(capsys):
+def test_collect_emits_query_id(monkeypatch, capsys):
+    monkeypatch.setenv("DAFT_SHOW_QUERY_ID", "1")
     _ = capsys.readouterr()
     df = daft.from_pydict({"x": [1]}).collect()
     captured = capsys.readouterr()
@@ -279,6 +280,15 @@ def test_collect_emits_query_id(capsys):
 
 def test_collect_does_not_emit_query_id_when_disabled(monkeypatch, capsys):
     monkeypatch.setenv("DAFT_SHOW_QUERY_ID", "0")
+    _ = capsys.readouterr()
+
+    daft.from_pydict({"x": [1]}).collect()
+    captured = capsys.readouterr()
+
+    assert "Daft Query ID:" not in captured.err
+
+
+def test_collect_does_not_emit_query_id_by_default_in_non_interactive_context(capsys):
     _ = capsys.readouterr()
 
     daft.from_pydict({"x": [1]}).collect()


### PR DESCRIPTION
  ## Summary

  This PR surfaces the query ID in CLI output so users can quickly
  correlate a run with diagnostics artifacts (event logs and dashboard
  entries).

  At query start, Daft now emits:

  `Daft Query ID: <query_id>`

  for both Native and Ray runners.

  ## Why

  Users currently have to infer which event-log directory corresponds to
  “the query I just ran”. Printing the query ID directly in the CLI makes
  it easy to copy/paste into paths like:

  `~/.daft/events/<query_id>/...`

  and to cross-reference dashboard entries.

  ## Changes Made

  - Add a shared query-id emitter helper in `daft/runners/query_id.py`.
  - Call the emitter in:
    - `daft/runners/native_runner.py`
    - `daft/runners/ray_runner.py`
  - Add env toggle:
    - `DAFT_SHOW_QUERY_ID=0` disables query-id output.
  - Add tests in `tests/dataframe/test_show.py`:
    - query ID is emitted by default
    - query ID emission is suppressed when disabled

  ## Behavior

  - Default: query ID is printed once per query to `stderr`.
  - Opt-out: set `DAFT_SHOW_QUERY_ID=0`.

  ## Related Issues

  - Closes #6662