### PR TITLE
test(iceberg): make predicate-pushdown limit test order-deterministic

### DIFF
--- a/tests/integration/iceberg/test_partition_pruning.py
+++ b/tests/integration/iceberg/test_partition_pruning.py
@@ -200,13 +200,18 @@ def test_daft_iceberg_table_predicate_pushdown_on_number(predicate, table, limit
     df = daft.read_table(f"{catalog_name}.default.{table}")
     df = df.where(predicate(df["number"]))
     if limit:
-        df = df.limit(limit)
+        # Sort before limit so the truncated set is deterministic across
+        # PyIceberg's manifest iteration order and Daft's distributed
+        # scan-task execution order. Without a sort, LIMIT N picks
+        # whichever rows happen to be read first, which differs between
+        # implementations and is fragile to scheduling changes.
+        df = df.sort("number").limit(limit)
     df.collect()
     daft_pandas = df.to_pandas()
     iceberg_pandas = tab.scan().to_arrow().to_pandas()
     iceberg_pandas = iceberg_pandas[predicate(iceberg_pandas["number"])]
     if limit:
-        iceberg_pandas = iceberg_pandas[:limit]
+        iceberg_pandas = iceberg_pandas.sort_values("number").reset_index(drop=True)[:limit]
 
     assert_df_equals(daft_pandas, iceberg_pandas, sort_key=["number"])
 


### PR DESCRIPTION
## Changes Made

`test_daft_iceberg_table_predicate_pushdown_on_number` compares the result of `df.where(predicate).limit(N)` against PyIceberg's predicate-filtered scan sliced to the first N rows. Both sides apply LIMIT without an ORDER BY, so the assertion compares two unordered samples of the predicate-matching rows.

The test only passes when Daft and PyIceberg happen to pick the same rows, which depends on:

- iceberg manifest file iteration order (PyIceberg side)
- distributed scan-task execution order (Daft side, ray runner)

When Daft's distributed `LimitNode` runs multiple scan tasks before the limit is satisfied — e.g. if it uses scan-task metadata lets it parallelize early reads, as implemented in #6763 — the rows that win are whichever tasks finish first, which doesn't necessarily match PyIceberg's left-to-right manifest scan. A 50% mismatch on a `LIMIT 2` slice over the `test_partitioned_by_bucket` table (16 bucket files) shows this: both sides return valid predicate-matching rows, just different ones.

Sort by `number` before clipping to `limit` on both sides so the comparison is over the same well-defined set of rows. The partition-pruning behaviour the test actually wants to check — that the predicate selects the right rows — is preserved; the limit-tie-breaking is just made deterministic.

The three sibling tests in this file
(`..._pushdown_on_date_column`, `..._pushdown_on_timestamp_column`, `..._pushdown_on_letter`) share the same shape and the same latent fragility. They are not currently failing in CI but are one scheduling change away from it. Left as a follow-up to keep this PR narrowly scoped to the actual failure.

https://claude.ai/code/session_019UkmN6JibhPKmMEqXrDSdk

## Related Issues

Exposed by #6763.
