### PR TITLE
feat(functions): add video_frames_from_bytes for row-level decoding from a binary column

### DIFF
--- a/daft/file/video.py
+++ b/daft/file/video.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from daft.datatype import MediaType
 from daft.dependencies import av, pil_image
@@ -142,81 +142,110 @@ class VideoFile(File):
             raise ValueError("sample_interval_seconds must be positive if provided")
         with self.open() as f:
             with av.open(f) as container:
-                video = next(
-                    (stream for stream in container.streams if stream.type == "video"),
-                    None,
+                yield from _iter_frames_from_container(
+                    container,
+                    start_time=start_time,
+                    end_time=end_time,
+                    width=width,
+                    height=height,
+                    is_key_frame=is_key_frame,
+                    sample_interval_seconds=sample_interval_seconds,
                 )
-                if video is None:
-                    raise ValueError("No video stream found")
 
-                if is_key_frame:
-                    video.codec_context.skip_frame = "NONKEY"
 
-                # Seek to start time
-                if start_time > 0 and video.time_base:
-                    seek_timestamp = int(start_time / float(video.time_base))
-                    container.seek(seek_timestamp, stream=video)
+def _iter_frames_from_container(
+    container: Any,
+    *,
+    start_time: float = 0,
+    end_time: float | None = None,
+    width: int | None = None,
+    height: int | None = None,
+    is_key_frame: bool | None = None,
+    sample_interval_seconds: float | None = None,
+) -> Iterator[VideoFrameData]:
+    """Iterate decoded frames from an opened PyAV container.
 
-                time_base = float(video.time_base) if video.time_base else None
-                fps = float(video.average_rate) if video.average_rate else None
-                if fps is None and video.guessed_rate:
-                    fps = float(video.guessed_rate)
-                start_pts = video.start_time or 0
+    Shared helper for :meth:`VideoFile.frames` and
+    :func:`daft.functions.video_frames_from_bytes`. The caller is responsible
+    for eager input validation (Pillow availability, width/height pairing,
+    positive ``sample_interval_seconds``) so it can fail fast without opening
+    a file or buffer; this function only assumes a usable container.
+    """
+    video = next(
+        (stream for stream in container.streams if stream.type == "video"),
+        None,
+    )
+    if video is None:
+        raise ValueError("No video stream found")
 
-                # Sampling targets are start_time, start_time + interval, ... — same algorithm
-                # as `daft.read_video_frames`. Epsilon absorbs float-precision drift between
-                # the target time and the frame's PTS-derived `frame.time`.
-                next_sample_time: float | None = float(start_time) if sample_interval_seconds is not None else None
-                epsilon: float = 1e-9 if sample_interval_seconds is None else max(1e-9, sample_interval_seconds * 1e-6)
+    if is_key_frame:
+        video.codec_context.skip_frame = "NONKEY"
 
-                frame_index: int = 0
-                for frame in container.decode(video):
-                    # Skip frames before start_time (seek may land earlier)
-                    if frame.time is not None and frame.time < start_time:
-                        frame_index += 1
-                        continue
+    # Seek to start time
+    if start_time > 0 and video.time_base:
+        seek_timestamp = int(start_time / float(video.time_base))
+        container.seek(seek_timestamp, stream=video)
 
-                    # Stop at end_time
-                    if end_time is not None:
-                        if frame.time is not None and frame.time > end_time:
-                            break
+    time_base = float(video.time_base) if video.time_base else None
+    fps = float(video.average_rate) if video.average_rate else None
+    if fps is None and video.guessed_rate:
+        fps = float(video.guessed_rate)
+    start_pts = video.start_time or 0
 
-                    if is_key_frame is False and frame.key_frame:
-                        frame_index += 1
-                        continue
+    # Sampling targets are start_time, start_time + interval, ... — same algorithm
+    # as `daft.read_video_frames`. Epsilon absorbs float-precision drift between
+    # the target time and the frame's PTS-derived `frame.time`.
+    next_sample_time: float | None = float(start_time) if sample_interval_seconds is not None else None
+    epsilon: float = 1e-9 if sample_interval_seconds is None else max(1e-9, sample_interval_seconds * 1e-6)
 
-                    # Time-interval sampling: emit only when the frame has reached the next target.
-                    if sample_interval_seconds is not None:
-                        if frame.time is None:
-                            frame_index += 1
-                            continue
-                        assert next_sample_time is not None
-                        if frame.time + epsilon < next_sample_time:
-                            frame_index += 1
-                            continue
-                        # Advance past every target this frame already covers, so a long gap
-                        # between frames (VFR / large interval) doesn't queue up extra emits.
-                        while next_sample_time is not None and frame.time + epsilon >= next_sample_time:
-                            next_sample_time += sample_interval_seconds
+    frame_index: int = 0
+    for frame in container.decode(video):
+        # Skip frames before start_time (seek may land earlier)
+        if frame.time is not None and frame.time < start_time:
+            frame_index += 1
+            continue
 
-                    # Resize if requested
-                    output_frame = frame
-                    if width is not None and height is not None:
-                        output_frame = frame.reformat(width=width, height=height)
+        # Stop at end_time
+        if end_time is not None:
+            if frame.time is not None and frame.time > end_time:
+                break
 
-                    current_frame_index = frame_index
-                    if frame.pts is not None and time_base is not None and fps is not None:
-                        current_frame_index = int(round((frame.pts - start_pts) * time_base * fps))
+        if is_key_frame is False and frame.key_frame:
+            frame_index += 1
+            continue
 
-                    yield VideoFrameData(
-                        frame_index=current_frame_index,
-                        frame_time=frame.time,
-                        frame_time_base=str(frame.time_base) if frame.time_base else None,
-                        frame_pts=frame.pts,
-                        frame_dts=frame.dts,
-                        frame_duration=frame.duration,
-                        is_key_frame=frame.key_frame,
-                        data=output_frame.to_image(),
-                    )
+        # Time-interval sampling: emit only when the frame has reached the next target.
+        if sample_interval_seconds is not None:
+            if frame.time is None:
+                frame_index += 1
+                continue
+            assert next_sample_time is not None
+            if frame.time + epsilon < next_sample_time:
+                frame_index += 1
+                continue
+            # Advance past every target this frame already covers, so a long gap
+            # between frames (VFR / large interval) doesn't queue up extra emits.
+            while next_sample_time is not None and frame.time + epsilon >= next_sample_time:
+                next_sample_time += sample_interval_seconds
 
-                    frame_index += 1
+        # Resize if requested
+        output_frame = frame
+        if width is not None and height is not None:
+            output_frame = frame.reformat(width=width, height=height)
+
+        current_frame_index = frame_index
+        if frame.pts is not None and time_base is not None and fps is not None:
+            current_frame_index = int(round((frame.pts - start_pts) * time_base * fps))
+
+        yield VideoFrameData(
+            frame_index=current_frame_index,
+            frame_time=frame.time,
+            frame_time_base=str(frame.time_base) if frame.time_base else None,
+            frame_pts=frame.pts,
+            frame_dts=frame.dts,
+            frame_duration=frame.duration,
+            is_key_frame=frame.key_frame,
+            data=output_frame.to_image(),
+        )
+
+        frame_index += 1

--- a/daft/functions/__init__.py
+++ b/daft/functions/__init__.py
@@ -276,7 +276,7 @@ from .str import (
 from .struct import unnest, to_struct
 from .url import download, upload, parse_url
 from .audio import audio_metadata, resample
-from .video import video_metadata, video_keyframes, video_frames
+from .video import video_metadata, video_keyframes, video_frames, video_frames_from_bytes
 from .window import (
     row_number,
     rank,
@@ -572,6 +572,7 @@ __all__ = [
     "var",
     "video_file",
     "video_frames",
+    "video_frames_from_bytes",
     "video_keyframes",
     "video_metadata",
     "week_of_year",

--- a/daft/functions/video.py
+++ b/daft/functions/video.py
@@ -115,22 +115,25 @@ def frames_impl(
     )
 
 
+_VIDEO_FRAMES_RETURN_DTYPE = daft.DataType.list(
+    daft.DataType.struct(
+        {
+            "frame_index": daft.DataType.int64(),
+            "frame_time": daft.DataType.float64(),
+            "frame_time_base": daft.DataType.string(),
+            "frame_pts": daft.DataType.int64(),
+            "frame_dts": daft.DataType.int64(),
+            "frame_duration": daft.DataType.int64(),
+            "is_key_frame": daft.DataType.bool(),
+            "data": daft.DataType.image(),
+        }
+    )
+)
+
+
 video_frames_fn = Func._from_func(
     frames_impl,
-    return_dtype=daft.DataType.list(
-        daft.DataType.struct(
-            {
-                "frame_index": daft.DataType.int64(),
-                "frame_time": daft.DataType.float64(),
-                "frame_time_base": daft.DataType.string(),
-                "frame_pts": daft.DataType.int64(),
-                "frame_dts": daft.DataType.int64(),
-                "frame_duration": daft.DataType.int64(),
-                "is_key_frame": daft.DataType.bool(),
-                "data": daft.DataType.image(),
-            }
-        )
-    ),
+    return_dtype=_VIDEO_FRAMES_RETURN_DTYPE,
     unnest=False,
     use_process=None,
     is_batch=False,
@@ -183,6 +186,123 @@ def video_frames(
     """
     return video_frames_fn(
         file_expr,
+        start_time=start_time,
+        end_time=end_time,
+        width=width,
+        height=height,
+        is_key_frame=is_key_frame,
+        sample_interval_seconds=sample_interval_seconds,
+    )  # type: ignore
+
+
+def frames_from_bytes_impl(
+    video_bytes: bytes | None,
+    *,
+    start_time: float = 0,
+    end_time: float | None = None,
+    width: int | None = None,
+    height: int | None = None,
+    is_key_frame: bool | None = None,
+    sample_interval_seconds: float | None = None,
+) -> list[VideoFrameData]:
+    import io
+
+    import av
+
+    from daft.dependencies import pil_image
+    from daft.file.video import _iter_frames_from_container
+
+    # Null bytes (e.g. from an upstream download UDF that signalled failure
+    # by returning None) are treated as "no frames" rather than an exception
+    # so the surrounding pipeline can branch on the original null column to
+    # decide how to surface the error — typically by populating an
+    # ``extract_error`` column. Raising here would abort the whole batch
+    # before any sibling expressions get to handle the null.
+    if video_bytes is None:
+        return []
+    if not pil_image.module_available():
+        raise ImportError(
+            "The 'pillow' module is required for frame decoding. Install it with `pip install daft[video]`."
+        )
+    if (width is None) != (height is None):
+        raise ValueError("Both width and height must be specified together for resizing.")
+    if sample_interval_seconds is not None and sample_interval_seconds <= 0:
+        raise ValueError("sample_interval_seconds must be positive if provided")
+
+    # PyAV's container.__exit__ does not close the underlying file-like, so we
+    # own the BytesIO lifetime here. Without an explicit close() the raw video
+    # bytes (often hundreds of MB per row) would stay pinned until the next GC
+    # pass — costly inside long-running Ray actor processes.
+    buf = io.BytesIO(video_bytes)
+    try:
+        with av.open(buf) as container:
+            return list(
+                _iter_frames_from_container(
+                    container,
+                    start_time=start_time,
+                    end_time=end_time,
+                    width=width,
+                    height=height,
+                    is_key_frame=is_key_frame,
+                    sample_interval_seconds=sample_interval_seconds,
+                )
+            )
+    finally:
+        buf.close()
+
+
+video_frames_from_bytes_fn = Func._from_func(
+    frames_from_bytes_impl,
+    return_dtype=_VIDEO_FRAMES_RETURN_DTYPE,
+    unnest=False,
+    use_process=None,
+    is_batch=False,
+    batch_size=None,
+    max_retries=None,
+    on_error=None,
+    name_override="video_frames_from_bytes",
+)
+
+
+def video_frames_from_bytes(
+    bytes_expr: Expression,
+    *,
+    start_time: float = 0,
+    end_time: float | None = None,
+    width: int | None = None,
+    height: int | None = None,
+    is_key_frame: bool | None = None,
+    sample_interval_seconds: float | None = None,
+) -> Expression:
+    """Decode video frames directly from a binary column holding the encoded video bytes.
+
+    Companion to :func:`video_frames` for cases where the video data is already in memory
+    (for example, downloaded from a non-URI-addressable storage system inside a UDF) and
+    you do not want to round-trip through a path. Returns the same per-frame schema as
+    :func:`video_frames`.
+
+    Null inputs are mapped to empty frame lists so that an upstream UDF can signal
+    download / fetch failure with ``None`` and let downstream operators (typically a
+    sibling ``when(col.is_null(), ...)`` populating an ``extract_error`` column) handle
+    it without aborting the whole batch.
+
+    Args:
+        bytes_expr (Binary Expression): A column of bytes, each row containing one encoded video.
+        start_time (float, optional): Start of the time range in seconds. Defaults to 0.
+        end_time (float | None, optional): End of the time range in seconds. Defaults to None.
+        width (int | None, optional): Target width for resizing frames. Must be provided with ``height``.
+        height (int | None, optional): Target height for resizing frames. Must be provided with ``width``.
+        is_key_frame (bool | None, optional): If True, decode only keyframes. If False,
+            decode only non-keyframes. If None, decode all frames.
+        sample_interval_seconds (float | None, optional): If provided and > 0, sample frames at
+            approximately this time interval in seconds. Same semantics as :func:`video_frames`.
+
+    Returns:
+        Expression (List[Struct] Expression): List of structs with the same schema as
+        :func:`video_frames`. Empty when the input row is null.
+    """
+    return video_frames_from_bytes_fn(
+        bytes_expr,
         start_time=start_time,
         end_time=end_time,
         width=width,

--- a/docs/modalities/videos.md
+++ b/docs/modalities/videos.md
@@ -285,3 +285,24 @@ df = df.with_column(
     video_frames(daft.col("video"), sample_interval_seconds=1.0),
 )
 ```
+
+#### Decoding from a binary column with `video_frames_from_bytes`
+
+When the encoded video is already in memory (for example, downloaded from a non-URI-addressable storage system inside a UDF) and you don't want to round-trip through a path, you can decode frames row-wise directly from a binary column with `video_frames_from_bytes`. The output schema is identical to `video_frames`.
+
+```python
+import daft
+from pathlib import Path
+from daft.functions import video_frames_from_bytes
+
+df = daft.from_pydict({"video_bytes": [Path("zoo.mp4").read_bytes()]})
+df = df.with_column(
+    "frames",
+    video_frames_from_bytes(
+        daft.col("video_bytes"),
+        sample_interval_seconds=1.0,
+    ),
+)
+
+df.select("frames").show()
+```

--- a/tests/file/test_video.py
+++ b/tests/file/test_video.py
@@ -338,3 +338,83 @@ def test_video_frames_expression_sample_interval(sample_video_path):
 
     result = df.to_pydict()["frames"][0]
     assert len(result) == 10
+
+
+# --- video_frames_from_bytes tests ---
+
+
+def test_video_frames_from_bytes_standalone(sample_video_path):
+    """video_frames_from_bytes() reads bytes column and produces same frames as video_frames()."""
+    from pathlib import Path
+
+    video_bytes = Path(sample_video_path).read_bytes()
+    df = daft.from_pydict({"video_bytes": [video_bytes]})
+    df = df.select(daft.functions.video_frames_from_bytes(df["video_bytes"]).alias("frames"))
+
+    result = df.to_pydict()["frames"][0]
+    assert len(result) == 290
+    first = result[0]
+    assert "frame_index" in first
+    assert "frame_time" in first
+    assert "is_key_frame" in first
+    assert "data" in first
+
+
+def test_video_frames_from_bytes_sample_interval(sample_video_path):
+    """video_frames_from_bytes() respects sample_interval_seconds."""
+    from pathlib import Path
+
+    video_bytes = Path(sample_video_path).read_bytes()
+    df = daft.from_pydict({"video_bytes": [video_bytes]})
+    df = df.select(
+        daft.functions.video_frames_from_bytes(df["video_bytes"], sample_interval_seconds=1.0).alias("frames")
+    )
+
+    result = df.to_pydict()["frames"][0]
+    assert len(result) == 10
+
+
+def test_video_frames_from_bytes_resize(sample_video_path):
+    """video_frames_from_bytes() respects width/height."""
+    from pathlib import Path
+
+    video_bytes = Path(sample_video_path).read_bytes()
+    df = daft.from_pydict({"video_bytes": [video_bytes]})
+    df = df.select(daft.functions.video_frames_from_bytes(df["video_bytes"], width=64, height=48).alias("frames"))
+
+    result = df.to_pydict()["frames"][0]
+    assert len(result) == 290
+    assert result[0]["data"].shape == (48, 64, 3)
+
+
+def test_video_frames_from_bytes_keyframe_filter(sample_video_path):
+    """video_frames_from_bytes() respects is_key_frame=True."""
+    from pathlib import Path
+
+    video_bytes = Path(sample_video_path).read_bytes()
+    df = daft.from_pydict({"video_bytes": [video_bytes]})
+    df = df.select(daft.functions.video_frames_from_bytes(df["video_bytes"], is_key_frame=True).alias("frames"))
+
+    result = df.to_pydict()["frames"][0]
+    assert len(result) == 13
+    assert all(frame["is_key_frame"] for frame in result)
+
+
+def test_video_frames_from_bytes_null_input_returns_empty_list(sample_video_path):
+    """video_frames_from_bytes() returns [] for null rows instead of crashing.
+
+    Lets upstream UDFs signal failure with None (e.g. a download UDF whose
+    blobstore client errored) without aborting the whole batch — the
+    surrounding pipeline can branch on the same null column to populate an
+    ``extract_error`` column.
+    """
+    from pathlib import Path
+
+    video_bytes = Path(sample_video_path).read_bytes()
+    df = daft.from_pydict({"video_bytes": [video_bytes, None]})
+    df = df.select(daft.functions.video_frames_from_bytes(df["video_bytes"]).alias("frames"))
+
+    out = df.to_pydict()["frames"]
+    assert len(out) == 2
+    assert len(out[0]) == 290  # ok row keeps the full frame list
+    assert out[1] == []  # null row yields empty list, no exception


### PR DESCRIPTION

## Changes Made

Adds `daft.functions.video_frames_from_bytes`, a row-level expression that decodes frames straight from a `Binary` column of encoded video bytes. Useful when the encoded video is already in memory (custom downloader UDFs, bytes streaming through other operators) and you don't want to round-trip through a path. Returns the same per-frame `Struct` schema as `video_frames`.

```python
import daft
from pathlib import Path
from daft.functions import video_frames_from_bytes

df = daft.from_pydict({\"video_bytes\": [Path(\"zoo.mp4\").read_bytes()]})
df = df.with_column(
    \"frames\",
    video_frames_from_bytes(daft.col(\"video_bytes\"), sample_interval_seconds=1.0),
)

df.select(\"frames\").show()
```

### Behavior

- **Null input ⇒ empty list.** A null row maps to `[]` rather than raising. This lets a sibling expression branch on the original null column (typically populating an `extract_error` column via `when(col.is_null(), ...)`) without aborting the whole batch when an upstream download UDF signalled failure with `None`.
- **Explicit BytesIO close.** PyAV's `container.__exit__` does not close the underlying file-like; without an explicit `close()` the raw bytes (often hundreds of MB per row) stay pinned until the next GC pass — costly inside long-running Ray actor processes. The implementation wraps the decode in `try`/`finally` to release the buffer immediately.
- **Eager input validation** matches `video_frames`: Pillow availability, width/height pairing, positive `sample_interval_seconds`.
- **Same per-frame schema** as `video_frames` / `daft.read_video_frames`; reusable in any pipeline that already consumes those.

### Refactor

The per-container iteration loop in `VideoFile.frames` is extracted into a module-level `_iter_frames_from_container` helper that both the file path and the new bytes path share — single source of truth for stream selection, seek, sampling, resize, and frame-index computation. The return dtype of the per-frame struct is hoisted into a `_VIDEO_FRAMES_RETURN_DTYPE` module constant for the same reason.

### Files

- `daft/file/video.py` — extract `_iter_frames_from_container`; `VideoFile.frames` becomes a thin wrapper that does eager validation, opens the file, and delegates to the helper.
- `daft/functions/video.py` — add `frames_from_bytes_impl`, `video_frames_from_bytes_fn`, and the public `video_frames_from_bytes` expression. Hoist the return dtype constant.
- `daft/functions/__init__.py` — export `video_frames_from_bytes`.
- `docs/modalities/videos.md` — add a \"Decoding from a binary column\" subsection with a runnable example.
- `tests/file/test_video.py` — 5 new tests (bytes happy path, `sample_interval_seconds` interaction, resize, keyframe filtering, null-input ⇒ empty list).

## Related Issues

Depends on #6832. Happy to file a tracking issue if maintainers consider this non-trivial.