### PR TITLE
fix(flight-shuffle): handle all-empty inputs in shuffle cache and shu…

### DIFF
--- a/src/daft-local-execution/src/pipeline.rs
+++ b/src/daft-local-execution/src/pipeline.rs
@@ -1601,11 +1601,11 @@ fn physical_plan_to_pipeline(
         LocalPhysicalPlan::RepartitionWrite(RepartitionWrite {
             input,
             num_partitions,
+            schema,
             backend,
             repartition_spec,
             stats_state,
             context,
-            ..
         }) => {
             let child_node = physical_plan_to_pipeline(input, cfg, ctx, input_senders)?;
             match backend {
@@ -1630,6 +1630,7 @@ fn physical_plan_to_pipeline(
                         .expect("Flight shuffle server must be initialized for Flight repartition plans when using flight_shuffle algorithm");
                     let repartition_sink = RepartitionSink::try_new_flight(
                         *num_partitions,
+                        schema.clone(),
                         *shuffle_id,
                         repartition_spec.clone(),
                         shuffle_dirs.clone(),
@@ -1654,10 +1655,10 @@ fn physical_plan_to_pipeline(
         }
         LocalPhysicalPlan::GatherWrite(GatherWrite {
             input,
+            schema,
             backend,
             stats_state,
             context,
-            ..
         }) => {
             let child_node = physical_plan_to_pipeline(input, cfg, ctx, input_senders)?;
             match backend {
@@ -1678,6 +1679,7 @@ fn physical_plan_to_pipeline(
                         .shuffle_server()
                         .expect("Flight shuffle server must be initialized for Flight gather plans when using flight_shuffle algorithm");
                     let gather_sink = GatherSink::try_new_flight(
+                        schema.clone(),
                         *shuffle_id,
                         shuffle_dirs.clone(),
                         compression.clone(),

--- a/src/daft-local-execution/src/sinks/gather.rs
+++ b/src/daft-local-execution/src/sinks/gather.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use common_error::DaftResult;
 use common_metrics::ops::NodeType;
+use daft_core::prelude::SchemaRef;
 use daft_micropartition::MicroPartition;
 use daft_partition_refs::FlightPartitionRef;
 use daft_shuffles::{
@@ -36,6 +37,7 @@ struct FlightShared {
     local_server: Arc<ShuffleFlightServer>,
     shuffle_address: String,
     target_in_memory_size_per_partition: usize,
+    schema: SchemaRef,
 }
 
 pub(crate) struct FlightGatherState {
@@ -50,6 +52,7 @@ impl FlightGatherState {
         let partition_ref_id = partition_ref_id(self.input_id, self.refs.len());
         let cache = InProgressShuffleCache::try_new(
             partition_ref_id,
+            shared.schema.clone(),
             &shared.shuffle_dirs,
             shared.shuffle_id,
             shared.target_in_memory_size_per_partition,
@@ -144,6 +147,7 @@ impl GatherSink {
     }
 
     pub fn try_new_flight(
+        schema: SchemaRef,
         shuffle_id: u64,
         shuffle_dirs: Vec<String>,
         compression: Option<String>,
@@ -162,6 +166,7 @@ impl GatherSink {
                 local_server,
                 shuffle_address,
                 target_in_memory_size_per_partition: TARGET_IN_MEMORY_SIZE_BYTES,
+                schema,
             })),
         })
     }

--- a/src/daft-local-execution/src/sinks/into_partitions.rs
+++ b/src/daft-local-execution/src/sinks/into_partitions.rs
@@ -71,6 +71,7 @@ impl FlightIntoPartitionsState {
             let partition_ref_id = partition_ref_id(input_id, partition_idx);
             let cache = InProgressShuffleCache::try_new(
                 partition_ref_id,
+                shared.schema.clone(),
                 &shared.shuffle_dirs,
                 shared.shuffle_id,
                 shared.target_in_memory_size_per_partition,
@@ -163,6 +164,7 @@ struct FlightShared {
     local_server: Arc<ShuffleFlightServer>,
     shuffle_address: String,
     target_in_memory_size_per_partition: usize,
+    schema: SchemaRef,
 }
 
 // Mirrors the pattern in `sinks/gather.rs::GatherBackend` and
@@ -170,14 +172,14 @@ struct FlightShared {
 // between the Ray path and the Flight path and carries Flight's runtime handles.
 #[derive(Clone)]
 enum IntoPartitionsBackend {
-    Ray,
+    Ray { schema: SchemaRef },
     Flight(Arc<FlightShared>),
 }
 
 impl IntoPartitionsBackend {
     fn name(&self) -> &'static str {
         match self {
-            Self::Ray => "Ray",
+            Self::Ray { .. } => "Ray",
             Self::Flight(_) => "Flight",
         }
     }
@@ -185,7 +187,6 @@ impl IntoPartitionsBackend {
 
 pub struct IntoPartitionsSink {
     num_partitions: usize,
-    schema: SchemaRef,
     backend: IntoPartitionsBackend,
 }
 
@@ -193,8 +194,7 @@ impl IntoPartitionsSink {
     pub fn new_ray(num_partitions: usize, schema: SchemaRef) -> Self {
         Self {
             num_partitions,
-            schema,
-            backend: IntoPartitionsBackend::Ray,
+            backend: IntoPartitionsBackend::Ray { schema },
         }
     }
 
@@ -216,7 +216,6 @@ impl IntoPartitionsSink {
         .clamp(1024 * 1024 * 8, 1024 * 1024 * 128);
         Ok(Self {
             num_partitions,
-            schema,
             backend: IntoPartitionsBackend::Flight(Arc::new(FlightShared {
                 shuffle_id,
                 shuffle_dirs,
@@ -224,6 +223,7 @@ impl IntoPartitionsSink {
                 local_server,
                 shuffle_address,
                 target_in_memory_size_per_partition,
+                schema,
             })),
         })
     }
@@ -259,13 +259,12 @@ impl BlockingSink for IntoPartitionsSink {
     ) -> BlockingSinkFinalizeResult {
         let backend = self.backend.clone();
         let num_partitions = self.num_partitions;
-        let schema = self.schema.clone();
 
         spawner
             .spawn(
                 async move {
                     match backend {
-                        IntoPartitionsBackend::Ray => {
+                        IntoPartitionsBackend::Ray { schema } => {
                             let ray_states = states
                                 .into_iter()
                                 .map(|s| match s {
@@ -322,9 +321,11 @@ impl BlockingSink for IntoPartitionsSink {
 
     fn make_state(&self, input_id: InputId) -> DaftResult<Self::State> {
         match &self.backend {
-            IntoPartitionsBackend::Ray => Ok(IntoPartitionsState::Ray(RayIntoPartitionsState {
-                partitions: Vec::new(),
-            })),
+            IntoPartitionsBackend::Ray { .. } => {
+                Ok(IntoPartitionsState::Ray(RayIntoPartitionsState {
+                    partitions: Vec::new(),
+                }))
+            }
             IntoPartitionsBackend::Flight(shared) => Ok(IntoPartitionsState::Flight(
                 FlightIntoPartitionsState::try_new(shared.clone(), input_id, self.num_partitions)?,
             )),

--- a/src/daft-local-execution/src/sinks/repartition.rs
+++ b/src/daft-local-execution/src/sinks/repartition.rs
@@ -5,6 +5,7 @@ use std::{
 
 use common_error::DaftResult;
 use common_metrics::ops::NodeType;
+use daft_core::prelude::SchemaRef;
 use daft_dsl::expr::bound_expr::BoundExpr;
 use daft_logical_plan::partitioning::RepartitionSpec;
 use daft_micropartition::MicroPartition;
@@ -83,6 +84,7 @@ enum RepartitionBackend {
         local_server: Arc<ShuffleFlightServer>,
         shuffle_address: String,
         target_in_memory_size_per_partition: usize,
+        schema: SchemaRef,
         // Only accessed from the single-threaded event loop; Mutex is just for Sync.
         partitions: Mutex<HashMap<InputId, Arc<Vec<Arc<InProgressShuffleCache>>>>>,
     },
@@ -115,6 +117,7 @@ impl RepartitionSink {
     #[allow(clippy::too_many_arguments)]
     pub fn try_new_flight(
         num_partitions: usize,
+        schema: SchemaRef,
         shuffle_id: u64,
         repartition_spec: RepartitionSpec,
         shuffle_dirs: Vec<String>,
@@ -133,6 +136,7 @@ impl RepartitionSink {
                 target_in_memory_size_per_partition: (TARGET_TOTAL_IN_MEMORY_SIZE_BYTES
                     / num_partitions)
                     .clamp(1024 * 1024 * 8, 1024 * 1024 * 128),
+                schema,
                 partitions: Mutex::new(HashMap::new()),
             },
             repartition_spec,
@@ -331,6 +335,7 @@ impl BlockingSink for RepartitionSink {
                 shuffle_id,
                 target_in_memory_size_per_partition,
                 compression,
+                schema,
                 partitions,
                 ..
             } => {
@@ -343,6 +348,7 @@ impl BlockingSink for RepartitionSink {
                                 .map(|partition_idx| {
                                     Ok(Arc::new(InProgressShuffleCache::try_new(
                                         partition_ref_id(input_id, partition_idx),
+                                        schema.clone(),
                                         shuffle_dirs,
                                         *shuffle_id,
                                         *target_in_memory_size_per_partition,

--- a/src/daft-local-execution/src/sources/shuffle_read.rs
+++ b/src/daft-local-execution/src/sources/shuffle_read.rs
@@ -211,8 +211,10 @@ async fn forward_partition_stream(
     sender: Sender<PipelineMessage>,
     input_id: InputId,
 ) -> DaftResult<InputId> {
+    let mut emitted_any = false;
     while let Some(batch) = stream.next().await {
         let mp = MicroPartition::new_loaded(schema.clone(), vec![batch?].into(), None);
+        emitted_any = true;
         if sender
             .send(PipelineMessage::Morsel {
                 input_id,
@@ -221,8 +223,21 @@ async fn forward_partition_stream(
             .await
             .is_err()
         {
-            break;
+            return Ok(input_id);
         }
+    }
+    // If the stream produced no batches (all refs were zero-row / file-less),
+    // still emit a single empty `MicroPartition` so the downstream pipeline
+    // sees one output per input. Matches the `inputs.is_empty()` branch in
+    // `spawn_flight_shuffle_processor`.
+    if !emitted_any {
+        let empty = MicroPartition::empty(Some(schema.clone()));
+        let _ = sender
+            .send(PipelineMessage::Morsel {
+                input_id,
+                partition: empty,
+            })
+            .await;
     }
     Ok(input_id)
 }

--- a/src/daft-shuffles/src/shuffle_cache.rs
+++ b/src/daft-shuffles/src/shuffle_cache.rs
@@ -25,7 +25,6 @@ pub fn partition_ref_id(input_id: u32, partition_idx: usize) -> u64 {
 
 // Result of a writer task
 struct WriterTaskResult {
-    schema: Option<SchemaRef>,
     bytes_per_file: Vec<usize>,
     total_rows_written: usize,
     total_bytes_written: usize,
@@ -43,11 +42,13 @@ pub struct InProgressShuffleCache {
     state: Mutex<InProgressShuffleCacheState>,
     writer_sender_weak: async_channel::WeakSender<MicroPartition>,
     partition_ref_id: u64,
+    schema: SchemaRef,
 }
 
 impl InProgressShuffleCache {
     pub fn try_new(
         partition_ref_id: u64,
+        schema: SchemaRef,
         dirs: &[String],
         shuffle_id: u64,
         target_filesize: usize,
@@ -79,12 +80,13 @@ impl InProgressShuffleCache {
 
         let writer = make_ipc_writer(&partition_dir, target_filesize, compression)?;
 
-        Self::try_new_with_writer(writer, partition_ref_id)
+        Self::try_new_with_writer(writer, partition_ref_id, schema)
     }
 
     fn try_new_with_writer(
         writer: Box<dyn AsyncFileWriter<Input = MicroPartition, Result = Vec<RecordBatch>>>,
         partition_ref_id: u64,
+        schema: SchemaRef,
     ) -> DaftResult<Self> {
         let num_cpus = std::thread::available_parallelism().unwrap().get();
         let (tx, rx) = async_channel::bounded(num_cpus * 2);
@@ -100,6 +102,7 @@ impl InProgressShuffleCache {
             }),
             writer_sender_weak,
             partition_ref_id,
+            schema,
         })
     }
 
@@ -143,9 +146,7 @@ impl InProgressShuffleCache {
         match writer_result {
             Some(result) => Ok(PartitionCache {
                 partition_ref_id: self.partition_ref_id,
-                schema: result.schema.unwrap_or_else(|| {
-                    panic!("No schema found in shuffle cache, this should never happen");
-                }),
+                schema: self.schema.clone(),
                 bytes_per_file: result.bytes_per_file,
                 file_paths: result.file_paths,
                 num_rows: result.total_rows_written,
@@ -180,13 +181,9 @@ async fn writer_task(
     mut writer: Box<dyn AsyncFileWriter<Input = MicroPartition, Result = Vec<RecordBatch>>>,
 ) -> DaftResult<WriterTaskResult> {
     let io_runtime = get_io_runtime(true);
-    let mut schema = None;
     let mut total_rows_written = 0;
     let mut total_bytes_written = 0;
     while let Ok(partition) = rx.recv().await {
-        if schema.is_none() {
-            schema = Some(partition.schema().clone());
-        }
         total_rows_written += partition.len();
         total_bytes_written += partition.size_bytes();
         writer = io_runtime
@@ -216,7 +213,6 @@ async fn writer_task(
     let bytes_per_file = writer.bytes_per_file();
     assert!(bytes_per_file.len() == file_paths.len());
     Ok(WriterTaskResult {
-        schema,
         bytes_per_file,
         total_rows_written,
         total_bytes_written,
@@ -238,12 +234,19 @@ pub struct PartitionCache {
 mod tests {
     use std::sync::Arc;
 
+    use daft_core::datatypes::DataType;
+    use daft_schema::{field::Field, schema::Schema};
     use daft_writers::test::{
         DummyWriterFactory, FailingWriterFactory, make_dummy_mp,
         make_dummy_target_file_size_writer_factory,
     };
 
     use super::*;
+
+    fn dummy_schema() -> SchemaRef {
+        // Matches the schema produced by `make_dummy_mp` in daft-writers tests.
+        Arc::new(Schema::new(vec![Field::new("ints", DataType::UInt8)]))
+    }
 
     #[tokio::test]
     async fn test_shuffle_cache_basic() -> DaftResult<()> {
@@ -254,7 +257,7 @@ mod tests {
         let writer = dummy_writer_factory.create_writer(0, None)?;
 
         // Create the cache with dummy writers
-        let cache = InProgressShuffleCache::try_new_with_writer(writer, 0)?;
+        let cache = InProgressShuffleCache::try_new_with_writer(writer, 0, dummy_schema())?;
 
         // Create and push some partitions
         // Since we have 1 partition, all data goes to partition 0
@@ -286,7 +289,7 @@ mod tests {
             make_dummy_target_file_size_writer_factory(100, 1.0, Arc::new(dummy_writer_factory));
         let writer = dummy_writer_factory.create_writer(0, None)?;
 
-        let cache = InProgressShuffleCache::try_new_with_writer(writer, 0)?;
+        let cache = InProgressShuffleCache::try_new_with_writer(writer, 0, dummy_schema())?;
 
         // Push 1000 empty partitions
         for _ in 0..1000 {
@@ -320,7 +323,7 @@ mod tests {
         let writer = failing_writer_factory.create_writer(0, None)?;
 
         // Create the cache with writers
-        let cache = InProgressShuffleCache::try_new_with_writer(writer, 0)?;
+        let cache = InProgressShuffleCache::try_new_with_writer(writer, 0, dummy_schema())?;
 
         let mut found_failure = false;
         // Technically, we can calculate the max number of iterations before failure, based on number of tasks and channel sizes,
@@ -383,7 +386,7 @@ mod tests {
         let writer = failing_writer_factory.create_writer(0, None)?;
 
         // Create the cache with writers
-        let cache = InProgressShuffleCache::try_new_with_writer(writer, 0)?;
+        let cache = InProgressShuffleCache::try_new_with_writer(writer, 0, dummy_schema())?;
 
         // Create and push a partition
         let partitions = vec![make_dummy_mp(100), make_dummy_mp(100)];

--- a/tests/dataframe/test_shuffles.py
+++ b/tests/dataframe/test_shuffles.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import io
 import random
 import tempfile
+import threading
 from collections.abc import Callable
 from contextlib import contextmanager
 from functools import partial
@@ -365,6 +366,95 @@ def test_flight_into_partitions_rotation_balance(flight_shuffle_ctx):
     get_tests_daft_runner_name() != "ray",
     reason="shuffle tests are meant for the ray runner",
 )
+def test_flight_into_partitions_all_empty_inputs(flight_shuffle_ctx):
+    """All inputs empty post-filter: `into_partitions(N)` must still emit exactly N zero-row output partitions.
+
+    Regression guard for both the caller-schema plumbing through
+    `InProgressShuffleCache` (needed so `close()` can report a schema
+    for an all-empty partition) and the empty-stream fallback in
+    `forward_partition_stream` for `ShuffleRead(Flight)`.
+    """
+    rows = 1000
+    input_partitions = 8
+    output_partitions = 5
+    with flight_shuffle_ctx():
+        df = (
+            daft.from_pydict({"x": list(range(rows))})
+            .into_partitions(input_partitions)
+            .filter(daft.col("x") < 0)
+            .into_partitions(output_partitions)
+            .collect()
+        )
+        assert len(list(df.iter_partitions())) == output_partitions
+        assert df.to_pydict()["x"] == []
+
+
+@pytest.mark.skipif(
+    get_tests_daft_runner_name() != "ray",
+    reason="shuffle tests are meant for the ray runner",
+)
+def test_flight_repartition_all_empty_inputs(flight_shuffle_ctx):
+    """All inputs empty post-filter: hash `.repartition(M, "x")` must still emit M zero-row output partitions.
+
+    Same shuffle-cache shape as `test_flight_into_partitions_all_empty_inputs`
+    (N caches opened per input in `make_state`, all closed with no data), but
+    routed through `RepartitionSink` instead of `IntoPartitionsSink`.
+    """
+    rows = 1000
+    input_partitions = 8
+    output_partitions = 5
+    with flight_shuffle_ctx():
+        df = (
+            daft.from_pydict({"x": list(range(rows))})
+            .into_partitions(input_partitions)
+            .filter(daft.col("x") < 0)
+            .repartition(output_partitions, "x")
+            .collect()
+        )
+        assert len(list(df.iter_partitions())) == output_partitions
+        assert df.to_pydict()["x"] == []
+
+
+@pytest.mark.skipif(
+    get_tests_daft_runner_name() != "ray",
+    reason="shuffle tests are meant for the ray runner",
+)
+def test_flight_gather_all_empty_inputs(flight_shuffle_ctx):
+    """Every upstream partition is empty post-filter: gather must still emit a single empty result without hanging.
+
+    Uses a daemon thread + timeout to protect pytest teardown in case the
+    hang regresses.
+    """
+    rows = 1000
+    input_partitions = 8
+    with flight_shuffle_ctx():
+        df = daft.from_pydict({"x": list(range(rows))}).into_partitions(input_partitions).filter(daft.col("x") < 0)
+
+        result: dict = {}
+
+        def run():
+            try:
+                result["value"] = df.sum("x").collect().to_pydict()["x"]
+            except Exception as e:
+                result["error"] = e
+
+        t = threading.Thread(target=run, daemon=True)
+        t.start()
+        t.join(timeout=30)
+        if t.is_alive():
+            # Hung. Leak the daemon thread (it'll die with the process) and
+            # fail the test with a clear diagnostic rather than blocking teardown.
+            raise TimeoutError("test_flight_gather_all_empty_inputs hung past 30s")
+        if "error" in result:
+            raise result["error"]
+        # The sum over an empty table should be 0 rows or a single NULL row.
+        assert result["value"] in ([], [None], [0])
+
+
+@pytest.mark.skipif(
+    get_tests_daft_runner_name() != "ray",
+    reason="shuffle tests are meant for the ray runner",
+)
 @pytest.mark.parametrize("input_partitions", [1, 8, 32])
 def test_flight_gather(flight_shuffle_ctx, input_partitions):
     """Gather is triggered by top_n and ungrouped agg on multi-partition inputs.
@@ -442,10 +532,8 @@ def test_flight_gather_mixed_empty_inputs(flight_shuffle_ctx):
 
     Exercises the FlightGatherState empty-input short-circuit: some input
     partitions have rows after the filter, others don't. Regressions in
-    the short-circuit would either miscount refs or skip data.
-
-    Note: the all-empty case (every partition filtered away) hangs in the
-    downstream ShuffleRead today and is intentionally not covered here.
+    the short-circuit would either miscount refs or skip data. The all-empty
+    case is covered by `test_flight_gather_all_empty_inputs`.
     """
     rows = 1000
     input_partitions = 8


### PR DESCRIPTION
  ## Changes Made

  Fixes two co-dependent bugs in the Flight shuffle engine that surface whenever every input partition is empty (e.g. after a filter that eliminates all rows upstream of `into_partitions`, `repartition`, or a gather-backed aggregation).

  **Failure mode 1:** `InProgressShuffleCache::close()` panicked on all-empty partitions because the writer task only captured schema lazily on the first push. `IntoPartitions` and `Repartition` both open N caches upfront and close them all in finalize, so when no data ever arrives, there's no schema to report.

  **Fix:** thread the caller's schema through `try_new` and use it directly. Every caller already has it, so the lazy-capture path is dropped entirely.

  **Failure mode 2:** `ShuffleRead(Flight)` stalled when refs existed but every ref was zero-row / empty-file. `forward_partition_stream` fell through its loop without emitting anything, and downstream stages that expect at least one morsel per input hung.

  **Fix:** emit a single empty `MicroPartition` when the stream produces zero batches, mirroring the existing `inputs.is_empty()` branch in`spawn_flight_shuffle_processor`.

  Regression tests cover all three sinks under all-empty input.
