### PR TITLE
feat(dashboard): render Repartition spec in human-readable form

### DIFF
--- a/src/daft-dashboard/frontend/src/app/query/plan-visualizer.tsx
+++ b/src/daft-dashboard/frontend/src/app/query/plan-visualizer.tsx
@@ -18,7 +18,7 @@ function parsePlan(planJson: string): PlanNode {
 /** Extract display properties from a node (everything except type and children). */
 function getNodeProps(node: PlanNode): [string, unknown][] {
   return Object.entries(node).filter(
-    ([key]) => key !== "type" && key !== "children"
+    ([key]) => key !== "type" && key !== "children",
   );
 }
 
@@ -26,90 +26,9 @@ function getColor(nodeType: string) {
   return categoryColors[nodeType] ?? defaultColor;
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
-}
-
-function formatCompactValue(value: unknown): string {
-  if (value === null) {
-    return "null";
-  }
-  if (value === undefined) {
-    return "undefined";
-  }
+function formatValue(value: unknown): string {
   if (Array.isArray(value)) {
-    return `[${value.map(v => formatCompactValue(v)).join(", ")}]`;
-  }
-  if (typeof value === "object") {
-    return JSON.stringify(value);
-  }
-  return String(value);
-}
-
-function formatRepartitionField(key: string, value: unknown): string | null {
-  if (key === "num_partitions" && (value === null || value === undefined)) {
-    return `${key}=auto`;
-  }
-  if (key === "seed" && (value === null || value === undefined)) {
-    return null;
-  }
-  return `${key}=${formatCompactValue(value)}`;
-}
-
-function formatRepartitionSpec(value: unknown): string | null {
-  if (!isRecord(value)) {
-    return null;
-  }
-
-  const entries = Object.entries(value);
-  if (entries.length !== 1) {
-    return null;
-  }
-
-  const [specType, specConfig] = entries[0];
-  if (
-    !isRecord(specConfig) ||
-    !["Random", "Hash", "Range"].includes(specType)
-  ) {
-    return null;
-  }
-
-  const parts: string[] = [];
-  const knownKeys = ["num_partitions", "by", "seed"];
-
-  for (const key of knownKeys) {
-    if (key in specConfig) {
-      const formatted = formatRepartitionField(key, specConfig[key]);
-      if (formatted !== null) {
-        parts.push(formatted);
-      }
-    }
-  }
-
-  for (const [key, fieldValue] of Object.entries(specConfig)) {
-    if (knownKeys.includes(key)) {
-      continue;
-    }
-
-    const formatted = formatRepartitionField(key, fieldValue);
-    if (formatted !== null) {
-      parts.push(formatted);
-    }
-  }
-
-  return parts.length > 0 ? `${specType} (${parts.join(", ")})` : specType;
-}
-
-function formatValue(key: string, value: unknown): string {
-  if (key.toLowerCase() === "repartition_spec") {
-    const formattedRepartitionSpec = formatRepartitionSpec(value);
-    if (formattedRepartitionSpec !== null) {
-      return formattedRepartitionSpec;
-    }
-  }
-
-  if (Array.isArray(value)) {
-    return value.map(v => String(v)).join(", ");
+    return value.map((v) => String(v)).join(", ");
   }
   if (value === null || value === undefined) {
     return "—";
@@ -162,7 +81,7 @@ function NodeCard({
               <span
                 className={`${main.className} text-xs text-zinc-300 break-all`}
               >
-                {formatValue(key, value)}
+                {formatValue(value)}
               </span>
             </div>
           ))}
@@ -233,8 +152,8 @@ export default function PlanVisualizer({ planJson }: { planJson: string }) {
           <div className="relative flex justify-center py-6 px-4 overflow-auto">
             <TreeLayout
               node={plan}
-              getChildren={node => node.children ?? []}
-              renderNode={node => <ExpandableNodeCard node={node} />}
+              getChildren={(node) => node.children ?? []}
+              renderNode={(node) => <ExpandableNodeCard node={node} />}
             />
           </div>
         ) : (

--- a/src/daft-dashboard/frontend/src/app/query/plan-visualizer.tsx
+++ b/src/daft-dashboard/frontend/src/app/query/plan-visualizer.tsx
@@ -18,7 +18,7 @@ function parsePlan(planJson: string): PlanNode {
 /** Extract display properties from a node (everything except type and children). */
 function getNodeProps(node: PlanNode): [string, unknown][] {
   return Object.entries(node).filter(
-    ([key]) => key !== "type" && key !== "children",
+    ([key]) => key !== "type" && key !== "children"
   );
 }
 
@@ -26,9 +26,71 @@ function getColor(nodeType: string) {
   return categoryColors[nodeType] ?? defaultColor;
 }
 
-function formatValue(value: unknown): string {
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function formatCompactValue(value: unknown): string {
+  if (value === null || value === undefined) {
+    return "auto";
+  }
   if (Array.isArray(value)) {
-    return value.map((v) => String(v)).join(", ");
+    return `[${value.map(v => formatCompactValue(v)).join(", ")}]`;
+  }
+  if (typeof value === "object") {
+    return JSON.stringify(value);
+  }
+  return String(value);
+}
+
+function formatRepartitionSpec(value: unknown): string | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const entries = Object.entries(value);
+  if (entries.length !== 1) {
+    return null;
+  }
+
+  const [specType, specConfig] = entries[0];
+  if (
+    !isRecord(specConfig) ||
+    !["Random", "Hash", "Range"].includes(specType)
+  ) {
+    return null;
+  }
+
+  const parts: string[] = [];
+  if ("num_partitions" in specConfig) {
+    parts.push(
+      `num_partitions=${formatCompactValue(specConfig.num_partitions)}`
+    );
+  }
+  if ("by" in specConfig) {
+    parts.push(`by=${formatCompactValue(specConfig.by)}`);
+  }
+  if (
+    "seed" in specConfig &&
+    specConfig.seed !== null &&
+    specConfig.seed !== undefined
+  ) {
+    parts.push(`seed=${formatCompactValue(specConfig.seed)}`);
+  }
+
+  return parts.length > 0 ? `${specType} (${parts.join(", ")})` : specType;
+}
+
+function formatValue(key: string, value: unknown): string {
+  if (key.toLowerCase() === "repartition_spec") {
+    const formattedRepartitionSpec = formatRepartitionSpec(value);
+    if (formattedRepartitionSpec !== null) {
+      return formattedRepartitionSpec;
+    }
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(v => String(v)).join(", ");
   }
   if (value === null || value === undefined) {
     return "—";
@@ -81,7 +143,7 @@ function NodeCard({
               <span
                 className={`${main.className} text-xs text-zinc-300 break-all`}
               >
-                {formatValue(value)}
+                {formatValue(key, value)}
               </span>
             </div>
           ))}
@@ -152,8 +214,8 @@ export default function PlanVisualizer({ planJson }: { planJson: string }) {
           <div className="relative flex justify-center py-6 px-4 overflow-auto">
             <TreeLayout
               node={plan}
-              getChildren={(node) => node.children ?? []}
-              renderNode={(node) => <ExpandableNodeCard node={node} />}
+              getChildren={node => node.children ?? []}
+              renderNode={node => <ExpandableNodeCard node={node} />}
             />
           </div>
         ) : (

--- a/src/daft-dashboard/frontend/src/app/query/plan-visualizer.tsx
+++ b/src/daft-dashboard/frontend/src/app/query/plan-visualizer.tsx
@@ -31,8 +31,11 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function formatCompactValue(value: unknown): string {
-  if (value === null || value === undefined) {
-    return "auto";
+  if (value === null) {
+    return "null";
+  }
+  if (value === undefined) {
+    return "undefined";
   }
   if (Array.isArray(value)) {
     return `[${value.map(v => formatCompactValue(v)).join(", ")}]`;
@@ -41,6 +44,16 @@ function formatCompactValue(value: unknown): string {
     return JSON.stringify(value);
   }
   return String(value);
+}
+
+function formatRepartitionField(key: string, value: unknown): string | null {
+  if (key === "num_partitions" && (value === null || value === undefined)) {
+    return `${key}=auto`;
+  }
+  if (key === "seed" && (value === null || value === undefined)) {
+    return null;
+  }
+  return `${key}=${formatCompactValue(value)}`;
 }
 
 function formatRepartitionSpec(value: unknown): string | null {
@@ -62,20 +75,26 @@ function formatRepartitionSpec(value: unknown): string | null {
   }
 
   const parts: string[] = [];
-  if ("num_partitions" in specConfig) {
-    parts.push(
-      `num_partitions=${formatCompactValue(specConfig.num_partitions)}`
-    );
+  const knownKeys = ["num_partitions", "by", "seed"];
+
+  for (const key of knownKeys) {
+    if (key in specConfig) {
+      const formatted = formatRepartitionField(key, specConfig[key]);
+      if (formatted !== null) {
+        parts.push(formatted);
+      }
+    }
   }
-  if ("by" in specConfig) {
-    parts.push(`by=${formatCompactValue(specConfig.by)}`);
-  }
-  if (
-    "seed" in specConfig &&
-    specConfig.seed !== null &&
-    specConfig.seed !== undefined
-  ) {
-    parts.push(`seed=${formatCompactValue(specConfig.seed)}`);
+
+  for (const [key, fieldValue] of Object.entries(specConfig)) {
+    if (knownKeys.includes(key)) {
+      continue;
+    }
+
+    const formatted = formatRepartitionField(key, fieldValue);
+    if (formatted !== null) {
+      parts.push(formatted);
+    }
   }
 
   return parts.length > 0 ? `${specType} (${parts.join(", ")})` : specType;

--- a/src/daft-logical-plan/src/display/json.rs
+++ b/src/daft-logical-plan/src/display/json.rs
@@ -53,7 +53,7 @@ pub(crate) fn to_json_value(node: &LogicalPlan) -> serde_json::Value {
             "descending": sort.descending,
         }),
         LogicalPlan::Repartition(repartition) => json!({
-            "repartition_spec": repartition.repartition_spec,
+            "repartition_spec": repartition.repartition_spec.to_string(),
         }),
         LogicalPlan::IntoPartitions(into_partitions) => json!({
             "num_partitions": into_partitions.num_partitions,
@@ -394,5 +394,26 @@ mod tests {
         let actual: serde_json::Value = serde_json::from_str(&output).unwrap();
 
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_repr_json_repartition_spec_human_readable() -> DaftResult<()> {
+        let plan = LogicalPlanBuilder::from(plan_1())
+            .hash_repartition(None, vec![resolved_col("id")])?
+            .build();
+
+        let mut output = String::new();
+        let mut json_vis = super::JsonVisitor::new(&mut output);
+        plan.visit(&mut json_vis).unwrap();
+
+        let actual: serde_json::Value = serde_json::from_str(&output).unwrap();
+
+        assert_eq!(actual["type"], "Repartition");
+        assert_eq!(
+            actual["repartition_spec"],
+            "Hash (num_partitions=auto, by=[col(id)])",
+        );
+
+        Ok(())
     }
 }

--- a/src/daft-logical-plan/src/partitioning.rs
+++ b/src/daft-logical-plan/src/partitioning.rs
@@ -74,7 +74,10 @@ impl RepartitionSpec {
         }
 
         fn format_list<T: Display>(items: impl IntoIterator<Item = T>) -> String {
-            format!("[{}]", items.into_iter().map(|item| item.to_string()).join(", "))
+            format!(
+                "[{}]",
+                items.into_iter().map(|item| item.to_string()).join(", ")
+            )
         }
 
         match self {
@@ -87,8 +90,10 @@ impl RepartitionSpec {
                 num_partitions,
                 seed,
             }) => {
-                let mut parts =
-                    vec![format!("num_partitions={}", format_num_partitions(*num_partitions))];
+                let mut parts = vec![format!(
+                    "num_partitions={}",
+                    format_num_partitions(*num_partitions)
+                )];
                 if let Some(seed) = seed {
                     parts.push(format!("seed={seed}"));
                 }

--- a/src/daft-logical-plan/src/partitioning.rs
+++ b/src/daft-logical-plan/src/partitioning.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{fmt::Display, sync::Arc};
 
 use daft_dsl::{
     Column, ExprRef, ResolvedColumn,
@@ -64,6 +64,59 @@ impl RepartitionSpec {
                 descending.clone(),
             )),
         }
+    }
+
+    pub fn compact_display(&self) -> String {
+        fn format_num_partitions(num_partitions: Option<usize>) -> String {
+            num_partitions
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "auto".to_string())
+        }
+
+        fn format_list<T: Display>(items: impl IntoIterator<Item = T>) -> String {
+            format!("[{}]", items.into_iter().map(|item| item.to_string()).join(", "))
+        }
+
+        match self {
+            Self::Hash(HashRepartitionConfig { num_partitions, by }) => format!(
+                "Hash (num_partitions={}, by={})",
+                format_num_partitions(*num_partitions),
+                format_list(by.iter().map(|expr| expr.to_string()))
+            ),
+            Self::Random(RandomShuffleConfig {
+                num_partitions,
+                seed,
+            }) => {
+                let mut parts =
+                    vec![format!("num_partitions={}", format_num_partitions(*num_partitions))];
+                if let Some(seed) = seed {
+                    parts.push(format!("seed={seed}"));
+                }
+                format!("Random ({})", parts.join(", "))
+            }
+            Self::Range(RangeRepartitionConfig {
+                num_partitions,
+                by,
+                descending,
+                ..
+            }) => {
+                let mut parts = vec![
+                    format!("num_partitions={}", format_num_partitions(*num_partitions)),
+                    format!("by={}", format_list(by.iter().map(|expr| expr.to_string()))),
+                ];
+
+                if !descending.is_empty() {
+                    parts.push(format!("descending={}", format_list(descending.iter())));
+                }
+                format!("Range ({})", parts.join(", "))
+            }
+        }
+    }
+}
+
+impl Display for RepartitionSpec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.compact_display())
     }
 }
 


### PR DESCRIPTION
## Summary

This PR renders `REPARTITION_SPEC` in dashboard plan cards as human-readable text by formatting it in Rust logical-plan display/JSON output, instead of frontend-specific parsing.

## Why

The prior frontend-only formatter added UI-specific parsing logic for repartition internals. Moving formatting to Rust keeps a single source of truth for plan representation and simplifies the dashboard.

## Changes Made

  - Add compact Display formatting for
    RepartitionSpec in src/daft-logical-plan/
    src/partitioning.rs.
  - Update logical-plan JSON display to emit
    repartition_spec via to_string() in src/
    daft-logical-plan/src/display/json.rs.
  - Add regression test
    test_repr_json_repartition_spec_human_read
    able in src/daft-logical-plan/src/display/
    json.rs.

## Behavior

- Dashboard plan cards now show human-readable repartition specs from backend JSON (e.g. `Hash (num_partitions=auto, by=[col(id)])`).
- No query planning or execution behavior changes.

## Test Plan

- Targeted Rust test intended: `cargo test -p daft-logical-plan test_repr_json_repartition_spec_human_readable -- --nocapture`
- Full matrix runs in CI.

## Related Issues

- Closes #6781

## Before
<img width="1912" height="632" alt="image" src="https://github.com/user-attachments/assets/26c3312f-429b-404b-bb14-20e64d708cc3" />

## After
<img width="1905" height="648" alt="image" src="https://github.com/user-attachments/assets/be8e4f66-14b4-4a06-afa9-d16e3b7371ef" />
