### PR TITLE
feat(native): emit TaskStart events from native executor

### DIFF
--- a/src/daft-context/src/subscribers/dashboard.rs
+++ b/src/daft-context/src/subscribers/dashboard.rs
@@ -556,6 +556,8 @@ impl Subscriber for DashboardSubscriber {
             Event::TaskEnd(e) => {
                 self.on_task_end(&e)?;
             }
+            // TODO: hook up with dashboard server
+            Event::TaskStart(_) => {}
         }
         Ok(())
     }

--- a/src/daft-context/src/subscribers/debug.rs
+++ b/src/daft-context/src/subscribers/debug.rs
@@ -6,7 +6,7 @@ use crate::subscribers::{
     events::{
         ExecEndEvent, ExecStartEvent, OperatorEndEvent, OperatorStartEvent,
         OptimizationCompleteEvent, OptimizationStartEvent, ProcessStatsEvent, QueryEndEvent,
-        QueryStartEvent, StatsEvent, TaskEndEvent, TaskSubmitEvent,
+        QueryStartEvent, ResultOutEvent, StatsEvent, TaskEndEvent, TaskStartEvent, TaskSubmitEvent,
     },
 };
 
@@ -162,6 +162,21 @@ impl DebugSubscriber {
         Ok(())
     }
 
+    fn handle_task_start(&self, event: &TaskStartEvent) -> DaftResult<()> {
+        if let Some(worker_id) = &event.worker_id {
+            eprintln!(
+                "task_start query_id={} task_id={} worker_id={} node_ids={:?}",
+                event.header.query_id, event.task.id, worker_id, event.task.node_ids
+            );
+        } else {
+            eprintln!(
+                "task_start query_id={} task_id={} node_ids={:?}",
+                event.header.query_id, event.task.id, event.task.node_ids
+            );
+        }
+        Ok(())
+    }
+
     fn handle_task_end(&self, event: &TaskEndEvent) -> DaftResult<()> {
         let rendered_stats = event
             .stats
@@ -221,6 +236,7 @@ impl Subscriber for DebugSubscriber {
             Event::Stats(e) => self.handle_stats(&e)?,
             Event::ProcessStats(e) => self.handle_process_stats(&e)?,
             Event::TaskSubmit(e) => self.handle_task_submit(&e)?,
+            Event::TaskStart(e) => self.handle_task_start(&e)?,
             Event::TaskEnd(e) => self.handle_task_end(&e)?,
         }
         Ok(())

--- a/src/daft-context/src/subscribers/debug.rs
+++ b/src/daft-context/src/subscribers/debug.rs
@@ -6,7 +6,7 @@ use crate::subscribers::{
     events::{
         ExecEndEvent, ExecStartEvent, OperatorEndEvent, OperatorStartEvent,
         OptimizationCompleteEvent, OptimizationStartEvent, ProcessStatsEvent, QueryEndEvent,
-        QueryStartEvent, ResultOutEvent, StatsEvent, TaskEndEvent, TaskStartEvent, TaskSubmitEvent,
+        QueryStartEvent, StatsEvent, TaskEndEvent, TaskStartEvent, TaskSubmitEvent,
     },
 };
 

--- a/src/daft-context/src/subscribers/events.rs
+++ b/src/daft-context/src/subscribers/events.rs
@@ -17,6 +17,7 @@ pub enum Event {
     ExecStart(ExecStartEvent),
     ExecEnd(ExecEndEvent),
     TaskSubmit(TaskSubmitEvent),
+    TaskStart(TaskStartEvent),
     TaskEnd(TaskEndEvent),
     OperatorStart(OperatorStartEvent),
     OperatorEnd(OperatorEndEvent),
@@ -157,6 +158,13 @@ pub struct TaskSubmitEvent {
     pub header: EventHeader,
     pub task: Arc<TaskInfo>,
     pub sources: Arc<Vec<TaskSource>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct TaskStartEvent {
+    pub header: EventHeader,
+    pub task: Arc<TaskInfo>,
+    pub worker_id: Option<Arc<str>>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/daft-context/src/subscribers/python.rs
+++ b/src/daft-context/src/subscribers/python.rs
@@ -176,6 +176,7 @@ fn build_py_event(py: Python<'_>, event: Event) -> PyResult<Option<Py<PyAny>>> {
         Event::Stats(event) => build_stats(py, &event).map(Some),
         Event::ProcessStats(event) => build_process_stats(py, &event).map(Some),
         Event::TaskSubmit(_event) => Ok(None),
+        Event::TaskStart(_event) => Ok(None),
         Event::TaskEnd(_event) => Ok(None),
     }
 }

--- a/src/daft-local-execution/src/run.rs
+++ b/src/daft-local-execution/src/run.rs
@@ -10,7 +10,13 @@ use common_error::DaftResult;
 use common_metrics::{QueryEndState, QueryID};
 use common_runtime::RuntimeTask;
 use common_tracing::flush_opentelemetry_providers;
-use daft_context::{DaftContext, Subscriber};
+use daft_context::{
+    DaftContext, Subscriber,
+    subscribers::{
+        Event, event_header,
+        events::{TaskInfo, TaskStartEvent},
+    },
+};
 use daft_local_plan::{ExecutionStats, Input, InputId, LocalPhysicalPlanRef, SourceId, translate};
 use daft_logical_plan::LogicalPlanBuilder;
 use daft_micropartition::MicroPartition;
@@ -276,7 +282,7 @@ impl PyNativeExecutor {
     }
 }
 
-fn parse_context(ctx: Option<&HashMap<String, String>>) -> (QueryID, u64) {
+fn parse_context(ctx: Option<&HashMap<String, String>>) -> (QueryID, u64, Option<u32>) {
     let query_id = ctx
         .as_ref()
         .and_then(|c| c.get("query_id"))
@@ -287,7 +293,22 @@ fn parse_context(ctx: Option<&HashMap<String, String>>) -> (QueryID, u64) {
         .and_then(|c| c.get("plan_fingerprint"))
         .and_then(|s| s.parse::<u64>().ok())
         .unwrap_or(0);
-    (query_id, fingerprint)
+    let task_id = ctx
+        .as_ref()
+        .and_then(|c| c.get("task_id"))
+        .and_then(|s| s.parse::<u32>().ok());
+
+    (query_id, fingerprint, task_id)
+}
+
+// TODO: fix configuration for events
+// This is copied from task_lifecycle.rs to avoid the daft-distributed dependency
+pub fn task_events_enabled() -> bool {
+    if let Ok(val) = std::env::var("DAFT_TASK_EVENTS_ENABLED") {
+        matches!(val.trim().to_lowercase().as_str(), "1" | "true")
+    } else {
+        false // Disabled by default; enable with DAFT_TASK_EVENTS_ENABLED=true
+    }
 }
 
 /// The core execution loop that drives a pipeline to completion.
@@ -420,7 +441,37 @@ impl NativeExecutor {
         input_id: InputId,
         maintain_order: bool,
     ) -> DaftResult<(u64, BoxFuture<'static, DaftResult<ExecutionEngineResult>>)> {
-        let (query_id, fingerprint) = parse_context(additional_context.as_ref());
+        let (query_id, fingerprint, task_id) = parse_context(additional_context.as_ref());
+
+        if self.is_flotilla_worker {
+            debug_assert_eq!(
+                task_id,
+                Some(input_id),
+                "Flotilla invariant violated: task_id must match input_id"
+            );
+        }
+
+        let task_start = if self.is_flotilla_worker
+            && task_events_enabled()
+            && let Some(task_id) = task_id
+        {
+            Some(TaskStartNotification {
+                event: Event::TaskStart(TaskStartEvent {
+                    header: event_header(query_id.clone()),
+                    task: Arc::new(TaskInfo {
+                        id: task_id,
+                        last_node_id: 0,  // TODO: propagate last_node_id
+                        node_ids: vec![], // TODO: propagate node_ids
+                        plan_fingerprint: fingerprint as u32,
+                        name: None,
+                    }),
+                    worker_id: None, // TODO: propagate worker id
+                }),
+                subscribers: subscribers.clone(),
+            })
+        } else {
+            None
+        };
 
         if !self.plans.contains_key(&fingerprint) {
             let cancel = self.cancel.clone();
@@ -488,6 +539,12 @@ impl NativeExecutor {
                         "Plan execution task has died; cannot enqueue new input".to_string(),
                     ));
                 }
+
+                // Send the event since the task has been dispatched to the executor
+                if let Some(task_start) = task_start {
+                    task_start.dispatch();
+                }
+
                 Ok(ExecutionEngineResult {
                     receiver: result_rx,
                 })
@@ -682,5 +739,20 @@ impl PyResultReceiver {
             let stats = finish_future.await?;
             Ok(PyExecutionStats::from(stats))
         })
+    }
+}
+
+struct TaskStartNotification {
+    event: Event,
+    subscribers: Vec<Arc<dyn Subscriber>>,
+}
+
+impl TaskStartNotification {
+    fn dispatch(&self) {
+        for subscriber in &self.subscribers {
+            if let Err(e) = subscriber.on_event(self.event.clone()) {
+                log::debug!("Failed to dispatch task start event: {}", e);
+            }
+        }
     }
 }

--- a/src/daft-local-execution/src/run.rs
+++ b/src/daft-local-execution/src/run.rs
@@ -451,12 +451,12 @@ impl NativeExecutor {
             );
         }
 
-        let task_start = if self.is_flotilla_worker
+        let task_start_dispatch = if self.is_flotilla_worker
             && task_events_enabled()
             && let Some(task_id) = task_id
         {
-            Some(TaskStartNotification {
-                event: Event::TaskStart(TaskStartEvent {
+            Some((
+                Event::TaskStart(TaskStartEvent {
                     header: event_header(query_id.clone()),
                     task: Arc::new(TaskInfo {
                         id: task_id,
@@ -467,8 +467,8 @@ impl NativeExecutor {
                     }),
                     worker_id: None, // TODO: propagate worker id
                 }),
-                subscribers: subscribers.clone(),
-            })
+                subscribers.clone(),
+            ))
         } else {
             None
         };
@@ -540,9 +540,9 @@ impl NativeExecutor {
                     ));
                 }
 
-                // Send the event since the task has been dispatched to the executor
-                if let Some(task_start) = task_start {
-                    task_start.dispatch();
+                // Send the event after the task has been enqueued for execution
+                if let Some((event, subscribers)) = task_start_dispatch {
+                    dispatch_task_start_event(&subscribers, &event);
                 }
 
                 Ok(ExecutionEngineResult {
@@ -742,17 +742,10 @@ impl PyResultReceiver {
     }
 }
 
-struct TaskStartNotification {
-    event: Event,
-    subscribers: Vec<Arc<dyn Subscriber>>,
-}
-
-impl TaskStartNotification {
-    fn dispatch(&self) {
-        for subscriber in &self.subscribers {
-            if let Err(e) = subscriber.on_event(self.event.clone()) {
-                log::debug!("Failed to dispatch task start event: {}", e);
-            }
+fn dispatch_task_start_event(subscribers: &[Arc<dyn Subscriber>], event: &Event) {
+    for subscriber in subscribers {
+        if let Err(e) = subscriber.on_event(event.clone()) {
+            log::debug!("Failed to dispatch task start event: {}", e);
         }
     }
 }


### PR DESCRIPTION
## Changes Made
Emit a `TaskStart` event after the native executor successfully enqueues an input into the pipeline. Gated on `is_flotilla_worker` and the `DAFT_TASK_EVENTS_ENABLED` env var (default off), so it's a no-op for non-distributed workloads and rolls out behind a flag.

The event represents "task admitted to native execution" — emitted from `NativeExecutor::run` where `query_id`, `task_id`, and subscribers are already available, avoiding plumbing through `BuilderContext` or each source. Source-level granularity (e.g. `TaskRunning` for first-byte processing) can be added later as a separate event if needed.
