### PR TITLE
feat: add `to_map` constructor function

### DIFF
--- a/daft/functions/__init__.py
+++ b/daft/functions/__init__.py
@@ -258,6 +258,7 @@ from .str import (
     find,
     hamming_distance_str,
 )
+from .map import to_map
 from .struct import unnest, to_struct
 from .url import download, upload, parse_url
 from .audio import audio_metadata, resample
@@ -513,6 +514,7 @@ __all__ = [
     "to_datetime",
     "to_kebab_case",
     "to_list",
+    "to_map",
     "to_snake_case",
     "to_struct",
     "to_title_case",

--- a/daft/functions/map.py
+++ b/daft/functions/map.py
@@ -1,0 +1,49 @@
+"""Map Functions."""
+
+from __future__ import annotations
+
+from daft.expressions import Expression
+
+
+def to_map(*pairs: tuple[Expression, Expression]) -> Expression:
+    """Constructs a map column from key-value expression pairs.
+
+    Args:
+        pairs: Tuples of (key, value) expressions. All keys must share the same type
+            and all values must share the same type.
+
+    Returns:
+        An expression for a map column.
+
+    Examples:
+        >>> import daft
+        >>> from daft.functions import to_map
+        >>>
+        >>> df = daft.from_pydict({"k1": ["a", "b"], "v1": [1, 2], "k2": ["c", "d"], "v2": [3, 4]})
+        >>> df.select(to_map((df["k1"], df["v1"]), (df["k2"], df["v2"])).alias("my_map")).show()
+        ╭──────────────────────────────────╮
+        │ my_map                           │
+        │ ---                              │
+        │ Map[String, Int64]               │
+        ╞══════════════════════════════════╡
+        │ [{key: a, value: 1},             │
+        │ {key: c, value: 3}]              │
+        ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+        │ [{key: b, value: 2},             │
+        │ {key: d, value: 4}]              │
+        ╰──────────────────────────────────╯
+        <BLANKLINE>
+        (Showing first 2 of 2 rows)
+    """
+    if not pairs:
+        raise ValueError("to_map requires at least one (key, value) pair")
+
+    flat_args = []
+    for pair in pairs:
+        if not isinstance(pair, tuple) or len(pair) != 2:
+            raise ValueError("Each argument to to_map must be a tuple of (key, value) expressions")
+        key, value = pair
+        flat_args.append(Expression._to_expression(key))
+        flat_args.append(Expression._to_expression(value))
+
+    return Expression._call_builtin_scalar_fn("map", *flat_args)

--- a/src/daft-functions/src/lib.rs
+++ b/src/daft-functions/src/lib.rs
@@ -17,6 +17,7 @@ pub mod random;
 pub mod simhash;
 pub mod similarity;
 pub mod slice;
+pub mod to_map;
 pub mod to_struct;
 pub mod uuid;
 pub mod vector_utils;
@@ -30,6 +31,7 @@ use minhash::MinHashFunction;
 pub use python::register as register_modules;
 use simhash::SimHashFunction;
 use snafu::Snafu;
+use to_map::ToMapFunction;
 use to_struct::ToStructFunction;
 use uuid::Uuid;
 
@@ -71,6 +73,7 @@ impl FunctionModule for MiscFunctions {
         parent.add_fn(MinHashFunction);
         parent.add_fn(SimHashFunction);
         parent.add_fn(Length);
+        parent.add_fn(ToMapFunction);
         parent.add_fn(ToStructFunction);
         parent.add_fn(Slice);
         parent.add_fn(Uuid);

--- a/src/daft-functions/src/to_map.rs
+++ b/src/daft-functions/src/to_map.rs
@@ -1,0 +1,173 @@
+use arrow_buffer::OffsetBuffer;
+use common_error::{DaftError, DaftResult};
+use daft_core::prelude::*;
+use daft_dsl::functions::{prelude::*, scalar::ScalarFn};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub(super) struct ToMapFunction;
+
+#[typetag::serde]
+impl ScalarUDF for ToMapFunction {
+    fn name(&self) -> &'static str {
+        "map"
+    }
+
+    fn call(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+        _ctx: &daft_dsl::functions::scalar::EvalContext,
+    ) -> DaftResult<Series> {
+        let inputs = inputs.into_inner();
+        if inputs.is_empty() || !inputs.len().is_multiple_of(2) {
+            return Err(DaftError::ValueError(
+                "to_map requires an even number of inputs (key-value pairs)".to_string(),
+            ));
+        }
+
+        let num_pairs = inputs.len() / 2;
+        let num_rows = inputs.iter().map(|s| s.len()).max().unwrap();
+
+        let inputs: Vec<Series> = inputs
+            .into_iter()
+            .map(|s| {
+                if s.len() == 1 && num_rows > 1 {
+                    s.broadcast(num_rows)
+                } else if s.len() != num_rows {
+                    Err(DaftError::ValueError(format!(
+                        "All inputs to to_map must have the same length or be length 1, got {}",
+                        s.len()
+                    )))
+                } else {
+                    Ok(s)
+                }
+            })
+            .collect::<DaftResult<_>>()?;
+
+        let keys: Vec<&Series> = inputs.iter().step_by(2).collect();
+        let values: Vec<&Series> = inputs.iter().skip(1).step_by(2).collect();
+
+        let key_dtype = keys[0].data_type();
+        for k in &keys[1..] {
+            if k.data_type() != key_dtype {
+                return Err(DaftError::ValueError(format!(
+                    "All keys in to_map must have the same type. Expected {}, got {}",
+                    key_dtype,
+                    k.data_type()
+                )));
+            }
+        }
+
+        let value_dtype = values[0].data_type();
+        for v in &values[1..] {
+            if v.data_type() != value_dtype {
+                return Err(DaftError::ValueError(format!(
+                    "All values in to_map must have the same type. Expected {}, got {}",
+                    value_dtype,
+                    v.data_type()
+                )));
+            }
+        }
+
+        // Concat all keys and all values (grouped by pair).
+        // Then transpose from (num_pairs, num_rows) to (num_rows, num_pairs)
+        // so each row's entries are contiguous in the flat child.
+        let concat_keys = Series::concat(&keys)?;
+        let concat_values = Series::concat(&values)?;
+
+        let total = num_pairs * num_rows;
+        let indices: Vec<u64> = (0..total)
+            .map(|p| {
+                let row = p / num_pairs;
+                let pair = p % num_pairs;
+                (pair * num_rows + row) as u64
+            })
+            .collect();
+
+        let idx = UInt64Array::from_vec("idx", indices);
+        let flat_keys = concat_keys.take(&idx)?.rename("key");
+        let flat_values = concat_values.take(&idx)?.rename("value");
+
+        let struct_field = Field::new(
+            "entries",
+            DataType::Struct(vec![
+                Field::new("key", key_dtype.clone()),
+                Field::new("value", value_dtype.clone()),
+            ]),
+        );
+        let struct_array = StructArray::new(struct_field, vec![flat_keys, flat_values], None);
+
+        let offsets: Vec<i64> = (0..=num_rows).map(|i| (i * num_pairs) as i64).collect();
+        let list_field = Field::new(
+            "map",
+            DataType::List(Box::new(DataType::Struct(vec![
+                Field::new("key", key_dtype.clone()),
+                Field::new("value", value_dtype.clone()),
+            ]))),
+        );
+        let list_array = ListArray::new(
+            list_field,
+            struct_array.into_series(),
+            OffsetBuffer::new(offsets.into()),
+            None,
+        );
+
+        let map_field = Field::new(
+            "map",
+            DataType::Map {
+                key: Box::new(key_dtype.clone()),
+                value: Box::new(value_dtype.clone()),
+            },
+        );
+        Ok(MapArray::new(map_field, list_array).into_series())
+    }
+
+    fn get_return_field(
+        &self,
+        inputs: FunctionArgs<ExprRef>,
+        schema: &Schema,
+    ) -> DaftResult<Field> {
+        let inputs = inputs.into_inner();
+        if inputs.is_empty() || !inputs.len().is_multiple_of(2) {
+            return Err(DaftError::ValueError(
+                "to_map requires an even number of inputs (key-value pairs)".to_string(),
+            ));
+        }
+
+        let key_field = inputs[0].to_field(schema)?;
+        let value_field = inputs[1].to_field(schema)?;
+
+        for i in (2..inputs.len()).step_by(2) {
+            let f = inputs[i].to_field(schema)?;
+            if f.dtype != key_field.dtype {
+                return Err(DaftError::ValueError(format!(
+                    "All keys in to_map must have the same type. Expected {}, got {}",
+                    key_field.dtype, f.dtype
+                )));
+            }
+        }
+
+        for i in (3..inputs.len()).step_by(2) {
+            let f = inputs[i].to_field(schema)?;
+            if f.dtype != value_field.dtype {
+                return Err(DaftError::ValueError(format!(
+                    "All values in to_map must have the same type. Expected {}, got {}",
+                    value_field.dtype, f.dtype
+                )));
+            }
+        }
+
+        Ok(Field::new(
+            "map",
+            DataType::Map {
+                key: Box::new(key_field.dtype),
+                value: Box::new(value_field.dtype),
+            },
+        ))
+    }
+}
+
+#[must_use]
+pub fn to_map(inputs: Vec<ExprRef>) -> ExprRef {
+    ScalarFn::builtin(ToMapFunction, inputs).into()
+}

--- a/tests/dataframe/test_to_map.py
+++ b/tests/dataframe/test_to_map.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import pytest
+
+import daft
+from daft import col, lit
+from daft.functions import map_get, to_map
+
+
+def test_to_map_basic():
+    df = daft.from_pydict({"k1": ["a", "b"], "v1": [1, 2], "k2": ["c", "d"], "v2": [3, 4]})
+    result = df.select(to_map((col("k1"), col("v1")), (col("k2"), col("v2"))).alias("my_map")).collect()
+    maps = result.to_pydict()["my_map"]
+    assert maps == [[("a", 1), ("c", 3)], [("b", 2), ("d", 4)]]
+
+
+def test_to_map_single_pair():
+    df = daft.from_pydict({"k": ["x", "y", "z"], "v": [10, 20, 30]})
+    result = df.select(to_map((col("k"), col("v"))).alias("m")).collect()
+    maps = result.to_pydict()["m"]
+    assert maps == [[("x", 10)], [("y", 20)], [("z", 30)]]
+
+
+def test_to_map_with_nulls():
+    df = daft.from_pydict({"k": ["a", "b", None], "v": [1, None, 3]})
+    result = df.select(to_map((col("k"), col("v"))).alias("m")).collect()
+    maps = result.to_pydict()["m"]
+    assert maps == [[("a", 1)], [("b", None)], [(None, 3)]]
+
+
+def test_to_map_empty_raises():
+    with pytest.raises(ValueError, match="at least one"):
+        to_map()
+
+
+def test_to_map_bad_tuple_raises():
+    with pytest.raises(ValueError, match="tuple of .key, value."):
+        to_map(col("a"))
+
+
+def test_to_map_mismatched_key_types():
+    df = daft.from_pydict({"k1": ["a", "b"], "v1": [1, 2], "k2": [1, 2], "v2": [3, 4]})
+    with pytest.raises(Exception, match="same type"):
+        df.select(to_map((col("k1"), col("v1")), (col("k2"), col("v2")))).collect()
+
+
+def test_to_map_mismatched_value_types():
+    df = daft.from_pydict({"k1": ["a", "b"], "v1": [1, 2], "k2": ["c", "d"], "v2": ["x", "y"]})
+    with pytest.raises(Exception, match="same type"):
+        df.select(to_map((col("k1"), col("v1")), (col("k2"), col("v2")))).collect()
+
+
+def test_to_map_with_literals():
+    df = daft.from_pydict({"v": [1, 2, 3]})
+    result = df.select(to_map((lit("key"), col("v"))).alias("m")).collect()
+    maps = result.to_pydict()["m"]
+    assert maps == [[("key", 1)], [("key", 2)], [("key", 3)]]
+
+
+def test_to_map_then_map_get():
+    df = daft.from_pydict({"k1": ["a", "b"], "v1": [1, 2], "k2": ["c", "d"], "v2": [3, 4]})
+    result = (
+        df.select(to_map((col("k1"), col("v1")), (col("k2"), col("v2"))).alias("m"))
+        .select(map_get(col("m"), "a"))
+        .collect()
+    )
+    values = result.to_pydict()["value"]
+    assert values == [1, None]


### PR DESCRIPTION
## Summary

- Adds a `to_map()` function that constructs map columns from key-value expression pairs via a tuple-based API: `to_map((key_expr, val_expr), (key_expr2, val_expr2), ...)`
- Follows the same patterns as `to_list` and `to_struct`, registering as a `ScalarUDF` in the function registry
- Supports literal broadcasting (e.g. `to_map((lit("key"), col("v")))`)

Closes #6885

## Test plan

- [x] `test_to_map_basic` — multiple key-value pairs
- [x] `test_to_map_single_pair` — single pair
- [x] `test_to_map_with_literals` — literal key broadcast
- [x] `test_to_map_with_nulls` — null keys and values
- [x] `test_to_map_empty_raises` — error on no arguments
- [x] `test_to_map_bad_tuple_raises` — error on non-tuple argument
- [x] `test_to_map_mismatched_key_types` — error on mixed key types
- [x] `test_to_map_mismatched_value_types` — error on mixed value types
- [x] `test_to_map_then_map_get` — roundtrip with `map_get`