### PR TITLE
feat(cast): support cross-TimeUnit Duration casts

### DIFF
--- a/src/daft-core/src/array/ops/cast.rs
+++ b/src/daft-core/src/array/ops/cast.rs
@@ -418,14 +418,34 @@ impl DurationArray {
             DataType::Null => {
                 Ok(NullArray::full_null(self.name(), dtype, self.len()).into_series())
             }
-            dtype if dtype == self.data_type() => Ok(self.clone().into_series()),
+            DataType::Duration(tu) => {
+                let self_tu = match self.data_type() {
+                    DataType::Duration(tu) => tu,
+                    ty => panic!("Wrong dtype for DurationArray: {ty}"),
+                };
+                let physical = match self_tu.cmp(tu) {
+                    std::cmp::Ordering::Equal => self.physical.clone(),
+                    std::cmp::Ordering::Greater => {
+                        let factor = tu.to_scale_factor() / self_tu.to_scale_factor();
+                        self.physical
+                            .mul(&Int64Array::from_slice("factor", &[factor]))?
+                    }
+                    std::cmp::Ordering::Less => {
+                        let factor = self_tu.to_scale_factor() / tu.to_scale_factor();
+                        self.physical
+                            .div(&Int64Array::from_slice("factor", &[factor]))?
+                    }
+                };
+                Ok(
+                    DurationArray::new(Field::new(self.name(), dtype.clone()), physical)
+                        .into_series(),
+                )
+            }
             dtype if dtype.is_numeric() => self.physical.cast(dtype),
-            DataType::Int64 => Ok(self.physical.clone().into_series()),
             #[cfg(feature = "python")]
             DataType::Python => self.clone().into_series().cast_to_python(),
             _ => Err(DaftError::TypeError(format!(
-                "Cannot cast Duration to {}",
-                dtype
+                "Cannot cast Duration to {dtype}"
             ))),
         }
     }

--- a/tests/series/test_cast.py
+++ b/tests/series/test_cast.py
@@ -1127,19 +1127,18 @@ def test_series_cast_timestamp_numeric(dtype, result_n1, result_0, result_p1) ->
             timedelta(microseconds=0),
             timedelta(microseconds=1),
         ),
-        # Casting between duration types is currently not supported in Arrow2.
-        # (
-        #     DataType.duration(TimeUnit.s()),
-        #     timedelta(seconds=-1),
-        #     timedelta(seconds=0),
-        #     timedelta(seconds=1),
-        # ),
-        # (
-        #     DataType.duration(TimeUnit.ms()),
-        #     timedelta(milliseconds=-1),
-        #     timedelta(milliseconds=0),
-        #     timedelta(milliseconds=1),
-        # ),
+        (
+            DataType.duration(TimeUnit.s()),
+            timedelta(seconds=-1),
+            timedelta(seconds=0),
+            timedelta(seconds=1),
+        ),
+        (
+            DataType.duration(TimeUnit.ms()),
+            timedelta(milliseconds=-1),
+            timedelta(milliseconds=0),
+            timedelta(milliseconds=1),
+        ),
     ],
 )
 def test_series_cast_duration_numeric(dtype, result_n1, result_0, result_p1) -> None:
@@ -1147,6 +1146,23 @@ def test_series_cast_duration_numeric(dtype, result_n1, result_0, result_p1) -> 
     series = Series.from_pylist([result_n1, result_0, result_p1]).cast(dtype)
     casted = series.cast(DataType.int64())
     assert casted.to_pylist() == [-1, 0, 1]
+
+
+@pytest.mark.parametrize(
+    ["from_tu", "to_tu", "from_vals", "to_vals"],
+    [
+        (TimeUnit.s(), TimeUnit.ms(), [1, 2], [timedelta(milliseconds=1000), timedelta(milliseconds=2000)]),
+        (TimeUnit.ms(), TimeUnit.s(), [1000, 2500], [timedelta(seconds=1), timedelta(seconds=2)]),
+        (TimeUnit.us(), TimeUnit.ns(), [1, 2], [timedelta(microseconds=1), timedelta(microseconds=2)]),
+        (TimeUnit.ns(), TimeUnit.us(), [1000, 2000], [timedelta(microseconds=1), timedelta(microseconds=2)]),
+        (TimeUnit.s(), TimeUnit.ns(), [1], [timedelta(seconds=1)]),
+    ],
+)
+def test_series_cast_duration_duration(from_tu, to_tu, from_vals, to_vals) -> None:
+    src = Series.from_pylist(from_vals).cast(DataType.duration(from_tu))
+    casted = src.cast(DataType.duration(to_tu))
+    assert casted.datatype() == DataType.duration(to_tu)
+    assert casted.to_pylist() == to_vals
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Changes Made

- Added `DataType::Duration(tu)` match arm to `DurationArray::cast` in `array/ops/cast.rs`, enabling `Series::cast(DataType::Duration(s|ms|us|ns))` for any source `DurationArray`
- Mirrors the existing cross-TimeUnit patterns in `TimestampArray::cast` and `TimeArray::cast`: `TimeUnit::to_scale_factor()` combined with `cmp` + `Int64Array::mul`/`div` on the physical buffer. This operates directly on the `Int64` physical storage, so we can remove Arrow2 limitation that previously blocked casts between duration types
- Also cleaned up a now-dead `DataType::Int64` arm (shadowed by the existing `is_numeric()` guard) and dropped the redundant same-dtype short-circuit (the new Duration arm's `Ordering::Equal` branch already handles it)

### Tests

- Uncommented the `Duration(s)` and `Duration(ms)` parametrize entries in `test_series_cast_duration_numeric` (previously disabled with "not supported in Arrow2").
- Added `test_series_cast_duration_duration` covering s <-> ms, us <-> ns, and s <-> ns.

## Related Issues

Closes #4399