### PR TITLE
fix: respect per-method max_retries/on_error overrides

### DIFF
--- a/daft/udf/udf_v2.py
+++ b/daft/udf/udf_v2.py
@@ -147,6 +147,10 @@ class Func(Generic[P, T, C]):
         unnest = getattr(method, UNNEST_ATTR, False)
         is_batch = getattr(method, BATCH_ATTR, False)
         batch_size = getattr(method, BATCH_SIZE_ATTR, None)
+        method_max_retries = getattr(method, MAX_RETRIES_ATTR, None)
+        method_on_error = getattr(method, ON_ERROR_ATTR, None)
+        effective_max_retries = max_retries if method_max_retries is None else method_max_retries
+        effective_on_error = on_error if method_on_error is None else method_on_error
         return_dtype = getattr(method, RETURN_DTYPE_ATTR, None)
         return_dtype = cls._get_return_dtype(method, return_dtype, is_generator, is_batch)
         return cls(
@@ -161,8 +165,8 @@ class Func(Generic[P, T, C]):
             gpus,
             use_process,
             max_concurrency,
-            max_retries,
-            on_error,
+            effective_max_retries,
+            effective_on_error,
             return_dtype,
             name_override,
             ray_options,

--- a/tests/udf/test_cls.py
+++ b/tests/udf/test_cls.py
@@ -391,3 +391,39 @@ def test_cls_gpus_one_point_five_is_rejected():
 
         BadRepeat(2)
     assert "num_gpus greater than 1 must be an integer" in str(excinfo.value)
+
+
+def test_cls_method_inherits_retry_and_on_error_from_class_defaults():
+    @daft.cls(max_retries=2, on_error="ignore")
+    class InheritDefaults:
+        @daft.method
+        def rowwise(self, x: int) -> int:
+            return x
+
+        @daft.method.batch(return_dtype=DataType.int64())
+        def batch(self, x: daft.Series) -> daft.Series:
+            return x
+
+    udf = InheritDefaults()
+    assert udf.rowwise.max_retries == 2
+    assert udf.rowwise.on_error == "ignore"
+    assert udf.batch.max_retries == 2
+    assert udf.batch.on_error == "ignore"
+
+
+def test_cls_method_overrides_retry_and_on_error_per_method():
+    @daft.cls(max_retries=0, on_error="raise")
+    class MethodOverrides:
+        @daft.method(max_retries=5, on_error="log")
+        def rowwise(self, x: int) -> int:
+            return x
+
+        @daft.method.batch(return_dtype=DataType.int64(), max_retries=3, on_error="ignore")
+        def batch(self, x: daft.Series) -> daft.Series:
+            return x
+
+    udf = MethodOverrides()
+    assert udf.rowwise.max_retries == 5
+    assert udf.rowwise.on_error == "log"
+    assert udf.batch.max_retries == 3
+    assert udf.batch.on_error == "ignore"


### PR DESCRIPTION
## Summary
Fixes `#6710`: `@daft.method` and `@daft.method.batch` now correctly respect per-method `max_retries` and `on_error` overrides.

Previously, these values were written by the decorators but never read in `Func._from_method`, so class-level defaults always won.

## Changes Made
- Update `Func._from_method` in `daft/udf/udf_v2.py` to read:
  - `MAX_RETRIES_ATTR`
  - `ON_ERROR_ATTR`
- Apply method-level values when explicitly set.
- Preserve class-level defaults when method-level values are unset (`None`).
- Add regression tests in `tests/udf/test_cls.py` covering both:
  - inheritance from class-level defaults
  - per-method overrides for both row-wise and batch methods

## Test Plan
- `DAFT_RUNNER=native python -m pytest -q tests/udf/test_cls.py -k "retry_and_on_error or inherits_retry"`
- `DAFT_RUNNER=native python -m pytest -q tests/udf/test_cls.py`

## Related Issues
Closes #6710
