### PR TITLE
refactor(flight): implement into_partitions for flight shuffle

### DIFF
--- a/src/daft-distributed/src/pipeline_node/into_partitions.rs
+++ b/src/daft-distributed/src/pipeline_node/into_partitions.rs
@@ -11,8 +11,8 @@ use futures::StreamExt;
 use super::{PipelineNodeImpl, TaskBuilderStream};
 use crate::{
     pipeline_node::{
-        DistributedPipelineNode, MaterializedOutput, NodeID, PipelineNodeConfig,
-        PipelineNodeContext,
+        DistributedPipelineNode, NodeID, PipelineNodeConfig, PipelineNodeContext,
+        shuffles::backends::{DistributedShuffleBackend, ShuffleBackend},
     },
     plan::{PlanConfig, PlanExecutionContext, TaskIDCounter},
     scheduling::{
@@ -27,6 +27,7 @@ pub(crate) struct IntoPartitionsNode {
     config: PipelineNodeConfig,
     context: PipelineNodeContext,
     num_partitions: usize,
+    shuffle_backend: ShuffleBackend,
     child: DistributedPipelineNode,
 }
 
@@ -38,6 +39,7 @@ impl IntoPartitionsNode {
         plan_config: &PlanConfig,
         num_partitions: usize,
         schema: SchemaRef,
+        backend: DistributedShuffleBackend,
         child: DistributedPipelineNode,
     ) -> Self {
         let context = PipelineNodeContext::new(
@@ -49,15 +51,17 @@ impl IntoPartitionsNode {
             NodeCategory::BlockingSink,
         );
         let config = PipelineNodeConfig::new(
-            schema,
+            schema.clone(),
             plan_config.config.clone(),
             Arc::new(UnknownClusteringConfig::new(num_partitions).into()),
         );
+        let shuffle_backend = ShuffleBackend::new(&context, schema, backend);
 
         Self {
             config,
             context,
             num_partitions,
+            shuffle_backend,
             child,
         }
     }
@@ -121,19 +125,26 @@ impl IntoPartitionsNode {
         while let Some(result) = output_futures.join_next().await {
             // Collect all the outputs from this task and coalesce them into a single task.
             let materialized_outputs = result??;
-            let (in_memory_scan, psets) = MaterializedOutput::into_in_memory_scan_with_psets(
-                materialized_outputs,
-                self.config.schema.clone(),
-                self.node_id(),
+            let partition_refs = materialized_outputs
+                .into_iter()
+                .flat_map(|output| output.into_inner().0)
+                .collect::<Vec<_>>();
+
+            let node_id = self.node_id();
+            let shuffle_backend = self.shuffle_backend.local_shuffle_backend();
+            let builder = self.shuffle_backend.build_refs_task_builder(
+                partition_refs,
+                self.as_ref(),
+                move |input| {
+                    LocalPhysicalPlan::into_partitions(
+                        input,
+                        1,
+                        shuffle_backend,
+                        StatsState::NotMaterialized,
+                        LocalNodeContext::new(Some(node_id as usize)),
+                    )
+                },
             );
-            let plan = LocalPhysicalPlan::into_partitions(
-                in_memory_scan,
-                1,
-                StatsState::NotMaterialized,
-                LocalNodeContext::new(Some(self.node_id() as usize)),
-            );
-            let builder = SwordfishTaskBuilder::new(plan, self.as_ref(), self.node_id())
-                .with_psets(self.node_id(), psets);
             if result_tx.send(builder).await.is_err() {
                 break;
             }
@@ -175,6 +186,7 @@ impl IntoPartitionsNode {
                 LocalPhysicalPlan::into_partitions(
                     plan,
                     num_outputs,
+                    self.shuffle_backend.local_shuffle_backend(),
                     StatsState::NotMaterialized,
                     LocalNodeContext::new(Some(self.node_id() as usize)),
                 )
@@ -191,21 +203,17 @@ impl IntoPartitionsNode {
             output_futures.spawn(task);
         }
 
-        // Collect all the outputs and emit a new task for each output.
+        // Collect all the outputs and emit a new pass-through task for each output ref.
         while let Some(result) = output_futures.join_next().await {
             let materialized_outputs = result??;
             if let Some(output) = materialized_outputs {
                 for output in output.split_into_materialized_outputs() {
-                    let materialized_outputs = vec![output];
-                    let (in_memory_scan, psets) =
-                        MaterializedOutput::into_in_memory_scan_with_psets(
-                            materialized_outputs,
-                            self.config.schema.clone(),
-                            self.node_id(),
-                        );
-                    let builder =
-                        SwordfishTaskBuilder::new(in_memory_scan, self.as_ref(), self.node_id())
-                            .with_psets(self.node_id(), psets);
+                    let partition_refs = output.into_inner().0;
+                    let builder = self.shuffle_backend.build_refs_task_builder(
+                        partition_refs,
+                        self.as_ref(),
+                        |input| input,
+                    );
                     if result_tx.send(builder).await.is_err() {
                         break;
                     }
@@ -240,6 +248,7 @@ impl IntoPartitionsNode {
                             LocalPhysicalPlan::into_partitions(
                                 plan,
                                 1,
+                                self.shuffle_backend.local_shuffle_backend(),
                                 StatsState::NotMaterialized,
                                 LocalNodeContext::new(Some(node_id as usize)),
                             )
@@ -291,8 +300,12 @@ impl PipelineNodeImpl for IntoPartitionsNode {
     }
 
     fn multiline_display(&self, _verbose: bool) -> Vec<String> {
+        let backend_name = match self.shuffle_backend.backend() {
+            DistributedShuffleBackend::Ray => "Ray",
+            DistributedShuffleBackend::Flight(_) => "Flight",
+        };
         vec![
-            "IntoPartitions".to_string(),
+            format!("IntoPartitions({})", backend_name),
             format!("Num partitions = {}", self.num_partitions),
         ]
     }
@@ -301,6 +314,7 @@ impl PipelineNodeImpl for IntoPartitionsNode {
         self: Arc<Self>,
         plan_context: &mut PlanExecutionContext,
     ) -> TaskBuilderStream {
+        self.shuffle_backend.register_cleanup(plan_context);
         let input_stream = self.child.clone().produce_tasks(plan_context);
         let (result_tx, result_rx) = create_channel(1);
 

--- a/src/daft-distributed/src/pipeline_node/random_shuffle.rs
+++ b/src/daft-distributed/src/pipeline_node/random_shuffle.rs
@@ -7,7 +7,7 @@ use common_error::DaftResult;
 use common_metrics::ops::{NodeCategory, NodeType};
 use daft_dsl::expr::bound_expr::BoundExpr;
 use daft_functions::random::random_int_expr;
-use daft_local_plan::{LocalNodeContext, LocalPhysicalPlan, RepartitionWriteBackend};
+use daft_local_plan::{LocalNodeContext, LocalPhysicalPlan, ShuffleBackend};
 use daft_logical_plan::{partitioning::RandomShuffleConfig, stats::StatsState};
 use daft_schema::schema::SchemaRef;
 
@@ -162,7 +162,7 @@ impl PipelineNodeImpl for RandomShuffleNode {
                 input,
                 num_partitions,
                 schema.clone(),
-                RepartitionWriteBackend::Ray,
+                ShuffleBackend::Ray,
                 daft_logical_plan::partitioning::RepartitionSpec::Random(
                     RandomShuffleConfig::new_with_seed(Some(num_partitions), seed),
                 ),

--- a/src/daft-distributed/src/pipeline_node/shuffles/backends/mod.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/backends/mod.rs
@@ -1,16 +1,15 @@
-use std::sync::Arc;
-
 use common_error::DaftResult;
+use common_partitioning::PartitionRef;
 use daft_local_plan::{
-    GatherWriteBackend, LocalNodeContext, LocalPhysicalPlan, RepartitionWriteBackend,
+    FlightShuffleReadInput, LocalNodeContext, LocalPhysicalPlan, LocalPhysicalPlanRef,
+    ShuffleBackend as LocalShuffleBackend, ShuffleReadBackend,
 };
-use daft_logical_plan::{partitioning::RepartitionSpec, stats::StatsState};
+use daft_logical_plan::stats::StatsState;
+use daft_partition_refs::FlightPartitionRef;
 use daft_schema::schema::SchemaRef;
 
 use crate::{
-    pipeline_node::{
-        MaterializedOutput, NodeID, PipelineNodeContext, PipelineNodeImpl, TaskBuilderStream,
-    },
+    pipeline_node::{MaterializedOutput, NodeID, PipelineNodeContext, PipelineNodeImpl},
     plan::PlanExecutionContext,
     scheduling::task::SwordfishTaskBuilder,
     utils::channel::Sender,
@@ -31,6 +30,7 @@ pub(crate) enum DistributedShuffleBackend {
     Flight(FlightShuffleBackendConfig),
 }
 
+#[derive(Clone)]
 pub(crate) struct ShuffleBackend {
     backend: DistributedShuffleBackend,
     schema: SchemaRef,
@@ -63,6 +63,14 @@ impl ShuffleBackend {
         &self.backend
     }
 
+    pub(crate) fn schema(&self) -> &SchemaRef {
+        &self.schema
+    }
+
+    pub(crate) fn node_id(&self) -> NodeID {
+        self.node_id
+    }
+
     pub(crate) fn register_cleanup(&self, plan_context: &mut PlanExecutionContext) {
         match &self.backend {
             DistributedShuffleBackend::Ray => {}
@@ -72,60 +80,72 @@ impl ShuffleBackend {
         }
     }
 
-    pub(crate) fn build_repartition_write_stage(
-        &self,
-        producer: Arc<dyn PipelineNodeImpl>,
-        input_node: TaskBuilderStream,
-        num_partitions: usize,
-        repartition_spec: RepartitionSpec,
-    ) -> TaskBuilderStream {
-        let schema = self.schema.clone();
-        let node_id = self.node_id;
-        let repartition_backend = match self.backend.clone() {
-            DistributedShuffleBackend::Ray => RepartitionWriteBackend::Ray,
-            DistributedShuffleBackend::Flight(backend) => RepartitionWriteBackend::Flight {
-                shuffle_id: backend.shuffle_id,
-                shuffle_dirs: backend.shuffle_dirs.clone(),
-                compression: backend.compression,
+    /// The local-plan `ShuffleBackend` matching this distributed shuffle
+    /// backend, for use when building local ops like `IntoPartitions`,
+    /// `GatherWrite`, or `RepartitionWrite`.
+    pub(crate) fn local_shuffle_backend(&self) -> LocalShuffleBackend {
+        match self.backend.clone() {
+            DistributedShuffleBackend::Ray => LocalShuffleBackend::Ray,
+            DistributedShuffleBackend::Flight(cfg) => LocalShuffleBackend::Flight {
+                shuffle_id: cfg.shuffle_id,
+                shuffle_dirs: cfg.shuffle_dirs,
+                compression: cfg.compression,
             },
-        };
-        input_node.pipeline_instruction(producer, move |input| {
-            LocalPhysicalPlan::repartition_write(
-                input,
-                num_partitions,
-                schema.clone(),
-                repartition_backend.clone(),
-                repartition_spec.clone(),
-                StatsState::NotMaterialized,
-                LocalNodeContext::new(Some(node_id as usize)),
-            )
-        })
+        }
     }
 
-    pub(crate) fn build_gather_write_stage(
+    /// Build a `SwordfishTaskBuilder` whose plan reads from already-materialized
+    /// partition refs (`in_memory_scan` for Ray, `shuffle_read(Flight)` for Flight)
+    /// and then applies `wrap_plan` on top. The partition refs are attached to
+    /// the task via the backend-appropriate API (`with_psets` /
+    /// `with_flight_shuffle_reads`).
+    pub(crate) fn build_refs_task_builder<F>(
         &self,
-        producer: Arc<dyn PipelineNodeImpl>,
-        input_node: TaskBuilderStream,
-    ) -> TaskBuilderStream {
-        let schema = self.schema.clone();
+        partition_refs: Vec<PartitionRef>,
+        node: &dyn PipelineNodeImpl,
+        wrap_plan: F,
+    ) -> SwordfishTaskBuilder
+    where
+        F: FnOnce(LocalPhysicalPlanRef) -> LocalPhysicalPlanRef,
+    {
         let node_id = self.node_id;
-        let gather_backend = match self.backend.clone() {
-            DistributedShuffleBackend::Ray => GatherWriteBackend::Ray,
-            DistributedShuffleBackend::Flight(backend) => GatherWriteBackend::Flight {
-                shuffle_id: backend.shuffle_id,
-                shuffle_dirs: backend.shuffle_dirs.clone(),
-                compression: backend.compression,
-            },
-        };
-        input_node.pipeline_instruction(producer, move |input| {
-            LocalPhysicalPlan::gather_write(
-                input,
-                schema.clone(),
-                gather_backend.clone(),
-                StatsState::NotMaterialized,
-                LocalNodeContext::new(Some(node_id as usize)),
-            )
-        })
+        match &self.backend {
+            DistributedShuffleBackend::Ray => {
+                let total_size_bytes = partition_refs.iter().map(|p| p.size_bytes()).sum::<usize>();
+                let in_memory_scan = LocalPhysicalPlan::in_memory_scan(
+                    node_id,
+                    self.schema.clone(),
+                    total_size_bytes,
+                    StatsState::NotMaterialized,
+                    LocalNodeContext::new(Some(node_id as usize)),
+                );
+                let plan = wrap_plan(in_memory_scan);
+                SwordfishTaskBuilder::new(plan, node, node_id).with_psets(node_id, partition_refs)
+            }
+            DistributedShuffleBackend::Flight(_) => {
+                let flight_refs = partition_refs
+                    .into_iter()
+                    .map(|p| {
+                        p.as_any()
+                            .downcast_ref::<FlightPartitionRef>()
+                            .expect("expected flight partition ref")
+                            .clone()
+                    })
+                    .collect::<Vec<_>>();
+                let shuffle_read = LocalPhysicalPlan::shuffle_read(
+                    node_id,
+                    self.schema.clone(),
+                    ShuffleReadBackend::Flight,
+                    StatsState::NotMaterialized,
+                    LocalNodeContext::new(Some(node_id as usize)),
+                );
+                let plan = wrap_plan(shuffle_read);
+                SwordfishTaskBuilder::new(plan, node, node_id).with_flight_shuffle_reads(
+                    node_id,
+                    vec![FlightShuffleReadInput { refs: flight_refs }],
+                )
+            }
+        }
     }
 
     pub(crate) async fn emit_read_tasks(

--- a/src/daft-distributed/src/pipeline_node/shuffles/gather.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/gather.rs
@@ -2,7 +2,8 @@ use std::sync::Arc;
 
 use common_error::DaftResult;
 use common_metrics::ops::{NodeCategory, NodeType};
-use daft_logical_plan::partitioning::UnknownClusteringConfig;
+use daft_local_plan::{LocalNodeContext, LocalPhysicalPlan};
+use daft_logical_plan::{partitioning::UnknownClusteringConfig, stats::StatsState};
 use daft_schema::schema::SchemaRef;
 use futures::TryStreamExt;
 
@@ -110,9 +111,19 @@ impl PipelineNodeImpl for GatherNode {
     ) -> TaskBuilderStream {
         let input_node = self.child.clone().produce_tasks(plan_context);
         self.shuffle_backend.register_cleanup(plan_context);
-        let local_gather_write_node = self
-            .shuffle_backend
-            .build_gather_write_stage(self.clone(), input_node);
+
+        let schema = self.shuffle_backend.schema().clone();
+        let node_id = self.shuffle_backend.node_id();
+        let local_shuffle_backend = self.shuffle_backend.local_shuffle_backend();
+        let local_gather_write_node = input_node.pipeline_instruction(self.clone(), move |input| {
+            LocalPhysicalPlan::gather_write(
+                input,
+                schema.clone(),
+                local_shuffle_backend.clone(),
+                StatsState::NotMaterialized,
+                LocalNodeContext::new(Some(node_id as usize)),
+            )
+        });
 
         let (result_tx, result_rx) = create_channel(1);
 

--- a/src/daft-distributed/src/pipeline_node/shuffles/repartition.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/repartition.rs
@@ -2,7 +2,8 @@ use std::sync::Arc;
 
 use common_error::DaftResult;
 use common_metrics::ops::{NodeCategory, NodeType};
-use daft_logical_plan::partitioning::RepartitionSpec;
+use daft_local_plan::{LocalNodeContext, LocalPhysicalPlan};
+use daft_logical_plan::{partitioning::RepartitionSpec, stats::StatsState};
 use daft_schema::schema::SchemaRef;
 
 use crate::{
@@ -112,12 +113,24 @@ impl PipelineNodeImpl for RepartitionNode {
         let input_node = self.child.clone().produce_tasks(plan_context);
         let self_arc = self.clone();
         self.shuffle_backend.register_cleanup(plan_context);
-        let local_shuffle_write_node = self.shuffle_backend.build_repartition_write_stage(
-            self.clone(),
-            input_node,
-            self.num_partitions,
-            self.repartition_spec.clone(),
-        );
+
+        let schema = self.shuffle_backend.schema().clone();
+        let node_id = self.shuffle_backend.node_id();
+        let local_shuffle_backend = self.shuffle_backend.local_shuffle_backend();
+        let num_partitions = self.num_partitions;
+        let repartition_spec = self.repartition_spec.clone();
+        let local_shuffle_write_node =
+            input_node.pipeline_instruction(self.clone(), move |input| {
+                LocalPhysicalPlan::repartition_write(
+                    input,
+                    num_partitions,
+                    schema.clone(),
+                    local_shuffle_backend.clone(),
+                    repartition_spec.clone(),
+                    StatsState::NotMaterialized,
+                    LocalNodeContext::new(Some(node_id as usize)),
+                )
+            });
 
         let (result_tx, result_rx) = create_channel(1);
 

--- a/src/daft-distributed/src/pipeline_node/shuffles/translate_shuffle.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/translate_shuffle.rs
@@ -17,7 +17,7 @@ use crate::pipeline_node::{
 
 impl LogicalPlanToPipelineNodeTranslator {
     /// Pick the shuffle backend implied by the current execution config.
-    fn select_backend(&self) -> DistributedShuffleBackend {
+    pub(crate) fn select_backend(&self) -> DistributedShuffleBackend {
         if self.plan_config.config.shuffle_algorithm.as_str() == "flight_shuffle" {
             DistributedShuffleBackend::Flight(FlightShuffleBackendConfig {
                 shuffle_dirs: self.plan_config.config.flight_shuffle_dirs.clone(),

--- a/src/daft-distributed/src/pipeline_node/sort.rs
+++ b/src/daft-distributed/src/pipeline_node/sort.rs
@@ -7,9 +7,7 @@ use common_metrics::{
     snapshot::StatSnapshotImpl,
 };
 use daft_dsl::expr::bound_expr::BoundExpr;
-use daft_local_plan::{
-    LocalNodeContext, LocalPhysicalPlan, RepartitionWriteBackend, SamplingMethod,
-};
+use daft_local_plan::{LocalNodeContext, LocalPhysicalPlan, SamplingMethod, ShuffleBackend};
 use daft_logical_plan::{
     partitioning::{RangeRepartitionConfig, RepartitionSpec},
     stats::StatsState,
@@ -250,7 +248,7 @@ pub(crate) fn create_range_repartition_tasks(
                 in_memory_source_plan,
                 num_partitions,
                 input_schema.clone(),
-                RepartitionWriteBackend::Ray,
+                ShuffleBackend::Ray,
                 RepartitionSpec::Range(RangeRepartitionConfig::new(
                     Some(num_partitions),
                     boundaries.clone(),

--- a/src/daft-distributed/src/pipeline_node/translate.rs
+++ b/src/daft-distributed/src/pipeline_node/translate.rs
@@ -363,16 +363,20 @@ impl TreeNodeVisitor for LogicalPlanToPipelineNodeTranslator {
                     )?
                 }
             },
-            LogicalPlan::IntoPartitions(into_partitions) => DistributedPipelineNode::new(
-                Arc::new(IntoPartitionsNode::new(
-                    self.get_next_pipeline_node_id(),
-                    &self.plan_config,
-                    into_partitions.num_partitions,
-                    node.schema(),
-                    self.curr_node.pop().unwrap(),
-                )),
-                &self.meter,
-            ),
+            LogicalPlan::IntoPartitions(into_partitions) => {
+                let backend = self.select_backend();
+                DistributedPipelineNode::new(
+                    Arc::new(IntoPartitionsNode::new(
+                        self.get_next_pipeline_node_id(),
+                        &self.plan_config,
+                        into_partitions.num_partitions,
+                        node.schema(),
+                        backend,
+                        self.curr_node.pop().unwrap(),
+                    )),
+                    &self.meter,
+                )
+            }
             LogicalPlan::Aggregate(aggregate) => {
                 let input_schema = aggregate.input.schema();
                 let group_by = BoundExpr::bind_all(&aggregate.groupby, &input_schema)?;

--- a/src/daft-local-execution/src/pipeline.rs
+++ b/src/daft-local-execution/src/pipeline.rs
@@ -18,12 +18,12 @@ use daft_dsl::{common_treenode::ConcreteTreeNode, join::get_common_join_cols};
 pub use daft_local_plan::InputId;
 use daft_local_plan::{
     AsofJoin, CommitWrite, Concat, CrossJoin, Dedup, Explode, Filter, FlightShuffleReadInput,
-    GatherWrite, GatherWriteBackend, GlobScan, HashAggregate, HashJoin, InMemoryScan, IntoBatches,
-    Limit, LocalNodeContext, LocalPhysicalPlan, MonotonicallyIncreasingId, PhysicalScan,
-    PhysicalWrite, Pivot, Project, RepartitionWrite, RepartitionWriteBackend, Sample,
-    ShuffleReadBackend, Sort, SortMergeJoin, SourceId, TopN, UDFProject, UnGroupedAggregate,
-    Unpivot, VLLMProject, WindowOrderByOnly, WindowPartitionAndDynamicFrame,
-    WindowPartitionAndOrderBy, WindowPartitionOnly,
+    GatherWrite, GlobScan, HashAggregate, HashJoin, InMemoryScan, IntoBatches, Limit,
+    LocalNodeContext, LocalPhysicalPlan, MonotonicallyIncreasingId, PhysicalScan, PhysicalWrite,
+    Pivot, Project, RepartitionWrite, Sample, ShuffleBackend, ShuffleReadBackend, Sort,
+    SortMergeJoin, SourceId, TopN, UDFProject, UnGroupedAggregate, Unpivot, VLLMProject,
+    WindowOrderByOnly, WindowPartitionAndDynamicFrame, WindowPartitionAndOrderBy,
+    WindowPartitionOnly,
 };
 use daft_logical_plan::{JoinType, stats::StatsState};
 use daft_micropartition::{MicroPartition, MicroPartitionRef};
@@ -1555,17 +1555,48 @@ fn physical_plan_to_pipeline(
             stats_state,
             schema,
             context,
+            backend,
         }) => {
             let child_node = physical_plan_to_pipeline(input, cfg, ctx, input_senders)?;
-            let into_partitions_op = IntoPartitionsSink::new(*num_partitions, schema.clone());
-            BlockingSinkNode::new(
-                Arc::new(into_partitions_op),
-                child_node,
-                stats_state.clone(),
-                ctx,
-                context,
-            )
-            .boxed()
+            match backend {
+                daft_local_plan::ShuffleBackend::Ray => BlockingSinkNode::new(
+                    Arc::new(IntoPartitionsSink::new_ray(*num_partitions, schema.clone())),
+                    child_node,
+                    stats_state.clone(),
+                    ctx,
+                    context,
+                )
+                .boxed(),
+                daft_local_plan::ShuffleBackend::Flight {
+                    shuffle_id,
+                    shuffle_dirs,
+                    compression,
+                } => {
+                    let (shuffle_server, shuffle_address) = ctx
+                        .shuffle_server()
+                        .expect("Flight shuffle server must be initialized for Flight into_partitions plans when using flight_shuffle algorithm");
+                    let into_partitions_sink = IntoPartitionsSink::try_new_flight(
+                        *num_partitions,
+                        schema.clone(),
+                        *shuffle_id,
+                        shuffle_dirs.clone(),
+                        compression.clone(),
+                        shuffle_server,
+                        shuffle_address,
+                    )
+                    .with_context(|_| PipelineCreationSnafu {
+                        plan_name: physical_plan.name(),
+                    })?;
+                    BlockingSinkNode::new(
+                        Arc::new(into_partitions_sink),
+                        child_node,
+                        stats_state.clone(),
+                        ctx,
+                        context,
+                    )
+                    .boxed()
+                }
+            }
         }
         LocalPhysicalPlan::RepartitionWrite(RepartitionWrite {
             input,
@@ -1578,7 +1609,7 @@ fn physical_plan_to_pipeline(
         }) => {
             let child_node = physical_plan_to_pipeline(input, cfg, ctx, input_senders)?;
             match backend {
-                RepartitionWriteBackend::Ray => BlockingSinkNode::new(
+                ShuffleBackend::Ray => BlockingSinkNode::new(
                     Arc::new(RepartitionSink::new_ray(
                         repartition_spec.clone(),
                         *num_partitions,
@@ -1589,7 +1620,7 @@ fn physical_plan_to_pipeline(
                     context,
                 )
                 .boxed(),
-                RepartitionWriteBackend::Flight {
+                ShuffleBackend::Flight {
                     shuffle_id,
                     shuffle_dirs,
                     compression,
@@ -1630,7 +1661,7 @@ fn physical_plan_to_pipeline(
         }) => {
             let child_node = physical_plan_to_pipeline(input, cfg, ctx, input_senders)?;
             match backend {
-                GatherWriteBackend::Ray => BlockingSinkNode::new(
+                ShuffleBackend::Ray => BlockingSinkNode::new(
                     Arc::new(GatherSink::new_ray()),
                     child_node,
                     stats_state.clone(),
@@ -1638,7 +1669,7 @@ fn physical_plan_to_pipeline(
                     context,
                 )
                 .boxed(),
-                GatherWriteBackend::Flight {
+                ShuffleBackend::Flight {
                     shuffle_id,
                     shuffle_dirs,
                     compression,

--- a/src/daft-local-execution/src/sinks/into_partitions.rs
+++ b/src/daft-local-execution/src/sinks/into_partitions.rs
@@ -281,6 +281,11 @@ impl BlockingSink for IntoPartitionsSink {
                             Ok(BlockingSinkOutput::Partitions(outputs))
                         }
                         IntoPartitionsBackend::Flight(_) => {
+                            debug_assert_eq!(
+                                states.len(),
+                                1,
+                                "IntoPartitionsSink Flight expects a single state (max_concurrency == 1)"
+                            );
                             let flight_state = states
                                 .into_iter()
                                 .map(|s| match s {

--- a/src/daft-local-execution/src/sinks/into_partitions.rs
+++ b/src/daft-local-execution/src/sinks/into_partitions.rs
@@ -4,6 +4,11 @@ use common_error::DaftResult;
 use common_metrics::ops::NodeType;
 use daft_core::prelude::SchemaRef;
 use daft_micropartition::MicroPartition;
+use daft_partition_refs::FlightPartitionRef;
+use daft_shuffles::{
+    server::flight_server::ShuffleFlightServer,
+    shuffle_cache::{InProgressShuffleCache, partition_ref_id},
+};
 use tracing::{Span, instrument};
 
 use super::blocking_sink::{
@@ -14,42 +19,213 @@ use crate::{
     pipeline::{InputId, NodeName},
 };
 
+pub(crate) struct RayIntoPartitionsState {
+    partitions: Vec<MicroPartition>,
+}
+
+impl RayIntoPartitionsState {
+    fn push(&mut self, part: MicroPartition) {
+        self.partitions.push(part);
+    }
+
+    fn finalize(
+        states: Vec<Self>,
+        num_partitions: usize,
+        schema: SchemaRef,
+    ) -> DaftResult<Vec<MicroPartition>> {
+        let all_parts: Vec<_> = states.into_iter().flat_map(|s| s.partitions).collect();
+        let concatenated = MicroPartition::concat(all_parts)?;
+
+        let total_rows = concatenated.len();
+        let rows_per_partition = total_rows.div_ceil(num_partitions);
+
+        let mut outputs = Vec::with_capacity(num_partitions);
+        for i in 0..num_partitions {
+            let start_idx = i * rows_per_partition;
+            let end_idx = std::cmp::min(start_idx + rows_per_partition, total_rows);
+
+            if start_idx < total_rows {
+                outputs.push(concatenated.slice(start_idx, end_idx)?);
+            } else {
+                outputs.push(MicroPartition::empty(Some(schema.clone())));
+            }
+        }
+        Ok(outputs)
+    }
+}
+
+pub(crate) struct FlightIntoPartitionsState {
+    shared: Arc<FlightShared>,
+    caches: Vec<InProgressShuffleCache>,
+    rotation_offset: usize,
+}
+
+impl FlightIntoPartitionsState {
+    fn try_new(
+        shared: Arc<FlightShared>,
+        input_id: InputId,
+        num_partitions: usize,
+    ) -> DaftResult<Self> {
+        let mut caches = Vec::with_capacity(num_partitions);
+        for partition_idx in 0..num_partitions {
+            let partition_ref_id = partition_ref_id(input_id, partition_idx);
+            let cache = InProgressShuffleCache::try_new(
+                partition_ref_id,
+                &shared.shuffle_dirs,
+                shared.shuffle_id,
+                shared.target_in_memory_size_per_partition,
+                shared.compression.as_deref(),
+            )?;
+            caches.push(cache);
+        }
+        Ok(Self {
+            shared,
+            caches,
+            rotation_offset: 0,
+        })
+    }
+
+    /// Slice the input into N row-chunks and append each to its cache,
+    /// rotating the bucket offset per call so that `div_ceil` front-loading
+    /// doesn't consistently favour early buckets.
+    async fn push(&mut self, input: MicroPartition) -> DaftResult<()> {
+        let total = input.len();
+        if total == 0 {
+            return Ok(());
+        }
+        let n = self.caches.len();
+        let rows_per_bucket = total.div_ceil(n);
+
+        for i in 0..n {
+            let start = i * rows_per_bucket;
+            if start >= total {
+                break;
+            }
+            let end = (start + rows_per_bucket).min(total);
+            let slice = input.slice(start, end)?;
+            let bucket = (i + self.rotation_offset) % n;
+            self.caches[bucket].push_partition_data(slice).await?;
+        }
+        self.rotation_offset = (self.rotation_offset + 1) % n;
+        Ok(())
+    }
+
+    async fn finalize(self) -> DaftResult<Vec<FlightPartitionRef>> {
+        let Self { shared, caches, .. } = self;
+
+        let closed_list = futures::future::try_join_all(
+            caches.into_iter().map(|c| async move { c.close().await }),
+        )
+        .await?;
+
+        let refs: Vec<_> = closed_list
+            .iter()
+            .map(|closed| FlightPartitionRef {
+                shuffle_id: shared.shuffle_id,
+                server_address: shared.shuffle_address.clone(),
+                partition_ref_id: closed.partition_ref_id,
+                num_rows: closed.num_rows,
+                size_bytes: closed.size_bytes,
+            })
+            .collect();
+
+        shared
+            .local_server
+            .register_shuffle_partitions(shared.shuffle_id, closed_list)
+            .await?;
+
+        Ok(refs)
+    }
+}
+
 pub(crate) enum IntoPartitionsState {
-    Building(Vec<MicroPartition>),
-    Done,
+    Ray(RayIntoPartitionsState),
+    Flight(FlightIntoPartitionsState),
 }
 
 impl IntoPartitionsState {
-    fn push(&mut self, part: MicroPartition) {
-        if let Self::Building(parts) = self {
-            parts.push(part);
-        } else {
-            panic!("IntoPartitionsSink should be in Building state");
+    async fn push(&mut self, input: MicroPartition) -> DaftResult<()> {
+        match self {
+            Self::Ray(state) => {
+                state.push(input);
+                Ok(())
+            }
+            Self::Flight(state) => state.push(input).await,
         }
     }
+}
 
-    fn finalize(&mut self) -> Vec<MicroPartition> {
-        let res = if let Self::Building(parts) = self {
-            std::mem::take(parts)
-        } else {
-            panic!("IntoPartitionsSink should be in Building state");
-        };
-        *self = Self::Done;
-        res
+/// Shared Flight config for all states produced by one IntoPartitionsSink.
+struct FlightShared {
+    shuffle_id: u64,
+    shuffle_dirs: Vec<String>,
+    compression: Option<String>,
+    local_server: Arc<ShuffleFlightServer>,
+    shuffle_address: String,
+    target_in_memory_size_per_partition: usize,
+}
+
+// Mirrors the pattern in `sinks/gather.rs::GatherBackend` and
+// `sinks/repartition.rs::RepartitionBackend` — a runtime enum that picks
+// between the Ray path and the Flight path and carries Flight's runtime handles.
+#[derive(Clone)]
+enum IntoPartitionsBackend {
+    Ray,
+    Flight(Arc<FlightShared>),
+}
+
+impl IntoPartitionsBackend {
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Ray => "Ray",
+            Self::Flight(_) => "Flight",
+        }
     }
 }
 
 pub struct IntoPartitionsSink {
     num_partitions: usize,
     schema: SchemaRef,
+    backend: IntoPartitionsBackend,
 }
 
 impl IntoPartitionsSink {
-    pub fn new(num_partitions: usize, schema: SchemaRef) -> Self {
+    pub fn new_ray(num_partitions: usize, schema: SchemaRef) -> Self {
         Self {
             num_partitions,
             schema,
+            backend: IntoPartitionsBackend::Ray,
         }
+    }
+
+    pub fn try_new_flight(
+        num_partitions: usize,
+        schema: SchemaRef,
+        shuffle_id: u64,
+        shuffle_dirs: Vec<String>,
+        compression: Option<String>,
+        local_server: Arc<ShuffleFlightServer>,
+        shuffle_address: String,
+    ) -> DaftResult<Self> {
+        // Mirror `RepartitionSink::try_new_flight`: divide a global 2000 MiB budget
+        // evenly across the output partitions, clamped to [8 MiB, 128 MiB] per
+        // cache so we spill at roughly the same rate regardless of N.
+        const TARGET_TOTAL_IN_MEMORY_SIZE_BYTES: usize = 1024 * 1024 * 2000;
+        let target_in_memory_size_per_partition = (TARGET_TOTAL_IN_MEMORY_SIZE_BYTES
+            / num_partitions.max(1))
+        .clamp(1024 * 1024 * 8, 1024 * 1024 * 128);
+        Ok(Self {
+            num_partitions,
+            schema,
+            backend: IntoPartitionsBackend::Flight(Arc::new(FlightShared {
+                shuffle_id,
+                shuffle_dirs,
+                compression,
+                local_server,
+                shuffle_address,
+                target_in_memory_size_per_partition,
+            })),
+        })
     }
 }
 
@@ -62,10 +238,17 @@ impl BlockingSink for IntoPartitionsSink {
         input: MicroPartition,
         mut state: Self::State,
         _runtime_stats: Arc<Self::Stats>,
-        _spawner: &ExecutionTaskSpawner,
+        spawner: &ExecutionTaskSpawner,
     ) -> BlockingSinkSinkResult<Self> {
-        state.push(input);
-        Ok(state).into()
+        spawner
+            .spawn(
+                async move {
+                    state.push(input).await?;
+                    Ok(state)
+                },
+                Span::current(),
+            )
+            .into()
     }
 
     #[instrument(skip_all, name = "IntoPartitionsSink::finalize")]
@@ -74,39 +257,42 @@ impl BlockingSink for IntoPartitionsSink {
         states: Vec<Self::State>,
         spawner: &ExecutionTaskSpawner,
     ) -> BlockingSinkFinalizeResult {
+        let backend = self.backend.clone();
         let num_partitions = self.num_partitions;
         let schema = self.schema.clone();
 
         spawner
             .spawn(
                 async move {
-                    // Collect all data from all states
-                    let all_parts: Vec<_> = states
-                        .into_iter()
-                        .flat_map(|mut state| state.finalize())
-                        .collect();
-
-                    // Concatenate all data
-                    let concatenated = MicroPartition::concat(all_parts)?;
-
-                    let total_rows = concatenated.len();
-                    let rows_per_partition = total_rows.div_ceil(num_partitions);
-
-                    let mut outputs = Vec::new();
-                    for i in 0..num_partitions {
-                        let start_idx = i * rows_per_partition;
-                        let end_idx = std::cmp::min(start_idx + rows_per_partition, total_rows);
-
-                        if start_idx < total_rows {
-                            let sliced_table = concatenated.slice(start_idx, end_idx)?;
-                            outputs.push(sliced_table);
-                        } else {
-                            // Empty partition
-                            let mp = MicroPartition::empty(Some(schema.clone()));
-                            outputs.push(mp);
+                    match backend {
+                        IntoPartitionsBackend::Ray => {
+                            let ray_states = states
+                                .into_iter()
+                                .map(|s| match s {
+                                    IntoPartitionsState::Ray(s) => s,
+                                    _ => unreachable!("IntoPartitionsSink state/backend mismatch"),
+                                })
+                                .collect();
+                            let outputs = RayIntoPartitionsState::finalize(
+                                ray_states,
+                                num_partitions,
+                                schema,
+                            )?;
+                            Ok(BlockingSinkOutput::Partitions(outputs))
+                        }
+                        IntoPartitionsBackend::Flight(_) => {
+                            let flight_state = states
+                                .into_iter()
+                                .map(|s| match s {
+                                    IntoPartitionsState::Flight(s) => s,
+                                    _ => unreachable!("IntoPartitionsSink state/backend mismatch"),
+                                })
+                                .next()
+                                .expect("IntoPartitionsSink Flight backend got no state");
+                            let refs = flight_state.finalize().await?;
+                            Ok(BlockingSinkOutput::FlightPartitionRefs(refs))
                         }
                     }
-                    Ok(BlockingSinkOutput::Partitions(outputs))
                 },
                 Span::current(),
             )
@@ -114,7 +300,7 @@ impl BlockingSink for IntoPartitionsSink {
     }
 
     fn name(&self) -> NodeName {
-        "IntoPartitions".into()
+        format!("IntoPartitions({})", self.backend.name()).into()
     }
 
     fn op_type(&self) -> NodeType {
@@ -123,13 +309,21 @@ impl BlockingSink for IntoPartitionsSink {
 
     fn multiline_display(&self) -> Vec<String> {
         vec![format!(
-            "IntoPartitions: Into {} partitions",
+            "IntoPartitions({}): Into {} partitions",
+            self.backend.name(),
             self.num_partitions
         )]
     }
 
-    fn make_state(&self, _input_id: InputId) -> DaftResult<Self::State> {
-        Ok(IntoPartitionsState::Building(Vec::new()))
+    fn make_state(&self, input_id: InputId) -> DaftResult<Self::State> {
+        match &self.backend {
+            IntoPartitionsBackend::Ray => Ok(IntoPartitionsState::Ray(RayIntoPartitionsState {
+                partitions: Vec::new(),
+            })),
+            IntoPartitionsBackend::Flight(shared) => Ok(IntoPartitionsState::Flight(
+                FlightIntoPartitionsState::try_new(shared.clone(), input_id, self.num_partitions)?,
+            )),
+        }
     }
 
     fn max_concurrency(&self) -> usize {

--- a/src/daft-local-plan/src/lib.rs
+++ b/src/daft-local-plan/src/lib.rs
@@ -9,13 +9,13 @@ use daft_micropartition::MicroPartitionRef;
 use daft_scan::ScanTaskRef;
 pub use plan::{
     AsofJoin, CommitWrite, Concat, CrossJoin, Dedup, Explode, Filter, FlightShuffleReadInput,
-    GatherWrite, GatherWriteBackend, GlobScan, HashAggregate, HashJoin, InMemoryScan, IntoBatches,
-    IntoPartitions, Limit, LocalNodeContext, LocalPhysicalPlan, LocalPhysicalPlanRef,
-    MonotonicallyIncreasingId, PhysicalScan, PhysicalWrite, Pivot, PlaceholderScan, Project,
-    RepartitionWrite, RepartitionWriteBackend, Sample, SamplingMethod, ShuffleRead,
-    ShuffleReadBackend, Sort, SortMergeJoin, StageCheckpointKeys, TopN, UDFProject,
-    UnGroupedAggregate, Unpivot, VLLMProject, WindowOrderByOnly, WindowPartitionAndDynamicFrame,
-    WindowPartitionAndOrderBy, WindowPartitionOnly,
+    GatherWrite, GlobScan, HashAggregate, HashJoin, InMemoryScan, IntoBatches, IntoPartitions,
+    Limit, LocalNodeContext, LocalPhysicalPlan, LocalPhysicalPlanRef, MonotonicallyIncreasingId,
+    PhysicalScan, PhysicalWrite, Pivot, PlaceholderScan, Project, RepartitionWrite, Sample,
+    SamplingMethod, ShuffleBackend, ShuffleRead, ShuffleReadBackend, Sort, SortMergeJoin,
+    StageCheckpointKeys, TopN, UDFProject, UnGroupedAggregate, Unpivot, VLLMProject,
+    WindowOrderByOnly, WindowPartitionAndDynamicFrame, WindowPartitionAndOrderBy,
+    WindowPartitionOnly,
 };
 #[cfg(feature = "python")]
 pub use plan::{CatalogWrite, DataSink, DistributedActorPoolProject, LanceWrite};

--- a/src/daft-local-plan/src/plan.rs
+++ b/src/daft-local-plan/src/plan.rs
@@ -972,6 +972,7 @@ impl LocalPhysicalPlan {
     pub fn into_partitions(
         input: LocalPhysicalPlanRef,
         num_partitions: usize,
+        backend: ShuffleBackend,
         stats_state: StatsState,
         context: LocalNodeContext,
     ) -> LocalPhysicalPlanRef {
@@ -980,6 +981,7 @@ impl LocalPhysicalPlan {
             input,
             num_partitions,
             schema,
+            backend,
             stats_state,
             context,
         })
@@ -1012,7 +1014,7 @@ impl LocalPhysicalPlan {
         input: LocalPhysicalPlanRef,
         num_partitions: usize,
         schema: SchemaRef,
-        backend: RepartitionWriteBackend,
+        backend: ShuffleBackend,
         repartition_spec: RepartitionSpec,
         stats_state: StatsState,
         context: LocalNodeContext,
@@ -1032,7 +1034,7 @@ impl LocalPhysicalPlan {
     pub fn gather_write(
         input: LocalPhysicalPlanRef,
         schema: SchemaRef,
-        backend: GatherWriteBackend,
+        backend: ShuffleBackend,
         stats_state: StatsState,
         context: LocalNodeContext,
     ) -> LocalPhysicalPlanRef {
@@ -1634,11 +1636,13 @@ impl LocalPhysicalPlan {
                 ),
                 Self::IntoPartitions(IntoPartitions {
                     num_partitions,
+                    backend,
                     context,
                     ..
                 }) => Self::into_partitions(
                     new_child.clone(),
                     *num_partitions,
+                    backend.clone(),
                     StatsState::NotMaterialized,
                     context.clone(),
                 ),
@@ -2263,8 +2267,19 @@ pub struct IntoPartitions {
     pub input: LocalPhysicalPlanRef,
     pub num_partitions: usize,
     pub schema: SchemaRef,
+    pub backend: ShuffleBackend,
     pub stats_state: StatsState,
     pub context: LocalNodeContext,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum ShuffleBackend {
+    Ray,
+    Flight {
+        shuffle_id: u64,
+        shuffle_dirs: Vec<String>,
+        compression: Option<String>,
+    },
 }
 
 #[derive(Serialize, Deserialize)]
@@ -2280,16 +2295,6 @@ pub struct VLLMProject {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum RepartitionWriteBackend {
-    Ray,
-    Flight {
-        shuffle_id: u64,
-        shuffle_dirs: Vec<String>,
-        compression: Option<String>,
-    },
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum ShuffleReadBackend {
     Ray,
     Flight,
@@ -2300,27 +2305,17 @@ pub struct RepartitionWrite {
     pub input: LocalPhysicalPlanRef,
     pub num_partitions: usize,
     pub schema: SchemaRef,
-    pub backend: RepartitionWriteBackend,
+    pub backend: ShuffleBackend,
     pub repartition_spec: RepartitionSpec,
     pub stats_state: StatsState,
     pub context: LocalNodeContext,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum GatherWriteBackend {
-    Ray,
-    Flight {
-        shuffle_id: u64,
-        shuffle_dirs: Vec<String>,
-        compression: Option<String>,
-    },
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GatherWrite {
     pub input: LocalPhysicalPlanRef,
     pub schema: SchemaRef,
-    pub backend: GatherWriteBackend,
+    pub backend: ShuffleBackend,
     pub stats_state: StatsState,
     pub context: LocalNodeContext,
 }

--- a/tests/dataframe/test_shuffles.py
+++ b/tests/dataframe/test_shuffles.py
@@ -229,6 +229,100 @@ def test_flight_shuffle(flight_shuffle_ctx, input_partitions, output_partitions)
     get_tests_daft_runner_name() != "ray",
     reason="shuffle tests are meant for the ray runner",
 )
+@pytest.mark.parametrize(
+    "input_partitions, output_partitions",
+    # Equal, coalesce (N > M), split (N < M), and single-output coalesce.
+    [(4, 4), (8, 2), (2, 8), (7, 1)],
+)
+def test_flight_into_partitions(flight_shuffle_ctx, input_partitions, output_partitions):
+    """Exercises IntoPartitionsNode under `shuffle_algorithm="flight_shuffle"`.
+
+    Verifies that both upstream materialized outputs (FlightPartitionRefs) are
+    consumed and downstream outputs are re-emitted as FlightPartitionRefs, across
+    the equal / coalesce / split branches.
+    """
+    rows = 1000
+    with flight_shuffle_ctx():
+        df = (
+            daft.from_pydict({"x": list(range(rows))})
+            .into_partitions(input_partitions)
+            .into_partitions(output_partitions)
+        )
+
+        # Plan-shape assertion: a regression that routes around IntoPartitionsNode
+        # or silently falls back to Ray would still yield correct row counts, so
+        # verify the Flight variant is in the plan explicitly.
+        buf = io.StringIO()
+        df.explain(show_all=True, file=buf)
+        plan = buf.getvalue()
+        assert "IntoPartitions(Flight)" in plan, f"expected IntoPartitions(Flight) in plan:\n{plan}"
+        assert "IntoPartitions(Ray)" not in plan, f"unexpected Ray IntoPartitions in plan:\n{plan}"
+
+        collected = df.collect()
+        # The core contract of into_partitions: exactly N output partitions.
+        assert len(list(collected.iter_partitions())) == output_partitions
+        assert sorted(collected.to_pydict()["x"]) == list(range(rows))
+
+
+@pytest.mark.skipif(
+    get_tests_daft_runner_name() != "ray",
+    reason="distributed IntoPartitions tests require the ray runner",
+)
+@pytest.mark.parametrize(
+    "input_partitions, output_partitions",
+    [(4, 4), (8, 2), (2, 8), (7, 1)],
+)
+def test_ray_into_partitions(input_partitions, output_partitions):
+    """IntoPartitions over the Ray backend (no flight_shuffle_ctx).
+
+    Mirrors test_flight_into_partitions but exercises the Ray IntoPartitionsNode
+    path and RayIntoPartitionsState finalize.
+    """
+    rows = 1000
+    df = daft.from_pydict({"x": list(range(rows))}).into_partitions(input_partitions).into_partitions(output_partitions)
+
+    buf = io.StringIO()
+    df.explain(show_all=True, file=buf)
+    plan = buf.getvalue()
+    assert "IntoPartitions(Ray)" in plan, f"expected IntoPartitions(Ray) in plan:\n{plan}"
+    assert "IntoPartitions(Flight)" not in plan, f"unexpected Flight IntoPartitions in plan:\n{plan}"
+
+    collected = df.collect()
+    assert len(list(collected.iter_partitions())) == output_partitions
+    assert sorted(collected.to_pydict()["x"]) == list(range(rows))
+
+
+@pytest.mark.skipif(
+    get_tests_daft_runner_name() != "ray",
+    reason="shuffle tests are meant for the ray runner",
+)
+def test_flight_into_partitions_mixed_empty_inputs(flight_shuffle_ctx):
+    """IntoPartitions (Flight) must still emit exactly N output partitions when some pre-filter partitions are empty.
+
+    FlightIntoPartitionsState opens N caches in `make_state` and `push` short-
+    circuits on empty inputs. As long as the rotation distributes surviving rows
+    across every cache, close() succeeds and we get N FlightPartitionRefs.
+    """
+    rows = 1000
+    input_partitions = 8
+    output_partitions = 5
+    filter_threshold = 500  # roughly half the data survives
+    with flight_shuffle_ctx():
+        partial = (
+            daft.from_pydict({"x": list(range(rows))})
+            .into_partitions(input_partitions)
+            .filter(daft.col("x") < filter_threshold)
+            .into_partitions(output_partitions)
+            .collect()
+        )
+        assert len(list(partial.iter_partitions())) == output_partitions
+        assert sorted(partial.to_pydict()["x"]) == list(range(filter_threshold))
+
+
+@pytest.mark.skipif(
+    get_tests_daft_runner_name() != "ray",
+    reason="shuffle tests are meant for the ray runner",
+)
 @pytest.mark.parametrize("input_partitions", [1, 8, 32])
 def test_flight_gather(flight_shuffle_ctx, input_partitions):
     """Gather is triggered by top_n and ungrouped agg on multi-partition inputs.

--- a/tests/dataframe/test_shuffles.py
+++ b/tests/dataframe/test_shuffles.py
@@ -323,6 +323,48 @@ def test_flight_into_partitions_mixed_empty_inputs(flight_shuffle_ctx):
     get_tests_daft_runner_name() != "ray",
     reason="shuffle tests are meant for the ray runner",
 )
+def test_flight_into_partitions_rotation_balance(flight_shuffle_ctx):
+    """Test that flight into partitions rotation is balanced.
+
+    Per-push `div_ceil` slicing front-loads early buckets; the rotation
+    offset in `FlightIntoPartitionsState::push` spreads that bias across
+    output buckets over many pushes.
+    With `rows_per_input=5` and `output_partitions=3`, each push distributes
+    rows as [2, 2, 1]. Without rotation (offset stuck at 0) the last bucket
+    consistently gets the short chunk, so 30 pushes yield [60, 60, 30] — a
+    30-row spread. With rotation the short chunk rotates and counts balance
+    to [50, 50, 50].
+    """
+    rows_per_input = 5
+    input_partitions = 30
+    output_partitions = 3
+    total_rows = rows_per_input * input_partitions
+
+    import ray
+
+    with flight_shuffle_ctx():
+        df = (
+            daft.from_pydict({"x": list(range(total_rows))})
+            .into_partitions(input_partitions)
+            .into_partitions(output_partitions)
+            .collect()
+        )
+
+        counts = [len(ray.get(p)) for p in df.iter_partitions()]
+        assert sum(counts) == total_rows
+        assert len(counts) == output_partitions
+
+        # Tight enough to catch the [60, 60, 30] failure mode, loose enough
+        # to tolerate scheduler variance in push ordering and MP fusion.
+        tolerance = rows_per_input * 2
+        spread = max(counts) - min(counts)
+        assert spread <= tolerance, f"rotation unbalanced: {counts} (spread={spread})"
+
+
+@pytest.mark.skipif(
+    get_tests_daft_runner_name() != "ray",
+    reason="shuffle tests are meant for the ray runner",
+)
 @pytest.mark.parametrize("input_partitions", [1, 8, 32])
 def test_flight_gather(flight_shuffle_ctx, input_partitions):
     """Gather is triggered by top_n and ungrouped agg on multi-partition inputs.


### PR DESCRIPTION
### Summary

  Flight shuffle support for `IntoPartitions`, plus consolidation of the local shuffle backend enum.

  ### `into_partitions`

  - `IntoPartitionsNode` (distributed) now carries a `ShuffleBackend` and routes its coalesce / split / equal paths through Ray or Flight based on the query's `shuffle_algorithm`. `LogicalPlan::IntoPartitions` picks the backend via the same `select_backend()` that Gather/Repartition use
  - `IntoPartitionsSink` (local) now has Ray and Flight variants, matching the shape of `GatherSink` / `RepartitionSink`:
    - **Ray** path unchanged — buffer MPs, concat+slice in `finalize`, return `BlockingSinkOutput::Partitions`.
    - **Flight** path streams: `make_state` opens N `InProgressShuffleCache`s up front (indexed deterministically by
  `partition_ref_id(input_id, partition_idx)`, same convention as `RepartitionSink`), and each `sink()` call slices its input MP into N zero-copy row chunks and appends to the caches with a rotating offset so `div_ceil` front-loading averages out. `finalize` just closes the caches in parallel and returns `BlockingSinkOutput::FlightPartitionRefs`.

  ### Details

Cleaned up some of the shuffle backends portion. Unified one ShuffleBackend local plan, then made is so that mod.rs only contains shuffle generic code, so `build_repartition_write_stage` and `build_gather_write_stage` are moved into their respective distributed operators