### PR TITLE
fix(udf): handle UDF expressions with no column references (#6805)

### DIFF
--- a/src/daft-dsl/src/utils.rs
+++ b/src/daft-dsl/src/utils.rs
@@ -10,8 +10,10 @@ use crate::{
 /// Given an expression, extract the indexes of used columns and remap them to
 /// new indexes from 0...count-1, where count is the # of used columns.
 ///
-/// Note that if there are no used columns, we just return the first
-/// because we can't execute UDFs on empty recordbatches.
+/// Returns an empty `Vec` when the expression has no column references (e.g.
+/// after constant folding inlines a literal-valued column). Callers pass the
+/// result to `RecordBatch::get_columns`, which preserves `num_rows` even when
+/// the column slice is empty.
 pub fn remap_used_cols(expr: BoundExpr) -> (BoundExpr, Vec<usize>) {
     let mut count = 0;
     let mut cols_to_idx = HashMap::new();
@@ -37,15 +39,10 @@ pub fn remap_used_cols(expr: BoundExpr) -> (BoundExpr, Vec<usize>) {
         })
         .expect("Error occurred when visiting for required columns");
 
-    let required_cols = if cols_to_idx.is_empty() {
-        vec![0]
-    } else {
-        let mut required_cols = vec![0; count];
-        for (original_idx, final_idx) in cols_to_idx {
-            required_cols[final_idx] = original_idx;
-        }
-        required_cols
-    };
+    let mut required_cols = vec![0; count];
+    for (original_idx, final_idx) in cols_to_idx {
+        required_cols[final_idx] = original_idx;
+    }
 
     (BoundExpr::new_unchecked(new_expr.data), required_cols)
 }

--- a/src/daft-recordbatch/src/lib.rs
+++ b/src/daft-recordbatch/src/lib.rs
@@ -1153,6 +1153,12 @@ impl RecordBatch {
                         .await?,
                     );
                 }
+                let row_count = self.len();
+                for series in &mut args {
+                    if series.len() == 1 && row_count != 1 {
+                        *series = series.broadcast(row_count)?;
+                    }
+                }
                 if python_udf.is_async() {
                     python_udf.call_async(args.as_slice(), metrics).await
                 } else {
@@ -1463,6 +1469,12 @@ impl RecordBatch {
                         &BoundExpr::new_unchecked(expr.clone()),
                         metrics,
                     )?);
+                }
+                let row_count = self.len();
+                for series in &mut args {
+                    if series.len() == 1 && row_count != 1 {
+                        *series = series.broadcast(row_count)?;
+                    }
                 }
                 #[cfg(feature = "python")]
                 {

--- a/tests/integration/ray/test_async_udf_literal_input.py
+++ b/tests/integration/ray/test_async_udf_literal_input.py
@@ -1,0 +1,58 @@
+"""Ray integration coverage for issue #6805.
+
+The actor UDF path (`src/daft-distributed/src/pipeline_node/actor_udf.rs`)
+calls `remap_used_cols` and feeds the result downstream to a Ray actor.
+This test exercises the same literal-only-input scenario as the unit
+tests but on the Ray runner, with multi-partition input to confirm the
+panic-free + per-row-invocation behavior holds across actors.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import daft
+from daft import DataType, Series, col, lit
+from tests.conftest import get_tests_daft_runner_name
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        get_tests_daft_runner_name() != "ray",
+        reason="Actor UDF path is only exercised on the Ray runner",
+    ),
+]
+
+
+def test_async_batch_udf_with_literal_input_on_ray_multi_partition():
+    """Async batch UDF with a literal-only input must run correctly on Ray.
+
+    Must not panic, and must process all N rows when split across multiple
+    partitions.
+    """
+
+    @daft.cls(on_error="raise", max_retries=0, max_concurrency=1)
+    class LengthEcho:
+        @daft.method.batch(return_dtype=DataType.int64())
+        async def run(self, inputs: Series) -> Series:
+            # Encode the per-call input length into each output row.
+            # If the UDF is invoked once with a length-1 literal and the
+            # result is broadcast to N, every output is 1; the assert
+            # below catches that.
+            return Series.from_pylist([len(inputs)] * len(inputs))
+
+    udf = LengthEcho()
+    n = 8
+    df = (
+        daft.from_pydict({"id": list(range(n))})
+        .into_partitions(2)
+        .with_column("msg", lit("x"))
+        .with_column("result", udf.run(col("msg")))
+    )
+    result = df.select("result").to_pydict()
+
+    assert len(result["result"]) == n
+    assert max(result["result"]) > 1, (
+        f"UDF appears to have been invoked once on a length-1 literal and "
+        f"broadcast across all rows (every output is 1). result={result!r}"
+    )

--- a/tests/udf/test_udf_no_column_input.py
+++ b/tests/udf/test_udf_no_column_input.py
@@ -1,0 +1,169 @@
+"""Regression tests for issue #6805.
+
+When a UDF expression has no column references (e.g. its only input is a
+literal column that gets folded away by the optimizer), two related bugs
+appear in the AsyncUdfSink path:
+
+1. The sink panics with `index out of bounds: the len is 0 but the index
+   is 0` when projection pushdown also narrows the upstream batch to
+   zero columns.
+2. Even when no panic fires, the UDF is invoked once on a length-1
+   literal input and the result is broadcast to N rows. This is wrong
+   for non-pure UDFs (random sampling, external API calls, anything
+   stateful) — the UDF must be invoked across all N upstream rows.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from pydantic import BaseModel, Field
+
+import daft
+from daft import DataType, Series, col, lit
+from tests.conftest import get_tests_daft_runner_name
+
+# These property tests rely on closure-captured Python state mutated inside
+# the UDF body. That works on the native runner (UDF runs in-process) but not
+# on Ray (UDF runs in an actor process). The Ray actor UDF path is exercised
+# by tests/integration/ray/test_async_udf_literal_input.py instead.
+_skip_on_ray_closure_state = pytest.mark.skipif(
+    get_tests_daft_runner_name() == "ray",
+    reason="Closure-captured state is not observable across Ray actor processes",
+)
+
+
+def test_issue_6805_verbatim_repro():
+    """Verbatim repro from issue #6805.
+
+    Originally panicked with `index out of bounds: the len is 0 but the
+    index is 0`.
+    """
+
+    class MyOutput(BaseModel):
+        text: str
+        tags: list[str] = Field(default_factory=list)
+
+    @daft.cls(on_error="raise", max_retries=0, max_concurrency=1)
+    class MyAsyncUDF:
+        def __init__(self):
+            pass
+
+        @daft.method.batch(return_dtype=DataType.infer_from_type(MyOutput))
+        async def run(self, inputs: daft.Series) -> daft.Series:
+            results = []
+            for val in inputs.to_pylist():
+                await asyncio.sleep(0.01)
+                results.append({"text": f"processed {val}", "tags": ["a", "b"]})
+            return daft.Series.from_pylist(results, dtype=DataType.infer_from_type(MyOutput))
+
+    df = daft.from_pydict({"id": [1, 2, 3, 4]}).with_column("msg", lit("hello"))
+    udf = MyAsyncUDF()
+    df = df.with_column("result", udf.run(df["msg"]))
+
+    actual = df.select("result").to_pydict()
+    assert actual == {"result": [{"text": "processed hello", "tags": ["a", "b"]}] * 4}
+
+
+@_skip_on_ray_closure_state
+def test_async_batch_udf_with_literal_input_receives_n_row_series():
+    """A non-pure UDF must be invoked with the upstream row count.
+
+    Even when its input expression has no column references, the UDF must
+    see a Series of length N — not a length-1 literal that gets broadcast.
+    """
+    seen_lengths: list[int] = []
+
+    @daft.cls(max_concurrency=1)
+    class LengthRecorder:
+        @daft.method.batch(return_dtype=DataType.int64())
+        async def run(self, inputs: Series) -> Series:
+            seen_lengths.append(len(inputs))
+            return Series.from_pylist([len(inputs)] * len(inputs))
+
+    udf = LengthRecorder()
+    n = 8
+    df = (
+        daft.from_pydict({"id": list(range(n))}).with_column("msg", lit("x")).with_column("result", udf.run(col("msg")))
+    )
+    df.select("result").to_pydict()
+
+    assert sum(seen_lengths) == n, (
+        f"UDF received total {sum(seen_lengths)} rows across {len(seen_lengths)} "
+        f"invocation(s); expected {n}. seen_lengths={seen_lengths!r}"
+    )
+
+
+@_skip_on_ray_closure_state
+def test_sync_batch_udf_with_literal_input_receives_n_row_series():
+    """Same property as the async case, on the sync UDF eval path.
+
+    Sync and async Python UDFs are dispatched through different branches
+    of the RecordBatch eval pipeline; the broadcast fix must apply to both.
+    """
+    seen_lengths: list[int] = []
+
+    @daft.func.batch(return_dtype=DataType.int64())
+    def length_recorder(inputs: Series) -> Series:
+        seen_lengths.append(len(inputs))
+        return Series.from_pylist([len(inputs)] * len(inputs))
+
+    n = 8
+    df = (
+        daft.from_pydict({"id": list(range(n))})
+        .with_column("msg", lit("x"))
+        .with_column("result", length_recorder(col("msg")))
+    )
+    df.select("result").to_pydict()
+
+    assert sum(seen_lengths) == n, (
+        f"UDF received total {sum(seen_lengths)} rows across {len(seen_lengths)} "
+        f"invocation(s); expected {n}. seen_lengths={seen_lengths!r}"
+    )
+
+
+@_skip_on_ray_closure_state
+def test_row_wise_udf_with_literal_input_runs_per_row():
+    """Row-wise (`@daft.func`) UDFs land on PyScalarFn::RowWise.
+
+    The same `Expr::ScalarFn(ScalarFn::Python)` branch handles both batch
+    and row-wise variants, but row-wise has its own dispatch in the UDF
+    impl. Verify the broadcast fix applies here too: the UDF must be
+    invoked once per row, not once-and-broadcast.
+    """
+    call_count = [0]
+
+    @daft.func(return_dtype=DataType.int64())
+    def row_wise_counter(_x: str) -> int:
+        call_count[0] += 1
+        return call_count[0]
+
+    n = 6
+    df = (
+        daft.from_pydict({"id": list(range(n))})
+        .with_column("msg", lit("x"))
+        .with_column("result", row_wise_counter(col("msg")))
+    )
+    df.select("result").to_pydict()
+
+    assert call_count[0] == n, f"Row-wise UDF was invoked {call_count[0]} time(s); expected {n}."
+
+
+def test_async_batch_udf_with_literal_input_on_empty_dataframe():
+    """Empty input batch with literal-only UDF input must not panic.
+
+    Guards the broadcast guard: when row_count is 0, the broadcast path
+    should be a no-op, not crash on `Series::broadcast(0)`.
+    """
+
+    @daft.cls(max_concurrency=1)
+    class EchoUDF:
+        @daft.method.batch(return_dtype=DataType.string())
+        async def run(self, inputs: Series) -> Series:
+            return Series.from_pylist([f"got: {v}" for v in inputs.to_pylist()])
+
+    udf = EchoUDF()
+    df = daft.from_pydict({"id": []}).with_column("msg", lit("x")).with_column("result", udf.run(col("msg")))
+    actual = df.select("result").to_pydict()
+    assert actual == {"result": []}


### PR DESCRIPTION
Fixes #6805. Two commits: failing tests (red), then the fix (green).

Two related bugs surface when a UDF expression has no column references after constant folding (e.g., `with_column("msg", lit("hello"))` followed by a UDF whose only input is `msg` — the optimizer inlines the literal and the UDF expression collapses to a literal-only form).

## Part 1 — `remap_used_cols` returns empty Vec instead of `vec![0]`

`daft_dsl::utils::remap_used_cols` previously returned `vec![0]` as a "borrow column 0 to keep the row count alive" fallback. The downstream UDF op (streaming sink for async UDFs, intermediate op for sync UDFs) then indexed into a batch that projection pushdown had narrowed to zero columns, panicking with `index out of bounds: the len is 0 but the index is 0`. `RecordBatch::get_columns(&[])` already preserves `num_rows`, so the fallback isn't needed.

## Part 2 — broadcast length-1 inputs in Python UDF eval branches

Even with the panic fixed, evaluating a literal-only input yields a length-1 Series, so the UDF was invoked once and the result broadcast to N rows. This is wrong for non-pure UDFs (random sampling, external API calls, anything stateful) — the user wrote `with_column` expecting per-row execution.

Fix: in both `Expr::ScalarFn(ScalarFn::Python)` branches (sync and async) of `daft-recordbatch/src/lib.rs`, broadcast any length-1 input Series to the upstream row count before invoking the UDF. Mirrors the post-result broadcast already in `async_udf.rs` and `intermediate_ops/udf.rs`.

## Tests

Six failing repros land in the first commit, all green after the fix:

1. Verbatim repro from #6805 (panic on async batch UDF + select)
2. Async batch UDF property test (UDF must see N rows, not run-once-broadcast)
3. Sync batch UDF (different eval branch)
4. Row-wise UDF (`@daft.func`)
5. Empty input batch (`row_count == 0`)
6. Ray integration: multi-partition input on the Ray runner exercises the actor UDF path

## Scope

- **Native runner**: panic + broadcast bugs both fixed.
- **Ray runner**: panic fixed via Part 1 (flows through `actor_udf.rs:156`'s call to `remap_used_cols`); the multi-partition Ray integration test confirms.
- **Legacy `@daft.udf` decorator**: NOT addressed — that decorator routes through `Expr::Function` / `LegacyPythonUDF` and is being removed in 0.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)