### PR TITLE
feat(checkpoint): decouple sealed-keys column name from source schema

### DIFF
--- a/src/common/checkpoint-config/src/lib.rs
+++ b/src/common/checkpoint-config/src/lib.rs
@@ -22,6 +22,17 @@ use common_io_config::IOConfig;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+/// Canonical column name used when persisting sealed keys to the checkpoint
+/// store, and when reading them back at filter time.
+///
+/// Decouples the on-disk key file schema from the source's key column name —
+/// re-running with a renamed source column does not invalidate previously
+/// sealed key files, because they always live under this canonical name.
+/// Callers that read the sealed key files (the scan operator) and the
+/// optimizer rule that wires the anti-join must reference this constant
+/// rather than the source's column name on the right side of the join.
+pub const SEALED_KEYS_COLUMN: &str = "key";
+
 /// Opaque identifier for a checkpoint.
 ///
 /// The inner string is guaranteed to be safe for use as a path segment in

--- a/src/daft-checkpoint/src/impls/s3.rs
+++ b/src/daft-checkpoint/src/impls/s3.rs
@@ -496,7 +496,11 @@ impl S3CheckpointStore {
 impl CheckpointStore for S3CheckpointStore {
     async fn stage_keys(&self, id: &CheckpointId, keys: Series) -> CheckpointResult<()> {
         self.check_first_error(id)?;
-        let parquet_bytes = super::keys_codec::write_series_as_parquet(&keys)?;
+        // Persist under the canonical column name so the on-disk key files
+        // are stable across renames of the source column. The scan operator
+        // and the optimizer rule both read using `SEALED_KEYS_COLUMN`.
+        let canonical = keys.rename(common_checkpoint_config::SEALED_KEYS_COLUMN);
+        let parquet_bytes = super::keys_codec::write_series_as_parquet(&canonical)?;
         let idx = self
             .reserve_slots(id, |e| {
                 let i = e.num_key_files;

--- a/src/daft-checkpoint/src/scan.rs
+++ b/src/daft-checkpoint/src/scan.rs
@@ -211,4 +211,35 @@ mod tests {
 
         assert_eq!(task_paths, expected_paths);
     }
+
+    #[tokio::test]
+    async fn advertised_schema_is_passed_through_verbatim() {
+        // The scan operator advertises whatever schema is handed to it, so
+        // callers (the optimizer rule) are responsible for passing the
+        // canonical sealed-keys column name. Pin that the operator does
+        // expose the schema given at construction — a regression that
+        // rewrote the schema internally would silently break the anti-join's
+        // right-side resolution.
+        use common_checkpoint_config::SEALED_KEYS_COLUMN;
+
+        let dir = tempfile::tempdir().unwrap();
+        let (config, _store) = make_store(dir.path());
+
+        let canonical_schema = Arc::new(Schema::new(vec![Field::new(
+            SEALED_KEYS_COLUMN,
+            DataType::Utf8,
+        )]));
+        let op = BlobStoreCheckpointedKeysScanOperator::new(config, canonical_schema);
+
+        let advertised = op.schema();
+        assert_eq!(
+            advertised.len(),
+            1,
+            "expected single-column schema, got: {advertised:?}"
+        );
+        assert!(
+            advertised.get_field(SEALED_KEYS_COLUMN).is_ok(),
+            "advertised schema must carry the canonical column name; got: {advertised:?}"
+        );
+    }
 }

--- a/src/daft-checkpoint/src/store.rs
+++ b/src/daft-checkpoint/src/store.rs
@@ -105,6 +105,13 @@ pub trait CheckpointStore: Send + Sync {
     /// Stream all checkpointed source keys (both checkpointed and committed)
     /// as columnar [`Series`] chunks. Useful for building a filter to skip
     /// already-processed inputs on re-run.
+    ///
+    /// Each streamed [`Series`] is named
+    /// [`SEALED_KEYS_COLUMN`](common_checkpoint_config::SEALED_KEYS_COLUMN)
+    /// regardless of what column name was passed to [`stage_keys`](Self::stage_keys).
+    /// Implementations must rename on staging so the read side is stable
+    /// across renames of the source's key column — see
+    /// [`SEALED_KEYS_COLUMN`](common_checkpoint_config::SEALED_KEYS_COLUMN).
     async fn get_checkpointed_keys(
         &self,
     ) -> CheckpointResult<BoxStream<'_, CheckpointResult<Series>>>;

--- a/src/daft-checkpoint/src/test_utils.rs
+++ b/src/daft-checkpoint/src/test_utils.rs
@@ -17,8 +17,11 @@ use crate::{
 // Helpers
 // ---------------------------------------------------------------------------
 
+/// Use a non-canonical input column name so every contract test that
+/// round-trips through `stage_keys` -> `get_checkpointed_keys` actually
+/// exercises the canonical-name rename inside the store impl.
 pub fn keys(values: &[&str]) -> Series {
-    Utf8Array::from_slice("key", values).into_series()
+    Utf8Array::from_slice("src_key", values).into_series()
 }
 
 pub fn file(data: &[u8]) -> FileMetadata {

--- a/src/daft-checkpoint/tests/s3_store.rs
+++ b/src/daft-checkpoint/tests/s3_store.rs
@@ -11,7 +11,7 @@ use daft_checkpoint::{
     impls::S3CheckpointStore,
 };
 use daft_core::{
-    datatypes::Utf8Array,
+    datatypes::{Int64Array, Utf8Array},
     series::{IntoSeries, Series},
 };
 use daft_io::IOConfig;
@@ -39,8 +39,13 @@ fn make_store() -> (tempfile::TempDir, S3CheckpointStore) {
     (dir, store)
 }
 
+/// Use a non-canonical input column name so every test that round-trips
+/// through `stage_keys` -> `get_checkpointed_keys` actually exercises the
+/// canonical-name rename. If this returned a series already named
+/// `SEALED_KEYS_COLUMN`, the rename inside `stage_keys` would be a silent
+/// no-op and a regression that removed it would not be caught.
 fn keys(values: &[&str]) -> Series {
-    Utf8Array::from_slice("key", values).into_series()
+    Utf8Array::from_slice("src_key", values).into_series()
 }
 
 fn file(data: &[u8]) -> FileMetadata {
@@ -377,7 +382,108 @@ async fn test_empty_inputs() {
 }
 
 // ---------------------------------------------------------------------------
-// 10. mark_committed: all IDs committed in a single concurrent batch
+// 10. stage_keys persists under the canonical column name regardless of input
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_stage_keys_renames_to_canonical_column() {
+    use common_checkpoint_config::SEALED_KEYS_COLUMN;
+
+    let (_dir, store) = make_store();
+    let id = CheckpointId::generate(0);
+
+    // Pass in a series whose field name is the source's column ("file_id"),
+    // not the canonical sealed-keys column ("key"). The store must rename it
+    // on the way in so the on-disk parquet uses the canonical name.
+    let source_named = Utf8Array::from_slice("file_id", &["a", "b", "c"]).into_series();
+    assert_eq!(source_named.name(), "file_id");
+    store.stage_keys(&id, source_named).await.unwrap();
+    store.checkpoint(&id).await.unwrap();
+
+    // Read back via get_checkpointed_keys — every chunk's series field must
+    // be the canonical name, regardless of what the caller passed in.
+    let chunks: Vec<Series> = store
+        .get_checkpointed_keys()
+        .await
+        .unwrap()
+        .try_collect()
+        .await
+        .unwrap();
+    assert!(!chunks.is_empty(), "expected at least one chunk");
+    for chunk in &chunks {
+        assert_eq!(
+            chunk.name(),
+            SEALED_KEYS_COLUMN,
+            "stage_keys must persist under the canonical column name; got {:?}",
+            chunk.name(),
+        );
+    }
+
+    // The rename must not corrupt values — only the column name changes.
+    assert_eq!(collect_key_strings(&store).await, vec!["a", "b", "c"]);
+}
+
+// ---------------------------------------------------------------------------
+// 11. Non-Utf8 dtypes round-trip through stage_keys → get_checkpointed_keys
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_stage_keys_round_trip_preserves_int64_dtype_across_batches() {
+    use common_checkpoint_config::SEALED_KEYS_COLUMN;
+    use daft_schema::dtype::DataType;
+
+    let (_dir, store) = make_store();
+    let id = CheckpointId::generate(0);
+
+    // Stage two batches of Int64 keys under a non-canonical input column
+    // name. Verifies (a) non-Utf8 dtypes survive the parquet round-trip
+    // through `stage_keys`, (b) the canonical-name rename applies across
+    // multiple stage_keys calls in a single checkpoint, (c) values are
+    // preserved exactly (not coerced or truncated).
+    let batch1 = Int64Array::from_vec("src_id", vec![10i64, 20, 30]).into_series();
+    let batch2 = Int64Array::from_vec("src_id", vec![40i64, 50]).into_series();
+    assert_eq!(batch1.name(), "src_id");
+    assert_eq!(batch2.name(), "src_id");
+
+    store.stage_keys(&id, batch1).await.unwrap();
+    store.stage_keys(&id, batch2).await.unwrap();
+    store.checkpoint(&id).await.unwrap();
+
+    let chunks: Vec<Series> = store
+        .get_checkpointed_keys()
+        .await
+        .unwrap()
+        .try_collect()
+        .await
+        .unwrap();
+    assert!(!chunks.is_empty(), "expected at least one chunk");
+
+    let mut values: Vec<i64> = Vec::new();
+    for chunk in &chunks {
+        assert_eq!(
+            chunk.name(),
+            SEALED_KEYS_COLUMN,
+            "rename must apply to every batch, got: {:?}",
+            chunk.name(),
+        );
+        assert_eq!(
+            chunk.data_type(),
+            &DataType::Int64,
+            "Int64 dtype must survive the parquet round-trip"
+        );
+        let arr = chunk.i64().expect("expected Int64 series");
+        for i in 0..arr.len() {
+            if let Some(v) = arr.get(i) {
+                values.push(v);
+            }
+        }
+    }
+    values.sort_unstable();
+    assert_eq!(values, vec![10, 20, 30, 40, 50]);
+}
+
+// ---------------------------------------------------------------------------
+// 12. mark_committed: all IDs committed in a single concurrent batch
 // ---------------------------------------------------------------------------
 
 #[tokio::test]

--- a/src/daft-logical-plan/src/optimization/rules/rewrite_checkpoint_source.rs
+++ b/src/daft-logical-plan/src/optimization/rules/rewrite_checkpoint_source.rs
@@ -154,8 +154,12 @@ impl OptimizerRule for RewriteCheckpointSource {
             // Right: scan over checkpointed key files. The on-disk schema uses
             // a canonical column name (`SEALED_KEYS_COLUMN`) regardless of
             // what the source calls its key column — see `stage_keys` in the
-            // store impl. This means renaming the source's key column between
-            // runs does not invalidate previously sealed key files.
+            // store impl. This means a user can rename the source's key column
+            // between runs (updating `cfg.key_column` to match) and existing
+            // sealed key files stay valid — only the *physical* on-disk format
+            // is decoupled from the source schema, not the config. If
+            // `cfg.key_column` ever disagrees with the source's actual schema,
+            // `get_field` below errors loudly at rule time.
             let source_key_field = source.output_schema.get_field(&cfg.key_column)?;
             let canonical_key_field =
                 Field::new(SEALED_KEYS_COLUMN, source_key_field.dtype.clone());
@@ -238,10 +242,13 @@ mod tests {
         // Use a source column name that is *not* the canonical sealed-keys
         // column name, so assertions that the right side of the anti-join
         // uses the canonical name (rather than the source's name) catch the
-        // decoupling.
+        // decoupling. Use `Int64` for the key dtype (instead of the typical
+        // `Utf8`) so the dtype-propagation assertion downstream is
+        // load-bearing — a regression that hardcoded Utf8 for the canonical
+        // field would fail loudly here.
         let scan_op = dummy_scan_operator(vec![
-            Field::new("file_id", DataType::Utf8),
-            Field::new("value", DataType::Int64),
+            Field::new("file_id", DataType::Int64),
+            Field::new("value", DataType::Utf8),
         ]);
         let plan = dummy_scan_node(scan_op).build();
         if let Some(cfg) = cfg {
@@ -324,6 +331,26 @@ mod tests {
         assert_eq!(
             physical.scan_state.get_scan_op().0.name(),
             "BlobStoreCheckpointedKeysScanOperator"
+        );
+
+        // Right plan's *actual schema* must carry the canonical column name
+        // with the source key column's dtype — guards against a regression
+        // that wires `kfc` correctly but builds the schema with the source's
+        // column name (or the wrong dtype). A schema mismatch would only
+        // surface at execution time, when the optimizer test wouldn't catch it.
+        let right_schema = join.right.schema();
+        let canonical_field = right_schema
+            .get_field(SEALED_KEYS_COLUMN)
+            .expect("right plan schema must carry the canonical sealed-keys column");
+        assert_eq!(
+            canonical_field.dtype,
+            DataType::Int64,
+            "canonical column dtype must propagate from the source key column dtype, not be hardcoded"
+        );
+        assert_eq!(
+            right_schema.len(),
+            1,
+            "right plan schema should have only the canonical key column"
         );
     }
 }

--- a/src/daft-logical-plan/src/optimization/rules/rewrite_checkpoint_source.rs
+++ b/src/daft-logical-plan/src/optimization/rules/rewrite_checkpoint_source.rs
@@ -4,13 +4,14 @@
 
 use std::sync::Arc;
 
+use common_checkpoint_config::SEALED_KEYS_COLUMN;
 use common_error::{DaftError, DaftResult};
 use common_treenode::{Transformed, TreeNode, TreeNodeRecursion};
 use daft_checkpoint::BlobStoreCheckpointedKeysScanOperator;
 use daft_core::join::{JoinStrategy, JoinType};
 use daft_dsl::unresolved_col;
 use daft_scan::ScanOperatorRef;
-use daft_schema::schema::Schema;
+use daft_schema::{field::Field, schema::Schema};
 
 use super::OptimizerRule;
 use crate::{
@@ -150,9 +151,15 @@ impl OptimizerRule for RewriteCheckpointSource {
                 Arc::new(LogicalPlan::Source(source_copy))
             };
 
-            // Right: scan over checkpointed key files.
-            let key_field = source.output_schema.get_field(&cfg.key_column)?;
-            let key_schema = Arc::new(Schema::new(vec![key_field.clone()]));
+            // Right: scan over checkpointed key files. The on-disk schema uses
+            // a canonical column name (`SEALED_KEYS_COLUMN`) regardless of
+            // what the source calls its key column — see `stage_keys` in the
+            // store impl. This means renaming the source's key column between
+            // runs does not invalidate previously sealed key files.
+            let source_key_field = source.output_schema.get_field(&cfg.key_column)?;
+            let canonical_key_field =
+                Field::new(SEALED_KEYS_COLUMN, source_key_field.dtype.clone());
+            let key_schema = Arc::new(Schema::new(vec![canonical_key_field]));
             let scan_op = ScanOperatorRef(Arc::new(BlobStoreCheckpointedKeysScanOperator::new(
                 cfg.store.clone(),
                 key_schema,
@@ -161,11 +168,12 @@ impl OptimizerRule for RewriteCheckpointSource {
 
             let left_schema = left_plan.schema();
             let right_schema = right_plan.schema();
-            // TODO: Decouple key column naming — the right side (checkpointed
-            // keys scan) should use a canonical column name (e.g. "key") instead
-            // of matching the source's column name.
+            // Left side resolves to the source's key column; right side resolves
+            // to the canonical sealed-keys column. The two are joined for
+            // equality, so the source can be renamed without breaking the
+            // anti-join against existing sealed key files.
             let l = unresolved_col(cfg.key_column.as_str()).to_left_cols(left_schema)?;
-            let r = unresolved_col(cfg.key_column.as_str()).to_right_cols(right_schema)?;
+            let r = unresolved_col(SEALED_KEYS_COLUMN).to_right_cols(right_schema)?;
             let on_expr = l.eq(r);
 
             // TODO: These KFJ parameters are hardcoded. They should
@@ -178,7 +186,10 @@ impl OptimizerRule for RewriteCheckpointSource {
                 None,      // filter_batch_size (unused by bridge)
             )
             .map_err(|e| DaftError::ComputeError(format!("{e}")))?
-            .with_key_columns(vec![cfg.key_column.clone()], vec![cfg.key_column.clone()])
+            .with_key_columns(
+                vec![cfg.key_column.clone()],
+                vec![SEALED_KEYS_COLUMN.to_string()],
+            )
             .map_err(|e| DaftError::ComputeError(format!("{e}")))?;
 
             let joined = LogicalPlanBuilder::from(left_plan).join(
@@ -224,8 +235,12 @@ mod tests {
     };
 
     fn scan_with_checkpoint(cfg: Option<CheckpointConfig>) -> Arc<LogicalPlan> {
+        // Use a source column name that is *not* the canonical sealed-keys
+        // column name, so assertions that the right side of the anti-join
+        // uses the canonical name (rather than the source's name) catch the
+        // decoupling.
         let scan_op = dummy_scan_operator(vec![
-            Field::new("key", DataType::Utf8),
+            Field::new("file_id", DataType::Utf8),
             Field::new("value", DataType::Int64),
         ]);
         let plan = dummy_scan_node(scan_op).build();
@@ -258,7 +273,7 @@ mod tests {
                 prefix: "s3://does-not-matter-for-rewrite".to_string(),
                 io_config: Box::new(common_io_config::IOConfig::default()),
             },
-            key_column: "key".to_string(),
+            key_column: "file_id".to_string(),
         };
         let plan = scan_with_checkpoint(Some(cfg));
 
@@ -272,7 +287,7 @@ mod tests {
                 result.data
             );
         };
-        assert_eq!(stage.checkpoint_config.key_column, "key");
+        assert_eq!(stage.checkpoint_config.key_column, "file_id");
 
         let LogicalPlan::Join(join) = stage.input.as_ref() else {
             panic!(
@@ -287,8 +302,10 @@ mod tests {
             .key_filtering_config
             .as_ref()
             .expect("KeyFilteringConfig must be attached");
-        assert_eq!(kfc.left_key_columns, vec!["key".to_string()]);
-        assert_eq!(kfc.right_key_columns, vec!["key".to_string()]);
+        // Left side resolves to the source's column; right side to the
+        // canonical sealed-keys column. They must NOT have to match.
+        assert_eq!(kfc.left_key_columns, vec!["file_id".to_string()]);
+        assert_eq!(kfc.right_key_columns, vec![SEALED_KEYS_COLUMN.to_string()]);
 
         // Left side: Source with `checkpoint` stripped — staging responsibility
         // lives on the wrapping StageCheckpointKeys node, not on the Source.


### PR DESCRIPTION
## Summary

Sealed key parquet files written by `CheckpointStore::stage_keys` now use a canonical column name (`"key"`) regardless of what the source's key column is called. The optimizer's anti-join still references the source's column name on the left, but matches against the canonical name on the right.

Without this change, renaming the source key column between runs (e.g. `daft.read_parquet(..., on="file_id")` → `daft.read_parquet(..., on="id")`) would silently invalidate every previously-sealed key file, because the right-side anti-join scan was using the source's name. After this change, the on-disk format is decoupled from the source schema; only `cfg.key_column` needs to follow the rename.

## What changes

- New `pub const SEALED_KEYS_COLUMN: &str = "key"` in `common-checkpoint-config`. Single source of truth shared by the persistence layer and the optimizer.
- `S3CheckpointStore::stage_keys` renames the input series to `SEALED_KEYS_COLUMN` before passing it to the parquet codec. Caller doesn't need to know the canonical name.
- The rewrite rule's right-side scan schema is built from the source key's *dtype* but the canonical *name*. The anti-join's `unresolved_col` on the right side, and `KeyFilteringConfig.with_key_columns`'s `right_key_columns`, both use `SEALED_KEYS_COLUMN`. Left side keeps using `cfg.key_column`.
- `CheckpointStore::get_checkpointed_keys` trait doc pins the canonical-name guarantee for future impls.

No behavior change for any caller that doesn't rename their source key column between runs.

## Test plan

- Optimizer-rule test uses `file_id` as source column with `Int64` dtype, asserts left/right key columns differ (`["file_id"]` vs `[SEALED_KEYS_COLUMN]`), and asserts the right plan's actual schema carries the canonical column with the source's dtype propagated. The dtype is `Int64` (not `Utf8`) so the propagation is load-bearing rather than tautological.
- New `test_stage_keys_renames_to_canonical_column` in `tests/s3_store.rs` stages a `"file_id"`-named series and asserts both the column name and the values round-trip back as canonical-named with content intact.
- New `test_stage_keys_round_trip_preserves_int64_dtype_across_batches` stages two batches of `Int64` keys, asserts the rename applies to every batch and that values + dtype survive the parquet round-trip.
- Both `keys()` test helpers now produce series under the non-canonical name `"src_key"`, so every existing contract test exercises the rename path through `stage_keys`.
- New `advertised_schema_is_passed_through_verbatim` in `scan.rs` pins that `BlobStoreCheckpointedKeysScanOperator` exposes whatever schema is given at construction.

End-to-end "rename the source column across runs" verification is left for a separate manual validation pass — not unit-testable cleanly without a Ray harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
