### PR TITLE
fix(checkpoint): normalize Windows tempdir paths in s3_store tests

### DIFF
--- a/src/daft-checkpoint/tests/s3_store.rs
+++ b/src/daft-checkpoint/tests/s3_store.rs
@@ -27,7 +27,11 @@ use futures::TryStreamExt;
 /// `file:///absolute/path`.
 fn make_store() -> (tempfile::TempDir, S3CheckpointStore) {
     let dir = tempfile::tempdir().expect("failed to create temp dir");
-    let prefix = format!("file://{}", dir.path().display());
+    // Normalize to forward slashes so the `file://` URL is well-formed on Windows.
+    let prefix = format!(
+        "file://{}",
+        dir.path().display().to_string().replace('\\', "/")
+    );
     let store = S3CheckpointStore::new(prefix, Arc::new(IOConfig::default())).unwrap();
     (dir, store)
 }

--- a/src/daft-checkpoint/tests/s3_store.rs
+++ b/src/daft-checkpoint/tests/s3_store.rs
@@ -27,11 +27,14 @@ use futures::TryStreamExt;
 /// `file:///absolute/path`.
 fn make_store() -> (tempfile::TempDir, S3CheckpointStore) {
     let dir = tempfile::tempdir().expect("failed to create temp dir");
-    // Normalize to forward slashes so the `file://` URL is well-formed on Windows.
-    let prefix = format!(
-        "file://{}",
-        dir.path().display().to_string().replace('\\', "/")
-    );
+    // Normalize to forward slashes and ensure the canonical triple-slash `file:///`
+    // form on Windows, where `display()` yields `C:\Users\...` without a leading slash.
+    let raw = dir.path().display().to_string().replace('\\', "/");
+    let prefix = if raw.starts_with('/') {
+        format!("file://{raw}")
+    } else {
+        format!("file:///{raw}")
+    };
     let store = S3CheckpointStore::new(prefix, Arc::new(IOConfig::default())).unwrap();
     (dir, store)
 }


### PR DESCRIPTION
## Summary

On Windows, `tempfile::tempdir().path().display()` yields a backslash path (`C:\Users\...\tmp`), which produces a malformed `file://` URL when concatenated. Downstream, the daft-io local glob fails to match manifest paths, and all tests that write+read data assert `left: []` vs the expected data.

Normalize to forward slashes at URL construction — no-op on POSIX.

## Test plan

- [x] `cargo test -p daft-checkpoint --test s3_store` passes locally (macOS).
- [ ] Windows rust-tests on main should go green after merge.