### PR TITLE
fix(io): emit canonical file:// URIs for Windows drive paths

### DIFF
--- a/src/daft-io/src/lib.rs
+++ b/src/daft-io/src/lib.rs
@@ -556,18 +556,25 @@ pub fn strip_file_uri_to_path(uri: &str) -> Option<&str> {
     Some(path)
 }
 
-/// Builds a canonical `file://` URI from a local path.
+/// Returns true if the path looks like a Windows drive-letter path (e.g. `C:/foo`).
+fn starts_with_windows_drive(path: &str) -> bool {
+    let bytes = path.as_bytes();
+    bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':'
+}
+
+/// Builds a `file://` URI from a local path, ensuring the canonical
+/// triple-slash form for Windows drive-letter paths.
 ///
-/// POSIX absolute paths (`/tmp/foo`) get two slashes (`file:///tmp/foo`).
-/// Windows drive-letter paths (`C:/Users/...`) get three (`file:///C:/Users/...`)
-/// so the URL parses correctly and round-trips through `strip_file_uri_to_path`.
+/// - POSIX absolute paths (`/tmp/foo`) → `file:///tmp/foo` (two slashes + leading `/`).
+/// - Windows drive-letter paths (`C:/Users/...`) → `file:///C:/Users/...` (three slashes).
+/// - Anything else (relative paths) → `file://{path}` (preserves prior behavior).
 ///
-/// Inverse of [`strip_file_uri_to_path`].
+/// Inverse of [`strip_file_uri_to_path`] for absolute inputs.
 pub fn local_path_to_file_uri(local_path: &str) -> String {
-    if local_path.starts_with('/') {
-        format!("file://{local_path}")
-    } else {
+    if starts_with_windows_drive(local_path) {
         format!("file:///{local_path}")
+    } else {
+        format!("file://{local_path}")
     }
 }
 

--- a/src/daft-io/src/lib.rs
+++ b/src/daft-io/src/lib.rs
@@ -556,6 +556,21 @@ pub fn strip_file_uri_to_path(uri: &str) -> Option<&str> {
     Some(path)
 }
 
+/// Builds a canonical `file://` URI from a local path.
+///
+/// POSIX absolute paths (`/tmp/foo`) get two slashes (`file:///tmp/foo`).
+/// Windows drive-letter paths (`C:/Users/...`) get three (`file:///C:/Users/...`)
+/// so the URL parses correctly and round-trips through `strip_file_uri_to_path`.
+///
+/// Inverse of [`strip_file_uri_to_path`].
+pub fn local_path_to_file_uri(local_path: &str) -> String {
+    if local_path.starts_with('/') {
+        format!("file://{local_path}")
+    } else {
+        format!("file:///{local_path}")
+    }
+}
+
 pub fn parse_url(input: &str) -> Result<(SourceType, Cow<'_, str>)> {
     let mut fixed_input = Cow::Borrowed(input);
     // handle tilde `~` expansion
@@ -565,7 +580,7 @@ pub fn parse_url(input: &str) -> Result<(SourceType, Cow<'_, str>)> {
                 let expanded = home_dir.join(&input[2..]);
                 let input = expanded.to_str()?;
 
-                Some((SourceType::File, Cow::Owned(format!("file://{input}"))))
+                Some((SourceType::File, Cow::Owned(local_path_to_file_uri(input))))
             })
             .ok_or_else(|| crate::Error::InvalidArgument {
                 msg: "Could not convert expanded path to string".to_string(),
@@ -575,7 +590,7 @@ pub fn parse_url(input: &str) -> Result<(SourceType, Cow<'_, str>)> {
     let url = match url::Url::parse(input) {
         Ok(url) => Ok(url),
         Err(ParseError::RelativeUrlWithoutBase) => {
-            fixed_input = Cow::Owned(format!("file://{input}"));
+            fixed_input = Cow::Owned(local_path_to_file_uri(input));
 
             url::Url::parse(fixed_input.as_ref())
         }
@@ -613,7 +628,7 @@ pub fn parse_url(input: &str) -> Result<(SourceType, Cow<'_, str>)> {
         "gvfs" => Ok((SourceType::Gravitino, fixed_input)),
         #[cfg(target_env = "msvc")]
         _ if scheme.len() == 1 && ("a" <= scheme.as_str() && (scheme.as_str() <= "z")) => {
-            Ok((SourceType::File, Cow::Owned(format!("file://{input}"))))
+            Ok((SourceType::File, Cow::Owned(local_path_to_file_uri(input))))
         }
         _ => Ok((SourceType::OpenDAL { scheme }, fixed_input)),
     }

--- a/src/daft-io/src/local.rs
+++ b/src/daft-io/src/local.rs
@@ -30,7 +30,7 @@ use crate::{
 /// as long as there is no "mix" of "\" and "/".
 const PATH_SEGMENT_DELIMITER: &str = "/";
 
-use crate::strip_file_uri_to_path;
+use crate::{local_path_to_file_uri, strip_file_uri_to_path};
 
 pub struct LocalSource {}
 
@@ -264,8 +264,7 @@ impl ObjectSource for LocalSource {
     }
 
     async fn delete(&self, uri: &str, io_stats: Option<IOStatsRef>) -> super::Result<()> {
-        const LOCAL_PROTOCOL: &str = "file://";
-        if let Some(path) = uri.strip_prefix(LOCAL_PROTOCOL) {
+        if let Some(path) = strip_file_uri_to_path(uri) {
             match tokio::fs::remove_file(path).await {
                 Err(err) => {
                     use std::io::ErrorKind;
@@ -302,7 +301,6 @@ impl ObjectSource for LocalSource {
             unimplemented!("Prefix-listing is not implemented for local.");
         }
 
-        const LOCAL_PROTOCOL: &str = "file://";
         let uri = if uri.is_empty() {
             std::borrow::Cow::Owned(
                 std::env::current_dir()
@@ -324,7 +322,7 @@ impl ObjectSource for LocalSource {
         if meta.file_type().is_file() {
             // Provided uri points to a file, so only return that file.
             return Ok(futures::stream::iter([Ok(FileMetadata {
-                filepath: format!("{LOCAL_PROTOCOL}{uri}"),
+                filepath: local_path_to_file_uri(&uri),
                 size: Some(meta.len()),
                 filetype: object_io::FileType::File,
             })])
@@ -359,9 +357,8 @@ impl ObjectSource for LocalSource {
                 })?;
                 Ok(FileMetadata {
                     filepath: format!(
-                        "{}{}{}",
-                        LOCAL_PROTOCOL,
-                        path,
+                        "{}{}",
+                        local_path_to_file_uri(&path),
                         if meta.is_dir() {
                             PATH_SEGMENT_DELIMITER
                         } else {


### PR DESCRIPTION
## Summary

Follow-up to #6791 / #6796. Both earlier PRs fixed Windows-path bugs in specific call sites (the test helper, `S3CheckpointStore::put_bytes`). This PR closes the loop on the matching emission side: `iter_dir` and a few other helpers in `daft-io` were producing **non-canonical** `file://` URIs on Windows drive-letter paths, which silently broke any caller that string-compared the result against a canonically-built prefix.

## Concrete failure

On Windows, an `S3CheckpointStore` is constructed against a canonical prefix (`file:///C:/Users/.../tmp_XYZ`). Writes succeed via `put_bytes`, which goes through `strip_file_uri_to_path` (handles both two- and three-slash forms).

Reads call `glob_paths` → `daft_io::glob` → `iter_dir`. `iter_dir` builds its emitted URI as:

```rust
filepath: format!("{LOCAL_PROTOCOL}{uri}")   // "file://" + "C:/Users/..."
```

The result, `file://C:/Users/...` (two slashes), does not match the canonical `file:///C:/Users/...` prefix the store was built with. In `S3CheckpointStore::parse_id_from_manifest_path`:

```rust
let after_prefix = path.strip_prefix(&self.prefix)?.strip_prefix('/')?;
```

`strip_prefix` returns `None` for every entry → empty Vec → every `get_checkpointed_keys` / `get_checkpointed_files` assertion on Windows fails with `left: []`.

Net effect: 11 of 14 tests in `daft-checkpoint::tests::s3_store` red on the Windows coverage job since #6791 + #6796 landed. POSIX is unaffected because POSIX absolute paths start with `/`, so the same `format!` already produces canonical `file:///tmp/...`.

## Fix

Add a `local_path_to_file_uri` helper alongside the existing `strip_file_uri_to_path` (symmetric inverse). POSIX paths get two slashes, Windows drive-letter paths get three.

Apply at every `daft-io` site that emits `file://` URIs:

- `iter_dir` file branch (the root cause)
- `iter_dir` dir-iteration branch (same bug for the directory variant)
- `parse_url` tilde-expansion fallback (`~/...`)
- `parse_url` `RelativeUrlWithoutBase` fallback
- `parse_url` Windows drive-letter scheme handler (`c:foo`)

Also switches `local::delete` from a hand-rolled `strip_prefix("file://")` to `strip_file_uri_to_path` — same Windows-drive-letter pitfall as the `put_bytes` issue fixed in #6796, would silently break `delete` on Windows-canonical URIs.

## Test plan

- [x] `cargo test -p daft-io` — 61/61 pass locally (macOS).
- [x] `cargo test -p daft-checkpoint --test s3_store` — 14/14 pass locally (macOS).
- [ ] Windows rust-tests on `main` should go from 3/14 to 14/14 after merge.

## Lesson

The audit caught one defensive case: `local::delete` had the same hand-rolled `strip_prefix("file://")` shape as the original `put_bytes` bug. Per #6796's lesson, every URL-parsing call site should use the canonical helpers — folded into this PR rather than left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)