### PR TITLE
fix(iceberg): recognize account-scoped ADLS property keys from catalogs

### DIFF
--- a/daft/io/iceberg/_iceberg.py
+++ b/daft/io/iceberg/_iceberg.py
@@ -27,6 +27,36 @@ def _convert_iceberg_file_io_properties_to_io_config(props: dict[str, Any]) -> I
                 return property_value
         return None
 
+    # Some catalogs (e.g. Polaris) vend Azure credentials scoped to a storage
+    # account, so the key is `adls.sas-token.<account>.dfs.core.windows.net`
+    # instead of the plain `adls.sas-token`. See #6357.
+    _ADLS_ACCOUNT_SUFFIX = ".dfs.core.windows.net"
+
+    def get_adls_scoped_value(*property_names: str) -> tuple[str | None, str | None]:
+        """Look up an ADLS property that may be plain or account-scoped.
+
+        Returns (value, inferred_account). `inferred_account` is None when the
+        matching key was unscoped or no match was found.
+        """
+        nonlocal any_props_set
+        for name in property_names:
+            if value := props.get(name):
+                any_props_set = True
+                return value, None
+            prefix = name + "."
+            for key, value in props.items():
+                if key.startswith(prefix) and key.endswith(_ADLS_ACCOUNT_SUFFIX):
+                    account = key[len(prefix) : -len(_ADLS_ACCOUNT_SUFFIX)]
+                    if account:
+                        any_props_set = True
+                        return value, account
+        return None, None
+
+    access_key, access_key_account = get_adls_scoped_value("adls.account-key", "adlfs.account-key")
+    sas_token, sas_token_account = get_adls_scoped_value("adls.sas-token", "adlfs.sas-token")
+    explicit_account = get_first_property_value("adls.account-name", "adlfs.account-name")
+    storage_account = explicit_account or access_key_account or sas_token_account
+
     io_config = IOConfig(
         s3=S3Config(
             endpoint_url=get_first_property_value("s3.endpoint"),
@@ -36,9 +66,9 @@ def _convert_iceberg_file_io_properties_to_io_config(props: dict[str, Any]) -> I
             session_token=get_first_property_value("s3.session-token", "client.session-token"),
         ),
         azure=AzureConfig(
-            storage_account=get_first_property_value("adls.account-name", "adlfs.account-name"),
-            access_key=get_first_property_value("adls.account-key", "adlfs.account-key"),
-            sas_token=get_first_property_value("adls.sas-token", "adlfs.sas-token"),
+            storage_account=storage_account,
+            access_key=access_key,
+            sas_token=sas_token,
             tenant_id=get_first_property_value("adls.tenant-id", "adlfs.tenant-id"),
             client_id=get_first_property_value("adls.client-id", "adlfs.client-id"),
             client_secret=get_first_property_value("adls.client-secret", "adlfs.client-secret"),

--- a/tests/io/iceberg/test_convert_file_io_properties.py
+++ b/tests/io/iceberg/test_convert_file_io_properties.py
@@ -1,0 +1,91 @@
+"""Tests for `_convert_iceberg_file_io_properties_to_io_config`.
+
+Focused on the ADLS account-scoped property key handling. PyIceberg (when used
+with Polaris and other catalogs that vend per-account credentials) returns
+scoped keys like `adls.sas-token.<account>.dfs.core.windows.net` instead of
+the plain `adls.sas-token` key. See issue #6357.
+"""
+
+from __future__ import annotations
+
+from daft.io.iceberg._iceberg import _convert_iceberg_file_io_properties_to_io_config
+
+
+def test_unscoped_sas_token_matches():
+    """Backward compat: plain unscoped keys still work."""
+    props = {"adls.sas-token": "plain-token"}
+    io_config = _convert_iceberg_file_io_properties_to_io_config(props)
+    assert io_config is not None
+    assert io_config.azure.sas_token == "plain-token"
+
+
+def test_unscoped_account_key_matches():
+    props = {"adls.account-key": "plain-key"}
+    io_config = _convert_iceberg_file_io_properties_to_io_config(props)
+    assert io_config is not None
+    assert io_config.azure.access_key == "plain-key"
+
+
+def test_scoped_sas_token_extracts_value_and_account():
+    """Polaris-vended credentials: scoped key yields both value and account name."""
+    props = {"adls.sas-token.myaccount.dfs.core.windows.net": "scoped-token"}
+    io_config = _convert_iceberg_file_io_properties_to_io_config(props)
+    assert io_config is not None
+    assert io_config.azure.sas_token == "scoped-token"
+    assert io_config.azure.storage_account == "myaccount"
+
+
+def test_scoped_account_key_extracts_value_and_account():
+    props = {"adls.account-key.myaccount.dfs.core.windows.net": "scoped-key"}
+    io_config = _convert_iceberg_file_io_properties_to_io_config(props)
+    assert io_config is not None
+    assert io_config.azure.access_key == "scoped-key"
+    assert io_config.azure.storage_account == "myaccount"
+
+
+def test_adlfs_prefix_scoped_also_works():
+    """Both `adls.*` and `adlfs.*` prefixes should accept scoped keys."""
+    props = {"adlfs.sas-token.myaccount.dfs.core.windows.net": "scoped-token"}
+    io_config = _convert_iceberg_file_io_properties_to_io_config(props)
+    assert io_config is not None
+    assert io_config.azure.sas_token == "scoped-token"
+    assert io_config.azure.storage_account == "myaccount"
+
+
+def test_explicit_account_name_overrides_scoped_key_suffix():
+    """Explicit `adls.account-name` beats a scoped-key suffix.
+
+    If both are present and disagree, the explicit value wins.
+    """
+    props = {
+        "adls.account-name": "explicit-account",
+        "adls.sas-token.other-account.dfs.core.windows.net": "scoped-token",
+    }
+    io_config = _convert_iceberg_file_io_properties_to_io_config(props)
+    assert io_config is not None
+    assert io_config.azure.storage_account == "explicit-account"
+    assert io_config.azure.sas_token == "scoped-token"
+
+
+def test_unscoped_account_name_with_unscoped_sas_token():
+    """Fully unscoped: account-name and sas-token both explicit."""
+    props = {"adls.account-name": "myacct", "adls.sas-token": "plain-token"}
+    io_config = _convert_iceberg_file_io_properties_to_io_config(props)
+    assert io_config is not None
+    assert io_config.azure.storage_account == "myacct"
+    assert io_config.azure.sas_token == "plain-token"
+
+
+def test_no_azure_props_returns_none_if_no_other_props():
+    """Function returns None only when NO relevant props of any kind are set."""
+    io_config = _convert_iceberg_file_io_properties_to_io_config({"unrelated.key": "x"})
+    assert io_config is None
+
+
+def test_s3_props_still_work():
+    """Existing non-Azure handling is untouched."""
+    props = {"s3.access-key-id": "AKIA", "s3.secret-access-key": "secret"}
+    io_config = _convert_iceberg_file_io_properties_to_io_config(props)
+    assert io_config is not None
+    assert io_config.s3.key_id == "AKIA"
+    assert io_config.s3.access_key == "secret"


### PR DESCRIPTION
## Summary

Fixes #6357. Catalogs that vend per-account Azure credentials (Polaris is the common case) return PyIceberg FileIO property keys scoped to the storage account — `adls.sas-token.<account>.dfs.core.windows.net` instead of the plain `adls.sas-token`. The previous exact-key lookup silently dropped these, causing downstream authentication failures with no indication of the miss.

After this change, scoped keys are recognized for `adls.sas-token` / `adls.account-key` (and `adlfs.*` aliases). When a scoped key matches, the storage account name is extracted from the key suffix and used to populate `AzureConfig.storage_account` — unless an explicit `adls.account-name` property is also present, in which case the explicit value wins. Unscoped keys continue to work unchanged.

## Commit structure (TDD)

1. **`test(iceberg): add failing tests`** — 9 cases covering backward compat, scoped `sas-token` / `account-key`, `adlfs.*` aliases, explicit-override precedence, no-props → None, and S3-props-untouched. 4 fail at this commit.
2. **`fix(iceberg): recognize account-scoped ADLS property keys`** — adds a `get_adls_scoped_value` helper that returns `(value, inferred_account)`; extracts account name from key suffix. 9/9 pass.

## Test plan

- [x] `pytest tests/io/iceberg/test_convert_file_io_properties.py` — 9 passed locally (macOS).
- [ ] CI verification.

## Notes

- Limitation: Daft's `AzureConfig` is single-account. If a catalog vends credentials for multiple storage accounts in one response, we pick the first scoped-key match. Filing a warning for that case would be a reasonable follow-up but isn't in scope here.
- The issue reporter (@firecast) has been waiting 49 days; I took the fix rather than routing since the shape was concrete.