### PR TITLE
fix(writers): strip partition columns from Hive-partitioned file bodies

### DIFF
--- a/src/daft-recordbatch/src/ops/partition.rs
+++ b/src/daft-recordbatch/src/ops/partition.rs
@@ -117,4 +117,25 @@ impl RecordBatch {
             .collect::<DaftResult<Vec<_>>>()?;
         Ok((output_tables, pkeys_per_output_table))
     }
+
+    pub fn partition_by_value_projected(
+        &self,
+        partition_keys: &[BoundExpr],
+        projection: &[usize],
+    ) -> DaftResult<(Vec<Self>, Self)> {
+        let partition_key_table = self.eval_expression_list(partition_keys)?;
+        let (key_idx, group_idx) = partition_key_table.make_groups()?;
+        let key_idx = UInt64Array::from_vec("idx", key_idx);
+        let pkeys_per_output_table = partition_key_table.take(&key_idx)?;
+        drop(partition_key_table);
+        let projected = self.get_columns(projection);
+        let output_tables = group_idx
+            .into_iter()
+            .map(|gidx| {
+                let gidx = UInt64Array::from_vec("idx", gidx.into_vec());
+                projected.take(&gidx)
+            })
+            .collect::<DaftResult<Vec<_>>>()?;
+        Ok((output_tables, pkeys_per_output_table))
+    }
 }

--- a/src/daft-writers/src/lib.rs
+++ b/src/daft-writers/src/lib.rs
@@ -27,6 +27,7 @@ mod sink;
 
 use std::{
     cmp::min,
+    collections::HashSet,
     sync::{Arc, Mutex},
 };
 
@@ -35,8 +36,8 @@ use batch::TargetBatchWriterFactory;
 use common_daft_config::DaftExecutionConfig;
 use common_error::{DaftError, DaftResult};
 use common_file_formats::FileFormat;
-use daft_core::prelude::SchemaRef;
-use daft_dsl::expr::bound_expr::BoundExpr;
+use daft_core::prelude::{Schema, SchemaRef};
+use daft_dsl::{Expr, expr::bound_expr::BoundExpr};
 use daft_logical_plan::OutputFileInfo;
 use daft_micropartition::MicroPartition;
 use daft_recordbatch::RecordBatch;
@@ -93,16 +94,50 @@ pub trait WriterFactory: Send + Sync {
     ) -> DaftResult<Box<dyn AsyncFileWriter<Input = Self::Input, Result = Self::Result>>>;
 }
 
+/// Strip plain-column partition refs from file_schema (Hive: values in paths).
+/// `keep_indices` is `None` when nothing to strip or stripping would empty the schema.
+fn split_schema_for_partitioned_write(
+    partition_cols: Option<&[BoundExpr]>,
+    file_schema: &SchemaRef,
+) -> (SchemaRef, Option<Arc<[usize]>>) {
+    let strip: HashSet<&str> = partition_cols
+        .unwrap_or(&[])
+        .iter()
+        .filter(|e| matches!(e.inner().as_ref(), Expr::Column(_)))
+        .map(|e| e.inner().name())
+        .collect();
+
+    let mut keep_indices = Vec::with_capacity(file_schema.len());
+    let mut kept_fields = Vec::with_capacity(file_schema.len());
+    for (i, field) in file_schema.fields().iter().enumerate() {
+        if !strip.contains(field.name.as_ref()) {
+            keep_indices.push(i);
+            kept_fields.push(field.clone());
+        }
+    }
+
+    let nothing_stripped = kept_fields.len() == file_schema.len();
+    let everything_stripped = kept_fields.is_empty();
+    if nothing_stripped || everything_stripped {
+        return (file_schema.clone(), None);
+    }
+
+    (
+        Arc::new(Schema::new(kept_fields)),
+        Some(Arc::from(keep_indices)),
+    )
+}
+
 pub fn make_physical_writer_factory(
     file_info: &OutputFileInfo<BoundExpr>,
     file_schema: &SchemaRef,
     cfg: &DaftExecutionConfig,
 ) -> DaftResult<Arc<dyn WriterFactory<Input = MicroPartition, Result = Vec<RecordBatch>>>> {
-    let base_writer_factory = PhysicalWriterFactory::new(
-        file_info.clone(),
-        file_schema.clone(),
-        cfg.native_parquet_writer,
-    )?;
+    let (data_schema, keep_indices) =
+        split_schema_for_partitioned_write(file_info.partition_cols.as_deref(), file_schema);
+
+    let base_writer_factory =
+        PhysicalWriterFactory::new(file_info.clone(), data_schema, cfg.native_parquet_writer)?;
     match file_info.file_format {
         FileFormat::Parquet => {
             let file_size_calculator = TargetInMemorySizeBytesCalculator::new(
@@ -129,6 +164,7 @@ pub fn make_physical_writer_factory(
                 let partitioned_writer_factory = PartitionedWriterFactory::new(
                     Arc::new(file_writer_factory),
                     partition_cols.clone(),
+                    keep_indices,
                 );
                 Ok(Arc::new(partitioned_writer_factory))
             } else {
@@ -150,6 +186,7 @@ pub fn make_physical_writer_factory(
                 let partitioned_writer_factory = PartitionedWriterFactory::new(
                     Arc::new(file_writer_factory),
                     partition_cols.clone(),
+                    keep_indices,
                 );
                 Ok(Arc::new(partitioned_writer_factory))
             } else {
@@ -171,6 +208,7 @@ pub fn make_physical_writer_factory(
                 let partitioned_writer_factory = PartitionedWriterFactory::new(
                     Arc::new(file_writer_factory),
                     partition_cols.clone(),
+                    keep_indices,
                 );
                 Ok(Arc::new(partitioned_writer_factory))
             } else {
@@ -241,8 +279,11 @@ pub fn make_catalog_writer_factory(
     );
 
     if let Some(partition_cols) = partition_cols {
-        let partitioned_writer_factory =
-            PartitionedWriterFactory::new(Arc::new(file_writer_factory), partition_cols.clone());
+        let partitioned_writer_factory = PartitionedWriterFactory::new(
+            Arc::new(file_writer_factory),
+            partition_cols.clone(),
+            None,
+        );
         Arc::new(partitioned_writer_factory)
     } else {
         Arc::new(file_writer_factory)

--- a/src/daft-writers/src/lib.rs
+++ b/src/daft-writers/src/lib.rs
@@ -94,8 +94,9 @@ pub trait WriterFactory: Send + Sync {
     ) -> DaftResult<Box<dyn AsyncFileWriter<Input = Self::Input, Result = Self::Result>>>;
 }
 
-/// Strip plain-column partition refs from file_schema (Hive: values in paths).
-/// `keep_indices` is `None` when nothing to strip or stripping would empty the schema.
+/// Strip plain-column partition refs from `file_schema` (Hive: values live in paths).
+/// Returns the stripped schema and indices of kept columns, or `(file_schema, None)` when
+/// nothing was stripped or stripping would empty the schema.
 fn split_schema_for_partitioned_write(
     partition_cols: Option<&[BoundExpr]>,
     file_schema: &SchemaRef,
@@ -107,24 +108,26 @@ fn split_schema_for_partitioned_write(
         .map(|e| e.inner().name())
         .collect();
 
-    let mut keep_indices = Vec::with_capacity(file_schema.len());
+    if strip.is_empty() {
+        return (file_schema.clone(), None);
+    }
+
+    let mut non_partition_column_indices = Vec::with_capacity(file_schema.len());
     let mut kept_fields = Vec::with_capacity(file_schema.len());
     for (i, field) in file_schema.fields().iter().enumerate() {
         if !strip.contains(field.name.as_ref()) {
-            keep_indices.push(i);
+            non_partition_column_indices.push(i);
             kept_fields.push(field.clone());
         }
     }
 
-    let nothing_stripped = kept_fields.len() == file_schema.len();
-    let everything_stripped = kept_fields.is_empty();
-    if nothing_stripped || everything_stripped {
+    if kept_fields.is_empty() {
         return (file_schema.clone(), None);
     }
 
     (
         Arc::new(Schema::new(kept_fields)),
-        Some(Arc::from(keep_indices)),
+        Some(Arc::from(non_partition_column_indices)),
     )
 }
 
@@ -133,7 +136,7 @@ pub fn make_physical_writer_factory(
     file_schema: &SchemaRef,
     cfg: &DaftExecutionConfig,
 ) -> DaftResult<Arc<dyn WriterFactory<Input = MicroPartition, Result = Vec<RecordBatch>>>> {
-    let (data_schema, keep_indices) =
+    let (data_schema, non_partition_column_indices) =
         split_schema_for_partitioned_write(file_info.partition_cols.as_deref(), file_schema);
 
     let base_writer_factory =
@@ -164,7 +167,7 @@ pub fn make_physical_writer_factory(
                 let partitioned_writer_factory = PartitionedWriterFactory::new(
                     Arc::new(file_writer_factory),
                     partition_cols.clone(),
-                    keep_indices,
+                    non_partition_column_indices,
                 );
                 Ok(Arc::new(partitioned_writer_factory))
             } else {
@@ -186,7 +189,7 @@ pub fn make_physical_writer_factory(
                 let partitioned_writer_factory = PartitionedWriterFactory::new(
                     Arc::new(file_writer_factory),
                     partition_cols.clone(),
-                    keep_indices,
+                    non_partition_column_indices,
                 );
                 Ok(Arc::new(partitioned_writer_factory))
             } else {
@@ -208,7 +211,7 @@ pub fn make_physical_writer_factory(
                 let partitioned_writer_factory = PartitionedWriterFactory::new(
                     Arc::new(file_writer_factory),
                     partition_cols.clone(),
-                    keep_indices,
+                    non_partition_column_indices,
                 );
                 Ok(Arc::new(partitioned_writer_factory))
             } else {

--- a/src/daft-writers/src/partition.rs
+++ b/src/daft-writers/src/partition.rs
@@ -24,6 +24,7 @@ struct PartitionedWriter {
     saved_partition_values: Vec<RecordBatch>,
     writer_factory: Arc<dyn WriterFactory<Input = MicroPartition, Result = Vec<RecordBatch>>>,
     partition_by: Vec<BoundExpr>,
+    keep_indices: Option<Arc<[usize]>>,
     is_closed: bool,
 }
 
@@ -31,6 +32,7 @@ impl PartitionedWriter {
     pub fn new(
         writer_factory: Arc<dyn WriterFactory<Input = MicroPartition, Result = Vec<RecordBatch>>>,
         partition_by: Vec<BoundExpr>,
+        keep_indices: Option<Arc<[usize]>>,
     ) -> Self {
         Self {
             per_partition_writers: HashMap::with_capacity_and_hasher(
@@ -40,16 +42,24 @@ impl PartitionedWriter {
             saved_partition_values: vec![],
             writer_factory,
             partition_by,
+            keep_indices,
             is_closed: false,
         }
     }
 
     fn partition(
         partition_cols: &[BoundExpr],
+        keep_indices: Option<&[usize]>,
         data: MicroPartition,
     ) -> DaftResult<(Vec<RecordBatch>, RecordBatch)> {
         let table = data.concat_or_get()?.unwrap();
-        let (split_tables, partition_values) = table.partition_by_value(partition_cols)?;
+        let (mut split_tables, partition_values) = table.partition_by_value(partition_cols)?;
+        if let Some(indices) = keep_indices {
+            for t in &mut split_tables {
+                *t = t.get_columns(indices);
+            }
+        }
+
         Ok((split_tables, partition_values))
     }
 }
@@ -71,8 +81,11 @@ impl AsyncFileWriter for PartitionedWriter {
             });
         }
 
-        let (split_tables, partition_values) =
-            Self::partition(self.partition_by.as_slice(), input)?;
+        let (split_tables, partition_values) = Self::partition(
+            self.partition_by.as_slice(),
+            self.keep_indices.as_deref(),
+            input,
+        )?;
         let partition_values_hash = partition_values.hash_rows()?;
 
         // Spawn tasks on compute runtime for writing each table
@@ -194,16 +207,19 @@ impl AsyncFileWriter for PartitionedWriter {
 pub(crate) struct PartitionedWriterFactory {
     writer_factory: Arc<dyn WriterFactory<Input = MicroPartition, Result = Vec<RecordBatch>>>,
     partition_cols: Vec<BoundExpr>,
+    keep_indices: Option<Arc<[usize]>>,
 }
 
 impl PartitionedWriterFactory {
     pub(crate) fn new(
         writer_factory: Arc<dyn WriterFactory<Input = MicroPartition, Result = Vec<RecordBatch>>>,
         partition_cols: Vec<BoundExpr>,
+        keep_indices: Option<Arc<[usize]>>,
     ) -> Self {
         Self {
             writer_factory,
             partition_cols,
+            keep_indices,
         }
     }
 }
@@ -219,6 +235,7 @@ impl WriterFactory for PartitionedWriterFactory {
         Ok(Box::new(PartitionedWriter::new(
             self.writer_factory.clone(),
             self.partition_cols.clone(),
+            self.keep_indices.clone(),
         ))
             as Box<
                 dyn AsyncFileWriter<Input = Self::Input, Result = Self::Result>,

--- a/src/daft-writers/src/partition.rs
+++ b/src/daft-writers/src/partition.rs
@@ -24,7 +24,8 @@ struct PartitionedWriter {
     saved_partition_values: Vec<RecordBatch>,
     writer_factory: Arc<dyn WriterFactory<Input = MicroPartition, Result = Vec<RecordBatch>>>,
     partition_by: Vec<BoundExpr>,
-    keep_indices: Option<Arc<[usize]>>,
+    /// Indices of columns to keep in the file body, or `None` to write all columns.
+    non_partition_column_indices: Option<Arc<[usize]>>,
     is_closed: bool,
 }
 
@@ -32,7 +33,7 @@ impl PartitionedWriter {
     pub fn new(
         writer_factory: Arc<dyn WriterFactory<Input = MicroPartition, Result = Vec<RecordBatch>>>,
         partition_by: Vec<BoundExpr>,
-        keep_indices: Option<Arc<[usize]>>,
+        non_partition_column_indices: Option<Arc<[usize]>>,
     ) -> Self {
         Self {
             per_partition_writers: HashMap::with_capacity_and_hasher(
@@ -42,25 +43,17 @@ impl PartitionedWriter {
             saved_partition_values: vec![],
             writer_factory,
             partition_by,
-            keep_indices,
+            non_partition_column_indices,
             is_closed: false,
         }
     }
 
-    fn partition(
-        partition_cols: &[BoundExpr],
-        keep_indices: Option<&[usize]>,
-        data: MicroPartition,
-    ) -> DaftResult<(Vec<RecordBatch>, RecordBatch)> {
+    fn partition(&self, data: MicroPartition) -> DaftResult<(Vec<RecordBatch>, RecordBatch)> {
         let table = data.concat_or_get()?.unwrap();
-        let (mut split_tables, partition_values) = table.partition_by_value(partition_cols)?;
-        if let Some(indices) = keep_indices {
-            for t in &mut split_tables {
-                *t = t.get_columns(indices);
-            }
+        match self.non_partition_column_indices.as_deref() {
+            Some(indices) => table.partition_by_value_projected(&self.partition_by, indices),
+            None => table.partition_by_value(&self.partition_by),
         }
-
-        Ok((split_tables, partition_values))
     }
 }
 
@@ -81,11 +74,7 @@ impl AsyncFileWriter for PartitionedWriter {
             });
         }
 
-        let (split_tables, partition_values) = Self::partition(
-            self.partition_by.as_slice(),
-            self.keep_indices.as_deref(),
-            input,
-        )?;
+        let (split_tables, partition_values) = self.partition(input)?;
         let partition_values_hash = partition_values.hash_rows()?;
 
         // Spawn tasks on compute runtime for writing each table
@@ -207,19 +196,19 @@ impl AsyncFileWriter for PartitionedWriter {
 pub(crate) struct PartitionedWriterFactory {
     writer_factory: Arc<dyn WriterFactory<Input = MicroPartition, Result = Vec<RecordBatch>>>,
     partition_cols: Vec<BoundExpr>,
-    keep_indices: Option<Arc<[usize]>>,
+    non_partition_column_indices: Option<Arc<[usize]>>,
 }
 
 impl PartitionedWriterFactory {
     pub(crate) fn new(
         writer_factory: Arc<dyn WriterFactory<Input = MicroPartition, Result = Vec<RecordBatch>>>,
         partition_cols: Vec<BoundExpr>,
-        keep_indices: Option<Arc<[usize]>>,
+        non_partition_column_indices: Option<Arc<[usize]>>,
     ) -> Self {
         Self {
             writer_factory,
             partition_cols,
-            keep_indices,
+            non_partition_column_indices,
         }
     }
 }
@@ -235,7 +224,7 @@ impl WriterFactory for PartitionedWriterFactory {
         Ok(Box::new(PartitionedWriter::new(
             self.writer_factory.clone(),
             self.partition_cols.clone(),
-            self.keep_indices.clone(),
+            self.non_partition_column_indices.clone(),
         ))
             as Box<
                 dyn AsyncFileWriter<Input = Self::Input, Result = Self::Result>,

--- a/tests/cookbook/test_write.py
+++ b/tests/cookbook/test_write.py
@@ -32,7 +32,7 @@ def test_parquet_write_with_partitioning(tmp_path, with_morsel_size):
 
     pd_df = df.write_parquet(tmp_path, partition_cols=["Borough"])
 
-    read_back_pd_df = daft.read_parquet(tmp_path.as_posix() + "/**/*.parquet").to_pandas()
+    read_back_pd_df = daft.read_parquet(tmp_path.as_posix() + "/**/*.parquet", hive_partitioning=True).to_pandas()
     assert_df_equals(df.to_pandas(), read_back_pd_df)
 
     assert len(pd_df) == 5
@@ -82,10 +82,10 @@ def test_parquet_write_with_partitioning_readback_values(tmp_path, with_morsel_s
 
     for path, bor in zip(output_dict["path"], output_dict["Borough"]):
         assert f"Borough={urllib.parse.quote(bor)}" in path
-        read_back = daft.read_parquet(path).to_pydict()
+        read_back = daft.read_parquet(path, hive_partitioning=True).to_pydict()
         assert all(b == bor for b in read_back["Borough"])
 
-    read_back_pd_df = daft.read_parquet(tmp_path.as_posix() + "/**/*.parquet").to_pandas()
+    read_back_pd_df = daft.read_parquet(tmp_path.as_posix() + "/**/*.parquet", hive_partitioning=True).to_pandas()
     assert_df_equals(df.to_pandas(), read_back_pd_df)
 
     assert len(output_files) == 5
@@ -203,7 +203,7 @@ def test_parquet_partitioned_write_with_some_empty_partitions(tmp_path, with_mor
 
     assert len(output_files) == 3
 
-    read_back = daft.read_parquet(tmp_path.as_posix() + "/**/*.parquet").sort("x").to_pydict()
+    read_back = daft.read_parquet(tmp_path.as_posix() + "/**/*.parquet", hive_partitioning=True).sort("x").to_pydict()
     assert read_back == data
 
 
@@ -230,7 +230,7 @@ def test_csv_write_with_partitioning(tmp_path, with_morsel_size):
         types[n] = schema[n].dtype
 
     pd_df = df.write_csv(tmp_path, partition_cols=["Borough"]).to_pandas()
-    read_back_pd_df = daft.read_csv(tmp_path.as_posix() + "/**/*.csv", schema=types).to_pandas()
+    read_back_pd_df = daft.read_csv(tmp_path.as_posix() + "/**/*.csv", schema=types, hive_partitioning=True).to_pandas()
     assert_df_equals(df.to_pandas().fillna(""), read_back_pd_df.fillna(""))
 
     assert len(pd_df) == 5
@@ -286,7 +286,7 @@ def test_csv_partitioned_write_with_some_empty_partitions(tmp_path, with_morsel_
 
     assert len(output_files) == 3
 
-    read_back = daft.read_csv(tmp_path.as_posix() + "/**/*.csv").sort("x").to_pydict()
+    read_back = daft.read_csv(tmp_path.as_posix() + "/**/*.csv", hive_partitioning=True).sort("x").to_pydict()
     assert read_back == data
 
 

--- a/tests/integration/gravitino/test_gravitino_fileset_s3.py
+++ b/tests/integration/gravitino/test_gravitino_fileset_s3.py
@@ -268,7 +268,7 @@ def test_s3_fileset_partitioned_data(
         glob_pattern = f"{gvfs_root}/**/*.parquet"
 
         # Read all partitions
-        read_df = daft.read_parquet(glob_pattern, io_config=gravitino_io_config)
+        read_df = daft.read_parquet(glob_pattern, io_config=gravitino_io_config, hive_partitioning=True)
         result = read_df.sort("id").to_pydict()
 
         assert len(result["id"]) == 6

--- a/tests/integration/io/test_s3_reads_include_path.py
+++ b/tests/integration/io/test_s3_reads_include_path.py
@@ -32,7 +32,9 @@ def test_read_multi_parquet_from_s3_with_include_file_path_column(minio_io_confi
         )
         assert len(file_paths) == 3
         file_paths = sorted([f"s3://{path}" for path in file_paths])
-        read_back = daft.read_parquet(file_paths, io_config=minio_io_config, file_path_column="path").to_pydict()
+        read_back = daft.read_parquet(
+            file_paths, io_config=minio_io_config, file_path_column="path", hive_partitioning=True
+        ).to_pydict()
         assert read_back["a"] == data["a"]
         assert read_back["b"] == data["b"]
         assert read_back["path"] == file_paths
@@ -64,7 +66,9 @@ def test_read_multi_csv_from_s3_with_include_file_path_column(minio_io_config):
         )
         assert len(file_paths) == 3
         file_paths = sorted([f"s3://{path}" for path in file_paths])
-        read_back = daft.read_csv(file_paths, io_config=minio_io_config, file_path_column="path").to_pydict()
+        read_back = daft.read_csv(
+            file_paths, io_config=minio_io_config, file_path_column="path", hive_partitioning=True
+        ).to_pydict()
         assert read_back["a"] == data["a"]
         assert read_back["b"] == data["b"]
         assert read_back["path"] == file_paths

--- a/tests/io/test_hive_style_partitions.py
+++ b/tests/io/test_hive_style_partitions.py
@@ -155,17 +155,18 @@ def test_hive_daft_roundtrip(tmpdir, partition_by, file_format, filter):
             hive_partitioning=True,
         )
         # TODO(desmond): Daft has an inconsistency with handling null string columns when using
-        # `from_arrow` vs `read_csv`. For now we read back an unpartitioned CSV table to check the
-        # result against.
-        plain_filepath = f"{tmpdir}-plain"
-        source.write_csv(plain_filepath)
-        source = daft.read_csv(
-            f"{plain_filepath}/**",
-            schema={
-                "nullable_str": daft.DataType.string(),
-                "nullable_int": daft.DataType.int64(),
-            },
-        )
+        # `from_arrow` vs `read_csv`. Only applies when nullable_str goes through CSV body;
+        # as a partition col it round-trips correctly via hive directory names.
+        if "nullable_str" not in partition_by:
+            plain_filepath = f"{tmpdir}-plain"
+            source.write_csv(plain_filepath)
+            source = daft.read_csv(
+                f"{plain_filepath}/**",
+                schema={
+                    "nullable_str": daft.DataType.string(),
+                    "nullable_int": daft.DataType.int64(),
+                },
+            )
     if file_format == "json":
         source.write_json(filepath, partition_cols=[daft.col(col) for col in partition_by])
         target = daft.read_json(
@@ -192,3 +193,93 @@ def test_hive_daft_roundtrip(tmpdir, partition_by, file_format, filter):
         source = source.where(daft.col(first_col) == sample_value)
         target = target.where(daft.col(first_col) == sample_value)
     assert_tables_equal(target.to_arrow(), source.to_arrow())
+
+
+# Regression tests for https://github.com/Eventual-Inc/Daft/issues/2111:
+# partition values must live only in directory paths (Hive), not duplicated
+# in file bodies, so pandas/pyarrow can read the dataset.
+
+
+def _issue_2111_sample_pydict():
+    import datetime
+
+    return {
+        "first_name": ["Ernesto", "Sari", "Wolfgang", "Jackie", "Zoya"],
+        "last_name": ["Evergreen", "Salama", "Winter", "Jale", "Zee"],
+        "age": [34, 57, 23, 62, 40],
+        "DoB": [
+            datetime.date(1990, 4, 3),
+            datetime.date(1967, 1, 2),
+            datetime.date(2001, 2, 12),
+            datetime.date(1962, 3, 24),
+            datetime.date(1984, 4, 7),
+        ],
+        "country": ["Canada", "United Kingdom", "Germany", "Canada", "United Kingdom"],
+        "has_dog": [True, True, False, True, True],
+    }
+
+
+def test_partition_cols_not_duplicated_in_parquet_file_bodies(tmpdir):
+    import pyarrow.parquet as pq
+
+    daft.from_pydict(_issue_2111_sample_pydict()).write_parquet(str(tmpdir), partition_cols=["country"])
+
+    written_files = [
+        os.path.join(root, f) for root, _, files in os.walk(tmpdir) for f in files if f.endswith(".parquet")
+    ]
+    assert written_files, "expected at least one written parquet file"
+
+    for file_path in written_files:
+        schema_names = pq.read_schema(file_path).names
+        assert "country" not in schema_names, (
+            f"partition column 'country' must not appear in {file_path} (found {schema_names})"
+        )
+
+
+def test_pandas_can_read_daft_partitioned_parquet(tmpdir):
+    pd = pytest.importorskip("pandas")
+
+    sample = _issue_2111_sample_pydict()
+    daft.from_pydict(sample).write_parquet(str(tmpdir), partition_cols=["country"])
+
+    result = pd.read_parquet(str(tmpdir)).sort_values("first_name").reset_index(drop=True)
+    expected = pd.DataFrame(sample).sort_values("first_name").reset_index(drop=True)
+    assert set(result["country"]) == set(expected["country"])
+    assert result["first_name"].tolist() == expected["first_name"].tolist()
+
+
+def test_pyarrow_dataset_can_read_daft_partitioned_parquet(tmpdir):
+    sample = _issue_2111_sample_pydict()
+    daft.from_pydict(sample).write_parquet(str(tmpdir), partition_cols=["country"])
+
+    pa_ds = ds.dataset(str(tmpdir), format="parquet", partitioning="hive")
+    table = pa_ds.to_table()
+    assert "country" in table.schema.names
+    assert set(table.column("country").to_pylist()) == set(sample["country"])
+
+
+def test_partition_cols_not_duplicated_in_csv_file_bodies(tmpdir):
+    daft.from_pydict(_issue_2111_sample_pydict()).write_csv(str(tmpdir), partition_cols=["country"])
+
+    written_files = [os.path.join(root, f) for root, _, files in os.walk(tmpdir) for f in files if f.endswith(".csv")]
+    assert written_files, "expected at least one written csv file"
+
+    for file_path in written_files:
+        with open(file_path) as fh:
+            header = fh.readline().strip().split(",")
+        assert "country" not in header, (
+            f"partition column 'country' must not appear in {file_path} header (found {header})"
+        )
+
+
+def test_partition_by_all_columns_falls_back(tmpdir):
+    # Stripping would leave zero-column files; fall back to keeping columns in bodies.
+    import pyarrow.parquet as pq
+
+    daft.from_pydict({"a": [1, 2, 3], "b": ["x", "y", "z"]}).write_parquet(str(tmpdir), partition_cols=["a", "b"])
+    written_files = [
+        os.path.join(root, f) for root, _, files in os.walk(tmpdir) for f in files if f.endswith(".parquet")
+    ]
+    assert written_files
+    schema = pq.read_schema(written_files[0])
+    assert set(schema.names) == {"a", "b"}

--- a/tests/io/test_hive_style_partitions.py
+++ b/tests/io/test_hive_style_partitions.py
@@ -5,6 +5,7 @@ from datetime import date, datetime
 
 import pyarrow as pa
 import pyarrow.dataset as ds
+import pyarrow.parquet as pq
 import pytest
 
 import daft
@@ -195,38 +196,31 @@ def test_hive_daft_roundtrip(tmpdir, partition_by, file_format, filter):
     assert_tables_equal(target.to_arrow(), source.to_arrow())
 
 
-# Regression tests for https://github.com/Eventual-Inc/Daft/issues/2111:
-# partition values must live only in directory paths (Hive), not duplicated
-# in file bodies, so pandas/pyarrow can read the dataset.
-
-
-def _issue_2111_sample_pydict():
-    import datetime
-
+def _owners_sample_pydict():
     return {
         "first_name": ["Ernesto", "Sari", "Wolfgang", "Jackie", "Zoya"],
         "last_name": ["Evergreen", "Salama", "Winter", "Jale", "Zee"],
         "age": [34, 57, 23, 62, 40],
         "DoB": [
-            datetime.date(1990, 4, 3),
-            datetime.date(1967, 1, 2),
-            datetime.date(2001, 2, 12),
-            datetime.date(1962, 3, 24),
-            datetime.date(1984, 4, 7),
+            date(1990, 4, 3),
+            date(1967, 1, 2),
+            date(2001, 2, 12),
+            date(1962, 3, 24),
+            date(1984, 4, 7),
         ],
         "country": ["Canada", "United Kingdom", "Germany", "Canada", "United Kingdom"],
         "has_dog": [True, True, False, True, True],
     }
 
 
+def _walk_files(root, suffix):
+    return [os.path.join(r, f) for r, _, files in os.walk(root) for f in files if f.endswith(suffix)]
+
+
 def test_partition_cols_not_duplicated_in_parquet_file_bodies(tmpdir):
-    import pyarrow.parquet as pq
+    daft.from_pydict(_owners_sample_pydict()).write_parquet(str(tmpdir), partition_cols=["country"])
 
-    daft.from_pydict(_issue_2111_sample_pydict()).write_parquet(str(tmpdir), partition_cols=["country"])
-
-    written_files = [
-        os.path.join(root, f) for root, _, files in os.walk(tmpdir) for f in files if f.endswith(".parquet")
-    ]
+    written_files = _walk_files(tmpdir, ".parquet")
     assert written_files, "expected at least one written parquet file"
 
     for file_path in written_files:
@@ -239,7 +233,7 @@ def test_partition_cols_not_duplicated_in_parquet_file_bodies(tmpdir):
 def test_pandas_can_read_daft_partitioned_parquet(tmpdir):
     pd = pytest.importorskip("pandas")
 
-    sample = _issue_2111_sample_pydict()
+    sample = _owners_sample_pydict()
     daft.from_pydict(sample).write_parquet(str(tmpdir), partition_cols=["country"])
 
     result = pd.read_parquet(str(tmpdir)).sort_values("first_name").reset_index(drop=True)
@@ -249,7 +243,7 @@ def test_pandas_can_read_daft_partitioned_parquet(tmpdir):
 
 
 def test_pyarrow_dataset_can_read_daft_partitioned_parquet(tmpdir):
-    sample = _issue_2111_sample_pydict()
+    sample = _owners_sample_pydict()
     daft.from_pydict(sample).write_parquet(str(tmpdir), partition_cols=["country"])
 
     pa_ds = ds.dataset(str(tmpdir), format="parquet", partitioning="hive")
@@ -259,9 +253,9 @@ def test_pyarrow_dataset_can_read_daft_partitioned_parquet(tmpdir):
 
 
 def test_partition_cols_not_duplicated_in_csv_file_bodies(tmpdir):
-    daft.from_pydict(_issue_2111_sample_pydict()).write_csv(str(tmpdir), partition_cols=["country"])
+    daft.from_pydict(_owners_sample_pydict()).write_csv(str(tmpdir), partition_cols=["country"])
 
-    written_files = [os.path.join(root, f) for root, _, files in os.walk(tmpdir) for f in files if f.endswith(".csv")]
+    written_files = _walk_files(tmpdir, ".csv")
     assert written_files, "expected at least one written csv file"
 
     for file_path in written_files:
@@ -273,13 +267,8 @@ def test_partition_cols_not_duplicated_in_csv_file_bodies(tmpdir):
 
 
 def test_partition_by_all_columns_falls_back(tmpdir):
-    # Stripping would leave zero-column files; fall back to keeping columns in bodies.
-    import pyarrow.parquet as pq
-
     daft.from_pydict({"a": [1, 2, 3], "b": ["x", "y", "z"]}).write_parquet(str(tmpdir), partition_cols=["a", "b"])
-    written_files = [
-        os.path.join(root, f) for root, _, files in os.walk(tmpdir) for f in files if f.endswith(".parquet")
-    ]
+    written_files = _walk_files(tmpdir, ".parquet")
     assert written_files
     schema = pq.read_schema(written_files[0])
     assert set(schema.names) == {"a", "b"}

--- a/tests/io/test_hive_style_partitions.py
+++ b/tests/io/test_hive_style_partitions.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 from datetime import date, datetime
 
@@ -264,6 +265,24 @@ def test_partition_cols_not_duplicated_in_csv_file_bodies(tmpdir):
         assert "country" not in header, (
             f"partition column 'country' must not appear in {file_path} header (found {header})"
         )
+
+
+def test_partition_cols_not_duplicated_in_json_file_bodies(tmpdir):
+    daft.from_pydict(_owners_sample_pydict()).write_json(str(tmpdir), partition_cols=["country"])
+
+    written_files = _walk_files(tmpdir, ".json")
+    assert written_files, "expected at least one written json file"
+
+    for file_path in written_files:
+        with open(file_path) as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                record = json.loads(line)
+                assert "country" not in record, (
+                    f"partition column 'country' must not appear in {file_path} record (found {sorted(record)})"
+                )
 
 
 def test_partition_by_all_columns_falls_back(tmpdir):

--- a/tests/io/test_json_roundtrip.py
+++ b/tests/io/test_json_roundtrip.py
@@ -515,6 +515,6 @@ def test_write_json_target_filesize_with_partitioning(tmp_path):
 
     assert len(output_files) >= 3, "Expected at least 3 partitions"
 
-    read_back = daft.read_json(str(tmp_path) + "/**/*.json").sort(by="x").to_pydict()
+    read_back = daft.read_json(str(tmp_path) + "/**/*.json", hive_partitioning=True).sort(by="x").to_pydict()
     assert read_back["x"] == data["x"]
     assert read_back["partition"] == data["partition"]

--- a/tests/io/test_opendal.py
+++ b/tests/io/test_opendal.py
@@ -192,7 +192,11 @@ def test_opendal_fs_roundtrip_parquet_partitioned(tmp_path):
     )
     df.write_parquet("fs://localhost/out", partition_cols=["group"], io_config=io_config)
 
-    result = daft.read_parquet("fs://localhost/out/**/*.parquet", io_config=io_config).sort("val").collect()
+    result = (
+        daft.read_parquet("fs://localhost/out/**/*.parquet", io_config=io_config, hive_partitioning=True)
+        .sort("val")
+        .collect()
+    )
     assert result.to_pydict() == {"val": [1, 2, 3, 4], "group": ["a", "a", "b", "b"]}
 
 

--- a/tests/io/test_write_modes.py
+++ b/tests/io/test_write_modes.py
@@ -65,11 +65,16 @@ def write(
         raise ValueError(f"Unsupported format: {format}")
 
 
-def read(path: str, format: str, io_config: daft.io.IOConfig | None = None):
+def read(
+    path: str,
+    format: str,
+    io_config: daft.io.IOConfig | None = None,
+    hive_partitioning: bool = False,
+):
     if format == "parquet":
-        return daft.read_parquet(path, io_config=io_config)
+        return daft.read_parquet(path, io_config=io_config, hive_partitioning=hive_partitioning)
     elif format == "csv":
-        return daft.read_csv(path, io_config=io_config)
+        return daft.read_csv(path, io_config=io_config, hive_partitioning=hive_partitioning)
     else:
         raise ValueError(f"Unsupported format: {format}")
 
@@ -89,9 +94,14 @@ def arrange_write_mode_test(
     # Write some new data
     write(new_data, path, format, write_mode, partition_cols, io_config)
 
-    # Read back the data
+    # Partition columns live only in directory paths; need hive_partitioning to recover them.
     read_path = path + "/**" if partition_cols is not None else path
-    read_back = read(read_path, format, io_config).collect()
+    read_back = read(
+        read_path,
+        format,
+        io_config,
+        hive_partitioning=partition_cols is not None,
+    ).collect()
     read_back = read_back.sort(sort_cols).to_pydict()
 
     return read_back


### PR DESCRIPTION
## Changes Made

`write_parquet` / `write_csv` / `write_json` with `partition_cols` previously kept the partition columns inside file bodies **and** in Hive directory paths. External readers (pandas, pyarrow, Spark) reject the result with `ArrowTypeError: Unable to merge: large_string vs dictionary<...>` because path-inferred types differ from file-body types.

This PR aligns with Spark / PyArrow / Delta: partition values live only in directory paths.

**How it works:**
- `make_physical_writer_factory` computes `(data_schema, keep_indices)` by stripping plain column refs (`col("country")`) from `file_schema`.
- `PhysicalWriterFactory` now bakes `data_schema` instead of the full schema, so native Parquet/CSV/JSON writers serialize without partition columns.
- `PartitionedWriter` applies the precomputed `keep_indices` via `RecordBatch::get_columns` to each per-partition batch before dispatch — PyArrow-fallback writers see the slimmed batch too.
- Derived partition expressions (`partition_days`, `partition_iceberg_bucket`, etc.) are untouched; their source column stays in the file.
- If stripping would leave a zero-column file (e.g. partitioning `daft.range` by `id`), fall back to keeping all columns — Parquet/CSV/JSON can't serialize zero-column records.
- Iceberg / Delta catalog writers are untouched (they manage partition columns per their own spec).

**Tests:**
- New regression tests in `tests/io/test_hive_style_partitions.py`: pandas / pyarrow dataset roundtrip, partition column absent from file schema (Parquet + CSV), zero-column fallback.
- Existing partitioned-write tests updated to pass `hive_partitioning=True` when reading back (required since partition columns no longer live in files).

## Related Issues

Closes #2111