### PR TITLE
docs: fix critical documentation issues 7-14 from audit

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,7 +67,7 @@ The data that we collect is:
 2. **Metadata-only:** We do not collect any of our users’ proprietary code or data
 3. **For development only:** We do not buy or sell any user data
 
-Please see our `documentation <https://docs.daft.ai/en/stable/resources/telemetry/>`_ for more details.
+Please see our `documentation <https://docs.daft.ai/en/stable/telemetry/>`_ for more details.
 
 .. image:: https://static.scarf.sh/a.png?x-pxid=31f8d5ba-7e09-4d75-8895-5252bbf06cf6
 

--- a/docs/ai-functions/prompt.md
+++ b/docs/ai-functions/prompt.md
@@ -46,7 +46,7 @@ df = daft.from_pydict({
 })
 
 # generate responses using a chat model
-df = df.with_column("response", prompt(daft.col("input"), model="gpt-5-mini"))
+df = df.with_column("response", prompt(daft.col("input"), model="gpt-5.4-mini"))
 
 df.show()
 ```

--- a/docs/connectors/aws.md
+++ b/docs/connectors/aws.md
@@ -30,7 +30,7 @@ You may also choose to pass these values into your Daft I/O function calls using
     ```python
     from daft.io import IOConfig, S3Config
 
-    # Supply actual values for the S3 secret key
+    # Supply actual values: key_id is the AWS Access Key ID, access_key is the AWS Secret Access Key
     io_config = IOConfig(s3=S3Config(key_id="key_id", session_token="session_token", access_key="access_key"))
 
     # Globally set the default IOConfig for any subsequent I/O calls

--- a/docs/connectors/aws.md
+++ b/docs/connectors/aws.md
@@ -31,7 +31,7 @@ You may also choose to pass these values into your Daft I/O function calls using
     from daft.io import IOConfig, S3Config
 
     # Supply actual values for the S3 secret key
-    io_config = IOConfig(s3=S3Config(key_id="key_id", session_token="session_token", secret_key="secret_key"))
+    io_config = IOConfig(s3=S3Config(key_id="key_id", session_token="session_token", access_key="access_key"))
 
     # Globally set the default IOConfig for any subsequent I/O calls
     daft.set_planning_config(default_io_config=io_config)

--- a/docs/connectors/sql.md
+++ b/docs/connectors/sql.md
@@ -73,7 +73,7 @@ You can also directly provide a SQL alchemy connection via a **connection factor
     from sqlalchemy import create_engine
 
     def create_connection():
-        return sqlalchemy.create_engine("sqlite:///example.db", echo=True).connect()
+        return create_engine("sqlite:///example.db", echo=True).connect()
 
     df = daft.read_sql("SELECT * FROM books", create_connection)
     ```

--- a/docs/examples/audio-transcription.md
+++ b/docs/examples/audio-transcription.md
@@ -167,7 +167,7 @@ df.write_csv("transcriptions.csv")
 Now let's run it!
 
 ```bash
-uv run example_1.py
+uv run example_2.py
 ```
 
 We should see an output that looks like this:

--- a/docs/examples/image-generation.md
+++ b/docs/examples/image-generation.md
@@ -13,7 +13,7 @@ Let's get started!
 First, let's install some dependencies.
 
 ```bash
-pip install daft --pre --extra-index-url https://pypi.anaconda.org/daft-nightly/simple
+pip install daft
 pip install transformers diffusers accelerate torch Pillow
 ```
 

--- a/docs/examples/minhash-dedupe.md
+++ b/docs/examples/minhash-dedupe.md
@@ -411,12 +411,12 @@ df_edges.show(5)
 First we need a few utilities
 
 ```python
-from daft import struct, Expression, DataFrame
-from daft.functions import when
+from daft import Expression, DataFrame
+from daft.functions import when, to_struct
 
 def ee(u: Expression, v: Expression):
     """Create a struct Expression with fields 'u' and 'v' for representing edges."""
-    return struct(u.alias("u"), v.alias("v"))
+    return to_struct(u.alias("u"), v.alias("v"))
 
 def canonicalize(edges: DataFrame) -> DataFrame:
     """Order edges so u < v and deduplicate for canonical representation."""

--- a/docs/install.md
+++ b/docs/install.md
@@ -34,14 +34,6 @@ Depending on your use case, you may need to install Daft with additional depende
       </label>
 
       <label class="checkbox-item">
-        <input type="checkbox" id="sentence-transformers" data-extra="sentence-transformers">
-        <span class="checkmark"></span>
-        <div class="checkbox-content">
-          <strong>Sentence Transformers</strong> <code>sentence-transformers</code>
-        </div>
-      </label>
-
-      <label class="checkbox-item">
         <input type="checkbox" id="transformers" data-extra="transformers">
         <span class="checkmark"></span>
         <div class="checkbox-content">


### PR DESCRIPTION
- Fix AWS S3 docs: change `secret_key` to correct param name `access_key`
- Fix SQL connector: use imported `create_engine` instead of `sqlalchemy.create_engine`
- Fix minhash example: use `to_struct` from `daft.functions` instead of non-existent `daft.struct`
- Fix audio transcription: correct run command from `example_1.py` to `example_2.py`
- Fix image generation: use stable `pip install daft` instead of nightly build
- Fix install.md: remove non-existent `sentence-transformers` extra option
- Fix README.rst: update telemetry link from `/resources/telemetry/` to `/telemetry/`
- Fix prompt.md: update model name from `gpt-5-mini` to `gpt-5.4-mini`

Slack thread: https://eventualgroup.slack.com/archives/C0ARMCJKZCN/p1776967990779909?thread_ts=1776932446.851829&cid=C0ARMCJKZCN

https://claude.ai/code/session_01JGgChywuKF933NhCYaNL5J

## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
