### PR TITLE
feat(ext): add C++ hello extension example

### DIFF
--- a/examples/hello_cpp/.clang-format
+++ b/examples/hello_cpp/.clang-format
@@ -1,0 +1,3 @@
+BasedOnStyle: LLVM
+IndentWidth: 4
+ColumnLimit: 100

--- a/examples/hello_cpp/CMakeLists.txt
+++ b/examples/hello_cpp/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.20)
+project(hello_cpp LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(Arrow REQUIRED)
+
+add_library(hello_cpp MODULE src/hello_cpp.cpp)
+target_link_libraries(hello_cpp PRIVATE Arrow::arrow_shared)
+
+# Python extensions use .so on all UNIX platforms (including macOS).
+set_target_properties(hello_cpp PROPERTIES
+    PREFIX "lib"
+    SUFFIX ".so"
+)
+
+# scikit-build-core: install into the Python package directory.
+install(TARGETS hello_cpp LIBRARY DESTINATION hello_cpp)

--- a/examples/hello_cpp/README.md
+++ b/examples/hello_cpp/README.md
@@ -1,0 +1,92 @@
+# Hello C++ Native Extension
+
+A minimal Daft native extension written in pure C++ using the [Apache Arrow C++ library](https://arrow.apache.org/docs/cpp/).
+
+This is the C++ counterpart of the [hello](../hello/) Rust example. It implements a single `greet_cpp` scalar function that prepends `"Hello, "` to every string in a column.
+
+## Prerequisites
+
+- CMake >= 3.20
+- A C++17 compiler
+- Apache Arrow C++ (with headers)
+
+### Install Arrow C++
+
+**macOS (Homebrew):**
+
+```bash
+brew install apache-arrow
+```
+
+**Ubuntu / Debian:**
+
+```bash
+sudo apt install -y libarrow-dev
+```
+
+**Conda:**
+
+```bash
+conda install -c conda-forge arrow-cpp
+```
+
+## Development
+
+### Build the shared library
+
+```bash
+cmake -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+cmake --build build
+```
+
+The `CMAKE_EXPORT_COMPILE_COMMANDS` flag generates `build/compile_commands.json` for clangd / LSP support. Symlink it to the project root if your editor needs it:
+
+```bash
+ln -sf build/compile_commands.json .
+```
+
+### Install as a Python package
+
+```bash
+uv pip install -e .
+```
+
+This uses [scikit-build-core](https://scikit-build-core.readthedocs.io/) to build the C++ library and install it into the Python package.
+
+### Run tests
+
+```bash
+pytest -v tests/
+```
+
+## Usage
+
+```python
+import daft
+import hello_cpp
+from hello_cpp import greet
+from daft import col
+from daft.session import Session
+
+sess = Session()
+sess.load_extension(hello_cpp)
+
+df = daft.from_pydict({"name": ["John", "Paul", "George", None]})
+
+with sess:
+    df.select(greet(col("name"))).show()
+
+# ╭──────────────────╮
+# │ greet_cpp         │
+# │ ---               │
+# │ Utf8              │
+# ╞══════════════════╡
+# │ Hello, John!      │
+# ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+# │ Hello, Paul!      │
+# ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+# │ Hello, George!    │
+# ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+# │ None              │
+# ╰──────────────────╯
+```

--- a/examples/hello_cpp/hello_cpp/__init__.py
+++ b/examples/hello_cpp/hello_cpp/__init__.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import daft
+
+if TYPE_CHECKING:
+    from daft.expressions import Expression
+
+
+def greet(name: Expression) -> Expression:
+    """Greet someone by name (C++ implementation)."""
+    return daft.get_function("greet_cpp", name)

--- a/examples/hello_cpp/pyproject.toml
+++ b/examples/hello_cpp/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["scikit-build-core"]
+build-backend = "scikit_build_core.build"
+
+[project]
+name = "hello_cpp"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = ["daft"]
+
+[project.optional-dependencies]
+test = ["pytest"]
+
+[tool.uv.sources]
+daft = {path = "../..", editable = true}

--- a/examples/hello_cpp/src/hello_cpp.cpp
+++ b/examples/hello_cpp/src/hello_cpp.cpp
@@ -1,0 +1,162 @@
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+#include <arrow/api.h>
+#include <arrow/c/abi.h>
+#include <arrow/c/bridge.h>
+
+// ── Daft ABI (must match daft-ext repr(C) layouts) ─────────────────
+
+static constexpr uint32_t DAFT_ABI_VERSION = 1;
+
+struct FFI_ScalarFunction {
+    const void *ctx;
+    const char *(*name)(const void *ctx);
+    int (*get_return_field)(const void *ctx, const ArrowSchema *args, size_t args_count,
+                            ArrowSchema *ret, char **errmsg);
+    int (*call)(const void *ctx, const ArrowArray *args, const ArrowSchema *args_schemas,
+                size_t args_count, ArrowArray *ret_array, ArrowSchema *ret_schema, char **errmsg);
+    void (*fini)(void *ctx);
+};
+
+struct FFI_SessionContext {
+    void *ctx;
+    int (*define_function)(void *ctx, FFI_ScalarFunction function);
+};
+
+struct FFI_Module {
+    uint32_t daft_abi_version;
+    const char *name;
+    int (*init)(FFI_SessionContext *session);
+    void (*free_string)(char *s);
+};
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+static char *alloc_error(const std::string &msg) { return strdup(msg.c_str()); }
+
+static void module_free_string(char *s) { free(s); }
+
+// ── greet_cpp scalar function ──────────────────────────────────────
+
+static const char *greet_name(const void *) { return "greet_cpp"; }
+
+static int greet_get_return_field(const void *, const ArrowSchema *args, size_t args_count,
+                                  ArrowSchema *ret, char **errmsg) {
+    if (args_count != 1) {
+        *errmsg = alloc_error("greet_cpp: expected 1 argument, got " + std::to_string(args_count));
+        return 1;
+    }
+
+    const char *fmt = args[0].format;
+    if (strcmp(fmt, "u") != 0 && strcmp(fmt, "U") != 0) {
+        *errmsg = alloc_error(std::string("greet_cpp: expected string argument, got format '") +
+                              fmt + "'");
+        return 1;
+    }
+
+    auto field = arrow::field("greet_cpp", arrow::utf8());
+    auto status = arrow::ExportField(*field, ret);
+    if (!status.ok()) {
+        *errmsg = alloc_error("greet_cpp: failed to export return field: " + status.ToString());
+        return 1;
+    }
+    return 0;
+}
+
+static int greet_call(const void *, const ArrowArray *args, const ArrowSchema *args_schemas,
+                      size_t args_count, ArrowArray *ret_array, ArrowSchema *ret_schema,
+                      char **errmsg) {
+    if (args_count != 1) {
+        *errmsg = alloc_error("greet_cpp: expected 1 argument, got " + std::to_string(args_count));
+        return 1;
+    }
+
+    // The host transfers ownership via these pointers (same semantics as
+    // Rust's ptr::read in the trampoline). Copy the C structs so Arrow C++
+    // can consume them through ImportArray.
+    ArrowArray in_array;
+    memcpy(&in_array, &args[0], sizeof(ArrowArray));
+
+    ArrowSchema in_schema;
+    memcpy(&in_schema, &args_schemas[0], sizeof(ArrowSchema));
+
+    auto import_result = arrow::ImportArray(&in_array, &in_schema);
+    if (!import_result.ok()) {
+        *errmsg =
+            alloc_error("greet_cpp: failed to import array: " + import_result.status().ToString());
+        return 1;
+    }
+    auto input = *import_result;
+
+    arrow::StringBuilder builder;
+    arrow::Status st;
+
+    if (input->type_id() == arrow::Type::LARGE_STRING) {
+        auto sa = std::static_pointer_cast<arrow::LargeStringArray>(input);
+        for (int64_t i = 0; i < sa->length(); i++) {
+            if (sa->IsNull(i)) {
+                st = builder.AppendNull();
+            } else {
+                st = builder.Append("Hello, " + sa->GetString(i) + "!");
+            }
+            if (!st.ok()) {
+                *errmsg = alloc_error("greet_cpp: " + st.ToString());
+                return 1;
+            }
+        }
+    } else {
+        auto sa = std::static_pointer_cast<arrow::StringArray>(input);
+        for (int64_t i = 0; i < sa->length(); i++) {
+            if (sa->IsNull(i)) {
+                st = builder.AppendNull();
+            } else {
+                st = builder.Append("Hello, " + sa->GetString(i) + "!");
+            }
+            if (!st.ok()) {
+                *errmsg = alloc_error("greet_cpp: " + st.ToString());
+                return 1;
+            }
+        }
+    }
+
+    auto finish_result = builder.Finish();
+    if (!finish_result.ok()) {
+        *errmsg = alloc_error("greet_cpp: " + finish_result.status().ToString());
+        return 1;
+    }
+
+    st = arrow::ExportArray(**finish_result, ret_array, ret_schema);
+    if (!st.ok()) {
+        *errmsg = alloc_error("greet_cpp: failed to export result: " + st.ToString());
+        return 1;
+    }
+    return 0;
+}
+
+static void greet_fini(void *) {}
+
+// ── Module init ────────────────────────────────────────────────────
+
+static int module_init(FFI_SessionContext *session) {
+    FFI_ScalarFunction greet{};
+    greet.ctx = nullptr;
+    greet.name = greet_name;
+    greet.get_return_field = greet_get_return_field;
+    greet.call = greet_call;
+    greet.fini = greet_fini;
+    return session->define_function(session->ctx, greet);
+}
+
+// ── Entry point ────────────────────────────────────────────────────
+
+extern "C" FFI_Module daft_module_magic() {
+    FFI_Module mod{};
+    mod.daft_abi_version = DAFT_ABI_VERSION;
+    mod.name = "hello_cpp";
+    mod.init = module_init;
+    mod.free_string = module_free_string;
+    return mod;
+}

--- a/examples/hello_cpp/tests/test_hello_cpp.py
+++ b/examples/hello_cpp/tests/test_hello_cpp.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import hello_cpp
+from hello_cpp import greet
+
+import daft
+from daft import col
+from daft.session import Session
+
+
+def test_greet():
+    sess = Session()
+    sess.load_extension(hello_cpp)
+
+    df = daft.from_pydict({"name": ["John", "Paul"]})
+
+    with sess:
+        result = df.select(greet(col("name"))).collect().to_pydict()
+
+    values = result["greet_cpp"]
+    assert values[0] == "Hello, John!"
+    assert values[1] == "Hello, Paul!"
+
+
+def test_greet_null():
+    sess = Session()
+    sess.load_extension(hello_cpp)
+
+    df = daft.from_pydict({"name": ["George", "Ringo", None]})
+
+    with sess:
+        result = df.select(greet(col("name"))).collect().to_pydict()
+
+    values = result["greet_cpp"]
+    assert values[0] == "Hello, George!"
+    assert values[1] == "Hello, Ringo!"
+    assert values[2] is None
+
+
+def test_greet_show(capsys):
+    sess = Session()
+    sess.load_extension(hello_cpp)
+
+    df = daft.from_pydict({"name": ["John", "Paul"]})
+
+    with sess:
+        df = df.select(hello_cpp.greet(df["name"]))
+        df.show()
+
+    captured = capsys.readouterr().out
+    assert "Hello, John!" in captured
+    assert "Hello, Paul!" in captured


### PR DESCRIPTION
## Summary
- Adds a `hello_cpp` extension example under `examples/hello_cpp/` that implements the daft-ext C ABI in pure C++ using the Apache Arrow C++ library
- Mirrors the existing Rust `hello` example (`greet_cpp` scalar function) to demonstrate writing extensions without Rust
- Includes CMakeLists.txt, scikit-build-core packaging, Python wrapper, tests, and a README with dev setup instructions

## Test plan
- [ ] `cmake -B build && cmake --build build` compiles successfully with Arrow C++ installed
- [ ] `uv pip install -e examples/hello_cpp && pytest examples/hello_cpp/tests/ -v` passes all 3 tests
- [ ] `python data/scratch.py` shows the greeted output