### PR TITLE
fix(flotilla): overreporting of bytes.read

### DIFF
--- a/src/daft-local-execution/src/sources/glob_scan.rs
+++ b/src/daft-local-execution/src/sources/glob_scan.rs
@@ -6,7 +6,7 @@ use common_io_config::IOConfig;
 use common_metrics::ops::NodeType;
 use common_runtime::{combine_stream, get_io_runtime};
 use daft_core::prelude::*;
-use daft_io::{IOStatsRef, get_io_client};
+use daft_io::get_io_client;
 // InputId now comes from pipeline_message module
 use daft_micropartition::MicroPartition;
 use daft_recordbatch::RecordBatch;
@@ -22,7 +22,7 @@ use super::source::Source;
 use crate::{
     channel::{Sender, UnboundedReceiver, create_channel},
     pipeline::{InputId, NodeName, PipelineMessage},
-    sources::source::SourceStream,
+    sources::source::{SourceStream, StatsProvider},
 };
 
 pub struct GlobScanSource {
@@ -51,7 +51,7 @@ impl GlobScanSource {
     fn spawn_glob_path_processor(
         mut receiver: UnboundedReceiver<(InputId, Vec<String>)>,
         output_sender: Sender<PipelineMessage>,
-        io_stats: IOStatsRef,
+        stats_provider: StatsProvider,
         chunk_size: usize,
         pushdowns: Pushdowns,
         schema: SchemaRef,
@@ -62,6 +62,7 @@ impl GlobScanSource {
         io_runtime.spawn(async move {
             let io_client = get_io_client(true, Arc::new(io_config.unwrap_or_default()))?;
             while let Some((input_id, glob_paths)) = receiver.recv().await {
+                let io_stats = stats_provider.get_or_create(input_id).io_stats;
                 let remaining_rows = Arc::new(AsyncMutex::new(pushdowns.limit));
                 let seen_paths = Arc::new(DashSet::new());
 
@@ -204,7 +205,7 @@ impl Source for GlobScanSource {
     fn get_data(
         self: Box<Self>,
         _maintain_order: bool,
-        io_stats: IOStatsRef,
+        stats_provider: StatsProvider,
         chunk_size: usize,
     ) -> DaftResult<SourceStream<'static>> {
         let (output_sender, output_receiver) = create_channel::<PipelineMessage>(1);
@@ -216,7 +217,7 @@ impl Source for GlobScanSource {
         let processor_task = Self::spawn_glob_path_processor(
             input_receiver,
             output_sender,
-            io_stats,
+            stats_provider,
             chunk_size,
             pushdowns,
             schema,

--- a/src/daft-local-execution/src/sources/in_memory.rs
+++ b/src/daft-local-execution/src/sources/in_memory.rs
@@ -14,7 +14,7 @@ use super::source::Source;
 use crate::{
     channel::{Sender, UnboundedReceiver, create_channel},
     pipeline::{InputId, NodeName, PipelineMessage},
-    sources::source::SourceStream,
+    sources::source::{SourceStream, StatsProvider},
 };
 
 pub struct InMemorySource {
@@ -40,6 +40,7 @@ impl InMemorySource {
         mut receiver: UnboundedReceiver<(InputId, Vec<MicroPartitionRef>)>,
         output_sender: Sender<PipelineMessage>,
         schema: SchemaRef,
+        stats_provider: StatsProvider,
     ) -> common_runtime::RuntimeTask<DaftResult<()>> {
         let io_runtime = get_io_runtime(true);
 
@@ -52,11 +53,13 @@ impl InMemorySource {
                     recv_result = receiver.recv(), if !receiver_exhausted => {
                         match recv_result {
                             Some((input_id, partitions)) => {
+                                let io_stats = stats_provider.get_or_create(input_id).io_stats;
                                 task_set.spawn(forward_partition_batch(
                                     partitions,
                                     schema.clone(),
                                     output_sender.clone(),
                                     input_id,
+                                    io_stats,
                                 ));
                             }
                             None => {
@@ -88,6 +91,7 @@ async fn forward_partition_batch(
     schema: SchemaRef,
     sender: Sender<PipelineMessage>,
     input_id: InputId,
+    io_stats: IOStatsRef,
 ) -> DaftResult<()> {
     if partitions.is_empty() {
         let empty = MicroPartition::empty(Some(schema));
@@ -100,6 +104,7 @@ async fn forward_partition_batch(
     } else {
         for partition in partitions {
             let owned = Arc::try_unwrap(partition).unwrap_or_else(|a| (*a).clone());
+            io_stats.mark_bytes_read(owned.size_bytes());
             if sender
                 .send(PipelineMessage::Morsel {
                     input_id,
@@ -122,15 +127,18 @@ impl Source for InMemorySource {
     fn get_data(
         self: Box<Self>,
         _maintain_order: bool,
-        io_stats: IOStatsRef,
+        stats_provider: StatsProvider,
         _chunk_size: usize,
     ) -> DaftResult<SourceStream<'static>> {
-        io_stats.mark_bytes_read(self.size_bytes);
         let (output_sender, output_receiver) = create_channel::<PipelineMessage>(1);
         let input_receiver = self.receiver;
 
-        let processor_task =
-            Self::spawn_partition_set_processor(input_receiver, output_sender, self.schema.clone());
+        let processor_task = Self::spawn_partition_set_processor(
+            input_receiver,
+            output_sender,
+            self.schema.clone(),
+            stats_provider,
+        );
 
         let result_stream = output_receiver.into_stream().map(Ok);
         let combined_stream = combine_stream(result_stream, processor_task.map(|x| x?));

--- a/src/daft-local-execution/src/sources/scan_task.rs
+++ b/src/daft-local-execution/src/sources/scan_task.rs
@@ -26,7 +26,7 @@ use crate::{
     pipeline::{InputId, NodeName, PipelineMessage},
     sources::{
         scan_task_reader,
-        source::{Source, SourceStream},
+        source::{Source, SourceStream, StatsProvider},
     },
 };
 
@@ -65,7 +65,7 @@ impl ScanTaskSource {
         num_parallel_tasks: usize,
         mut receiver: UnboundedReceiver<(InputId, Vec<ScanTaskRef>)>,
         output_sender: Sender<PipelineMessage>,
-        io_stats: IOStatsRef,
+        stats_provider: StatsProvider,
         chunk_size: usize,
         schema: SchemaRef,
         maintain_order: bool,
@@ -110,7 +110,7 @@ impl ScanTaskSource {
                     };
                     task_set.spawn(forward_scan_task_stream(
                         scan_task,
-                        io_stats.clone(),
+                        stats_provider.get_or_create(input_id).io_stats,
                         delete_map,
                         maintain_order,
                         chunk_size,
@@ -218,7 +218,7 @@ impl Source for ScanTaskSource {
     fn get_data(
         self: Box<Self>,
         maintain_order: bool,
-        io_stats: IOStatsRef,
+        stats_provider: StatsProvider,
         chunk_size: usize,
     ) -> DaftResult<SourceStream<'static>> {
         let (output_sender, output_receiver) = create_channel::<PipelineMessage>(1);
@@ -229,7 +229,7 @@ impl Source for ScanTaskSource {
             num_parallel_tasks,
             input_receiver,
             output_sender,
-            io_stats,
+            stats_provider,
             chunk_size,
             self.schema.clone(),
             maintain_order,

--- a/src/daft-local-execution/src/sources/shuffle_read.rs
+++ b/src/daft-local-execution/src/sources/shuffle_read.rs
@@ -18,7 +18,7 @@ use daft_shuffles::{client::FlightClientManager, server::flight_server::ShuffleF
 use futures::{FutureExt, StreamExt, stream::BoxStream};
 use tracing::instrument;
 
-use super::source::{Source, SourceStream};
+use super::source::{Source, SourceStream, StatsProvider};
 use crate::{
     channel::{Sender, UnboundedReceiver, create_channel},
     pipeline::{NodeName, PipelineMessage},
@@ -131,6 +131,7 @@ impl ShuffleReadSource {
     fn spawn_flight_shuffle_processor(
         self,
         output_sender: Sender<PipelineMessage>,
+        stats_provider: StatsProvider,
     ) -> common_runtime::RuntimeTask<DaftResult<()>> {
         let mut receiver = self.receiver;
         let num_parallel_tasks = self.num_parallel_tasks;
@@ -151,7 +152,8 @@ impl ShuffleReadSource {
                     && let Some((input_id, input)) = pending_tasks.pop_front()
                 {
                     let stream = Self::get_partition_stream(client_manager.clone(), local_server.clone(), &local_address, input.refs, schema.clone()).await?;
-                    task_set.spawn(forward_partition_stream(stream, schema.clone(), output_sender.clone(), input_id));
+                    let io_stats = stats_provider.get_or_create(input_id).io_stats;
+                    task_set.spawn(forward_partition_stream(stream, schema.clone(), output_sender.clone(), input_id, io_stats));
                 }
 
                 tokio::select! {
@@ -210,9 +212,11 @@ async fn forward_partition_stream(
     schema: SchemaRef,
     sender: Sender<PipelineMessage>,
     input_id: InputId,
+    io_stats: IOStatsRef,
 ) -> DaftResult<InputId> {
     while let Some(batch) = stream.next().await {
         let mp = MicroPartition::new_loaded(schema.clone(), vec![batch?].into(), None);
+        io_stats.mark_bytes_read(mp.size_bytes());
         if sender
             .send(PipelineMessage::Morsel {
                 input_id,
@@ -249,11 +253,11 @@ impl Source for ShuffleReadSource {
     fn get_data(
         self: Box<Self>,
         _maintain_order: bool,
-        _io_stats: IOStatsRef,
+        stats_provider: StatsProvider,
         _chunk_size: usize,
     ) -> DaftResult<SourceStream<'static>> {
         let (output_sender, output_receiver) = create_channel::<PipelineMessage>(1);
-        let processor_task = self.spawn_flight_shuffle_processor(output_sender);
+        let processor_task = self.spawn_flight_shuffle_processor(output_sender, stats_provider);
 
         let result_stream = output_receiver.into_stream().map(Ok);
         let combined_stream = combine_stream(result_stream, processor_task.map(|x| x?));

--- a/src/daft-local-execution/src/sources/shuffle_read.rs
+++ b/src/daft-local-execution/src/sources/shuffle_read.rs
@@ -9,7 +9,6 @@ use common_error::DaftResult;
 use common_metrics::ops::NodeType;
 use common_runtime::{JoinSet, combine_stream, get_compute_pool_num_threads, get_io_runtime};
 use daft_core::prelude::SchemaRef;
-use daft_io::IOStatsRef;
 use daft_local_plan::{FlightShuffleReadInput, InputId};
 use daft_micropartition::MicroPartition;
 use daft_partition_refs::FlightPartitionRef;
@@ -131,7 +130,6 @@ impl ShuffleReadSource {
     fn spawn_flight_shuffle_processor(
         self,
         output_sender: Sender<PipelineMessage>,
-        stats_provider: StatsProvider,
     ) -> common_runtime::RuntimeTask<DaftResult<()>> {
         let mut receiver = self.receiver;
         let num_parallel_tasks = self.num_parallel_tasks;
@@ -152,8 +150,7 @@ impl ShuffleReadSource {
                     && let Some((input_id, input)) = pending_tasks.pop_front()
                 {
                     let stream = Self::get_partition_stream(client_manager.clone(), local_server.clone(), &local_address, input.refs, schema.clone()).await?;
-                    let io_stats = stats_provider.get_or_create(input_id).io_stats;
-                    task_set.spawn(forward_partition_stream(stream, schema.clone(), output_sender.clone(), input_id, io_stats));
+                    task_set.spawn(forward_partition_stream(stream, schema.clone(), output_sender.clone(), input_id));
                 }
 
                 tokio::select! {
@@ -212,11 +209,9 @@ async fn forward_partition_stream(
     schema: SchemaRef,
     sender: Sender<PipelineMessage>,
     input_id: InputId,
-    io_stats: IOStatsRef,
 ) -> DaftResult<InputId> {
     while let Some(batch) = stream.next().await {
         let mp = MicroPartition::new_loaded(schema.clone(), vec![batch?].into(), None);
-        io_stats.mark_bytes_read(mp.size_bytes());
         if sender
             .send(PipelineMessage::Morsel {
                 input_id,
@@ -253,11 +248,11 @@ impl Source for ShuffleReadSource {
     fn get_data(
         self: Box<Self>,
         _maintain_order: bool,
-        stats_provider: StatsProvider,
+        _stats_provider: StatsProvider,
         _chunk_size: usize,
     ) -> DaftResult<SourceStream<'static>> {
         let (output_sender, output_receiver) = create_channel::<PipelineMessage>(1);
-        let processor_task = self.spawn_flight_shuffle_processor(output_sender, stats_provider);
+        let processor_task = self.spawn_flight_shuffle_processor(output_sender);
 
         let result_stream = output_receiver.into_stream().map(Ok);
         let combined_stream = combine_stream(result_stream, processor_task.map(|x| x?));

--- a/src/daft-local-execution/src/sources/source.rs
+++ b/src/daft-local-execution/src/sources/source.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::HashMap,
-    sync::{Arc, Mutex, atomic::Ordering},
+    sync::{Arc, atomic::Ordering},
     time::Instant,
 };
 
@@ -17,6 +17,7 @@ use daft_io::IOStatsRef;
 use daft_local_plan::{InputId, LocalNodeContext};
 use daft_logical_plan::stats::StatsState;
 use daft_micropartition::MicroPartition;
+use dashmap::DashMap;
 // MicroPartition is used in PipelineMessage
 use futures::{StreamExt, stream::BoxStream};
 use opentelemetry::KeyValue;
@@ -47,20 +48,18 @@ pub(crate) struct InputStats {
 /// reused pipeline.
 #[derive(Clone)]
 pub(crate) struct StatsProvider {
-    inner: Arc<Mutex<HashMap<InputId, InputStats>>>,
+    inner: Arc<DashMap<InputId, InputStats>>,
 }
 
 impl StatsProvider {
     pub(crate) fn new() -> Self {
         Self {
-            inner: Arc::new(Mutex::new(HashMap::new())),
+            inner: Arc::new(DashMap::new()),
         }
     }
 
     pub(crate) fn get_or_create(&self, input_id: InputId) -> InputStats {
         self.inner
-            .lock()
-            .expect("StatsProvider mutex poisoned")
             .entry(input_id)
             .or_insert_with(|| InputStats {
                 io_stats: IOStatsRef::default(),

--- a/src/daft-local-execution/src/sources/source.rs
+++ b/src/daft-local-execution/src/sources/source.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::HashMap,
-    sync::{Arc, atomic::Ordering},
+    sync::{Arc, Mutex, atomic::Ordering},
     time::Instant,
 };
 
@@ -31,24 +31,61 @@ use crate::{
 
 pub type SourceStream<'a> = BoxStream<'a, DaftResult<PipelineMessage>>;
 
+/// Per-input stats handle bundling the counters that sources record against.
+/// Cheap to clone; every holder of the same `InputStats` shares the same
+/// underlying counters.
+#[derive(Clone)]
+pub(crate) struct InputStats {
+    pub io_stats: IOStatsRef,
+}
+
+/// Per-input-id `InputStats` registry shared between a `Source` implementation
+/// and the `SourceNode` that owns it. Sources resolve the right counters for
+/// each morsel via `get_or_create`, and the matching per-input `SourceStats`
+/// reads from the same entry — so `bytes_read` naturally scopes to one
+/// `input_id` rather than accumulating across every task that runs on a
+/// reused pipeline.
+#[derive(Clone)]
+pub(crate) struct StatsProvider {
+    inner: Arc<Mutex<HashMap<InputId, InputStats>>>,
+}
+
+impl StatsProvider {
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    pub(crate) fn get_or_create(&self, input_id: InputId) -> InputStats {
+        self.inner
+            .lock()
+            .expect("StatsProvider mutex poisoned")
+            .entry(input_id)
+            .or_insert_with(|| InputStats {
+                io_stats: IOStatsRef::default(),
+            })
+            .clone()
+    }
+}
+
 pub(crate) struct SourceStats {
     duration_us: Counter,
     rows_out: Counter,
     bytes_out: Counter,
     num_tasks: Counter,
-    io_stats: IOStatsRef,
-
+    input_stats: InputStats,
     node_kv: Vec<KeyValue>,
 }
 
 impl SourceStats {
-    fn with_io_stats(meter: &Meter, node_info: &NodeInfo, io_stats: IOStatsRef) -> Self {
+    fn with_input_stats(meter: &Meter, node_info: &NodeInfo, input_stats: InputStats) -> Self {
         Self {
             duration_us: meter.duration_us_metric(),
             rows_out: meter.rows_out_metric(),
             bytes_out: meter.bytes_out_metric(),
             num_tasks: meter.num_tasks_metric(),
-            io_stats,
+            input_stats,
             node_kv: node_info.to_key_values(),
         }
     }
@@ -56,13 +93,16 @@ impl SourceStats {
 
 impl RuntimeStats for SourceStats {
     fn new(meter: &Meter, node_info: &NodeInfo) -> Self {
-        Self::with_io_stats(meter, node_info, IOStatsRef::default())
+        let input_stats = InputStats {
+            io_stats: IOStatsRef::default(),
+        };
+        Self::with_input_stats(meter, node_info, input_stats)
     }
 
     fn build_snapshot(&self, ordering: Ordering) -> StatSnapshot {
         let cpu_us = self.duration_us.load(ordering);
         let rows_out = self.rows_out.load(ordering);
-        let bytes_read = self.io_stats.load_bytes_read() as u64;
+        let bytes_read = self.input_stats.io_stats.load_bytes_read() as u64;
         StatSnapshot::Source(SourceSnapshot {
             cpu_us,
             rows_out,
@@ -105,7 +145,7 @@ pub trait Source: Send + Sync {
     fn get_data(
         self: Box<Self>,
         maintain_order: bool,
-        io_stats: IOStatsRef,
+        stats_provider: StatsProvider,
         chunk_size: usize,
     ) -> DaftResult<SourceStream<'static>>;
     fn schema(&self) -> &SchemaRef;
@@ -218,13 +258,13 @@ impl PipelineNode for SourceNode {
         maintain_order: bool,
         runtime_handle: &mut ExecutionRuntimeContext,
     ) -> crate::Result<crate::channel::Receiver<PipelineMessage>> {
-        let io_stats = IOStatsRef::default();
         let stats_manager = runtime_handle.stats_manager();
         let node_id = self.node_id();
         let schema = self.source.schema().clone();
         let name = self.name();
         let meter = self.meter.clone();
         let node_info = self.node_info.clone();
+        let stats_provider = StatsProvider::new();
 
         let (destination_sender, destination_receiver) = create_channel(1);
         let chunk_size = match self.morsel_size_requirement {
@@ -234,7 +274,7 @@ impl PipelineNode for SourceNode {
 
         let mut source_stream = self
             .source
-            .get_data(maintain_order, io_stats.clone(), chunk_size.into())
+            .get_data(maintain_order, stats_provider.clone(), chunk_size.into())
             .with_context(|_| PipelineExecutionSnafu {
                 node_name: name.to_string(),
             })?;
@@ -264,7 +304,7 @@ impl PipelineNode for SourceNode {
                                 *input_id,
                                 &meter,
                                 &node_info,
-                                &io_stats,
+                                &stats_provider,
                                 &stats_manager,
                                 node_id,
                             );
@@ -298,7 +338,7 @@ impl PipelineNode for SourceNode {
                         0,
                         &meter,
                         &node_info,
-                        &io_stats,
+                        &stats_provider,
                         &stats_manager,
                         node_id,
                     );
@@ -337,20 +377,95 @@ fn get_or_create_source_stats(
     input_id: InputId,
     meter: &Meter,
     node_info: &NodeInfo,
-    io_stats: &IOStatsRef,
+    stats_provider: &StatsProvider,
     stats_manager: &RuntimeStatsManagerHandle,
     node_id: usize,
 ) -> Arc<SourceStats> {
     per_input_stats
         .entry(input_id)
         .or_insert_with(|| {
-            let stats = Arc::new(SourceStats::with_io_stats(
-                meter,
-                node_info,
-                io_stats.clone(),
-            ));
+            let input_stats = stats_provider.get_or_create(input_id);
+            let stats = Arc::new(SourceStats::with_input_stats(meter, node_info, input_stats));
             stats_manager.register_runtime_stats(node_id, input_id, stats.clone());
             stats
         })
         .clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use common_metrics::{Meter, ops::NodeInfo};
+
+    use super::*;
+    use crate::runtime_stats::RuntimeStats;
+
+    #[test]
+    fn provider_returns_same_io_stats_for_same_input_id() {
+        let provider = StatsProvider::new();
+        let a = provider.get_or_create(5);
+        let b = provider.get_or_create(5);
+        assert!(Arc::ptr_eq(&a.io_stats, &b.io_stats));
+    }
+
+    #[test]
+    fn provider_returns_distinct_io_stats_for_distinct_input_ids() {
+        let provider = StatsProvider::new();
+        let a = provider.get_or_create(5);
+        let b = provider.get_or_create(6);
+        assert!(!Arc::ptr_eq(&a.io_stats, &b.io_stats));
+    }
+
+    #[test]
+    fn provider_clone_shares_underlying_map() {
+        let provider_a = StatsProvider::new();
+        let provider_b = provider_a.clone();
+        let from_a = provider_a.get_or_create(1);
+        let from_b = provider_b.get_or_create(1);
+        assert!(Arc::ptr_eq(&from_a.io_stats, &from_b.io_stats));
+    }
+
+    /// Regression test for the bytes.read N× inflation bug.
+    ///
+    /// Before this refactor every `SourceStats` on a reused worker pipeline
+    /// shared one `IOStatsRef`, so each per-input snapshot reported the
+    /// shared counter's cumulative value. Across N tasks, the driver's
+    /// `Counter::add` accumulated those cumulatives → N×/triangular
+    /// inflation (500× observed in practice).
+    ///
+    /// Post-refactor each per-input `SourceStats` resolves its own
+    /// `InputStats` via the provider, so bytes recorded against one
+    /// `input_id` must not surface in another `input_id`'s snapshot.
+    #[test]
+    fn per_input_source_stats_are_isolated() {
+        let meter = Meter::test_scope("per_input_source_stats_are_isolated");
+        let node_info = NodeInfo::default();
+        let provider = StatsProvider::new();
+
+        let stats_a = SourceStats::with_input_stats(&meter, &node_info, provider.get_or_create(1));
+        let stats_b = SourceStats::with_input_stats(&meter, &node_info, provider.get_or_create(2));
+        let stats_c = SourceStats::with_input_stats(&meter, &node_info, provider.get_or_create(3));
+
+        // Each input "reads" 100 MB independently.
+        provider
+            .get_or_create(1)
+            .io_stats
+            .mark_bytes_read(100_000_000);
+        provider
+            .get_or_create(2)
+            .io_stats
+            .mark_bytes_read(100_000_000);
+        provider
+            .get_or_create(3)
+            .io_stats
+            .mark_bytes_read(100_000_000);
+
+        // Without the fix each snapshot would report the cumulative
+        // 300M (shared counter's current value).
+        for stats in [&stats_a, &stats_b, &stats_c] {
+            let StatSnapshot::Source(snapshot) = stats.flush() else {
+                panic!("expected Source snapshot");
+            };
+            assert_eq!(snapshot.bytes_read, 100_000_000);
+        }
+    }
 }


### PR DESCRIPTION
## Changes Made

fixes overreporting of bytes.read by making io stats unique per inputid instead of per source. 

Explanation of bug: 

`bytes_read` counter starts at 0

task 1 reads 20mb -> bytes_read is now at 20mb.
task 2 reads 20mb -> bytes_read is now at 40mb,
task 2 reads 20mb -> bytes_read is now at 60mb,


this part is fine and working as expected, but the issue is during the snapshotting, and summing for distributed. 
Since all tasks are sharing the same count for bytes_read, the reporting becomes wrong. 
They pull from the cumulative bytes_read, not their individual bytes_read.

so
task_1 build_snapshot produces bytes_read of 20MB
task_2 build_snapshot produces bytes_read of 40MB
task_2 build_snapshot produces bytes_read of 60MB

so then when we sum those inside handle_worker_node_stats, we end up with 120MB instead of 60MB.

Fix itself is pretty straightforward. The individual tasks no longer share an io stats ref and have their own instance of it. 

## Related Issues

Closes https://github.com/Eventual-Inc/Daft/issues/6761
