### PR TITLE
feat(distributed): Add task metadata to task events

### DIFF
--- a/src/daft-context/src/subscribers/events.rs
+++ b/src/daft-context/src/subscribers/events.rs
@@ -147,7 +147,7 @@ pub struct ResultOutEvent {
 }
 
 #[derive(Debug, Clone)]
-pub struct TaskMeta {
+pub struct TaskInfo {
     pub id: u32,
     pub node_ids: Vec<u32>,
 }
@@ -155,13 +155,14 @@ pub struct TaskMeta {
 #[derive(Debug, Clone)]
 pub struct TaskSubmitEvent {
     pub header: EventHeader,
-    pub task: Arc<TaskMeta>,
+    pub task: Arc<TaskInfo>,
+    pub sources: Arc<Vec<TaskSource>>,
 }
 
 #[derive(Debug, Clone)]
 pub struct TaskEndEvent {
     pub header: EventHeader,
-    pub task: Arc<TaskMeta>,
+    pub task: Arc<TaskInfo>,
     pub worker_id: Option<Arc<str>>,
     pub outcome: TaskOutcome,
     pub stats: Vec<(Arc<NodeInfo>, StatSnapshot)>,
@@ -172,4 +173,26 @@ pub enum TaskOutcome {
     Success,
     Failed { message: String },
     Cancelled,
+}
+
+#[derive(Debug, Clone)]
+pub enum TaskSource {
+    PhysicalScan(PhysicalScanSource),
+    InMemoryScan(InMemoryScanSource),
+}
+
+#[derive(Debug, Clone)]
+pub struct PhysicalScanSource {
+    pub source_id: u32,
+    pub scan_tasks: u32,
+    pub paths: Vec<String>,
+    pub storage_bytes: Option<usize>,
+    pub estimated_memory_bytes: Option<usize>,
+}
+
+#[derive(Debug, Clone)]
+pub struct InMemoryScanSource {
+    pub source_id: u32,
+    pub partitions: usize,
+    pub total_bytes: Option<usize>,
 }

--- a/src/daft-distributed/src/python/progress_bar.rs
+++ b/src/daft-distributed/src/python/progress_bar.rs
@@ -69,7 +69,7 @@ impl Drop for FlotillaProgressBar {
 impl StatisticsSubscriber for FlotillaProgressBar {
     fn handle_event(&mut self, event: &TaskEvent) -> DaftResult<()> {
         match event {
-            TaskEvent::Submitted { context, name } => {
+            TaskEvent::Submitted { context, name, .. } => {
                 self.make_bar_or_update_total(BarId::from(context), name)?;
                 Ok(())
             }
@@ -82,7 +82,7 @@ impl StatisticsSubscriber for FlotillaProgressBar {
             // We don't care about failed tasks as they will be retried
             TaskEvent::Failed { .. } => Ok(()),
             // We consider cancelled tasks as finished tasks
-            TaskEvent::Cancelled { context } => {
+            TaskEvent::Cancelled { context, .. } => {
                 self.update_bar(BarId::from(context))?;
                 Ok(())
             }

--- a/src/daft-distributed/src/scheduling/mod.rs
+++ b/src/daft-distributed/src/scheduling/mod.rs
@@ -3,6 +3,7 @@ pub(super) mod dispatcher;
 pub(crate) mod local_worker;
 pub(super) mod scheduler;
 pub(crate) mod task;
+pub(crate) mod task_metadata;
 
 #[cfg(test)]
 pub(crate) mod tests;

--- a/src/daft-distributed/src/scheduling/scheduler/mod.rs
+++ b/src/daft-distributed/src/scheduling/scheduler/mod.rs
@@ -9,7 +9,7 @@ use super::{
 };
 use crate::{
     pipeline_node::MaterializedOutput,
-    scheduling::task::{TaskContext, TaskResourceRequest},
+    scheduling::task::{TaskContext, TaskMetadata, TaskResourceRequest},
     utils::channel::OneshotSender,
 };
 
@@ -75,6 +75,10 @@ impl<T: Task> PendingTask<T> {
         CancellationToken,
     ) {
         (self.task, self.result_tx, self.cancel_token)
+    }
+
+    fn task_metadata(&self) -> TaskMetadata {
+        self.task.task_metadata()
     }
 }
 

--- a/src/daft-distributed/src/scheduling/scheduler/scheduler_actor.rs
+++ b/src/daft-distributed/src/scheduling/scheduler/scheduler_actor.rs
@@ -82,6 +82,11 @@ where
                 self.statistics_manager.handle_event(TaskEvent::Submitted {
                     context: task.task_context(),
                     name: task.task.task_name().clone(),
+                    // TODO(perf): Avoid building TaskMetadata unless a subscriber/export path needs it.
+                    // This currently clones scan paths and estimates scan sizes for every submitted task,
+                    // even when task lifecycle event emission is disabled. The right fix likely belongs
+                    // in the task-event wiring layer rather than StatisticsSubscriber.
+                    metadata: task.task_metadata(),
                 })?;
             }
 

--- a/src/daft-distributed/src/scheduling/task.rs
+++ b/src/daft-distributed/src/scheduling/task.rs
@@ -115,6 +115,10 @@ pub(crate) trait Task: Send + Sync + Clone + Debug + 'static {
     }
 
     fn task_name(&self) -> TaskName;
+
+    fn task_metadata(&self) -> TaskMetadata {
+        TaskMetadata::default()
+    }
 }
 
 #[derive(Clone)]
@@ -157,6 +161,34 @@ impl std::fmt::Debug for TaskDetails {
             self.memory_bytes()
         )
     }
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct TaskMetadata {
+    pub sources: Vec<TaskSource>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum TaskSource {
+    PhysicalScan(PhysicalScanSource),
+    InMemoryScan(InMemoryScanSource),
+    // TODO: Add glob and flight sources
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct PhysicalScanSource {
+    pub source_id: SourceId,
+    pub scan_tasks: u32,
+    pub paths: Vec<String>,
+    pub storage_bytes: Option<usize>,
+    pub estimated_memory_bytes: Option<usize>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct InMemoryScanSource {
+    pub source_id: SourceId,
+    pub partitions: usize,
+    pub total_bytes: Option<usize>,
 }
 
 #[derive(Debug, Clone)]
@@ -267,6 +299,10 @@ impl Task for SwordfishTask {
             node_id: self.task_context.last_node_id,
             task_id: self.task_context.task_id,
         }
+    }
+
+    fn task_metadata(&self) -> TaskMetadata {
+        self.build_metadata()
     }
 }
 

--- a/src/daft-distributed/src/scheduling/task_metadata.rs
+++ b/src/daft-distributed/src/scheduling/task_metadata.rs
@@ -1,0 +1,68 @@
+use daft_local_plan::Input;
+
+use super::task::{
+    InMemoryScanSource, PhysicalScanSource, SwordfishTask, TaskMetadata, TaskSource,
+};
+
+impl SwordfishTask {
+    pub(crate) fn build_metadata(&self) -> TaskMetadata {
+        let sources: Vec<TaskSource> = self.task_sources();
+        TaskMetadata { sources }
+    }
+
+    fn task_sources(&self) -> Vec<TaskSource> {
+        let inputs = self.inputs();
+        let mut sources: Vec<TaskSource> = Vec::with_capacity(inputs.len() + self.psets().len());
+        for (source_id, input) in inputs {
+            match input {
+                Input::ScanTasks(scan_tasks) => {
+                    let mut paths: Vec<String> = Vec::new();
+                    let mut storage_bytes: Option<usize> = None;
+                    let mut estimated_memory_bytes: Option<usize> = None;
+                    for scan_task in scan_tasks {
+                        paths.extend(scan_task.get_file_paths().iter().cloned());
+                        if let Some(size) = scan_task.size_bytes_on_disk() {
+                            storage_bytes = Some(storage_bytes.unwrap_or(0) + size);
+                        }
+                        if let Some(memory_bytes) =
+                            scan_task.estimate_in_memory_size_bytes(Some(self.config()))
+                        {
+                            estimated_memory_bytes =
+                                Some(estimated_memory_bytes.unwrap_or(0) + memory_bytes);
+                        }
+                    }
+
+                    sources.push(TaskSource::PhysicalScan(PhysicalScanSource {
+                        source_id: *source_id,
+                        scan_tasks: scan_tasks.len() as u32,
+                        paths,
+                        storage_bytes,
+                        estimated_memory_bytes,
+                    }));
+                }
+                // TODO: support glob and flight shuffle inputs
+                Input::GlobPaths(_paths) => {}
+                Input::FlightShuffle(_inputs) => {}
+                Input::InMemory(_) => {
+                    debug_assert!(
+                        false,
+                        "Input::InMemory should never appear in SwordfishTask.inputs; in-memory data lives in psets"
+                    );
+                }
+            }
+        }
+
+        // Get in memory sources
+        for (source_id, pset) in self.psets() {
+            let partitions = pset.len();
+            let total_bytes = pset.iter().map(|p| p.size_bytes()).sum();
+            sources.push(TaskSource::InMemoryScan(InMemoryScanSource {
+                source_id: *source_id,
+                partitions,
+                total_bytes: Some(total_bytes),
+            }));
+        }
+
+        sources
+    }
+}

--- a/src/daft-distributed/src/statistics/mod.rs
+++ b/src/daft-distributed/src/statistics/mod.rs
@@ -15,7 +15,7 @@ pub use stats::RuntimeStats;
 use crate::{
     pipeline_node::{DistributedPipelineNode, NodeID},
     scheduling::{
-        task::{TaskContext, TaskName, TaskStatus},
+        task::{TaskContext, TaskMetadata, TaskName, TaskStatus},
         worker::WorkerId,
     },
     statistics::stats::RuntimeNodeManager,
@@ -29,6 +29,7 @@ pub(crate) enum TaskEvent {
     Submitted {
         context: TaskContext,
         name: TaskName,
+        metadata: TaskMetadata,
     },
     Scheduled {
         context: TaskContext,

--- a/src/daft-distributed/src/statistics/task_lifecycle.rs
+++ b/src/daft-distributed/src/statistics/task_lifecycle.rs
@@ -6,12 +6,15 @@ use daft_context::{
     DaftContext, get_context,
     subscribers::{
         event_header,
-        events::{Event, TaskEndEvent, TaskMeta, TaskOutcome, TaskSubmitEvent},
+        events::{
+            Event, InMemoryScanSource, PhysicalScanSource, TaskEndEvent, TaskInfo, TaskOutcome,
+            TaskSource as EventTaskSource, TaskSubmitEvent,
+        },
     },
 };
 
 use crate::{
-    scheduling::task::TaskContext,
+    scheduling::task::{TaskContext, TaskSource},
     statistics::{StatisticsSubscriber, TaskEvent},
 };
 
@@ -39,13 +42,37 @@ impl TaskLifecycleEventSubscriber {
     }
 }
 
+fn to_task_source(source: &TaskSource) -> EventTaskSource {
+    match source {
+        TaskSource::PhysicalScan(scan) => EventTaskSource::PhysicalScan(PhysicalScanSource {
+            source_id: scan.source_id,
+            scan_tasks: scan.scan_tasks,
+            paths: scan.paths.clone(),
+            storage_bytes: scan.storage_bytes,
+            estimated_memory_bytes: scan.estimated_memory_bytes,
+        }),
+        TaskSource::InMemoryScan(scan) => EventTaskSource::InMemoryScan(InMemoryScanSource {
+            source_id: scan.source_id,
+            partitions: scan.partitions,
+            total_bytes: scan.total_bytes,
+        }),
+    }
+}
+
 impl StatisticsSubscriber for TaskLifecycleEventSubscriber {
     fn handle_event(&mut self, event: &TaskEvent) -> DaftResult<()> {
         match event {
-            TaskEvent::Submitted { context, .. } => {
+            TaskEvent::Submitted {
+                context,
+                name: _,
+                metadata,
+            } => {
+                let sources: Vec<EventTaskSource> =
+                    metadata.sources.iter().map(to_task_source).collect();
                 let submit_event = Event::TaskSubmit(TaskSubmitEvent {
                     header: event_header(self.query_id.clone()),
-                    task: task_meta_from_context(context),
+                    task: task_info_from_context(context),
+                    sources: Arc::new(sources),
                 });
                 self.dispatch_event(&submit_event)
             }
@@ -56,7 +83,7 @@ impl StatisticsSubscriber for TaskLifecycleEventSubscriber {
             } => {
                 let end_event = Event::TaskEnd(TaskEndEvent {
                     header: event_header(self.query_id.clone()),
-                    task: task_meta_from_context(context),
+                    task: task_info_from_context(context),
                     worker_id: Some(worker_id.clone()),
                     outcome: TaskOutcome::Success,
                     stats: stats.nodes.clone(),
@@ -74,7 +101,7 @@ impl StatisticsSubscriber for TaskLifecycleEventSubscriber {
                 } else {
                     let end_event = Event::TaskEnd(TaskEndEvent {
                         header: event_header(self.query_id.clone()),
-                        task: task_meta_from_context(context),
+                        task: task_info_from_context(context),
                         worker_id: worker_id.clone(),
                         outcome: TaskOutcome::Failed {
                             message: reason.into(),
@@ -87,7 +114,7 @@ impl StatisticsSubscriber for TaskLifecycleEventSubscriber {
             TaskEvent::Cancelled { context } => {
                 let end_event = Event::TaskEnd(TaskEndEvent {
                     header: event_header(self.query_id.clone()),
-                    task: task_meta_from_context(context),
+                    task: task_info_from_context(context),
                     worker_id: None,
                     outcome: TaskOutcome::Cancelled,
                     stats: vec![],
@@ -99,10 +126,10 @@ impl StatisticsSubscriber for TaskLifecycleEventSubscriber {
     }
 }
 
-fn task_meta_from_context(context: &TaskContext) -> Arc<TaskMeta> {
-    let meta = TaskMeta {
+fn task_info_from_context(context: &TaskContext) -> Arc<TaskInfo> {
+    let info = TaskInfo {
         id: context.task_id,
         node_ids: context.node_ids.clone(),
     };
-    Arc::new(meta)
+    Arc::new(info)
 }

--- a/src/daft-distributed/src/statistics/task_lifecycle.rs
+++ b/src/daft-distributed/src/statistics/task_lifecycle.rs
@@ -14,7 +14,10 @@ use daft_context::{
 };
 
 use crate::{
-    scheduling::task::{TaskContext, TaskSource},
+    scheduling::{
+        task,
+        task::{TaskContext, TaskSource},
+    },
     statistics::{StatisticsSubscriber, TaskEvent},
 };
 
@@ -42,23 +45,6 @@ impl TaskLifecycleEventSubscriber {
     }
 }
 
-fn to_task_source(source: &TaskSource) -> EventTaskSource {
-    match source {
-        TaskSource::PhysicalScan(scan) => EventTaskSource::PhysicalScan(PhysicalScanSource {
-            source_id: scan.source_id,
-            scan_tasks: scan.scan_tasks,
-            paths: scan.paths.clone(),
-            storage_bytes: scan.storage_bytes,
-            estimated_memory_bytes: scan.estimated_memory_bytes,
-        }),
-        TaskSource::InMemoryScan(scan) => EventTaskSource::InMemoryScan(InMemoryScanSource {
-            source_id: scan.source_id,
-            partitions: scan.partitions,
-            total_bytes: scan.total_bytes,
-        }),
-    }
-}
-
 impl StatisticsSubscriber for TaskLifecycleEventSubscriber {
     fn handle_event(&mut self, event: &TaskEvent) -> DaftResult<()> {
         match event {
@@ -68,7 +54,7 @@ impl StatisticsSubscriber for TaskLifecycleEventSubscriber {
                 metadata,
             } => {
                 let sources: Vec<EventTaskSource> =
-                    metadata.sources.iter().map(to_task_source).collect();
+                    metadata.sources.iter().map(Into::into).collect();
                 let submit_event = Event::TaskSubmit(TaskSubmitEvent {
                     header: event_header(self.query_id.clone()),
                     task: task_info_from_context(context),
@@ -132,4 +118,35 @@ fn task_info_from_context(context: &TaskContext) -> Arc<TaskInfo> {
         node_ids: context.node_ids.clone(),
     };
     Arc::new(info)
+}
+
+impl From<&task::PhysicalScanSource> for PhysicalScanSource {
+    fn from(scan: &task::PhysicalScanSource) -> Self {
+        Self {
+            source_id: scan.source_id,
+            scan_tasks: scan.scan_tasks,
+            paths: scan.paths.clone(),
+            storage_bytes: scan.storage_bytes,
+            estimated_memory_bytes: scan.estimated_memory_bytes,
+        }
+    }
+}
+
+impl From<&task::InMemoryScanSource> for InMemoryScanSource {
+    fn from(scan: &task::InMemoryScanSource) -> Self {
+        Self {
+            source_id: scan.source_id,
+            partitions: scan.partitions,
+            total_bytes: scan.total_bytes,
+        }
+    }
+}
+
+impl From<&TaskSource> for EventTaskSource {
+    fn from(source: &TaskSource) -> Self {
+        match source {
+            TaskSource::PhysicalScan(scan) => Self::PhysicalScan(scan.into()),
+            TaskSource::InMemoryScan(scan) => Self::InMemoryScan(scan.into()),
+        }
+    }
 }


### PR DESCRIPTION
## Changes Made

Adds a TaskMetadata struct to hold additional task information, currently it exposes TaskSources. This is attached to the TaskEvent::Submitted and subscribers can now observe what data each task is reading.                                                                                                                            
                      
Renames TaskMeta to TaskInfo.
                                                                                                                          
Known follow-ups:
  - Build TaskMetadata lazily so non-subscribed runs don't pay the
    per-task scan-path clone (see TODO at scheduler_actor.rs).
  - Emit Glob and Flight shuffle sources (TODO in TaskSource enum). 
