### PR TITLE
feat(distributed): support flight shuffle in RandomShuffle

### DIFF
--- a/src/daft-distributed/src/pipeline_node/into_batches.rs
+++ b/src/daft-distributed/src/pipeline_node/into_batches.rs
@@ -174,6 +174,7 @@ impl IntoBatchesNode {
                 current_group_size += rows;
                 if current_group_size >= (self.batch_size as f64 * BATCH_SIZE_THRESHOLD) as usize {
                     let group_size = std::mem::take(&mut current_group_size);
+
                     let materialized_outputs = std::mem::take(&mut current_group);
                     let builder = self.build_rebatch_task(materialized_outputs, group_size);
                     if result_tx.send(builder).await.is_err() {

--- a/src/daft-distributed/src/pipeline_node/into_batches.rs
+++ b/src/daft-distributed/src/pipeline_node/into_batches.rs
@@ -16,6 +16,7 @@ use crate::{
     pipeline_node::{
         DistributedPipelineNode, MaterializedOutput, NodeID, PipelineNodeConfig,
         PipelineNodeContext,
+        shuffles::backends::{DistributedShuffleBackend, ShuffleBackend},
     },
     plan::{PlanConfig, PlanExecutionContext, TaskIDCounter},
     scheduling::{
@@ -74,6 +75,7 @@ pub(crate) struct IntoBatchesNode {
     config: PipelineNodeConfig,
     context: PipelineNodeContext,
     batch_size: usize,
+    shuffle_backend: ShuffleBackend,
     child: DistributedPipelineNode,
 }
 
@@ -93,6 +95,7 @@ impl IntoBatchesNode {
         plan_config: &PlanConfig,
         batch_size: usize,
         schema: SchemaRef,
+        backend: DistributedShuffleBackend,
         child: DistributedPipelineNode,
     ) -> Self {
         let context = PipelineNodeContext::new(
@@ -104,7 +107,7 @@ impl IntoBatchesNode {
             NodeCategory::StreamingSink,
         );
         let config = PipelineNodeConfig::new(
-            schema,
+            schema.clone(),
             plan_config.config.clone(),
             Arc::new(
                 UnknownClusteringConfig::new(
@@ -113,12 +116,38 @@ impl IntoBatchesNode {
                 .into(),
             ),
         );
+        let shuffle_backend = ShuffleBackend::new(&context, schema, backend);
         Self {
             config,
             context,
             batch_size,
+            shuffle_backend,
             child,
         }
+    }
+
+    /// Build the rebatch task for a group of materialized upstream outputs.
+    fn build_rebatch_task(
+        &self,
+        group: Vec<MaterializedOutput>,
+        group_size: usize,
+    ) -> SwordfishTaskBuilder {
+        let node_id = self.node_id();
+        let refs = group
+            .into_iter()
+            .flat_map(|output| output.into_inner().0)
+            .collect::<Vec<_>>();
+
+        self.shuffle_backend
+            .build_refs_task_builder(refs, self, move |read_plan| {
+                LocalPhysicalPlan::into_batches(
+                    read_plan,
+                    group_size,
+                    true,
+                    StatsState::NotMaterialized,
+                    LocalNodeContext::new(Some(node_id as usize)).with_phase(REBATCH_PHASE),
+                )
+            })
     }
 
     async fn execute_into_batches(
@@ -145,24 +174,8 @@ impl IntoBatchesNode {
                 current_group_size += rows;
                 if current_group_size >= (self.batch_size as f64 * BATCH_SIZE_THRESHOLD) as usize {
                     let group_size = std::mem::take(&mut current_group_size);
-
                     let materialized_outputs = std::mem::take(&mut current_group);
-                    let (in_memory_scan, psets) =
-                        MaterializedOutput::into_in_memory_scan_with_psets(
-                            materialized_outputs,
-                            self.config.schema.clone(),
-                            self.node_id(),
-                        );
-                    let plan = LocalPhysicalPlan::into_batches(
-                        in_memory_scan,
-                        group_size,
-                        true, // Strict batch sizes for the downstream tasks, as they have been coalesced.
-                        StatsState::NotMaterialized,
-                        LocalNodeContext::new(Some(self.node_id() as usize))
-                            .with_phase(REBATCH_PHASE),
-                    );
-                    let builder = SwordfishTaskBuilder::new(plan, self.as_ref(), self.node_id())
-                        .with_psets(self.node_id(), psets);
+                    let builder = self.build_rebatch_task(materialized_outputs, group_size);
                     if result_tx.send(builder).await.is_err() {
                         break;
                     }
@@ -171,20 +184,7 @@ impl IntoBatchesNode {
         }
 
         if !current_group.is_empty() {
-            let (in_memory_source_plan, psets) = MaterializedOutput::into_in_memory_scan_with_psets(
-                current_group,
-                self.config.schema.clone(),
-                self.node_id(),
-            );
-            let plan = LocalPhysicalPlan::into_batches(
-                in_memory_source_plan,
-                current_group_size,
-                true, // Strict batch sizes for the downstream tasks, as they have been coalesced.
-                StatsState::NotMaterialized,
-                LocalNodeContext::new(Some(self.node_id() as usize)).with_phase(REBATCH_PHASE),
-            );
-            let builder = SwordfishTaskBuilder::new(plan, self.as_ref(), self.node_id())
-                .with_psets(self.node_id(), psets);
+            let builder = self.build_rebatch_task(current_group, current_group_size);
             let _ = result_tx.send(builder).await;
         }
         Ok(())
@@ -209,25 +209,45 @@ impl PipelineNodeImpl for IntoBatchesNode {
     }
 
     fn multiline_display(&self, _verbose: bool) -> Vec<String> {
-        vec![format!("IntoBatches: {}", self.batch_size)]
+        let backend_name = match self.shuffle_backend.backend() {
+            DistributedShuffleBackend::Ray => "Ray",
+            DistributedShuffleBackend::Flight(_) => "Flight",
+        };
+        vec![format!(
+            "IntoBatches({}): {}",
+            backend_name, self.batch_size
+        )]
     }
 
     fn produce_tasks(
         self: Arc<Self>,
         plan_context: &mut PlanExecutionContext,
     ) -> TaskBuilderStream {
-        let input_node = self.child.clone().produce_tasks(plan_context);
+        self.shuffle_backend.register_cleanup(plan_context);
         let node_id = self.node_id();
         let batch_size = self.batch_size;
-        let local_into_batches_node = input_node.pipeline_instruction(self.clone(), move |input| {
-            LocalPhysicalPlan::into_batches(
-                input,
-                batch_size,
-                false, // No need strict batch sizes for the child tasks, as we coalesce them later on.
-                StatsState::NotMaterialized,
-                LocalNodeContext::new(Some(node_id as usize)).with_phase(INITIAL_BATCH_PHASE),
-            )
-        });
+        let schema = self.shuffle_backend.schema().clone();
+        let local_shuffle_backend = self.shuffle_backend.local_shuffle_backend();
+        let local_into_batches_node = self
+            .child
+            .clone()
+            .produce_tasks(plan_context)
+            .pipeline_instruction(self.clone(), move |input| {
+                let into_batches_plan = LocalPhysicalPlan::into_batches(
+                    input,
+                    batch_size,
+                    false, // No need strict batch sizes for the child tasks, as we coalesce them later on.
+                    StatsState::NotMaterialized,
+                    LocalNodeContext::new(Some(node_id as usize)).with_phase(INITIAL_BATCH_PHASE),
+                );
+                LocalPhysicalPlan::gather_write(
+                    into_batches_plan,
+                    schema.clone(),
+                    local_shuffle_backend.clone(),
+                    StatsState::NotMaterialized,
+                    LocalNodeContext::new(Some(node_id as usize)),
+                )
+            });
 
         let (result_tx, result_rx) = create_channel(1);
         let execution_future = self.execute_into_batches(

--- a/src/daft-distributed/src/pipeline_node/into_batches.rs
+++ b/src/daft-distributed/src/pipeline_node/into_batches.rs
@@ -210,13 +210,10 @@ impl PipelineNodeImpl for IntoBatchesNode {
     }
 
     fn multiline_display(&self, _verbose: bool) -> Vec<String> {
-        let backend_name = match self.shuffle_backend.backend() {
-            DistributedShuffleBackend::Ray => "Ray",
-            DistributedShuffleBackend::Flight(_) => "Flight",
-        };
         vec![format!(
             "IntoBatches({}): {}",
-            backend_name, self.batch_size
+            self.shuffle_backend.backend().name(),
+            self.batch_size
         )]
     }
 

--- a/src/daft-distributed/src/pipeline_node/into_partitions.rs
+++ b/src/daft-distributed/src/pipeline_node/into_partitions.rs
@@ -333,12 +333,8 @@ impl PipelineNodeImpl for IntoPartitionsNode {
     }
 
     fn multiline_display(&self, _verbose: bool) -> Vec<String> {
-        let backend_name = match self.shuffle_backend.backend() {
-            DistributedShuffleBackend::Ray => "Ray",
-            DistributedShuffleBackend::Flight(_) => "Flight",
-        };
         vec![
-            format!("IntoPartitions({})", backend_name),
+            format!("IntoPartitions({})", self.shuffle_backend.backend().name()),
             format!("Num partitions = {}", self.num_partitions),
         ]
     }

--- a/src/daft-distributed/src/pipeline_node/into_partitions.rs
+++ b/src/daft-distributed/src/pipeline_node/into_partitions.rs
@@ -98,11 +98,20 @@ impl IntoPartitionsNode {
                 chunk_size += 1;
             }
 
-            // Build and submit all the tasks for this partition
+            let node_id = self.node_id();
             let submitted_tasks = builder_iter
                 .by_ref()
                 .take(chunk_size)
                 .map(|builder| {
+                    let builder = builder.map_plan(self.as_ref(), |plan| {
+                        LocalPhysicalPlan::into_partitions(
+                            plan,
+                            1,
+                            self.shuffle_backend.local_shuffle_backend(),
+                            StatsState::NotMaterialized,
+                            LocalNodeContext::new(Some(node_id as usize)),
+                        )
+                    });
                     let submittable_task = builder.build(self.context.query_idx, task_id_counter);
                     submittable_task.submit(scheduler_handle)
                 })
@@ -112,44 +121,47 @@ impl IntoPartitionsNode {
 
         let mut output_futures = OrderedJoinSet::new();
         for tasks in tasks_per_partition {
+            let self_clone = self.clone();
+            let sched = scheduler_handle.clone();
+            let counter = task_id_counter.clone();
             output_futures.spawn(async move {
-                let materialized_output = futures::future::try_join_all(tasks)
+                let materialized_outputs: Vec<_> = futures::future::try_join_all(tasks)
                     .await?
                     .into_iter()
                     .flatten()
+                    .collect();
+                let partition_refs = materialized_outputs
+                    .into_iter()
+                    .flat_map(|output| output.into_inner().0)
                     .collect::<Vec<_>>();
-                DaftResult::Ok(materialized_output)
+                let merge_task = self_clone
+                    .shuffle_backend
+                    .build_refs_task_builder(partition_refs, self_clone.as_ref(), |input| input)
+                    .map_plan(self_clone.as_ref(), |plan| {
+                        LocalPhysicalPlan::into_partitions(
+                            plan,
+                            1,
+                            self_clone.shuffle_backend.local_shuffle_backend(),
+                            StatsState::NotMaterialized,
+                            LocalNodeContext::new(Some(self_clone.node_id() as usize)),
+                        )
+                    })
+                    .build(self_clone.context.query_idx, &counter);
+                merge_task.submit(&sched)?.await
             });
         }
 
         while let Some(result) = output_futures.join_next().await {
-            // Collect all the outputs from this task and coalesce them into a single task.
-            let materialized_outputs = result??;
-            let partition_refs = materialized_outputs
-                .into_iter()
-                .flat_map(|output| output.into_inner().0)
-                .collect::<Vec<_>>();
-
-            let node_id = self.node_id();
-            let shuffle_backend = self.shuffle_backend.local_shuffle_backend();
-            let builder = self.shuffle_backend.build_refs_task_builder(
-                partition_refs,
-                self.as_ref(),
-                move |input| {
-                    LocalPhysicalPlan::into_partitions(
-                        input,
-                        1,
-                        shuffle_backend,
-                        StatsState::NotMaterialized,
-                        LocalNodeContext::new(Some(node_id as usize)),
-                    )
-                },
-            );
-            if result_tx.send(builder).await.is_err() {
-                break;
+            let materialized_output = result??;
+            if let Some(output) = materialized_output {
+                let builder = self.shuffle_backend.build_refs_task_builder(
+                    output.into_inner().0,
+                    self.as_ref(),
+                    |input| input,
+                );
+                let _ = result_tx.send(builder).await;
             }
         }
-
         Ok(())
     }
 
@@ -214,9 +226,7 @@ impl IntoPartitionsNode {
                         self.as_ref(),
                         |input| input,
                     );
-                    if result_tx.send(builder).await.is_err() {
-                        break;
-                    }
+                    let _ = result_tx.send(builder).await;
                 }
             }
         }
@@ -242,18 +252,32 @@ impl IntoPartitionsNode {
                     .execution_config
                     .enable_scan_task_split_and_merge
                 {
-                    let node_id = self.node_id();
+                    let mut output_futures = OrderedJoinSet::new();
                     for builder in input_builders {
-                        let builder = builder.map_plan(self.as_ref(), |plan| {
-                            LocalPhysicalPlan::into_partitions(
-                                plan,
-                                1,
-                                self.shuffle_backend.local_shuffle_backend(),
-                                StatsState::NotMaterialized,
-                                LocalNodeContext::new(Some(node_id as usize)),
-                            )
-                        });
-                        let _ = result_tx.send(builder).await;
+                        let merge_task = builder
+                            .map_plan(self.as_ref(), |plan| {
+                                LocalPhysicalPlan::into_partitions(
+                                    plan,
+                                    1,
+                                    self.shuffle_backend.local_shuffle_backend(),
+                                    StatsState::NotMaterialized,
+                                    LocalNodeContext::new(Some(self.node_id() as usize)),
+                                )
+                            })
+                            .build(self.context.query_idx, &task_id_counter);
+                        let sched = scheduler_handle.clone();
+                        output_futures.spawn(async move { merge_task.submit(&sched)?.await });
+                    }
+                    while let Some(result) = output_futures.join_next().await {
+                        let materialized_output = result??;
+                        if let Some(output) = materialized_output {
+                            let builder = self.shuffle_backend.build_refs_task_builder(
+                                output.into_inner().0,
+                                self.as_ref(),
+                                |input| input,
+                            );
+                            let _ = result_tx.send(builder).await;
+                        }
                     }
                 } else {
                     for builder in input_builders {

--- a/src/daft-distributed/src/pipeline_node/into_partitions.rs
+++ b/src/daft-distributed/src/pipeline_node/into_partitions.rs
@@ -98,6 +98,7 @@ impl IntoPartitionsNode {
                 chunk_size += 1;
             }
 
+            // Build and submit all the tasks for this partition
             let node_id = self.node_id();
             let submitted_tasks = builder_iter
                 .by_ref()
@@ -159,7 +160,9 @@ impl IntoPartitionsNode {
                     self.as_ref(),
                     |input| input,
                 );
-                let _ = result_tx.send(builder).await;
+                if result_tx.send(builder).await.is_err() {
+                    break;
+                }
             }
         }
         Ok(())
@@ -226,7 +229,9 @@ impl IntoPartitionsNode {
                         self.as_ref(),
                         |input| input,
                     );
-                    let _ = result_tx.send(builder).await;
+                    if result_tx.send(builder).await.is_err() {
+                        break;
+                    }
                 }
             }
         }
@@ -276,12 +281,16 @@ impl IntoPartitionsNode {
                                 self.as_ref(),
                                 |input| input,
                             );
-                            let _ = result_tx.send(builder).await;
+                            if result_tx.send(builder).await.is_err() {
+                                break;
+                            }
                         }
                     }
                 } else {
                     for builder in input_builders {
-                        let _ = result_tx.send(builder).await;
+                        if result_tx.send(builder).await.is_err() {
+                            break;
+                        }
                     }
                 }
             }

--- a/src/daft-distributed/src/pipeline_node/random_shuffle.rs
+++ b/src/daft-distributed/src/pipeline_node/random_shuffle.rs
@@ -7,7 +7,7 @@ use common_error::DaftResult;
 use common_metrics::ops::{NodeCategory, NodeType};
 use daft_dsl::expr::bound_expr::BoundExpr;
 use daft_functions::random::random_int_expr;
-use daft_local_plan::{LocalNodeContext, LocalPhysicalPlan, ShuffleBackend};
+use daft_local_plan::{LocalNodeContext, LocalPhysicalPlan};
 use daft_logical_plan::{partitioning::RandomShuffleConfig, stats::StatsState};
 use daft_schema::schema::SchemaRef;
 
@@ -16,6 +16,7 @@ use crate::{
     pipeline_node::{
         DistributedPipelineNode, MaterializedOutput, NodeID, PipelineNodeConfig,
         PipelineNodeContext,
+        shuffles::backends::{DistributedShuffleBackend, ShuffleBackend},
     },
     plan::{PlanConfig, PlanExecutionContext, TaskIDCounter},
     scheduling::{
@@ -32,6 +33,7 @@ pub(crate) struct RandomShuffleNode {
     config: PipelineNodeConfig,
     context: PipelineNodeContext,
     seed: Option<u64>,
+    shuffle_backend: ShuffleBackend,
     child: DistributedPipelineNode,
 }
 
@@ -43,6 +45,7 @@ impl RandomShuffleNode {
         plan_config: &PlanConfig,
         seed: Option<u64>,
         output_schema: SchemaRef,
+        backend: DistributedShuffleBackend,
         child: DistributedPipelineNode,
     ) -> Self {
         let context = PipelineNodeContext::new(
@@ -55,14 +58,16 @@ impl RandomShuffleNode {
         );
 
         let config = PipelineNodeConfig::new(
-            output_schema,
+            output_schema.clone(),
             plan_config.config.clone(),
             child.config().clustering_spec.clone(),
         );
+        let shuffle_backend = ShuffleBackend::new(&context, output_schema, backend);
         Self {
             config,
             context,
             seed,
+            shuffle_backend,
             child,
         }
     }
@@ -72,12 +77,6 @@ impl RandomShuffleNode {
         partition_group: Vec<MaterializedOutput>,
         partition_idx: usize,
     ) -> DaftResult<SwordfishTaskBuilder> {
-        let (in_memory_scan, psets) = MaterializedOutput::into_in_memory_scan_with_psets(
-            partition_group,
-            self.config.schema.clone(),
-            self.node_id(),
-        );
-
         let partition_seed = self.seed.map(|s| {
             let mut hasher = DefaultHasher::new();
             s.hash(&mut hasher);
@@ -89,15 +88,23 @@ impl RandomShuffleNode {
             &[random_int_expr(i64::MIN, i64::MAX, partition_seed)],
             &self.config.schema,
         )?;
-        let plan = LocalPhysicalPlan::sort(
-            in_memory_scan,
-            sort_by,
-            vec![false],
-            vec![false],
-            StatsState::NotMaterialized,
-            LocalNodeContext::new(Some(self.node_id() as usize)),
-        );
-        Ok(SwordfishTaskBuilder::new(plan, self, self.node_id()).with_psets(self.node_id(), psets))
+        let node_id = self.node_id();
+        let partition_refs = partition_group
+            .into_iter()
+            .flat_map(|output| output.into_inner().0)
+            .collect::<Vec<_>>();
+        Ok(self
+            .shuffle_backend
+            .build_refs_task_builder(partition_refs, self, |source| {
+                LocalPhysicalPlan::sort(
+                    source,
+                    sort_by,
+                    vec![false],
+                    vec![false],
+                    StatsState::NotMaterialized,
+                    LocalNodeContext::new(Some(node_id as usize)),
+                )
+            }))
     }
 
     async fn execution_loop(
@@ -140,8 +147,10 @@ impl PipelineNodeImpl for RandomShuffleNode {
 
     fn multiline_display(&self, _verbose: bool) -> Vec<String> {
         vec![
-            "RandomShuffle: random row order (via random repartition + random_int + sort)"
-                .to_string(),
+            format!(
+                "RandomShuffle({}): random row order (via random repartition + random_int + sort)",
+                self.shuffle_backend.backend().name()
+            ),
             format!("Seed = {:?}", self.seed),
         ]
     }
@@ -150,19 +159,21 @@ impl PipelineNodeImpl for RandomShuffleNode {
         self: Arc<Self>,
         plan_context: &mut PlanExecutionContext,
     ) -> TaskBuilderStream {
+        self.shuffle_backend.register_cleanup(plan_context);
         let input_node = self.child.clone().produce_tasks(plan_context);
 
         let num_partitions = self.child.config().clustering_spec.num_partitions();
         let node_id = self.node_id();
         let schema = self.config.schema.clone();
         let seed = self.seed;
+        let local_backend = self.shuffle_backend.local_shuffle_backend();
 
         let partitioned_input = input_node.pipeline_instruction(self.clone(), move |input| {
             LocalPhysicalPlan::repartition_write(
                 input,
                 num_partitions,
                 schema.clone(),
-                ShuffleBackend::Ray,
+                local_backend.clone(),
                 daft_logical_plan::partitioning::RepartitionSpec::Random(
                     RandomShuffleConfig::new_with_seed(Some(num_partitions), seed),
                 ),

--- a/src/daft-distributed/src/pipeline_node/shuffles/backends/mod.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/backends/mod.rs
@@ -30,6 +30,17 @@ pub(crate) enum DistributedShuffleBackend {
     Flight(FlightShuffleBackendConfig),
 }
 
+impl DistributedShuffleBackend {
+    /// Short label for this backend, used to build op names in `multiline_display`
+    /// (e.g. `IntoPartitions({name})`, `{name}Gather`).
+    pub(crate) fn name(&self) -> &'static str {
+        match self {
+            Self::Ray => "Ray",
+            Self::Flight(_) => "Flight",
+        }
+    }
+}
+
 #[derive(Clone)]
 pub(crate) struct ShuffleBackend {
     backend: DistributedShuffleBackend,

--- a/src/daft-distributed/src/pipeline_node/shuffles/backends/mod.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/backends/mod.rs
@@ -111,15 +111,14 @@ impl ShuffleBackend {
         let node_id = self.node_id;
         match &self.backend {
             DistributedShuffleBackend::Ray => {
-                let total_size_bytes = partition_refs.iter().map(|p| p.size_bytes()).sum::<usize>();
-                let in_memory_scan = LocalPhysicalPlan::in_memory_scan(
+                let shuffle_read = LocalPhysicalPlan::shuffle_read(
                     node_id,
                     self.schema.clone(),
-                    total_size_bytes,
+                    ShuffleReadBackend::Ray,
                     StatsState::NotMaterialized,
                     LocalNodeContext::new(Some(node_id as usize)),
                 );
-                let plan = wrap_plan(in_memory_scan);
+                let plan = wrap_plan(shuffle_read);
                 SwordfishTaskBuilder::new(plan, node, node_id).with_psets(node_id, partition_refs)
             }
             DistributedShuffleBackend::Flight(_) => {

--- a/src/daft-distributed/src/pipeline_node/shuffles/gather.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/gather.rs
@@ -98,11 +98,7 @@ impl PipelineNodeImpl for GatherNode {
     }
 
     fn multiline_display(&self, _verbose: bool) -> Vec<String> {
-        let backend_name = match self.shuffle_backend.backend() {
-            DistributedShuffleBackend::Ray => "RayGather",
-            DistributedShuffleBackend::Flight(_) => "FlightGather",
-        };
-        vec![backend_name.to_string()]
+        vec![format!("{}Gather", self.shuffle_backend.backend().name())]
     }
 
     fn produce_tasks(

--- a/src/daft-distributed/src/pipeline_node/shuffles/repartition.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/repartition.rs
@@ -153,12 +153,9 @@ impl PipelineNodeImpl for RepartitionNode {
     }
 
     fn multiline_display(&self, _verbose: bool) -> Vec<String> {
-        let backend_name = match self.shuffle_backend.backend() {
-            DistributedShuffleBackend::Ray => "RayShuffle",
-            DistributedShuffleBackend::Flight(_) => "FlightShuffle",
-        };
         let mut res = vec![format!(
-            "{backend_name}: {}",
+            "{}Shuffle: {}",
+            self.shuffle_backend.backend().name(),
             self.repartition_spec.var_name()
         )];
         res.extend(self.repartition_spec.multiline_display());

--- a/src/daft-distributed/src/pipeline_node/translate.rs
+++ b/src/daft-distributed/src/pipeline_node/translate.rs
@@ -236,16 +236,20 @@ impl TreeNodeVisitor for LogicalPlanToPipelineNodeTranslator {
                 )),
                 &self.meter,
             ),
-            LogicalPlan::IntoBatches(into_batches) => DistributedPipelineNode::new(
-                Arc::new(IntoBatchesNode::new(
-                    self.get_next_pipeline_node_id(),
-                    &self.plan_config,
-                    into_batches.batch_size,
-                    node.schema(),
-                    self.curr_node.pop().unwrap(),
-                )),
-                &self.meter,
-            ),
+            LogicalPlan::IntoBatches(into_batches) => {
+                let backend = self.select_backend();
+                DistributedPipelineNode::new(
+                    Arc::new(IntoBatchesNode::new(
+                        self.get_next_pipeline_node_id(),
+                        &self.plan_config,
+                        into_batches.batch_size,
+                        node.schema(),
+                        backend,
+                        self.curr_node.pop().unwrap(),
+                    )),
+                    &self.meter,
+                )
+            }
             LogicalPlan::Limit(limit) => DistributedPipelineNode::new(
                 Arc::new(LimitNode::new(
                     self.get_next_pipeline_node_id(),

--- a/src/daft-distributed/src/pipeline_node/translate.rs
+++ b/src/daft-distributed/src/pipeline_node/translate.rs
@@ -639,16 +639,20 @@ impl TreeNodeVisitor for LogicalPlanToPipelineNodeTranslator {
                     &self.meter,
                 )
             }
-            LogicalPlan::Shuffle(shuffle) => DistributedPipelineNode::new(
-                Arc::new(RandomShuffleNode::new(
-                    self.get_next_pipeline_node_id(),
-                    &self.plan_config,
-                    shuffle.seed,
-                    shuffle.input.schema(),
-                    self.curr_node.pop().unwrap(),
-                )),
-                &self.meter,
-            ),
+            LogicalPlan::Shuffle(shuffle) => {
+                let backend = self.select_backend();
+                DistributedPipelineNode::new(
+                    Arc::new(RandomShuffleNode::new(
+                        self.get_next_pipeline_node_id(),
+                        &self.plan_config,
+                        shuffle.seed,
+                        shuffle.input.schema(),
+                        backend,
+                        self.curr_node.pop().unwrap(),
+                    )),
+                    &self.meter,
+                )
+            }
             LogicalPlan::SubqueryAlias(_)
             | LogicalPlan::Union(_)
             | LogicalPlan::Intersect(_)

--- a/src/daft-local-execution/src/sinks/gather.rs
+++ b/src/daft-local-execution/src/sinks/gather.rs
@@ -6,8 +6,7 @@ use daft_core::prelude::SchemaRef;
 use daft_micropartition::MicroPartition;
 use daft_partition_refs::FlightPartitionRef;
 use daft_shuffles::{
-    server::flight_server::ShuffleFlightServer,
-    shuffle_cache::{InProgressShuffleCache, partition_ref_id},
+    server::flight_server::ShuffleFlightServer, shuffle_cache::InProgressShuffleCache,
 };
 use tracing::{Span, instrument};
 
@@ -42,16 +41,14 @@ struct FlightShared {
 
 pub(crate) struct FlightGatherState {
     shared: Arc<FlightShared>,
-    input_id: InputId,
     refs: Vec<FlightPartitionRef>,
 }
 
 impl FlightGatherState {
     async fn push(&mut self, input: MicroPartition) -> DaftResult<()> {
         let shared = &self.shared;
-        let partition_ref_id = partition_ref_id(self.input_id, self.refs.len());
         let cache = InProgressShuffleCache::try_new(
-            partition_ref_id,
+            &shared.local_server,
             shared.schema.clone(),
             &shared.shuffle_dirs,
             shared.shuffle_id,
@@ -221,14 +218,13 @@ impl BlockingSink for GatherSink {
         vec![format!("Gather({})", self.backend.name())]
     }
 
-    fn make_state(&self, input_id: InputId) -> DaftResult<Self::State> {
+    fn make_state(&self, _input_id: InputId) -> DaftResult<Self::State> {
         match &self.backend {
             GatherBackend::Ray => Ok(GatherState::Ray(RayGatherState {
                 partitions: Vec::new(),
             })),
             GatherBackend::Flight(shared) => Ok(GatherState::Flight(FlightGatherState {
                 shared: shared.clone(),
-                input_id,
                 refs: Vec::new(),
             })),
         }

--- a/src/daft-local-execution/src/sinks/into_partitions.rs
+++ b/src/daft-local-execution/src/sinks/into_partitions.rs
@@ -6,8 +6,7 @@ use daft_core::prelude::SchemaRef;
 use daft_micropartition::MicroPartition;
 use daft_partition_refs::FlightPartitionRef;
 use daft_shuffles::{
-    server::flight_server::ShuffleFlightServer,
-    shuffle_cache::{InProgressShuffleCache, partition_ref_id},
+    server::flight_server::ShuffleFlightServer, shuffle_cache::InProgressShuffleCache,
 };
 use tracing::{Span, instrument};
 
@@ -61,16 +60,11 @@ pub(crate) struct FlightIntoPartitionsState {
 }
 
 impl FlightIntoPartitionsState {
-    fn try_new(
-        shared: Arc<FlightShared>,
-        input_id: InputId,
-        num_partitions: usize,
-    ) -> DaftResult<Self> {
+    fn try_new(shared: Arc<FlightShared>, num_partitions: usize) -> DaftResult<Self> {
         let mut caches = Vec::with_capacity(num_partitions);
-        for partition_idx in 0..num_partitions {
-            let partition_ref_id = partition_ref_id(input_id, partition_idx);
+        for _ in 0..num_partitions {
             let cache = InProgressShuffleCache::try_new(
-                partition_ref_id,
+                &shared.local_server,
                 shared.schema.clone(),
                 &shared.shuffle_dirs,
                 shared.shuffle_id,
@@ -319,7 +313,7 @@ impl BlockingSink for IntoPartitionsSink {
         )]
     }
 
-    fn make_state(&self, input_id: InputId) -> DaftResult<Self::State> {
+    fn make_state(&self, _: InputId) -> DaftResult<Self::State> {
         match &self.backend {
             IntoPartitionsBackend::Ray { .. } => {
                 Ok(IntoPartitionsState::Ray(RayIntoPartitionsState {
@@ -327,7 +321,7 @@ impl BlockingSink for IntoPartitionsSink {
                 }))
             }
             IntoPartitionsBackend::Flight(shared) => Ok(IntoPartitionsState::Flight(
-                FlightIntoPartitionsState::try_new(shared.clone(), input_id, self.num_partitions)?,
+                FlightIntoPartitionsState::try_new(shared.clone(), self.num_partitions)?,
             )),
         }
     }

--- a/src/daft-local-execution/src/sinks/repartition.rs
+++ b/src/daft-local-execution/src/sinks/repartition.rs
@@ -11,8 +11,7 @@ use daft_logical_plan::partitioning::RepartitionSpec;
 use daft_micropartition::MicroPartition;
 use daft_partition_refs::FlightPartitionRef;
 use daft_shuffles::{
-    server::flight_server::ShuffleFlightServer,
-    shuffle_cache::{InProgressShuffleCache, partition_ref_id},
+    server::flight_server::ShuffleFlightServer, shuffle_cache::InProgressShuffleCache,
 };
 use itertools::Itertools;
 use tracing::{Span, instrument};
@@ -337,6 +336,7 @@ impl BlockingSink for RepartitionSink {
                 compression,
                 schema,
                 partitions,
+                local_server,
                 ..
             } => {
                 let mut partitions = partitions.lock().unwrap();
@@ -345,9 +345,9 @@ impl BlockingSink for RepartitionSink {
                     std::collections::hash_map::Entry::Vacant(e) => {
                         let partition_set = Arc::new(
                             (0..self.num_partitions)
-                                .map(|partition_idx| {
+                                .map(|_| {
                                     Ok(Arc::new(InProgressShuffleCache::try_new(
-                                        partition_ref_id(input_id, partition_idx),
+                                        local_server,
                                         schema.clone(),
                                         shuffle_dirs,
                                         *shuffle_id,

--- a/src/daft-shuffles/src/server/flight_server.rs
+++ b/src/daft-shuffles/src/server/flight_server.rs
@@ -1,4 +1,11 @@
-use std::{collections::HashMap, pin::Pin, sync::Arc};
+use std::{
+    collections::HashMap,
+    pin::Pin,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+};
 
 use arrow_flight::{
     Action, ActionType, Criteria, Empty, FlightData, FlightDescriptor, FlightInfo,
@@ -69,11 +76,17 @@ struct FlightPartitionKey {
 #[derive(Clone, Default)]
 pub struct ShuffleFlightServer {
     shuffle_partitions: Arc<Mutex<HashMap<FlightPartitionKey, PartitionCache>>>,
+    /// Server-wide counter for `partition_ref_id` minting.
+    ref_id_counter: Arc<AtomicU64>,
 }
 
 impl ShuffleFlightServer {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    pub fn new_partition_ref_id(&self) -> u64 {
+        self.ref_id_counter.fetch_add(1, Ordering::Relaxed)
     }
 
     pub async fn register_shuffle_partitions(

--- a/src/daft-shuffles/src/shuffle_cache.rs
+++ b/src/daft-shuffles/src/shuffle_cache.rs
@@ -7,6 +7,8 @@ use daft_schema::schema::SchemaRef;
 use daft_writers::{AsyncFileWriter, make_ipc_writer};
 use tokio::sync::Mutex;
 
+use crate::server::flight_server::ShuffleFlightServer;
+
 fn get_shuffle_dirs(shuffle_dirs: &[String], shuffle_id: u64) -> Vec<String> {
     shuffle_dirs
         .iter()
@@ -17,10 +19,6 @@ fn get_shuffle_dirs(shuffle_dirs: &[String], shuffle_id: u64) -> Vec<String> {
 fn get_partition_dir(shuffle_dirs: &[String], partition_ref_id: u64) -> String {
     let dir = &shuffle_dirs[(partition_ref_id as usize) % shuffle_dirs.len()];
     format!("{}/partition_ref_{}", dir, partition_ref_id)
-}
-
-pub fn partition_ref_id(input_id: u32, partition_idx: usize) -> u64 {
-    ((input_id as u64) << 32) | partition_idx as u64
 }
 
 // Result of a writer task
@@ -47,13 +45,14 @@ pub struct InProgressShuffleCache {
 
 impl InProgressShuffleCache {
     pub fn try_new(
-        partition_ref_id: u64,
+        server: &ShuffleFlightServer,
         schema: SchemaRef,
         dirs: &[String],
         shuffle_id: u64,
         target_filesize: usize,
         compression: Option<&str>,
     ) -> DaftResult<Self> {
+        let partition_ref_id = server.new_partition_ref_id();
         // Create the directories
         // TODO: Add checks here, as well as periodic checks to ensure that the dirs are not too full. If so, we switch to directories with more space.
         // And raise an error if we can't find any directories with space.

--- a/tests/dataframe/test_shuffles.py
+++ b/tests/dataframe/test_shuffles.py
@@ -537,7 +537,7 @@ def test_into_batches(flight, shuffle_ctx, rows, batch_size):
     reason="distributed IntoBatches tests require the ray runner",
 )
 def test_into_batches_all_empty_inputs(shuffle_ctx):
-    """Empty-input regression: filter drops everything, into_batches must not panic or hang."""
+    """Ensures `into_batches` handles all-empty inputs (post-filter) without panicking or hanging."""
     with shuffle_ctx():
         df = (
             daft.from_pydict({"x": list(range(1000))})
@@ -555,11 +555,9 @@ def test_into_batches_all_empty_inputs(shuffle_ctx):
     reason="distributed IntoPartitions tests require the ray runner",
 )
 def test_into_partitions_coalesce_with_fused_downstream(shuffle_ctx):
-    """Fused Project on top of `into_partitions(2)` Coalesce path produces correct values.
+    """Ensures the `into_partitions` Coalesce path re-reads its materialized partition refs into a fused downstream's morsel stream, so a fused Project sees real row values rather than the refs themselves.
 
-    Regresses a bug where the Coalesce path forwarded materialized partition
-    refs into the fused downstream's morsel stream instead of re-reading them
-    first. Setup: 8→2 forces Coalesce.
+    Setup: 8→2 forces Coalesce.
     """
     rows = 100
     with shuffle_ctx():
@@ -582,11 +580,9 @@ def test_into_partitions_coalesce_with_fused_downstream(shuffle_ctx):
     reason="distributed IntoPartitions tests require the ray runner",
 )
 def test_into_partitions_equal_split_and_merge_with_fused_downstream(shuffle_ctx):
-    """Fused Project on top of the Equal+`enable_scan_task_split_and_merge=True` path produces correct values.
+    """Ensures the `into_partitions` Equal+`enable_scan_task_split_and_merge=True` path re-reads its materialized partition refs into a fused downstream's morsel stream, mirroring the Coalesce variant.
 
-    Regresses the same partition-ref-leakage bug as the Coalesce variant, but
-    on the Equal+split-merge path. Setup: N→N with split-and-merge forces the
-    Equal path.
+    Setup: N→N with split-and-merge forces the Equal path.
     """
     rows = 100
     n = 4
@@ -594,7 +590,7 @@ def test_into_partitions_equal_split_and_merge_with_fused_downstream(shuffle_ctx
         df = (
             daft.from_pydict({"x": list(range(rows))})
             .into_partitions(n)
-            .into_partitions(n)  # Equal path — exercises the partition-ref re-read fix.
+            .into_partitions(n)  # Equal path — exercises the partition-ref re-read.
             .with_column("y", daft.col("x") * 2)
             .collect()
         )
@@ -610,12 +606,10 @@ def test_into_partitions_equal_split_and_merge_with_fused_downstream(shuffle_ctx
     reason="distributed IntoBatches tests require the ray runner",
 )
 def test_into_batches_followed_by_streaming_project(shuffle_ctx):
-    """Fused Project on top of `into_batches` produces correct values.
+    """Ensures the `into_batches` rebatch step re-reads its materialized partition refs into a fused downstream's morsel stream, so a fused Project sees real row values rather than the refs themselves.
 
-    Regresses a bug where the rebatch step forwarded materialized partition
-    refs into the fused downstream's morsel stream instead of re-reading them
-    first. `with_column` is used over `filter` because the optimizer can't
-    push a derived column below IntoBatches.
+    `with_column` is used over `filter` because the optimizer can't push a
+    derived column below IntoBatches.
     """
     rows = 1000
     with shuffle_ctx():
@@ -638,12 +632,7 @@ def test_into_batches_followed_by_streaming_project(shuffle_ctx):
     reason="distributed IntoBatches tests require the ray runner",
 )
 def test_into_batches_emits_batch_size_partitions(shuffle_ctx):
-    """Output partition sizes track the requested `batch_size`, not the upstream partition size.
-
-    Regresses a bug where each upstream task was consolidated into a single
-    partition ref before rebatching, so the rebatch step emitted refs sized
-    to the upstream partition (potentially >> `batch_size`).
-    """
+    """Ensures `into_batches` emits partitions sized to the requested `batch_size`, not to the upstream partition — each upstream task must split its rows across multiple refs rather than consolidating them into one ref sized to the upstream partition."""
     rows = 1000
     batch_size = 100
     input_partitions = 2  # 500 rows per input partition — still > batch_size, exercises the "input partition larger than batch_size" path

--- a/tests/dataframe/test_shuffles.py
+++ b/tests/dataframe/test_shuffles.py
@@ -66,13 +66,42 @@ def flight_shuffle_ctx():
     return _ctx
 
 
+@pytest.fixture(params=[False, True], ids=["ray", "flight"])
+def flight(request) -> bool:
+    """Parametrizes a test on `flight=False` (Ray backend) and `flight=True` (Flight backend).
+
+    Tests that depend on this fixture run twice — once per backend — without
+    needing a per-test `@pytest.mark.parametrize("flight", ...)` decorator.
+    """
+    return request.param
+
+
+@pytest.fixture
+def shuffle_ctx(flight, flight_shuffle_ctx):
+    """Context-manager fixture that enters `flight_shuffle_ctx` when flight=True, else no-op.
+
+    Pair with the `flight` fixture to write tests that exercise both shuffle
+    backends with `with shuffle_ctx(): ...`.
+    """
+
+    @contextmanager
+    def _ctx():
+        if flight:
+            with flight_shuffle_ctx():
+                yield
+        else:
+            yield
+
+    return _ctx
+
+
 @pytest.mark.skipif(
     get_tests_daft_runner_name() != "ray",
     reason="shuffle tests are meant for the ray runner",
 )
 @pytest.mark.parametrize(
     "input_partitions, output_partitions",
-    [(100, 100), (100, 1), (100, 50), (100, 200)],
+    [(10, 10), (10, 1), (10, 5), (10, 20)],
 )
 def test_pre_shuffle_merge_small_partitions(pre_shuffle_merge_ctx, input_partitions, output_partitions):
     """Test that pre-shuffle merge is working for small partitions less than the memory threshold."""
@@ -109,7 +138,7 @@ def test_pre_shuffle_merge_small_partitions(pre_shuffle_merge_ctx, input_partiti
 )
 @pytest.mark.parametrize(
     "input_partitions, output_partitions",
-    [(100, 100), (100, 1), (100, 50), (100, 200)],
+    [(10, 10), (10, 1), (10, 5), (10, 20)],
 )
 def test_pre_shuffle_merge_big_partitions(pre_shuffle_merge_ctx, input_partitions, output_partitions):
     """Test that pre-shuffle merge is working for big partitions greater than the threshold."""
@@ -146,7 +175,7 @@ def test_pre_shuffle_merge_big_partitions(pre_shuffle_merge_ctx, input_partition
 )
 @pytest.mark.parametrize(
     "input_partitions, output_partitions",
-    [(100, 100), (100, 1), (100, 50), (100, 200)],
+    [(10, 10), (10, 1), (10, 5), (10, 20)],
 )
 def test_pre_shuffle_merge_randomly_sized_partitions(pre_shuffle_merge_ctx, input_partitions, output_partitions):
     """Test that pre-shuffle merge is working for randomly sized partitions."""
@@ -197,7 +226,7 @@ def test_random_shuffle_uses_ray_shuffle_path_under_flight_shuffle_config(flight
 )
 @pytest.mark.parametrize(
     "input_partitions, output_partitions",
-    [(100, 100), (100, 1), (100, 50), (100, 200)],
+    [(10, 10), (10, 1), (10, 5), (10, 20)],
 )
 def test_flight_shuffle(flight_shuffle_ctx, input_partitions, output_partitions):
     """Test that flight shuffle is working."""
@@ -228,36 +257,31 @@ def test_flight_shuffle(flight_shuffle_ctx, input_partitions, output_partitions)
 
 @pytest.mark.skipif(
     get_tests_daft_runner_name() != "ray",
-    reason="shuffle tests are meant for the ray runner",
+    reason="distributed IntoPartitions tests require the ray runner",
 )
 @pytest.mark.parametrize(
     "input_partitions, output_partitions",
     # Equal, coalesce (N > M), split (N < M), and single-output coalesce.
     [(4, 4), (8, 2), (2, 8), (7, 1)],
 )
-def test_flight_into_partitions(flight_shuffle_ctx, input_partitions, output_partitions):
-    """Exercises IntoPartitionsNode under `shuffle_algorithm="flight_shuffle"`.
-
-    Verifies that both upstream materialized outputs (FlightPartitionRefs) are
-    consumed and downstream outputs are re-emitted as FlightPartitionRefs, across
-    the equal / coalesce / split branches.
-    """
+def test_into_partitions(flight, shuffle_ctx, input_partitions, output_partitions):
+    """Exercises IntoPartitionsNode across the equal / coalesce / split branches under both backends."""
     rows = 1000
-    with flight_shuffle_ctx():
+    with shuffle_ctx():
         df = (
             daft.from_pydict({"x": list(range(rows))})
             .into_partitions(input_partitions)
             .into_partitions(output_partitions)
         )
 
-        # Plan-shape assertion: a regression that routes around IntoPartitionsNode
-        # or silently falls back to Ray would still yield correct row counts, so
-        # verify the Flight variant is in the plan explicitly.
+        # Plan-shape assertion guards against routing regressions that would
+        # still yield correct row counts (e.g. silent fallback to the wrong backend).
         buf = io.StringIO()
         df.explain(show_all=True, file=buf)
         plan = buf.getvalue()
-        assert "IntoPartitions(Flight)" in plan, f"expected IntoPartitions(Flight) in plan:\n{plan}"
-        assert "IntoPartitions(Ray)" not in plan, f"unexpected Ray IntoPartitions in plan:\n{plan}"
+        expected, other = ("Flight", "Ray") if flight else ("Ray", "Flight")
+        assert f"IntoPartitions({expected})" in plan, f"expected IntoPartitions({expected}) in plan:\n{plan}"
+        assert f"IntoPartitions({other})" not in plan, f"unexpected IntoPartitions({other}) in plan:\n{plan}"
 
         collected = df.collect()
         # The core contract of into_partitions: exactly N output partitions.
@@ -269,46 +293,13 @@ def test_flight_into_partitions(flight_shuffle_ctx, input_partitions, output_par
     get_tests_daft_runner_name() != "ray",
     reason="distributed IntoPartitions tests require the ray runner",
 )
-@pytest.mark.parametrize(
-    "input_partitions, output_partitions",
-    [(4, 4), (8, 2), (2, 8), (7, 1)],
-)
-def test_ray_into_partitions(input_partitions, output_partitions):
-    """IntoPartitions over the Ray backend (no flight_shuffle_ctx).
-
-    Mirrors test_flight_into_partitions but exercises the Ray IntoPartitionsNode
-    path and RayIntoPartitionsState finalize.
-    """
-    rows = 1000
-    df = daft.from_pydict({"x": list(range(rows))}).into_partitions(input_partitions).into_partitions(output_partitions)
-
-    buf = io.StringIO()
-    df.explain(show_all=True, file=buf)
-    plan = buf.getvalue()
-    assert "IntoPartitions(Ray)" in plan, f"expected IntoPartitions(Ray) in plan:\n{plan}"
-    assert "IntoPartitions(Flight)" not in plan, f"unexpected Flight IntoPartitions in plan:\n{plan}"
-
-    collected = df.collect()
-    assert len(list(collected.iter_partitions())) == output_partitions
-    assert sorted(collected.to_pydict()["x"]) == list(range(rows))
-
-
-@pytest.mark.skipif(
-    get_tests_daft_runner_name() != "ray",
-    reason="shuffle tests are meant for the ray runner",
-)
-def test_flight_into_partitions_mixed_empty_inputs(flight_shuffle_ctx):
-    """IntoPartitions (Flight) must still emit exactly N output partitions when some pre-filter partitions are empty.
-
-    FlightIntoPartitionsState opens N caches in `make_state` and `push` short-
-    circuits on empty inputs. As long as the rotation distributes surviving rows
-    across every cache, close() succeeds and we get N FlightPartitionRefs.
-    """
+def test_into_partitions_mixed_empty_inputs(shuffle_ctx):
+    """N output partitions when some pre-filter inputs are empty."""
     rows = 1000
     input_partitions = 8
     output_partitions = 5
     filter_threshold = 500  # roughly half the data survives
-    with flight_shuffle_ctx():
+    with shuffle_ctx():
         partial = (
             daft.from_pydict({"x": list(range(rows))})
             .into_partitions(input_partitions)
@@ -325,16 +316,10 @@ def test_flight_into_partitions_mixed_empty_inputs(flight_shuffle_ctx):
     reason="shuffle tests are meant for the ray runner",
 )
 def test_flight_into_partitions_rotation_balance(flight_shuffle_ctx):
-    """Test that flight into partitions rotation is balanced.
+    """Flight rotation evenly distributes ragged per-push chunks across output buckets.
 
-    Per-push `div_ceil` slicing front-loads early buckets; the rotation
-    offset in `FlightIntoPartitionsState::push` spreads that bias across
-    output buckets over many pushes.
-    With `rows_per_input=5` and `output_partitions=3`, each push distributes
-    rows as [2, 2, 1]. Without rotation (offset stuck at 0) the last bucket
-    consistently gets the short chunk, so 30 pushes yield [60, 60, 30] — a
-    30-row spread. With rotation the short chunk rotates and counts balance
-    to [50, 50, 50].
+    Without rotation, [2, 2, 1] chunks would consistently short the last
+    bucket: 30 pushes yield [60, 60, 30]. With rotation: ~[50, 50, 50].
     """
     rows_per_input = 5
     input_partitions = 30
@@ -364,20 +349,14 @@ def test_flight_into_partitions_rotation_balance(flight_shuffle_ctx):
 
 @pytest.mark.skipif(
     get_tests_daft_runner_name() != "ray",
-    reason="shuffle tests are meant for the ray runner",
+    reason="distributed IntoPartitions tests require the ray runner",
 )
-def test_flight_into_partitions_all_empty_inputs(flight_shuffle_ctx):
-    """All inputs empty post-filter: `into_partitions(N)` must still emit exactly N zero-row output partitions.
-
-    Regression guard for both the caller-schema plumbing through
-    `InProgressShuffleCache` (needed so `close()` can report a schema
-    for an all-empty partition) and the empty-stream fallback in
-    `forward_partition_stream` for `ShuffleRead(Flight)`.
-    """
+def test_into_partitions_all_empty_inputs(shuffle_ctx):
+    """N zero-row output partitions when all pre-filter inputs are empty."""
     rows = 1000
     input_partitions = 8
     output_partitions = 5
-    with flight_shuffle_ctx():
+    with shuffle_ctx():
         df = (
             daft.from_pydict({"x": list(range(rows))})
             .into_partitions(input_partitions)
@@ -391,19 +370,14 @@ def test_flight_into_partitions_all_empty_inputs(flight_shuffle_ctx):
 
 @pytest.mark.skipif(
     get_tests_daft_runner_name() != "ray",
-    reason="shuffle tests are meant for the ray runner",
+    reason="distributed shuffle tests require the ray runner",
 )
-def test_flight_repartition_all_empty_inputs(flight_shuffle_ctx):
-    """All inputs empty post-filter: hash `.repartition(M, "x")` must still emit M zero-row output partitions.
-
-    Same shuffle-cache shape as `test_flight_into_partitions_all_empty_inputs`
-    (N caches opened per input in `make_state`, all closed with no data), but
-    routed through `RepartitionSink` instead of `IntoPartitionsSink`.
-    """
+def test_repartition_all_empty_inputs(shuffle_ctx):
+    """Hash `.repartition(M, "x")` emits M zero-row output partitions when all inputs are empty."""
     rows = 1000
     input_partitions = 8
     output_partitions = 5
-    with flight_shuffle_ctx():
+    with shuffle_ctx():
         df = (
             daft.from_pydict({"x": list(range(rows))})
             .into_partitions(input_partitions)
@@ -417,17 +391,16 @@ def test_flight_repartition_all_empty_inputs(flight_shuffle_ctx):
 
 @pytest.mark.skipif(
     get_tests_daft_runner_name() != "ray",
-    reason="shuffle tests are meant for the ray runner",
+    reason="distributed gather tests require the ray runner",
 )
-def test_flight_gather_all_empty_inputs(flight_shuffle_ctx):
-    """Every upstream partition is empty post-filter: gather must still emit a single empty result without hanging.
+def test_gather_all_empty_inputs(shuffle_ctx):
+    """Gather over all-empty inputs emits a single empty result without hanging.
 
-    Uses a daemon thread + timeout to protect pytest teardown in case the
-    hang regresses.
+    Daemon thread + 30s timeout guards pytest teardown if the hang regresses.
     """
     rows = 1000
     input_partitions = 8
-    with flight_shuffle_ctx():
+    with shuffle_ctx():
         df = daft.from_pydict({"x": list(range(rows))}).into_partitions(input_partitions).filter(daft.col("x") < 0)
 
         result: dict = {}
@@ -444,7 +417,7 @@ def test_flight_gather_all_empty_inputs(flight_shuffle_ctx):
         if t.is_alive():
             # Hung. Leak the daemon thread (it'll die with the process) and
             # fail the test with a clear diagnostic rather than blocking teardown.
-            raise TimeoutError("test_flight_gather_all_empty_inputs hung past 30s")
+            raise TimeoutError("test_gather_all_empty_inputs hung past 30s")
         if "error" in result:
             raise result["error"]
         # The sum over an empty table should be 0 rows or a single NULL row.
@@ -453,17 +426,13 @@ def test_flight_gather_all_empty_inputs(flight_shuffle_ctx):
 
 @pytest.mark.skipif(
     get_tests_daft_runner_name() != "ray",
-    reason="shuffle tests are meant for the ray runner",
+    reason="distributed gather tests require the ray runner",
 )
 @pytest.mark.parametrize("input_partitions", [1, 8, 32])
-def test_flight_gather(flight_shuffle_ctx, input_partitions):
-    """Gather is triggered by top_n and ungrouped agg on multi-partition inputs.
-
-    Under `shuffle_algorithm="flight_shuffle"` this exercises the GatherWrite
-    blocking sink → ShuffleRead path (rather than the in-memory-scan shortcut).
-    """
+def test_gather(flight, shuffle_ctx, input_partitions):
+    """`top_n` and ungrouped agg correctness across both backends; single-partition inputs short-circuit Gather entirely."""
     rows = 1000
-    with flight_shuffle_ctx():
+    with shuffle_ctx():
         df = daft.from_pydict({"x": list(range(rows))}).into_partitions(input_partitions)
 
         agg_df = df.sum("x")
@@ -477,7 +446,11 @@ def test_flight_gather(flight_shuffle_ctx, input_partitions):
             plan_df.explain(show_all=True, file=buf)
             plan = buf.getvalue()
             if input_partitions > 1:
-                assert "FlightGather" in plan, f"expected FlightGather in plan:\n{plan}"
+                if flight:
+                    assert "FlightGather" in plan, f"expected FlightGather in plan:\n{plan}"
+                else:
+                    assert "Gather" in plan, f"expected Gather in plan:\n{plan}"
+                    assert "FlightGather" not in plan, f"expected Ray gather, got Flight:\n{plan}"
             else:
                 assert "Gather" not in plan, f"unexpected Gather for single-partition input:\n{plan}"
 
@@ -494,51 +467,12 @@ def test_flight_gather(flight_shuffle_ctx, input_partitions):
     get_tests_daft_runner_name() != "ray",
     reason="distributed gather tests require the ray runner",
 )
-@pytest.mark.parametrize("input_partitions", [1, 8, 32])
-def test_ray_gather(input_partitions):
-    """Gather over the Ray backend (no flight_shuffle_ctx).
-
-    Mirrors test_flight_gather but exercises GatherSink::Ray → emit_read_tasks.
-    """
-    rows = 1000
-    df = daft.from_pydict({"x": list(range(rows))}).into_partitions(input_partitions)
-
-    agg_df = df.sum("x")
-    top_df = df.sort("x", desc=True).limit(5)
-
-    for plan_df in (agg_df, top_df):
-        buf = io.StringIO()
-        plan_df.explain(show_all=True, file=buf)
-        plan = buf.getvalue()
-        if input_partitions > 1:
-            assert "Gather" in plan, f"expected Gather in plan:\n{plan}"
-            assert "FlightGather" not in plan, f"expected Ray gather, got Flight:\n{plan}"
-        else:
-            assert "Gather" not in plan, f"unexpected Gather for single-partition input:\n{plan}"
-
-    total = agg_df.collect().to_pydict()["x"]
-    assert total == [sum(range(rows))]
-
-    top = top_df.collect().to_pydict()["x"]
-    assert top == [rows - 1, rows - 2, rows - 3, rows - 4, rows - 5]
-
-
-@pytest.mark.skipif(
-    get_tests_daft_runner_name() != "ray",
-    reason="shuffle tests are meant for the ray runner",
-)
-def test_flight_gather_mixed_empty_inputs(flight_shuffle_ctx):
-    """Gather handles a mix of empty and non-empty input partitions.
-
-    Exercises the FlightGatherState empty-input short-circuit: some input
-    partitions have rows after the filter, others don't. Regressions in
-    the short-circuit would either miscount refs or skip data. The all-empty
-    case is covered by `test_flight_gather_all_empty_inputs`.
-    """
+def test_gather_mixed_empty_inputs(shuffle_ctx):
+    """Gather handles a mix of empty and non-empty input partitions (all-empty covered by `test_gather_all_empty_inputs`)."""
     rows = 1000
     input_partitions = 8
     filter_threshold = 500  # roughly half the data survives
-    with flight_shuffle_ctx():
+    with shuffle_ctx():
         df = (
             daft.from_pydict({"x": list(range(rows))})
             .into_partitions(input_partitions)
@@ -552,3 +486,189 @@ def test_flight_gather_mixed_empty_inputs(flight_shuffle_ctx):
 
         top = df.sort("x", desc=True).limit(5).collect().to_pydict()["x"]
         assert top == sorted(expected_rows, reverse=True)[:5]
+
+
+@pytest.mark.skipif(
+    get_tests_daft_runner_name() != "ray",
+    reason="distributed IntoBatches tests require the ray runner",
+)
+@pytest.mark.parametrize(
+    "rows, batch_size",
+    # Divisible, ragged tail, small input + small batch, batch_size > rows (tail-only).
+    # Scales kept small: each Flight rebatch task creates a shuffle-cache dir
+    # on disk, and many tiny dirs make filesystem ops dominate the test time.
+    [(100, 10), (100, 7), (10, 3), (50, 100)],
+)
+def test_into_batches(flight, shuffle_ctx, rows, batch_size):
+    """IntoBatches under both backends: rebatch tasks must produce the right row set and partition shape."""
+    with shuffle_ctx():
+        df = daft.from_pydict({"x": list(range(rows))}).into_partitions(8).into_batches(batch_size)
+
+        buf = io.StringIO()
+        df.explain(show_all=True, file=buf)
+        plan = buf.getvalue()
+        expected, other = ("Flight", "Ray") if flight else ("Ray", "Flight")
+        assert f"IntoBatches({expected})" in plan, f"expected IntoBatches({expected}) in plan:\n{plan}"
+        assert f"IntoBatches({other})" not in plan, f"unexpected IntoBatches({other}) in plan:\n{plan}"
+
+        collected = df.collect()
+        partitions = list(collected.iter_partitions())
+        if get_tests_daft_runner_name() == "ray":
+            import ray
+
+            partitions = ray.get(partitions)
+
+        # Total row set must match input (every row present exactly once).
+        all_rows = [v for part in partitions for v in part.to_pydict()["x"]]
+        assert sorted(all_rows) == list(range(rows))
+
+        sizes = [len(part.to_pydict()["x"]) for part in partitions]
+        if batch_size >= rows:
+            # Tail-only flush: single partition with all rows (or none if rows == 0).
+            assert sizes == [rows] or sizes == []
+        else:
+            # Sizes can exceed batch_size under Flight (task-boundary concat);
+            # row-set correctness is covered above, just rule out empty batches.
+            assert all(s > 0 for s in sizes), f"empty batch in sizes: {sizes}"
+
+
+@pytest.mark.skipif(
+    get_tests_daft_runner_name() != "ray",
+    reason="distributed IntoBatches tests require the ray runner",
+)
+def test_into_batches_all_empty_inputs(shuffle_ctx):
+    """Empty-input regression: filter drops everything, into_batches must not panic or hang."""
+    with shuffle_ctx():
+        df = (
+            daft.from_pydict({"x": list(range(1000))})
+            .into_partitions(8)
+            .filter(daft.col("x") < 0)
+            .into_batches(100)
+            .collect()
+        )
+        rows_out = df.to_pydict()["x"]
+        assert rows_out == []
+
+
+@pytest.mark.skipif(
+    get_tests_daft_runner_name() != "ray",
+    reason="distributed IntoPartitions tests require the ray runner",
+)
+def test_into_partitions_coalesce_with_fused_downstream(shuffle_ctx):
+    """Fused Project on top of `into_partitions(2)` Coalesce path produces correct values.
+
+    Regresses a bug where the Coalesce path forwarded materialized partition
+    refs into the fused downstream's morsel stream instead of re-reading them
+    first. Setup: 8→2 forces Coalesce.
+    """
+    rows = 100
+    with shuffle_ctx():
+        df = (
+            daft.from_pydict({"x": list(range(rows))})
+            .into_partitions(8)
+            .into_partitions(2)
+            .with_column("y", daft.col("x") * 2)
+            .collect()
+        )
+        out = df.to_pydict()
+        assert sorted(out["x"]) == list(range(rows)), f"lost rows; got {len(out['x'])} expected {rows}"
+        assert sorted(zip(out["x"], out["y"])) == [(i, i * 2) for i in range(rows)], (
+            "fused Project after coalesce produced wrong column values"
+        )
+
+
+@pytest.mark.skipif(
+    get_tests_daft_runner_name() != "ray",
+    reason="distributed IntoPartitions tests require the ray runner",
+)
+def test_into_partitions_equal_split_and_merge_with_fused_downstream(shuffle_ctx):
+    """Fused Project on top of the Equal+`enable_scan_task_split_and_merge=True` path produces correct values.
+
+    Regresses the same partition-ref-leakage bug as the Coalesce variant, but
+    on the Equal+split-merge path. Setup: N→N with split-and-merge forces the
+    Equal path.
+    """
+    rows = 100
+    n = 4
+    with shuffle_ctx(), daft.execution_config_ctx(enable_scan_task_split_and_merge=True):
+        df = (
+            daft.from_pydict({"x": list(range(rows))})
+            .into_partitions(n)
+            .into_partitions(n)  # Equal path — exercises the partition-ref re-read fix.
+            .with_column("y", daft.col("x") * 2)
+            .collect()
+        )
+        out = df.to_pydict()
+        assert sorted(out["x"]) == list(range(rows)), f"lost rows; got {len(out['x'])} expected {rows}"
+        assert sorted(zip(out["x"], out["y"])) == [(i, i * 2) for i in range(rows)], (
+            "fused Project after Equal+split-merge produced wrong column values"
+        )
+
+
+@pytest.mark.skipif(
+    get_tests_daft_runner_name() != "ray",
+    reason="distributed IntoBatches tests require the ray runner",
+)
+def test_into_batches_followed_by_streaming_project(shuffle_ctx):
+    """Fused Project on top of `into_batches` produces correct values.
+
+    Regresses a bug where the rebatch step forwarded materialized partition
+    refs into the fused downstream's morsel stream instead of re-reading them
+    first. `with_column` is used over `filter` because the optimizer can't
+    push a derived column below IntoBatches.
+    """
+    rows = 1000
+    with shuffle_ctx():
+        df = (
+            daft.from_pydict({"x": list(range(rows))})
+            .into_partitions(8)
+            .into_batches(100)
+            .with_column("y", daft.col("x") * 2)
+            .collect()
+        )
+        out = df.to_pydict()
+        assert sorted(out["x"]) == list(range(rows)), f"lost rows; got {len(out['x'])} expected {rows}"
+        # `y` must be derived correctly from the post-batched data.
+        pairs = sorted(zip(out["x"], out["y"]))
+        assert pairs == [(i, i * 2) for i in range(rows)], "project-after-into_batches produced wrong column values"
+
+
+@pytest.mark.skipif(
+    get_tests_daft_runner_name() != "ray",
+    reason="distributed IntoBatches tests require the ray runner",
+)
+def test_into_batches_emits_batch_size_partitions(shuffle_ctx):
+    """Output partition sizes track the requested `batch_size`, not the upstream partition size.
+
+    Regresses a bug where each upstream task was consolidated into a single
+    partition ref before rebatching, so the rebatch step emitted refs sized
+    to the upstream partition (potentially >> `batch_size`).
+    """
+    rows = 1000
+    batch_size = 100
+    input_partitions = 2  # 500 rows per input partition — still > batch_size, exercises the "input partition larger than batch_size" path
+    with shuffle_ctx():
+        df = (
+            daft.from_pydict({"x": list(range(rows))})
+            .into_partitions(input_partitions)
+            .into_batches(batch_size)
+            .collect()
+        )
+        partitions = list(df.iter_partitions())
+        if get_tests_daft_runner_name() == "ray":
+            import ray
+
+            partitions = ray.get(partitions)
+        sizes = [len(p.to_pydict()["x"]) for p in partitions]
+
+        # Total row count must be preserved.
+        assert sum(sizes) == rows, f"lost rows; sizes={sizes}"
+
+        # Every non-tail batch should be approximately `batch_size` rows.
+        # Allow a tolerance for non-strict bucketing at task boundaries.
+        tolerance = batch_size  # allow up to 2× batch_size; anything beyond points at a regression
+        oversized = [s for s in sizes if s > batch_size + tolerance]
+        assert not oversized, (
+            f"expected batches ≤ {batch_size + tolerance} rows; "
+            f"oversized batches: {oversized[:5]} (out of {len(sizes)} total)"
+        )

--- a/tests/dataframe/test_shuffles.py
+++ b/tests/dataframe/test_shuffles.py
@@ -209,10 +209,11 @@ def test_pre_shuffle_merge_randomly_sized_partitions(pre_shuffle_merge_ctx, inpu
 
 @pytest.mark.skipif(
     get_tests_daft_runner_name() != "ray",
-    reason="shuffle tests are meant for the ray runner",
+    reason="distributed shuffle tests require the ray runner",
 )
-def test_random_shuffle_uses_ray_shuffle_path_under_flight_shuffle_config(flight_shuffle_ctx):
-    with flight_shuffle_ctx():
+def test_random_shuffle(shuffle_ctx):
+    """Ensures `df.shuffle(...)` produces a permutation of the input under both backends."""
+    with shuffle_ctx():
         df = daft.from_pydict({"id": list(range(32))}).repartition(4, "id")
         shuffled = df.shuffle(seed=0).to_pydict()["id"]
 


### PR DESCRIPTION
## Summary

  Plumbs `DistributedShuffleBackend` into `RandomShuffleNode` so it picks up the configured shuffle algorithm instead of
  hard-coding Ray. The local `repartition_write` now uses the backend's local variant, and the post-shuffle re-read goes
  through `ShuffleBackend::build_refs_task_builder` — matching the pattern used by
  gather/repartition/into_partitions/into_batches.

  Previously, `random_shuffle` silently fell back to Ray under `flight_shuffle` config; it now uses Flight end-to-end.

  ## Test plan

  - [x] `test_random_shuffle` (replaces the obsolete `test_random_shuffle_uses_ray_shuffle_path_under_flight_shuffle_config`)
  runs under both backends via the `shuffle_ctx` fixture
  - [x] Full `tests/dataframe/test_shuffles.py` suite passes
  - [x] Spot-check broadcast-join tests for regression (no shared code path, but adjacent in the migration plan)

