### PR TITLE
test: extend distributed test infrastructure to match real Ray Flotilla

### DIFF
--- a/src/daft-distributed/src/pipeline_node/mod.rs
+++ b/src/daft-distributed/src/pipeline_node/mod.rs
@@ -455,6 +455,8 @@ pub(crate) use filter::FilterNode;
 #[cfg(test)]
 pub(crate) use in_memory_source::InMemorySourceNode;
 #[cfg(test)]
+pub(crate) use scan_source::ScanSourceNode;
+#[cfg(test)]
 pub(crate) use sort::SortNode;
 
 #[cfg(test)]

--- a/src/daft-distributed/src/plan/mod.rs
+++ b/src/daft-distributed/src/plan/mod.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 
 mod runner;
-pub(crate) use runner::{PlanConfig, PlanExecutionContext, PlanRunner, TaskIDCounter};
+pub(crate) use runner::{PlanConfig, PlanExecutionContext, PlanRunner, RunningPlan, TaskIDCounter};
 
 /// Internal scheduler counter for the # of queries executed so far.
 static QUERY_IDX_COUNTER: AtomicU16 = AtomicU16::new(0);

--- a/src/daft-distributed/src/plan/runner.rs
+++ b/src/daft-distributed/src/plan/runner.rs
@@ -119,7 +119,7 @@ pub(crate) struct RunningPlan {
 }
 
 impl RunningPlan {
-    fn new(task_stream: TaskBuilderStream, plan_context: PlanExecutionContext) -> Self {
+    pub(crate) fn new(task_stream: TaskBuilderStream, plan_context: PlanExecutionContext) -> Self {
         Self {
             task_stream,
             plan_context,

--- a/src/daft-distributed/src/scheduling/local_worker.rs
+++ b/src/daft-distributed/src/scheduling/local_worker.rs
@@ -1,17 +1,28 @@
 //! Test-only worker that executes `SwordfishTask`s in-process via the local
 //! execution pipeline, producing real `ExecutionStats` without needing Ray.
 //!
+//! Each `LocalSwordfishWorker` owns one `NativeExecutor` — the same type a
+//! real Ray Flotilla worker process owns — so tasks with matching
+//! `plan_fingerprint`s routed to the same worker share a pipeline,
+//! `IOStatsRef`, and `RuntimeStatsManager`. This matches production Flotilla's
+//! per-worker plan-sharing behavior and is the reason tests using this worker
+//! can catch bugs in shared-state accounting (e.g. bytes_read counters).
+//!
 //! This module is `#[cfg(test)]` at the parent `scheduling/mod.rs`.
 
 use std::{
     collections::HashMap,
     future::Future,
-    sync::{Arc, Mutex},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicU32, Ordering},
+    },
 };
 
 use common_error::DaftResult;
 use common_partitioning::PartitionRef;
-use daft_local_plan::{ExecutionStats, Input, SourceId};
+use daft_local_execution::testing::NativeExecutor;
+use daft_local_plan::{ExecutionStats, Input, InputId, SourceId};
 use daft_micropartition::MicroPartition;
 
 use super::{
@@ -24,23 +35,70 @@ use super::{
 };
 use crate::pipeline_node::MaterializedOutput;
 
-/// A worker that executes `SwordfishTask`s in-process via the local execution pipeline.
+/// A worker that executes `SwordfishTask`s in-process via a real `NativeExecutor`.
 ///
-/// This avoids the need for a Ray cluster while still exercising the real local execution
-/// code path, producing genuine `ExecutionStats` with real `StatSnapshot` data.
-#[derive(Debug, Clone)]
+/// One `NativeExecutor` is owned per worker — matching real Ray Flotilla, where
+/// each worker process has its own executor with a pipeline cache keyed by
+/// `plan_fingerprint`. Tasks with matching fingerprints routed to this worker
+/// share a local Swordfish pipeline (and all the state hanging off it).
+#[derive(Clone)]
 pub struct LocalSwordfishWorker {
     worker_id: WorkerId,
     total_num_cpus: f64,
     active_task_details: Arc<Mutex<HashMap<TaskContext, TaskDetails>>>,
+    /// Shared executor; all tasks routed to this worker run through it, so
+    /// same-fingerprint tasks share a pipeline exactly as they would on a real
+    /// Ray worker.
+    executor: Arc<Mutex<NativeExecutor>>,
+    /// Fresh `InputId` generator. Each task submitted gets a unique input_id so
+    /// multiple same-fingerprint tasks can run concurrently on one pipeline.
+    input_id_counter: Arc<AtomicU32>,
+}
+
+impl std::fmt::Debug for LocalSwordfishWorker {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LocalSwordfishWorker")
+            .field("worker_id", &self.worker_id)
+            .field("total_num_cpus", &self.total_num_cpus)
+            .finish_non_exhaustive()
+    }
 }
 
 impl LocalSwordfishWorker {
+    /// Create a new worker with its own `NativeExecutor`.
+    ///
+    /// Defaults to enough CPUs that the scheduler will dispatch tasks
+    /// concurrently — matching what a multi-core Ray worker does. Without
+    /// this, single-CPU serialization would prevent same-fingerprint tasks
+    /// from sharing a live pipeline in the executor's plan cache (the first
+    /// `try_finish` tears the plan down before the next `run` starts), which
+    /// would hide classes of shared-state bugs that the production path can
+    /// exhibit.
+    ///
+    /// `is_flotilla_worker` mirrors the real `NativeExecutor::new` flag. When
+    /// `true`, the executor starts a `ShuffleFlightServer` bound to `ip`
+    /// (default `127.0.0.1:0`) — set this for tests that exercise shuffles.
+    /// When `false`, no server is started, which is sufficient for tests that
+    /// only need plan-sharing realism (the common case).
     pub fn new(worker_id: WorkerId) -> Self {
+        Self::with_flotilla_mode(worker_id, 8.0, false, "")
+    }
+
+    /// Create a new worker, explicitly controlling CPU count and whether the
+    /// underlying `NativeExecutor` starts a shuffle server (as real Ray
+    /// workers do).
+    pub fn with_flotilla_mode(
+        worker_id: WorkerId,
+        total_num_cpus: f64,
+        is_flotilla_worker: bool,
+        ip: &str,
+    ) -> Self {
         Self {
             worker_id,
-            total_num_cpus: 1.0,
+            total_num_cpus,
             active_task_details: Arc::new(Mutex::new(HashMap::new())),
+            executor: Arc::new(Mutex::new(NativeExecutor::new(is_flotilla_worker, ip))),
+            input_id_counter: Arc::new(AtomicU32::new(0)),
         }
     }
 
@@ -56,6 +114,10 @@ impl LocalSwordfishWorker {
             .lock()
             .unwrap()
             .remove(&task_context);
+    }
+
+    fn next_input_id(&self) -> InputId {
+        self.input_id_counter.fetch_add(1, Ordering::Relaxed)
     }
 }
 
@@ -99,14 +161,22 @@ impl LocalSwordfishWorker {
     }
 }
 
-/// Task result handle that executes the SwordfishTask's local plan in-process.
+/// Task result handle that runs a task through the worker's shared `NativeExecutor`.
 pub struct LocalSwordfishTaskResultHandle {
     task: SwordfishTask,
+    worker_id: WorkerId,
+    executor: Arc<Mutex<NativeExecutor>>,
+    input_id: InputId,
 }
 
 impl LocalSwordfishTaskResultHandle {
-    pub fn new(task: SwordfishTask) -> Self {
-        Self { task }
+    fn new(task: SwordfishTask, worker: &LocalSwordfishWorker) -> Self {
+        Self {
+            task,
+            worker_id: worker.worker_id.clone(),
+            executor: worker.executor.clone(),
+            input_id: worker.next_input_id(),
+        }
     }
 }
 
@@ -120,10 +190,18 @@ impl TaskResultHandle for LocalSwordfishTaskResultHandle {
         let config = self.task.config().clone();
         let inputs = self.task.inputs().clone();
         let psets = self.task.psets().clone();
+        let context = self.task.context().clone();
         let task_id = self.task.task_context().task_id;
+        let worker_id = self.worker_id.clone();
+        let executor = self.executor.clone();
+        let input_id = self.input_id;
 
         async move {
-            match execute_swordfish_task_locally(plan, config, inputs, psets, task_id).await {
+            match execute_swordfish_task_on_executor(
+                executor, plan, config, context, inputs, psets, input_id, task_id, worker_id,
+            )
+            .await
+            {
                 Ok((output, stats)) => TaskStatus::Success {
                     result: output,
                     stats,
@@ -138,19 +216,25 @@ impl TaskResultHandle for LocalSwordfishTaskResultHandle {
     }
 }
 
-/// Execute a SwordfishTask's local plan in-process.
+/// Run a `SwordfishTask` through a shared `NativeExecutor` — the same path a
+/// real Ray Flotilla worker takes.
 ///
-/// Converts the task's psets (partition refs containing MicroPartitions) into
-/// `Input::InMemory` entries and runs the plan via the local execution pipeline.
-async fn execute_swordfish_task_locally(
+/// Converts `psets` (`PartitionRef`s wrapping `MicroPartition`s) into
+/// `Input::InMemory` entries, then enqueues the task on the executor keyed by
+/// `plan_fingerprint` (carried in `context`), drains the output stream, and
+/// harvests per-input_id stats via `try_finish`.
+#[allow(clippy::too_many_arguments)]
+async fn execute_swordfish_task_on_executor(
+    executor: Arc<Mutex<NativeExecutor>>,
     plan: daft_local_plan::LocalPhysicalPlanRef,
     config: Arc<common_daft_config::DaftExecutionConfig>,
+    context: HashMap<String, String>,
     task_inputs: HashMap<SourceId, Input>,
     psets: HashMap<SourceId, Vec<PartitionRef>>,
+    input_id: InputId,
     task_id: u32,
+    worker_id: WorkerId,
 ) -> DaftResult<(MaterializedOutput, ExecutionStats)> {
-    use daft_local_execution::testing::LocalPlanOutput;
-
     // Merge psets into inputs. Psets contain PartitionRefs that are Arc<MicroPartition>
     // in local execution. Convert them to Input::InMemory.
     let mut inputs = task_inputs;
@@ -172,25 +256,40 @@ async fn execute_swordfish_task_locally(
         inputs.insert(source_id, Input::InMemory(micro_partitions));
     }
 
-    let (output, stats) =
-        daft_local_execution::testing::execute_local_plan(&plan, config, inputs).await?;
+    let (fingerprint, run_fut) = {
+        let mut exec = executor.lock().unwrap();
+        exec.run(
+            &plan,
+            config,
+            vec![], // subscribers
+            Some(context),
+            inputs,
+            input_id,
+            true, // maintain_order
+        )?
+    };
+    let result = run_fut.await?;
+    // Mirror the production Python flow: drain this input_id's output so the
+    // pipeline has finished reading bytes before stats are harvested.
+    let partitions = result.collect_partitions_for_testing().await;
 
-    let LocalPlanOutput::Partitions(partitions) = output;
+    let stats = {
+        let mut exec = executor.lock().unwrap();
+        exec.try_finish(fingerprint, input_id)?
+    }
+    .await?;
+
     let partition_refs: Vec<PartitionRef> = partitions
         .into_iter()
         .map(|mp| Arc::new(mp) as PartitionRef)
         .collect();
-    let materialized = MaterializedOutput::new(
-        partition_refs,
-        "local-worker".into(),
-        String::new(),
-        task_id,
-    );
+    let materialized =
+        MaterializedOutput::new(partition_refs, worker_id, String::new(), task_id);
 
     Ok((materialized, stats))
 }
 
-/// A worker manager for LocalSwordfishWorkers.
+/// A worker manager for `LocalSwordfishWorker`s.
 #[derive(Clone)]
 pub struct LocalSwordfishWorkerManager {
     workers: Arc<Mutex<HashMap<WorkerId, LocalSwordfishWorker>>>,
@@ -220,12 +319,16 @@ impl WorkerManager for LocalSwordfishWorkerManager {
         tasks_per_worker: HashMap<WorkerId, Vec<SwordfishTask>>,
     ) -> DaftResult<Vec<LocalSwordfishTaskResultHandle>> {
         let mut result = Vec::new();
+        let workers = self.workers.lock().unwrap();
         for (worker_id, tasks) in tasks_per_worker {
+            let worker = workers.get(&worker_id).ok_or_else(|| {
+                common_error::DaftError::InternalError(format!(
+                    "LocalSwordfishWorkerManager: unknown worker_id {worker_id}"
+                ))
+            })?;
             for task in tasks {
-                if let Some(worker) = self.workers.lock().unwrap().get(&worker_id) {
-                    worker.add_active_task(&task);
-                }
-                result.push(LocalSwordfishTaskResultHandle::new(task));
+                worker.add_active_task(&task);
+                result.push(LocalSwordfishTaskResultHandle::new(task, worker));
             }
         }
         Ok(result)

--- a/src/daft-distributed/src/statistics/tests.rs
+++ b/src/daft-distributed/src/statistics/tests.rs
@@ -510,16 +510,15 @@ fn build_scan_pipeline(
 /// caches local pipelines by `plan_fingerprint` and reuses a single pipeline
 /// across tasks with identical plans. All scan tasks produced by a single
 /// `ScanSourceNode` share the same fingerprint, so they share one
-/// `SourceNode` — which owns a single `IOStatsRef` shared across per-input_id
+/// `SourceNode` — which owns a single `IOStatsRef` shared across per-InputId
 /// `SourceStats`. Every `SourceStats::build_snapshot` reads the same atomic
 /// counter, so `take_input_snapshot(input_id=N)` for each of N scan tasks
 /// returns the cumulative bytes read by *all* tasks so far. When Flotilla's
 /// `StatisticsManager` sums those per-task snapshots it reports ~N× the true
 /// bytes read.
 ///
-/// This test exercises that exact path via `execute_local_plan_shared`, which
-/// mirrors `NativeExecutor::run` by driving multiple scan inputs through one
-/// pipeline.
+/// This test exercises the real production path via `NativeExecutor::run` /
+/// `NativeExecutor::try_finish` — the same calls Flotilla workers use.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_scan_source_bytes_read_multiple_files() -> DaftResult<()> {
     let meter = Meter::test_scope("test_scan_bytes_read_multi_file");
@@ -558,43 +557,55 @@ async fn test_scan_source_bytes_read_multiple_files() -> DaftResult<()> {
     );
 
     // All tasks from a single ScanSourceNode share the same plan fingerprint,
-    // so in production Flotilla they would share one NativeExecutor pipeline.
-    // We simulate that via `execute_local_plan_shared`: one pipeline, N inputs,
-    // each on a distinct InputId — matching NativeExecutor's plan-sharing path.
-    let first = &tasks[0];
-    let plan = first.plan();
-    let config = first.config().clone();
-    let shared_fingerprint = first.task_context().plan_fingerprint;
+    // so in production Flotilla they share one NativeExecutor pipeline.
+    let shared_fp = tasks[0].task_context().plan_fingerprint;
     for (i, t) in tasks.iter().enumerate() {
         assert_eq!(
-            t.task_context().plan_fingerprint,
-            shared_fingerprint,
-            "task {i} has a different plan_fingerprint from task 0; shared-pipeline test \
+            t.task_context().plan_fingerprint, shared_fp,
+            "task {i} has a different plan_fingerprint from task 0; shared-pipeline \
              assumption broken — Flotilla would not share a pipeline across these tasks"
         );
     }
 
-    let batches: Vec<(daft_local_plan::InputId, HashMap<SourceId, Input>)> = tasks
-        .iter()
-        .enumerate()
-        .map(|(i, task)| {
-            let inputs = task.inputs().clone();
-            let input_id = i as daft_local_plan::InputId;
-            (input_id, inputs)
-        })
-        .collect();
+    // Drive tasks through the real `NativeExecutor` that production uses.
+    // First enqueue every task on its own InputId, then call `try_finish` on
+    // each to harvest the per-task `ExecutionStats` — exactly as Flotilla's
+    // worker loop does when running multiple same-plan tasks concurrently.
+    let mut executor = daft_local_execution::testing::NativeExecutor::new(false, "");
 
-    let per_input_stats =
-        daft_local_execution::testing::execute_local_plan_shared(&plan, config, batches)
-            .await?;
+    let mut enqueued: Vec<(u64, daft_local_plan::InputId, _)> = Vec::with_capacity(tasks.len());
+    for (i, task) in tasks.iter().enumerate() {
+        let input_id = i as daft_local_plan::InputId;
+        let (fingerprint, run_fut) = executor.run(
+            &task.plan(),
+            task.config().clone(),
+            vec![], // subscribers
+            Some(task.context().clone()),
+            task.inputs().clone(),
+            input_id,
+            true, // maintain_order
+        )?;
+        let result = run_fut.await?;
+        enqueued.push((fingerprint, input_id, result));
+    }
+
+    // Sanity: every task's fingerprint is the same in the executor's plan cache.
+    let executor_fp = enqueued[0].0;
+    for (fp, _, _) in &enqueued {
+        assert_eq!(
+            *fp, executor_fp,
+            "NativeExecutor reported different fingerprints for same-plan tasks"
+        );
+    }
 
     let mut per_task_bytes_read: Vec<u64> = Vec::with_capacity(tasks.len());
-    for (i, task) in tasks.iter().enumerate() {
-        let stats = per_input_stats
-            .iter()
-            .find(|(iid, _)| *iid as usize == i)
-            .map(|(_, s)| s.clone())
-            .expect("per-input_id stats should be present");
+    for (fp, input_id, result) in enqueued {
+        // Match the production Python flow: drain all output partitions for
+        // this input_id before calling `try_finish`, so the pipeline has
+        // actually finished reading bytes before stats are harvested.
+        result.drain_for_testing().await;
+        let stats_fut = executor.try_finish(fp, input_id)?;
+        let stats = stats_fut.await?;
         let mut task_bytes_read: u64 = 0;
         for (_info, snapshot) in &stats.nodes {
             if let StatSnapshot::Source(s) = snapshot {
@@ -602,10 +613,11 @@ async fn test_scan_source_bytes_read_multiple_files() -> DaftResult<()> {
             }
         }
         per_task_bytes_read.push(task_bytes_read);
+        let task = &tasks[input_id as usize];
         feed_stats_to_manager(&stats_manager, task, stats)?;
     }
 
-    let swordfish_sum: u64 = per_task_bytes_read.iter().sum();
+    let per_task_sum: u64 = per_task_bytes_read.iter().sum();
 
     let exported = stats_manager.export_metrics();
     let source_stats = exported
@@ -625,12 +637,12 @@ async fn test_scan_source_bytes_read_multiple_files() -> DaftResult<()> {
     eprintln!(
         "total_bytes_on_disk = {total_bytes_on_disk}, \
          per-task bytes_read (as Flotilla sees them) = {per_task_bytes_read:?} \
-         (sum = {swordfish_sum}), \
+         (sum = {per_task_sum}), \
          flotilla aggregated bytes_read = {flotilla_bytes_read}"
     );
 
     // Flotilla aggregated bytes_read is a sum of per-task snapshots, so by
-    // construction it equals `swordfish_sum`. The real assertion is that this
+    // construction it equals `per_task_sum`. The real assertion is that this
     // sum is close to the actual bytes on disk — not a large multiple of it.
     assert!(
         flotilla_bytes_read <= total_bytes_on_disk * 3,

--- a/src/daft-distributed/src/statistics/tests.rs
+++ b/src/daft-distributed/src/statistics/tests.rs
@@ -6,7 +6,7 @@ use common_metrics::{Meter, QueryID, StatSnapshot};
 use common_partitioning::PartitionRef;
 use common_runtime::JoinSet;
 use daft_dsl::expr::{BoundColumn, Expr, bound_expr::BoundExpr};
-use daft_local_plan::{ExecutionStats, Input, SourceId};
+use daft_local_plan::ExecutionStats;
 use daft_logical_plan::InMemoryInfo;
 use daft_micropartition::MicroPartition;
 use daft_recordbatch::RecordBatch;
@@ -21,13 +21,11 @@ use crate::{
     pipeline_node::{
         DistributedPipelineNode, FilterNode, InMemorySourceNode, ScanSourceNode, SortNode,
     },
-    plan::{PlanConfig, PlanExecutionContext},
+    plan::{PlanConfig, PlanExecutionContext, RunningPlan},
     scheduling::{
-        local_worker::LocalSwordfishWorkerManager,
-        scheduler::spawn_scheduler_actor,
-        task::{SwordfishTask, Task},
+        local_worker::LocalSwordfishWorkerManager, scheduler::spawn_scheduler_actor,
     },
-    statistics::{StatisticsManager, TaskEvent},
+    statistics::StatisticsManager,
 };
 
 /// Create a simple test schema with one Int64 column named "x".
@@ -173,101 +171,65 @@ fn build_filter_pipeline(
     DistributedPipelineNode::new(Arc::new(filter_node), meter)
 }
 
-/// Extract SwordfishTasks from a DistributedPipelineNode by calling produce_tasks().
+/// End-to-end test harness: drive a `DistributedPipelineNode` to completion
+/// via the same scheduler + worker path Ray Flotilla uses, and return the
+/// aggregated `ExecutionStats`.
 ///
-/// Creates a scheduler to satisfy PlanExecutionContext requirements. For non-blocking
-/// nodes (Filter, Project, etc.) the scheduler is not used during task production.
-/// For blocking nodes (Sort, etc.), the scheduler actually executes intermediate tasks.
+/// The pipeline is produced into a task stream, submitted to a real
+/// `SchedulerActor`, and dispatched to a `LocalSwordfishWorker` whose
+/// `NativeExecutor` matches what each Ray worker process owns. The dispatcher
+/// feeds `TaskEvent`s into the `StatisticsManager` exactly as in production;
+/// the test just awaits completion and reads the final snapshot. This is the
+/// canonical harness — new operator tests should use it.
 ///
-/// The `stats_manager` is passed to the scheduler so that intermediate task completions
-/// can be routed to RuntimeNodeManagers without panicking.
-async fn extract_tasks(
-    pipeline: &DistributedPipelineNode,
-    stats_manager: &crate::statistics::StatisticsManagerRef,
-) -> DaftResult<Vec<SwordfishTask>> {
-    let worker_manager = Arc::new(LocalSwordfishWorkerManager::single_worker());
-    let mut joinset = JoinSet::new();
-    let scheduler_handle =
-        spawn_scheduler_actor(worker_manager, &mut joinset, stats_manager.clone());
-
-    let mut plan_context = PlanExecutionContext::new(0, scheduler_handle.clone());
-    let task_stream = pipeline.clone().produce_tasks(&mut plan_context);
-
-    let task_id_counter = plan_context.task_id_counter();
-    let mut tasks = Vec::new();
-    tokio::pin!(task_stream);
-    while let Some(builder) = task_stream.next().await {
-        let submittable = builder.build(0, &task_id_counter);
-        tasks.push(submittable.into_task());
-    }
-
-    // Clean up: drop the handle and abort the scheduler.
-    drop(scheduler_handle);
-    joinset.abort_all();
-
-    Ok(tasks)
-}
-
-/// Run a SwordfishTask's local plan and return the ExecutionStats.
-async fn run_task_locally(task: &SwordfishTask) -> DaftResult<ExecutionStats> {
-    let plan = task.plan();
-    let config = task.config().clone();
-    let psets = task.psets().clone();
-
-    // Convert psets (PartitionRef = Arc<MicroPartition>) to Input::InMemory
-    let mut inputs: HashMap<SourceId, Input> = task.inputs().clone();
-    for (source_id, partition_refs) in psets {
-        let micro_partitions: Vec<Arc<MicroPartition>> = partition_refs
-            .into_iter()
-            .map(|pr| {
-                pr.as_any()
-                    .downcast_ref::<MicroPartition>()
-                    .map(|mp| Arc::new(mp.clone()))
-                    .ok_or_else(|| {
-                        common_error::DaftError::InternalError(
-                            "PartitionRef is not a MicroPartition".into(),
-                        )
-                    })
-            })
-            .collect::<DaftResult<Vec<_>>>()?;
-        inputs.insert(source_id, Input::InMemory(micro_partitions));
-    }
-
-    let (_partitions, stats) =
-        daft_local_execution::testing::execute_local_plan(&plan, config, inputs).await?;
-    Ok(stats)
-}
-
-/// Feed ExecutionStats from a task into a StatisticsManager.
-fn feed_stats_to_manager(
-    stats_manager: &StatisticsManager,
-    task: &SwordfishTask,
-    exec_stats: ExecutionStats,
-) -> DaftResult<()> {
-    let event = TaskEvent::Completed {
-        context: task.task_context(),
-        stats: exec_stats,
-    };
-    stats_manager.handle_event(event)
-}
-
-/// End-to-end test helper: build pipeline, extract tasks via produce_tasks(),
-/// run each task locally, feed stats to StatisticsManager, export and return.
+/// Differences from a real Ray Flotilla run (all inherent to running without
+/// a Ray cluster):
+/// - Single process, single tokio runtime — no serialization boundary, no
+///   network hops, no worker-death scenarios.
+/// - One worker by default (`single_worker`). Callers that want to spread
+///   tasks across multiple per-worker `NativeExecutor`s can assemble their own
+///   `LocalSwordfishWorkerManager` and call `run_pipeline_with_manager`.
 async fn run_pipeline_and_get_stats(
     pipeline: &DistributedPipelineNode,
     meter: &Meter,
 ) -> DaftResult<Vec<(Arc<common_metrics::ops::NodeInfo>, StatSnapshot)>> {
+    let worker_manager = Arc::new(LocalSwordfishWorkerManager::single_worker());
+    run_pipeline_with_manager(pipeline, meter, worker_manager)
+        .await
+        .map(|stats| stats.nodes)
+}
+
+async fn run_pipeline_with_manager(
+    pipeline: &DistributedPipelineNode,
+    meter: &Meter,
+    worker_manager: Arc<LocalSwordfishWorkerManager>,
+) -> DaftResult<ExecutionStats> {
     let stats_manager = StatisticsManager::from_pipeline_node(pipeline, vec![], meter)?;
 
-    let tasks = extract_tasks(pipeline, &stats_manager).await?;
+    let mut scheduler_joinset = JoinSet::new();
+    let scheduler_handle = spawn_scheduler_actor(
+        worker_manager,
+        &mut scheduler_joinset,
+        stats_manager.clone(),
+    );
 
-    for task in &tasks {
-        let exec_stats = run_task_locally(task).await?;
-        feed_stats_to_manager(&stats_manager, task, exec_stats)?;
+    let mut plan_context = PlanExecutionContext::new(0, scheduler_handle.clone());
+    let task_stream = pipeline.clone().produce_tasks(&mut plan_context);
+    let running_plan = RunningPlan::new(task_stream, plan_context);
+
+    // Drive the real materialization path: every task flows through the
+    // scheduler → dispatcher → worker → NativeExecutor, and per-task stats
+    // are fed to `stats_manager` by the dispatcher via `handle_task_event`.
+    let mut materialized = running_plan.materialize(scheduler_handle.clone());
+    while let Some(result) = materialized.next().await {
+        // Discard output partitions; tests read the aggregated stats instead.
+        let _ = result?;
     }
 
-    let exported = stats_manager.export_metrics();
-    Ok(exported.nodes)
+    drop(scheduler_handle);
+    scheduler_joinset.abort_all();
+
+    Ok(stats_manager.export_metrics())
 }
 
 /// Test: Single-partition sort produces correct aggregated stats.
@@ -506,8 +468,8 @@ fn build_scan_pipeline(
 /// `io_stats.mark_bytes_read` on every buffer fill (daft-parquet's local path
 /// skips the counting reader, so parquet can't reproduce it without S3).
 ///
-/// Root cause (to be fixed): in Flotilla production, `NativeExecutor::run`
-/// caches local pipelines by `plan_fingerprint` and reuses a single pipeline
+/// Root cause (to be fixed): on a real Ray Flotilla worker, `NativeExecutor`
+/// caches local Swordfish pipelines by `plan_fingerprint` and reuses them
 /// across tasks with identical plans. All scan tasks produced by a single
 /// `ScanSourceNode` share the same fingerprint, so they share one
 /// `SourceNode` — which owns a single `IOStatsRef` shared across per-InputId
@@ -517,8 +479,9 @@ fn build_scan_pipeline(
 /// `StatisticsManager` sums those per-task snapshots it reports ~N× the true
 /// bytes read.
 ///
-/// This test exercises the real production path via `NativeExecutor::run` /
-/// `NativeExecutor::try_finish` — the same calls Flotilla workers use.
+/// The test uses the shared harness `run_pipeline_and_get_stats`, which
+/// routes every task through `LocalSwordfishWorker`'s `NativeExecutor` —
+/// exactly the same production code a Ray worker runs.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_scan_source_bytes_read_multiple_files() -> DaftResult<()> {
     let meter = Meter::test_scope("test_scan_bytes_read_multi_file");
@@ -548,80 +511,9 @@ async fn test_scan_source_bytes_read_multiple_files() -> DaftResult<()> {
 
     let pipeline = build_scan_pipeline(&file_paths, &meter);
 
-    let stats_manager = StatisticsManager::from_pipeline_node(&pipeline, vec![], &meter)?;
-    let tasks = extract_tasks(&pipeline, &stats_manager).await?;
-    assert_eq!(
-        tasks.len(),
-        num_files,
-        "expected one SwordfishTask per file (ScanTaskRef)"
-    );
+    let stats = run_pipeline_and_get_stats(&pipeline, &meter).await?;
 
-    // All tasks from a single ScanSourceNode share the same plan fingerprint,
-    // so in production Flotilla they share one NativeExecutor pipeline.
-    let shared_fp = tasks[0].task_context().plan_fingerprint;
-    for (i, t) in tasks.iter().enumerate() {
-        assert_eq!(
-            t.task_context().plan_fingerprint, shared_fp,
-            "task {i} has a different plan_fingerprint from task 0; shared-pipeline \
-             assumption broken — Flotilla would not share a pipeline across these tasks"
-        );
-    }
-
-    // Drive tasks through the real `NativeExecutor` that production uses.
-    // First enqueue every task on its own InputId, then call `try_finish` on
-    // each to harvest the per-task `ExecutionStats` — exactly as Flotilla's
-    // worker loop does when running multiple same-plan tasks concurrently.
-    let mut executor = daft_local_execution::testing::NativeExecutor::new(false, "");
-
-    let mut enqueued: Vec<(u64, daft_local_plan::InputId, _)> = Vec::with_capacity(tasks.len());
-    for (i, task) in tasks.iter().enumerate() {
-        let input_id = i as daft_local_plan::InputId;
-        let (fingerprint, run_fut) = executor.run(
-            &task.plan(),
-            task.config().clone(),
-            vec![], // subscribers
-            Some(task.context().clone()),
-            task.inputs().clone(),
-            input_id,
-            true, // maintain_order
-        )?;
-        let result = run_fut.await?;
-        enqueued.push((fingerprint, input_id, result));
-    }
-
-    // Sanity: every task's fingerprint is the same in the executor's plan cache.
-    let executor_fp = enqueued[0].0;
-    for (fp, _, _) in &enqueued {
-        assert_eq!(
-            *fp, executor_fp,
-            "NativeExecutor reported different fingerprints for same-plan tasks"
-        );
-    }
-
-    let mut per_task_bytes_read: Vec<u64> = Vec::with_capacity(tasks.len());
-    for (fp, input_id, result) in enqueued {
-        // Match the production Python flow: drain all output partitions for
-        // this input_id before calling `try_finish`, so the pipeline has
-        // actually finished reading bytes before stats are harvested.
-        result.drain_for_testing().await;
-        let stats_fut = executor.try_finish(fp, input_id)?;
-        let stats = stats_fut.await?;
-        let mut task_bytes_read: u64 = 0;
-        for (_info, snapshot) in &stats.nodes {
-            if let StatSnapshot::Source(s) = snapshot {
-                task_bytes_read += s.bytes_read;
-            }
-        }
-        per_task_bytes_read.push(task_bytes_read);
-        let task = &tasks[input_id as usize];
-        feed_stats_to_manager(&stats_manager, task, stats)?;
-    }
-
-    let per_task_sum: u64 = per_task_bytes_read.iter().sum();
-
-    let exported = stats_manager.export_metrics();
-    let source_stats = exported
-        .nodes
+    let source_stats = stats
         .iter()
         .find(|(info, _)| info.node_origin_id == 0)
         .expect("scan source node stats should be present");
@@ -636,19 +528,15 @@ async fn test_scan_source_bytes_read_multiple_files() -> DaftResult<()> {
 
     eprintln!(
         "total_bytes_on_disk = {total_bytes_on_disk}, \
-         per-task bytes_read (as Flotilla sees them) = {per_task_bytes_read:?} \
-         (sum = {per_task_sum}), \
          flotilla aggregated bytes_read = {flotilla_bytes_read}"
     );
 
-    // Flotilla aggregated bytes_read is a sum of per-task snapshots, so by
-    // construction it equals `per_task_sum`. The real assertion is that this
-    // sum is close to the actual bytes on disk — not a large multiple of it.
+    // Allow up to 3x slack for read-planner coalescing / footer re-reads.
+    // When the bug is present, bytes_read comes out as ~N × total_bytes_on_disk.
     assert!(
         flotilla_bytes_read <= total_bytes_on_disk * 3,
         "Flotilla bytes_read ({flotilla_bytes_read}) is more than 3x total file size \
-         ({total_bytes_on_disk}) — bytes.read is being overreported. Per-task \
-         bytes_read = {per_task_bytes_read:?}"
+         ({total_bytes_on_disk}) — bytes.read is being overreported."
     );
 
     Ok(())

--- a/src/daft-distributed/src/statistics/tests.rs
+++ b/src/daft-distributed/src/statistics/tests.rs
@@ -482,6 +482,12 @@ fn build_scan_pipeline(
 /// The test uses the shared harness `run_pipeline_and_get_stats`, which
 /// routes every task through `LocalSwordfishWorker`'s `NativeExecutor` —
 /// exactly the same production code a Ray worker runs.
+///
+/// Ignored until the bytes_read overreport is fixed; re-enable (remove the
+/// `#[ignore]`) when that fix lands. Run locally with
+/// `cargo test -p daft-distributed test_scan_source_bytes_read_multiple_files
+/// -- --ignored`.
+#[ignore = "reproduces an unfixed bug: Flotilla overreports bytes.read on multi-file scans"]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_scan_source_bytes_read_multiple_files() -> DaftResult<()> {
     let meter = Meter::test_scope("test_scan_bytes_read_multi_file");

--- a/src/daft-distributed/src/statistics/tests.rs
+++ b/src/daft-distributed/src/statistics/tests.rs
@@ -18,7 +18,9 @@ use daft_schema::{
 use futures::StreamExt;
 
 use crate::{
-    pipeline_node::{DistributedPipelineNode, FilterNode, InMemorySourceNode, SortNode},
+    pipeline_node::{
+        DistributedPipelineNode, FilterNode, InMemorySourceNode, ScanSourceNode, SortNode,
+    },
     plan::{PlanConfig, PlanExecutionContext},
     scheduling::{
         local_worker::LocalSwordfishWorkerManager,
@@ -409,6 +411,233 @@ async fn test_filter_stats_multi_partition() -> DaftResult<()> {
         }
         other => panic!("Expected Filter snapshot, got: {:?}", other),
     }
+
+    Ok(())
+}
+
+/// Write a single-column Int64 CSV file with the given values and return the
+/// number of bytes on disk. Uses the `x` column from `test_schema()`.
+///
+/// CSV is used here rather than parquet because daft-io's local parquet read
+/// path doesn't increment `bytes_read` (local files skip the `CountingReader`
+/// wrapper), while daft-csv's local reader calls `io_stats.mark_bytes_read`
+/// on every buffer fill.
+fn write_csv_file(path: &std::path::Path, values: &[i64]) -> u64 {
+    use std::io::Write;
+    let mut file = std::fs::File::create(path).expect("create csv file");
+    writeln!(file, "x").expect("write header");
+    for v in values {
+        writeln!(file, "{v}").expect("write row");
+    }
+    file.sync_all().expect("sync");
+    drop(file);
+    std::fs::metadata(path).expect("metadata").len()
+}
+
+/// Build a Flotilla pipeline with a `ScanSourceNode` over the given CSV files,
+/// one `ScanTaskRef` per file.
+fn build_scan_pipeline(
+    file_paths: &[std::path::PathBuf],
+    meter: &Meter,
+) -> DistributedPipelineNode {
+    use daft_scan::{
+        CsvSourceConfig, FileFormatConfig, Pushdowns, ScanSource, ScanSourceKind, ScanTask,
+        ScanTaskRef, SourceConfig, storage_config::StorageConfig,
+    };
+
+    let schema = test_schema();
+    let csv_cfg = CsvSourceConfig {
+        delimiter: None,
+        has_headers: true,
+        double_quote: true,
+        quote: None,
+        escape_char: None,
+        comment: None,
+        allow_variable_columns: false,
+        buffer_size: None,
+        chunk_size: None,
+    };
+    let source_config = Arc::new(SourceConfig::File(FileFormatConfig::Csv(csv_cfg)));
+    let storage_config = Arc::new(StorageConfig::new_internal(false, None));
+    let pushdowns = Pushdowns::default();
+
+    let scan_tasks: Vec<ScanTaskRef> = file_paths
+        .iter()
+        .map(|path| {
+            let size = std::fs::metadata(path).expect("file metadata").len();
+            Arc::new(ScanTask::new(
+                vec![ScanSource {
+                    size_bytes: Some(size),
+                    metadata: None,
+                    statistics: None,
+                    partition_spec: None,
+                    kind: ScanSourceKind::File {
+                        path: path.to_string_lossy().into_owned(),
+                        chunk_spec: None,
+                        iceberg_delete_files: None,
+                        parquet_metadata: None,
+                    },
+                }],
+                source_config.clone(),
+                schema.clone(),
+                storage_config.clone(),
+                pushdowns.clone(),
+                None,
+            ))
+        })
+        .collect();
+
+    let plan_config = test_plan_config();
+    let scan_source_node = ScanSourceNode::new(
+        0,
+        &plan_config,
+        pushdowns,
+        Arc::new(scan_tasks),
+        schema,
+    );
+
+    DistributedPipelineNode::new(Arc::new(scan_source_node), meter)
+}
+
+/// Repro: Flotilla overreports `bytes_read` when a scan has multiple files.
+///
+/// Originally observed when reading from S3. The same overreporting reproduces
+/// locally with CSV files because daft-csv's local reader calls
+/// `io_stats.mark_bytes_read` on every buffer fill (daft-parquet's local path
+/// skips the counting reader, so parquet can't reproduce it without S3).
+///
+/// Root cause (to be fixed): in Flotilla production, `NativeExecutor::run`
+/// caches local pipelines by `plan_fingerprint` and reuses a single pipeline
+/// across tasks with identical plans. All scan tasks produced by a single
+/// `ScanSourceNode` share the same fingerprint, so they share one
+/// `SourceNode` — which owns a single `IOStatsRef` shared across per-input_id
+/// `SourceStats`. Every `SourceStats::build_snapshot` reads the same atomic
+/// counter, so `take_input_snapshot(input_id=N)` for each of N scan tasks
+/// returns the cumulative bytes read by *all* tasks so far. When Flotilla's
+/// `StatisticsManager` sums those per-task snapshots it reports ~N× the true
+/// bytes read.
+///
+/// This test exercises that exact path via `execute_local_plan_shared`, which
+/// mirrors `NativeExecutor::run` by driving multiple scan inputs through one
+/// pipeline.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_scan_source_bytes_read_multiple_files() -> DaftResult<()> {
+    let meter = Meter::test_scope("test_scan_bytes_read_multi_file");
+
+    // Write N distinct CSV files to a fresh temp directory.
+    let tmpdir = std::env::temp_dir().join(format!(
+        "daft_flotilla_bytes_read_repro_{}_{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos(),
+    ));
+    std::fs::create_dir_all(&tmpdir).expect("create tmpdir");
+
+    let num_files: usize = 5;
+    let rows_per_file: usize = 1_000;
+    let mut file_paths = Vec::with_capacity(num_files);
+    let mut total_bytes_on_disk: u64 = 0;
+    for i in 0..num_files {
+        let path = tmpdir.join(format!("file_{i}.csv"));
+        let values: Vec<i64> =
+            (0..rows_per_file).map(|j| (i * rows_per_file + j) as i64).collect();
+        total_bytes_on_disk += write_csv_file(&path, &values);
+        file_paths.push(path);
+    }
+
+    let pipeline = build_scan_pipeline(&file_paths, &meter);
+
+    let stats_manager = StatisticsManager::from_pipeline_node(&pipeline, vec![], &meter)?;
+    let tasks = extract_tasks(&pipeline, &stats_manager).await?;
+    assert_eq!(
+        tasks.len(),
+        num_files,
+        "expected one SwordfishTask per file (ScanTaskRef)"
+    );
+
+    // All tasks from a single ScanSourceNode share the same plan fingerprint,
+    // so in production Flotilla they would share one NativeExecutor pipeline.
+    // We simulate that via `execute_local_plan_shared`: one pipeline, N inputs,
+    // each on a distinct InputId — matching NativeExecutor's plan-sharing path.
+    let first = &tasks[0];
+    let plan = first.plan();
+    let config = first.config().clone();
+    let shared_fingerprint = first.task_context().plan_fingerprint;
+    for (i, t) in tasks.iter().enumerate() {
+        assert_eq!(
+            t.task_context().plan_fingerprint,
+            shared_fingerprint,
+            "task {i} has a different plan_fingerprint from task 0; shared-pipeline test \
+             assumption broken — Flotilla would not share a pipeline across these tasks"
+        );
+    }
+
+    let batches: Vec<(daft_local_plan::InputId, HashMap<SourceId, Input>)> = tasks
+        .iter()
+        .enumerate()
+        .map(|(i, task)| {
+            let inputs = task.inputs().clone();
+            let input_id = i as daft_local_plan::InputId;
+            (input_id, inputs)
+        })
+        .collect();
+
+    let per_input_stats =
+        daft_local_execution::testing::execute_local_plan_shared(&plan, config, batches)
+            .await?;
+
+    let mut per_task_bytes_read: Vec<u64> = Vec::with_capacity(tasks.len());
+    for (i, task) in tasks.iter().enumerate() {
+        let stats = per_input_stats
+            .iter()
+            .find(|(iid, _)| *iid as usize == i)
+            .map(|(_, s)| s.clone())
+            .expect("per-input_id stats should be present");
+        let mut task_bytes_read: u64 = 0;
+        for (_info, snapshot) in &stats.nodes {
+            if let StatSnapshot::Source(s) = snapshot {
+                task_bytes_read += s.bytes_read;
+            }
+        }
+        per_task_bytes_read.push(task_bytes_read);
+        feed_stats_to_manager(&stats_manager, task, stats)?;
+    }
+
+    let swordfish_sum: u64 = per_task_bytes_read.iter().sum();
+
+    let exported = stats_manager.export_metrics();
+    let source_stats = exported
+        .nodes
+        .iter()
+        .find(|(info, _)| info.node_origin_id == 0)
+        .expect("scan source node stats should be present");
+
+    let flotilla_bytes_read = match &source_stats.1 {
+        StatSnapshot::Source(s) => s.bytes_read,
+        other => panic!("expected Source snapshot for scan source, got: {:?}", other),
+    };
+
+    // Cleanup before any assertion may fail.
+    let _ = std::fs::remove_dir_all(&tmpdir);
+
+    eprintln!(
+        "total_bytes_on_disk = {total_bytes_on_disk}, \
+         per-task bytes_read (as Flotilla sees them) = {per_task_bytes_read:?} \
+         (sum = {swordfish_sum}), \
+         flotilla aggregated bytes_read = {flotilla_bytes_read}"
+    );
+
+    // Flotilla aggregated bytes_read is a sum of per-task snapshots, so by
+    // construction it equals `swordfish_sum`. The real assertion is that this
+    // sum is close to the actual bytes on disk — not a large multiple of it.
+    assert!(
+        flotilla_bytes_read <= total_bytes_on_disk * 3,
+        "Flotilla bytes_read ({flotilla_bytes_read}) is more than 3x total file size \
+         ({total_bytes_on_disk}) — bytes.read is being overreported. Per-task \
+         bytes_read = {per_task_bytes_read:?}"
+    );
 
     Ok(())
 }

--- a/src/daft-local-execution/src/lib.rs
+++ b/src/daft-local-execution/src/lib.rs
@@ -34,7 +34,7 @@ pub use run::ExecutionEngineResult;
 /// Used by distributed execution tests (e.g. `LocalSwordfishWorker` in
 /// `daft-distributed`) to exercise real local execution without Ray.
 pub mod testing {
-    pub use super::run::{LocalPlanOutput, execute_local_plan, execute_local_plan_shared};
+    pub use super::run::{LocalPlanOutput, NativeExecutor, execute_local_plan};
 }
 use runtime_stats::RuntimeStatsManagerHandle;
 use snafu::{ResultExt, Snafu, futures::TryFutureExt};

--- a/src/daft-local-execution/src/lib.rs
+++ b/src/daft-local-execution/src/lib.rs
@@ -34,7 +34,7 @@ pub use run::ExecutionEngineResult;
 /// Used by distributed execution tests (e.g. `LocalSwordfishWorker` in
 /// `daft-distributed`) to exercise real local execution without Ray.
 pub mod testing {
-    pub use super::run::{LocalPlanOutput, execute_local_plan};
+    pub use super::run::{LocalPlanOutput, execute_local_plan, execute_local_plan_shared};
 }
 use runtime_stats::RuntimeStatsManagerHandle;
 use snafu::{ResultExt, Snafu, futures::TryFutureExt};

--- a/src/daft-local-execution/src/run.rs
+++ b/src/daft-local-execution/src/run.rs
@@ -671,6 +671,95 @@ pub async fn execute_local_plan(
     Ok((LocalPlanOutput::Partitions(partitions), stats))
 }
 
+/// Run multiple batches of inputs through a **single, shared** pipeline and
+/// return each batch's `ExecutionStats` snapshot.
+///
+/// This mirrors how `NativeExecutor::run` handles tasks with identical
+/// `plan_fingerprint`s: one pipeline is constructed and reused across all
+/// inputs, with each batch tagged by a distinct `InputId`. It is intended for
+/// tests that need to exercise the plan-sharing path (e.g. verifying that
+/// per-input stats reported via `take_input_snapshot` do not double-count
+/// shared source state such as `IOStats`).
+///
+/// Must be called from within a tokio runtime context.
+pub async fn execute_local_plan_shared(
+    plan: &LocalPhysicalPlanRef,
+    config: std::sync::Arc<DaftExecutionConfig>,
+    batches: Vec<(daft_local_plan::InputId, HashMap<SourceId, Input>)>,
+) -> DaftResult<Vec<(daft_local_plan::InputId, ExecutionStats)>> {
+    use tokio::runtime::Handle;
+
+    use crate::pipeline::{BuilderContext, PipelineMessage};
+
+    let handle = Handle::current();
+    let query_id = QueryID::from("");
+
+    let ctx = BuilderContext::new();
+    let (pipeline, input_senders) =
+        crate::pipeline::translate_physical_plan_to_pipeline(plan, &config, &ctx)?;
+
+    let stats_manager = RuntimeStatsManager::try_new(
+        &handle,
+        &pipeline,
+        vec![],
+        query_id,
+        false, // not a flotilla worker
+    )?;
+    let stats_handle = stats_manager.handle();
+
+    // Send each batch on its own InputId, then drop senders to signal EOF.
+    let mut input_ids: Vec<daft_local_plan::InputId> = Vec::with_capacity(batches.len());
+    for (input_id, inputs) in batches {
+        input_ids.push(input_id);
+        for (key, plan_input) in inputs {
+            if let Some(sender) = input_senders.get(&key) {
+                let _ = sender.send(input_id, plan_input);
+            }
+        }
+    }
+    drop(input_senders);
+
+    let memory_manager = get_or_init_memory_manager();
+    let mut runtime_handle =
+        ExecutionRuntimeContext::new(memory_manager.clone(), stats_handle.clone());
+    let mut output_receiver = pipeline.start(true, &mut runtime_handle)?;
+
+    // Drain pipeline output until completion (discarding partitions — tests
+    // that need data should use `execute_local_plan` per-input).
+    loop {
+        tokio::select! {
+            Some(join_result) = runtime_handle.join_next() => {
+                join_result?;
+            }
+            msg = output_receiver.recv() => {
+                match msg {
+                    Some(PipelineMessage::Morsel { .. })
+                    | Some(PipelineMessage::FlightPartitionRef { .. })
+                    | Some(PipelineMessage::Flush(_)) => {}
+                    None => {
+                        runtime_handle.shutdown().await?;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    stats_manager
+        .finish(common_metrics::QueryEndState::Finished)
+        .await;
+
+    let mut per_input_stats = Vec::with_capacity(input_ids.len());
+    for input_id in input_ids {
+        let stats = stats_handle
+            .take_input_snapshot(input_id)
+            .await
+            .unwrap_or_else(|_| ExecutionStats::new(QueryID::from(""), vec![]));
+        per_input_stats.push((input_id, stats));
+    }
+    Ok(per_input_stats)
+}
+
 pub struct ExecutionEngineResult {
     receiver: crate::channel::UnboundedReceiver<ExecutionEngineResultItem>,
 }

--- a/src/daft-local-execution/src/run.rs
+++ b/src/daft-local-execution/src/run.rs
@@ -69,7 +69,18 @@ fn get_global_runtime() -> &'static Handle {
 
 #[cfg(not(feature = "python"))]
 fn get_global_runtime() -> &'static Handle {
-    unimplemented!("get_global_runtime is not implemented without python feature");
+    GLOBAL_RUNTIME.get_or_init(|| {
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("build global tokio runtime for NativeExecutor");
+        let handle = rt.handle().clone();
+        // Keep the runtime alive for the duration of the process.
+        std::thread::spawn(move || {
+            rt.block_on(futures::future::pending::<()>());
+        });
+        handle
+    })
 }
 
 /// Message sent to the execution task to enqueue inputs
@@ -359,7 +370,7 @@ async fn run_execution_loop(
     result
 }
 
-pub(crate) struct NativeExecutor {
+pub struct NativeExecutor {
     cancel: CancellationToken,
     is_flotilla_worker: bool,
     shuffle_server: Option<Arc<ShuffleFlightServer>>,
@@ -671,95 +682,6 @@ pub async fn execute_local_plan(
     Ok((LocalPlanOutput::Partitions(partitions), stats))
 }
 
-/// Run multiple batches of inputs through a **single, shared** pipeline and
-/// return each batch's `ExecutionStats` snapshot.
-///
-/// This mirrors how `NativeExecutor::run` handles tasks with identical
-/// `plan_fingerprint`s: one pipeline is constructed and reused across all
-/// inputs, with each batch tagged by a distinct `InputId`. It is intended for
-/// tests that need to exercise the plan-sharing path (e.g. verifying that
-/// per-input stats reported via `take_input_snapshot` do not double-count
-/// shared source state such as `IOStats`).
-///
-/// Must be called from within a tokio runtime context.
-pub async fn execute_local_plan_shared(
-    plan: &LocalPhysicalPlanRef,
-    config: std::sync::Arc<DaftExecutionConfig>,
-    batches: Vec<(daft_local_plan::InputId, HashMap<SourceId, Input>)>,
-) -> DaftResult<Vec<(daft_local_plan::InputId, ExecutionStats)>> {
-    use tokio::runtime::Handle;
-
-    use crate::pipeline::{BuilderContext, PipelineMessage};
-
-    let handle = Handle::current();
-    let query_id = QueryID::from("");
-
-    let ctx = BuilderContext::new();
-    let (pipeline, input_senders) =
-        crate::pipeline::translate_physical_plan_to_pipeline(plan, &config, &ctx)?;
-
-    let stats_manager = RuntimeStatsManager::try_new(
-        &handle,
-        &pipeline,
-        vec![],
-        query_id,
-        false, // not a flotilla worker
-    )?;
-    let stats_handle = stats_manager.handle();
-
-    // Send each batch on its own InputId, then drop senders to signal EOF.
-    let mut input_ids: Vec<daft_local_plan::InputId> = Vec::with_capacity(batches.len());
-    for (input_id, inputs) in batches {
-        input_ids.push(input_id);
-        for (key, plan_input) in inputs {
-            if let Some(sender) = input_senders.get(&key) {
-                let _ = sender.send(input_id, plan_input);
-            }
-        }
-    }
-    drop(input_senders);
-
-    let memory_manager = get_or_init_memory_manager();
-    let mut runtime_handle =
-        ExecutionRuntimeContext::new(memory_manager.clone(), stats_handle.clone());
-    let mut output_receiver = pipeline.start(true, &mut runtime_handle)?;
-
-    // Drain pipeline output until completion (discarding partitions — tests
-    // that need data should use `execute_local_plan` per-input).
-    loop {
-        tokio::select! {
-            Some(join_result) = runtime_handle.join_next() => {
-                join_result?;
-            }
-            msg = output_receiver.recv() => {
-                match msg {
-                    Some(PipelineMessage::Morsel { .. })
-                    | Some(PipelineMessage::FlightPartitionRef { .. })
-                    | Some(PipelineMessage::Flush(_)) => {}
-                    None => {
-                        runtime_handle.shutdown().await?;
-                        break;
-                    }
-                }
-            }
-        }
-    }
-
-    stats_manager
-        .finish(common_metrics::QueryEndState::Finished)
-        .await;
-
-    let mut per_input_stats = Vec::with_capacity(input_ids.len());
-    for input_id in input_ids {
-        let stats = stats_handle
-            .take_input_snapshot(input_id)
-            .await
-            .unwrap_or_else(|_| ExecutionStats::new(QueryID::from(""), vec![]));
-        per_input_stats.push((input_id, stats));
-    }
-    Ok(per_input_stats)
-}
-
 pub struct ExecutionEngineResult {
     receiver: crate::channel::UnboundedReceiver<ExecutionEngineResultItem>,
 }
@@ -767,6 +689,14 @@ pub struct ExecutionEngineResult {
 impl ExecutionEngineResult {
     async fn next(&mut self) -> Option<ExecutionEngineResultItem> {
         self.receiver.recv().await
+    }
+
+    /// Consume all pipeline output for this input_id until EOF. Intended for
+    /// tests that exercise `NativeExecutor` and don't care about partition
+    /// contents but need the pipeline to finish producing output before
+    /// `try_finish` is called.
+    pub async fn drain_for_testing(mut self) {
+        while self.receiver.recv().await.is_some() {}
     }
 }
 

--- a/src/daft-local-execution/src/run.rs
+++ b/src/daft-local-execution/src/run.rs
@@ -691,12 +691,20 @@ impl ExecutionEngineResult {
         self.receiver.recv().await
     }
 
-    /// Consume all pipeline output for this input_id until EOF. Intended for
-    /// tests that exercise `NativeExecutor` and don't care about partition
-    /// contents but need the pipeline to finish producing output before
-    /// `try_finish` is called.
-    pub async fn drain_for_testing(mut self) {
-        while self.receiver.recv().await.is_some() {}
+    /// Consume all pipeline output for this input_id until EOF, returning any
+    /// emitted `MicroPartition`s. `FlightPartitionRef` items are skipped (they
+    /// are only relevant when shuffles are enabled). Intended for tests that
+    /// exercise `NativeExecutor` end-to-end and need the pipeline to finish
+    /// producing output before `try_finish` is called — mirroring what the
+    /// production Python `__anext__` loop does.
+    pub async fn collect_partitions_for_testing(mut self) -> Vec<MicroPartition> {
+        let mut out = Vec::new();
+        while let Some(item) = self.receiver.recv().await {
+            if let ExecutionEngineResultItem::Partition(p) = item {
+                out.push(p);
+            }
+        }
+        out
     }
 }
 


### PR DESCRIPTION
## Summary

Extends the distributed test infrastructure added in #6697 so tests exercise the real Ray Flotilla execution path — scheduler → worker → `NativeExecutor` with plan sharing — without needing a Ray cluster.

## Motivation

#6697 added `LocalSwordfishWorker` and a statistics-tests suite, but the worker ran each task through a fresh `execute_local_plan` pipeline. That diverges from real Flotilla on the hottest piece of execution state: each Ray worker process owns one `NativeExecutor` and caches pipelines by `plan_fingerprint`, so tasks with identical plans share the same pipeline, `IOStatsRef`, `RuntimeStatsManager`, and so on. Shared-state bugs that exist in production can't be caught by tests that isolate every task.

This change brings the local harness into alignment with the real worker topology, so operator tests all follow one pattern and the pattern matches production.

## Changes

**`LocalSwordfishWorker` now owns a `NativeExecutor`** — one per worker, matching one Ray worker process = one executor. All tasks routed to the worker flow through it, so same-fingerprint tasks share a pipeline exactly as in production. Defaults to 8 CPUs so the scheduler dispatches concurrently; at 1 CPU the first `try_finish` would tear down the plan before the next task started and mask shared-state behavior.

**End-to-end scheduler-driven harness** — `run_pipeline_and_get_stats` now drives the pipeline through the same `SchedulerActor → Dispatcher → LocalSwordfishWorker → NativeExecutor` chain that `PlanRunner::run_plan` uses in production. Stats are fed to the `StatisticsManager` by the real `Dispatcher::await_completed_tasks` path, so tests no longer manually call `feed_stats_to_manager`. The old helpers (`run_task_locally`, `feed_stats_to_manager`, `extract_tasks`) are removed — operator tests just build a pipeline and call `run_pipeline_and_get_stats`.

**Optional flotilla-worker mode** — `LocalSwordfishWorker::with_flotilla_mode(..., is_flotilla_worker: true, ip)` lets tests start the real `ShuffleFlightServer` that Ray workers run. Default stays `false` since most tests don't need shuffles.

**Supporting changes in `daft-local-execution`**:
- Promote `NativeExecutor` to `pub` and re-export via `testing`.
- Implement `get_global_runtime` for non-python builds (was `unimplemented!()`), so `NativeExecutor::run` is callable from plain `cargo test`.
- Add `ExecutionEngineResult::collect_partitions_for_testing` so the worker returns real `MaterializedOutput`s to the scheduler.

**Supporting changes in `daft-distributed`**:
- Export `RunningPlan` from `plan::*` and make its `new` `pub(crate)` so tests can drive materialization without `PlanRunner` (whose `block_on_current_thread` can't be called from inside a tokio test).

## Differences from real Ray Flotilla

Only what's inherent to running without a cluster:
- Single process, single tokio runtime — no serialization boundary, no network hops, no worker-death scenarios.
- `is_flotilla_worker=false` by default.

## Validation

The four existing statistics tests (`test_sort_{single,multi}_partition_stats`, `test_filter_stats_{aggregation,multi_partition}`) pass on the new harness without any assertion changes — confirming the refactor is behavior-preserving.

There's also an `#[ignore]`'d test `test_scan_source_bytes_read_multiple_files` included as a concrete demonstration of what the harness can now catch: it reproduces a `bytes.read` overreport on multi-file scans (5 files → 5× overreport) by exercising the per-worker plan-sharing path. Kept ignored so CI stays green on this PR; it can be un-ignored once the underlying bug is fixed in a follow-up.

## Test plan
- [x] `cargo test -p daft-distributed statistics::tests::` — 4 passed, 1 ignored, 0 failed
- [x] `cargo test -p daft-distributed test_scan_source_bytes_read_multiple_files -- --ignored` — still fails, demonstrating the harness exercises the shared-state path

https://claude.ai/code/session_01KBvXEhnwa3EkbvsXYHyat2