### PR TITLE
fix(udf): resolve use_process=True subprocess deadlocks

### DIFF
--- a/daft/execution/udf.py
+++ b/daft/execution/udf.py
@@ -6,6 +6,7 @@ import secrets
 import subprocess
 import sys
 import tempfile
+from collections import deque
 from multiprocessing import resource_tracker, shared_memory
 from multiprocessing.connection import Listener, wait
 from typing import IO, TYPE_CHECKING, cast
@@ -99,8 +100,9 @@ class UdfHandle:
 
         # Lines drained from the child's stdout pipe while eval_input was
         # waiting on recv(). Consumed by trace_output() before falling back to
-        # reading more from the pipe. See issue #6762.
-        self._pending_lines: list[bytes] = []
+        # reading more from the pipe. See issue #6762. deque so popleft is O(1)
+        # even when a flooding UDF builds up a large queue.
+        self._pending_lines: deque[bytes] = deque()
 
         # Serialize and send the expression projection
         expr_projection = ExpressionsProjection([Expression._from_pyexpr(udf_expr)])
@@ -114,11 +116,16 @@ class UdfHandle:
         lines = []
         while True:
             if self._pending_lines:
-                line = self._pending_lines.pop(0)
+                line = self._pending_lines.popleft()
             else:
                 line = cast("IO[bytes]", self.process.stdout).readline()
-            # UDF process is expected to return the divider
-            # after initialization and every iteration
+            # UDF process is expected to return the divider after
+            # initialization and every iteration. The divider is preceded by a
+            # bare "\n" byte so the divider always lands on its own line even
+            # when a UDF's last write lacked a trailing newline — skip that
+            # padding newline here rather than surface it as a blank line.
+            if line == b"\n":
+                continue
             if line == b"" or line == _OUTPUT_DIVIDER or self.process.poll() is not None:
                 break
             lines.append(line.decode().rstrip())

--- a/daft/execution/udf.py
+++ b/daft/execution/udf.py
@@ -7,7 +7,7 @@ import subprocess
 import sys
 import tempfile
 from multiprocessing import resource_tracker, shared_memory
-from multiprocessing.connection import Listener
+from multiprocessing.connection import Listener, wait
 from typing import IO, TYPE_CHECKING, cast
 
 import daft.pickle
@@ -97,6 +97,11 @@ class UdfHandle:
         self.handle_conn = self.listener.accept()
         self.transport = SharedMemoryTransport()
 
+        # Lines drained from the child's stdout pipe while eval_input was
+        # waiting on recv(). Consumed by trace_output() before falling back to
+        # reading more from the pipe. See issue #6762.
+        self._pending_lines: list[bytes] = []
+
         # Serialize and send the expression projection
         expr_projection = ExpressionsProjection([Expression._from_pyexpr(udf_expr)])
         expr_projection_bytes = daft.pickle.dumps(expr_projection)
@@ -108,7 +113,10 @@ class UdfHandle:
     def trace_output(self) -> list[str]:
         lines = []
         while True:
-            line = cast("IO[bytes]", self.process.stdout).readline()
+            if self._pending_lines:
+                line = self._pending_lines.pop(0)
+            else:
+                line = cast("IO[bytes]", self.process.stdout).readline()
             # UDF process is expected to return the divider
             # after initialization and every iteration
             if line == b"" or line == _OUTPUT_DIVIDER or self.process.poll() is not None:
@@ -124,8 +132,24 @@ class UdfHandle:
         shm_name, shm_size = self.transport.write_and_close(serialized)
         self.handle_conn.send((shm_name, shm_size))
 
+        # Drain the child's stdout concurrently with waiting for the response.
+        # Without this, a batch whose output exceeds the ~64 KiB OS pipe
+        # buffer would deadlock: the child blocks in write() before reaching
+        # conn.send, while the parent blocks in recv() and never drains the
+        # pipe. See issue #6762.
+        stdout_stream = cast("IO[bytes]", self.process.stdout)
+        stdout_fd = stdout_stream.fileno()
         try:
-            response = self.handle_conn.recv()
+            response = None
+            while response is None:
+                ready = wait([self.handle_conn, stdout_fd])
+                if self.handle_conn in ready:
+                    response = self.handle_conn.recv()
+                if stdout_fd in ready:
+                    line = stdout_stream.readline()
+                    if line == b"":
+                        raise EOFError()
+                    self._pending_lines.append(line)
         except EOFError:
             stdout = self.trace_output()
             raise RuntimeError(f"UDF process closed the connection unexpectedly (EOF reached), stdout: {stdout}")

--- a/daft/execution/udf_worker.py
+++ b/daft/execution/udf_worker.py
@@ -62,8 +62,12 @@ def udf_event_loop(
             output_bytes = evaluated.to_ipc_stream()
             out_name, out_size = transport.write_and_close(output_bytes)
 
-            # Mark end of UDF's stdout and flush
-            print(_OUTPUT_DIVIDER.decode(), end="", file=sys.stderr, flush=True)
+            # Mark end of UDF's stdout and flush.
+            # Leading newline ensures the divider lands on its own line even if
+            # the UDF's last write lacked a trailing newline — otherwise
+            # readline() on the parent would fuse them and never match the
+            # divider. See issue #6762.
+            print("\n" + _OUTPUT_DIVIDER.decode(), end="", file=sys.stderr, flush=True)
             sys.stdout.flush()
             sys.stderr.flush()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ dev = [
   "pytest-cov==7.0.0",
   "pytest-profiling>=1.8.1",
   "pytest-xdist[psutil]>=3.8.0",
+  "pytest-timeout>=2.3.0",
   "memray==1.19.1; platform_system != \"Windows\"",
   # Testing dependencies
   "lxml==6.0.2",

--- a/tests/udf/test_use_process_deadlocks.py
+++ b/tests/udf/test_use_process_deadlocks.py
@@ -52,3 +52,41 @@ def test_stderr_without_trailing_newline_does_not_deadlock_on_divider_merge():
     df = daft.from_pydict({"x": list(range(4))})
     actual = df.with_column("y", no_newline(df["x"])).to_pydict()
     assert actual == {"x": [0, 1, 2, 3], "y": [1, 2, 3, 4]}
+
+
+@pytest.mark.timeout(30)
+def test_silent_udf_produces_no_spurious_stdout_lines(monkeypatch):
+    r"""trace_output() must not surface the divider-padding newline as a line.
+
+    The divider-merge fix prepends `\n` to `_OUTPUT_DIVIDER` so the divider
+    always lands on its own line. Without filtering that padding in
+    trace_output(), every batch of every use_process=True UDF returns an
+    extra empty line, which the Rust caller then prints as `[`udf` Worker #N]`
+    noise to the terminal.
+
+    Intercept trace_output() to capture what it returns and assert the
+    silent-UDF case yields an empty list.
+    """
+    from daft.execution import udf as udf_mod
+
+    captured: list[list[str]] = []
+    original = udf_mod.UdfHandle.trace_output
+
+    def spy(self: object) -> list[str]:
+        result = original(self)  # type: ignore[arg-type]
+        captured.append(result)
+        return result
+
+    monkeypatch.setattr(udf_mod.UdfHandle, "trace_output", spy)
+
+    @daft.func(use_process=True)
+    def silent_udf(x: int) -> int:
+        return x + 1
+
+    df = daft.from_pydict({"x": list(range(4))})
+    actual = df.with_column("y", silent_udf(df["x"])).to_pydict()
+    assert actual == {"x": [0, 1, 2, 3], "y": [1, 2, 3, 4]}
+
+    # Every trace_output() call for a silent UDF should return exactly [].
+    non_empty_results = [r for r in captured if r]
+    assert non_empty_results == [], f"Silent UDF produced spurious stdout lines: {non_empty_results!r}"

--- a/tests/udf/test_use_process_deadlocks.py
+++ b/tests/udf/test_use_process_deadlocks.py
@@ -1,0 +1,54 @@
+"""Regression tests for use_process=True UDF subprocess deadlocks.
+
+See issue #6762 for the full root-cause analysis.
+
+Two distinct deadlocks live in UdfHandle's stdout plumbing
+(daft/execution/udf.py). Both stem from the parent blocking on
+handle_conn.recv() before draining the child's stdout pipe.
+
+- Large stderr output (>64 KiB per batch) fills the OS pipe buffer; the child
+  blocks in write() before reaching conn.send(_SUCCESS), while the parent
+  waits forever on recv() without draining the pipe.
+- Stderr output without a trailing newline fuses with the _OUTPUT_DIVIDER
+  sentinel into a single readline() result that never matches the exact
+  equality check, so trace_output() loops on readline() forever.
+
+Both tests use @pytest.mark.timeout — a hang here means a regression, and
+pytest fails the test cleanly via SIGALRM rather than wedging CI.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+import daft
+
+
+@pytest.mark.timeout(30)
+def test_large_stderr_does_not_deadlock_on_pipe_buffer():
+    STDERR_BYTES_PER_ROW = 100_000  # well over any OS pipe buffer (~64 KiB)
+
+    @daft.func(use_process=True)
+    def noisy(x: int) -> int:
+        sys.stderr.buffer.write(b"x" * STDERR_BYTES_PER_ROW + b"\n")
+        sys.stderr.flush()
+        return x + 1
+
+    df = daft.from_pydict({"x": list(range(4))})
+    actual = df.with_column("y", noisy(df["x"])).to_pydict()
+    assert actual == {"x": [0, 1, 2, 3], "y": [1, 2, 3, 4]}
+
+
+@pytest.mark.timeout(30)
+def test_stderr_without_trailing_newline_does_not_deadlock_on_divider_merge():
+    @daft.func(use_process=True)
+    def no_newline(x: int) -> int:
+        sys.stderr.buffer.write(b"hello-no-newline")
+        sys.stderr.flush()
+        return x + 1
+
+    df = daft.from_pydict({"x": list(range(4))})
+    actual = df.with_column("y", no_newline(df["x"])).to_pydict()
+    assert actual == {"x": [0, 1, 2, 3], "y": [1, 2, 3, 4]}

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
@@ -1594,6 +1594,7 @@ dev = [
     { name = "pytest-codspeed" },
     { name = "pytest-cov" },
     { name = "pytest-profiling" },
+    { name = "pytest-timeout" },
     { name = "pytest-xdist", extra = ["psutil"] },
     { name = "ray", extra = ["client", "data"] },
     { name = "reportlab" },
@@ -1741,6 +1742,7 @@ dev = [
     { name = "pytest-codspeed", specifier = "==4.3.0" },
     { name = "pytest-cov", specifier = "==7.0.0" },
     { name = "pytest-profiling", specifier = ">=1.8.1" },
+    { name = "pytest-timeout", specifier = ">=2.3.0" },
     { name = "pytest-xdist", extras = ["psutil"], specifier = ">=3.8.0" },
     { name = "ray", extras = ["data", "client"], specifier = "==2.55.0" },
     { name = "reportlab", specifier = "==4.4.10" },
@@ -2633,6 +2635,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/92/db/b4c12cff13ebac2786f4f217f06588bccd8b53d260453404ef22b121fc3a/greenlet-3.2.3-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:1afd685acd5597349ee6d7a88a8bec83ce13c106ac78c196ee9dde7c04fe87be", size = 268977, upload-time = "2025-06-05T16:10:24.001Z" },
     { url = "https://files.pythonhosted.org/packages/52/61/75b4abd8147f13f70986df2801bf93735c1bd87ea780d70e3b3ecda8c165/greenlet-3.2.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:761917cac215c61e9dc7324b2606107b3b292a8349bdebb31503ab4de3f559ac", size = 627351, upload-time = "2025-06-05T16:38:50.685Z" },
     { url = "https://files.pythonhosted.org/packages/35/aa/6894ae299d059d26254779a5088632874b80ee8cf89a88bca00b0709d22f/greenlet-3.2.3-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:a433dbc54e4a37e4fff90ef34f25a8c00aed99b06856f0119dcf09fbafa16392", size = 638599, upload-time = "2025-06-05T16:41:34.057Z" },
+    { url = "https://files.pythonhosted.org/packages/30/64/e01a8261d13c47f3c082519a5e9dbf9e143cc0498ed20c911d04e54d526c/greenlet-3.2.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:72e77ed69312bab0434d7292316d5afd6896192ac4327d44f3d613ecb85b037c", size = 634482, upload-time = "2025-06-05T16:48:16.26Z" },
     { url = "https://files.pythonhosted.org/packages/47/48/ff9ca8ba9772d083a4f5221f7b4f0ebe8978131a9ae0909cf202f94cd879/greenlet-3.2.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:68671180e3849b963649254a882cd544a3c75bfcd2c527346ad8bb53494444db", size = 633284, upload-time = "2025-06-05T16:13:01.599Z" },
     { url = "https://files.pythonhosted.org/packages/e9/45/626e974948713bc15775b696adb3eb0bd708bec267d6d2d5c47bb47a6119/greenlet-3.2.3-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:49c8cfb18fb419b3d08e011228ef8a25882397f3a859b9fe1436946140b6756b", size = 582206, upload-time = "2025-06-05T16:12:48.51Z" },
     { url = "https://files.pythonhosted.org/packages/b1/8e/8b6f42c67d5df7db35b8c55c9a850ea045219741bb14416255616808c690/greenlet-3.2.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:efc6dc8a792243c31f2f5674b670b3a95d46fa1c6a912b8e310d6f542e7b0712", size = 1111412, upload-time = "2025-06-05T16:36:45.479Z" },
@@ -2641,6 +2644,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fc/2e/d4fcb2978f826358b673f779f78fa8a32ee37df11920dc2bb5589cbeecef/greenlet-3.2.3-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:784ae58bba89fa1fa5733d170d42486580cab9decda3484779f4759345b29822", size = 270219, upload-time = "2025-06-05T16:10:10.414Z" },
     { url = "https://files.pythonhosted.org/packages/16/24/929f853e0202130e4fe163bc1d05a671ce8dcd604f790e14896adac43a52/greenlet-3.2.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0921ac4ea42a5315d3446120ad48f90c3a6b9bb93dd9b3cf4e4d84a66e42de83", size = 630383, upload-time = "2025-06-05T16:38:51.785Z" },
     { url = "https://files.pythonhosted.org/packages/d1/b2/0320715eb61ae70c25ceca2f1d5ae620477d246692d9cc284c13242ec31c/greenlet-3.2.3-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:d2971d93bb99e05f8c2c0c2f4aa9484a18d98c4c3bd3c62b65b7e6ae33dfcfaf", size = 642422, upload-time = "2025-06-05T16:41:35.259Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/49/445fd1a210f4747fedf77615d941444349c6a3a4a1135bba9701337cd966/greenlet-3.2.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c667c0bf9d406b77a15c924ef3285e1e05250948001220368e039b6aa5b5034b", size = 638375, upload-time = "2025-06-05T16:48:18.235Z" },
     { url = "https://files.pythonhosted.org/packages/7e/c8/ca19760cf6eae75fa8dc32b487e963d863b3ee04a7637da77b616703bc37/greenlet-3.2.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:592c12fb1165be74592f5de0d70f82bc5ba552ac44800d632214b76089945147", size = 637627, upload-time = "2025-06-05T16:13:02.858Z" },
     { url = "https://files.pythonhosted.org/packages/65/89/77acf9e3da38e9bcfca881e43b02ed467c1dedc387021fc4d9bd9928afb8/greenlet-3.2.3-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29e184536ba333003540790ba29829ac14bb645514fbd7e32af331e8202a62a5", size = 585502, upload-time = "2025-06-05T16:12:49.642Z" },
     { url = "https://files.pythonhosted.org/packages/97/c6/ae244d7c95b23b7130136e07a9cc5aadd60d59b5951180dc7dc7e8edaba7/greenlet-3.2.3-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:93c0bb79844a367782ec4f429d07589417052e621aa39a5ac1fb99c5aa308edc", size = 1114498, upload-time = "2025-06-05T16:36:46.598Z" },
@@ -2649,6 +2653,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/94/ad0d435f7c48debe960c53b8f60fb41c2026b1d0fa4a99a1cb17c3461e09/greenlet-3.2.3-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:25ad29caed5783d4bd7a85c9251c651696164622494c00802a139c00d639242d", size = 271992, upload-time = "2025-06-05T16:11:23.467Z" },
     { url = "https://files.pythonhosted.org/packages/93/5d/7c27cf4d003d6e77749d299c7c8f5fd50b4f251647b5c2e97e1f20da0ab5/greenlet-3.2.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88cd97bf37fe24a6710ec6a3a7799f3f81d9cd33317dcf565ff9950c83f55e0b", size = 638820, upload-time = "2025-06-05T16:38:52.882Z" },
     { url = "https://files.pythonhosted.org/packages/c6/7e/807e1e9be07a125bb4c169144937910bf59b9d2f6d931578e57f0bce0ae2/greenlet-3.2.3-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:baeedccca94880d2f5666b4fa16fc20ef50ba1ee353ee2d7092b383a243b0b0d", size = 653046, upload-time = "2025-06-05T16:41:36.343Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/ab/158c1a4ea1068bdbc78dba5a3de57e4c7aeb4e7fa034320ea94c688bfb61/greenlet-3.2.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:be52af4b6292baecfa0f397f3edb3c6092ce071b499dd6fe292c9ac9f2c8f264", size = 647701, upload-time = "2025-06-05T16:48:19.604Z" },
     { url = "https://files.pythonhosted.org/packages/cc/0d/93729068259b550d6a0288da4ff72b86ed05626eaf1eb7c0d3466a2571de/greenlet-3.2.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0cc73378150b8b78b0c9fe2ce56e166695e67478550769536a6742dca3651688", size = 649747, upload-time = "2025-06-05T16:13:04.628Z" },
     { url = "https://files.pythonhosted.org/packages/f6/f6/c82ac1851c60851302d8581680573245c8fc300253fc1ff741ae74a6c24d/greenlet-3.2.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:706d016a03e78df129f68c4c9b4c4f963f7d73534e48a24f5f5a7101ed13dbbb", size = 605461, upload-time = "2025-06-05T16:12:50.792Z" },
     { url = "https://files.pythonhosted.org/packages/98/82/d022cf25ca39cf1200650fc58c52af32c90f80479c25d1cbf57980ec3065/greenlet-3.2.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:419e60f80709510c343c57b4bb5a339d8767bf9aef9b8ce43f4f143240f88b7c", size = 1121190, upload-time = "2025-06-05T16:36:48.59Z" },
@@ -2657,6 +2662,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b1/cf/f5c0b23309070ae93de75c90d29300751a5aacefc0a3ed1b1d8edb28f08b/greenlet-3.2.3-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:500b8689aa9dd1ab26872a34084503aeddefcb438e2e7317b89b11eaea1901ad", size = 270732, upload-time = "2025-06-05T16:10:08.26Z" },
     { url = "https://files.pythonhosted.org/packages/48/ae/91a957ba60482d3fecf9be49bc3948f341d706b52ddb9d83a70d42abd498/greenlet-3.2.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a07d3472c2a93117af3b0136f246b2833fdc0b542d4a9799ae5f41c28323faef", size = 639033, upload-time = "2025-06-05T16:38:53.983Z" },
     { url = "https://files.pythonhosted.org/packages/6f/df/20ffa66dd5a7a7beffa6451bdb7400d66251374ab40b99981478c69a67a8/greenlet-3.2.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:8704b3768d2f51150626962f4b9a9e4a17d2e37c8a8d9867bbd9fa4eb938d3b3", size = 652999, upload-time = "2025-06-05T16:41:37.89Z" },
+    { url = "https://files.pythonhosted.org/packages/51/b4/ebb2c8cb41e521f1d72bf0465f2f9a2fd803f674a88db228887e6847077e/greenlet-3.2.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:5035d77a27b7c62db6cf41cf786cfe2242644a7a337a0e155c80960598baab95", size = 647368, upload-time = "2025-06-05T16:48:21.467Z" },
     { url = "https://files.pythonhosted.org/packages/8e/6a/1e1b5aa10dced4ae876a322155705257748108b7fd2e4fae3f2a091fe81a/greenlet-3.2.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2d8aa5423cd4a396792f6d4580f88bdc6efcb9205891c9d40d20f6e670992efb", size = 650037, upload-time = "2025-06-05T16:13:06.402Z" },
     { url = "https://files.pythonhosted.org/packages/26/f2/ad51331a157c7015c675702e2d5230c243695c788f8f75feba1af32b3617/greenlet-3.2.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2c724620a101f8170065d7dded3f962a2aea7a7dae133a009cada42847e04a7b", size = 608402, upload-time = "2025-06-05T16:12:51.91Z" },
     { url = "https://files.pythonhosted.org/packages/26/bc/862bd2083e6b3aff23300900a956f4ea9a4059de337f5c8734346b9b34fc/greenlet-3.2.3-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:873abe55f134c48e1f2a6f53f7d1419192a3d1a4e873bace00499a4e45ea6af0", size = 1119577, upload-time = "2025-06-05T16:36:49.787Z" },
@@ -2665,6 +2671,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d8/ca/accd7aa5280eb92b70ed9e8f7fd79dc50a2c21d8c73b9a0856f5b564e222/greenlet-3.2.3-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:3d04332dddb10b4a211b68111dabaee2e1a073663d117dc10247b5b1642bac86", size = 271479, upload-time = "2025-06-05T16:10:47.525Z" },
     { url = "https://files.pythonhosted.org/packages/55/71/01ed9895d9eb49223280ecc98a557585edfa56b3d0e965b9fa9f7f06b6d9/greenlet-3.2.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8186162dffde068a465deab08fc72c767196895c39db26ab1c17c0b77a6d8b97", size = 683952, upload-time = "2025-06-05T16:38:55.125Z" },
     { url = "https://files.pythonhosted.org/packages/ea/61/638c4bdf460c3c678a0a1ef4c200f347dff80719597e53b5edb2fb27ab54/greenlet-3.2.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f4bfbaa6096b1b7a200024784217defedf46a07c2eee1a498e94a1b5f8ec5728", size = 696917, upload-time = "2025-06-05T16:41:38.959Z" },
+    { url = "https://files.pythonhosted.org/packages/22/cc/0bd1a7eb759d1f3e3cc2d1bc0f0b487ad3cc9f34d74da4b80f226fde4ec3/greenlet-3.2.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:ed6cfa9200484d234d8394c70f5492f144b20d4533f69262d530a1a082f6ee9a", size = 692443, upload-time = "2025-06-05T16:48:23.113Z" },
     { url = "https://files.pythonhosted.org/packages/67/10/b2a4b63d3f08362662e89c103f7fe28894a51ae0bc890fabf37d1d780e52/greenlet-3.2.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:02b0df6f63cd15012bed5401b47829cfd2e97052dc89da3cfaf2c779124eb892", size = 692995, upload-time = "2025-06-05T16:13:07.972Z" },
     { url = "https://files.pythonhosted.org/packages/5a/c6/ad82f148a4e3ce9564056453a71529732baf5448ad53fc323e37efe34f66/greenlet-3.2.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:86c2d68e87107c1792e2e8d5399acec2487a4e993ab76c792408e59394d52141", size = 655320, upload-time = "2025-06-05T16:12:53.453Z" },
     { url = "https://files.pythonhosted.org/packages/5c/4f/aab73ecaa6b3086a4c89863d94cf26fa84cbff63f52ce9bc4342b3087a06/greenlet-3.2.3-cp314-cp314-win_amd64.whl", hash = "sha256:8c47aae8fbbfcf82cc13327ae802ba13c9c36753b67e760023fd116bc124a62a", size = 301236, upload-time = "2025-06-05T16:15:20.111Z" },
@@ -7417,6 +7424,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/44/74/806cafd6f2108d37979ec71e73b2ff7f7db88eabd19d3b79c5d6cc229c36/pytest-profiling-1.8.1.tar.gz", hash = "sha256:3f171fa69d5c82fa9aab76d66abd5f59da69135c37d6ae5bf7557f1b154cb08d", size = 33135, upload-time = "2024-11-29T19:34:13.85Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e3/ac/c428c66241a144617a8af7a28e2e055e1438d23b949b62ac4b401a69fb79/pytest_profiling-1.8.1-py3-none-any.whl", hash = "sha256:3dd8713a96298b42d83de8f5951df3ada3e61b3e5d2a06956684175529e17aea", size = 9929, upload-time = "2024-11-29T19:33:02.111Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Fixes two distinct deadlocks in `UdfHandle`'s stdout plumbing (see #6762 for full root-cause analysis):

1. **Pipe-buffer overflow**: when a `use_process=True` UDF writes more than the OS pipe buffer (~64 KiB on Linux/macOS) to stderr per batch, the child blocks in `write()` before reaching `conn.send(_SUCCESS)` while the parent blocks in `recv()` without draining the pipe — classic two-channel ordering deadlock. Fixed by using `multiprocessing.connection.wait()` to multiplex between the control channel and the stdout pipe, draining lines into a per-handle buffer while waiting for the response.

2. **Divider-merge**: when a UDF's last stderr write lacks a trailing newline, those bytes and `_OUTPUT_DIVIDER` fuse into a single `readline()` result that never matches the exact-equality check in `trace_output()`, hanging the parent on an empty pipe forever. Fixed by prepending `\n` to the divider write so it always lands on its own line.

Closes #6762.

## Commit structure (TDD)

Three commits on the branch, each verified locally:

1. **`test(udf): add failing regression tests`** — introduces `pytest-timeout` dev dep and two integration tests that reproduce each deadlock. Tests hang and time out at this commit (60s total runtime).
2. **`fix(udf): prepend newline to output divider`** — one-line fix in `udf_worker.py`. Divider-merge test passes; pipe-buffer test still hangs.
3. **`fix(udf): drain stdout concurrently with recv`** — `mp.connection.wait`-based drain in `udf.py`. Both tests pass (~0.3s).

## Test plan

- [x] `pytest tests/udf/test_use_process_deadlocks.py` passes (0.4s) on macOS, native runner
- [x] `pytest tests/expressions/test_legacy_udf.py` — 165 passed, 0 regressions
- [x] `pytest tests/udf/test_row_wise_udf.py -k use_process` — existing async use_process test still passes
- [ ] CI verification

## Notes

- This subsystem is POSIX-only in practice: `UdfHandle.__init__` uses a Unix-socket `Listener` with a `tempfile.NamedTemporaryFile` path that won't work on Windows. `mp.connection.wait()` is stdlib-blessed for this "wait on Connection + pipe fd concurrently" pattern on POSIX. A follow-up could add an explicit `NotImplementedError` for Windows users.
- At commit #2 of this branch, running the pipe-buffer test first causes `pytest-timeout`'s SIGALRM to leave a dangling subprocess that affects the next test in the same pytest session. Cosmetic — HEAD has both fixes so the pathology can't reproduce.