### PR TITLE
feat(distributed): Add env to enable task events

### DIFF
--- a/src/daft-context/src/subscribers/events.rs
+++ b/src/daft-context/src/subscribers/events.rs
@@ -159,13 +159,6 @@ pub struct TaskSubmitEvent {
 }
 
 #[derive(Debug, Clone)]
-pub struct TaskStartEvent {
-    pub header: EventHeader,
-    pub task: Arc<TaskMeta>,
-    pub worker_id: Arc<str>,
-}
-
-#[derive(Debug, Clone)]
 pub struct TaskEndEvent {
     pub header: EventHeader,
     pub task: Arc<TaskMeta>,

--- a/src/daft-distributed/src/python/mod.rs
+++ b/src/daft-distributed/src/python/mod.rs
@@ -26,7 +26,10 @@ use crate::{
     },
     plan::{DistributedPhysicalPlan, PlanConfig, PlanResultStream, PlanRunner},
     python::ray::RayTaskResult,
-    statistics::{StatisticsManager, StatisticsManagerRef, StatisticsSubscriber},
+    statistics::{
+        StatisticsManager, StatisticsManagerRef, StatisticsSubscriber,
+        task_lifecycle::{TaskLifecycleEventSubscriber, task_events_enabled},
+    },
 };
 
 #[pyclass(frozen)]
@@ -232,6 +235,13 @@ impl PyDistributedPhysicalPlanRunner {
         // Create subscribers list with progress bar always included
         let mut subscribers: Vec<Box<dyn StatisticsSubscriber>> =
             vec![Box::new(FlotillaProgressBar::try_new(py)?)];
+
+        // Add the TaskLifecycleEventSubscriber if task emitting enabled
+        if task_events_enabled() {
+            subscribers.push(Box::new(TaskLifecycleEventSubscriber::new(
+                plan.plan.query_id(),
+            )));
+        }
 
         // Only add DashboardStatisticsSubscriber if RAY_DISABLE_DASHBOARD is not set to "1"
         if std::env::var("RAY_DISABLE_DASHBOARD").as_deref() != Ok("1") {

--- a/src/daft-distributed/src/statistics/task_lifecycle.rs
+++ b/src/daft-distributed/src/statistics/task_lifecycle.rs
@@ -15,13 +15,19 @@ use crate::{
     statistics::{StatisticsSubscriber, TaskEvent},
 };
 
-#[allow(dead_code)]
+pub fn task_events_enabled() -> bool {
+    if let Ok(val) = std::env::var("DAFT_TASK_EVENTS_ENABLED") {
+        matches!(val.trim().to_lowercase().as_str(), "1" | "true")
+    } else {
+        false // Disabled by default; enable with DAFT_TASK_EVENTS_ENABLED=true
+    }
+}
+
 pub(crate) struct TaskLifecycleEventSubscriber {
     context: DaftContext,
     query_id: QueryID,
 }
 
-#[allow(dead_code)]
 impl TaskLifecycleEventSubscriber {
     pub fn new(query_id: QueryID) -> Self {
         let context = get_context();
@@ -93,7 +99,6 @@ impl StatisticsSubscriber for TaskLifecycleEventSubscriber {
     }
 }
 
-#[allow(dead_code)]
 fn task_meta_from_context(context: &TaskContext) -> Arc<TaskMeta> {
     let meta = TaskMeta {
         id: context.task_id,


### PR DESCRIPTION
## Changes Made
This add `DAFT_TASK_EVENTS_ENABLED` to enable emitting tasks events to subsribers.
