### PR TITLE
feat(checkpoint): track in-flight writes and seal empty manifests

### DIFF
--- a/src/daft-checkpoint/Cargo.toml
+++ b/src/daft-checkpoint/Cargo.toml
@@ -22,6 +22,7 @@ pyo3 = {workspace = true, optional = true}
 serde = {workspace = true}
 serde_json = {workspace = true}
 snafu = {workspace = true}
+tokio = {workspace = true, features = ["rt"]}
 
 [dependencies.daft-io]
 optional = true

--- a/src/daft-checkpoint/src/impls/s3.rs
+++ b/src/daft-checkpoint/src/impls/s3.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::HashMap,
-    sync::{Arc, Mutex},
+    sync::{Arc, Mutex, OnceLock},
     time::SystemTime,
 };
 
@@ -16,6 +16,7 @@ use futures::{
     stream::{self, BoxStream},
 };
 use serde::{Deserialize, Serialize};
+use tokio::task::JoinSet;
 
 use crate::{
     Checkpoint, CheckpointId, CheckpointStatus, CheckpointStore, FileMetadata,
@@ -65,6 +66,13 @@ struct StagedEntry {
     num_key_files: usize,
     num_file_files: usize,
     created_at: SystemTime,
+    /// In-flight PUTs spawned by `stage_keys` / `stage_files`.
+    /// Drained by `checkpoint()`. Aborts on drop (e.g. abandoned checkpoint).
+    pending: JoinSet<CheckpointResult<()>>,
+    /// First background-PUT failure for this checkpoint, as a formatted message.
+    /// Read by `stage_*` and `checkpoint()` to fail fast.
+    /// `Arc` so spawned futures can write to it without re-locking the staged map.
+    first_error: Arc<OnceLock<String>>,
 }
 
 impl StagedEntry {
@@ -73,6 +81,8 @@ impl StagedEntry {
             num_key_files: 0,
             num_file_files: 0,
             created_at: SystemTime::now(),
+            pending: JoinSet::new(),
+            first_error: Arc::new(OnceLock::new()),
         }
     }
 }
@@ -132,7 +142,7 @@ impl S3CheckpointStore {
         format!("{}/*/manifest.json", self.prefix)
     }
 
-    async fn put_bytes(&self, path: &str, data: Vec<u8>) -> CheckpointResult<()> {
+    async fn put_bytes(client: &IOClient, path: &str, data: Vec<u8>) -> CheckpointResult<()> {
         // Local filesystem backend (`file://`) requires parent directories
         // to exist before writing — S3 does not. Use `strip_file_uri_to_path`
         // (rather than a hand-rolled `strip_prefix("file://")`) so the
@@ -146,7 +156,7 @@ impl S3CheckpointStore {
                 message: format!("failed to create directory {}: {e}", parent.display()),
             })?;
         }
-        self.client
+        client
             .single_url_put(path, Bytes::from(data), None)
             .await
             .map_err(|e| CheckpointError::Internal {
@@ -292,7 +302,7 @@ impl S3CheckpointStore {
         let raw = serde_json::to_vec(manifest).map_err(|e| CheckpointError::Internal {
             message: format!("failed to serialize manifest: {e}"),
         })?;
-        self.put_bytes(&path, raw).await
+        Self::put_bytes(&self.client, &path, raw).await
     }
 
     /// Ensures the checkpoint is not yet sealed, then atomically reserves index
@@ -422,6 +432,53 @@ impl S3CheckpointStore {
         )
     }
 
+    /// Returns Err early if a prior background PUT for this id failed,
+    /// so callers fail fast on the next operation rather than waiting for `checkpoint()`.
+    fn check_first_error(&self, id: &CheckpointId) -> CheckpointResult<()> {
+        let staged = self.staged.lock().map_err(|e| CheckpointError::Internal {
+            message: format!("staged lock poisoned: {e}"),
+        })?;
+        if let Some(entry) = staged.get(id)
+            && let Some(msg) = entry.first_error.get()
+        {
+            return Err(CheckpointError::Internal {
+                message: msg.clone(),
+            });
+        }
+        Ok(())
+    }
+
+    /// Spawn a PUT onto the I/O runtime and push the handle into the entry's `pending` JoinSet.
+    /// Failure of the spawned PUT records the message in `first_error` (first one wins).
+    fn spawn_put(&self, id: &CheckpointId, path: String, data: Vec<u8>) -> CheckpointResult<()> {
+        let io_runtime = common_runtime::get_io_runtime(true);
+        let client = Arc::clone(&self.client);
+
+        let mut staged = self.staged.lock().map_err(|e| CheckpointError::Internal {
+            message: format!("staged lock poisoned: {e}"),
+        })?;
+        let entry = staged
+            .get_mut(id)
+            .ok_or_else(|| CheckpointError::Internal {
+                message: format!(
+                    "staged entry for {id} disappeared between reserve_slots and spawn_put"
+                ),
+            })?;
+        let first_error = Arc::clone(&entry.first_error);
+
+        entry.pending.spawn_on(
+            async move {
+                let result = Self::put_bytes(&client, &path, data).await;
+                if let Err(ref e) = result {
+                    let _ = first_error.set(format!("{e}"));
+                }
+                result
+            },
+            io_runtime.runtime.handle(),
+        );
+        Ok(())
+    }
+
     /// Enumerate paths of sealed (checkpointed or committed) key parquet files.
     pub async fn sealed_file_paths(&self) -> CheckpointResult<Vec<String>> {
         let sealed = self.sealed_manifests().await?;
@@ -438,6 +495,7 @@ impl S3CheckpointStore {
 #[async_trait]
 impl CheckpointStore for S3CheckpointStore {
     async fn stage_keys(&self, id: &CheckpointId, keys: Series) -> CheckpointResult<()> {
+        self.check_first_error(id)?;
         let parquet_bytes = super::keys_codec::write_series_as_parquet(&keys)?;
         let idx = self
             .reserve_slots(id, |e| {
@@ -446,7 +504,7 @@ impl CheckpointStore for S3CheckpointStore {
                 i
             })
             .await?;
-        self.put_bytes(&self.key_path(id, idx), parquet_bytes).await
+        self.spawn_put(id, self.key_path(id, idx), parquet_bytes)
     }
 
     async fn stage_files(
@@ -457,6 +515,7 @@ impl CheckpointStore for S3CheckpointStore {
         if files.is_empty() {
             return Ok(());
         }
+        self.check_first_error(id)?;
         let blob = Self::encode_file_metadata(&files)?;
         let idx = self
             .reserve_slots(id, |e| {
@@ -465,30 +524,52 @@ impl CheckpointStore for S3CheckpointStore {
                 i
             })
             .await?;
-        self.put_bytes(&self.file_path(id, idx), blob).await
+        self.spawn_put(id, self.file_path(id, idx), blob)
     }
 
     async fn checkpoint(&self, id: &CheckpointId) -> CheckpointResult<()> {
-        // If staged by this process, reserve_slots already verified no manifest exists —
-        // skip the S3 GET. Otherwise (e.g. post-restart retry), read the manifest.
-        let staged_data = {
-            let staged = self.staged.lock().map_err(|e| CheckpointError::Internal {
+        // Take ownership of the staged entry's `pending` JoinSet (replacing with empty)
+        // and copy its scalar fields. Holding the lock for the swap is fine — the swap
+        // doesn't await, and keeping the entry in the map lets a retry of `checkpoint()`
+        // after a write_manifest failure proceed (drained pending → empty → re-write).
+        let drain = {
+            let mut staged = self.staged.lock().map_err(|e| CheckpointError::Internal {
                 message: format!("staged lock poisoned: {e}"),
             })?;
-            staged
-                .get(id)
-                .map(|e| (e.num_key_files, e.num_file_files, e.created_at))
-        }; // lock released here, before any await
+            staged.get_mut(id).map(|entry| {
+                let pending = std::mem::replace(&mut entry.pending, JoinSet::new());
+                (
+                    entry.num_key_files,
+                    entry.num_file_files,
+                    entry.created_at,
+                    pending,
+                )
+            })
+        };
 
-        let (num_key_files, num_file_files, created_at) = match staged_data {
+        let (num_key_files, num_file_files, created_at, pending) = match drain {
             Some(data) => data,
             None => {
-                return match self.read_manifest(id).await {
-                    Ok(_) => Ok(()),
-                    Err(e) => Err(e),
-                };
+                // No staged entry. Two sub-cases:
+                //   (a) Already sealed in a prior call — idempotent retry. read_manifest succeeds.
+                //   (b) Never staged at all (e.g. 0-row source after anti-join). Write empty manifest.
+                match self.read_manifest(id).await {
+                    Ok(_) => return Ok(()),
+                    Err(CheckpointError::CheckpointNotFound { .. }) => {
+                        (0, 0, SystemTime::now(), JoinSet::new())
+                    }
+                    Err(e) => return Err(e),
+                }
             }
         };
+
+        // Drain all in-flight PUTs; surface the first one that returned `Err`.
+        // `join_all` resumes panics — those are bugs in `put_bytes` and should propagate.
+        // Cancellation can't occur in this flow: the JoinSet was just `mem::replace`d
+        // out of the staged entry and is owned solely by this stack.
+        for r in pending.join_all().await {
+            r?;
+        }
 
         // manifest.json is written last — its presence is the atomic seal.
         let manifest = Manifest {

--- a/src/daft-checkpoint/tests/s3_store.rs
+++ b/src/daft-checkpoint/tests/s3_store.rs
@@ -201,13 +201,6 @@ async fn test_idempotency() {
 async fn test_error_paths() {
     let (_dir, store) = make_store();
 
-    // checkpoint() on an unknown ID
-    let err = store
-        .checkpoint(&CheckpointId::generate(0))
-        .await
-        .unwrap_err();
-    assert!(matches!(err, CheckpointError::CheckpointNotFound { .. }));
-
     // mark_committed() on an unknown ID
     let err = store
         .mark_committed(&[CheckpointId::generate(0)])
@@ -512,4 +505,25 @@ async fn test_sealed_file_paths_lifecycle() {
         .await
         .unwrap();
     assert!(!store.sealed_file_paths().await.unwrap().is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// 15. checkpoint() on empty source seals an empty manifest
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_checkpoint_empty_source_seals_empty_manifest() {
+    let (_dir, store) = make_store();
+    let id = CheckpointId::generate(0);
+
+    // Never call stage_keys / stage_files. Empty-source case: a task processed
+    // 0 rows after the anti-join, so nothing was staged.
+    store.checkpoint(&id).await.unwrap();
+
+    let ckpt = store.get_checkpoint(&id).await.unwrap();
+    assert_eq!(ckpt.status, CheckpointStatus::Checkpointed);
+    assert!(store.sealed_file_paths().await.unwrap().is_empty());
+
+    // Idempotent retry on already-sealed empty checkpoint.
+    store.checkpoint(&id).await.unwrap();
 }

--- a/src/daft-local-execution/src/sinks/blocking_sink.rs
+++ b/src/daft-local-execution/src/sinks/blocking_sink.rs
@@ -395,10 +395,27 @@ impl<Op: BlockingSink + 'static> BlockingSinkNode<Op> {
                     )
                 }
                 PipelineEvent::Flush(input_id) => {
-                    if let Some(p) = inputs.get_mut(&input_id) {
-                        p.flushed = true;
+                    // A Flush can arrive for an input that received zero morsels (e.g.
+                    // an empty source after the checkpoint anti-join). Without a
+                    // PerInputState the flush was silently dropped and finalize never
+                    // ran, leaving the checkpoint unsealed. Create one on demand,
+                    // mirroring the Vacant arm in the partition handler above.
+                    if let Entry::Vacant(e) = inputs.entry(input_id) {
+                        let runtime_stats = Arc::new(Op::Stats::new(&meter, &node_info));
+                        stats_manager.register_runtime_stats(
+                            node_id,
+                            input_id,
+                            runtime_stats.clone(),
+                        );
+                        e.insert(PerInputState::new(
+                            &op,
+                            max_concurrency,
+                            runtime_stats,
+                            input_id,
+                        )?);
                     }
-                    if inputs.get(&input_id).is_some_and(|p| p.ready_to_finalize()) {
+                    inputs.get_mut(&input_id).unwrap().flushed = true;
+                    if inputs[&input_id].ready_to_finalize() {
                         Self::spawn_finalize(
                             op.clone(),
                             inputs.remove(&input_id).unwrap(),

--- a/tests/integration/checkpoint/test_checkpoint_s3.py
+++ b/tests/integration/checkpoint/test_checkpoint_s3.py
@@ -187,10 +187,6 @@ def test_checkpoint_s3_lifecycle(minio_io_config):
         assert count == 0, f"Expected 0 rows after commit + re-run, got {count}"
 
 
-@pytest.mark.xfail(
-    reason="checkpoint() on empty task errors — store needs to track in-flight writes",
-    strict=True,
-)
 def test_checkpoint_s3_empty_source(minio_io_config):
     """Empty source with checkpoint should produce 0 rows without error."""
     with minio_create_bucket(minio_io_config) as bucket:


### PR DESCRIPTION
## Summary
- Make `stage_keys` / `stage_files` **non-blocking** — they spawn the underlying PUT onto the I/O runtime via a per-checkpoint `JoinSet`. `checkpoint(id)` is the sole sync point: it `join_all`s pending PUTs, surfaces the first failure, then writes the manifest. Pipeline no longer blocks on per-row uploads.
- Seal an **empty manifest** (`num_keys=0, num_files=0`) when nothing was staged — fixes the 0-row-source case after the checkpoint anti-join, which previously errored `CheckpointNotFound`.
- Fix `BlockingSinkNode::Flush` to create a `PerInputState` on demand for inputs that received zero morsels, so `spawn_finalize` (and thus checkpoint sealing) actually runs.

`StagedEntry` grows a `pending: JoinSet<...>` (aborts on drop, structured-concurrency parent-child lifetime) and a shared `first_error` atom that lets `stage_*` fail fast on the next call if a prior background PUT failed.

## Notes on prior art
This bug was originally targeted in #6800 by @chenghuichen as a stop-gap that introduced a `register(id)` trait method on `CheckpointStore` to pre-create staged entries before `checkpoint()`. That works but pushes responsibility onto every `checkpoint()` caller. This PR closes the same bug at the internal seam (`checkpoint()` itself accepts an empty staged set), keeping the trait surface clean.

The `BlockingSinkNode::Flush` fix is ported verbatim from #6800 with co-author credit. Supersedes #6800.

## Test plan
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings` passes locally
- [x] `cargo test -p daft-checkpoint --features s3,test-utils` — 15 tests pass, including new `test_checkpoint_empty_source_seals_empty_manifest`
- [x] `xfail` removed from `test_checkpoint_s3_empty_source` (integration; exercises the full empty-source path against minio in CI)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)