### PR TITLE
feat(observability): enable event logs by default

### DIFF
--- a/daft/__init__.py
+++ b/daft/__init__.py
@@ -151,6 +151,7 @@ from daft.io import (
 )
 from daft.runners import get_or_create_runner, get_or_infer_runner_type, set_runner_native, set_runner_ray
 from daft.sql import sql, sql_expr
+from daft.subscribers.event_log import maybe_enable_event_log
 from daft.viz import register_viz_hook
 from daft.window import Window
 from daft.file import File, VideoFile, AudioFile
@@ -162,6 +163,9 @@ from daft import io
 from daft import runners
 from daft import datasets
 from daft import functions
+
+# Enable event logs by default for easier diagnostics.
+maybe_enable_event_log()
 
 
 # Lance is lazy-loaded because lance_namespace pulls in ~450ms of pydantic models.

--- a/daft/subscribers/event_log.py
+++ b/daft/subscribers/event_log.py
@@ -6,6 +6,7 @@ import logging
 import os
 import queue
 import socket
+import tempfile
 import threading
 import time
 from datetime import timedelta
@@ -30,8 +31,6 @@ if TYPE_CHECKING:
         Stats,
     )
 
-from typing import TYPE_CHECKING
-
 from daft.context import get_context
 from daft.subscribers.abc import Subscriber
 
@@ -41,8 +40,10 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _EVENT_LOG_ALIAS = "_daft_event_log"
-_DEFAULT_EVENT_LOG_DIR = Path("~/.daft/events").expanduser()
+_DEFAULT_EVENT_LOG_DIR = Path(tempfile.gettempdir()) / "daft" / "events"
 _EVENT_LOG_ATEXIT_REGISTERED = False
+_EVENT_LOG_ENABLED_ENV = "DAFT_ENABLE_EVENT_LOG"
+_EVENT_LOG_DIR_ENV = "DAFT_EVENT_LOG_DIR"
 
 _REMOTE_DRAIN_TIMEOUT_SEC = 30.0
 
@@ -382,6 +383,19 @@ def query_state_str(state: QueryEndState) -> str:
 _EVENT_LOG_SUBSCRIBER: EventLogSubscriber | None = None
 
 
+def _is_truthy_env(value: str | None) -> bool:
+    if value is None:
+        return True
+    return value.strip().lower() not in {"0", "false", "no", "off"}
+
+
+def default_event_log_dir() -> Path:
+    env_dir = os.environ.get(_EVENT_LOG_DIR_ENV)
+    if env_dir:
+        return Path(env_dir).expanduser()
+    return _DEFAULT_EVENT_LOG_DIR
+
+
 def enable_event_log(log_dir: str | Path | None = None) -> None:
     """Experimental helper that attaches an event-log subscriber.
 
@@ -395,7 +409,7 @@ def enable_event_log(log_dir: str | Path | None = None) -> None:
         atexit.register(disable_event_log)
         _EVENT_LOG_ATEXIT_REGISTERED = True
 
-    subscriber = EventLogSubscriber(log_dir or _DEFAULT_EVENT_LOG_DIR)
+    subscriber = EventLogSubscriber(log_dir or default_event_log_dir())
     try:
         get_context().attach_subscriber(_EVENT_LOG_ALIAS, subscriber)
     except Exception:
@@ -418,4 +432,16 @@ def disable_event_log() -> None:
     subscriber.close()
 
 
-__all__ = ["EventLogSubscriber", "disable_event_log", "enable_event_log"]
+def maybe_enable_event_log() -> None:
+    """Enable local event logging unless explicitly disabled via env var."""
+    if not _is_truthy_env(os.environ.get(_EVENT_LOG_ENABLED_ENV)):
+        return
+    if _EVENT_LOG_SUBSCRIBER is not None:
+        return
+    try:
+        enable_event_log(default_event_log_dir())
+    except Exception as e:
+        logger.warning("Failed to enable default event logging: %s", e)
+
+
+__all__ = ["EventLogSubscriber", "disable_event_log", "enable_event_log", "maybe_enable_event_log"]

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import json
+import tempfile
 from collections.abc import Iterator
+from pathlib import Path
 
 import pytest
 
@@ -46,6 +48,37 @@ def _make_query_metadata() -> PyQueryMetadata:
         ray_dashboard_url=None,
         entrypoint="pytest",
     )
+
+
+def test_default_event_log_dir_uses_temp_dir(monkeypatch):
+    monkeypatch.delenv("DAFT_EVENT_LOG_DIR", raising=False)
+    assert subscriber_event_log.default_event_log_dir() == Path(tempfile.gettempdir()) / "daft" / "events"
+
+
+def test_maybe_enable_event_log_attaches_by_default(tmp_path, monkeypatch):
+    monkeypatch.setenv("DAFT_EVENT_LOG_DIR", str(tmp_path))
+    monkeypatch.delenv("DAFT_ENABLE_EVENT_LOG", raising=False)
+
+    subscriber_event_log.maybe_enable_event_log()
+    subscriber = subscriber_event_log._EVENT_LOG_SUBSCRIBER
+    assert subscriber is not None
+    assert subscriber._log_dir == tmp_path.resolve()
+
+    daft.from_pydict({"x": [1, 2, 3]}).collect()
+
+    event_logs = list(tmp_path.rglob("events.jsonl"))
+    assert len(event_logs) == 1
+
+
+def test_maybe_enable_event_log_respects_opt_out(tmp_path, monkeypatch):
+    monkeypatch.setenv("DAFT_EVENT_LOG_DIR", str(tmp_path))
+    monkeypatch.setenv("DAFT_ENABLE_EVENT_LOG", "0")
+
+    subscriber_event_log.maybe_enable_event_log()
+    assert subscriber_event_log._EVENT_LOG_SUBSCRIBER is None
+
+    daft.from_pydict({"x": [1, 2, 3]}).collect()
+    assert list(tmp_path.rglob("events.jsonl")) == []
 
 
 def test_no_files_created_without_query(tmp_path):


### PR DESCRIPTION
  ## Summary

  Enable event logging by default so query diagnostics are available
  without requiring users to call `enable_event_log()` manually.

  This also changes the default event-log location from `~/.daft/events`
  to a temp-directory path so logs do not accumulate indefinitely in user
  home directories.

  ## Motivation

  Today, event logs are opt-in, which means logs are often missing when
  users hit slow queries/failures.
  By enabling logs by default, users and maintainers can immediately
  correlate a query run to its log artifacts.

  ## Changes Made

  - Enable event logs by default at import time via
  `maybe_enable_event_log()`.
  - Add environment-based opt-out:
    - `DAFT_ENABLE_EVENT_LOG=0` disables default event-log attachment.
  - Update default log directory:
    - from `~/.daft/events`
    - to `tempfile.gettempdir()/daft/events`
  - Keep explicit APIs intact:
    - `enable_event_log(...)` and `disable_event_log()` continue to work.
  - Respect explicit directory override:
    - `DAFT_EVENT_LOG_DIR=/path/to/logs`

  ## Behavior

  - Default:
    - Event-log subscriber is attached automatically.
    - Logs are written under OS temp dir (`<tmp>/daft/events/<query_id>/
  events.jsonl`).
  - Opt out:
    - Set `DAFT_ENABLE_EVENT_LOG=0`.
  - Override path:
    - Set `DAFT_EVENT_LOG_DIR=/custom/path`.

  ## Test Coverage

  Added tests for:

  - default event-log dir resolution to temp dir
  - default-on attachment behavior
  - opt-out behavior (`DAFT_ENABLE_EVENT_LOG=0`)

  ## Related Issues

  - Closes #6661