### PR TITLE
feat(distributed): support into_batches under flight shuffle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3058,6 +3058,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "typetag",
+ "uuid",
 ]
 
 [[package]]
@@ -3216,6 +3217,7 @@ dependencies = [
  "common-py-serde",
  "pyo3",
  "serde",
+ "uuid",
 ]
 
 [[package]]
@@ -3366,6 +3368,7 @@ dependencies = [
  "futures",
  "tokio",
  "tonic",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -375,7 +375,7 @@ tracing-subscriber = {version = "0.3.22", default-features = false, features = [
 typetag = "0.2.21"
 rustfft = "6"
 url = "2.4.0"
-uuid = {version = "1.19.0", features = ["v4", "serde"]}
+uuid = {version = "1.19.0", features = ["v4", "v7", "serde"]}
 xxhash-rust = {version = "0.8.15", features = ["const_xxh3", "const_xxh64", "const_xxh32", "xxh64", "xxh3", "xxh32"]}
 libc = {version = "^0.2.150", default-features = false}
 hex = "0.4.3"

--- a/daft/daft/__init__.pyi
+++ b/daft/daft/__init__.pyi
@@ -2312,7 +2312,7 @@ class RayPartitionRef:
 class FlightPartitionRef:
     shuffle_id: int
     server_address: str
-    partition_ref_id: int
+    partition_ref_id: str
     num_rows: int
     size_bytes: int
 
@@ -2320,7 +2320,7 @@ class FlightPartitionRef:
         self,
         shuffle_id: int,
         server_address: str,
-        partition_ref_id: int,
+        partition_ref_id: str,
         num_rows: int,
         size_bytes: int,
     ): ...

--- a/src/daft-distributed/src/pipeline_node/into_batches.rs
+++ b/src/daft-distributed/src/pipeline_node/into_batches.rs
@@ -174,6 +174,7 @@ impl IntoBatchesNode {
                 current_group_size += rows;
                 if current_group_size >= (self.batch_size as f64 * BATCH_SIZE_THRESHOLD) as usize {
                     let group_size = std::mem::take(&mut current_group_size);
+
                     let materialized_outputs = std::mem::take(&mut current_group);
                     let builder = self.build_rebatch_task(materialized_outputs, group_size);
                     if result_tx.send(builder).await.is_err() {

--- a/src/daft-distributed/src/pipeline_node/into_batches.rs
+++ b/src/daft-distributed/src/pipeline_node/into_batches.rs
@@ -16,6 +16,7 @@ use crate::{
     pipeline_node::{
         DistributedPipelineNode, MaterializedOutput, NodeID, PipelineNodeConfig,
         PipelineNodeContext,
+        shuffles::backends::{DistributedShuffleBackend, ShuffleBackend},
     },
     plan::{PlanConfig, PlanExecutionContext, TaskIDCounter},
     scheduling::{
@@ -74,6 +75,7 @@ pub(crate) struct IntoBatchesNode {
     config: PipelineNodeConfig,
     context: PipelineNodeContext,
     batch_size: usize,
+    shuffle_backend: ShuffleBackend,
     child: DistributedPipelineNode,
 }
 
@@ -93,6 +95,7 @@ impl IntoBatchesNode {
         plan_config: &PlanConfig,
         batch_size: usize,
         schema: SchemaRef,
+        backend: DistributedShuffleBackend,
         child: DistributedPipelineNode,
     ) -> Self {
         let context = PipelineNodeContext::new(
@@ -104,7 +107,7 @@ impl IntoBatchesNode {
             NodeCategory::StreamingSink,
         );
         let config = PipelineNodeConfig::new(
-            schema,
+            schema.clone(),
             plan_config.config.clone(),
             Arc::new(
                 UnknownClusteringConfig::new(
@@ -113,12 +116,38 @@ impl IntoBatchesNode {
                 .into(),
             ),
         );
+        let shuffle_backend = ShuffleBackend::new(&context, schema, backend);
         Self {
             config,
             context,
             batch_size,
+            shuffle_backend,
             child,
         }
+    }
+
+    /// Build the rebatch task for a group of materialized upstream outputs.
+    fn build_rebatch_task(
+        &self,
+        group: Vec<MaterializedOutput>,
+        group_size: usize,
+    ) -> SwordfishTaskBuilder {
+        let node_id = self.node_id();
+        let refs = group
+            .into_iter()
+            .flat_map(|output| output.into_inner().0)
+            .collect::<Vec<_>>();
+
+        self.shuffle_backend
+            .build_refs_task_builder(refs, self, move |read_plan| {
+                LocalPhysicalPlan::into_batches(
+                    read_plan,
+                    group_size,
+                    true,
+                    StatsState::NotMaterialized,
+                    LocalNodeContext::new(Some(node_id as usize)).with_phase(REBATCH_PHASE),
+                )
+            })
     }
 
     async fn execute_into_batches(
@@ -145,24 +174,8 @@ impl IntoBatchesNode {
                 current_group_size += rows;
                 if current_group_size >= (self.batch_size as f64 * BATCH_SIZE_THRESHOLD) as usize {
                     let group_size = std::mem::take(&mut current_group_size);
-
                     let materialized_outputs = std::mem::take(&mut current_group);
-                    let (in_memory_scan, psets) =
-                        MaterializedOutput::into_in_memory_scan_with_psets(
-                            materialized_outputs,
-                            self.config.schema.clone(),
-                            self.node_id(),
-                        );
-                    let plan = LocalPhysicalPlan::into_batches(
-                        in_memory_scan,
-                        group_size,
-                        true, // Strict batch sizes for the downstream tasks, as they have been coalesced.
-                        StatsState::NotMaterialized,
-                        LocalNodeContext::new(Some(self.node_id() as usize))
-                            .with_phase(REBATCH_PHASE),
-                    );
-                    let builder = SwordfishTaskBuilder::new(plan, self.as_ref(), self.node_id())
-                        .with_psets(self.node_id(), psets);
+                    let builder = self.build_rebatch_task(materialized_outputs, group_size);
                     if result_tx.send(builder).await.is_err() {
                         break;
                     }
@@ -171,20 +184,7 @@ impl IntoBatchesNode {
         }
 
         if !current_group.is_empty() {
-            let (in_memory_source_plan, psets) = MaterializedOutput::into_in_memory_scan_with_psets(
-                current_group,
-                self.config.schema.clone(),
-                self.node_id(),
-            );
-            let plan = LocalPhysicalPlan::into_batches(
-                in_memory_source_plan,
-                current_group_size,
-                true, // Strict batch sizes for the downstream tasks, as they have been coalesced.
-                StatsState::NotMaterialized,
-                LocalNodeContext::new(Some(self.node_id() as usize)).with_phase(REBATCH_PHASE),
-            );
-            let builder = SwordfishTaskBuilder::new(plan, self.as_ref(), self.node_id())
-                .with_psets(self.node_id(), psets);
+            let builder = self.build_rebatch_task(current_group, current_group_size);
             let _ = result_tx.send(builder).await;
         }
         Ok(())
@@ -209,25 +209,45 @@ impl PipelineNodeImpl for IntoBatchesNode {
     }
 
     fn multiline_display(&self, _verbose: bool) -> Vec<String> {
-        vec![format!("IntoBatches: {}", self.batch_size)]
+        let backend_name = match self.shuffle_backend.backend() {
+            DistributedShuffleBackend::Ray => "Ray",
+            DistributedShuffleBackend::Flight(_) => "Flight",
+        };
+        vec![format!(
+            "IntoBatches({}): {}",
+            backend_name, self.batch_size
+        )]
     }
 
     fn produce_tasks(
         self: Arc<Self>,
         plan_context: &mut PlanExecutionContext,
     ) -> TaskBuilderStream {
-        let input_node = self.child.clone().produce_tasks(plan_context);
+        self.shuffle_backend.register_cleanup(plan_context);
         let node_id = self.node_id();
         let batch_size = self.batch_size;
-        let local_into_batches_node = input_node.pipeline_instruction(self.clone(), move |input| {
-            LocalPhysicalPlan::into_batches(
-                input,
-                batch_size,
-                false, // No need strict batch sizes for the child tasks, as we coalesce them later on.
-                StatsState::NotMaterialized,
-                LocalNodeContext::new(Some(node_id as usize)).with_phase(INITIAL_BATCH_PHASE),
-            )
-        });
+        let schema = self.shuffle_backend.schema().clone();
+        let local_shuffle_backend = self.shuffle_backend.local_shuffle_backend();
+        let local_into_batches_node = self
+            .child
+            .clone()
+            .produce_tasks(plan_context)
+            .pipeline_instruction(self.clone(), move |input| {
+                let into_batches_plan = LocalPhysicalPlan::into_batches(
+                    input,
+                    batch_size,
+                    false, // No need strict batch sizes for the child tasks, as we coalesce them later on.
+                    StatsState::NotMaterialized,
+                    LocalNodeContext::new(Some(node_id as usize)).with_phase(INITIAL_BATCH_PHASE),
+                );
+                LocalPhysicalPlan::gather_write(
+                    into_batches_plan,
+                    schema.clone(),
+                    local_shuffle_backend.clone(),
+                    StatsState::NotMaterialized,
+                    LocalNodeContext::new(Some(node_id as usize)),
+                )
+            });
 
         let (result_tx, result_rx) = create_channel(1);
         let execution_future = self.execute_into_batches(

--- a/src/daft-distributed/src/pipeline_node/into_batches.rs
+++ b/src/daft-distributed/src/pipeline_node/into_batches.rs
@@ -210,13 +210,10 @@ impl PipelineNodeImpl for IntoBatchesNode {
     }
 
     fn multiline_display(&self, _verbose: bool) -> Vec<String> {
-        let backend_name = match self.shuffle_backend.backend() {
-            DistributedShuffleBackend::Ray => "Ray",
-            DistributedShuffleBackend::Flight(_) => "Flight",
-        };
         vec![format!(
             "IntoBatches({}): {}",
-            backend_name, self.batch_size
+            self.shuffle_backend.backend().name(),
+            self.batch_size
         )]
     }
 

--- a/src/daft-distributed/src/pipeline_node/into_partitions.rs
+++ b/src/daft-distributed/src/pipeline_node/into_partitions.rs
@@ -333,12 +333,8 @@ impl PipelineNodeImpl for IntoPartitionsNode {
     }
 
     fn multiline_display(&self, _verbose: bool) -> Vec<String> {
-        let backend_name = match self.shuffle_backend.backend() {
-            DistributedShuffleBackend::Ray => "Ray",
-            DistributedShuffleBackend::Flight(_) => "Flight",
-        };
         vec![
-            format!("IntoPartitions({})", backend_name),
+            format!("IntoPartitions({})", self.shuffle_backend.backend().name()),
             format!("Num partitions = {}", self.num_partitions),
         ]
     }

--- a/src/daft-distributed/src/pipeline_node/into_partitions.rs
+++ b/src/daft-distributed/src/pipeline_node/into_partitions.rs
@@ -98,11 +98,20 @@ impl IntoPartitionsNode {
                 chunk_size += 1;
             }
 
-            // Build and submit all the tasks for this partition
+            let node_id = self.node_id();
             let submitted_tasks = builder_iter
                 .by_ref()
                 .take(chunk_size)
                 .map(|builder| {
+                    let builder = builder.map_plan(self.as_ref(), |plan| {
+                        LocalPhysicalPlan::into_partitions(
+                            plan,
+                            1,
+                            self.shuffle_backend.local_shuffle_backend(),
+                            StatsState::NotMaterialized,
+                            LocalNodeContext::new(Some(node_id as usize)),
+                        )
+                    });
                     let submittable_task = builder.build(self.context.query_idx, task_id_counter);
                     submittable_task.submit(scheduler_handle)
                 })
@@ -112,44 +121,47 @@ impl IntoPartitionsNode {
 
         let mut output_futures = OrderedJoinSet::new();
         for tasks in tasks_per_partition {
+            let self_clone = self.clone();
+            let sched = scheduler_handle.clone();
+            let counter = task_id_counter.clone();
             output_futures.spawn(async move {
-                let materialized_output = futures::future::try_join_all(tasks)
+                let materialized_outputs: Vec<_> = futures::future::try_join_all(tasks)
                     .await?
                     .into_iter()
                     .flatten()
+                    .collect();
+                let partition_refs = materialized_outputs
+                    .into_iter()
+                    .flat_map(|output| output.into_inner().0)
                     .collect::<Vec<_>>();
-                DaftResult::Ok(materialized_output)
+                let merge_task = self_clone
+                    .shuffle_backend
+                    .build_refs_task_builder(partition_refs, self_clone.as_ref(), |input| input)
+                    .map_plan(self_clone.as_ref(), |plan| {
+                        LocalPhysicalPlan::into_partitions(
+                            plan,
+                            1,
+                            self_clone.shuffle_backend.local_shuffle_backend(),
+                            StatsState::NotMaterialized,
+                            LocalNodeContext::new(Some(self_clone.node_id() as usize)),
+                        )
+                    })
+                    .build(self_clone.context.query_idx, &counter);
+                merge_task.submit(&sched)?.await
             });
         }
 
         while let Some(result) = output_futures.join_next().await {
-            // Collect all the outputs from this task and coalesce them into a single task.
-            let materialized_outputs = result??;
-            let partition_refs = materialized_outputs
-                .into_iter()
-                .flat_map(|output| output.into_inner().0)
-                .collect::<Vec<_>>();
-
-            let node_id = self.node_id();
-            let shuffle_backend = self.shuffle_backend.local_shuffle_backend();
-            let builder = self.shuffle_backend.build_refs_task_builder(
-                partition_refs,
-                self.as_ref(),
-                move |input| {
-                    LocalPhysicalPlan::into_partitions(
-                        input,
-                        1,
-                        shuffle_backend,
-                        StatsState::NotMaterialized,
-                        LocalNodeContext::new(Some(node_id as usize)),
-                    )
-                },
-            );
-            if result_tx.send(builder).await.is_err() {
-                break;
+            let materialized_output = result??;
+            if let Some(output) = materialized_output {
+                let builder = self.shuffle_backend.build_refs_task_builder(
+                    output.into_inner().0,
+                    self.as_ref(),
+                    |input| input,
+                );
+                let _ = result_tx.send(builder).await;
             }
         }
-
         Ok(())
     }
 
@@ -214,9 +226,7 @@ impl IntoPartitionsNode {
                         self.as_ref(),
                         |input| input,
                     );
-                    if result_tx.send(builder).await.is_err() {
-                        break;
-                    }
+                    let _ = result_tx.send(builder).await;
                 }
             }
         }
@@ -242,18 +252,32 @@ impl IntoPartitionsNode {
                     .execution_config
                     .enable_scan_task_split_and_merge
                 {
-                    let node_id = self.node_id();
+                    let mut output_futures = OrderedJoinSet::new();
                     for builder in input_builders {
-                        let builder = builder.map_plan(self.as_ref(), |plan| {
-                            LocalPhysicalPlan::into_partitions(
-                                plan,
-                                1,
-                                self.shuffle_backend.local_shuffle_backend(),
-                                StatsState::NotMaterialized,
-                                LocalNodeContext::new(Some(node_id as usize)),
-                            )
-                        });
-                        let _ = result_tx.send(builder).await;
+                        let merge_task = builder
+                            .map_plan(self.as_ref(), |plan| {
+                                LocalPhysicalPlan::into_partitions(
+                                    plan,
+                                    1,
+                                    self.shuffle_backend.local_shuffle_backend(),
+                                    StatsState::NotMaterialized,
+                                    LocalNodeContext::new(Some(self.node_id() as usize)),
+                                )
+                            })
+                            .build(self.context.query_idx, &task_id_counter);
+                        let sched = scheduler_handle.clone();
+                        output_futures.spawn(async move { merge_task.submit(&sched)?.await });
+                    }
+                    while let Some(result) = output_futures.join_next().await {
+                        let materialized_output = result??;
+                        if let Some(output) = materialized_output {
+                            let builder = self.shuffle_backend.build_refs_task_builder(
+                                output.into_inner().0,
+                                self.as_ref(),
+                                |input| input,
+                            );
+                            let _ = result_tx.send(builder).await;
+                        }
                     }
                 } else {
                     for builder in input_builders {

--- a/src/daft-distributed/src/pipeline_node/into_partitions.rs
+++ b/src/daft-distributed/src/pipeline_node/into_partitions.rs
@@ -98,6 +98,7 @@ impl IntoPartitionsNode {
                 chunk_size += 1;
             }
 
+            // Build and submit all the tasks for this partition
             let node_id = self.node_id();
             let submitted_tasks = builder_iter
                 .by_ref()
@@ -159,7 +160,9 @@ impl IntoPartitionsNode {
                     self.as_ref(),
                     |input| input,
                 );
-                let _ = result_tx.send(builder).await;
+                if result_tx.send(builder).await.is_err() {
+                    break;
+                }
             }
         }
         Ok(())
@@ -226,7 +229,9 @@ impl IntoPartitionsNode {
                         self.as_ref(),
                         |input| input,
                     );
-                    let _ = result_tx.send(builder).await;
+                    if result_tx.send(builder).await.is_err() {
+                        break;
+                    }
                 }
             }
         }
@@ -276,12 +281,16 @@ impl IntoPartitionsNode {
                                 self.as_ref(),
                                 |input| input,
                             );
-                            let _ = result_tx.send(builder).await;
+                            if result_tx.send(builder).await.is_err() {
+                                break;
+                            }
                         }
                     }
                 } else {
                     for builder in input_builders {
-                        let _ = result_tx.send(builder).await;
+                        if result_tx.send(builder).await.is_err() {
+                            break;
+                        }
                     }
                 }
             }

--- a/src/daft-distributed/src/pipeline_node/shuffles/backends/mod.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/backends/mod.rs
@@ -30,6 +30,17 @@ pub(crate) enum DistributedShuffleBackend {
     Flight(FlightShuffleBackendConfig),
 }
 
+impl DistributedShuffleBackend {
+    /// Short label for this backend, used to build op names in `multiline_display`
+    /// (e.g. `IntoPartitions({name})`, `{name}Gather`).
+    pub(crate) fn name(&self) -> &'static str {
+        match self {
+            Self::Ray => "Ray",
+            Self::Flight(_) => "Flight",
+        }
+    }
+}
+
 #[derive(Clone)]
 pub(crate) struct ShuffleBackend {
     backend: DistributedShuffleBackend,

--- a/src/daft-distributed/src/pipeline_node/shuffles/backends/mod.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/backends/mod.rs
@@ -111,15 +111,14 @@ impl ShuffleBackend {
         let node_id = self.node_id;
         match &self.backend {
             DistributedShuffleBackend::Ray => {
-                let total_size_bytes = partition_refs.iter().map(|p| p.size_bytes()).sum::<usize>();
-                let in_memory_scan = LocalPhysicalPlan::in_memory_scan(
+                let shuffle_read = LocalPhysicalPlan::shuffle_read(
                     node_id,
                     self.schema.clone(),
-                    total_size_bytes,
+                    ShuffleReadBackend::Ray,
                     StatsState::NotMaterialized,
                     LocalNodeContext::new(Some(node_id as usize)),
                 );
-                let plan = wrap_plan(in_memory_scan);
+                let plan = wrap_plan(shuffle_read);
                 SwordfishTaskBuilder::new(plan, node, node_id).with_psets(node_id, partition_refs)
             }
             DistributedShuffleBackend::Flight(_) => {

--- a/src/daft-distributed/src/pipeline_node/shuffles/gather.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/gather.rs
@@ -98,11 +98,7 @@ impl PipelineNodeImpl for GatherNode {
     }
 
     fn multiline_display(&self, _verbose: bool) -> Vec<String> {
-        let backend_name = match self.shuffle_backend.backend() {
-            DistributedShuffleBackend::Ray => "RayGather",
-            DistributedShuffleBackend::Flight(_) => "FlightGather",
-        };
-        vec![backend_name.to_string()]
+        vec![format!("{}Gather", self.shuffle_backend.backend().name())]
     }
 
     fn produce_tasks(

--- a/src/daft-distributed/src/pipeline_node/shuffles/repartition.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/repartition.rs
@@ -153,12 +153,9 @@ impl PipelineNodeImpl for RepartitionNode {
     }
 
     fn multiline_display(&self, _verbose: bool) -> Vec<String> {
-        let backend_name = match self.shuffle_backend.backend() {
-            DistributedShuffleBackend::Ray => "RayShuffle",
-            DistributedShuffleBackend::Flight(_) => "FlightShuffle",
-        };
         let mut res = vec![format!(
-            "{backend_name}: {}",
+            "{}Shuffle: {}",
+            self.shuffle_backend.backend().name(),
             self.repartition_spec.var_name()
         )];
         res.extend(self.repartition_spec.multiline_display());

--- a/src/daft-distributed/src/pipeline_node/translate.rs
+++ b/src/daft-distributed/src/pipeline_node/translate.rs
@@ -236,16 +236,20 @@ impl TreeNodeVisitor for LogicalPlanToPipelineNodeTranslator {
                 )),
                 &self.meter,
             ),
-            LogicalPlan::IntoBatches(into_batches) => DistributedPipelineNode::new(
-                Arc::new(IntoBatchesNode::new(
-                    self.get_next_pipeline_node_id(),
-                    &self.plan_config,
-                    into_batches.batch_size,
-                    node.schema(),
-                    self.curr_node.pop().unwrap(),
-                )),
-                &self.meter,
-            ),
+            LogicalPlan::IntoBatches(into_batches) => {
+                let backend = self.select_backend();
+                DistributedPipelineNode::new(
+                    Arc::new(IntoBatchesNode::new(
+                        self.get_next_pipeline_node_id(),
+                        &self.plan_config,
+                        into_batches.batch_size,
+                        node.schema(),
+                        backend,
+                        self.curr_node.pop().unwrap(),
+                    )),
+                    &self.meter,
+                )
+            }
             LogicalPlan::Limit(limit) => DistributedPipelineNode::new(
                 Arc::new(LimitNode::new(
                     self.get_next_pipeline_node_id(),

--- a/src/daft-local-execution/Cargo.toml
+++ b/src/daft-local-execution/Cargo.toml
@@ -59,6 +59,7 @@ serde_json = {workspace = true}
 opentelemetry = {workspace = true}
 dashmap = {workspace = true}
 sysinfo = {workspace = true}
+uuid = {workspace = true}
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemalloc-ctl = {version = "0.6.0", features = ["stats"]}

--- a/src/daft-local-execution/src/sinks/gather.rs
+++ b/src/daft-local-execution/src/sinks/gather.rs
@@ -6,8 +6,7 @@ use daft_core::prelude::SchemaRef;
 use daft_micropartition::MicroPartition;
 use daft_partition_refs::FlightPartitionRef;
 use daft_shuffles::{
-    server::flight_server::ShuffleFlightServer,
-    shuffle_cache::{InProgressShuffleCache, partition_ref_id},
+    server::flight_server::ShuffleFlightServer, shuffle_cache::InProgressShuffleCache,
 };
 use tracing::{Span, instrument};
 
@@ -42,16 +41,14 @@ struct FlightShared {
 
 pub(crate) struct FlightGatherState {
     shared: Arc<FlightShared>,
-    input_id: InputId,
     refs: Vec<FlightPartitionRef>,
 }
 
 impl FlightGatherState {
     async fn push(&mut self, input: MicroPartition) -> DaftResult<()> {
         let shared = &self.shared;
-        let partition_ref_id = partition_ref_id(self.input_id, self.refs.len());
         let cache = InProgressShuffleCache::try_new(
-            partition_ref_id,
+            &shared.local_server,
             shared.schema.clone(),
             &shared.shuffle_dirs,
             shared.shuffle_id,
@@ -221,14 +218,13 @@ impl BlockingSink for GatherSink {
         vec![format!("Gather({})", self.backend.name())]
     }
 
-    fn make_state(&self, input_id: InputId) -> DaftResult<Self::State> {
+    fn make_state(&self, _input_id: InputId) -> DaftResult<Self::State> {
         match &self.backend {
             GatherBackend::Ray => Ok(GatherState::Ray(RayGatherState {
                 partitions: Vec::new(),
             })),
             GatherBackend::Flight(shared) => Ok(GatherState::Flight(FlightGatherState {
                 shared: shared.clone(),
-                input_id,
                 refs: Vec::new(),
             })),
         }

--- a/src/daft-local-execution/src/sinks/gather.rs
+++ b/src/daft-local-execution/src/sinks/gather.rs
@@ -48,7 +48,6 @@ impl FlightGatherState {
     async fn push(&mut self, input: MicroPartition) -> DaftResult<()> {
         let shared = &self.shared;
         let cache = InProgressShuffleCache::try_new(
-            &shared.local_server,
             shared.schema.clone(),
             &shared.shuffle_dirs,
             shared.shuffle_id,

--- a/src/daft-local-execution/src/sinks/into_partitions.rs
+++ b/src/daft-local-execution/src/sinks/into_partitions.rs
@@ -64,7 +64,6 @@ impl FlightIntoPartitionsState {
         let mut caches = Vec::with_capacity(num_partitions);
         for _ in 0..num_partitions {
             let cache = InProgressShuffleCache::try_new(
-                &shared.local_server,
                 shared.schema.clone(),
                 &shared.shuffle_dirs,
                 shared.shuffle_id,

--- a/src/daft-local-execution/src/sinks/into_partitions.rs
+++ b/src/daft-local-execution/src/sinks/into_partitions.rs
@@ -6,8 +6,7 @@ use daft_core::prelude::SchemaRef;
 use daft_micropartition::MicroPartition;
 use daft_partition_refs::FlightPartitionRef;
 use daft_shuffles::{
-    server::flight_server::ShuffleFlightServer,
-    shuffle_cache::{InProgressShuffleCache, partition_ref_id},
+    server::flight_server::ShuffleFlightServer, shuffle_cache::InProgressShuffleCache,
 };
 use tracing::{Span, instrument};
 
@@ -61,16 +60,11 @@ pub(crate) struct FlightIntoPartitionsState {
 }
 
 impl FlightIntoPartitionsState {
-    fn try_new(
-        shared: Arc<FlightShared>,
-        input_id: InputId,
-        num_partitions: usize,
-    ) -> DaftResult<Self> {
+    fn try_new(shared: Arc<FlightShared>, num_partitions: usize) -> DaftResult<Self> {
         let mut caches = Vec::with_capacity(num_partitions);
-        for partition_idx in 0..num_partitions {
-            let partition_ref_id = partition_ref_id(input_id, partition_idx);
+        for _ in 0..num_partitions {
             let cache = InProgressShuffleCache::try_new(
-                partition_ref_id,
+                &shared.local_server,
                 shared.schema.clone(),
                 &shared.shuffle_dirs,
                 shared.shuffle_id,
@@ -319,7 +313,7 @@ impl BlockingSink for IntoPartitionsSink {
         )]
     }
 
-    fn make_state(&self, input_id: InputId) -> DaftResult<Self::State> {
+    fn make_state(&self, _: InputId) -> DaftResult<Self::State> {
         match &self.backend {
             IntoPartitionsBackend::Ray { .. } => {
                 Ok(IntoPartitionsState::Ray(RayIntoPartitionsState {
@@ -327,7 +321,7 @@ impl BlockingSink for IntoPartitionsSink {
                 }))
             }
             IntoPartitionsBackend::Flight(shared) => Ok(IntoPartitionsState::Flight(
-                FlightIntoPartitionsState::try_new(shared.clone(), input_id, self.num_partitions)?,
+                FlightIntoPartitionsState::try_new(shared.clone(), self.num_partitions)?,
             )),
         }
     }

--- a/src/daft-local-execution/src/sinks/repartition.rs
+++ b/src/daft-local-execution/src/sinks/repartition.rs
@@ -336,7 +336,6 @@ impl BlockingSink for RepartitionSink {
                 compression,
                 schema,
                 partitions,
-                local_server,
                 ..
             } => {
                 let mut partitions = partitions.lock().unwrap();
@@ -347,7 +346,6 @@ impl BlockingSink for RepartitionSink {
                             (0..self.num_partitions)
                                 .map(|_| {
                                     Ok(Arc::new(InProgressShuffleCache::try_new(
-                                        local_server,
                                         schema.clone(),
                                         shuffle_dirs,
                                         *shuffle_id,

--- a/src/daft-local-execution/src/sinks/repartition.rs
+++ b/src/daft-local-execution/src/sinks/repartition.rs
@@ -11,8 +11,7 @@ use daft_logical_plan::partitioning::RepartitionSpec;
 use daft_micropartition::MicroPartition;
 use daft_partition_refs::FlightPartitionRef;
 use daft_shuffles::{
-    server::flight_server::ShuffleFlightServer,
-    shuffle_cache::{InProgressShuffleCache, partition_ref_id},
+    server::flight_server::ShuffleFlightServer, shuffle_cache::InProgressShuffleCache,
 };
 use itertools::Itertools;
 use tracing::{Span, instrument};
@@ -337,6 +336,7 @@ impl BlockingSink for RepartitionSink {
                 compression,
                 schema,
                 partitions,
+                local_server,
                 ..
             } => {
                 let mut partitions = partitions.lock().unwrap();
@@ -345,9 +345,9 @@ impl BlockingSink for RepartitionSink {
                     std::collections::hash_map::Entry::Vacant(e) => {
                         let partition_set = Arc::new(
                             (0..self.num_partitions)
-                                .map(|partition_idx| {
+                                .map(|_| {
                                     Ok(Arc::new(InProgressShuffleCache::try_new(
-                                        partition_ref_id(input_id, partition_idx),
+                                        local_server,
                                         schema.clone(),
                                         shuffle_dirs,
                                         *shuffle_id,

--- a/src/daft-local-execution/src/sources/shuffle_read.rs
+++ b/src/daft-local-execution/src/sources/shuffle_read.rs
@@ -16,6 +16,7 @@ use daft_recordbatch::RecordBatch;
 use daft_shuffles::{client::FlightClientManager, server::flight_server::ShuffleFlightServer};
 use futures::{FutureExt, StreamExt, stream::BoxStream};
 use tracing::instrument;
+use uuid::Uuid;
 
 use super::source::{Source, SourceStream, StatsProvider};
 use crate::{
@@ -85,7 +86,7 @@ impl ShuffleReadSource {
         let remote_stream = if remote_refs.is_empty() {
             None
         } else {
-            let mut refs_by_server: HashMap<(u64, String), Vec<u64>> = HashMap::new();
+            let mut refs_by_server: HashMap<(u64, String), Vec<Uuid>> = HashMap::new();
             for partition_ref in remote_refs {
                 refs_by_server
                     .entry((

--- a/src/daft-partition-refs/Cargo.toml
+++ b/src/daft-partition-refs/Cargo.toml
@@ -3,6 +3,7 @@ common-partitioning = {path = "../common/partitioning", default-features = false
 common-py-serde = {path = "../common/py-serde", default-features = false, optional = true}
 pyo3 = {workspace = true, optional = true}
 serde = {workspace = true}
+uuid = {workspace = true}
 
 [features]
 python = [

--- a/src/daft-partition-refs/src/flight.rs
+++ b/src/daft-partition-refs/src/flight.rs
@@ -2,12 +2,13 @@ use std::any::Any;
 
 use common_partitioning::Partition;
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FlightPartitionRef {
     pub shuffle_id: u64,
     pub server_address: String,
-    pub partition_ref_id: u64,
+    pub partition_ref_id: Uuid,
     pub num_rows: usize,
     pub size_bytes: usize,
 }
@@ -29,8 +30,12 @@ impl Partition for FlightPartitionRef {
 #[cfg(feature = "python")]
 mod python {
     use common_py_serde::impl_bincode_py_state_serialization;
-    use pyo3::{Bound, PyResult, Python, pyclass, pymethods, types::PyModuleMethods};
+    use pyo3::{
+        Bound, PyResult, Python, exceptions::PyValueError, pyclass, pymethods,
+        types::PyModuleMethods,
+    };
     use serde::{Deserialize, Serialize};
+    use uuid::Uuid;
 
     use crate::flight::FlightPartitionRef;
 
@@ -53,11 +58,14 @@ mod python {
         pub fn new(
             shuffle_id: u64,
             server_address: String,
-            partition_ref_id: u64,
+            partition_ref_id: &str,
             num_rows: usize,
             size_bytes: usize,
-        ) -> Self {
-            Self {
+        ) -> PyResult<Self> {
+            let partition_ref_id = Uuid::parse_str(partition_ref_id).map_err(|e| {
+                PyValueError::new_err(format!("Invalid partition_ref_id UUID: {e}"))
+            })?;
+            Ok(Self {
                 inner: FlightPartitionRef {
                     shuffle_id,
                     server_address,
@@ -65,7 +73,7 @@ mod python {
                     num_rows,
                     size_bytes,
                 },
-            }
+            })
         }
 
         #[getter]
@@ -79,8 +87,8 @@ mod python {
         }
 
         #[getter]
-        pub fn partition_ref_id(&self) -> u64 {
-            self.inner.partition_ref_id
+        pub fn partition_ref_id(&self) -> String {
+            self.inner.partition_ref_id.to_string()
         }
 
         #[getter]

--- a/src/daft-shuffles/Cargo.toml
+++ b/src/daft-shuffles/Cargo.toml
@@ -14,6 +14,7 @@ daft-writers = {path = "../daft-writers", default-features = false}
 futures = {workspace = true}
 tokio = {workspace = true, features = ["fs", "io-util"]}
 tonic = {workspace = true}
+uuid = {workspace = true, features = ["v7"]}
 
 [lints]
 workspace = true

--- a/src/daft-shuffles/src/client/flight_client.rs
+++ b/src/daft-shuffles/src/client/flight_client.rs
@@ -11,6 +11,7 @@ use daft_recordbatch::RecordBatch;
 use daft_schema::field::FieldRef;
 use futures::{FutureExt, Stream, StreamExt};
 use tonic::transport::Endpoint;
+use uuid::Uuid;
 
 #[allow(clippy::large_enum_variant)]
 enum ClientState {
@@ -57,7 +58,7 @@ impl ShuffleFlightClient {
     pub async fn get_partition(
         &mut self,
         shuffle_id: u64,
-        partition_ref_ids: &[u64],
+        partition_ref_ids: &[Uuid],
         schema: SchemaRef,
     ) -> DaftResult<FlightRecordBatchStreamToDaftRecordBatchStream> {
         let ticket = Ticket::new(format!(

--- a/src/daft-shuffles/src/client/mod.rs
+++ b/src/daft-shuffles/src/client/mod.rs
@@ -7,6 +7,7 @@ use daft_core::prelude::SchemaRef;
 use daft_recordbatch::RecordBatch;
 use futures::{StreamExt, stream::BoxStream};
 use tokio::sync::Mutex;
+use uuid::Uuid;
 
 use crate::client::flight_client::ShuffleFlightClient;
 
@@ -24,7 +25,7 @@ impl FlightClientManager {
         &self,
         shuffle_id: u64,
         server_address: &str,
-        partition_ref_ids: &[u64],
+        partition_ref_ids: &[Uuid],
         schema: SchemaRef,
     ) -> DaftResult<BoxStream<'static, DaftResult<RecordBatch>>> {
         let client = {

--- a/src/daft-shuffles/src/server/flight_server.rs
+++ b/src/daft-shuffles/src/server/flight_server.rs
@@ -1,4 +1,11 @@
-use std::{collections::HashMap, pin::Pin, sync::Arc};
+use std::{
+    collections::HashMap,
+    pin::Pin,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+};
 
 use arrow_flight::{
     Action, ActionType, Criteria, Empty, FlightData, FlightDescriptor, FlightInfo,
@@ -69,11 +76,17 @@ struct FlightPartitionKey {
 #[derive(Clone, Default)]
 pub struct ShuffleFlightServer {
     shuffle_partitions: Arc<Mutex<HashMap<FlightPartitionKey, PartitionCache>>>,
+    /// Server-wide counter for `partition_ref_id` minting.
+    ref_id_counter: Arc<AtomicU64>,
 }
 
 impl ShuffleFlightServer {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    pub fn new_partition_ref_id(&self) -> u64 {
+        self.ref_id_counter.fetch_add(1, Ordering::Relaxed)
     }
 
     pub async fn register_shuffle_partitions(

--- a/src/daft-shuffles/src/server/flight_server.rs
+++ b/src/daft-shuffles/src/server/flight_server.rs
@@ -1,11 +1,4 @@
-use std::{
-    collections::HashMap,
-    pin::Pin,
-    sync::{
-        Arc,
-        atomic::{AtomicU64, Ordering},
-    },
-};
+use std::{collections::HashMap, pin::Pin, sync::Arc};
 
 use arrow_flight::{
     Action, ActionType, Criteria, Empty, FlightData, FlightDescriptor, FlightInfo,
@@ -22,6 +15,7 @@ use daft_recordbatch::RecordBatch;
 use futures::{Stream, StreamExt, TryStreamExt, stream::BoxStream};
 use tokio::{io::BufReader, sync::Mutex};
 use tonic::{Request, Response, Status, transport::Server};
+use uuid::Uuid;
 
 use super::stream::FlightDataStreamReader;
 use crate::{
@@ -31,7 +25,7 @@ use crate::{
 
 struct ParsedTicket {
     shuffle_id: u64,
-    partition_ref_ids: Vec<u64>,
+    partition_ref_ids: Vec<Uuid>,
 }
 
 impl ParsedTicket {
@@ -39,7 +33,8 @@ impl ParsedTicket {
         let ticket_str = String::from_utf8(ticket.ticket.to_vec())
             .map_err(|e| Status::invalid_argument(e.to_string()))?;
 
-        // Ticket format: "shuffle_id:partition_ref_ids" where partition_ref_ids is comma-separated list of u64s
+        // Ticket format: "shuffle_id:partition_ref_ids" where partition_ref_ids is a
+        // comma-separated list of UUIDs.
         let parts: Vec<&str> = ticket_str.splitn(2, ':').collect();
         if parts.len() < 2 {
             return Err(Status::invalid_argument(
@@ -54,7 +49,7 @@ impl ParsedTicket {
             .split(',')
             .filter(|id| !id.is_empty())
             .map(|id| {
-                id.parse::<u64>().map_err(|e| {
+                Uuid::parse_str(id).map_err(|e| {
                     Status::invalid_argument(format!("Invalid partition ref id: {}", e))
                 })
             })
@@ -70,23 +65,17 @@ impl ParsedTicket {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 struct FlightPartitionKey {
     shuffle_id: u64,
-    partition_ref_id: u64,
+    partition_ref_id: Uuid,
 }
 
 #[derive(Clone, Default)]
 pub struct ShuffleFlightServer {
     shuffle_partitions: Arc<Mutex<HashMap<FlightPartitionKey, PartitionCache>>>,
-    /// Server-wide counter for `partition_ref_id` minting.
-    ref_id_counter: Arc<AtomicU64>,
 }
 
 impl ShuffleFlightServer {
     pub fn new() -> Self {
         Self::default()
-    }
-
-    pub fn new_partition_ref_id(&self) -> u64 {
-        self.ref_id_counter.fetch_add(1, Ordering::Relaxed)
     }
 
     pub async fn register_shuffle_partitions(
@@ -110,7 +99,7 @@ impl ShuffleFlightServer {
     async fn get_shuffle_file_paths(
         &self,
         shuffle_id: u64,
-        partition_ref_ids: &[u64],
+        partition_ref_ids: &[Uuid],
     ) -> Option<(Vec<String>, SchemaRef)> {
         let partitions = self.shuffle_partitions.lock().await;
 
@@ -146,7 +135,7 @@ impl ShuffleFlightServer {
     pub async fn get_partition_local(
         &self,
         shuffle_id: u64,
-        partition_ref_ids: &[u64],
+        partition_ref_ids: &[Uuid],
     ) -> DaftResult<BoxStream<'static, DaftResult<RecordBatch>>> {
         let (file_paths, schema) = self
             .get_shuffle_file_paths(shuffle_id, partition_ref_ids)

--- a/src/daft-shuffles/src/shuffle_cache.rs
+++ b/src/daft-shuffles/src/shuffle_cache.rs
@@ -6,8 +6,7 @@ use daft_recordbatch::RecordBatch;
 use daft_schema::schema::SchemaRef;
 use daft_writers::{AsyncFileWriter, make_ipc_writer};
 use tokio::sync::Mutex;
-
-use crate::server::flight_server::ShuffleFlightServer;
+use uuid::Uuid;
 
 fn get_shuffle_dirs(shuffle_dirs: &[String], shuffle_id: u64) -> Vec<String> {
     shuffle_dirs
@@ -16,8 +15,11 @@ fn get_shuffle_dirs(shuffle_dirs: &[String], shuffle_id: u64) -> Vec<String> {
         .collect()
 }
 
-fn get_partition_dir(shuffle_dirs: &[String], partition_ref_id: u64) -> String {
-    let dir = &shuffle_dirs[(partition_ref_id as usize) % shuffle_dirs.len()];
+fn get_partition_dir(shuffle_dirs: &[String], partition_ref_id: Uuid) -> String {
+    // Bucket across `shuffle_dirs` using the low 64 bits of the UUID (the random
+    // tail in v7), so bucketing distribution doesn't depend on the timestamp prefix.
+    let (_, low) = partition_ref_id.as_u64_pair();
+    let dir = &shuffle_dirs[(low as usize) % shuffle_dirs.len()];
     format!("{}/partition_ref_{}", dir, partition_ref_id)
 }
 
@@ -39,20 +41,19 @@ struct InProgressShuffleCacheState {
 pub struct InProgressShuffleCache {
     state: Mutex<InProgressShuffleCacheState>,
     writer_sender_weak: async_channel::WeakSender<MicroPartition>,
-    partition_ref_id: u64,
+    partition_ref_id: Uuid,
     schema: SchemaRef,
 }
 
 impl InProgressShuffleCache {
     pub fn try_new(
-        server: &ShuffleFlightServer,
         schema: SchemaRef,
         dirs: &[String],
         shuffle_id: u64,
         target_filesize: usize,
         compression: Option<&str>,
     ) -> DaftResult<Self> {
-        let partition_ref_id = server.new_partition_ref_id();
+        let partition_ref_id = Uuid::now_v7();
         // Create the directories
         // TODO: Add checks here, as well as periodic checks to ensure that the dirs are not too full. If so, we switch to directories with more space.
         // And raise an error if we can't find any directories with space.
@@ -84,7 +85,7 @@ impl InProgressShuffleCache {
 
     fn try_new_with_writer(
         writer: Box<dyn AsyncFileWriter<Input = MicroPartition, Result = Vec<RecordBatch>>>,
-        partition_ref_id: u64,
+        partition_ref_id: Uuid,
         schema: SchemaRef,
     ) -> DaftResult<Self> {
         let num_cpus = std::thread::available_parallelism().unwrap().get();
@@ -221,7 +222,7 @@ async fn writer_task(
 
 #[derive(Debug, Clone)]
 pub struct PartitionCache {
-    pub partition_ref_id: u64,
+    pub partition_ref_id: Uuid,
     pub schema: SchemaRef,
     pub bytes_per_file: Vec<usize>,
     pub file_paths: Vec<String>,
@@ -256,7 +257,8 @@ mod tests {
         let writer = dummy_writer_factory.create_writer(0, None)?;
 
         // Create the cache with dummy writers
-        let cache = InProgressShuffleCache::try_new_with_writer(writer, 0, dummy_schema())?;
+        let cache =
+            InProgressShuffleCache::try_new_with_writer(writer, Uuid::now_v7(), dummy_schema())?;
 
         // Create and push some partitions
         // Since we have 1 partition, all data goes to partition 0
@@ -288,7 +290,8 @@ mod tests {
             make_dummy_target_file_size_writer_factory(100, 1.0, Arc::new(dummy_writer_factory));
         let writer = dummy_writer_factory.create_writer(0, None)?;
 
-        let cache = InProgressShuffleCache::try_new_with_writer(writer, 0, dummy_schema())?;
+        let cache =
+            InProgressShuffleCache::try_new_with_writer(writer, Uuid::now_v7(), dummy_schema())?;
 
         // Push 1000 empty partitions
         for _ in 0..1000 {
@@ -322,7 +325,8 @@ mod tests {
         let writer = failing_writer_factory.create_writer(0, None)?;
 
         // Create the cache with writers
-        let cache = InProgressShuffleCache::try_new_with_writer(writer, 0, dummy_schema())?;
+        let cache =
+            InProgressShuffleCache::try_new_with_writer(writer, Uuid::now_v7(), dummy_schema())?;
 
         let mut found_failure = false;
         // Technically, we can calculate the max number of iterations before failure, based on number of tasks and channel sizes,
@@ -385,7 +389,8 @@ mod tests {
         let writer = failing_writer_factory.create_writer(0, None)?;
 
         // Create the cache with writers
-        let cache = InProgressShuffleCache::try_new_with_writer(writer, 0, dummy_schema())?;
+        let cache =
+            InProgressShuffleCache::try_new_with_writer(writer, Uuid::now_v7(), dummy_schema())?;
 
         // Create and push a partition
         let partitions = vec![make_dummy_mp(100), make_dummy_mp(100)];

--- a/src/daft-shuffles/src/shuffle_cache.rs
+++ b/src/daft-shuffles/src/shuffle_cache.rs
@@ -7,6 +7,8 @@ use daft_schema::schema::SchemaRef;
 use daft_writers::{AsyncFileWriter, make_ipc_writer};
 use tokio::sync::Mutex;
 
+use crate::server::flight_server::ShuffleFlightServer;
+
 fn get_shuffle_dirs(shuffle_dirs: &[String], shuffle_id: u64) -> Vec<String> {
     shuffle_dirs
         .iter()
@@ -17,10 +19,6 @@ fn get_shuffle_dirs(shuffle_dirs: &[String], shuffle_id: u64) -> Vec<String> {
 fn get_partition_dir(shuffle_dirs: &[String], partition_ref_id: u64) -> String {
     let dir = &shuffle_dirs[(partition_ref_id as usize) % shuffle_dirs.len()];
     format!("{}/partition_ref_{}", dir, partition_ref_id)
-}
-
-pub fn partition_ref_id(input_id: u32, partition_idx: usize) -> u64 {
-    ((input_id as u64) << 32) | partition_idx as u64
 }
 
 // Result of a writer task
@@ -47,13 +45,14 @@ pub struct InProgressShuffleCache {
 
 impl InProgressShuffleCache {
     pub fn try_new(
-        partition_ref_id: u64,
+        server: &ShuffleFlightServer,
         schema: SchemaRef,
         dirs: &[String],
         shuffle_id: u64,
         target_filesize: usize,
         compression: Option<&str>,
     ) -> DaftResult<Self> {
+        let partition_ref_id = server.new_partition_ref_id();
         // Create the directories
         // TODO: Add checks here, as well as periodic checks to ensure that the dirs are not too full. If so, we switch to directories with more space.
         // And raise an error if we can't find any directories with space.

--- a/tests/dataframe/test_shuffles.py
+++ b/tests/dataframe/test_shuffles.py
@@ -66,13 +66,42 @@ def flight_shuffle_ctx():
     return _ctx
 
 
+@pytest.fixture(params=[False, True], ids=["ray", "flight"])
+def flight(request) -> bool:
+    """Parametrizes a test on `flight=False` (Ray backend) and `flight=True` (Flight backend).
+
+    Tests that depend on this fixture run twice — once per backend — without
+    needing a per-test `@pytest.mark.parametrize("flight", ...)` decorator.
+    """
+    return request.param
+
+
+@pytest.fixture
+def shuffle_ctx(flight, flight_shuffle_ctx):
+    """Context-manager fixture that enters `flight_shuffle_ctx` when flight=True, else no-op.
+
+    Pair with the `flight` fixture to write tests that exercise both shuffle
+    backends with `with shuffle_ctx(): ...`.
+    """
+
+    @contextmanager
+    def _ctx():
+        if flight:
+            with flight_shuffle_ctx():
+                yield
+        else:
+            yield
+
+    return _ctx
+
+
 @pytest.mark.skipif(
     get_tests_daft_runner_name() != "ray",
     reason="shuffle tests are meant for the ray runner",
 )
 @pytest.mark.parametrize(
     "input_partitions, output_partitions",
-    [(100, 100), (100, 1), (100, 50), (100, 200)],
+    [(10, 10), (10, 1), (10, 5), (10, 20)],
 )
 def test_pre_shuffle_merge_small_partitions(pre_shuffle_merge_ctx, input_partitions, output_partitions):
     """Test that pre-shuffle merge is working for small partitions less than the memory threshold."""
@@ -109,7 +138,7 @@ def test_pre_shuffle_merge_small_partitions(pre_shuffle_merge_ctx, input_partiti
 )
 @pytest.mark.parametrize(
     "input_partitions, output_partitions",
-    [(100, 100), (100, 1), (100, 50), (100, 200)],
+    [(10, 10), (10, 1), (10, 5), (10, 20)],
 )
 def test_pre_shuffle_merge_big_partitions(pre_shuffle_merge_ctx, input_partitions, output_partitions):
     """Test that pre-shuffle merge is working for big partitions greater than the threshold."""
@@ -146,7 +175,7 @@ def test_pre_shuffle_merge_big_partitions(pre_shuffle_merge_ctx, input_partition
 )
 @pytest.mark.parametrize(
     "input_partitions, output_partitions",
-    [(100, 100), (100, 1), (100, 50), (100, 200)],
+    [(10, 10), (10, 1), (10, 5), (10, 20)],
 )
 def test_pre_shuffle_merge_randomly_sized_partitions(pre_shuffle_merge_ctx, input_partitions, output_partitions):
     """Test that pre-shuffle merge is working for randomly sized partitions."""
@@ -227,7 +256,7 @@ def test_ray_random_shuffle():
 )
 @pytest.mark.parametrize(
     "input_partitions, output_partitions",
-    [(100, 100), (100, 1), (100, 50), (100, 200)],
+    [(10, 10), (10, 1), (10, 5), (10, 20)],
 )
 def test_flight_shuffle(flight_shuffle_ctx, input_partitions, output_partitions):
     """Test that flight shuffle is working."""
@@ -258,36 +287,31 @@ def test_flight_shuffle(flight_shuffle_ctx, input_partitions, output_partitions)
 
 @pytest.mark.skipif(
     get_tests_daft_runner_name() != "ray",
-    reason="shuffle tests are meant for the ray runner",
+    reason="distributed IntoPartitions tests require the ray runner",
 )
 @pytest.mark.parametrize(
     "input_partitions, output_partitions",
     # Equal, coalesce (N > M), split (N < M), and single-output coalesce.
     [(4, 4), (8, 2), (2, 8), (7, 1)],
 )
-def test_flight_into_partitions(flight_shuffle_ctx, input_partitions, output_partitions):
-    """Exercises IntoPartitionsNode under `shuffle_algorithm="flight_shuffle"`.
-
-    Verifies that both upstream materialized outputs (FlightPartitionRefs) are
-    consumed and downstream outputs are re-emitted as FlightPartitionRefs, across
-    the equal / coalesce / split branches.
-    """
+def test_into_partitions(flight, shuffle_ctx, input_partitions, output_partitions):
+    """Exercises IntoPartitionsNode across the equal / coalesce / split branches under both backends."""
     rows = 1000
-    with flight_shuffle_ctx():
+    with shuffle_ctx():
         df = (
             daft.from_pydict({"x": list(range(rows))})
             .into_partitions(input_partitions)
             .into_partitions(output_partitions)
         )
 
-        # Plan-shape assertion: a regression that routes around IntoPartitionsNode
-        # or silently falls back to Ray would still yield correct row counts, so
-        # verify the Flight variant is in the plan explicitly.
+        # Plan-shape assertion guards against routing regressions that would
+        # still yield correct row counts (e.g. silent fallback to the wrong backend).
         buf = io.StringIO()
         df.explain(show_all=True, file=buf)
         plan = buf.getvalue()
-        assert "IntoPartitions(Flight)" in plan, f"expected IntoPartitions(Flight) in plan:\n{plan}"
-        assert "IntoPartitions(Ray)" not in plan, f"unexpected Ray IntoPartitions in plan:\n{plan}"
+        expected, other = ("Flight", "Ray") if flight else ("Ray", "Flight")
+        assert f"IntoPartitions({expected})" in plan, f"expected IntoPartitions({expected}) in plan:\n{plan}"
+        assert f"IntoPartitions({other})" not in plan, f"unexpected IntoPartitions({other}) in plan:\n{plan}"
 
         collected = df.collect()
         # The core contract of into_partitions: exactly N output partitions.
@@ -299,46 +323,13 @@ def test_flight_into_partitions(flight_shuffle_ctx, input_partitions, output_par
     get_tests_daft_runner_name() != "ray",
     reason="distributed IntoPartitions tests require the ray runner",
 )
-@pytest.mark.parametrize(
-    "input_partitions, output_partitions",
-    [(4, 4), (8, 2), (2, 8), (7, 1)],
-)
-def test_ray_into_partitions(input_partitions, output_partitions):
-    """IntoPartitions over the Ray backend (no flight_shuffle_ctx).
-
-    Mirrors test_flight_into_partitions but exercises the Ray IntoPartitionsNode
-    path and RayIntoPartitionsState finalize.
-    """
-    rows = 1000
-    df = daft.from_pydict({"x": list(range(rows))}).into_partitions(input_partitions).into_partitions(output_partitions)
-
-    buf = io.StringIO()
-    df.explain(show_all=True, file=buf)
-    plan = buf.getvalue()
-    assert "IntoPartitions(Ray)" in plan, f"expected IntoPartitions(Ray) in plan:\n{plan}"
-    assert "IntoPartitions(Flight)" not in plan, f"unexpected Flight IntoPartitions in plan:\n{plan}"
-
-    collected = df.collect()
-    assert len(list(collected.iter_partitions())) == output_partitions
-    assert sorted(collected.to_pydict()["x"]) == list(range(rows))
-
-
-@pytest.mark.skipif(
-    get_tests_daft_runner_name() != "ray",
-    reason="shuffle tests are meant for the ray runner",
-)
-def test_flight_into_partitions_mixed_empty_inputs(flight_shuffle_ctx):
-    """IntoPartitions (Flight) must still emit exactly N output partitions when some pre-filter partitions are empty.
-
-    FlightIntoPartitionsState opens N caches in `make_state` and `push` short-
-    circuits on empty inputs. As long as the rotation distributes surviving rows
-    across every cache, close() succeeds and we get N FlightPartitionRefs.
-    """
+def test_into_partitions_mixed_empty_inputs(shuffle_ctx):
+    """N output partitions when some pre-filter inputs are empty."""
     rows = 1000
     input_partitions = 8
     output_partitions = 5
     filter_threshold = 500  # roughly half the data survives
-    with flight_shuffle_ctx():
+    with shuffle_ctx():
         partial = (
             daft.from_pydict({"x": list(range(rows))})
             .into_partitions(input_partitions)
@@ -355,16 +346,10 @@ def test_flight_into_partitions_mixed_empty_inputs(flight_shuffle_ctx):
     reason="shuffle tests are meant for the ray runner",
 )
 def test_flight_into_partitions_rotation_balance(flight_shuffle_ctx):
-    """Test that flight into partitions rotation is balanced.
+    """Flight rotation evenly distributes ragged per-push chunks across output buckets.
 
-    Per-push `div_ceil` slicing front-loads early buckets; the rotation
-    offset in `FlightIntoPartitionsState::push` spreads that bias across
-    output buckets over many pushes.
-    With `rows_per_input=5` and `output_partitions=3`, each push distributes
-    rows as [2, 2, 1]. Without rotation (offset stuck at 0) the last bucket
-    consistently gets the short chunk, so 30 pushes yield [60, 60, 30] — a
-    30-row spread. With rotation the short chunk rotates and counts balance
-    to [50, 50, 50].
+    Without rotation, [2, 2, 1] chunks would consistently short the last
+    bucket: 30 pushes yield [60, 60, 30]. With rotation: ~[50, 50, 50].
     """
     rows_per_input = 5
     input_partitions = 30
@@ -394,20 +379,14 @@ def test_flight_into_partitions_rotation_balance(flight_shuffle_ctx):
 
 @pytest.mark.skipif(
     get_tests_daft_runner_name() != "ray",
-    reason="shuffle tests are meant for the ray runner",
+    reason="distributed IntoPartitions tests require the ray runner",
 )
-def test_flight_into_partitions_all_empty_inputs(flight_shuffle_ctx):
-    """All inputs empty post-filter: `into_partitions(N)` must still emit exactly N zero-row output partitions.
-
-    Regression guard for both the caller-schema plumbing through
-    `InProgressShuffleCache` (needed so `close()` can report a schema
-    for an all-empty partition) and the empty-stream fallback in
-    `forward_partition_stream` for `ShuffleRead(Flight)`.
-    """
+def test_into_partitions_all_empty_inputs(shuffle_ctx):
+    """N zero-row output partitions when all pre-filter inputs are empty."""
     rows = 1000
     input_partitions = 8
     output_partitions = 5
-    with flight_shuffle_ctx():
+    with shuffle_ctx():
         df = (
             daft.from_pydict({"x": list(range(rows))})
             .into_partitions(input_partitions)
@@ -421,19 +400,14 @@ def test_flight_into_partitions_all_empty_inputs(flight_shuffle_ctx):
 
 @pytest.mark.skipif(
     get_tests_daft_runner_name() != "ray",
-    reason="shuffle tests are meant for the ray runner",
+    reason="distributed shuffle tests require the ray runner",
 )
-def test_flight_repartition_all_empty_inputs(flight_shuffle_ctx):
-    """All inputs empty post-filter: hash `.repartition(M, "x")` must still emit M zero-row output partitions.
-
-    Same shuffle-cache shape as `test_flight_into_partitions_all_empty_inputs`
-    (N caches opened per input in `make_state`, all closed with no data), but
-    routed through `RepartitionSink` instead of `IntoPartitionsSink`.
-    """
+def test_repartition_all_empty_inputs(shuffle_ctx):
+    """Hash `.repartition(M, "x")` emits M zero-row output partitions when all inputs are empty."""
     rows = 1000
     input_partitions = 8
     output_partitions = 5
-    with flight_shuffle_ctx():
+    with shuffle_ctx():
         df = (
             daft.from_pydict({"x": list(range(rows))})
             .into_partitions(input_partitions)
@@ -447,17 +421,16 @@ def test_flight_repartition_all_empty_inputs(flight_shuffle_ctx):
 
 @pytest.mark.skipif(
     get_tests_daft_runner_name() != "ray",
-    reason="shuffle tests are meant for the ray runner",
+    reason="distributed gather tests require the ray runner",
 )
-def test_flight_gather_all_empty_inputs(flight_shuffle_ctx):
-    """Every upstream partition is empty post-filter: gather must still emit a single empty result without hanging.
+def test_gather_all_empty_inputs(shuffle_ctx):
+    """Gather over all-empty inputs emits a single empty result without hanging.
 
-    Uses a daemon thread + timeout to protect pytest teardown in case the
-    hang regresses.
+    Daemon thread + 30s timeout guards pytest teardown if the hang regresses.
     """
     rows = 1000
     input_partitions = 8
-    with flight_shuffle_ctx():
+    with shuffle_ctx():
         df = daft.from_pydict({"x": list(range(rows))}).into_partitions(input_partitions).filter(daft.col("x") < 0)
 
         result: dict = {}
@@ -474,7 +447,7 @@ def test_flight_gather_all_empty_inputs(flight_shuffle_ctx):
         if t.is_alive():
             # Hung. Leak the daemon thread (it'll die with the process) and
             # fail the test with a clear diagnostic rather than blocking teardown.
-            raise TimeoutError("test_flight_gather_all_empty_inputs hung past 30s")
+            raise TimeoutError("test_gather_all_empty_inputs hung past 30s")
         if "error" in result:
             raise result["error"]
         # The sum over an empty table should be 0 rows or a single NULL row.
@@ -483,17 +456,13 @@ def test_flight_gather_all_empty_inputs(flight_shuffle_ctx):
 
 @pytest.mark.skipif(
     get_tests_daft_runner_name() != "ray",
-    reason="shuffle tests are meant for the ray runner",
+    reason="distributed gather tests require the ray runner",
 )
 @pytest.mark.parametrize("input_partitions", [1, 8, 32])
-def test_flight_gather(flight_shuffle_ctx, input_partitions):
-    """Gather is triggered by top_n and ungrouped agg on multi-partition inputs.
-
-    Under `shuffle_algorithm="flight_shuffle"` this exercises the GatherWrite
-    blocking sink → ShuffleRead path (rather than the in-memory-scan shortcut).
-    """
+def test_gather(flight, shuffle_ctx, input_partitions):
+    """`top_n` and ungrouped agg correctness across both backends; single-partition inputs short-circuit Gather entirely."""
     rows = 1000
-    with flight_shuffle_ctx():
+    with shuffle_ctx():
         df = daft.from_pydict({"x": list(range(rows))}).into_partitions(input_partitions)
 
         agg_df = df.sum("x")
@@ -507,7 +476,11 @@ def test_flight_gather(flight_shuffle_ctx, input_partitions):
             plan_df.explain(show_all=True, file=buf)
             plan = buf.getvalue()
             if input_partitions > 1:
-                assert "FlightGather" in plan, f"expected FlightGather in plan:\n{plan}"
+                if flight:
+                    assert "FlightGather" in plan, f"expected FlightGather in plan:\n{plan}"
+                else:
+                    assert "Gather" in plan, f"expected Gather in plan:\n{plan}"
+                    assert "FlightGather" not in plan, f"expected Ray gather, got Flight:\n{plan}"
             else:
                 assert "Gather" not in plan, f"unexpected Gather for single-partition input:\n{plan}"
 
@@ -524,51 +497,12 @@ def test_flight_gather(flight_shuffle_ctx, input_partitions):
     get_tests_daft_runner_name() != "ray",
     reason="distributed gather tests require the ray runner",
 )
-@pytest.mark.parametrize("input_partitions", [1, 8, 32])
-def test_ray_gather(input_partitions):
-    """Gather over the Ray backend (no flight_shuffle_ctx).
-
-    Mirrors test_flight_gather but exercises GatherSink::Ray → emit_read_tasks.
-    """
-    rows = 1000
-    df = daft.from_pydict({"x": list(range(rows))}).into_partitions(input_partitions)
-
-    agg_df = df.sum("x")
-    top_df = df.sort("x", desc=True).limit(5)
-
-    for plan_df in (agg_df, top_df):
-        buf = io.StringIO()
-        plan_df.explain(show_all=True, file=buf)
-        plan = buf.getvalue()
-        if input_partitions > 1:
-            assert "Gather" in plan, f"expected Gather in plan:\n{plan}"
-            assert "FlightGather" not in plan, f"expected Ray gather, got Flight:\n{plan}"
-        else:
-            assert "Gather" not in plan, f"unexpected Gather for single-partition input:\n{plan}"
-
-    total = agg_df.collect().to_pydict()["x"]
-    assert total == [sum(range(rows))]
-
-    top = top_df.collect().to_pydict()["x"]
-    assert top == [rows - 1, rows - 2, rows - 3, rows - 4, rows - 5]
-
-
-@pytest.mark.skipif(
-    get_tests_daft_runner_name() != "ray",
-    reason="shuffle tests are meant for the ray runner",
-)
-def test_flight_gather_mixed_empty_inputs(flight_shuffle_ctx):
-    """Gather handles a mix of empty and non-empty input partitions.
-
-    Exercises the FlightGatherState empty-input short-circuit: some input
-    partitions have rows after the filter, others don't. Regressions in
-    the short-circuit would either miscount refs or skip data. The all-empty
-    case is covered by `test_flight_gather_all_empty_inputs`.
-    """
+def test_gather_mixed_empty_inputs(shuffle_ctx):
+    """Gather handles a mix of empty and non-empty input partitions (all-empty covered by `test_gather_all_empty_inputs`)."""
     rows = 1000
     input_partitions = 8
     filter_threshold = 500  # roughly half the data survives
-    with flight_shuffle_ctx():
+    with shuffle_ctx():
         df = (
             daft.from_pydict({"x": list(range(rows))})
             .into_partitions(input_partitions)
@@ -582,3 +516,189 @@ def test_flight_gather_mixed_empty_inputs(flight_shuffle_ctx):
 
         top = df.sort("x", desc=True).limit(5).collect().to_pydict()["x"]
         assert top == sorted(expected_rows, reverse=True)[:5]
+
+
+@pytest.mark.skipif(
+    get_tests_daft_runner_name() != "ray",
+    reason="distributed IntoBatches tests require the ray runner",
+)
+@pytest.mark.parametrize(
+    "rows, batch_size",
+    # Divisible, ragged tail, small input + small batch, batch_size > rows (tail-only).
+    # Scales kept small: each Flight rebatch task creates a shuffle-cache dir
+    # on disk, and many tiny dirs make filesystem ops dominate the test time.
+    [(100, 10), (100, 7), (10, 3), (50, 100)],
+)
+def test_into_batches(flight, shuffle_ctx, rows, batch_size):
+    """IntoBatches under both backends: rebatch tasks must produce the right row set and partition shape."""
+    with shuffle_ctx():
+        df = daft.from_pydict({"x": list(range(rows))}).into_partitions(8).into_batches(batch_size)
+
+        buf = io.StringIO()
+        df.explain(show_all=True, file=buf)
+        plan = buf.getvalue()
+        expected, other = ("Flight", "Ray") if flight else ("Ray", "Flight")
+        assert f"IntoBatches({expected})" in plan, f"expected IntoBatches({expected}) in plan:\n{plan}"
+        assert f"IntoBatches({other})" not in plan, f"unexpected IntoBatches({other}) in plan:\n{plan}"
+
+        collected = df.collect()
+        partitions = list(collected.iter_partitions())
+        if get_tests_daft_runner_name() == "ray":
+            import ray
+
+            partitions = ray.get(partitions)
+
+        # Total row set must match input (every row present exactly once).
+        all_rows = [v for part in partitions for v in part.to_pydict()["x"]]
+        assert sorted(all_rows) == list(range(rows))
+
+        sizes = [len(part.to_pydict()["x"]) for part in partitions]
+        if batch_size >= rows:
+            # Tail-only flush: single partition with all rows (or none if rows == 0).
+            assert sizes == [rows] or sizes == []
+        else:
+            # Sizes can exceed batch_size under Flight (task-boundary concat);
+            # row-set correctness is covered above, just rule out empty batches.
+            assert all(s > 0 for s in sizes), f"empty batch in sizes: {sizes}"
+
+
+@pytest.mark.skipif(
+    get_tests_daft_runner_name() != "ray",
+    reason="distributed IntoBatches tests require the ray runner",
+)
+def test_into_batches_all_empty_inputs(shuffle_ctx):
+    """Empty-input regression: filter drops everything, into_batches must not panic or hang."""
+    with shuffle_ctx():
+        df = (
+            daft.from_pydict({"x": list(range(1000))})
+            .into_partitions(8)
+            .filter(daft.col("x") < 0)
+            .into_batches(100)
+            .collect()
+        )
+        rows_out = df.to_pydict()["x"]
+        assert rows_out == []
+
+
+@pytest.mark.skipif(
+    get_tests_daft_runner_name() != "ray",
+    reason="distributed IntoPartitions tests require the ray runner",
+)
+def test_into_partitions_coalesce_with_fused_downstream(shuffle_ctx):
+    """Fused Project on top of `into_partitions(2)` Coalesce path produces correct values.
+
+    Regresses a bug where the Coalesce path forwarded materialized partition
+    refs into the fused downstream's morsel stream instead of re-reading them
+    first. Setup: 8→2 forces Coalesce.
+    """
+    rows = 100
+    with shuffle_ctx():
+        df = (
+            daft.from_pydict({"x": list(range(rows))})
+            .into_partitions(8)
+            .into_partitions(2)
+            .with_column("y", daft.col("x") * 2)
+            .collect()
+        )
+        out = df.to_pydict()
+        assert sorted(out["x"]) == list(range(rows)), f"lost rows; got {len(out['x'])} expected {rows}"
+        assert sorted(zip(out["x"], out["y"])) == [(i, i * 2) for i in range(rows)], (
+            "fused Project after coalesce produced wrong column values"
+        )
+
+
+@pytest.mark.skipif(
+    get_tests_daft_runner_name() != "ray",
+    reason="distributed IntoPartitions tests require the ray runner",
+)
+def test_into_partitions_equal_split_and_merge_with_fused_downstream(shuffle_ctx):
+    """Fused Project on top of the Equal+`enable_scan_task_split_and_merge=True` path produces correct values.
+
+    Regresses the same partition-ref-leakage bug as the Coalesce variant, but
+    on the Equal+split-merge path. Setup: N→N with split-and-merge forces the
+    Equal path.
+    """
+    rows = 100
+    n = 4
+    with shuffle_ctx(), daft.execution_config_ctx(enable_scan_task_split_and_merge=True):
+        df = (
+            daft.from_pydict({"x": list(range(rows))})
+            .into_partitions(n)
+            .into_partitions(n)  # Equal path — exercises the partition-ref re-read fix.
+            .with_column("y", daft.col("x") * 2)
+            .collect()
+        )
+        out = df.to_pydict()
+        assert sorted(out["x"]) == list(range(rows)), f"lost rows; got {len(out['x'])} expected {rows}"
+        assert sorted(zip(out["x"], out["y"])) == [(i, i * 2) for i in range(rows)], (
+            "fused Project after Equal+split-merge produced wrong column values"
+        )
+
+
+@pytest.mark.skipif(
+    get_tests_daft_runner_name() != "ray",
+    reason="distributed IntoBatches tests require the ray runner",
+)
+def test_into_batches_followed_by_streaming_project(shuffle_ctx):
+    """Fused Project on top of `into_batches` produces correct values.
+
+    Regresses a bug where the rebatch step forwarded materialized partition
+    refs into the fused downstream's morsel stream instead of re-reading them
+    first. `with_column` is used over `filter` because the optimizer can't
+    push a derived column below IntoBatches.
+    """
+    rows = 1000
+    with shuffle_ctx():
+        df = (
+            daft.from_pydict({"x": list(range(rows))})
+            .into_partitions(8)
+            .into_batches(100)
+            .with_column("y", daft.col("x") * 2)
+            .collect()
+        )
+        out = df.to_pydict()
+        assert sorted(out["x"]) == list(range(rows)), f"lost rows; got {len(out['x'])} expected {rows}"
+        # `y` must be derived correctly from the post-batched data.
+        pairs = sorted(zip(out["x"], out["y"]))
+        assert pairs == [(i, i * 2) for i in range(rows)], "project-after-into_batches produced wrong column values"
+
+
+@pytest.mark.skipif(
+    get_tests_daft_runner_name() != "ray",
+    reason="distributed IntoBatches tests require the ray runner",
+)
+def test_into_batches_emits_batch_size_partitions(shuffle_ctx):
+    """Output partition sizes track the requested `batch_size`, not the upstream partition size.
+
+    Regresses a bug where each upstream task was consolidated into a single
+    partition ref before rebatching, so the rebatch step emitted refs sized
+    to the upstream partition (potentially >> `batch_size`).
+    """
+    rows = 1000
+    batch_size = 100
+    input_partitions = 2  # 500 rows per input partition — still > batch_size, exercises the "input partition larger than batch_size" path
+    with shuffle_ctx():
+        df = (
+            daft.from_pydict({"x": list(range(rows))})
+            .into_partitions(input_partitions)
+            .into_batches(batch_size)
+            .collect()
+        )
+        partitions = list(df.iter_partitions())
+        if get_tests_daft_runner_name() == "ray":
+            import ray
+
+            partitions = ray.get(partitions)
+        sizes = [len(p.to_pydict()["x"]) for p in partitions]
+
+        # Total row count must be preserved.
+        assert sum(sizes) == rows, f"lost rows; sizes={sizes}"
+
+        # Every non-tail batch should be approximately `batch_size` rows.
+        # Allow a tolerance for non-strict bucketing at task boundaries.
+        tolerance = batch_size  # allow up to 2× batch_size; anything beyond points at a regression
+        oversized = [s for s in sizes if s > batch_size + tolerance]
+        assert not oversized, (
+            f"expected batches ≤ {batch_size + tolerance} rows; "
+            f"oversized batches: {oversized[:5]} (out of {len(sizes)} total)"
+        )

--- a/tests/dataframe/test_shuffles.py
+++ b/tests/dataframe/test_shuffles.py
@@ -567,7 +567,7 @@ def test_into_batches(flight, shuffle_ctx, rows, batch_size):
     reason="distributed IntoBatches tests require the ray runner",
 )
 def test_into_batches_all_empty_inputs(shuffle_ctx):
-    """Empty-input regression: filter drops everything, into_batches must not panic or hang."""
+    """Ensures `into_batches` handles all-empty inputs (post-filter) without panicking or hanging."""
     with shuffle_ctx():
         df = (
             daft.from_pydict({"x": list(range(1000))})
@@ -585,11 +585,9 @@ def test_into_batches_all_empty_inputs(shuffle_ctx):
     reason="distributed IntoPartitions tests require the ray runner",
 )
 def test_into_partitions_coalesce_with_fused_downstream(shuffle_ctx):
-    """Fused Project on top of `into_partitions(2)` Coalesce path produces correct values.
+    """Ensures the `into_partitions` Coalesce path re-reads its materialized partition refs into a fused downstream's morsel stream, so a fused Project sees real row values rather than the refs themselves.
 
-    Regresses a bug where the Coalesce path forwarded materialized partition
-    refs into the fused downstream's morsel stream instead of re-reading them
-    first. Setup: 8→2 forces Coalesce.
+    Setup: 8→2 forces Coalesce.
     """
     rows = 100
     with shuffle_ctx():
@@ -612,11 +610,9 @@ def test_into_partitions_coalesce_with_fused_downstream(shuffle_ctx):
     reason="distributed IntoPartitions tests require the ray runner",
 )
 def test_into_partitions_equal_split_and_merge_with_fused_downstream(shuffle_ctx):
-    """Fused Project on top of the Equal+`enable_scan_task_split_and_merge=True` path produces correct values.
+    """Ensures the `into_partitions` Equal+`enable_scan_task_split_and_merge=True` path re-reads its materialized partition refs into a fused downstream's morsel stream, mirroring the Coalesce variant.
 
-    Regresses the same partition-ref-leakage bug as the Coalesce variant, but
-    on the Equal+split-merge path. Setup: N→N with split-and-merge forces the
-    Equal path.
+    Setup: N→N with split-and-merge forces the Equal path.
     """
     rows = 100
     n = 4
@@ -624,7 +620,7 @@ def test_into_partitions_equal_split_and_merge_with_fused_downstream(shuffle_ctx
         df = (
             daft.from_pydict({"x": list(range(rows))})
             .into_partitions(n)
-            .into_partitions(n)  # Equal path — exercises the partition-ref re-read fix.
+            .into_partitions(n)  # Equal path — exercises the partition-ref re-read.
             .with_column("y", daft.col("x") * 2)
             .collect()
         )
@@ -640,12 +636,10 @@ def test_into_partitions_equal_split_and_merge_with_fused_downstream(shuffle_ctx
     reason="distributed IntoBatches tests require the ray runner",
 )
 def test_into_batches_followed_by_streaming_project(shuffle_ctx):
-    """Fused Project on top of `into_batches` produces correct values.
+    """Ensures the `into_batches` rebatch step re-reads its materialized partition refs into a fused downstream's morsel stream, so a fused Project sees real row values rather than the refs themselves.
 
-    Regresses a bug where the rebatch step forwarded materialized partition
-    refs into the fused downstream's morsel stream instead of re-reading them
-    first. `with_column` is used over `filter` because the optimizer can't
-    push a derived column below IntoBatches.
+    `with_column` is used over `filter` because the optimizer can't push a
+    derived column below IntoBatches.
     """
     rows = 1000
     with shuffle_ctx():
@@ -668,12 +662,7 @@ def test_into_batches_followed_by_streaming_project(shuffle_ctx):
     reason="distributed IntoBatches tests require the ray runner",
 )
 def test_into_batches_emits_batch_size_partitions(shuffle_ctx):
-    """Output partition sizes track the requested `batch_size`, not the upstream partition size.
-
-    Regresses a bug where each upstream task was consolidated into a single
-    partition ref before rebatching, so the rebatch step emitted refs sized
-    to the upstream partition (potentially >> `batch_size`).
-    """
+    """Ensures `into_batches` emits partitions sized to the requested `batch_size`, not to the upstream partition — each upstream task must split its rows across multiple refs rather than consolidating them into one ref sized to the upstream partition."""
     rows = 1000
     batch_size = 100
     input_partitions = 2  # 500 rows per input partition — still > batch_size, exercises the "input partition larger than batch_size" path


### PR DESCRIPTION
  ## Changes Made

  Implements `into_batches` for the distributed (Ray) runner under the flight shuffle backend.

  In the process, this PR uncovers and fixes a couple of latent flight-shuffle bugs that the new code path exposed:

  - **Partition ref ID collisions in `into_batches → gather`.** Partition ref IDs were derived deterministically from `(input_id, partition_idx)`, so multiple state-pool instances of a Flight gather state could compute identical IDs for the same shuffle cache and clobber each other's data. Fixed by minting ref IDs from a process-unique atomic counter on the flight server.
  - **`IntoPartitions` tasks missing explicit write | read stage blockers.** The `IntoPartitions` Equal+split-merge and Coalesce paths emitted task builders whose plans ended in a write sink. Without a materialize-and-re-read step between stages, fused downstream ops (e.g. a `Project` from `with_column`) received the materialized partition refs into their morsel stream and crashed. Fixed by explicitly submitting + materializing the write stage and re-emitting a passthrough reader builder.

Tests for `into_batches`, `into_partitions`, `repartition`, and `gather` are now parametrized to run under both the Ray and Flight backends via a shared `flight` / `shuffle_ctx` fixture pair, with plan-shape assertions guarding against silent routing fallback.

  ## Related Issues

  <!-- Link to related GitHub issues, e.g., "Closes #123" -->
