### PR TITLE
fix(checkpoint): use strip_file_uri_to_path in put_bytes for Windows

### DIFF
--- a/src/daft-checkpoint/src/impls/s3.rs
+++ b/src/daft-checkpoint/src/impls/s3.rs
@@ -8,7 +8,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use daft_core::series::Series;
-use daft_io::{IOClient, IOConfig, get_io_client};
+use daft_io::{IOClient, IOConfig, get_io_client, strip_file_uri_to_path};
 use futures::{
     StreamExt, TryStreamExt,
     future::{join_all, try_join_all},
@@ -134,8 +134,12 @@ impl S3CheckpointStore {
 
     async fn put_bytes(&self, path: &str, data: Vec<u8>) -> CheckpointResult<()> {
         // Local filesystem backend (`file://`) requires parent directories
-        // to exist before writing — S3 does not.
-        if let Some(local) = path.strip_prefix("file://")
+        // to exist before writing — S3 does not. Use `strip_file_uri_to_path`
+        // (rather than a hand-rolled `strip_prefix("file://")`) so the
+        // Windows-canonical `file:///C:/Users/...` form has its leading slash
+        // before the drive letter stripped — otherwise `std::path::Path` fails
+        // with os error 123 on Windows.
+        if let Some(local) = strip_file_uri_to_path(path)
             && let Some(parent) = std::path::Path::new(local).parent()
         {
             std::fs::create_dir_all(parent).map_err(|e| CheckpointError::Internal {


### PR DESCRIPTION
## Summary

Follow-up to #6791. The earlier PR fixed the test helper to produce a canonical `file:///C:/Users/...` URL on Windows. That unblocked the **reader** path (which routes through `daft_io::strip_file_uri_to_path` and `#[cfg(windows)] strip_leading_slash_before_drive`), but **`S3CheckpointStore::put_bytes` still did its own** `path.strip_prefix("file://")` and handed `/C:/Users/...` to `Path::new(...)`. Windows rejects that with os error 123 (`"filename, directory name, or volume label syntax is incorrect"`), so every write blew up at the first `create_dir_all`.

Net effect on the Windows coverage job: went from `3 passed / 11 failed` (pre-#6791) to `0 passed / 14 failed` (post-#6791). Reads worked; writes didn't.

This PR switches `put_bytes` to use `daft_io::strip_file_uri_to_path` — the canonical helper — so both platforms get correct handling:
- POSIX: `file:///tmp/foo` → `/tmp/foo`
- Windows: `file:///C:/Users/...` → `C:/Users/...`

## Why no local test

The failing shape is Windows-specific (the `Path::new("/C:/...")` parse failure) and not reproducible on macOS/Linux. Relying on the existing Windows rust-tests CI to verify.

## Test plan

- [x] `cargo test -p daft-checkpoint --test s3_store` — 14/14 pass locally (macOS).
- [ ] Windows rust-tests on `main` should go back to 14/14 after merge.