### PR TITLE
feat(extensions): add proc macro for making writing extension functio…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,7 +178,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4754a624e5ae42081f464514be454b39711daae0458906dacde5f4c632f33a8"
 dependencies = [
  "arrow-arith",
- "arrow-array",
+ "arrow-array 57.3.0",
  "arrow-buffer 57.3.0",
  "arrow-cast",
  "arrow-csv",
@@ -198,12 +198,28 @@ version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7b3141e0ec5145a22d8694ea8b6d6f69305971c4fa1c1a13ef0195aef2d678b"
 dependencies = [
- "arrow-array",
+ "arrow-array 57.3.0",
  "arrow-buffer 57.3.0",
  "arrow-data 57.3.0",
  "arrow-schema 57.3.0",
  "chrono",
  "num-traits",
+]
+
+[[package]]
+name = "arrow-array"
+version = "56.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8548ca7c070d8db9ce7aa43f37393e4bfcf3f2d3681df278490772fd1673d08d"
+dependencies = [
+ "ahash",
+ "arrow-buffer 56.2.0",
+ "arrow-data 56.2.0",
+ "arrow-schema 56.2.0",
+ "chrono",
+ "half",
+ "hashbrown 0.16.1",
+ "num",
 ]
 
 [[package]]
@@ -218,6 +234,24 @@ dependencies = [
  "arrow-schema 57.3.0",
  "chrono",
  "chrono-tz",
+ "half",
+ "hashbrown 0.16.1",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-array"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "772bd34cacdda8baec9418d80d23d0fb4d50ef0735685bd45158b83dfeb6e62d"
+dependencies = [
+ "ahash",
+ "arrow-buffer 58.1.0",
+ "arrow-data 58.1.0",
+ "arrow-schema 58.1.0",
+ "chrono",
  "half",
  "hashbrown 0.16.1",
  "num-complex",
@@ -266,7 +300,7 @@ version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "646bbb821e86fd57189c10b4fcdaa941deaf4181924917b0daa92735baa6ada5"
 dependencies = [
- "arrow-array",
+ "arrow-array 57.3.0",
  "arrow-buffer 57.3.0",
  "arrow-data 57.3.0",
  "arrow-ord",
@@ -287,7 +321,7 @@ version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da746f4180004e3ce7b83c977daf6394d768332349d3d913998b10a120b790a"
 dependencies = [
- "arrow-array",
+ "arrow-array 57.3.0",
  "arrow-cast",
  "arrow-schema 57.3.0",
  "chrono",
@@ -340,7 +374,7 @@ version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58c5b083668e6230eae3eab2fc4b5fb989974c845d0aa538dde61a4327c78675"
 dependencies = [
- "arrow-array",
+ "arrow-array 57.3.0",
  "arrow-buffer 57.3.0",
  "arrow-cast",
  "arrow-ipc",
@@ -360,7 +394,7 @@ version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abf7df950701ab528bf7c0cf7eeadc0445d03ef5d6ffc151eaae6b38a58feff1"
 dependencies = [
- "arrow-array",
+ "arrow-array 57.3.0",
  "arrow-buffer 57.3.0",
  "arrow-data 57.3.0",
  "arrow-schema 57.3.0",
@@ -374,7 +408,7 @@ version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ff8357658bedc49792b13e2e862b80df908171275f8e6e075c460da5ee4bf86"
 dependencies = [
- "arrow-array",
+ "arrow-array 57.3.0",
  "arrow-buffer 57.3.0",
  "arrow-cast",
  "arrow-data 57.3.0",
@@ -398,7 +432,7 @@ version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d8f1870e03d4cbed632959498bcc84083b5a24bded52905ae1695bd29da45b"
 dependencies = [
- "arrow-array",
+ "arrow-array 57.3.0",
  "arrow-buffer 57.3.0",
  "arrow-data 57.3.0",
  "arrow-schema 57.3.0",
@@ -411,7 +445,7 @@ version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18228633bad92bff92a95746bbeb16e5fc318e8382b75619dec26db79e4de4c0"
 dependencies = [
- "arrow-array",
+ "arrow-array 57.3.0",
  "arrow-buffer 57.3.0",
  "arrow-data 57.3.0",
  "arrow-schema 57.3.0",
@@ -452,7 +486,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68bf3e3efbd1278f770d67e5dc410257300b161b93baedb3aae836144edcaf4b"
 dependencies = [
  "ahash",
- "arrow-array",
+ "arrow-array 57.3.0",
  "arrow-buffer 57.3.0",
  "arrow-data 57.3.0",
  "arrow-schema 57.3.0",
@@ -465,7 +499,7 @@ version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85e968097061b3c0e9fe3079cf2e703e487890700546b5b0647f60fca1b5a8d8"
 dependencies = [
- "arrow-array",
+ "arrow-array 57.3.0",
  "arrow-buffer 57.3.0",
  "arrow-data 57.3.0",
  "arrow-schema 57.3.0",
@@ -2353,7 +2387,7 @@ dependencies = [
 name = "daft-checkpoint"
 version = "0.3.0-dev0"
 dependencies = [
- "arrow-array",
+ "arrow-array 57.3.0",
  "arrow-schema 57.3.0",
  "async-trait",
  "bytes",
@@ -2524,7 +2558,7 @@ dependencies = [
 name = "daft-decoding"
 version = "0.3.0-dev0"
 dependencies = [
- "arrow-array",
+ "arrow-array 57.3.0",
  "arrow-schema 57.3.0",
  "atoi_simd",
  "chrono",
@@ -2613,6 +2647,9 @@ dependencies = [
 name = "daft-ext"
 version = "0.1.1"
 dependencies = [
+ "arrow-array 56.2.0",
+ "arrow-array 57.3.0",
+ "arrow-array 58.1.0",
  "arrow-data 56.2.0",
  "arrow-data 57.3.0",
  "arrow-data 58.1.0",
@@ -2627,7 +2664,7 @@ name = "daft-ext-internal"
 version = "0.3.0-dev0"
 dependencies = [
  "arrow",
- "arrow-array",
+ "arrow-array 57.3.0",
  "arrow-schema 57.3.0",
  "common-error",
  "daft-core",
@@ -2669,7 +2706,7 @@ dependencies = [
 name = "daft-functions"
 version = "0.3.0-dev0"
 dependencies = [
- "arrow-array",
+ "arrow-array 57.3.0",
  "arrow-buffer 57.3.0",
  "common-error",
  "daft-core",
@@ -2748,7 +2785,7 @@ dependencies = [
 name = "daft-functions-temporal"
 version = "0.3.0-dev0"
 dependencies = [
- "arrow-array",
+ "arrow-array 57.3.0",
  "chrono",
  "chrono-tz",
  "common-error",
@@ -2957,7 +2994,7 @@ name = "daft-local-execution"
 version = "0.3.0-dev0"
 dependencies = [
  "arc-swap",
- "arrow-array",
+ "arrow-array 57.3.0",
  "arrow-buffer 57.3.0",
  "arrow-ipc",
  "arrow-schema 57.3.0",
@@ -3025,7 +3062,7 @@ dependencies = [
 name = "daft-local-plan"
 version = "0.3.0-dev0"
 dependencies = [
- "arrow-array",
+ "arrow-array 57.3.0",
  "arrow-schema 57.3.0",
  "bincode",
  "common-checkpoint-config",
@@ -3100,7 +3137,7 @@ dependencies = [
 name = "daft-micropartition"
 version = "0.3.0-dev0"
 dependencies = [
- "arrow-array",
+ "arrow-array 57.3.0",
  "arrow-ipc",
  "bincode",
  "common-error",
@@ -3184,7 +3221,7 @@ name = "daft-recordbatch"
 version = "0.3.0-dev0"
 dependencies = [
  "arrow",
- "arrow-array",
+ "arrow-array 57.3.0",
  "arrow-ipc",
  "async-recursion",
  "comfy-table",
@@ -3333,7 +3370,7 @@ dependencies = [
 name = "daft-sketch"
 version = "0.3.0-dev0"
 dependencies = [
- "arrow-array",
+ "arrow-array 57.3.0",
  "arrow-schema 57.3.0",
  "common-error",
  "serde_arrow",
@@ -3404,7 +3441,7 @@ dependencies = [
 name = "daft-warc"
 version = "0.3.0-dev0"
 dependencies = [
- "arrow-array",
+ "arrow-array 57.3.0",
  "chrono",
  "common-error",
  "common-runtime",
@@ -3427,7 +3464,7 @@ dependencies = [
 name = "daft-writers"
 version = "0.3.0-dev0"
 dependencies = [
- "arrow-array",
+ "arrow-array 57.3.0",
  "arrow-csv",
  "arrow-ipc",
  "arrow-json",
@@ -5307,7 +5344,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5240d6977234968ff9ad254bfa73aa397fb51e41dcb22b1eb85835e9295485b"
 dependencies = [
- "arrow-array",
+ "arrow-array 57.3.0",
  "arrow-buffer 57.3.0",
  "arrow-data 57.3.0",
  "arrow-schema 57.3.0",
@@ -5864,7 +5901,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ee96b29972a257b855ff2341b37e61af5f12d6af1158b6dcdb5b31ea07bb3cb"
 dependencies = [
  "ahash",
- "arrow-array",
+ "arrow-array 57.3.0",
  "arrow-buffer 57.3.0",
  "arrow-cast",
  "arrow-data 57.3.0",
@@ -7198,7 +7235,7 @@ version = "0.13.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "038967a6dda16f5c6ca5b6e1afec9cd2361d39f0db681ca338ac5f0ccece6469"
 dependencies = [
- "arrow-array",
+ "arrow-array 57.3.0",
  "arrow-schema 57.3.0",
  "bytemuck",
  "chrono",

--- a/examples/dvector/Cargo.toml
+++ b/examples/dvector/Cargo.toml
@@ -10,7 +10,7 @@ name = "dvector"
 crate-type = ["cdylib"]
 
 [dependencies]
-daft-ext = {path = "../../src/daft-ext"}
+daft-ext = {path = "../../src/daft-ext", features = ["arrow-57"]}
 arrow-array = {version = "57.1.0", features = ["chrono-tz"]}
 arrow-buffer = "57.1.0"
 arrow-schema = "57.1.0"

--- a/examples/dvector/src/lib.rs
+++ b/examples/dvector/src/lib.rs
@@ -1,14 +1,13 @@
-use std::ffi::CStr;
+use std::sync::Arc;
 
 use arrow_array::ArrayRef;
-use arrow_schema::Field;
+use arrow_schema::DataType;
 use daft_ext::prelude::*;
 
 mod vectors;
 
 use vectors::{
     map_bool_vectors_f64, map_bool_vectors_u32, map_float_vectors, map_float_vectors_nullable,
-    return_field_float, return_field_hamming, return_field_jaccard,
 };
 
 #[daft_extension]
@@ -16,147 +15,81 @@ struct DvectorExtension;
 
 impl DaftExtension for DvectorExtension {
     fn install(session: &mut dyn DaftSession) {
-        session.define_function(Arc::new(L2Distance));
-        session.define_function(Arc::new(InnerProduct));
-        session.define_function(Arc::new(CosineDistance));
-        session.define_function(Arc::new(L1Distance));
-        session.define_function(Arc::new(HammingDistance));
-        session.define_function(Arc::new(JaccardDistance));
+        session.define_function(Arc::new(DvectorL2Distance));
+        session.define_function(Arc::new(DvectorInnerProduct));
+        session.define_function(Arc::new(DvectorCosineDistance));
+        session.define_function(Arc::new(DvectorL1Distance));
+        session.define_function(Arc::new(DvectorHammingDistance));
+        session.define_function(Arc::new(DvectorJaccardDistance));
     }
 }
 
-struct L2Distance;
-
-impl DaftScalarFunction for L2Distance {
-    fn name(&self) -> &CStr {
-        c"dvector_l2_distance"
-    }
-
-    fn return_field(&self, args: &[Field]) -> DaftResult<Field> {
-        return_field_float("dvector_l2_distance", args)
-    }
-
-    fn call(&self, args: &[ArrayRef]) -> DaftResult<ArrayRef> {
-        map_float_vectors(&args[0], &args[1], |a, b| {
-            a.iter()
-                .zip(b)
-                .map(|(x, y)| (x - y).powi(2))
-                .sum::<f64>()
-                .sqrt()
-        })
-    }
+#[daft_func_batch(return_dtype = DataType::Float64)]
+fn dvector_l2_distance(a: ArrayRef, b: ArrayRef) -> DaftResult<ArrayRef> {
+    map_float_vectors(&a, &b, |a, b| {
+        a.iter()
+            .zip(b)
+            .map(|(x, y)| (x - y).powi(2))
+            .sum::<f64>()
+            .sqrt()
+    })
 }
 
-struct InnerProduct;
-
-impl DaftScalarFunction for InnerProduct {
-    fn name(&self) -> &CStr {
-        c"dvector_inner_product"
-    }
-
-    fn return_field(&self, args: &[Field]) -> DaftResult<Field> {
-        return_field_float("dvector_inner_product", args)
-    }
-
-    fn call(&self, args: &[ArrayRef]) -> DaftResult<ArrayRef> {
-        map_float_vectors(&args[0], &args[1], |a, b| {
-            -(a.iter().zip(b).map(|(x, y)| x * y).sum::<f64>())
-        })
-    }
+#[daft_func_batch(return_dtype = DataType::Float64)]
+fn dvector_inner_product(a: ArrayRef, b: ArrayRef) -> DaftResult<ArrayRef> {
+    map_float_vectors(&a, &b, |a, b| {
+        -(a.iter().zip(b).map(|(x, y)| x * y).sum::<f64>())
+    })
 }
 
-struct CosineDistance;
-
-impl DaftScalarFunction for CosineDistance {
-    fn name(&self) -> &CStr {
-        c"dvector_cosine_distance"
-    }
-
-    fn return_field(&self, args: &[Field]) -> DaftResult<Field> {
-        return_field_float("dvector_cosine_distance", args)
-    }
-
-    fn call(&self, args: &[ArrayRef]) -> DaftResult<ArrayRef> {
-        map_float_vectors_nullable(&args[0], &args[1], |a, b| {
-            let (mut dot, mut na, mut nb) = (0.0, 0.0, 0.0);
-            for (x, y) in a.iter().zip(b) {
-                dot += x * y;
-                na += x * x;
-                nb += y * y;
-            }
-            let denom = na.sqrt() * nb.sqrt();
-            if denom == 0.0 {
-                None
-            } else {
-                Some(1.0 - dot / denom)
-            }
-        })
-    }
+#[daft_func_batch(return_dtype = DataType::Float64)]
+fn dvector_cosine_distance(a: ArrayRef, b: ArrayRef) -> DaftResult<ArrayRef> {
+    map_float_vectors_nullable(&a, &b, |a, b| {
+        let (mut dot, mut na, mut nb) = (0.0, 0.0, 0.0);
+        for (x, y) in a.iter().zip(b) {
+            dot += x * y;
+            na += x * x;
+            nb += y * y;
+        }
+        let denom = na.sqrt() * nb.sqrt();
+        if denom == 0.0 {
+            None
+        } else {
+            Some(1.0 - dot / denom)
+        }
+    })
 }
 
-struct L1Distance;
-
-impl DaftScalarFunction for L1Distance {
-    fn name(&self) -> &CStr {
-        c"dvector_l1_distance"
-    }
-
-    fn return_field(&self, args: &[Field]) -> DaftResult<Field> {
-        return_field_float("dvector_l1_distance", args)
-    }
-
-    fn call(&self, args: &[ArrayRef]) -> DaftResult<ArrayRef> {
-        map_float_vectors(&args[0], &args[1], |a, b| {
-            a.iter().zip(b).map(|(x, y)| (x - y).abs()).sum::<f64>()
-        })
-    }
+#[daft_func_batch(return_dtype = DataType::Float64)]
+fn dvector_l1_distance(a: ArrayRef, b: ArrayRef) -> DaftResult<ArrayRef> {
+    map_float_vectors(&a, &b, |a, b| {
+        a.iter().zip(b).map(|(x, y)| (x - y).abs()).sum::<f64>()
+    })
 }
 
-struct HammingDistance;
-
-impl DaftScalarFunction for HammingDistance {
-    fn name(&self) -> &CStr {
-        c"dvector_hamming_distance"
-    }
-
-    fn return_field(&self, args: &[Field]) -> DaftResult<Field> {
-        return_field_hamming("dvector_hamming_distance", args)
-    }
-
-    fn call(&self, args: &[ArrayRef]) -> DaftResult<ArrayRef> {
-        map_bool_vectors_u32(&args[0], &args[1], |a, b| {
-            Some(a.iter().zip(b.iter()).filter(|(x, y)| x != y).count() as u32)
-        })
-    }
+#[daft_func_batch(return_dtype = DataType::UInt32)]
+fn dvector_hamming_distance(a: ArrayRef, b: ArrayRef) -> DaftResult<ArrayRef> {
+    map_bool_vectors_u32(&a, &b, |a, b| {
+        Some(a.iter().zip(b.iter()).filter(|(x, y)| x != y).count() as u32)
+    })
 }
 
-struct JaccardDistance;
-
-impl DaftScalarFunction for JaccardDistance {
-    fn name(&self) -> &CStr {
-        c"dvector_jaccard_distance"
-    }
-
-    fn return_field(&self, args: &[Field]) -> DaftResult<Field> {
-        return_field_jaccard("dvector_jaccard_distance", args)
-    }
-
-    fn call(&self, args: &[ArrayRef]) -> DaftResult<ArrayRef> {
-        map_bool_vectors_f64(&args[0], &args[1], |a, b| {
-            let union_ct = a
-                .iter()
-                .zip(b.iter())
-                .filter(|(x, y)| x.unwrap_or(false) || y.unwrap_or(false))
-                .count();
-            if union_ct == 0 {
-                return None;
-            }
-            let inter_ct = a
-                .iter()
-                .zip(b.iter())
-                .filter(|(x, y)| x.unwrap_or(false) && y.unwrap_or(false))
-                .count();
-            Some(1.0 - inter_ct as f64 / union_ct as f64)
-        })
-    }
+#[daft_func_batch(return_dtype = DataType::Float64)]
+fn dvector_jaccard_distance(a: ArrayRef, b: ArrayRef) -> DaftResult<ArrayRef> {
+    map_bool_vectors_f64(&a, &b, |a, b| {
+        let union_ct = a
+            .iter()
+            .zip(b.iter())
+            .filter(|(x, y)| x.unwrap_or(false) || y.unwrap_or(false))
+            .count();
+        if union_ct == 0 {
+            return None;
+        }
+        let inter_ct = a
+            .iter()
+            .zip(b.iter())
+            .filter(|(x, y)| x.unwrap_or(false) && y.unwrap_or(false))
+            .count();
+        Some(1.0 - inter_ct as f64 / union_ct as f64)
+    })
 }

--- a/examples/dvector/src/vectors.rs
+++ b/examples/dvector/src/vectors.rs
@@ -1,7 +1,3 @@
-/// Arrow vector column abstractions for float and boolean list arrays.
-///
-/// Provides unified views over FixedSizeList, List, and LargeList columns
-/// and map helpers for pairwise distance computations.
 use std::sync::Arc;
 
 use arrow_array::{
@@ -11,82 +7,8 @@ use arrow_array::{
     types::{Float32Type, Float64Type},
 };
 use arrow_buffer::{NullBuffer, OffsetBuffer};
-use arrow_schema::{DataType, Field};
+use arrow_schema::DataType;
 use daft_ext::prelude::{DaftError, DaftResult};
-
-/// Validates that two list-typed args have compatible element types and dimensions.
-pub fn return_field_float(fn_name: &str, args: &[Field]) -> DaftResult<Field> {
-    validate_two_args(fn_name, args)?;
-    let float_types = [DataType::Float32, DataType::Float64];
-    validate_list_element(&args[0], fn_name, &float_types)?;
-    validate_list_element(&args[1], fn_name, &float_types)?;
-    validate_fixed_dims_match(fn_name, &args[0], &args[1])?;
-    Ok(Field::new(fn_name, DataType::Float64, true))
-}
-
-/// Validates boolean list args, returns UInt32 field.
-pub fn return_field_hamming(fn_name: &str, args: &[Field]) -> DaftResult<Field> {
-    validate_two_args(fn_name, args)?;
-    let bool_types = [DataType::Boolean];
-    validate_list_element(&args[0], fn_name, &bool_types)?;
-    validate_list_element(&args[1], fn_name, &bool_types)?;
-    validate_fixed_dims_match(fn_name, &args[0], &args[1])?;
-    Ok(Field::new(fn_name, DataType::UInt32, true))
-}
-
-/// Validates boolean list args, returns Float64 field.
-pub fn return_field_jaccard(fn_name: &str, args: &[Field]) -> DaftResult<Field> {
-    validate_two_args(fn_name, args)?;
-    let bool_types = [DataType::Boolean];
-    validate_list_element(&args[0], fn_name, &bool_types)?;
-    validate_list_element(&args[1], fn_name, &bool_types)?;
-    validate_fixed_dims_match(fn_name, &args[0], &args[1])?;
-    Ok(Field::new(fn_name, DataType::Float64, true))
-}
-
-fn validate_list_element(
-    field: &Field,
-    fn_name: &str,
-    allowed: &[DataType],
-) -> DaftResult<DataType> {
-    match field.data_type() {
-        DataType::FixedSizeList(inner, _) | DataType::List(inner) | DataType::LargeList(inner) => {
-            let elem = inner.data_type().clone();
-            if allowed.contains(&elem) {
-                Ok(elem)
-            } else {
-                Err(DaftError::TypeError(format!(
-                    "{fn_name}: unsupported element type {elem:?}, expected one of {allowed:?}"
-                )))
-            }
-        }
-        other => Err(DaftError::TypeError(format!(
-            "{fn_name}: expected List or FixedSizeList, got {other:?}"
-        ))),
-    }
-}
-
-fn validate_two_args(fn_name: &str, args: &[Field]) -> DaftResult<()> {
-    if args.len() != 2 {
-        return Err(DaftError::TypeError(format!(
-            "{fn_name}: expected 2 arguments, got {}",
-            args.len()
-        )));
-    }
-    Ok(())
-}
-
-fn validate_fixed_dims_match(fn_name: &str, a: &Field, b: &Field) -> DaftResult<()> {
-    if let (DataType::FixedSizeList(_, da), DataType::FixedSizeList(_, db)) =
-        (a.data_type(), b.data_type())
-        && da != db
-    {
-        return Err(DaftError::TypeError(format!(
-            "{fn_name}: dimension mismatch: {da} vs {db}"
-        )));
-    }
-    Ok(())
-}
 
 /// Borrowed or owned f64 slice over float array values.
 enum F64Values<'a> {

--- a/examples/hello/Cargo.toml
+++ b/examples/hello/Cargo.toml
@@ -11,4 +11,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 daft-ext = {path = "../../src/daft-ext", features = ["arrow-58"]}
-arrow = {version = "58", features = ["ffi"]}
+arrow-array = {version = "58", features = ["chrono-tz"]}
+arrow-schema = "58"

--- a/examples/hello/src/lib.rs
+++ b/examples/hello/src/lib.rs
@@ -1,9 +1,7 @@
 use std::{ffi::CStr, sync::Arc};
 
-use arrow::{
-    array::{Array, builder::StringBuilder, cast::AsArray},
-    datatypes::{DataType, Field},
-};
+use arrow_array::{Array, ArrayRef, builder::StringBuilder, cast::AsArray};
+use arrow_schema::{DataType, Field};
 use daft_ext::prelude::*;
 
 // ── Module ──────────────────────────────────────────────────────────
@@ -18,70 +16,20 @@ impl DaftExtension for HelloExtension {
     }
 }
 
-// ── Function ────────────────────────────────────────────────────────
+// ── Scalar Function ────────────────────────────────────────────────
 
-struct Greet;
-
-impl DaftScalarFunction for Greet {
-    fn name(&self) -> &CStr {
-        c"greet"
-    }
-
-    fn return_field(&self, args: &[ArrowSchema]) -> DaftResult<ArrowSchema> {
-        if args.len() != 1 {
-            return Err(DaftError::TypeError(format!(
-                "greet: expected 1 argument, got {}",
-                args.len()
-            )));
+#[daft_func_batch(return_dtype = DataType::Utf8)]
+fn greet(input: ArrayRef) -> DaftResult<ArrayRef> {
+    let names = input.as_string::<i64>();
+    let mut builder = StringBuilder::with_capacity(names.len(), names.len() * 16);
+    for i in 0..names.len() {
+        if names.is_null(i) {
+            builder.append_null();
+        } else {
+            builder.append_value(format!("Hello, {}!", names.value(i)));
         }
-        let field = Field::try_from(&args[0])?;
-        let dt = field.data_type();
-        if *dt != DataType::Utf8 && *dt != DataType::LargeUtf8 {
-            return Err(DaftError::TypeError(format!(
-                "greet: expected string argument, got {:?}",
-                dt
-            )));
-        }
-        Ok(ArrowSchema::try_from(&Field::new(
-            "greet",
-            DataType::Utf8,
-            true,
-        ))?)
     }
-
-    fn call(&self, args: Vec<ArrowData>) -> DaftResult<ArrowData> {
-        // Extract the first (and only) argument from the function call, this is the mutual type.
-        let data = args.into_iter().next().unwrap();
-
-        // Convert the ArrowData input structs to FFI-compatible Arrow array and schema so we can get it into the arrow-rs library.
-        let ffi_array: arrow::ffi::FFI_ArrowArray = data.array.into();
-        let ffi_schema: arrow::ffi::FFI_ArrowSchema = data.schema.into();
-
-        // Now make it into an arrow-rs string array.
-        let arrow_data = unsafe { arrow::ffi::from_ffi(ffi_array, &ffi_schema) }?;
-        let input = arrow::array::make_array(arrow_data);
-        let names = input.as_string::<i64>();
-
-        // Actually do the computation: build a result array of "Hello, <name>!" strings.
-        let mut builder = StringBuilder::with_capacity(names.len(), names.len() * 16);
-        for i in 0..names.len() {
-            if names.is_null(i) {
-                builder.append_null();
-            } else {
-                builder.append_value(format!("Hello, {}!", names.value(i)));
-            }
-        }
-        let output = builder.finish();
-
-        // Convert the result array back to FFI-compatible objects required by Daft.
-        let (out_arr, out_sch) = arrow::ffi::to_ffi(&output.to_data())?;
-
-        // Wrap as Daft's ArrowData for integration with Python and Daft machinery.
-        Ok(ArrowData {
-            array: out_arr.into(),
-            schema: out_sch.into(),
-        })
-    }
+    Ok(Arc::new(builder.finish()))
 }
 
 // ── Aggregate Function ─────────────────────────────────────────────
@@ -100,15 +48,11 @@ impl DaftAggregateFunction for StringCount {
                 args.len()
             )));
         }
-        Ok(ArrowSchema::try_from(&Field::new(
-            "string_count",
-            DataType::Int64,
-            false,
-        ))?)
+        export_field(&Field::new("string_count", DataType::Int64, false))
     }
 
     fn state_fields(&self, _args: &[ArrowSchema]) -> DaftResult<Vec<ArrowSchema>> {
-        Ok(vec![ArrowSchema::try_from(&Field::new(
+        Ok(vec![export_field(&Field::new(
             "count",
             DataType::Int64,
             false,
@@ -116,31 +60,17 @@ impl DaftAggregateFunction for StringCount {
     }
 
     fn aggregate(&self, inputs: Vec<ArrowData>) -> DaftResult<Vec<ArrowData>> {
-        let data = inputs.into_iter().next().unwrap();
-        let ffi_array: arrow::ffi::FFI_ArrowArray = data.array.into();
-        let ffi_schema: arrow::ffi::FFI_ArrowSchema = data.schema.into();
-        let arrow_data = unsafe { arrow::ffi::from_ffi(ffi_array, &ffi_schema) }?;
-        let input = arrow::array::make_array(arrow_data);
-
+        let input = import_array(inputs.into_iter().next().unwrap())?;
         let non_null_count = input.len() - input.null_count();
-        let count_array = arrow::array::Int64Array::from(vec![non_null_count as i64]);
-
-        let (out_arr, out_sch) = arrow::ffi::to_ffi(&count_array.to_data())?;
-        Ok(vec![ArrowData {
-            array: out_arr.into(),
-            schema: out_sch.into(),
-        }])
+        let result: ArrayRef = Arc::new(arrow_array::Int64Array::from(vec![non_null_count as i64]));
+        Ok(vec![export_array(result, "count")?])
     }
 
     fn combine(&self, states: Vec<ArrowData>) -> DaftResult<Vec<ArrowData>> {
-        let data = states.into_iter().next().unwrap();
-        let ffi_array: arrow::ffi::FFI_ArrowArray = data.array.into();
-        let ffi_schema: arrow::ffi::FFI_ArrowSchema = data.schema.into();
-        let arrow_data = unsafe { arrow::ffi::from_ffi(ffi_array, &ffi_schema) }?;
-        let counts = arrow::array::make_array(arrow_data);
+        let counts = import_array(states.into_iter().next().unwrap())?;
         let counts = counts
             .as_any()
-            .downcast_ref::<arrow::array::Int64Array>()
+            .downcast_ref::<arrow_array::Int64Array>()
             .unwrap();
 
         let total: i64 = (0..counts.len())
@@ -148,31 +78,19 @@ impl DaftAggregateFunction for StringCount {
             .map(|i| counts.value(i))
             .sum();
 
-        let result = arrow::array::Int64Array::from(vec![total]);
-        let (out_arr, out_sch) = arrow::ffi::to_ffi(&result.to_data())?;
-        Ok(vec![ArrowData {
-            array: out_arr.into(),
-            schema: out_sch.into(),
-        }])
+        let result: ArrayRef = Arc::new(arrow_array::Int64Array::from(vec![total]));
+        Ok(vec![export_array(result, "count")?])
     }
 
     fn finalize(&self, states: Vec<ArrowData>) -> DaftResult<ArrowData> {
-        let data = states.into_iter().next().unwrap();
-        let ffi_array: arrow::ffi::FFI_ArrowArray = data.array.into();
-        let ffi_schema: arrow::ffi::FFI_ArrowSchema = data.schema.into();
-        let arrow_data = unsafe { arrow::ffi::from_ffi(ffi_array, &ffi_schema) }?;
-        let counts = arrow::array::make_array(arrow_data);
+        let counts = import_array(states.into_iter().next().unwrap())?;
         let counts = counts
             .as_any()
-            .downcast_ref::<arrow::array::Int64Array>()
+            .downcast_ref::<arrow_array::Int64Array>()
             .unwrap();
 
         let total: i64 = counts.value(0);
-        let result = arrow::array::Int64Array::from(vec![total]);
-        let (out_arr, out_sch) = arrow::ffi::to_ffi(&result.to_data())?;
-        Ok(ArrowData {
-            array: out_arr.into(),
-            schema: out_sch.into(),
-        })
+        let result: ArrayRef = Arc::new(arrow_array::Int64Array::from(vec![total]));
+        export_array(result, "string_count")
     }
 }

--- a/src/daft-ext-macros/Cargo.toml
+++ b/src/daft-ext-macros/Cargo.toml
@@ -15,4 +15,4 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = "2.0"
+syn = {version = "2.0", features = ["full", "extra-traits"]}

--- a/src/daft-ext-macros/src/lib.rs
+++ b/src/daft-ext-macros/src/lib.rs
@@ -1,7 +1,7 @@
 use proc_macro::TokenStream;
 use proc_macro2::Literal;
-use quote::quote;
-use syn::{DeriveInput, parse_macro_input};
+use quote::{format_ident, quote};
+use syn::{ItemFn, parse_macro_input};
 
 /// Generates the `daft_module_magic` entry point for a Daft extension module.
 ///
@@ -25,11 +25,11 @@ use syn::{DeriveInput, parse_macro_input};
 /// ```
 #[proc_macro_attribute]
 pub fn daft_extension(_attr: TokenStream, item: TokenStream) -> TokenStream {
-    let input = parse_macro_input!(item as DeriveInput);
+    let input = parse_macro_input!(item as syn::DeriveInput);
     let ident = &input.ident;
     let name = pascal_to_snake(&ident.to_string());
     let mut name_bytes = name.into_bytes();
-    name_bytes.push(0); // null terminator
+    name_bytes.push(0);
     let name_lit = Literal::byte_string(&name_bytes);
 
     let output = quote! {
@@ -48,7 +48,6 @@ pub fn daft_extension(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
             ::daft_ext::abi::FFI_Module {
                 daft_abi_version: ::daft_ext::abi::DAFT_ABI_VERSION,
-                // SAFETY: literal is null-terminated and valid UTF-8.
                 name: unsafe {
                     ::std::ffi::CStr::from_bytes_with_nul_unchecked(#name_lit)
                 }.as_ptr(),
@@ -59,6 +58,165 @@ pub fn daft_extension(_attr: TokenStream, item: TokenStream) -> TokenStream {
     };
 
     output.into()
+}
+
+/// Generates a [`DaftScalarFunction`] implementation for a batch-level function.
+///
+/// The annotated function receives arrow-rs `ArrayRef` arguments and returns
+/// `DaftResult<ArrayRef>`. The macro generates a PascalCase struct that
+/// implements `DaftScalarFunction`, handling all FFI conversion automatically.
+///
+/// # Attributes
+///
+/// - `return_dtype = <expr>` — the arrow `DataType` of the output column (required)
+///
+/// # Example
+///
+/// ```ignore
+/// use std::sync::Arc;
+/// use daft_ext::prelude::*;
+/// use arrow_array::{ArrayRef, Float64Array, cast::AsArray, types::Float64Type};
+/// use arrow_schema::DataType;
+///
+/// #[daft_func_batch(return_dtype = DataType::Float64)]
+/// fn add_one(input: ArrayRef) -> DaftResult<ArrayRef> {
+///     let arr = input.as_primitive::<Float64Type>();
+///     let result: ArrayRef = Arc::new(
+///         arr.iter()
+///             .map(|v| v.map(|x| x + 1.0))
+///             .collect::<Float64Array>(),
+///     );
+///     Ok(result)
+/// }
+///
+/// // Generates struct `AddOne` implementing `DaftScalarFunction`.
+/// // Register with: session.define_function(Arc::new(AddOne));
+/// ```
+#[proc_macro_attribute]
+pub fn daft_func_batch(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let func = parse_macro_input!(item as ItemFn);
+    let attr_args = parse_macro_input!(attr as DaftFuncBatchArgs);
+
+    match daft_func_batch_impl(func, attr_args) {
+        Ok(tokens) => tokens.into(),
+        Err(err) => err.to_compile_error().into(),
+    }
+}
+
+struct DaftFuncBatchArgs {
+    return_dtype: syn::Expr,
+}
+
+impl syn::parse::Parse for DaftFuncBatchArgs {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let mut return_dtype = None;
+
+        while !input.is_empty() {
+            let ident: syn::Ident = input.parse()?;
+            let _eq: syn::Token![=] = input.parse()?;
+
+            if ident == "return_dtype" {
+                return_dtype = Some(input.parse::<syn::Expr>()?);
+            } else {
+                return Err(syn::Error::new(
+                    ident.span(),
+                    format!("unknown attribute `{ident}`"),
+                ));
+            }
+
+            if !input.is_empty() {
+                let _comma: syn::Token![,] = input.parse()?;
+            }
+        }
+
+        let return_dtype = return_dtype.ok_or_else(|| {
+            syn::Error::new(
+                proc_macro2::Span::call_site(),
+                "missing `return_dtype` attribute",
+            )
+        })?;
+
+        Ok(DaftFuncBatchArgs { return_dtype })
+    }
+}
+
+fn daft_func_batch_impl(
+    func: ItemFn,
+    args: DaftFuncBatchArgs,
+) -> syn::Result<proc_macro2::TokenStream> {
+    let fn_name = &func.sig.ident;
+    let struct_name = format_ident!("{}", snake_to_pascal(&fn_name.to_string()));
+    let return_dtype = &args.return_dtype;
+
+    let fn_name_str = fn_name.to_string();
+    let mut name_bytes = fn_name_str.clone().into_bytes();
+    name_bytes.push(0);
+    let name_lit = Literal::byte_string(&name_bytes);
+
+    let param_count = func.sig.inputs.len();
+
+    // Generate parameter bindings: let __arg0 = arrays[0].clone(); ...
+    // and the call arguments: __arg0, __arg1, ...
+    let param_bindings: Vec<_> = (0..param_count)
+        .map(|i| {
+            let var = format_ident!("__arg{}", i);
+            quote! { let #var = arrays[#i].clone(); }
+        })
+        .collect();
+
+    let call_args: Vec<_> = (0..param_count)
+        .map(|i| {
+            let var = format_ident!("__arg{}", i);
+            quote! { #var }
+        })
+        .collect();
+
+    Ok(quote! {
+        #func
+
+        pub struct #struct_name;
+
+        impl ::daft_ext::prelude::DaftScalarFunction for #struct_name {
+            fn name(&self) -> &::std::ffi::CStr {
+                unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(#name_lit) }
+            }
+
+            fn return_field(
+                &self,
+                args: &[::daft_ext::abi::ArrowSchema],
+            ) -> ::daft_ext::prelude::DaftResult<::daft_ext::abi::ArrowSchema> {
+                if args.len() != #param_count {
+                    return Err(::daft_ext::prelude::DaftError::TypeError(
+                        format!(
+                            "{}: expected {} argument(s), got {}",
+                            #fn_name_str, #param_count, args.len()
+                        ),
+                    ));
+                }
+                let first_field = ::daft_ext::prelude::import_field(&args[0])?;
+                let field = ::daft_ext::helpers::new_field(
+                    first_field.name(),
+                    #return_dtype,
+                );
+                ::daft_ext::prelude::export_field(&field)
+            }
+
+            fn call(
+                &self,
+                args: Vec<::daft_ext::abi::ArrowData>,
+            ) -> ::daft_ext::prelude::DaftResult<::daft_ext::abi::ArrowData> {
+                let arrays: Vec<_> = args
+                    .into_iter()
+                    .map(::daft_ext::prelude::import_array)
+                    .collect::<::daft_ext::prelude::DaftResult<_>>()?;
+
+                #(#param_bindings)*
+                let result = #fn_name(#(#call_args),*)?;
+
+                ::daft_ext::prelude::export_array(result, #fn_name_str)
+            }
+        }
+    })
 }
 
 /// Convert a PascalCase identifier to snake_case.
@@ -75,4 +233,21 @@ fn pascal_to_snake(s: &str) -> String {
         }
     }
     out
+}
+
+/// Convert a snake_case identifier to PascalCase.
+fn snake_to_pascal(s: &str) -> String {
+    s.split('_')
+        .map(|word| {
+            let mut chars = word.chars();
+            match chars.next() {
+                Some(c) => {
+                    let mut out = c.to_uppercase().to_string();
+                    out.extend(chars);
+                    out
+                }
+                None => String::new(),
+            }
+        })
+        .collect()
 }

--- a/src/daft-ext-macros/src/lib.rs
+++ b/src/daft-ext-macros/src/lib.rs
@@ -193,9 +193,15 @@ fn daft_func_batch_impl(
                         ),
                     ));
                 }
-                let first_field = ::daft_ext::prelude::import_field(&args[0])?;
+                let name = if args.is_empty() {
+                    #fn_name_str.to_string()
+                } else {
+                    ::daft_ext::prelude::import_field(&args[0])?
+                        .name()
+                        .clone()
+                };
                 let field = ::daft_ext::helpers::new_field(
-                    first_field.name(),
+                    &name,
                     #return_dtype,
                 );
                 ::daft_ext::prelude::export_field(&field)
@@ -205,6 +211,14 @@ fn daft_func_batch_impl(
                 &self,
                 args: Vec<::daft_ext::abi::ArrowData>,
             ) -> ::daft_ext::prelude::DaftResult<::daft_ext::abi::ArrowData> {
+                if args.len() != #param_count {
+                    return Err(::daft_ext::prelude::DaftError::TypeError(
+                        format!(
+                            "{}: expected {} argument(s) in call, got {}",
+                            #fn_name_str, #param_count, args.len()
+                        ),
+                    ));
+                }
                 let arrays: Vec<_> = args
                     .into_iter()
                     .map(::daft_ext::prelude::import_array)

--- a/src/daft-ext/Cargo.toml
+++ b/src/daft-ext/Cargo.toml
@@ -16,23 +16,29 @@ ignored = [
   "arrow-data-58",
   "arrow-schema-56",
   "arrow-schema-57",
-  "arrow-schema-58"
+  "arrow-schema-58",
+  "arrow-array-56",
+  "arrow-array-57",
+  "arrow-array-58"
 ]
 
 [features]
-arrow-56 = ["dep:arrow-schema-56", "dep:arrow-data-56"]
-arrow-57 = ["dep:arrow-schema-57", "dep:arrow-data-57"]
-arrow-58 = ["dep:arrow-schema-58", "dep:arrow-data-58"]
+arrow-56 = ["dep:arrow-schema-56", "dep:arrow-data-56", "dep:arrow-array-56"]
+arrow-57 = ["dep:arrow-schema-57", "dep:arrow-data-57", "dep:arrow-array-57"]
+arrow-58 = ["dep:arrow-schema-58", "dep:arrow-data-58", "dep:arrow-array-58"]
 
 [dependencies]
 daft-ext-macros = {path = "../daft-ext-macros", version = "0.1.1"}
 # Arrow C Data Interface compatibility (optional, feature-gated)
 arrow-schema-56 = {package = "arrow-schema", version = "56", features = ["ffi"], optional = true}
 arrow-data-56 = {package = "arrow-data", version = "56", features = ["ffi"], optional = true}
+arrow-array-56 = {package = "arrow-array", version = "56", features = ["ffi"], optional = true}
 arrow-schema-57 = {package = "arrow-schema", version = "57", features = ["ffi"], optional = true}
 arrow-data-57 = {package = "arrow-data", version = "57", features = ["ffi"], optional = true}
+arrow-array-57 = {package = "arrow-array", version = "57", features = ["ffi"], optional = true}
 arrow-schema-58 = {package = "arrow-schema", version = "58", features = ["ffi"], optional = true}
 arrow-data-58 = {package = "arrow-data", version = "58", features = ["ffi"], optional = true}
+arrow-array-58 = {package = "arrow-array", version = "58", features = ["ffi"], optional = true}
 
 [lints]
 workspace = true

--- a/src/daft-ext/src/helpers.rs
+++ b/src/daft-ext/src/helpers.rs
@@ -1,0 +1,79 @@
+//! Convenience helpers for converting between `daft-ext` FFI types and arrow-rs types.
+//!
+//! Requires one of the `arrow-56`, `arrow-57`, or `arrow-58` feature flags.
+
+#[allow(unused_macros)]
+macro_rules! impl_helpers {
+    ($arrow_schema_crate:ident, $arrow_data_crate:ident, $arrow_array_crate:ident) => {
+        use $arrow_array_crate::ArrayRef;
+        use $arrow_schema_crate::Field;
+
+        use crate::{
+            abi::{ArrowArray, ArrowData, ArrowSchema},
+            error::{DaftError, DaftResult},
+        };
+
+        /// Convert an [`ArrowData`] (FFI) into an arrow-rs [`ArrayRef`].
+        pub fn import_array(data: ArrowData) -> DaftResult<ArrayRef> {
+            let ffi_array: $arrow_array_crate::ffi::FFI_ArrowArray =
+                unsafe { data.array.into_owned() };
+            let ffi_schema: $arrow_array_crate::ffi::FFI_ArrowSchema =
+                unsafe { data.schema.into_owned() };
+            let arrow_data = unsafe { $arrow_array_crate::ffi::from_ffi(ffi_array, &ffi_schema) }
+                .map_err(|e| {
+                DaftError::RuntimeError(format!("Arrow FFI import failed: {e}"))
+            })?;
+            Ok($arrow_array_crate::make_array(arrow_data))
+        }
+
+        /// Convert an arrow-rs [`ArrayRef`] into an [`ArrowData`] (FFI) with the given field name.
+        pub fn export_array(array: ArrayRef, field_name: &str) -> DaftResult<ArrowData> {
+            let field = Field::new(field_name, array.data_type().clone(), true);
+            let ffi_schema = $arrow_array_crate::ffi::FFI_ArrowSchema::try_from(&field)
+                .map_err(|e| DaftError::RuntimeError(format!("schema export failed: {e}")))?;
+            let mut arrow_data = array.to_data();
+            arrow_data.align_buffers();
+            let ffi_array = $arrow_array_crate::ffi::FFI_ArrowArray::new(&arrow_data);
+            Ok(ArrowData {
+                schema: unsafe { ArrowSchema::from_owned(ffi_schema) },
+                array: unsafe { ArrowArray::from_owned(ffi_array) },
+            })
+        }
+
+        /// Convert an [`ArrowSchema`] (FFI) into an arrow-rs [`Field`].
+        pub fn import_field(schema: &ArrowSchema) -> DaftResult<Field> {
+            let ffi: &$arrow_array_crate::ffi::FFI_ArrowSchema = unsafe { schema.as_raw() };
+            Field::try_from(ffi)
+                .map_err(|e| DaftError::RuntimeError(format!("schema import failed: {e}")))
+        }
+
+        /// Convert an arrow-rs [`Field`] into an [`ArrowSchema`] (FFI).
+        pub fn export_field(field: &Field) -> DaftResult<ArrowSchema> {
+            let ffi = $arrow_array_crate::ffi::FFI_ArrowSchema::try_from(field)
+                .map_err(|e| DaftError::RuntimeError(format!("schema export failed: {e}")))?;
+            Ok(unsafe { ArrowSchema::from_owned(ffi) })
+        }
+
+        /// Create an arrow-rs [`Field`] with the given name and [`DataType`](arrow DataType).
+        ///
+        /// Used by generated macro code to avoid re-exporting arrow crates.
+        pub fn new_field(name: &str, dtype: $arrow_schema_crate::DataType) -> Field {
+            Field::new(name, dtype, true)
+        }
+    };
+}
+
+// When multiple arrow features are enabled (e.g. --all-features), pick exactly one.
+// Prefer the highest version.
+#[cfg(feature = "arrow-58")]
+impl_helpers!(arrow_schema_58, arrow_data_58, arrow_array_58);
+
+#[cfg(all(feature = "arrow-57", not(feature = "arrow-58")))]
+impl_helpers!(arrow_schema_57, arrow_data_57, arrow_array_57);
+
+#[cfg(all(
+    feature = "arrow-56",
+    not(feature = "arrow-57"),
+    not(feature = "arrow-58")
+))]
+impl_helpers!(arrow_schema_56, arrow_data_56, arrow_array_56);

--- a/src/daft-ext/src/lib.rs
+++ b/src/daft-ext/src/lib.rs
@@ -7,4 +7,6 @@ pub mod session;
 
 mod ffi;
 
+#[cfg(any(feature = "arrow-56", feature = "arrow-57", feature = "arrow-58"))]
+pub mod helpers;
 pub use daft_ext_macros::*;

--- a/src/daft-ext/src/prelude.rs
+++ b/src/daft-ext/src/prelude.rs
@@ -1,5 +1,7 @@
-pub use daft_ext_macros::daft_extension;
+pub use daft_ext_macros::{daft_extension, daft_func_batch};
 
+#[cfg(any(feature = "arrow-56", feature = "arrow-57", feature = "arrow-58"))]
+pub use crate::helpers::{export_array, export_field, import_array, import_field};
 pub use crate::{
     abi::{ArrowArray, ArrowArrayStream, ArrowData, ArrowSchema, ffi::strings::free_string},
     aggregate::{DaftAggregateFunction, DaftAggregateFunctionRef},


### PR DESCRIPTION
…ns easier

## Changes Made

creates new `#[daft_func_batch]` for daft-ext that attempts to mirror our python ergonomics of `daft.func.batch`, and uses a proc_macro to expand that to the correct trait impl. 

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
