### PR TITLE
feat: genericize RandomShuffle to support Flight shuffle backend

### DIFF
--- a/src/daft-distributed/src/pipeline_node/random_shuffle.rs
+++ b/src/daft-distributed/src/pipeline_node/random_shuffle.rs
@@ -7,7 +7,7 @@ use common_error::DaftResult;
 use common_metrics::ops::{NodeCategory, NodeType};
 use daft_dsl::expr::bound_expr::BoundExpr;
 use daft_functions::random::random_int_expr;
-use daft_local_plan::{LocalNodeContext, LocalPhysicalPlan, ShuffleBackend};
+use daft_local_plan::{LocalNodeContext, LocalPhysicalPlan};
 use daft_logical_plan::{partitioning::RandomShuffleConfig, stats::StatsState};
 use daft_schema::schema::SchemaRef;
 
@@ -16,6 +16,7 @@ use crate::{
     pipeline_node::{
         DistributedPipelineNode, MaterializedOutput, NodeID, PipelineNodeConfig,
         PipelineNodeContext,
+        shuffles::backends::{DistributedShuffleBackend, ShuffleBackend},
     },
     plan::{PlanConfig, PlanExecutionContext, TaskIDCounter},
     scheduling::{
@@ -32,6 +33,7 @@ pub(crate) struct RandomShuffleNode {
     config: PipelineNodeConfig,
     context: PipelineNodeContext,
     seed: Option<u64>,
+    shuffle_backend: ShuffleBackend,
     child: DistributedPipelineNode,
 }
 
@@ -43,6 +45,7 @@ impl RandomShuffleNode {
         plan_config: &PlanConfig,
         seed: Option<u64>,
         output_schema: SchemaRef,
+        backend: DistributedShuffleBackend,
         child: DistributedPipelineNode,
     ) -> Self {
         let context = PipelineNodeContext::new(
@@ -55,14 +58,16 @@ impl RandomShuffleNode {
         );
 
         let config = PipelineNodeConfig::new(
-            output_schema,
+            output_schema.clone(),
             plan_config.config.clone(),
             child.config().clustering_spec.clone(),
         );
+        let shuffle_backend = ShuffleBackend::new(&context, output_schema, backend);
         Self {
             config,
             context,
             seed,
+            shuffle_backend,
             child,
         }
     }
@@ -72,11 +77,10 @@ impl RandomShuffleNode {
         partition_group: Vec<MaterializedOutput>,
         partition_idx: usize,
     ) -> DaftResult<SwordfishTaskBuilder> {
-        let (in_memory_scan, psets) = MaterializedOutput::into_in_memory_scan_with_psets(
-            partition_group,
-            self.config.schema.clone(),
-            self.node_id(),
-        );
+        let partition_refs = partition_group
+            .into_iter()
+            .flat_map(|output| output.into_inner().0)
+            .collect::<Vec<_>>();
 
         let partition_seed = self.seed.map(|s| {
             let mut hasher = DefaultHasher::new();
@@ -89,15 +93,19 @@ impl RandomShuffleNode {
             &[random_int_expr(i64::MIN, i64::MAX, partition_seed)],
             &self.config.schema,
         )?;
-        let plan = LocalPhysicalPlan::sort(
-            in_memory_scan,
-            sort_by,
-            vec![false],
-            vec![false],
-            StatsState::NotMaterialized,
-            LocalNodeContext::new(Some(self.node_id() as usize)),
-        );
-        Ok(SwordfishTaskBuilder::new(plan, self, self.node_id()).with_psets(self.node_id(), psets))
+        let node_id = self.node_id();
+        Ok(self
+            .shuffle_backend
+            .build_refs_task_builder(partition_refs, self, |input| {
+                LocalPhysicalPlan::sort(
+                    input,
+                    sort_by,
+                    vec![false],
+                    vec![false],
+                    StatsState::NotMaterialized,
+                    LocalNodeContext::new(Some(node_id as usize)),
+                )
+            }))
     }
 
     async fn execution_loop(
@@ -139,9 +147,15 @@ impl PipelineNodeImpl for RandomShuffleNode {
     }
 
     fn multiline_display(&self, _verbose: bool) -> Vec<String> {
+        let backend_name = match self.shuffle_backend.backend() {
+            DistributedShuffleBackend::Ray => "Ray",
+            DistributedShuffleBackend::Flight(_) => "Flight",
+        };
         vec![
-            "RandomShuffle: random row order (via random repartition + random_int + sort)"
-                .to_string(),
+            format!(
+                "RandomShuffle({}): random row order (via random repartition + random_int + sort)",
+                backend_name
+            ),
             format!("Seed = {:?}", self.seed),
         ]
     }
@@ -151,18 +165,20 @@ impl PipelineNodeImpl for RandomShuffleNode {
         plan_context: &mut PlanExecutionContext,
     ) -> TaskBuilderStream {
         let input_node = self.child.clone().produce_tasks(plan_context);
+        self.shuffle_backend.register_cleanup(plan_context);
 
         let num_partitions = self.child.config().clustering_spec.num_partitions();
         let node_id = self.node_id();
         let schema = self.config.schema.clone();
         let seed = self.seed;
+        let local_shuffle_backend = self.shuffle_backend.local_shuffle_backend();
 
         let partitioned_input = input_node.pipeline_instruction(self.clone(), move |input| {
             LocalPhysicalPlan::repartition_write(
                 input,
                 num_partitions,
                 schema.clone(),
-                ShuffleBackend::Ray,
+                local_shuffle_backend.clone(),
                 daft_logical_plan::partitioning::RepartitionSpec::Random(
                     RandomShuffleConfig::new_with_seed(Some(num_partitions), seed),
                 ),

--- a/src/daft-distributed/src/pipeline_node/translate.rs
+++ b/src/daft-distributed/src/pipeline_node/translate.rs
@@ -635,16 +635,20 @@ impl TreeNodeVisitor for LogicalPlanToPipelineNodeTranslator {
                     &self.meter,
                 )
             }
-            LogicalPlan::Shuffle(shuffle) => DistributedPipelineNode::new(
-                Arc::new(RandomShuffleNode::new(
-                    self.get_next_pipeline_node_id(),
-                    &self.plan_config,
-                    shuffle.seed,
-                    shuffle.input.schema(),
-                    self.curr_node.pop().unwrap(),
-                )),
-                &self.meter,
-            ),
+            LogicalPlan::Shuffle(shuffle) => {
+                let backend = self.select_backend();
+                DistributedPipelineNode::new(
+                    Arc::new(RandomShuffleNode::new(
+                        self.get_next_pipeline_node_id(),
+                        &self.plan_config,
+                        shuffle.seed,
+                        shuffle.input.schema(),
+                        backend,
+                        self.curr_node.pop().unwrap(),
+                    )),
+                    &self.meter,
+                )
+            }
             LogicalPlan::SubqueryAlias(_)
             | LogicalPlan::Union(_)
             | LogicalPlan::Intersect(_)

--- a/tests/dataframe/test_shuffles.py
+++ b/tests/dataframe/test_shuffles.py
@@ -180,12 +180,42 @@ def test_pre_shuffle_merge_randomly_sized_partitions(pre_shuffle_merge_ctx, inpu
 
 @pytest.mark.skipif(
     get_tests_daft_runner_name() != "ray",
-    reason="shuffle tests are meant for the ray runner",
+    reason="distributed shuffle tests require the ray runner",
 )
-def test_random_shuffle_uses_ray_shuffle_path_under_flight_shuffle_config(flight_shuffle_ctx):
+def test_flight_random_shuffle(flight_shuffle_ctx):
+    """Ensures `df.shuffle(...)` produces a permutation of the input under the Flight backend."""
     with flight_shuffle_ctx():
         df = daft.from_pydict({"id": list(range(32))}).repartition(4, "id")
-        shuffled = df.shuffle(seed=0).to_pydict()["id"]
+        shuffle_df = df.shuffle(seed=0)
+
+        buf = io.StringIO()
+        shuffle_df.explain(show_all=True, file=buf)
+        plan = buf.getvalue()
+        assert "RandomShuffle(Flight)" in plan, f"expected RandomShuffle(Flight) in plan:\n{plan}"
+        assert "RandomShuffle(Ray)" not in plan, f"unexpected RandomShuffle(Ray) in plan:\n{plan}"
+
+        shuffled = shuffle_df.to_pydict()["id"]
+
+    assert sorted(shuffled) == list(range(32))
+    assert shuffled != list(range(32))
+
+
+@pytest.mark.skipif(
+    get_tests_daft_runner_name() != "ray",
+    reason="distributed shuffle tests require the ray runner",
+)
+def test_ray_random_shuffle():
+    """Ensures `df.shuffle(...)` produces a permutation of the input under the Ray backend."""
+    df = daft.from_pydict({"id": list(range(32))}).repartition(4, "id")
+    shuffle_df = df.shuffle(seed=0)
+
+    buf = io.StringIO()
+    shuffle_df.explain(show_all=True, file=buf)
+    plan = buf.getvalue()
+    assert "RandomShuffle(Ray)" in plan, f"expected RandomShuffle(Ray) in plan:\n{plan}"
+    assert "RandomShuffle(Flight)" not in plan, f"unexpected RandomShuffle(Flight) in plan:\n{plan}"
+
+    shuffled = shuffle_df.to_pydict()["id"]
 
     assert sorted(shuffled) == list(range(32))
     assert shuffled != list(range(32))


### PR DESCRIPTION
## Changes Made
Genericize RandomShuffleNode to support both Ray and Flight shuffle backends, following the same ShuffleBackend pattern established in #6751 and #6764. Replaces hardcoded ShuffleBackend::Ray with configurable backend dispatch, and uses build_refs_task_builder() for the read side so both backends work correctly.

## Related Issues

Part of Phase 2 shuffle genericization (#6472).
<!-- Link to related GitHub issues, e.g., "Closes #123" -->
