### PR TITLE
fix: infer audio file return dtype

### DIFF
--- a/daft/datatype.py
+++ b/daft/datatype.py
@@ -242,6 +242,8 @@ class DataType:
             return cls.duration(TimeUnit.us())
         elif check_type(daft.file.VideoFile):
             return cls.file(MediaType.video())
+        elif check_type(daft.file.AudioFile):
+            return cls.file(MediaType.audio())
         elif check_type(daft.file.File):
             return cls.file(MediaType.unknown())
         elif check_type(list):

--- a/tests/file/test_audio.py
+++ b/tests/file/test_audio.py
@@ -32,6 +32,18 @@ def test_audio_file_dtype(sample_audio_path):
     assert field.dtype == daft.DataType.file(daft.MediaType.audio())
 
 
+def test_audio_file_udf_return_dtype(sample_audio_path):
+    @daft.func
+    def make_audio_file(path: str) -> daft.AudioFile:
+        return daft.AudioFile(path)
+
+    df = daft.from_pydict({"path": [sample_audio_path]})
+    df = df.select(make_audio_file(df["path"]).alias("audio"))
+
+    assert df.schema() == daft.Schema.from_pydict({"audio": daft.DataType.file(daft.MediaType.audio())})
+    df.collect()
+
+
 def test_audio_file_verify():
     df = daft.from_pydict({"path": ["tests/assets/sampled-tpch.jsonl"]})
 


### PR DESCRIPTION
## Summary
- Infers `daft.AudioFile` annotations as `File[Audio]` instead of falling through to the generic `File[Unknown]` case.
- Adds a regression test for a Python UDF returning `daft.AudioFile`.

## MRE
Before this change, a UDF annotated as returning `daft.AudioFile` produced a generic file column:

```python
import daft

@daft.func
def make_audio_file(path: str) -> daft.AudioFile:
    return daft.AudioFile(path)

df = daft.from_pydict({"path": ["tests/assets/sample_audio.mp3"]})
df = df.select(make_audio_file(df["path"]).alias("audio"))
print(df.schema())  # expected File[Audio], got File[Unknown]
```

This showed up in the resample/write pipeline as an `AudioFile` result displayed as `File[Unknown]`.

## Test plan
- `DAFT_RUNNER=native make test EXTRA_ARGS="-v tests/file/test_audio.py::test_audio_file_udf_return_dtype"`

Made with [Cursor](https://cursor.com)