### PR TITLE
test(udf): cover combined large-stderr + no-newline use_process case

### DIFF
--- a/tests/udf/test_use_process_deadlocks.py
+++ b/tests/udf/test_use_process_deadlocks.py
@@ -55,6 +55,32 @@ def test_stderr_without_trailing_newline_does_not_deadlock_on_divider_merge():
 
 
 @pytest.mark.timeout(30)
+def test_large_stderr_without_trailing_newline_does_not_deadlock():
+    r"""Combines both deadlock pathologies: pipe-buffer fill AND no trailing newline.
+
+    The earlier two tests cover each pathology in isolation:
+    - Large stderr WITH newline (covered by `mp.connection.wait()`-based drain).
+    - Small stderr WITHOUT newline (covered by the prepended-`\\n` divider fix).
+
+    Per a review concern: even with the drain in place, if the child writes
+    >64 KiB without ever emitting a newline, the parent's `readline()`-based
+    scan in `trace_output()` could still block waiting for a delimiter while
+    the child writes are stalled against a full OS pipe buffer.
+    """
+    STDERR_BYTES_PER_ROW = 100_000  # well over any OS pipe buffer (~64 KiB)
+
+    @daft.func(use_process=True)
+    def noisy_no_newline(x: int) -> int:
+        sys.stderr.buffer.write(b"x" * STDERR_BYTES_PER_ROW)
+        sys.stderr.flush()
+        return x + 1
+
+    df = daft.from_pydict({"x": list(range(4))})
+    actual = df.with_column("y", noisy_no_newline(df["x"])).to_pydict()
+    assert actual == {"x": [0, 1, 2, 3], "y": [1, 2, 3, 4]}
+
+
+@pytest.mark.timeout(30)
 def test_silent_udf_produces_no_spurious_stdout_lines(monkeypatch):
     r"""trace_output() must not surface the divider-padding newline as a line.
 


### PR DESCRIPTION
## Summary

Follow-up test to #6793. The two existing tests in `test_use_process_deadlocks.py` cover each deadlock pathology in isolation:

- Large stderr **with** newline → exercises the `mp.connection.wait()`-based drain.
- Small stderr **without** newline → exercises the prepended-`\n` divider fix.

Per @ohbh's review on #6793: even with the drain in place, `readline()` in `trace_output()` could in principle still block on a no-newline buffer while the child is stalled on a full OS pipe. This test combines both pathologies — a UDF that writes >64 KiB to stderr without ever emitting a newline — and confirms the current implementation handles the combined case correctly.

## Test plan

- [x] `DAFT_RUNNER=native pytest tests/udf/test_use_process_deadlocks.py` — all 4 tests pass locally (macOS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)