### PR TITLE
feat(show): env defaults and auto alignment for preview output

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -32,7 +32,14 @@ from daft.daft import (
     WriteMode,
 )
 from daft.dataframe.display import MermaidOptions
-from daft.dataframe.preview import Preview, PreviewAlign, PreviewColumn, PreviewFormat, PreviewFormatter
+from daft.dataframe.preview import (
+    Preview,
+    PreviewAlign,
+    PreviewColumn,
+    PreviewFormat,
+    PreviewFormatter,
+    resolve_show_defaults,
+)
 from daft.datatype import DataType
 from daft.errors import ExpressionTypeError
 from daft.execution.native_executor import NativeExecutor
@@ -5035,8 +5042,8 @@ class DataFrame:
         n: int = 8,
         format: PreviewFormat | None = None,
         verbose: bool = False,
-        max_width: int = 30,
-        align: PreviewAlign = "left",
+        max_width: int | None = 30,
+        align: PreviewAlign = "auto",
         columns: list[PreviewColumn] | None = None,
     ) -> None:
         """Executes enough of the DataFrame in order to display the first ``n`` rows.
@@ -5049,12 +5056,17 @@ class DataFrame:
             - Headers contain the column's data type.
             - Columns are truncated to 30 characters.
             - The table's overall width is limited to 10 columns.
+        Default values can be overridden with environment variables:
+            - ``DAFT_SHOW_FORMAT``
+            - ``DAFT_SHOW_VERBOSE``
+            - ``DAFT_SHOW_MAX_WIDTH``
+            - ``DAFT_SHOW_ALIGN``
 
         Args:
             n: number of rows to show. Defaults to 8.
             format (PreviewFormat): the box-drawing format e.g. "fancy" or "markdown".
             verbose (bool): if True, headers include the column's data type.
-            max_width (int): global max column width
+            max_width (int | None): global max column width
             align (PreviewAlign): global column align
             columns (list[PreviewColumn]): column overrides
 
@@ -5067,7 +5079,7 @@ class DataFrame:
             >>> df.show()  # doctest: +SKIP
             >>> df.show(format="markdown")  # doctest: +SKIP
             >>> df.show(max_width=50)  # doctest: +SKIP
-            >>> df.show(align="left")  # doctest: +SKIP
+            >>> df.show(align="auto")  # doctest: +SKIP
 
         Tip: Usage
             - If columns are given, their length MUST match the schema.
@@ -5076,6 +5088,7 @@ class DataFrame:
         """
         schema = self.schema()
         preview = self._construct_show_preview(n)
+        format, verbose, max_width, align = resolve_show_defaults(format, verbose, max_width, align)
         preview_formatter = PreviewFormatter(
             preview,
             schema,

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -5041,9 +5041,9 @@ class DataFrame:
         self,
         n: int = 8,
         format: PreviewFormat | None = None,
-        verbose: bool = False,
-        max_width: int | None = 30,
-        align: PreviewAlign = "auto",
+        verbose: bool | None = None,
+        max_width: int | None = None,
+        align: PreviewAlign | None = None,
         columns: list[PreviewColumn] | None = None,
     ) -> None:
         """Executes enough of the DataFrame in order to display the first ``n`` rows.

--- a/daft/dataframe/preview.py
+++ b/daft/dataframe/preview.py
@@ -36,13 +36,14 @@ PreviewAlign = Literal[
 
 _SHOW_DEFAULT_VERBOSE = False
 _SHOW_DEFAULT_MAX_WIDTH = 30
-_SHOW_DEFAULT_ALIGN: PreviewAlign = "auto"
+_SHOW_DEFAULT_ALIGN: PreviewAlign = "left"
 
 _SHOW_FORMATS = {"fancy", "plain", "simple", "grid", "markdown", "html"}
 _SHOW_ALIGNS = {"auto", "left", "center", "right"}
 _SHOW_TRUTHY = {"1", "true", "yes", "on"}
 _SHOW_FALSY = {"0", "false", "no", "off"}
-_SHOW_NONE = {"none", "null", "off"}
+_SHOW_NONE = {"none", "null"}
+
 
 def _parse_bool_env(name: str) -> bool | None:
     value = os.environ.get(name)
@@ -94,9 +95,9 @@ def _parse_show_align_env() -> PreviewAlign | None:
 
 def resolve_show_defaults(
     format: PreviewFormat | None,
-    verbose: bool,
+    verbose: bool | None,
     max_width: int | None,
-    align: PreviewAlign,
+    align: PreviewAlign | None,
 ) -> tuple[PreviewFormat | None, bool, int | None, PreviewAlign]:
     """Resolve .show() defaults from env vars when arguments are left at defaults.
 
@@ -111,20 +112,20 @@ def resolve_show_defaults(
         if env_format is not None:
             format = env_format
 
-    if verbose is _SHOW_DEFAULT_VERBOSE:
+    if verbose is None:
         env_verbose = _parse_bool_env("DAFT_SHOW_VERBOSE")
-        if env_verbose is not None:
-            verbose = env_verbose
+        verbose = env_verbose if env_verbose is not None else _SHOW_DEFAULT_VERBOSE
 
-    if max_width == _SHOW_DEFAULT_MAX_WIDTH:
+    if max_width is None:
         max_width_set, env_max_width = _parse_max_width_env("DAFT_SHOW_MAX_WIDTH")
         if max_width_set:
             max_width = env_max_width
+        else:
+            max_width = _SHOW_DEFAULT_MAX_WIDTH
 
-    if align == _SHOW_DEFAULT_ALIGN:
+    if align is None:
         env_align = _parse_show_align_env()
-        if env_align is not None:
-            align = env_align
+        align = env_align if env_align is not None else _SHOW_DEFAULT_ALIGN
 
     return format, verbose, max_width, align
 

--- a/daft/dataframe/preview.py
+++ b/daft/dataframe/preview.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import json
+import os
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal, TypedDict
+from typing import TYPE_CHECKING, Any, Literal, TypedDict, cast
 
 if TYPE_CHECKING:
     from daft.logical.schema import Schema
@@ -32,6 +33,100 @@ PreviewAlign = Literal[
     "center",
     "right",
 ]
+
+_SHOW_DEFAULT_VERBOSE = False
+_SHOW_DEFAULT_MAX_WIDTH = 30
+_SHOW_DEFAULT_ALIGN: PreviewAlign = "auto"
+
+_SHOW_FORMATS = {"fancy", "plain", "simple", "grid", "markdown", "html"}
+_SHOW_ALIGNS = {"auto", "left", "center", "right"}
+_SHOW_TRUTHY = {"1", "true", "yes", "on"}
+_SHOW_FALSY = {"0", "false", "no", "off"}
+_SHOW_NONE = {"none", "null", "off"}
+
+def _parse_bool_env(name: str) -> bool | None:
+    value = os.environ.get(name)
+    if value is None:
+        return None
+    normalized = value.strip().lower()
+    if normalized in _SHOW_TRUTHY:
+        return True
+    if normalized in _SHOW_FALSY:
+        return False
+    return None
+
+
+def _parse_max_width_env(name: str) -> tuple[bool, int | None]:
+    value = os.environ.get(name)
+    if value is None:
+        return False, None
+    normalized = value.strip().lower()
+    if normalized in _SHOW_NONE:
+        return True, None
+    try:
+        parsed = int(normalized)
+    except ValueError:
+        return False, None
+    if parsed < 1:
+        return False, None
+    return True, parsed
+
+
+def _parse_show_format_env() -> PreviewFormat | None:
+    value = os.environ.get("DAFT_SHOW_FORMAT")
+    if value is None:
+        return None
+    normalized = value.strip().lower()
+    if normalized in _SHOW_FORMATS:
+        return cast("PreviewFormat", normalized)
+    return None
+
+
+def _parse_show_align_env() -> PreviewAlign | None:
+    value = os.environ.get("DAFT_SHOW_ALIGN")
+    if value is None:
+        return None
+    normalized = value.strip().lower()
+    if normalized in _SHOW_ALIGNS:
+        return cast("PreviewAlign", normalized)
+    return None
+
+
+def resolve_show_defaults(
+    format: PreviewFormat | None,
+    verbose: bool,
+    max_width: int | None,
+    align: PreviewAlign,
+) -> tuple[PreviewFormat | None, bool, int | None, PreviewAlign]:
+    """Resolve .show() defaults from env vars when arguments are left at defaults.
+
+    Supported env vars:
+    - DAFT_SHOW_FORMAT: fancy|plain|simple|grid|markdown|html
+    - DAFT_SHOW_VERBOSE: 1/0, true/false, yes/no, on/off
+    - DAFT_SHOW_MAX_WIDTH: positive integer, or none/null/off
+    - DAFT_SHOW_ALIGN: auto|left|center|right
+    """
+    if format is None:
+        env_format = _parse_show_format_env()
+        if env_format is not None:
+            format = env_format
+
+    if verbose is _SHOW_DEFAULT_VERBOSE:
+        env_verbose = _parse_bool_env("DAFT_SHOW_VERBOSE")
+        if env_verbose is not None:
+            verbose = env_verbose
+
+    if max_width == _SHOW_DEFAULT_MAX_WIDTH:
+        max_width_set, env_max_width = _parse_max_width_env("DAFT_SHOW_MAX_WIDTH")
+        if max_width_set:
+            max_width = env_max_width
+
+    if align == _SHOW_DEFAULT_ALIGN:
+        env_align = _parse_show_align_env()
+        if env_align is not None:
+            align = env_align
+
+    return format, verbose, max_width, align
 
 
 class PreviewColumn(TypedDict, total=False):

--- a/daft/dataframe/preview.py
+++ b/daft/dataframe/preview.py
@@ -36,7 +36,7 @@ PreviewAlign = Literal[
 
 _SHOW_DEFAULT_VERBOSE = False
 _SHOW_DEFAULT_MAX_WIDTH = 30
-_SHOW_DEFAULT_ALIGN: PreviewAlign = "auto"
+_SHOW_DEFAULT_ALIGN: PreviewAlign = "left"
 
 _SHOW_FORMATS = {"fancy", "plain", "simple", "grid", "markdown", "html"}
 _SHOW_ALIGNS = {"auto", "left", "center", "right"}

--- a/daft/dataframe/preview.py
+++ b/daft/dataframe/preview.py
@@ -36,7 +36,7 @@ PreviewAlign = Literal[
 
 _SHOW_DEFAULT_VERBOSE = False
 _SHOW_DEFAULT_MAX_WIDTH = 30
-_SHOW_DEFAULT_ALIGN: PreviewAlign = "left"
+_SHOW_DEFAULT_ALIGN: PreviewAlign = "auto"
 
 _SHOW_FORMATS = {"fancy", "plain", "simple", "grid", "markdown", "html"}
 _SHOW_ALIGNS = {"auto", "left", "center", "right"}
@@ -104,7 +104,7 @@ def resolve_show_defaults(
     Supported env vars:
     - DAFT_SHOW_FORMAT: fancy|plain|simple|grid|markdown|html
     - DAFT_SHOW_VERBOSE: 1/0, true/false, yes/no, on/off
-    - DAFT_SHOW_MAX_WIDTH: positive integer, or none/null/off
+    - DAFT_SHOW_MAX_WIDTH: positive integer, or none/null
     - DAFT_SHOW_ALIGN: auto|left|center|right
     """
     if format is None:

--- a/daft/dataframe/preview.py
+++ b/daft/dataframe/preview.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import os
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal, TypedDict, cast
+from typing import TYPE_CHECKING, Any, Literal, TypedDict, cast, get_args
 
 if TYPE_CHECKING:
     from daft.logical.schema import Schema
@@ -38,8 +38,8 @@ _SHOW_DEFAULT_VERBOSE = False
 _SHOW_DEFAULT_MAX_WIDTH = 30
 _SHOW_DEFAULT_ALIGN: PreviewAlign = "left"
 
-_SHOW_FORMATS = {"fancy", "plain", "simple", "grid", "markdown", "html"}
-_SHOW_ALIGNS = {"auto", "left", "center", "right"}
+_SHOW_FORMATS = set(get_args(PreviewFormat))
+_SHOW_ALIGNS = set(get_args(PreviewAlign))
 _SHOW_TRUTHY = {"1", "true", "yes", "on"}
 _SHOW_FALSY = {"0", "false", "no", "off"}
 _SHOW_NONE = {"none", "null"}

--- a/src/daft-recordbatch/src/preview.rs
+++ b/src/daft-recordbatch/src/preview.rs
@@ -213,7 +213,7 @@ impl Preview {
             .schema
             .into_iter()
             .enumerate()
-            .map(|(idx, _)| {
+            .map(|(idx, field)| {
                 // Use column overrides if any, falling back to the global settings.
                 let mut max_width = self.options.max_width;
                 let mut align = self.options.align;
@@ -223,7 +223,13 @@ impl Preview {
                 }
                 // If some alignment, translate to comfy_table
                 let align = align.map(|align| match align {
-                    PreviewAlign::Auto => CellAlignment::Left,
+                    PreviewAlign::Auto => {
+                        if field.dtype.is_numeric() || field.dtype.is_decimal128() {
+                            CellAlignment::Right
+                        } else {
+                            CellAlignment::Left
+                        }
+                    }
                     PreviewAlign::Left => CellAlignment::Left,
                     PreviewAlign::Center => CellAlignment::Center,
                     PreviewAlign::Right => CellAlignment::Right,
@@ -309,4 +315,37 @@ mod presets {
     /// | c     | d     |
     /// ```
     pub const MARKDOWN: &str = "||  |-|||           ";
+}
+
+#[cfg(test)]
+mod tests {
+    use daft_core::prelude::{Int64Array, Utf8Array};
+    use daft_core::series::IntoSeries;
+
+    use super::*;
+
+    #[test]
+    fn test_auto_aligns_numeric_right_and_non_numeric_left() {
+        let rb = RecordBatch::from_nonempty_columns(vec![
+            Int64Array::from_vec("n", vec![1, 22]).into_series(),
+            Utf8Array::from_slice("s", &["a", "bb"]).into_series(),
+        ])
+        .unwrap();
+
+        let preview = Preview::new(
+            rb,
+            PreviewFormat::Markdown,
+            PreviewOptions {
+                verbose: false,
+                null: "None".to_string(),
+                max_width: Some(30),
+                align: Some(PreviewAlign::Auto),
+                columns: None,
+            },
+        );
+
+        let out = preview.to_string();
+        assert!(out.contains("|  1 | a  |"));
+        assert!(out.contains("| 22 | bb |"));
+    }
 }

--- a/src/daft-recordbatch/src/preview.rs
+++ b/src/daft-recordbatch/src/preview.rs
@@ -319,8 +319,10 @@ mod presets {
 
 #[cfg(test)]
 mod tests {
-    use daft_core::prelude::{Int64Array, Utf8Array};
-    use daft_core::series::IntoSeries;
+    use daft_core::{
+        prelude::{Int64Array, Utf8Array},
+        series::IntoSeries,
+    };
 
     use super::*;
 

--- a/tests/dataframe/test_show.py
+++ b/tests/dataframe/test_show.py
@@ -8,7 +8,7 @@ import re
 
 import daft
 from daft.dataframe import DataFrame
-from daft.dataframe.preview import PreviewFormat, PreviewFormatter
+from daft.dataframe.preview import PreviewFormat, PreviewFormatter, resolve_show_defaults
 from daft.runners import get_or_create_runner
 
 
@@ -160,6 +160,24 @@ def test_show_with_options():
     )
 
 
+def test_show_with_auto_align():
+    df = daft.from_pydict(
+        {
+            "N": [1, 22],
+            "S": ["a", "bb"],
+        }
+    )
+
+    assert (
+        show(df, format="markdown", align="auto")
+        == """
+| N  | S  |
+|----|----|
+|  1 | a  |
+| 22 | bb |"""[1:]
+    )
+
+
 def test_show_with_wide_columns():
     df = daft.from_pydict(
         {
@@ -201,6 +219,34 @@ def test_show_default_respects_options():
 ╞══════════════════════════════════════════════════════════════╡
 │ this is a really long string that should not be be truncated │
 ╰──────────────────────────────────────────────────────────────╯"""[1:]
+
+
+def test_resolve_show_defaults_from_env(monkeypatch):
+    monkeypatch.setenv("DAFT_SHOW_FORMAT", "markdown")
+    monkeypatch.setenv("DAFT_SHOW_VERBOSE", "true")
+    monkeypatch.setenv("DAFT_SHOW_MAX_WIDTH", "12")
+    monkeypatch.setenv("DAFT_SHOW_ALIGN", "right")
+
+    format, verbose, max_width, align = resolve_show_defaults(None, False, 30, "auto")
+
+    assert format == "markdown"
+    assert verbose is True
+    assert max_width == 12
+    assert align == "right"
+
+
+def test_resolve_show_defaults_respects_explicit_args(monkeypatch):
+    monkeypatch.setenv("DAFT_SHOW_FORMAT", "markdown")
+    monkeypatch.setenv("DAFT_SHOW_VERBOSE", "true")
+    monkeypatch.setenv("DAFT_SHOW_MAX_WIDTH", "12")
+    monkeypatch.setenv("DAFT_SHOW_ALIGN", "right")
+
+    format, verbose, max_width, align = resolve_show_defaults("grid", True, 50, "left")
+
+    assert format == "grid"
+    assert verbose is True
+    assert max_width == 50
+    assert align == "left"
 
 
 def test_show_with_many_columns():

--- a/tests/dataframe/test_show.py
+++ b/tests/dataframe/test_show.py
@@ -227,7 +227,7 @@ def test_resolve_show_defaults_from_env(monkeypatch):
     monkeypatch.setenv("DAFT_SHOW_MAX_WIDTH", "12")
     monkeypatch.setenv("DAFT_SHOW_ALIGN", "right")
 
-    format, verbose, max_width, align = resolve_show_defaults(None, False, 30, "auto")
+    format, verbose, max_width, align = resolve_show_defaults(None, None, None, None)
 
     assert format == "markdown"
     assert verbose is True
@@ -246,6 +246,18 @@ def test_resolve_show_defaults_respects_explicit_args(monkeypatch):
     assert format == "grid"
     assert verbose is True
     assert max_width == 50
+    assert align == "left"
+
+
+def test_resolve_show_defaults_respects_explicit_default_values(monkeypatch):
+    monkeypatch.setenv("DAFT_SHOW_VERBOSE", "true")
+    monkeypatch.setenv("DAFT_SHOW_MAX_WIDTH", "12")
+    monkeypatch.setenv("DAFT_SHOW_ALIGN", "right")
+
+    _, verbose, max_width, align = resolve_show_defaults(None, False, 30, "left")
+
+    assert verbose is False
+    assert max_width == 30
     assert align == "left"
 
 

--- a/tests/dataframe/test_show.py
+++ b/tests/dataframe/test_show.py
@@ -261,9 +261,10 @@ def test_resolve_show_defaults_respects_explicit_default_values(monkeypatch):
     assert align == "left"
 
 
-def test_resolve_show_defaults_align_defaults_to_auto(monkeypatch):
-    # With no env vars and no explicit argument, align should default to "auto"
-    # so numeric columns are right-aligned in the preview renderer.
+def test_resolve_show_defaults_falls_back_to_left_align(monkeypatch):
+    # With no env vars and no explicit argument, align stays "left" to keep
+    # existing docstring/doctest output stable. Users opt into numeric-right
+    # behavior via DAFT_SHOW_ALIGN=auto or an explicit align="auto" argument.
     for var in ("DAFT_SHOW_FORMAT", "DAFT_SHOW_VERBOSE", "DAFT_SHOW_MAX_WIDTH", "DAFT_SHOW_ALIGN"):
         monkeypatch.delenv(var, raising=False)
 
@@ -271,7 +272,7 @@ def test_resolve_show_defaults_align_defaults_to_auto(monkeypatch):
 
     assert verbose is False
     assert max_width == 30
-    assert align == "auto"
+    assert align == "left"
 
 
 def test_show_with_many_columns():

--- a/tests/dataframe/test_show.py
+++ b/tests/dataframe/test_show.py
@@ -261,6 +261,19 @@ def test_resolve_show_defaults_respects_explicit_default_values(monkeypatch):
     assert align == "left"
 
 
+def test_resolve_show_defaults_align_defaults_to_auto(monkeypatch):
+    # With no env vars and no explicit argument, align should default to "auto"
+    # so numeric columns are right-aligned in the preview renderer.
+    for var in ("DAFT_SHOW_FORMAT", "DAFT_SHOW_VERBOSE", "DAFT_SHOW_MAX_WIDTH", "DAFT_SHOW_ALIGN"):
+        monkeypatch.delenv(var, raising=False)
+
+    _, verbose, max_width, align = resolve_show_defaults(None, None, None, None)
+
+    assert verbose is False
+    assert max_width == 30
+    assert align == "auto"
+
+
 def test_show_with_many_columns():
     df = daft.from_pylist(
         [


### PR DESCRIPTION
## Summary

Implements 1 and 5 bullet points of issue by improving `.show()` preview defaults and adding meaningful `align="auto"` behavior.

This PR adds environment-variable defaults for `.show()` formatting options and makes `align="auto"` behave as expected: numeric/decimal columns are right-aligned and non-numeric columns are left-aligned. Auto-alignment is opt-in via the new env var or an explicit `align="auto"` argument; the hard-coded default stays `"left"` so existing docstring/doctest output (~40 examples) remains stable.

## Why

The issue asks for more formatting control in `.show()` output. This PR focuses on two practical pieces:

- Configurable default preview formatting without changing callsites.
- Correct automatic alignment for mixed numeric/text previews when the user opts in.

## Changes Made

- Add `.show()` default resolution helper in `daft/dataframe/preview.py`:
  - `DAFT_SHOW_FORMAT`
  - `DAFT_SHOW_VERBOSE`
  - `DAFT_SHOW_MAX_WIDTH`
  - `DAFT_SHOW_ALIGN`
- Wire default resolution into `DataFrame.show(...)` in `daft/dataframe/dataframe.py`.
- Update Rust preview alignment logic in `src/daft-recordbatch/src/preview.rs`:
  - `PreviewAlign::Auto` now maps numeric/decimal dtypes to right alignment.
  - Non-numeric dtypes remain left-aligned.
- Add focused tests:
  - Rust unit test for auto alignment behavior.
  - Python tests for env default resolution, sentinel `None` handling, explicit-arg precedence, and the unchanged `"left"` fallback default.
  - Python formatting test covering `align="auto"` behavior.

## Behavior

- Existing explicit `.show(...)` arguments keep precedence.
- When callers leave defaults, env vars can now control show formatting defaults.
- `align="auto"` (whether set via env var or explicit argument) produces numeric-right / non-numeric-left alignment in preview rendering.
- The hard-coded default alignment remains `"left"` to keep existing examples stable; users opt into the new behavior with `DAFT_SHOW_ALIGN=auto` or `df.show(align="auto")`.

## Test Plan

- `python -m ruff check daft/dataframe/preview.py daft/dataframe/dataframe.py tests/dataframe/test_show.py`
- `cargo test -p daft-recordbatch test_auto_aligns_numeric_right_and_non_numeric_left -- --nocapture`
- `DAFT_RUNNER=native pytest -q tests/dataframe/test_show.py -k 'resolve_show_defaults'`

## Related Issues

- Part of #4114

<img width="887" height="702" alt="image" src="https://github.com/user-attachments/assets/eb81e69b-17b5-4992-83a9-e4de2b5805e0" />
<img width="968" height="618" alt="image" src="https://github.com/user-attachments/assets/45a98587-0910-400c-bc5c-f2655f4a5bb9" />
<img width="962" height="703" alt="image" src="https://github.com/user-attachments/assets/c8d5fe48-c896-4eb4-8b31-86fc5fefa983" />