### PR TITLE
fix: add missing serde feature to uuid workspace dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -371,7 +371,7 @@ tracing-subscriber = {version = "0.3.22", default-features = false, features = [
 typetag = "0.2.21"
 rustfft = "6"
 url = "2.4.0"
-uuid = {version = "1.19.0", features = ["v4"]}
+uuid = {version = "1.19.0", features = ["v4", "serde"]}
 xxhash-rust = {version = "0.8.15", features = ["const_xxh3", "const_xxh64", "const_xxh32", "xxh64", "xxh3", "xxh32"]}
 libc = {version = "^0.2.150", default-features = false}
 hex = "0.4.3"


### PR DESCRIPTION
## Changes Made

The workspace `uuid` dependency is missing the `serde` feature required by `Literal`'s `Uuid` variant. Targeted commands like `cargo test -p daft-core` fail to compile, making it harder to iterate on individual crates during development. ( CI and full workspace builds are unaffected because `azure_storage_blobs` transitively activates `uuid/serde` via feature unification.)

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
