### PR TITLE
feat(functions): add simhash and hamming_distance for near-duplicate detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2670,6 +2670,7 @@ name = "daft-functions"
 version = "0.3.0-dev0"
 dependencies = [
  "arrow-array",
+ "arrow-buffer 57.3.0",
  "common-error",
  "daft-core",
  "daft-dsl",
@@ -2681,6 +2682,7 @@ dependencies = [
  "snafu",
  "typetag",
  "uuid",
+ "xxhash-rust",
 ]
 
 [[package]]

--- a/daft/expressions/expressions.py
+++ b/daft/expressions/expressions.py
@@ -1339,6 +1339,31 @@ class Expression:
 
         return minhash(self, num_hashes=num_hashes, ngram_size=ngram_size, seed=seed, hash_function=hash_function)
 
+    def simhash(
+        self,
+        *,
+        ngram_size: int = 3,
+        hash_function: Literal["murmurhash3", "xxhash", "xxhash32", "xxhash64", "xxhash3_64", "sha1"] = "xxhash3_64",
+    ) -> Expression:
+        """Compute a SimHash fingerprint of this string expression.
+
+        Tip: See Also
+            [`daft.functions.simhash`](https://docs.daft.ai/en/stable/api/functions/simhash/)
+        """
+        from daft.functions import simhash
+
+        return simhash(self, ngram_size=ngram_size, hash_function=hash_function)
+
+    def hamming_distance(self, other: Expression) -> Expression:
+        """Compute the bitwise Hamming distance between two hash fingerprints.
+
+        Tip: See Also
+            [`daft.functions.hamming_distance`](https://docs.daft.ai/en/stable/api/functions/hamming_distance/)
+        """
+        from daft.functions import hamming_distance
+
+        return hamming_distance(self, other)
+
     def encode(self, charset: ENCODING_CHARSET) -> Expression:
         """Encode binary or string values using the specified character set.
 
@@ -2306,15 +2331,15 @@ class Expression:
 
         return length_bytes(self)
 
-    def hamming_distance(self, other: Expression) -> Expression:
-        """Compute the Hamming distance between two strings.
+    def hamming_distance_str(self, other: Expression) -> Expression:
+        """Compute the character-level Hamming distance between two strings.
 
         Tip: See Also
-            [`daft.functions.hamming_distance`](https://docs.daft.ai/en/stable/api/functions/hamming_distance/)
+            [`daft.functions.hamming_distance_str`](https://docs.daft.ai/en/stable/api/functions/hamming_distance_str/)
         """
-        from daft.functions import hamming_distance
+        from daft.functions import hamming_distance_str
 
-        return hamming_distance(self, other)
+        return hamming_distance_str(self, other)
 
     def value_counts(self) -> Expression:
         """Counts the occurrences of each distinct value in the list.

--- a/daft/functions/__init__.py
+++ b/daft/functions/__init__.py
@@ -85,6 +85,7 @@ from .datetime import (
 )
 from .distance import cosine_distance, dot_product, euclidean_distance
 from .similarity import (
+    hamming_distance,
     cosine_similarity,
     pearson_correlation,
     jaccard_similarity,
@@ -140,6 +141,7 @@ from .misc import (
     is_in,
     hash,
     minhash,
+    simhash,
     length,
     concat,
     coalesce,
@@ -251,7 +253,7 @@ from .str import (
     replace,
     regexp_replace,
     find,
-    hamming_distance,
+    hamming_distance_str,
 )
 from .struct import unnest, to_struct
 from .url import download, upload, parse_url
@@ -364,6 +366,7 @@ __all__ = [
     "great_circle_distance",
     "guess_mime_type",
     "hamming_distance",
+    "hamming_distance_str",
     "hash",
     "hour",
     "hypot",
@@ -477,6 +480,7 @@ __all__ = [
     "shift_left",
     "shift_right",
     "sign",
+    "simhash",
     "sin",
     "sinh",
     "skew",

--- a/daft/functions/misc.py
+++ b/daft/functions/misc.py
@@ -401,6 +401,29 @@ def minhash(
     )
 
 
+def simhash(
+    text: Expression,
+    *,
+    ngram_size: int = 3,
+    hash_function: Literal["murmurhash3", "xxhash", "xxhash32", "xxhash64", "xxhash3_64", "sha1"] = "xxhash3_64",
+) -> Expression:
+    """Compute a SimHash fingerprint of the input text.
+
+    SimHash produces a 64-bit locality-sensitive hash from character n-grams.
+    Similar texts produce fingerprints with small bitwise Hamming distance,
+    making it useful for near-duplicate detection.
+
+    Args:
+        text (String Expression): The expression to hash.
+        ngram_size (int, default=3): Character n-gram size. Defaults to 3.
+        hash_function (str, default="xxhash3_64"): Hash function for n-grams. One of "murmurhash3", "xxhash" (alias for "xxhash3_64"), "xxhash32", "xxhash64", "xxhash3_64", or "sha1". Defaults to "xxhash3_64".
+
+    Returns:
+        Expression (UInt64 Expression): SimHash fingerprint.
+    """
+    return Expression._call_builtin_scalar_fn("simhash", text, ngram_size=ngram_size, hash_function=hash_function)
+
+
 def length(expr: Expression) -> Expression:
     """Retrieves the length of the given expression.
 

--- a/daft/functions/similarity.py
+++ b/daft/functions/similarity.py
@@ -5,6 +5,23 @@ from __future__ import annotations
 from daft.expressions import Expression
 
 
+def hamming_distance(left: Expression, right: Expression) -> Expression:
+    """Compute the Hamming distance (number of differing bits) between two hash fingerprints.
+
+    Counts the number of differing bits (popcount of XOR).
+    Supports integer inputs (e.g., UInt64 from simhash) and FixedSizeBinary
+    inputs (e.g., from image_hash).
+
+    Args:
+        left (Integer or FixedSizeBinary Expression): The left fingerprint.
+        right (Integer or FixedSizeBinary Expression): The right fingerprint (must match left's type).
+
+    Returns:
+        Expression (UInt32 Expression): Number of differing bits.
+    """
+    return Expression._call_builtin_scalar_fn("hamming_distance", left, right)
+
+
 def cosine_similarity(left: Expression, right: Expression) -> Expression:
     """Compute the cosine similarity between two embeddings.
 

--- a/daft/functions/str.py
+++ b/daft/functions/str.py
@@ -1442,8 +1442,8 @@ def find(expr: Expression, substr: str | Expression) -> Expression:
     return Expression._call_builtin_scalar_fn("find", expr, substr)
 
 
-def hamming_distance(left: Expression, right: Expression) -> Expression:
-    """Compute the Hamming distance between two strings.
+def hamming_distance_str(left: Expression, right: Expression) -> Expression:
+    """Compute the character-level Hamming distance between two strings.
 
     The Hamming distance is the number of positions at which the corresponding
     characters are different.
@@ -1458,9 +1458,9 @@ def hamming_distance(left: Expression, right: Expression) -> Expression:
 
     Examples:
         >>> import daft
-        >>> from daft.functions import hamming_distance
+        >>> from daft.functions import hamming_distance_str
         >>> df = daft.from_pydict({"x": ["ronald", "ronald", "ronald"], "y": ["ronald", "renuld", "ronaldo"]})
-        >>> df = df.with_column("distance", hamming_distance(df["x"], df["y"]))
+        >>> df = df.with_column("distance", hamming_distance_str(df["x"], df["y"]))
         >>> df.collect()
         ╭────────┬─────────┬──────────╮
         │ x      ┆ y       ┆ distance │
@@ -1476,4 +1476,4 @@ def hamming_distance(left: Expression, right: Expression) -> Expression:
         <BLANKLINE>
         (Showing first 3 of 3 rows)
     """
-    return Expression._call_builtin_scalar_fn("hamming_distance", left, right)
+    return Expression._call_builtin_scalar_fn("hamming_distance_str", left, right)

--- a/docs/modalities/images.md
+++ b/docs/modalities/images.md
@@ -344,19 +344,13 @@ The `hash` column has dtype `FixedSizeBinary(8)` — 64 bits per image for the d
 
 ### Finding near-duplicates
 
-Compare hashes within a dataset by joining the DataFrame with itself and computing Hamming distance in a UDF:
+Compare hashes within a dataset by joining the DataFrame with itself and computing the bitwise Hamming distance using the built-in [`hamming_distance`][daft.functions.hamming_distance]:
 
 === "🐍 Python"
 
     ```python
     import daft
-    from daft.functions import image_hash
-
-    @daft.func(return_dtype=daft.DataType.int32())
-    def hamming(a, b):
-        if a is None or b is None:
-            return None
-        return sum(bin(x ^ y).count("1") for x, y in zip(a, b))
+    from daft.functions import image_hash, hamming_distance
 
     df = daft.from_pydict({
         "id": [1, 2, 3],
@@ -371,7 +365,7 @@ Compare hashes within a dataset by joining the DataFrame with itself and computi
     pairs = (
         left.join(right, how="cross")
             .where(daft.col("id_a") < daft.col("id_b"))
-            .with_column("dist", hamming(daft.col("hash_a"), daft.col("hash_b")))
+            .with_column("dist", hamming_distance(daft.col("hash_a"), daft.col("hash_b")))
             .where(daft.col("dist") <= 10)  # threshold: ≤10 bits differ
     )
     pairs.show()

--- a/src/daft-functions-utf8/src/hamming.rs
+++ b/src/daft-functions-utf8/src/hamming.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 const NULL_SENTINEL: i64 = 0;
 
-fn hamming_distance_str(left: &str, right: &str) -> Option<i64> {
+fn compute_hamming_distance(left: &str, right: &str) -> Option<i64> {
     let mut left_chars = left.chars();
     let mut right_chars = right.chars();
 
@@ -51,7 +51,7 @@ impl ScalarUDF for HammingDistance {
 
                 for i in 0..len {
                     match (left.get(i), right.get(i)) {
-                        (Some(l), Some(r)) => match hamming_distance_str(l, r) {
+                        (Some(l), Some(r)) => match compute_hamming_distance(l, r) {
                             Some(dist) => {
                                 values.push(dist);
                                 validity.append_non_null();

--- a/src/daft-functions-utf8/src/hamming.rs
+++ b/src/daft-functions-utf8/src/hamming.rs
@@ -32,7 +32,7 @@ pub struct HammingDistance;
 #[typetag::serde]
 impl ScalarUDF for HammingDistance {
     fn name(&self) -> &'static str {
-        "hamming_distance"
+        "hamming_distance_str"
     }
 
     fn call(
@@ -111,6 +111,6 @@ impl ScalarUDF for HammingDistance {
 }
 
 #[must_use]
-pub fn hamming_distance(left: ExprRef, right: ExprRef) -> ExprRef {
+pub fn hamming_distance_str(left: ExprRef, right: ExprRef) -> ExprRef {
     ScalarFn::builtin(HammingDistance, vec![left, right]).into()
 }

--- a/src/daft-functions/Cargo.toml
+++ b/src/daft-functions/Cargo.toml
@@ -3,7 +3,9 @@ common-error = {path = "../common/error", default-features = false}
 daft-core = {path = "../daft-core", default-features = false}
 daft-dsl = {path = "../daft-dsl", default-features = false}
 daft-hash = {workspace = true}
+xxhash-rust = {workspace = true}
 arrow-array = {workspace = true}
+arrow-buffer = {workspace = true}
 num-traits = {workspace = true}
 pyo3 = {workspace = true, optional = true}
 typetag = {workspace = true}

--- a/src/daft-functions/src/lib.rs
+++ b/src/daft-functions/src/lib.rs
@@ -14,6 +14,7 @@ pub mod numeric;
 #[cfg(feature = "python")]
 pub mod python;
 pub mod random;
+pub mod simhash;
 pub mod similarity;
 pub mod slice;
 pub mod to_struct;
@@ -27,6 +28,7 @@ use length::Length;
 use minhash::MinHashFunction;
 #[cfg(feature = "python")]
 pub use python::register as register_modules;
+use simhash::SimHashFunction;
 use snafu::Snafu;
 use to_struct::ToStructFunction;
 use uuid::Uuid;
@@ -67,6 +69,7 @@ impl FunctionModule for MiscFunctions {
         parent.add_fn(ConcatWs);
         parent.add_fn(HashFunction);
         parent.add_fn(MinHashFunction);
+        parent.add_fn(SimHashFunction);
         parent.add_fn(Length);
         parent.add_fn(ToStructFunction);
         parent.add_fn(Slice);

--- a/src/daft-functions/src/simhash.rs
+++ b/src/daft-functions/src/simhash.rs
@@ -77,7 +77,7 @@ fn hash_ngram(ngram: &str, hash_function: HashFunctionKind) -> u64 {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct SimHashFunction;
 
 #[derive(FunctionArgs)]

--- a/src/daft-functions/src/simhash.rs
+++ b/src/daft-functions/src/simhash.rs
@@ -1,0 +1,181 @@
+use std::{
+    hash::{BuildHasher, Hasher},
+    sync::Arc,
+};
+
+use arrow_buffer::NullBufferBuilder;
+use common_error::{DaftError, DaftResult};
+use daft_core::prelude::*;
+use daft_dsl::functions::{prelude::*, scalar::ScalarFn};
+use daft_hash::{HashFunctionKind, MurBuildHasher, XxHash32BuildHasher};
+use serde::{Deserialize, Serialize};
+
+const NUM_BITS: usize = 64;
+
+fn compute_simhash(s: &str, ngram_size: usize, hash_function: HashFunctionKind) -> u64 {
+    let mut weights = [0i32; NUM_BITS];
+
+    let chars: Vec<char> = s.chars().collect();
+    if chars.len() < ngram_size {
+        return 0;
+    }
+
+    for window in chars.windows(ngram_size) {
+        let ngram: String = window.iter().collect();
+        let hash = hash_ngram(&ngram, hash_function);
+
+        for (i, w) in weights.iter_mut().enumerate() {
+            if hash & (1u64 << i) != 0 {
+                *w += 1;
+            } else {
+                *w -= 1;
+            }
+        }
+    }
+
+    let mut fingerprint: u64 = 0;
+    for (i, &w) in weights.iter().enumerate() {
+        if w > 0 {
+            fingerprint |= 1u64 << i;
+        }
+    }
+    fingerprint
+}
+
+fn hash_ngram(ngram: &str, hash_function: HashFunctionKind) -> u64 {
+    match hash_function {
+        HashFunctionKind::MurmurHash3 => {
+            let bh = MurBuildHasher::new(0);
+            let mut h = bh.build_hasher();
+            h.write(ngram.as_bytes());
+            h.finish()
+        }
+        HashFunctionKind::XxHash32 => {
+            let bh = XxHash32BuildHasher::new(0);
+            let mut h = bh.build_hasher();
+            h.write(ngram.as_bytes());
+            h.finish()
+        }
+        HashFunctionKind::XxHash64 => {
+            let bh = xxhash_rust::xxh64::Xxh64Builder::new(0);
+            let mut h = bh.build_hasher();
+            h.write(ngram.as_bytes());
+            h.finish()
+        }
+        HashFunctionKind::XxHash3_64 => {
+            let bh = xxhash_rust::xxh3::Xxh3Builder::new().with_seed(0);
+            let mut h = bh.build_hasher();
+            h.write(ngram.as_bytes());
+            h.finish()
+        }
+        HashFunctionKind::Sha1 => {
+            let bh = std::hash::BuildHasherDefault::<daft_hash::Sha1Hasher>::default();
+            let mut h = bh.build_hasher();
+            h.write(ngram.as_bytes());
+            h.finish()
+        }
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct SimHashFunction;
+
+#[derive(FunctionArgs)]
+struct Args<T> {
+    input: T,
+    #[arg(optional)]
+    ngram_size: Option<usize>,
+    #[arg(optional)]
+    hash_function: Option<String>,
+}
+
+#[typetag::serde]
+impl ScalarUDF for SimHashFunction {
+    fn name(&self) -> &'static str {
+        "simhash"
+    }
+
+    fn call(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+        _ctx: &daft_dsl::functions::scalar::EvalContext,
+    ) -> DaftResult<Series> {
+        let Args {
+            input,
+            ngram_size,
+            hash_function,
+        } = inputs.try_into()?;
+
+        let ngram_size = ngram_size.unwrap_or(3);
+        if ngram_size == 0 {
+            return Err(DaftError::ValueError(
+                "ngram_size must be a positive integer".to_string(),
+            ));
+        }
+
+        let hash_function = hash_function
+            .map(|s| s.parse::<HashFunctionKind>())
+            .transpose()?
+            .unwrap_or(HashFunctionKind::XxHash3_64);
+
+        input.with_utf8_array(|utf8_arr| {
+            let len = utf8_arr.len();
+            let mut values = Vec::with_capacity(len);
+            let mut validity = NullBufferBuilder::new(len);
+
+            for i in 0..len {
+                match utf8_arr.get(i) {
+                    Some(s) => {
+                        values.push(compute_simhash(s, ngram_size, hash_function));
+                        validity.append_non_null();
+                    }
+                    None => {
+                        values.push(0);
+                        validity.append_null();
+                    }
+                }
+            }
+
+            let field = Arc::new(Field::new(utf8_arr.name(), DataType::UInt64));
+            let result =
+                UInt64Array::from_field_and_values(field, values).with_nulls(validity.finish())?;
+            Ok(result.into_series())
+        })
+    }
+
+    fn get_return_field(
+        &self,
+        inputs: FunctionArgs<ExprRef>,
+        schema: &Schema,
+    ) -> DaftResult<Field> {
+        let Args { input, .. } = inputs.try_into()?;
+        let input = input.to_field(schema)?;
+        ensure!(
+            input.dtype.is_string(),
+            TypeError: "Expected input to simhash to be a string type, but received {}",
+            input.dtype
+        );
+        Ok(Field::new(input.name, DataType::UInt64))
+    }
+
+    fn docstring(&self) -> &'static str {
+        "Compute a SimHash fingerprint (UInt64) from text using character n-grams. \
+        Similar texts produce fingerprints with small bitwise Hamming distance."
+    }
+}
+
+#[must_use]
+pub fn simhash(
+    input: ExprRef,
+    ngram_size: Option<ExprRef>,
+    hash_function: Option<ExprRef>,
+) -> ExprRef {
+    let mut inputs = vec![input];
+    if let Some(n) = ngram_size {
+        inputs.push(n);
+    }
+    if let Some(h) = hash_function {
+        inputs.push(h);
+    }
+    ScalarFn::builtin(SimHashFunction, inputs).into()
+}

--- a/src/daft-functions/src/similarity/bitwise_hamming.rs
+++ b/src/daft-functions/src/similarity/bitwise_hamming.rs
@@ -1,0 +1,186 @@
+use std::sync::Arc;
+
+use arrow_buffer::NullBufferBuilder;
+use common_error::{DaftError, DaftResult};
+use daft_core::prelude::*;
+use daft_dsl::functions::{prelude::*, scalar::ScalarFn};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct BitwiseHammingDistanceFunction;
+
+#[typetag::serde]
+impl ScalarUDF for BitwiseHammingDistanceFunction {
+    fn name(&self) -> &'static str {
+        "hamming_distance"
+    }
+
+    fn call(
+        &self,
+        inputs: FunctionArgs<Series>,
+        _ctx: &daft_dsl::functions::scalar::EvalContext,
+    ) -> DaftResult<Series> {
+        let left = inputs.required(0)?;
+        let right = inputs.required(1)?;
+
+        match (left.data_type(), right.data_type()) {
+            (DataType::UInt64, DataType::UInt64) => compute_u64(&left, &right),
+            (DataType::FixedSizeBinary(n1), DataType::FixedSizeBinary(n2)) if n1 == n2 => {
+                compute_fixed_size_binary(&left, &right)
+            }
+            (l, r) if l.is_integer() && r.is_integer() => {
+                let left = left.cast(&DataType::UInt64)?;
+                let right = right.cast(&DataType::UInt64)?;
+                compute_u64(&left, &right)
+            }
+            (l, r) => Err(DaftError::TypeError(format!(
+                "hamming_distance requires both inputs to be integer types or \
+                 FixedSizeBinary of matching size, got {} and {}",
+                l, r
+            ))),
+        }
+    }
+
+    fn get_return_field(
+        &self,
+        inputs: FunctionArgs<ExprRef>,
+        schema: &Schema,
+    ) -> DaftResult<Field> {
+        ensure!(
+            inputs.len() == 2,
+            SchemaMismatch: "Expected 2 inputs, but received {}",
+            inputs.len()
+        );
+
+        let left = inputs.required(0)?.to_field(schema)?;
+        let right = inputs.required(1)?.to_field(schema)?;
+
+        match (&left.dtype, &right.dtype) {
+            (DataType::UInt64, DataType::UInt64) => {}
+            (DataType::FixedSizeBinary(n1), DataType::FixedSizeBinary(n2)) => {
+                ensure!(
+                    n1 == n2,
+                    TypeError: "FixedSizeBinary sizes must match, got {} and {}",
+                    n1, n2
+                );
+            }
+            (l, r) if l.is_integer() && r.is_integer() => {}
+            (l, r) => {
+                return Err(DaftError::TypeError(format!(
+                    "hamming_distance requires both inputs to be integer types or \
+                     FixedSizeBinary of matching size, got {} and {}",
+                    l, r
+                )));
+            }
+        }
+
+        Ok(Field::new(left.name, DataType::UInt32))
+    }
+
+    fn docstring(&self) -> &'static str {
+        "Compute the bitwise Hamming distance (popcount of XOR) between two hash \
+        fingerprints. Supports integer and FixedSizeBinary inputs."
+    }
+}
+
+fn compute_u64(left: &Series, right: &Series) -> DaftResult<Series> {
+    let left = left.cast(&DataType::UInt64)?;
+    let right = right.cast(&DataType::UInt64)?;
+    let left_arr = left.u64()?;
+    let right_arr = right.u64()?;
+
+    let (longer, shorter, len) = if left_arr.len() >= right_arr.len() {
+        (left_arr, right_arr, left_arr.len())
+    } else {
+        (right_arr, left_arr, right_arr.len())
+    };
+
+    let broadcast = shorter.len() == 1;
+    if !broadcast && shorter.len() != len {
+        return Err(DaftError::ValueError(format!(
+            "Inputs must have the same length or one must be a scalar, got {} and {}",
+            left_arr.len(),
+            right_arr.len()
+        )));
+    }
+
+    let mut values = Vec::with_capacity(len);
+    let mut validity = NullBufferBuilder::new(len);
+
+    for (i, l_opt) in longer.iter().enumerate() {
+        let r_opt = if broadcast {
+            shorter.get(0)
+        } else {
+            shorter.get(i)
+        };
+        match (l_opt, r_opt) {
+            (Some(l), Some(r)) => {
+                values.push((l ^ r).count_ones());
+                validity.append_non_null();
+            }
+            _ => {
+                values.push(0);
+                validity.append_null();
+            }
+        }
+    }
+
+    let field = Arc::new(Field::new(longer.name(), DataType::UInt32));
+    let result = UInt32Array::from_field_and_values(field, values).with_nulls(validity.finish())?;
+    Ok(result.into_series())
+}
+
+fn compute_fixed_size_binary(left: &Series, right: &Series) -> DaftResult<Series> {
+    let left_arr = left.fixed_size_binary()?;
+    let right_arr = right.fixed_size_binary()?;
+
+    let (longer, shorter, len) = if left_arr.len() >= right_arr.len() {
+        (left_arr, right_arr, left_arr.len())
+    } else {
+        (right_arr, left_arr, right_arr.len())
+    };
+
+    let broadcast = shorter.len() == 1;
+    if !broadcast && shorter.len() != len {
+        return Err(DaftError::ValueError(format!(
+            "Inputs must have the same length or one must be a scalar, got {} and {}",
+            left_arr.len(),
+            right_arr.len()
+        )));
+    }
+
+    let mut values = Vec::with_capacity(len);
+    let mut validity = NullBufferBuilder::new(len);
+
+    for (i, l_opt) in longer.iter().enumerate() {
+        let r_opt = if broadcast {
+            shorter.get(0)
+        } else {
+            shorter.get(i)
+        };
+        match (l_opt, r_opt) {
+            (Some(l_bytes), Some(r_bytes)) => {
+                let dist: u32 = l_bytes
+                    .iter()
+                    .zip(r_bytes.iter())
+                    .map(|(a, b)| (a ^ b).count_ones())
+                    .sum();
+                values.push(dist);
+                validity.append_non_null();
+            }
+            _ => {
+                values.push(0);
+                validity.append_null();
+            }
+        }
+    }
+
+    let field = Arc::new(Field::new(longer.name(), DataType::UInt32));
+    let result = UInt32Array::from_field_and_values(field, values).with_nulls(validity.finish())?;
+    Ok(result.into_series())
+}
+
+#[must_use]
+pub fn hamming_distance(left: ExprRef, right: ExprRef) -> ExprRef {
+    ScalarFn::builtin(BitwiseHammingDistanceFunction, vec![left, right]).into()
+}

--- a/src/daft-functions/src/similarity/bitwise_hamming.rs
+++ b/src/daft-functions/src/similarity/bitwise_hamming.rs
@@ -24,9 +24,9 @@ impl ScalarUDF for BitwiseHammingDistanceFunction {
         let right = inputs.required(1)?;
 
         match (left.data_type(), right.data_type()) {
-            (DataType::UInt64, DataType::UInt64) => compute_u64(&left, &right),
+            (DataType::UInt64, DataType::UInt64) => compute_u64(left, right),
             (DataType::FixedSizeBinary(n1), DataType::FixedSizeBinary(n2)) if n1 == n2 => {
-                compute_fixed_size_binary(&left, &right)
+                compute_fixed_size_binary(left, right)
             }
             (l, r) if l.is_integer() && r.is_integer() => {
                 let left = left.cast(&DataType::UInt64)?;

--- a/src/daft-functions/src/similarity/mod.rs
+++ b/src/daft-functions/src/similarity/mod.rs
@@ -1,9 +1,11 @@
 use daft_dsl::functions::FunctionModule;
 
+pub mod bitwise_hamming;
 pub mod cosine;
 pub mod jaccard;
 pub mod pearson;
 
+pub use bitwise_hamming::hamming_distance;
 pub use cosine::cosine_similarity;
 pub use jaccard::jaccard_similarity;
 pub use pearson::pearson_correlation;
@@ -12,6 +14,7 @@ pub struct SimilarityFunctions;
 
 impl FunctionModule for SimilarityFunctions {
     fn register(parent: &mut daft_dsl::functions::FunctionRegistry) {
+        parent.add_fn(bitwise_hamming::BitwiseHammingDistanceFunction);
         parent.add_fn(cosine::CosineSimilarityFunction);
         parent.add_fn(pearson::PearsonCorrelationFunction);
         parent.add_fn(jaccard::JaccardSimilarityFunction);

--- a/tests/expressions/test_bitwise_hamming.py
+++ b/tests/expressions/test_bitwise_hamming.py
@@ -1,55 +1,63 @@
 from __future__ import annotations
 
-import pytest
-
 import daft
 from daft.datatype import DataType
 from daft.expressions import col, lit
-from daft.functions import hamming_distance, simhash
+from daft.functions import hamming_distance
 from daft.series import Series
 
 
 def test_bitwise_hamming_identical_uint64():
-    df = daft.from_pydict({
-        "a": Series.from_pylist([42, 100, 0]).cast(DataType.uint64()),
-        "b": Series.from_pylist([42, 100, 0]).cast(DataType.uint64()),
-    })
+    df = daft.from_pydict(
+        {
+            "a": Series.from_pylist([42, 100, 0]).cast(DataType.uint64()),
+            "b": Series.from_pylist([42, 100, 0]).cast(DataType.uint64()),
+        }
+    )
     result = df.select(hamming_distance(col("a"), col("b"))).to_pydict()["a"]
     assert result == [0, 0, 0]
 
 
 def test_bitwise_hamming_known_values_uint64():
-    df = daft.from_pydict({
-        "a": Series.from_pylist([0b1010, 0b1111, 1]).cast(DataType.uint64()),
-        "b": Series.from_pylist([0b0101, 0b0000, 0]).cast(DataType.uint64()),
-    })
+    df = daft.from_pydict(
+        {
+            "a": Series.from_pylist([0b1010, 0b1111, 1]).cast(DataType.uint64()),
+            "b": Series.from_pylist([0b0101, 0b0000, 0]).cast(DataType.uint64()),
+        }
+    )
     result = df.select(hamming_distance(col("a"), col("b"))).to_pydict()["a"]
     assert result == [4, 4, 1]
 
 
 def test_bitwise_hamming_max_distance_uint64():
-    df = daft.from_pydict({
-        "a": Series.from_pylist([0]).cast(DataType.uint64()),
-        "b": Series.from_pylist([0xFFFFFFFFFFFFFFFF]).cast(DataType.uint64()),
-    })
+    df = daft.from_pydict(
+        {
+            "a": Series.from_pylist([0]).cast(DataType.uint64()),
+            "b": Series.from_pylist([0xFFFFFFFFFFFFFFFF]).cast(DataType.uint64()),
+        }
+    )
     result = df.select(hamming_distance(col("a"), col("b"))).to_pydict()["a"]
     assert result == [64]
 
 
 def test_bitwise_hamming_returns_uint32():
-    df = daft.from_pydict({
-        "a": Series.from_pylist([1]).cast(DataType.uint64()),
-        "b": Series.from_pylist([2]).cast(DataType.uint64()),
-    })
+    df = daft.from_pydict(
+        {
+            "a": Series.from_pylist([1]).cast(DataType.uint64()),
+            "b": Series.from_pylist([2]).cast(DataType.uint64()),
+        }
+    )
     result = df.select(hamming_distance(col("a"), col("b"))).collect()
     assert result.schema()["a"].dtype == DataType.uint32()
 
 
 def test_bitwise_hamming_null_propagation():
-    df = daft.from_pydict({
-        "a": Series.from_pylist([1, None, 3]).cast(DataType.uint64()),
-        "b": Series.from_pylist([1, 2, None]).cast(DataType.uint64()),
-    })
+    df = daft.from_pydict(
+        {
+            "a": Series.from_pylist([1, None, 3]).cast(DataType.uint64()),
+            "b": Series.from_pylist([1, 2, None]).cast(DataType.uint64()),
+        }
+    )
     result = df.select(hamming_distance(col("a"), col("b"))).to_pydict()["a"]
     assert result[0] == 0
     assert result[1] is None
@@ -57,10 +65,12 @@ def test_bitwise_hamming_null_propagation():
 
 
 def test_bitwise_hamming_integer_types():
-    df = daft.from_pydict({
-        "a": [10, 20, 30],
-        "b": [10, 21, 31],
-    })
+    df = daft.from_pydict(
+        {
+            "a": [10, 20, 30],
+            "b": [10, 21, 31],
+        }
+    )
     result = df.select(hamming_distance(col("a"), col("b"))).to_pydict()["a"]
     assert result[0] == 0
     assert result[1] == bin(20 ^ 21).count("1")
@@ -68,58 +78,68 @@ def test_bitwise_hamming_integer_types():
 
 
 def test_bitwise_hamming_fixed_size_binary_identical():
-    df = daft.from_pydict({
-        "a": Series.from_pylist([b"\x00\x00\x00\x00"]).cast(DataType.fixed_size_binary(4)),
-        "b": Series.from_pylist([b"\x00\x00\x00\x00"]).cast(DataType.fixed_size_binary(4)),
-    })
+    df = daft.from_pydict(
+        {
+            "a": Series.from_pylist([b"\x00\x00\x00\x00"]).cast(DataType.fixed_size_binary(4)),
+            "b": Series.from_pylist([b"\x00\x00\x00\x00"]).cast(DataType.fixed_size_binary(4)),
+        }
+    )
     result = df.select(hamming_distance(col("a"), col("b"))).to_pydict()["a"]
     assert result == [0]
 
 
 def test_bitwise_hamming_fixed_size_binary_known():
-    df = daft.from_pydict({
-        "a": Series.from_pylist([b"\xff\x00"]).cast(DataType.fixed_size_binary(2)),
-        "b": Series.from_pylist([b"\x00\xff"]).cast(DataType.fixed_size_binary(2)),
-    })
+    df = daft.from_pydict(
+        {
+            "a": Series.from_pylist([b"\xff\x00"]).cast(DataType.fixed_size_binary(2)),
+            "b": Series.from_pylist([b"\x00\xff"]).cast(DataType.fixed_size_binary(2)),
+        }
+    )
     result = df.select(hamming_distance(col("a"), col("b"))).to_pydict()["a"]
     assert result == [16]
 
 
 def test_bitwise_hamming_fixed_size_binary_null():
-    df = daft.from_pydict({
-        "a": Series.from_pylist([b"\xff", None]).cast(DataType.fixed_size_binary(1)),
-        "b": Series.from_pylist([b"\x00", b"\x00"]).cast(DataType.fixed_size_binary(1)),
-    })
+    df = daft.from_pydict(
+        {
+            "a": Series.from_pylist([b"\xff", None]).cast(DataType.fixed_size_binary(1)),
+            "b": Series.from_pylist([b"\x00", b"\x00"]).cast(DataType.fixed_size_binary(1)),
+        }
+    )
     result = df.select(hamming_distance(col("a"), col("b"))).to_pydict()["a"]
     assert result[0] == 8
     assert result[1] is None
 
 
 def test_bitwise_hamming_end_to_end_with_simhash():
-    df = daft.from_pydict({
-        "text": [
-            "the quick brown fox jumps over the lazy dog",
-            "the quick brown fox jumps over the lazy cat",
-            "1234567890 abcdefghijklmnopqrstuvwxyz",
-        ]
-    })
+    df = daft.from_pydict(
+        {
+            "text": [
+                "the quick brown fox jumps over the lazy dog",
+                "the quick brown fox jumps over the lazy cat",
+                "1234567890 abcdefghijklmnopqrstuvwxyz",
+            ]
+        }
+    )
     hashed = df.select(col("text").simhash().alias("hash")).collect()
     hashes = hashed.to_pydict()["hash"]
 
-    pair_df = daft.from_pydict({
-        "a": Series.from_pylist([hashes[0], hashes[0]]).cast(DataType.uint64()),
-        "b": Series.from_pylist([hashes[1], hashes[2]]).cast(DataType.uint64()),
-    })
+    pair_df = daft.from_pydict(
+        {
+            "a": Series.from_pylist([hashes[0], hashes[0]]).cast(DataType.uint64()),
+            "b": Series.from_pylist([hashes[1], hashes[2]]).cast(DataType.uint64()),
+        }
+    )
     distances = pair_df.select(hamming_distance(col("a"), col("b"))).to_pydict()["a"]
 
     assert distances[0] < distances[1]
 
 
 def test_bitwise_hamming_broadcast_scalar():
-    df = daft.from_pydict({
-        "a": Series.from_pylist([0b1010, 0b1100, 0b1111]).cast(DataType.uint64()),
-    })
-    result = df.select(
-        hamming_distance(col("a"), lit(0).cast(DataType.uint64()))
-    ).to_pydict()["a"]
+    df = daft.from_pydict(
+        {
+            "a": Series.from_pylist([0b1010, 0b1100, 0b1111]).cast(DataType.uint64()),
+        }
+    )
+    result = df.select(hamming_distance(col("a"), lit(0).cast(DataType.uint64()))).to_pydict()["a"]
     assert result == [2, 2, 4]

--- a/tests/expressions/test_bitwise_hamming.py
+++ b/tests/expressions/test_bitwise_hamming.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import pytest
+
+import daft
+from daft.datatype import DataType
+from daft.expressions import col, lit
+from daft.functions import hamming_distance, simhash
+from daft.series import Series
+
+
+def test_bitwise_hamming_identical_uint64():
+    df = daft.from_pydict({
+        "a": Series.from_pylist([42, 100, 0]).cast(DataType.uint64()),
+        "b": Series.from_pylist([42, 100, 0]).cast(DataType.uint64()),
+    })
+    result = df.select(hamming_distance(col("a"), col("b"))).to_pydict()["a"]
+    assert result == [0, 0, 0]
+
+
+def test_bitwise_hamming_known_values_uint64():
+    df = daft.from_pydict({
+        "a": Series.from_pylist([0b1010, 0b1111, 1]).cast(DataType.uint64()),
+        "b": Series.from_pylist([0b0101, 0b0000, 0]).cast(DataType.uint64()),
+    })
+    result = df.select(hamming_distance(col("a"), col("b"))).to_pydict()["a"]
+    assert result == [4, 4, 1]
+
+
+def test_bitwise_hamming_max_distance_uint64():
+    df = daft.from_pydict({
+        "a": Series.from_pylist([0]).cast(DataType.uint64()),
+        "b": Series.from_pylist([0xFFFFFFFFFFFFFFFF]).cast(DataType.uint64()),
+    })
+    result = df.select(hamming_distance(col("a"), col("b"))).to_pydict()["a"]
+    assert result == [64]
+
+
+def test_bitwise_hamming_returns_uint32():
+    df = daft.from_pydict({
+        "a": Series.from_pylist([1]).cast(DataType.uint64()),
+        "b": Series.from_pylist([2]).cast(DataType.uint64()),
+    })
+    result = df.select(hamming_distance(col("a"), col("b"))).collect()
+    assert result.schema()["a"].dtype == DataType.uint32()
+
+
+def test_bitwise_hamming_null_propagation():
+    df = daft.from_pydict({
+        "a": Series.from_pylist([1, None, 3]).cast(DataType.uint64()),
+        "b": Series.from_pylist([1, 2, None]).cast(DataType.uint64()),
+    })
+    result = df.select(hamming_distance(col("a"), col("b"))).to_pydict()["a"]
+    assert result[0] == 0
+    assert result[1] is None
+    assert result[2] is None
+
+
+def test_bitwise_hamming_integer_types():
+    df = daft.from_pydict({
+        "a": [10, 20, 30],
+        "b": [10, 21, 31],
+    })
+    result = df.select(hamming_distance(col("a"), col("b"))).to_pydict()["a"]
+    assert result[0] == 0
+    assert result[1] == bin(20 ^ 21).count("1")
+    assert result[2] == bin(30 ^ 31).count("1")
+
+
+def test_bitwise_hamming_fixed_size_binary_identical():
+    df = daft.from_pydict({
+        "a": Series.from_pylist([b"\x00\x00\x00\x00"]).cast(DataType.fixed_size_binary(4)),
+        "b": Series.from_pylist([b"\x00\x00\x00\x00"]).cast(DataType.fixed_size_binary(4)),
+    })
+    result = df.select(hamming_distance(col("a"), col("b"))).to_pydict()["a"]
+    assert result == [0]
+
+
+def test_bitwise_hamming_fixed_size_binary_known():
+    df = daft.from_pydict({
+        "a": Series.from_pylist([b"\xff\x00"]).cast(DataType.fixed_size_binary(2)),
+        "b": Series.from_pylist([b"\x00\xff"]).cast(DataType.fixed_size_binary(2)),
+    })
+    result = df.select(hamming_distance(col("a"), col("b"))).to_pydict()["a"]
+    assert result == [16]
+
+
+def test_bitwise_hamming_fixed_size_binary_null():
+    df = daft.from_pydict({
+        "a": Series.from_pylist([b"\xff", None]).cast(DataType.fixed_size_binary(1)),
+        "b": Series.from_pylist([b"\x00", b"\x00"]).cast(DataType.fixed_size_binary(1)),
+    })
+    result = df.select(hamming_distance(col("a"), col("b"))).to_pydict()["a"]
+    assert result[0] == 8
+    assert result[1] is None
+
+
+def test_bitwise_hamming_end_to_end_with_simhash():
+    df = daft.from_pydict({
+        "text": [
+            "the quick brown fox jumps over the lazy dog",
+            "the quick brown fox jumps over the lazy cat",
+            "1234567890 abcdefghijklmnopqrstuvwxyz",
+        ]
+    })
+    hashed = df.select(col("text").simhash().alias("hash")).collect()
+    hashes = hashed.to_pydict()["hash"]
+
+    pair_df = daft.from_pydict({
+        "a": Series.from_pylist([hashes[0], hashes[0]]).cast(DataType.uint64()),
+        "b": Series.from_pylist([hashes[1], hashes[2]]).cast(DataType.uint64()),
+    })
+    distances = pair_df.select(hamming_distance(col("a"), col("b"))).to_pydict()["a"]
+
+    assert distances[0] < distances[1]
+
+
+def test_bitwise_hamming_broadcast_scalar():
+    df = daft.from_pydict({
+        "a": Series.from_pylist([0b1010, 0b1100, 0b1111]).cast(DataType.uint64()),
+    })
+    result = df.select(
+        hamming_distance(col("a"), lit(0).cast(DataType.uint64()))
+    ).to_pydict()["a"]
+    assert result == [2, 2, 4]

--- a/tests/expressions/test_simhash.py
+++ b/tests/expressions/test_simhash.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import pytest
+
+import daft
+from daft.datatype import DataType
+from daft.expressions import col
+from daft.functions import simhash
+
+
+def test_simhash_identical_strings():
+    df = daft.from_pydict({"text": ["hello world", "hello world"]})
+    result = df.select(col("text").simhash()).to_pydict()["text"]
+    assert result[0] == result[1]
+
+
+def test_simhash_deterministic():
+    df = daft.from_pydict({"text": ["the quick brown fox jumps over the lazy dog"]})
+    r1 = df.select(col("text").simhash()).to_pydict()["text"][0]
+    r2 = df.select(col("text").simhash()).to_pydict()["text"][0]
+    assert r1 == r2
+
+
+def test_simhash_returns_uint64():
+    df = daft.from_pydict({"text": ["hello"]})
+    result = df.select(col("text").simhash()).collect()
+    assert result.schema()["text"].dtype == DataType.uint64()
+
+
+def test_simhash_null_propagation():
+    df = daft.from_pydict({"text": ["hello", None, "world"]})
+    result = df.select(col("text").simhash()).to_pydict()["text"]
+    assert result[0] is not None
+    assert result[1] is None
+    assert result[2] is not None
+
+
+def test_simhash_empty_string():
+    df = daft.from_pydict({"text": [""]})
+    result = df.select(col("text").simhash()).to_pydict()["text"]
+    assert result[0] == 0
+
+
+def test_simhash_short_string():
+    df = daft.from_pydict({"text": ["ab"]})
+    result = df.select(col("text").simhash(ngram_size=3)).to_pydict()["text"]
+    assert result[0] == 0
+
+
+def test_simhash_similar_strings_small_distance():
+    df = daft.from_pydict({
+        "text": [
+            "the quick brown fox jumps over the lazy dog",
+            "the quick brown fox jumps over the lazy cat",
+        ]
+    })
+    result = df.select(col("text").simhash()).to_pydict()["text"]
+    distance = bin(result[0] ^ result[1]).count("1")
+    assert distance < 32
+
+
+def test_simhash_different_strings_large_distance():
+    df = daft.from_pydict({
+        "text": [
+            "the quick brown fox jumps over the lazy dog",
+            "1234567890 abcdefghijklmnopqrstuvwxyz !@#$%",
+        ]
+    })
+    result = df.select(col("text").simhash()).to_pydict()["text"]
+    distance = bin(result[0] ^ result[1]).count("1")
+    assert distance > 5
+
+
+@pytest.mark.parametrize("ngram_size", [1, 2, 3, 5])
+def test_simhash_different_ngram_sizes(ngram_size):
+    df = daft.from_pydict({"text": ["hello world"]})
+    result = df.select(col("text").simhash(ngram_size=ngram_size)).to_pydict()["text"]
+    assert result[0] is not None
+    assert isinstance(result[0], int)
+
+
+@pytest.mark.parametrize("hash_function", ["murmurhash3", "xxhash", "xxhash32", "xxhash64", "xxhash3_64", "sha1"])
+def test_simhash_different_hash_functions(hash_function):
+    df = daft.from_pydict({"text": ["hello world"]})
+    result = df.select(col("text").simhash(hash_function=hash_function)).to_pydict()["text"]
+    assert result[0] is not None
+    assert isinstance(result[0], int)
+
+
+def test_simhash_different_hash_functions_produce_different_results():
+    df = daft.from_pydict({"text": ["the quick brown fox jumps over the lazy dog"]})
+    r1 = df.select(col("text").simhash(hash_function="murmurhash3")).to_pydict()["text"][0]
+    r2 = df.select(col("text").simhash(hash_function="xxhash3_64")).to_pydict()["text"][0]
+    assert r1 != r2
+
+
+def test_simhash_standalone_function():
+    df = daft.from_pydict({"text": ["hello world"]})
+    result = df.select(simhash(col("text"))).to_pydict()["text"]
+    assert result[0] is not None
+
+
+def test_simhash_multiple_rows():
+    texts = [f"document number {i} with some content" for i in range(10)]
+    df = daft.from_pydict({"text": texts})
+    result = df.select(col("text").simhash()).to_pydict()["text"]
+    assert len(result) == 10
+    assert all(r is not None for r in result)
+
+
+def test_simhash_unicode():
+    df = daft.from_pydict({"text": ["hello world", "你好世界"]})
+    result = df.select(col("text").simhash()).to_pydict()["text"]
+    assert result[0] is not None
+    assert result[1] is not None
+    assert result[0] != result[1]

--- a/tests/expressions/test_simhash.py
+++ b/tests/expressions/test_simhash.py
@@ -48,24 +48,28 @@ def test_simhash_short_string():
 
 
 def test_simhash_similar_strings_small_distance():
-    df = daft.from_pydict({
-        "text": [
-            "the quick brown fox jumps over the lazy dog",
-            "the quick brown fox jumps over the lazy cat",
-        ]
-    })
+    df = daft.from_pydict(
+        {
+            "text": [
+                "the quick brown fox jumps over the lazy dog",
+                "the quick brown fox jumps over the lazy cat",
+            ]
+        }
+    )
     result = df.select(col("text").simhash()).to_pydict()["text"]
     distance = bin(result[0] ^ result[1]).count("1")
     assert distance < 32
 
 
 def test_simhash_different_strings_large_distance():
-    df = daft.from_pydict({
-        "text": [
-            "the quick brown fox jumps over the lazy dog",
-            "1234567890 abcdefghijklmnopqrstuvwxyz !@#$%",
-        ]
-    })
+    df = daft.from_pydict(
+        {
+            "text": [
+                "the quick brown fox jumps over the lazy dog",
+                "1234567890 abcdefghijklmnopqrstuvwxyz !@#$%",
+            ]
+        }
+    )
     result = df.select(col("text").simhash()).to_pydict()["text"]
     distance = bin(result[0] ^ result[1]).count("1")
     assert distance > 5

--- a/tests/expressions/test_utf8.py
+++ b/tests/expressions/test_utf8.py
@@ -115,7 +115,7 @@ def test_regexp_replace(test_expression):
     )
 
 
-def test_hamming_distance(test_binary_expression):
+def test_hamming_distance_str(test_binary_expression):
     left = ["ronald", "ronald", "ronald", "ronald", "ronald", None]
     right = ["ronald", "renuld", "ronaldo", "r", None, None]
     expected = [0, 2, None, None, None, None]
@@ -123,6 +123,6 @@ def test_hamming_distance(test_binary_expression):
     test_binary_expression(
         left=left,
         right=right,
-        name="hamming_distance",
+        name="hamming_distance_str",
         expected=expected,
     )


### PR DESCRIPTION

## Changes Made

This PR adds two new functions that together form a complete text near-duplicate detection pipeline, complementary to the existing MinHash approach:

- `simhash(text, *, ngram_size=3, hash_function="xxhash3_64")` — Computes a 64-bit locality-sensitive fingerprint from text using character n-grams. Similar texts produce fingerprints that differ in only a few bits.

- `hamming_distance(left, right)` — Computes the bitwise Hamming distance (popcount of XOR) between integer or FixedSizeBinary inputs. This is the standard metric for comparing hash fingerprints produced by **`simhash`**, **`image_hash`**, or any other bit-oriented hash.

Daft already has MinHash for Jaccard-based LSH deduplication. SimHash is complementary: it produces a single UInt64 fingerprint (vs MinHash's FixedSizeList\[UInt32, N\] signature vector), making it significantly cheaper to store, index, and compare at scale. The tradeoff is that SimHash captures weighted feature similarity rather than set overlap, making it better suited for document-level near-duplicate detection.

---

### Rename: existing hamming\_distance → hamming\_distance\_str

This PR also renames the character-level hamming\_distance function (introduced in #6797 yesterday, not yet released) to hamming\_distance\_str, and gives the hamming\_distance name to the bitwise version.

Why:

- "Hamming distance" in information theory and data engineering universally refers to the number of differing bits. The character-level variant is a valid but niche definition.
- The internal Rust implementation already named this function hamming_distance_str, which is intuitive.
- Since #6797 has not shipped in any release, renaming now is free; after a release it would be breaking.
