### PR TITLE
feat(distributed): emit TaskSubmit and TaskEnd lifecycle events

### DIFF
--- a/src/daft-context/src/lib.rs
+++ b/src/daft-context/src/lib.rs
@@ -241,6 +241,10 @@ impl DaftContext {
         self.dispatch_event(&event, "notify exec emit stats")
     }
 
+    pub fn notify_event(&self, event: &Event) -> DaftResult<()> {
+        self.dispatch_event(event, "notify event")
+    }
+
     fn dispatch_event(&self, event: &Event, err_context: &'static str) -> DaftResult<()> {
         let subscribers = self.with_state(|state| {
             state

--- a/src/daft-context/src/lib.rs
+++ b/src/daft-context/src/lib.rs
@@ -241,7 +241,7 @@ impl DaftContext {
         self.dispatch_event(&event, "notify exec emit stats")
     }
 
-    pub fn notify_event(&self, event: &Event) -> DaftResult<()> {
+    pub fn notify(&self, event: &Event) -> DaftResult<()> {
         self.dispatch_event(event, "notify event")
     }
 

--- a/src/daft-context/src/subscribers/dashboard.rs
+++ b/src/daft-context/src/subscribers/dashboard.rs
@@ -527,6 +527,9 @@ impl Subscriber for DashboardSubscriber {
                     self.on_result_out(e.header.query_id.clone(), result.clone())?;
                 }
             }
+            // TODO: hook up with dashboard server
+            Event::TaskEnd(_) => {}
+            Event::TaskSubmit(_) => {}
         }
         Ok(())
     }

--- a/src/daft-context/src/subscribers/debug.rs
+++ b/src/daft-context/src/subscribers/debug.rs
@@ -7,7 +7,7 @@ use crate::subscribers::{
     events::{
         ExecEndEvent, ExecStartEvent, OperatorEndEvent, OperatorStartEvent,
         OptimizationCompleteEvent, OptimizationStartEvent, ProcessStatsEvent, QueryEndEvent,
-        QueryStartEvent, ResultOutEvent, StatsEvent,
+        QueryStartEvent, ResultOutEvent, StatsEvent, TaskEndEvent, TaskSubmitEvent,
     },
 };
 
@@ -176,6 +176,56 @@ impl DebugSubscriber {
         );
         Ok(())
     }
+
+    fn handle_task_submit(&self, event: &TaskSubmitEvent) -> DaftResult<()> {
+        eprintln!(
+            "task_submit query_id={} task_id={} node_ids={:?}",
+            event.header.query_id, event.task.id, event.task.node_ids
+        );
+        Ok(())
+    }
+
+    fn handle_task_end(&self, event: &TaskEndEvent) -> DaftResult<()> {
+        let rendered_stats = event
+            .stats
+            .iter()
+            .map(|(node_info, snapshot)| {
+                if let Some(origin_node_id) = node_info.node_origin_id {
+                    format!(
+                        "node_id={} origin_node_id={} stats={snapshot:?}",
+                        node_info.id, origin_node_id
+                    )
+                } else {
+                    format!("node_id={} stats={snapshot:?}", node_info.id)
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(" ");
+
+        match (&event.worker_id, &event.outcome, rendered_stats.is_empty()) {
+            (Some(worker_id), outcome, true) => eprintln!(
+                "task_end query_id={} task_id={} worker_id={} outcome={outcome:?} node_ids={:?}",
+                event.header.query_id, event.task.id, worker_id, event.task.node_ids
+            ),
+            (None, outcome, true) => eprintln!(
+                "task_end query_id={} task_id={} outcome={outcome:?} node_ids={:?}",
+                event.header.query_id, event.task.id, event.task.node_ids
+            ),
+            (Some(worker_id), outcome, false) => eprintln!(
+                "task_end query_id={} task_id={} worker_id={} outcome={outcome:?} node_ids={:?} {}",
+                event.header.query_id,
+                event.task.id,
+                worker_id,
+                event.task.node_ids,
+                rendered_stats
+            ),
+            (None, outcome, false) => eprintln!(
+                "task_end query_id={} task_id={} outcome={outcome:?} node_ids={:?} {}",
+                event.header.query_id, event.task.id, event.task.node_ids, rendered_stats
+            ),
+        }
+        Ok(())
+    }
 }
 
 impl Subscriber for DebugSubscriber {
@@ -194,6 +244,8 @@ impl Subscriber for DebugSubscriber {
             Event::Stats(e) => self.handle_stats(&e)?,
             Event::ProcessStats(e) => self.handle_process_stats(&e)?,
             Event::ResultOut(e) => self.handle_result_out(&e)?,
+            Event::TaskSubmit(e) => self.handle_task_submit(&e)?,
+            Event::TaskEnd(e) => self.handle_task_end(&e)?,
         }
         Ok(())
     }

--- a/src/daft-context/src/subscribers/events.rs
+++ b/src/daft-context/src/subscribers/events.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use common_metrics::{
-    NodeID, QueryID, QueryPlan, Stats,
+    NodeID, QueryID, QueryPlan, StatSnapshot, Stats,
     ops::{NodeCategory, NodeInfo, NodeType},
 };
 use daft_micropartition::MicroPartitionRef;
@@ -17,6 +17,8 @@ pub enum Event {
     OptimizationComplete(OptimizationCompleteEvent),
     ExecStart(ExecStartEvent),
     ExecEnd(ExecEndEvent),
+    TaskSubmit(TaskSubmitEvent),
+    TaskEnd(TaskEndEvent),
     OperatorStart(OperatorStartEvent),
     OperatorEnd(OperatorEndEvent),
     Stats(StatsEvent),
@@ -142,4 +144,39 @@ pub struct ResultOutEvent {
     pub num_rows: u64,
     // needed by the dashboard subscriber
     pub data: Option<MicroPartitionRef>,
+}
+
+#[derive(Debug, Clone)]
+pub struct TaskMeta {
+    pub id: u32,
+    pub node_ids: Vec<u32>,
+}
+
+#[derive(Debug, Clone)]
+pub struct TaskSubmitEvent {
+    pub header: EventHeader,
+    pub task: Arc<TaskMeta>,
+}
+
+#[derive(Debug, Clone)]
+pub struct TaskStartEvent {
+    pub header: EventHeader,
+    pub task: Arc<TaskMeta>,
+    pub worker_id: Arc<str>,
+}
+
+#[derive(Debug, Clone)]
+pub struct TaskEndEvent {
+    pub header: EventHeader,
+    pub task: Arc<TaskMeta>,
+    pub worker_id: Option<Arc<str>>,
+    pub outcome: TaskOutcome,
+    pub stats: Vec<(Arc<NodeInfo>, StatSnapshot)>,
+}
+
+#[derive(Debug, Clone)]
+pub enum TaskOutcome {
+    Success,
+    Failed { message: String },
+    Cancelled,
 }

--- a/src/daft-context/src/subscribers/python.rs
+++ b/src/daft-context/src/subscribers/python.rs
@@ -26,9 +26,10 @@ pub struct PySubscriberWrapper(pub(crate) Py<PyAny>);
 impl Subscriber for PySubscriberWrapper {
     fn on_event(&self, event: Event) -> DaftResult<()> {
         Python::attach(|py| {
-            let py_event = build_py_event(py, event)?;
-            self.0
-                .call_method1(py, intern!(py, "on_event"), (py_event,))?;
+            if let Some(py_event) = build_py_event(py, event)? {
+                self.0
+                    .call_method1(py, intern!(py, "on_event"), (py_event,))?;
+            }
             Ok(())
         })
     }
@@ -167,19 +168,21 @@ fn build_result_produced(py: Python<'_>, event: &ResultOutEvent) -> PyResult<Py<
         .map(Into::into)
 }
 
-fn build_py_event(py: Python<'_>, event: Event) -> PyResult<Py<PyAny>> {
+fn build_py_event(py: Python<'_>, event: Event) -> PyResult<Option<Py<PyAny>>> {
     match event {
-        Event::QueryStart(event) => build_query_started(py, &event),
-        Event::QueryHeartbeat(event) => build_query_heartbeat(py, &event),
-        Event::QueryEnd(event) => build_query_finished(py, &event),
-        Event::OptimizationStart(event) => build_optimization_started(py, &event),
-        Event::OptimizationComplete(event) => build_optimization_completed(py, &event),
-        Event::ExecStart(event) => build_execution_started(py, &event),
-        Event::ExecEnd(event) => build_execution_finished(py, &event),
-        Event::OperatorStart(event) => build_operator_started(py, &event),
-        Event::OperatorEnd(event) => build_operator_finished(py, &event),
-        Event::Stats(event) => build_stats(py, &event),
-        Event::ProcessStats(event) => build_process_stats(py, &event),
-        Event::ResultOut(event) => build_result_produced(py, &event),
+        Event::QueryStart(event) => build_query_started(py, &event).map(Some),
+        Event::QueryHeartbeat(event) => build_query_heartbeat(py, &event).map(Some),
+        Event::QueryEnd(event) => build_query_finished(py, &event).map(Some),
+        Event::OptimizationStart(event) => build_optimization_started(py, &event).map(Some),
+        Event::OptimizationComplete(event) => build_optimization_completed(py, &event).map(Some),
+        Event::ExecStart(event) => build_execution_started(py, &event).map(Some),
+        Event::ExecEnd(event) => build_execution_finished(py, &event).map(Some),
+        Event::OperatorStart(event) => build_operator_started(py, &event).map(Some),
+        Event::OperatorEnd(event) => build_operator_finished(py, &event).map(Some),
+        Event::Stats(event) => build_stats(py, &event).map(Some),
+        Event::ProcessStats(event) => build_process_stats(py, &event).map(Some),
+        Event::ResultOut(event) => build_result_produced(py, &event).map(Some),
+        Event::TaskSubmit(_event) => Ok(None),
+        Event::TaskEnd(_event) => Ok(None),
     }
 }

--- a/src/daft-distributed/src/scheduling/dispatcher.rs
+++ b/src/daft-distributed/src/scheduling/dispatcher.rs
@@ -102,8 +102,9 @@ impl<W: Worker> Dispatcher<W> {
                 // Always mark the task as finished regardless of the result
                 worker_manager.mark_task_finished(task.task_context(), worker_id.clone());
                 // Send the event to the statistics manager
-                self.statistics_manager
-                    .handle_event((task.task_context(), &task_result).into())?;
+
+                let event = (task.task_context(), &task_result, worker_id.clone()).into();
+                self.statistics_manager.handle_event(event)?;
 
                 match task_result {
                     Ok(task_status) => match task_status {

--- a/src/daft-distributed/src/scheduling/dispatcher.rs
+++ b/src/daft-distributed/src/scheduling/dispatcher.rs
@@ -8,7 +8,10 @@ use super::{
     task::{Task, TaskResultAwaiter, TaskStatus},
     worker::{Worker, WorkerManager},
 };
-use crate::{scheduling::task::TaskResultHandle, statistics::StatisticsManagerRef};
+use crate::{
+    scheduling::task::TaskResultHandle,
+    statistics::{StatisticsManagerRef, TaskEvent},
+};
 
 const DISPATCHER_LOG_TARGET: &str = "DaftFlotillaDispatcher";
 
@@ -102,8 +105,7 @@ impl<W: Worker> Dispatcher<W> {
                 // Always mark the task as finished regardless of the result
                 worker_manager.mark_task_finished(task.task_context(), worker_id.clone());
                 // Send the event to the statistics manager
-
-                let event = (task.task_context(), &task_result, worker_id.clone()).into();
+                let event = TaskEvent::new(task.task_context(), &task_result, worker_id.clone());
                 self.statistics_manager.handle_event(event)?;
 
                 match task_result {

--- a/src/daft-distributed/src/statistics/mod.rs
+++ b/src/daft-distributed/src/statistics/mod.rs
@@ -50,22 +50,8 @@ pub(crate) enum TaskEvent {
 }
 
 impl TaskEvent {
-    pub fn context(&self) -> &TaskContext {
-        match self {
-            Self::Submitted { context, .. } => context,
-            Self::Scheduled { context, .. } => context,
-            Self::Completed { context, .. } => context,
-            Self::Failed { context, .. } => context,
-            Self::Cancelled { context, .. } => context,
-        }
-    }
-}
-
-impl From<(TaskContext, &DaftResult<TaskStatus>, WorkerId)> for TaskEvent {
-    fn from(
-        (context, task_result, worker_id): (TaskContext, &DaftResult<TaskStatus>, WorkerId),
-    ) -> Self {
-        match task_result {
+    pub fn new(context: TaskContext, result: &DaftResult<TaskStatus>, worker_id: WorkerId) -> Self {
+        match result {
             Ok(task_status) => match task_status {
                 TaskStatus::Success { stats, .. } => Self::Completed {
                     context,
@@ -85,22 +71,32 @@ impl From<(TaskContext, &DaftResult<TaskStatus>, WorkerId)> for TaskEvent {
                 TaskStatus::WorkerDied => Self::Failed {
                     context,
                     reason: "Worker died".to_string(),
-                    worker_id: None,
+                    worker_id: Some(worker_id),
                     retryable: true,
                 },
                 TaskStatus::WorkerUnavailable => Self::Failed {
                     context,
                     reason: "Worker unavailable".to_string(),
-                    worker_id: None,
+                    worker_id: Some(worker_id),
                     retryable: true,
                 },
             },
             Err(error) => Self::Failed {
                 context,
                 reason: error.to_string(),
-                worker_id: None,
+                worker_id: Some(worker_id),
                 retryable: false,
             },
+        }
+    }
+
+    pub fn context(&self) -> &TaskContext {
+        match self {
+            Self::Submitted { context, .. } => context,
+            Self::Scheduled { context, .. } => context,
+            Self::Completed { context, .. } => context,
+            Self::Failed { context, .. } => context,
+            Self::Cancelled { context, .. } => context,
         }
     }
 }

--- a/src/daft-distributed/src/statistics/mod.rs
+++ b/src/daft-distributed/src/statistics/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod stats;
+pub(crate) mod task_lifecycle;
 
 use std::{
     collections::HashMap,
@@ -13,7 +14,10 @@ pub use stats::RuntimeStats;
 
 use crate::{
     pipeline_node::{DistributedPipelineNode, NodeID},
-    scheduling::task::{TaskContext, TaskName, TaskStatus},
+    scheduling::{
+        task::{TaskContext, TaskName, TaskStatus},
+        worker::WorkerId,
+    },
     statistics::stats::RuntimeNodeManager,
 };
 
@@ -26,17 +30,19 @@ pub(crate) enum TaskEvent {
         context: TaskContext,
         name: TaskName,
     },
-
     Scheduled {
         context: TaskContext,
     },
     Completed {
         context: TaskContext,
         stats: ExecutionStats,
+        worker_id: WorkerId,
     },
     Failed {
         context: TaskContext,
         reason: String,
+        worker_id: Option<WorkerId>,
+        retryable: bool,
     },
     Cancelled {
         context: TaskContext,
@@ -55,31 +61,45 @@ impl TaskEvent {
     }
 }
 
-impl From<(TaskContext, &DaftResult<TaskStatus>)> for TaskEvent {
-    fn from((context, task_result): (TaskContext, &DaftResult<TaskStatus>)) -> Self {
+impl From<(TaskContext, &DaftResult<TaskStatus>, WorkerId)> for TaskEvent {
+    fn from(
+        (context, task_result, worker_id): (TaskContext, &DaftResult<TaskStatus>, WorkerId),
+    ) -> Self {
         match task_result {
             Ok(task_status) => match task_status {
                 TaskStatus::Success { stats, .. } => Self::Completed {
                     context,
                     stats: stats.clone(),
+                    worker_id,
                 },
                 TaskStatus::Failed { error } => Self::Failed {
                     context,
                     reason: error.to_string(),
+                    worker_id: Some(worker_id),
+                    retryable: false,
                 },
                 TaskStatus::Cancelled => Self::Cancelled { context },
+                // WorkerDied and WorkerUnavailable are the only
+                // task statuses that get retried in the dispatcher
+                // src/daft-distributed/src/scheduling/dispatcher.rs
                 TaskStatus::WorkerDied => Self::Failed {
                     context,
                     reason: "Worker died".to_string(),
+                    worker_id: None,
+                    retryable: true,
                 },
                 TaskStatus::WorkerUnavailable => Self::Failed {
                     context,
                     reason: "Worker unavailable".to_string(),
+                    worker_id: None,
+                    retryable: true,
                 },
             },
             Err(error) => Self::Failed {
                 context,
                 reason: error.to_string(),
+                worker_id: None,
+                retryable: false,
             },
         }
     }

--- a/src/daft-distributed/src/statistics/stats.rs
+++ b/src/daft-distributed/src/statistics/stats.rs
@@ -474,6 +474,7 @@ mod tests {
             let event = TaskEvent::Completed {
                 context: TaskContext::new(0, 42, 1, vec![42], 0),
                 stats: ExecutionStats::new("".into(), vec![(local_node_info, local_snapshot)]),
+                worker_id: "worker-1".into(),
             };
 
             manager.handle_task_event(&event);

--- a/src/daft-distributed/src/statistics/stats.rs
+++ b/src/daft-distributed/src/statistics/stats.rs
@@ -326,6 +326,7 @@ mod tests {
         TaskEvent::Completed {
             context: TaskContext::default(),
             stats: ExecutionStats::new("q".into(), nodes),
+            worker_id: "worker-1".into(),
         }
     }
 
@@ -358,6 +359,8 @@ mod tests {
         TaskEvent::Failed {
             context: TaskContext::default(),
             reason: "boom".into(),
+            worker_id: None,
+            retryable: false,
         }
     }
 

--- a/src/daft-distributed/src/statistics/task_lifecycle.rs
+++ b/src/daft-distributed/src/statistics/task_lifecycle.rs
@@ -33,7 +33,7 @@ impl TaskLifecycleEventSubscriber {
 
 impl StatisticsSubscriber for TaskLifecycleEventSubscriber {
     fn handle_event(&mut self, event: &TaskEvent) -> DaftResult<()> {
-        let result = match event {
+        match event {
             TaskEvent::Submitted { context, .. } => {
                 let submit_event = Event::TaskSubmit(TaskSubmitEvent {
                     header: event_header(self.query_id.clone()),
@@ -87,8 +87,7 @@ impl StatisticsSubscriber for TaskLifecycleEventSubscriber {
                 self.dispatch_event(&end_event)
             }
             _ => Ok(()),
-        };
-        result
+        }
     }
 }
 

--- a/src/daft-distributed/src/statistics/task_lifecycle.rs
+++ b/src/daft-distributed/src/statistics/task_lifecycle.rs
@@ -1,0 +1,101 @@
+use std::sync::Arc;
+
+use common_error::DaftResult;
+use common_metrics::QueryID;
+use daft_context::{
+    DaftContext, get_context,
+    subscribers::{
+        event_header,
+        events::{Event, TaskEndEvent, TaskMeta, TaskOutcome, TaskSubmitEvent},
+    },
+};
+
+use crate::{
+    scheduling::task::TaskContext,
+    statistics::{StatisticsSubscriber, TaskEvent},
+};
+
+pub(crate) struct TaskLifecycleEventSubscriber {
+    context: DaftContext,
+    query_id: QueryID,
+}
+
+impl TaskLifecycleEventSubscriber {
+    pub fn new(query_id: QueryID) -> Self {
+        let context = get_context();
+        Self { context, query_id }
+    }
+
+    fn dispatch_event(&self, event: &Event) -> DaftResult<()> {
+        self.context.notify_event(event)
+    }
+}
+
+impl StatisticsSubscriber for TaskLifecycleEventSubscriber {
+    fn handle_event(&mut self, event: &TaskEvent) -> DaftResult<()> {
+        let result = match event {
+            TaskEvent::Submitted { context, .. } => {
+                let submit_event = Event::TaskSubmit(TaskSubmitEvent {
+                    header: event_header(self.query_id.clone()),
+                    task: task_meta_from_context(context),
+                });
+                self.dispatch_event(&submit_event)
+            }
+            TaskEvent::Completed {
+                context,
+                stats,
+                worker_id,
+            } => {
+                let end_event = Event::TaskEnd(TaskEndEvent {
+                    header: event_header(self.query_id.clone()),
+                    task: task_meta_from_context(context),
+                    worker_id: Some(worker_id.clone()),
+                    outcome: TaskOutcome::Success,
+                    stats: stats.nodes.clone(),
+                });
+                self.dispatch_event(&end_event)
+            }
+            TaskEvent::Failed {
+                context,
+                reason,
+                worker_id,
+                retryable,
+            } => {
+                if *retryable {
+                    Ok(())
+                } else {
+                    let end_event = Event::TaskEnd(TaskEndEvent {
+                        header: event_header(self.query_id.clone()),
+                        task: task_meta_from_context(context),
+                        worker_id: worker_id.clone(),
+                        outcome: TaskOutcome::Failed {
+                            message: reason.into(),
+                        },
+                        stats: vec![],
+                    });
+                    self.dispatch_event(&end_event)
+                }
+            }
+            TaskEvent::Cancelled { context } => {
+                let end_event = Event::TaskEnd(TaskEndEvent {
+                    header: event_header(self.query_id.clone()),
+                    task: task_meta_from_context(context),
+                    worker_id: None,
+                    outcome: TaskOutcome::Cancelled,
+                    stats: vec![],
+                });
+                self.dispatch_event(&end_event)
+            }
+            _ => Ok(()),
+        };
+        result
+    }
+}
+
+fn task_meta_from_context(context: &TaskContext) -> Arc<TaskMeta> {
+    let meta = TaskMeta {
+        id: context.task_id,
+        node_ids: context.node_ids.clone(),
+    };
+    Arc::new(meta)
+}

--- a/src/daft-distributed/src/statistics/task_lifecycle.rs
+++ b/src/daft-distributed/src/statistics/task_lifecycle.rs
@@ -29,7 +29,7 @@ impl TaskLifecycleEventSubscriber {
     }
 
     fn dispatch_event(&self, event: &Event) -> DaftResult<()> {
-        self.context.notify_event(event)
+        self.context.notify(event)
     }
 }
 

--- a/src/daft-distributed/src/statistics/task_lifecycle.rs
+++ b/src/daft-distributed/src/statistics/task_lifecycle.rs
@@ -15,11 +15,13 @@ use crate::{
     statistics::{StatisticsSubscriber, TaskEvent},
 };
 
+#[allow(dead_code)]
 pub(crate) struct TaskLifecycleEventSubscriber {
     context: DaftContext,
     query_id: QueryID,
 }
 
+#[allow(dead_code)]
 impl TaskLifecycleEventSubscriber {
     pub fn new(query_id: QueryID) -> Self {
         let context = get_context();
@@ -91,6 +93,7 @@ impl StatisticsSubscriber for TaskLifecycleEventSubscriber {
     }
 }
 
+#[allow(dead_code)]
 fn task_meta_from_context(context: &TaskContext) -> Arc<TaskMeta> {
     let meta = TaskMeta {
         id: context.task_id,


### PR DESCRIPTION
## Changes Made

Introduce a new TaskLifecycleEventSubscriber that bridges the internal TaskEvent stream to the daft-context Event bus as TaskSubmit and TaskEnd events, giving subscribers a 1:1 submit/end pairing per logical task. 
Follow ups will include
* emitting the TaskStart event 
* attaching the subscriber when enabled through an environment variable
* task retry accounting
