### PR TITLE
docs: Fix docsearch results to respect current documentation version

### DIFF
--- a/docs/js/docsearch.js
+++ b/docs/js/docsearch.js
@@ -1,4 +1,7 @@
 document.addEventListener('DOMContentLoaded', function () {
+  const versionMatch = window.location.pathname.match(/^\/en\/([^/]+)\//);
+  const currentVersion = versionMatch ? versionMatch[1] : 'stable';
+
   docsearch({
     container: '#docsearch',
     appId: 'CTX8NKR4GC',
@@ -6,5 +9,11 @@ document.addEventListener('DOMContentLoaded', function () {
     indexName: 'getdaft',
     debug: false,
     insights: true,
+    transformItems(items) {
+      return items.map((item) => ({
+        ...item,
+        url: item.url.replace('/en/stable/', `/en/${currentVersion}/`),
+      }));
+    },
   });
 });


### PR DESCRIPTION


## Changes Made

When you search for something in 'latest' docs the results direct to 'stable', which can lead to 404s. So we dynamically detect the current documentation version from the URL pathname and transform search results to link to the same version the user is currently viewing.

**Implementation details:**
- Extract the current version from the URL pattern `/en/{version}/` using a regex match
- Default to 'stable' version if no version is detected in the pathname
- Added a `transformItems` callback to the docsearch config that rewrites result URLs from the hardcoded `/en/stable/` path to the current version path

This ensures that when users search documentation in a specific version (e.g., `/en/dev/`), the search results will link back to that same version instead of always redirecting to the stable version.

## Related Issues

<!-- Link to related GitHub issues if applicable -->

https://claude.ai/code/session_01PzHJ8ANu8JoFz22HHMnh5x