### PR TITLE
fix: ensure paimon is installed for integration tests

### DIFF
--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -936,6 +936,7 @@ jobs:
         GRAVITINO_METALAKE: metalake_demo
       # Paimon tests: pypaimon is installed separately here because its dependencies conflict with the project's main dependencies
     - name: Install pypaimon
+      if: always()
       run: |
         source .venv/bin/activate
         uv pip install pypaimon==1.3.1

--- a/tests/io/paimon/conftest.py
+++ b/tests/io/paimon/conftest.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 import pyarrow as pa
 import pytest
 
-pypaimon = pytest.importorskip("pypaimon")
+try:
+    import pypaimon
+except ImportError:
+    # Skip all tests in this directory if pypaimon is not installed
+    pytest.skip("pypaimon not installed", allow_module_level=True)
 
 # Apply pypaimon patch for complex types before any writes
 from daft.io.paimon.paimon_write import _patch_pypaimon_stats_for_complex_types


### PR DESCRIPTION
## Changes Made

- Ensure paimon is install for integ tests
- Skip whole package/module if not installed

## Related Issues

I was getting CI failures for paimon not being installed, which was impacting other PRs.
