### PR TITLE
feat: Adds Qdrant as a write destination

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -2222,6 +2222,52 @@ class DataFrame:
         return self.write_sink(sink)
 
     @DataframePublicAPI
+    def write_qdrant(
+        self,
+        collection_name: str | Expression,
+        url: str | None = None,
+        api_key: str | None = None,
+        id_column: str | None = None,
+        vector_column: str | None = None,
+        client_kwargs: dict[str, Any] | None = None,
+        upsert_kwargs: dict[str, Any] | None = None,
+    ) -> "DataFrame":
+        """Writes the DataFrame to a Qdrant collection.
+
+        This method transforms each row of the dataframe into a Qdrant point.
+        An `id` column is required. Optionally, the `id_column` parameter can be used to specify the column name to use for the id column.
+        Note that the column with the name specified by `id_column` will be renamed to "id" when written to Qdrant.
+        Qdrant point ids must be either unsigned integers or UUID strings.
+
+        A `vector` column is required. Optionally, the `vector_column` parameter can be used to specify the column name to use for the vector.
+        Note that the column with the name specified by `vector_column` will be renamed to "vector" when written to Qdrant.
+        The vector column may contain a list of floats (single vector) or a dict (named vectors).
+
+        All other columns become the point's payload.
+
+        The `collection_name` parameter can be either a string (for a single collection) or an expression (for multiple collections).
+        When using an expression, the data will be partitioned by the computed collection values and written to each collection separately.
+
+        The target collection(s) must already exist in Qdrant.
+
+        For more details on creating collections, please refer to: https://qdrant.tech/documentation/manage-data/collections/#create-a-collection
+
+        Args:
+            collection_name: The collection to write to. Can be a string for a single collection or an expression for multiple collections.
+            url: Qdrant server URL (e.g. ``"http://localhost:6333"``).
+            api_key: Qdrant API key.
+            id_column: Optional column name for the id column. The data sink will automatically rename the column to "id".
+            vector_column: Optional column name for the vector column. The data sink will automatically rename the column to "vector".
+            client_kwargs: Optional dictionary of arguments to pass to the ``QdrantClient`` constructor.
+                Explicit arguments (``url``, ``api_key``) will be merged into ``client_kwargs``.
+            upsert_kwargs: Optional dictionary of arguments to pass to the ``QdrantClient.upsert()`` method.
+        """
+        from daft.io.qdrant.qdrant_data_sink import QdrantDataSink
+
+        sink = QdrantDataSink(collection_name, url, api_key, id_column, vector_column, client_kwargs, upsert_kwargs)
+        return self.write_sink(sink)
+
+    @DataframePublicAPI
     def write_clickhouse(
         self,
         table: str,

--- a/daft/io/qdrant/__init__.py
+++ b/daft/io/qdrant/__init__.py
@@ -1,0 +1,3 @@
+from .qdrant_data_sink import QdrantDataSink
+
+__all__ = ["QdrantDataSink"]

--- a/daft/io/qdrant/qdrant_data_sink.py
+++ b/daft/io/qdrant/qdrant_data_sink.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Any
+
+from qdrant_client import QdrantClient, models
+from qdrant_client.http.exceptions import ResponseHandlingException, UnexpectedResponse
+
+from daft.datatype import DataType
+from daft.dependencies import pc
+from daft.expressions import ExpressionsProjection
+from daft.io import DataSink
+from daft.io.sink import WriteResult
+from daft.recordbatch import MicroPartition
+from daft.schema import Schema
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from types import ModuleType
+
+    from daft.dependencies import pa
+    from daft.expressions import Expression
+
+
+_TRANSIENT_STATUS_CODES = frozenset({408, 429, 500, 502, 503, 504})
+
+
+class QdrantDataSink(DataSink[dict[str, Any]]):
+    _collection: str | ExpressionsProjection
+
+    @staticmethod
+    def _import_qdrant() -> ModuleType:
+        try:
+            import qdrant_client
+
+            return qdrant_client
+        except ImportError:
+            raise ImportError(
+                "qdrant-client is not installed. Please install qdrant-client using `pip install qdrant-client`"
+            )
+
+    @staticmethod
+    def _check_collection_name(collection_name: str) -> None:
+        if not isinstance(collection_name, str):
+            raise ValueError(
+                f"Collection name must be a string, got {collection_name} with type {type(collection_name)}"
+            )
+
+    def __init__(
+        self,
+        collection_name: str | Expression,
+        url: str | None = None,
+        api_key: str | None = None,
+        id_column: str | None = None,
+        vector_column: str | None = None,
+        client_kwargs: dict[str, Any] | None = None,
+        upsert_kwargs: dict[str, Any] | None = None,
+    ) -> None:
+        if isinstance(collection_name, str):
+            QdrantDataSink._check_collection_name(collection_name)
+            self._collection = collection_name
+        else:
+            self._collection = ExpressionsProjection([collection_name])
+
+        self._api_key = api_key or os.getenv("QDRANT_API_KEY")
+
+        self._url = url
+        self._id_column = id_column
+        self._vector_column = vector_column
+
+        self._client_kwargs = client_kwargs or {}
+        if url is not None:
+            if "url" in self._client_kwargs:
+                raise ValueError("url is already set in client_kwargs")
+            self._client_kwargs["url"] = url
+        if api_key is not None:
+            if "api_key" in self._client_kwargs:
+                raise ValueError("api_key is already set in client_kwargs")
+            self._client_kwargs["api_key"] = api_key
+
+        self._upsert_kwargs = upsert_kwargs or {}
+
+        self._result_schema = Schema._from_field_name_and_types([("write_responses", DataType.python())])
+
+    def name(self) -> str:
+        return "Qdrant Write"
+
+    def schema(self) -> Schema:
+        return self._result_schema
+
+    def _prepare_arrow_table(self, arrow_table: pa.Table) -> pa.Table:
+        if self._id_column:
+            if self._id_column not in arrow_table.column_names:
+                raise ValueError(f"ID column {self._id_column} not found in schema, cannot use as column for id")
+            arrow_table = arrow_table.rename_columns({self._id_column: "id"})
+
+        if self._vector_column:
+            if self._vector_column not in arrow_table.column_names:
+                raise ValueError(
+                    f"Vector column {self._vector_column} not found in schema, cannot use as column for vector"
+                )
+            arrow_table = arrow_table.rename_columns({self._vector_column: "vector"})
+
+        id_column = arrow_table.column("id")
+        mask = pc.invert(pc.is_null(id_column))
+        return arrow_table.filter(mask)
+
+    @staticmethod
+    def _build_points(arrow_table: pa.Table) -> list[models.PointStruct]:
+        points = []
+        for row in arrow_table.to_pylist():
+            point_id = row.pop("id")
+            vector = row.pop("vector")
+            points.append(models.PointStruct(id=point_id, vector=vector, payload=row))
+        return points
+
+    def _write_with_error_handling(
+        self, client: QdrantClient, collection_name: str, arrow_table: pa.Table
+    ) -> WriteResult[dict[str, Any]]:
+        points = QdrantDataSink._build_points(arrow_table)
+        try:
+            response = client.upsert(
+                collection_name=collection_name,
+                points=points,
+                **self._upsert_kwargs,
+            )
+            result = {
+                "status": "success",
+                "response": response,
+            }
+            return WriteResult(
+                result=result,
+                bytes_written=arrow_table.nbytes,
+                rows_written=arrow_table.num_rows,
+            )
+        except (ResponseHandlingException, UnexpectedResponse) as e:
+            # Network/timeout errors and transient HTTP status codes are handled gracefully so that
+            # writes can continue. Other UnexpectedResponse codes (e.g. 4xx) propagate.
+            if isinstance(e, UnexpectedResponse) and e.status_code not in _TRANSIENT_STATUS_CODES:
+                raise
+            result = {
+                "status": "failed",
+                "error": str(e),
+                "rows_not_written": arrow_table.num_rows,
+            }
+            return WriteResult(
+                result=result,
+                bytes_written=0,
+                rows_written=0,
+            )
+
+    def write(self, micropartitions: Iterator[MicroPartition]) -> Iterator[WriteResult[dict[str, Any]]]:
+        qdrant_client = QdrantDataSink._import_qdrant()
+        client = qdrant_client.QdrantClient(**self._client_kwargs)
+
+        for micropartition in micropartitions:
+            if isinstance(self._collection, str):
+                arrow_table = self._prepare_arrow_table(micropartition.to_arrow())
+                if arrow_table.num_rows == 0:
+                    continue
+                yield self._write_with_error_handling(client, self._collection, arrow_table)
+            else:
+                (partitioned_data, partition_keys) = micropartition.partition_by_value(self._collection)
+                for data, collection_name in zip(partitioned_data, partition_keys.get_column(0)):
+                    arrow_table = self._prepare_arrow_table(data.to_arrow())
+                    if arrow_table.num_rows == 0:
+                        continue
+                    QdrantDataSink._check_collection_name(collection_name)
+                    yield self._write_with_error_handling(client, collection_name, arrow_table)
+
+    def finalize(self, write_results: list[WriteResult[dict[str, Any]]]) -> MicroPartition:
+        if len(write_results) == 0:
+            return MicroPartition.empty(self._result_schema)
+        else:
+            result_table = MicroPartition.from_pydict(
+                {
+                    "write_responses": write_results,
+                }
+            )
+
+            return result_table

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -56,6 +56,7 @@
         * [SQL Databases](connectors/sql.md)
         * [Text Files](connectors/text.md)
         * [Turbopuffer](connectors/turbopuffer.md)
+        * [Qdrant](connectors/qdrant.md)
         * [Unity Catalog (Databricks)](connectors/unity_catalog.md)
     * Extensions
         * [Overview](extensions/overview.md)

--- a/docs/ai-functions/embed.md
+++ b/docs/ai-functions/embed.md
@@ -199,4 +199,4 @@ results.show()
     - Pre-computing and storing embeddings to avoid re-generation
     - Using approximate nearest neighbor (ANN) algorithms for huge datasets
     - Filtering documents before computing similarity to reduce comparisons
-    - Writing results to a vector database like [Turbopuffer](../connectors/turbopuffer.md) for efficient retrieval
+    - Writing results to a vector database like [Turbopuffer](../connectors/turbopuffer.md) or [Qdrant](../connectors/qdrant.md) for efficient retrieval

--- a/docs/api/io.md
+++ b/docs/api/io.md
@@ -136,6 +136,10 @@ Daft offers a variety of approaches to creating a DataFrame from reading various
     options:
         heading_level: 3
 
+::: daft.dataframe.DataFrame.write_qdrant
+    options:
+        heading_level: 3
+
 ::: daft.dataframe.DataFrame.write_sink
     options:
         heading_level: 3

--- a/docs/connectors/custom.md
+++ b/docs/connectors/custom.md
@@ -366,4 +366,5 @@ For further reference, feel free to check out some of our notable data connector
 - [Writes to Hugging Face 🤗](https://github.com/Eventual-Inc/Daft/blob/main/daft/io/huggingface/sink.py)
 - [Writes to ClickHouse](https://github.com/Eventual-Inc/Daft/blob/main/daft/io/clickhouse/clickhouse_data_sink.py)
 - [Writes to Turbopuffer](https://github.com/Eventual-Inc/Daft/blob/main/daft/io/turbopuffer/turbopuffer_data_sink.py)
+- [Writes to Qdrant](https://github.com/Eventual-Inc/Daft/blob/main/daft/io/qdrant/qdrant_data_sink.py)
 - [Writes to LanceDB](https://github.com/Eventual-Inc/Daft/blob/main/daft/io/lance/lance_data_sink.py)

--- a/docs/connectors/qdrant.md
+++ b/docs/connectors/qdrant.md
@@ -1,0 +1,56 @@
+# Writing to Qdrant
+
+[Qdrant](https://qdrant.tech/) is an open-source vector search engine built for high-performance and massive-scale.
+
+## Example
+
+This example does the following:
+
+1. Reads the [`Open-Orca/OpenOrca`](https://huggingface.co/datasets/Open-Orca/OpenOrca) dataset from [Hugging Face](https://huggingface.co/).
+2. Computes text embeddings on the `response` column, using either an [OpenAI model](https://platform.openai.com/docs/models/text-embedding-3-small) or the [`BAAI/bge-base-en-v1.5`](https://huggingface.co/BAAI/bge-base-en-v1.5) open model on Hugging Face with [Sentence Transformers](https://sbert.net/index.html).
+3. Writes the results to a Qdrant collection.
+
+=== "🐍 Python"
+
+    ```python
+    # $ pip install -U "daft[qdrant]"
+    # $ pip install -U "daft[openai]"
+    # OR
+    # $ pip install -U "daft[sentence-transformers]"
+    import os
+
+    import daft
+    from daft.functions import monotonically_increasing_id
+    from daft.functions.ai import embed_text
+    from qdrant_client import QdrantClient, models
+
+    # Create an embedding with OpenAI, or Sentence Transformers
+    # Requires OPENAI_API_KEY to be set (https://platform.openai.com/settings/organization/api-keys)
+    if os.getenv("OPENAI_API_KEY"):
+        provider = "openai"
+        model = "text-embedding-3-small"
+        vector_size = 1536
+    else:
+        provider = "sentence_transformers"
+        model = "BAAI/bge-base-en-v1.5"
+        vector_size = 768
+
+    # Create the collection once before writing.
+    QdrantClient(url=os.environ.get("QDRANT_URL", "http://localhost:6333")).create_collection(
+        "daft-qdrant-example",
+        vectors_config=models.VectorParams(size=vector_size, distance=models.Distance.COSINE),
+    )
+
+    (
+        daft.read_huggingface("Open-Orca/OpenOrca")
+        .limit(8)
+        .with_column("vector", embed_text(daft.col("response"), provider=provider, model=model))
+        .with_column("id", monotonically_increasing_id())
+        .write_qdrant(
+            collection_name="daft-qdrant-example",
+            url=os.environ.get("QDRANT_URL", "http://localhost:6333"),
+        )
+    )
+    ```
+
+Check out our [`DataFrame.write_qdrant` documentation][daft.DataFrame.write_qdrant] for more customization options.

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -24,7 +24,7 @@
 
 - [Build a 100% GPU Utilization Text Embedding Pipeline featuring spaCy and Turbopuffer](text-embeddings.md)
 
-    Generate and store millions of text embeddings in vector databases using distributed GPU processing and state-of-the-art models.
+    Generate and store millions of text embeddings in vector databases (Turbopuffer, Qdrant) using distributed GPU processing and state-of-the-art models.
 
 - [Generate Images with Stable Diffusion](image-generation.md)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -247,6 +247,7 @@ const MODALITIES = {
         details: ["# use CLIP model on GPU", "# use OpenAI text-embedding-3"],
         destinations: {
           "Turbopuffer": "# for vector search",
+          "Qdrant": "# for vector search",
           "LanceDB": "# for vector search"
         }
       }
@@ -273,6 +274,7 @@ const MODALITIES = {
         details: ["# use OpenAI's API for text-embedding-3", "# use sentence-transformers on GPU"],
         destinations: {
           "Turbopuffer": "# for vector search",
+          "Qdrant": "# for vector search",
           "LanceDB": "# for vector search"
         }
       },
@@ -319,6 +321,7 @@ const MODALITIES = {
         details: ["# use CLIP model on CPU", "# use CLIP model on GPU"],
         destinations: {
           "Turbopuffer": "# for vector search",
+          "Qdrant": "# for vector search",
           "LanceDB": "# for vector search"
         }
       }
@@ -354,6 +357,7 @@ const MODALITIES = {
         details: ["# use custom Python code with wav2vec2", "# use OpenAI's endpoint for text-embedding-3"],
         destinations: {
           "Turbopuffer": "# for vector search",
+          "Qdrant": "# for vector search",
           "LanceDB": "# for vector search"
         }
       }
@@ -373,6 +377,7 @@ const MODALITIES = {
         details: ["# use OpenAI's endpoint for text-embedding-3", "# use sentence-transformers on GPUs", "# use BERT model on GPUs"],
         destinations: {
           "Turbopuffer": "# for vector search",
+          "Qdrant": "# for vector search",
           "LanceDB": "# for vector search"
         }
       }

--- a/docs/install.md
+++ b/docs/install.md
@@ -58,6 +58,14 @@ Depending on your use case, you may need to install Daft with additional depende
       </label>
 
       <label class="checkbox-item">
+        <input type="checkbox" id="qdrant" data-extra="qdrant">
+        <span class="checkmark"></span>
+        <div class="checkbox-content">
+          <strong>Qdrant</strong> <code>qdrant</code>
+        </div>
+      </label>
+
+      <label class="checkbox-item">
         <input type="checkbox" id="aws" data-extra="aws">
         <span class="checkmark"></span>
         <div class="checkbox-content">

--- a/docs/modalities/embeddings.md
+++ b/docs/modalities/embeddings.md
@@ -7,7 +7,7 @@ With the native [`daft.DataType.embedding`](../api/datatypes/all_datatypes.md#da
 - **Generate embeddings** from any text column using providers like OpenAI, Cohere, or local models
 - **Compute similarity** with built-in distance functions like `cosine_distance`
 - **Build search pipelines** that scale from local development to distributed clusters
-- **Write to vector databases** like Turbopuffer, Pinecone, or LanceDB
+- **Write to vector databases** like Turbopuffer, Qdrant, Pinecone, or LanceDB
 
 ## Semantic Search Example
 
@@ -154,5 +154,17 @@ df.write_turbopuffer(
         "abstract": "string",
         "abstract_embedding": "vector",
     }
+)
+```
+
+The same pipeline can target [Qdrant](../connectors/qdrant.md) instead by swapping the final write step:
+
+```python
+# Write to Qdrant — the collection must already exist with the appropriate vector config.
+df.write_qdrant(
+    collection_name="ai_papers",
+    url=os.environ.get("QDRANT_URL", "http://localhost:6333"),
+    api_key=os.environ.get("QDRANT_API_KEY"),
+    vector_column="abstract_embedding",
 )
 ```

--- a/docs/modalities/text.md
+++ b/docs/modalities/text.md
@@ -128,7 +128,7 @@ model = "text-embedding-nomic-embed-text-v1.5"
 
 It's common to use embeddings for various tasks like similarity search or retrieval with a vector database.
 
-Check out our guide on [writing to turbopuffer](../connectors/turbopuffer.md) to work with a popular fast vector database.
+Check out our guides on [writing to Turbopuffer](../connectors/turbopuffer.md) or [writing to Qdrant](../connectors/qdrant.md) to work with popular vector databases.
 
 
 ## Chunk text into smaller pieces
@@ -174,4 +174,4 @@ For a fuller discussion on text chunking strategies, check out the [text chunkin
 
 ## More examples
 
-Check out our [end-to-end tutorial](../examples/text-embeddings.md) for a complete workflow: chunking text, generating embeddings, and uploading to vector databases like [turbopuffer](../connectors/turbopuffer.md).
+Check out our [end-to-end tutorial](../examples/text-embeddings.md) for a complete workflow: chunking text, generating embeddings, and uploading to vector databases like [Turbopuffer](../connectors/turbopuffer.md) or [Qdrant](../connectors/qdrant.md).

--- a/docs/use-case/batch-inference.md
+++ b/docs/use-case/batch-inference.md
@@ -98,4 +98,5 @@ Ready to explore Daft further? Check out these topics:
   - [S3](../connectors/aws.md)
   - [Hugging Face 🤗](../connectors/huggingface.md)
   - [Turbopuffer](../connectors/turbopuffer.md)
+  - [Qdrant](../connectors/qdrant.md)
 - [Scaling out and deployment](../distributed/index.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ homepage = "https://www.daft.ai"
 repository = "https://github.com/Eventual-Inc/Daft"
 
 [project.optional-dependencies]
-all = ["daft[aws, azure, clickhouse, deltalake, gcp, google, gravitino, hudi, huggingface, iceberg, lance, numpy, openai, pandas, postgres, ray, sentence-transformers, sql, transformers, turbopuffer, unity, video]"]
+all = ["daft[aws, azure, clickhouse, deltalake, gcp, google, gravitino, hudi, huggingface, iceberg, lance, numpy, openai, pandas, postgres, qdrant, ray, sentence-transformers, sql, transformers, turbopuffer, unity, video]"]
 aws = ["boto3<1.43.0", "mypy-boto3-glue"]
 azure = []
 clickhouse = ["clickhouse_connect<0.12.0"]
@@ -46,6 +46,7 @@ numpy = ["numpy<2.4.0"]
 openai = ["openai<2.21.0", "numpy<2.4.0", "pillow==12.1.1"]
 pandas = ["pandas<2.4.0"]
 postgres = ["psycopg[binary]<3.4.0", "pgvector<0.5.0", "sqlglot<28.11.0", "connectorx>=0.4.4,<0.5.0"]
+qdrant = ["qdrant-client<2.0.0"]
 ray = [
   # Inherit existing Ray version. Get the "default" extra for the Ray dashboard.
   'ray[data, client]>=2.0.0,<2.56.0; platform_system != "Windows"',

--- a/tests/io/test_qdrant_write.py
+++ b/tests/io/test_qdrant_write.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+import pytest
+import qdrant_client
+from qdrant_client.http.exceptions import ApiException, ResponseHandlingException, UnexpectedResponse
+
+import daft
+from tests.conftest import get_tests_daft_runner_name
+
+
+@pytest.fixture
+def sample_df() -> daft.DataFrame:
+    return daft.from_pydict(
+        {
+            "id": [1, 2, 3],
+            "text": ["hello", "world", "test"],
+            "vector": [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.7, 0.8, 0.9]],
+        }
+    )
+
+
+def _make_unexpected_response(status_code: int, message: str) -> UnexpectedResponse:
+    return UnexpectedResponse(
+        status_code=status_code,
+        reason_phrase=message,
+        content=message.encode(),
+        headers=None,
+    )
+
+
+@pytest.mark.skipif(
+    get_tests_daft_runner_name() == "ray",
+    reason="Mocking the data sink's dependencies doesn't work in Ray execution environment",
+)
+@pytest.mark.parametrize(
+    "error",
+    [
+        _make_unexpected_response(429, "Too Many Requests"),
+        _make_unexpected_response(500, "Internal Server Error"),
+        _make_unexpected_response(502, "Bad Gateway"),
+        _make_unexpected_response(503, "Service Unavailable"),
+        _make_unexpected_response(504, "Gateway Timeout"),
+        ResponseHandlingException("connection reset"),
+    ],
+)
+def test_resilience_to_transient_errors(sample_df, error):
+    mock_client = Mock()
+    mock_client.upsert.side_effect = error
+
+    with (
+        patch(
+            "daft.io.qdrant.qdrant_data_sink.QdrantDataSink._import_qdrant",
+            return_value=qdrant_client,
+        ),
+        patch("qdrant_client.QdrantClient", return_value=mock_client),
+    ):
+        results = sample_df.write_qdrant(
+            collection_name="test_collection", url="http://localhost:6333", api_key="test_api_key"
+        ).collect()
+        rows_not_written = 0
+        for result in results:
+            write_result = result["write_responses"].result
+            assert write_result["status"] == "failed"
+            assert "error" in write_result
+            rows_not_written += write_result["rows_not_written"]
+
+        assert rows_not_written == sample_df.count_rows()
+
+
+@pytest.mark.skipif(
+    get_tests_daft_runner_name() == "ray",
+    reason="Mocking the data sink's dependencies doesn't work in Ray execution environment",
+)
+@pytest.mark.parametrize(
+    "error",
+    [
+        _make_unexpected_response(400, "Bad Request"),
+        _make_unexpected_response(401, "Unauthorized"),
+        _make_unexpected_response(403, "Forbidden"),
+        _make_unexpected_response(404, "Not Found"),
+        _make_unexpected_response(422, "Unprocessable Entity"),
+        ApiException("validation failed"),
+    ],
+)
+def test_fail_fast_on_non_transient_errors(sample_df, error):
+    mock_client = Mock()
+    mock_client.upsert.side_effect = error
+
+    with (
+        patch(
+            "daft.io.qdrant.qdrant_data_sink.QdrantDataSink._import_qdrant",
+            return_value=qdrant_client,
+        ),
+        patch("qdrant_client.QdrantClient", return_value=mock_client),
+    ):
+        with pytest.raises(RuntimeError) as exc_info:
+            sample_df.write_qdrant(
+                collection_name="test_collection", url="http://localhost:6333", api_key="test_api_key"
+            ).collect()
+
+        assert isinstance(exc_info.value.__cause__, type(error))

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
@@ -1443,6 +1443,7 @@ all = [
     { name = "pyarrow" },
     { name = "pyiceberg" },
     { name = "pylance" },
+    { name = "qdrant-client" },
     { name = "ray", extra = ["client", "data"] },
     { name = "requests" },
     { name = "sentence-transformers" },
@@ -1509,6 +1510,9 @@ postgres = [
     { name = "pgvector" },
     { name = "psycopg", extra = ["binary"] },
     { name = "sqlglot" },
+]
+qdrant = [
+    { name = "qdrant-client" },
 ]
 ray = [
     { name = "ray", extra = ["client", "data"] },
@@ -1641,7 +1645,7 @@ requires-dist = [
     { name = "clickhouse-connect", marker = "extra == 'clickhouse'", specifier = "<0.12.0" },
     { name = "connectorx", marker = "extra == 'postgres'", specifier = ">=0.4.4,<0.5.0" },
     { name = "connectorx", marker = "extra == 'sql'", specifier = ">=0.4.4,<0.5.0" },
-    { name = "daft", extras = ["aws", "azure", "clickhouse", "deltalake", "gcp", "google", "gravitino", "hudi", "huggingface", "iceberg", "lance", "numpy", "openai", "pandas", "postgres", "ray", "sentence-transformers", "sql", "transformers", "turbopuffer", "unity", "video"], marker = "extra == 'all'" },
+    { name = "daft", extras = ["aws", "azure", "clickhouse", "deltalake", "gcp", "google", "gravitino", "hudi", "huggingface", "iceberg", "lance", "numpy", "openai", "pandas", "postgres", "qdrant", "ray", "sentence-transformers", "sql", "transformers", "turbopuffer", "unity", "video"], marker = "extra == 'all'" },
     { name = "datasets", marker = "extra == 'huggingface'", specifier = "<4.6.0" },
     { name = "deltalake", marker = "extra == 'deltalake'", specifier = ">=1.5.0,<1.6.0" },
     { name = "deltalake", marker = "extra == 'unity'", specifier = ">=1.5.0,<1.6.0" },
@@ -1666,6 +1670,7 @@ requires-dist = [
     { name = "pyarrow", marker = "extra == 'hudi'", specifier = ">=8.0.0,<22.1.0" },
     { name = "pyiceberg", marker = "extra == 'iceberg'", specifier = ">=0.7.0,!=0.9.1,!=0.10.0,<=0.11.0" },
     { name = "pylance", marker = "extra == 'lance'", specifier = "<0.40.0" },
+    { name = "qdrant-client", marker = "extra == 'qdrant'", specifier = "<2.0.0" },
     { name = "ray", extras = ["data", "client"], marker = "sys_platform == 'win32' and extra == 'ray'", specifier = ">=2.10.0,<2.56.0" },
     { name = "ray", extras = ["data", "client"], marker = "sys_platform != 'win32' and extra == 'ray'", specifier = ">=2.0.0,<2.56.0" },
     { name = "requests", marker = "extra == 'gravitino'", specifier = ">=2.28.0,<3.0.0" },
@@ -1682,7 +1687,7 @@ requires-dist = [
     { name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.0.0" },
     { name = "unitycatalog", marker = "extra == 'unity'", specifier = "<0.2.0" },
 ]
-provides-extras = ["all", "audio", "aws", "azure", "clickhouse", "deltalake", "gcp", "google", "gravitino", "hudi", "huggingface", "iceberg", "lance", "numpy", "openai", "pandas", "postgres", "ray", "sql", "transformers", "turbopuffer", "unity", "video", "viz"]
+provides-extras = ["all", "audio", "aws", "azure", "clickhouse", "deltalake", "gcp", "google", "gravitino", "hudi", "huggingface", "iceberg", "lance", "numpy", "openai", "pandas", "postgres", "qdrant", "ray", "sql", "transformers", "turbopuffer", "unity", "video", "viz"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -2635,7 +2640,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/92/db/b4c12cff13ebac2786f4f217f06588bccd8b53d260453404ef22b121fc3a/greenlet-3.2.3-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:1afd685acd5597349ee6d7a88a8bec83ce13c106ac78c196ee9dde7c04fe87be", size = 268977, upload-time = "2025-06-05T16:10:24.001Z" },
     { url = "https://files.pythonhosted.org/packages/52/61/75b4abd8147f13f70986df2801bf93735c1bd87ea780d70e3b3ecda8c165/greenlet-3.2.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:761917cac215c61e9dc7324b2606107b3b292a8349bdebb31503ab4de3f559ac", size = 627351, upload-time = "2025-06-05T16:38:50.685Z" },
     { url = "https://files.pythonhosted.org/packages/35/aa/6894ae299d059d26254779a5088632874b80ee8cf89a88bca00b0709d22f/greenlet-3.2.3-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:a433dbc54e4a37e4fff90ef34f25a8c00aed99b06856f0119dcf09fbafa16392", size = 638599, upload-time = "2025-06-05T16:41:34.057Z" },
-    { url = "https://files.pythonhosted.org/packages/30/64/e01a8261d13c47f3c082519a5e9dbf9e143cc0498ed20c911d04e54d526c/greenlet-3.2.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:72e77ed69312bab0434d7292316d5afd6896192ac4327d44f3d613ecb85b037c", size = 634482, upload-time = "2025-06-05T16:48:16.26Z" },
     { url = "https://files.pythonhosted.org/packages/47/48/ff9ca8ba9772d083a4f5221f7b4f0ebe8978131a9ae0909cf202f94cd879/greenlet-3.2.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:68671180e3849b963649254a882cd544a3c75bfcd2c527346ad8bb53494444db", size = 633284, upload-time = "2025-06-05T16:13:01.599Z" },
     { url = "https://files.pythonhosted.org/packages/e9/45/626e974948713bc15775b696adb3eb0bd708bec267d6d2d5c47bb47a6119/greenlet-3.2.3-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:49c8cfb18fb419b3d08e011228ef8a25882397f3a859b9fe1436946140b6756b", size = 582206, upload-time = "2025-06-05T16:12:48.51Z" },
     { url = "https://files.pythonhosted.org/packages/b1/8e/8b6f42c67d5df7db35b8c55c9a850ea045219741bb14416255616808c690/greenlet-3.2.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:efc6dc8a792243c31f2f5674b670b3a95d46fa1c6a912b8e310d6f542e7b0712", size = 1111412, upload-time = "2025-06-05T16:36:45.479Z" },
@@ -2644,7 +2648,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fc/2e/d4fcb2978f826358b673f779f78fa8a32ee37df11920dc2bb5589cbeecef/greenlet-3.2.3-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:784ae58bba89fa1fa5733d170d42486580cab9decda3484779f4759345b29822", size = 270219, upload-time = "2025-06-05T16:10:10.414Z" },
     { url = "https://files.pythonhosted.org/packages/16/24/929f853e0202130e4fe163bc1d05a671ce8dcd604f790e14896adac43a52/greenlet-3.2.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0921ac4ea42a5315d3446120ad48f90c3a6b9bb93dd9b3cf4e4d84a66e42de83", size = 630383, upload-time = "2025-06-05T16:38:51.785Z" },
     { url = "https://files.pythonhosted.org/packages/d1/b2/0320715eb61ae70c25ceca2f1d5ae620477d246692d9cc284c13242ec31c/greenlet-3.2.3-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:d2971d93bb99e05f8c2c0c2f4aa9484a18d98c4c3bd3c62b65b7e6ae33dfcfaf", size = 642422, upload-time = "2025-06-05T16:41:35.259Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/49/445fd1a210f4747fedf77615d941444349c6a3a4a1135bba9701337cd966/greenlet-3.2.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c667c0bf9d406b77a15c924ef3285e1e05250948001220368e039b6aa5b5034b", size = 638375, upload-time = "2025-06-05T16:48:18.235Z" },
     { url = "https://files.pythonhosted.org/packages/7e/c8/ca19760cf6eae75fa8dc32b487e963d863b3ee04a7637da77b616703bc37/greenlet-3.2.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:592c12fb1165be74592f5de0d70f82bc5ba552ac44800d632214b76089945147", size = 637627, upload-time = "2025-06-05T16:13:02.858Z" },
     { url = "https://files.pythonhosted.org/packages/65/89/77acf9e3da38e9bcfca881e43b02ed467c1dedc387021fc4d9bd9928afb8/greenlet-3.2.3-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29e184536ba333003540790ba29829ac14bb645514fbd7e32af331e8202a62a5", size = 585502, upload-time = "2025-06-05T16:12:49.642Z" },
     { url = "https://files.pythonhosted.org/packages/97/c6/ae244d7c95b23b7130136e07a9cc5aadd60d59b5951180dc7dc7e8edaba7/greenlet-3.2.3-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:93c0bb79844a367782ec4f429d07589417052e621aa39a5ac1fb99c5aa308edc", size = 1114498, upload-time = "2025-06-05T16:36:46.598Z" },
@@ -2653,7 +2656,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/94/ad0d435f7c48debe960c53b8f60fb41c2026b1d0fa4a99a1cb17c3461e09/greenlet-3.2.3-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:25ad29caed5783d4bd7a85c9251c651696164622494c00802a139c00d639242d", size = 271992, upload-time = "2025-06-05T16:11:23.467Z" },
     { url = "https://files.pythonhosted.org/packages/93/5d/7c27cf4d003d6e77749d299c7c8f5fd50b4f251647b5c2e97e1f20da0ab5/greenlet-3.2.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88cd97bf37fe24a6710ec6a3a7799f3f81d9cd33317dcf565ff9950c83f55e0b", size = 638820, upload-time = "2025-06-05T16:38:52.882Z" },
     { url = "https://files.pythonhosted.org/packages/c6/7e/807e1e9be07a125bb4c169144937910bf59b9d2f6d931578e57f0bce0ae2/greenlet-3.2.3-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:baeedccca94880d2f5666b4fa16fc20ef50ba1ee353ee2d7092b383a243b0b0d", size = 653046, upload-time = "2025-06-05T16:41:36.343Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/ab/158c1a4ea1068bdbc78dba5a3de57e4c7aeb4e7fa034320ea94c688bfb61/greenlet-3.2.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:be52af4b6292baecfa0f397f3edb3c6092ce071b499dd6fe292c9ac9f2c8f264", size = 647701, upload-time = "2025-06-05T16:48:19.604Z" },
     { url = "https://files.pythonhosted.org/packages/cc/0d/93729068259b550d6a0288da4ff72b86ed05626eaf1eb7c0d3466a2571de/greenlet-3.2.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0cc73378150b8b78b0c9fe2ce56e166695e67478550769536a6742dca3651688", size = 649747, upload-time = "2025-06-05T16:13:04.628Z" },
     { url = "https://files.pythonhosted.org/packages/f6/f6/c82ac1851c60851302d8581680573245c8fc300253fc1ff741ae74a6c24d/greenlet-3.2.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:706d016a03e78df129f68c4c9b4c4f963f7d73534e48a24f5f5a7101ed13dbbb", size = 605461, upload-time = "2025-06-05T16:12:50.792Z" },
     { url = "https://files.pythonhosted.org/packages/98/82/d022cf25ca39cf1200650fc58c52af32c90f80479c25d1cbf57980ec3065/greenlet-3.2.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:419e60f80709510c343c57b4bb5a339d8767bf9aef9b8ce43f4f143240f88b7c", size = 1121190, upload-time = "2025-06-05T16:36:48.59Z" },
@@ -2662,7 +2664,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b1/cf/f5c0b23309070ae93de75c90d29300751a5aacefc0a3ed1b1d8edb28f08b/greenlet-3.2.3-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:500b8689aa9dd1ab26872a34084503aeddefcb438e2e7317b89b11eaea1901ad", size = 270732, upload-time = "2025-06-05T16:10:08.26Z" },
     { url = "https://files.pythonhosted.org/packages/48/ae/91a957ba60482d3fecf9be49bc3948f341d706b52ddb9d83a70d42abd498/greenlet-3.2.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a07d3472c2a93117af3b0136f246b2833fdc0b542d4a9799ae5f41c28323faef", size = 639033, upload-time = "2025-06-05T16:38:53.983Z" },
     { url = "https://files.pythonhosted.org/packages/6f/df/20ffa66dd5a7a7beffa6451bdb7400d66251374ab40b99981478c69a67a8/greenlet-3.2.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:8704b3768d2f51150626962f4b9a9e4a17d2e37c8a8d9867bbd9fa4eb938d3b3", size = 652999, upload-time = "2025-06-05T16:41:37.89Z" },
-    { url = "https://files.pythonhosted.org/packages/51/b4/ebb2c8cb41e521f1d72bf0465f2f9a2fd803f674a88db228887e6847077e/greenlet-3.2.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:5035d77a27b7c62db6cf41cf786cfe2242644a7a337a0e155c80960598baab95", size = 647368, upload-time = "2025-06-05T16:48:21.467Z" },
     { url = "https://files.pythonhosted.org/packages/8e/6a/1e1b5aa10dced4ae876a322155705257748108b7fd2e4fae3f2a091fe81a/greenlet-3.2.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2d8aa5423cd4a396792f6d4580f88bdc6efcb9205891c9d40d20f6e670992efb", size = 650037, upload-time = "2025-06-05T16:13:06.402Z" },
     { url = "https://files.pythonhosted.org/packages/26/f2/ad51331a157c7015c675702e2d5230c243695c788f8f75feba1af32b3617/greenlet-3.2.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2c724620a101f8170065d7dded3f962a2aea7a7dae133a009cada42847e04a7b", size = 608402, upload-time = "2025-06-05T16:12:51.91Z" },
     { url = "https://files.pythonhosted.org/packages/26/bc/862bd2083e6b3aff23300900a956f4ea9a4059de337f5c8734346b9b34fc/greenlet-3.2.3-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:873abe55f134c48e1f2a6f53f7d1419192a3d1a4e873bace00499a4e45ea6af0", size = 1119577, upload-time = "2025-06-05T16:36:49.787Z" },
@@ -2671,7 +2672,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d8/ca/accd7aa5280eb92b70ed9e8f7fd79dc50a2c21d8c73b9a0856f5b564e222/greenlet-3.2.3-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:3d04332dddb10b4a211b68111dabaee2e1a073663d117dc10247b5b1642bac86", size = 271479, upload-time = "2025-06-05T16:10:47.525Z" },
     { url = "https://files.pythonhosted.org/packages/55/71/01ed9895d9eb49223280ecc98a557585edfa56b3d0e965b9fa9f7f06b6d9/greenlet-3.2.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8186162dffde068a465deab08fc72c767196895c39db26ab1c17c0b77a6d8b97", size = 683952, upload-time = "2025-06-05T16:38:55.125Z" },
     { url = "https://files.pythonhosted.org/packages/ea/61/638c4bdf460c3c678a0a1ef4c200f347dff80719597e53b5edb2fb27ab54/greenlet-3.2.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f4bfbaa6096b1b7a200024784217defedf46a07c2eee1a498e94a1b5f8ec5728", size = 696917, upload-time = "2025-06-05T16:41:38.959Z" },
-    { url = "https://files.pythonhosted.org/packages/22/cc/0bd1a7eb759d1f3e3cc2d1bc0f0b487ad3cc9f34d74da4b80f226fde4ec3/greenlet-3.2.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:ed6cfa9200484d234d8394c70f5492f144b20d4533f69262d530a1a082f6ee9a", size = 692443, upload-time = "2025-06-05T16:48:23.113Z" },
     { url = "https://files.pythonhosted.org/packages/67/10/b2a4b63d3f08362662e89c103f7fe28894a51ae0bc890fabf37d1d780e52/greenlet-3.2.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:02b0df6f63cd15012bed5401b47829cfd2e97052dc89da3cfaf2c779124eb892", size = 692995, upload-time = "2025-06-05T16:13:07.972Z" },
     { url = "https://files.pythonhosted.org/packages/5a/c6/ad82f148a4e3ce9564056453a71529732baf5448ad53fc323e37efe34f66/greenlet-3.2.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:86c2d68e87107c1792e2e8d5399acec2487a4e993ab76c792408e59394d52141", size = 655320, upload-time = "2025-06-05T16:12:53.453Z" },
     { url = "https://files.pythonhosted.org/packages/5c/4f/aab73ecaa6b3086a4c89863d94cf26fa84cbff63f52ce9bc4342b3087a06/greenlet-3.2.3-cp314-cp314-win_amd64.whl", hash = "sha256:8c47aae8fbbfcf82cc13327ae802ba13c9c36753b67e760023fd116bc124a62a", size = 301236, upload-time = "2025-06-05T16:15:20.111Z" },
@@ -2892,6 +2892,19 @@ wheels = [
 ]
 
 [[package]]
+name = "h2"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hpack" },
+    { name = "hyperframe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
+]
+
+[[package]]
 name = "hf-xet"
 version = "1.1.8"
 source = { registry = "https://pypi.org/simple" }
@@ -2913,6 +2926,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/e5/0b56d723a76ca67abadbf7fb71609fb0ea7e6926e94fcca6c65a85b36a0e/hjson-3.1.0.tar.gz", hash = "sha256:55af475a27cf83a7969c808399d7bccdec8fb836a07ddbd574587593b9cdcf75", size = 40541, upload-time = "2022-08-13T02:53:01.919Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/7f/13cd798d180af4bf4c0ceddeefba2b864a63c71645abc0308b768d67bb81/hjson-3.1.0-py3-none-any.whl", hash = "sha256:65713cdcf13214fb554eb8b4ef803419733f4f5e551047c9b711098ab7186b89", size = 54018, upload-time = "2022-08-13T02:52:59.899Z" },
+]
+
+[[package]]
+name = "hpack"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/48/71de9ed269fdae9c8057e5a4c0aa7402e8bb16f2c6e90b3aa53327b113f8/hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca", size = 51276, upload-time = "2025-01-22T21:44:58.347Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496", size = 34357, upload-time = "2025-01-22T21:44:56.92Z" },
 ]
 
 [[package]]
@@ -2987,6 +3009,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
+[package.optional-dependencies]
+http2 = [
+    { name = "h2" },
+]
+
 [[package]]
 name = "huggingface-hub"
 version = "0.36.0"
@@ -3004,6 +3031,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/98/63/4910c5fa9128fdadf6a9c5ac138e8b1b6cee4ca44bf7915bbfbce4e355ee/huggingface_hub-0.36.0.tar.gz", hash = "sha256:47b3f0e2539c39bf5cde015d63b72ec49baff67b6931c3d97f3f84532e2b8d25", size = 463358, upload-time = "2025-10-23T12:12:01.413Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/bd/1a875e0d592d447cbc02805fd3fe0f497714d6a2583f59d14fa9ebad96eb/huggingface_hub-0.36.0-py3-none-any.whl", hash = "sha256:7bcc9ad17d5b3f07b57c78e79d527102d08313caa278a641993acddcb894548d", size = 566094, upload-time = "2025-10-23T12:11:59.557Z" },
+]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
 ]
 
 [[package]]
@@ -6257,6 +6293,18 @@ wheels = [
 ]
 
 [[package]]
+name = "portalocker"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/77/65b857a69ed876e1951e88aaba60f5ce6120c33703f7cb61a3c894b8c1b6/portalocker-3.2.0.tar.gz", hash = "sha256:1f3002956a54a8c3730586c5c77bf18fae4149e07eaf1c29fc3faf4d5a3f89ac", size = 95644, upload-time = "2025-06-14T13:20:40.03Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/a6/38c8e2f318bf67d338f4d629e93b0b4b9af331f455f0390ea8ce4a099b26/portalocker-3.2.0-py3-none-any.whl", hash = "sha256:3cdc5f565312224bc570c49337bd21428bba0ef363bbcf58b9ef4a9f11779968", size = 22424, upload-time = "2025-06-14T13:20:38.083Z" },
+]
+
+[[package]]
 name = "pre-commit"
 version = "4.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -7662,6 +7710,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/25/5c147307de546b502c9373688ce5b25dc22288d23a1ebebe5d587bf77610/pyzmq-27.0.2-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f3dba49ff037d02373a9306b58d6c1e0be031438f822044e8767afccfdac4c6b", size = 567459, upload-time = "2025-08-21T04:23:03.593Z" },
     { url = "https://files.pythonhosted.org/packages/71/06/0dc56ffc615c8095cd089c9b98ce5c733e990f09ce4e8eea4aaf1041a532/pyzmq-27.0.2-pp311-pypy311_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:de84e1694f9507b29e7b263453a2255a73e3d099d258db0f14539bad258abe41", size = 747088, upload-time = "2025-08-21T04:23:05.334Z" },
     { url = "https://files.pythonhosted.org/packages/06/f6/4a50187e023b8848edd3f0a8e197b1a7fb08d261d8c60aae7cb6c3d71612/pyzmq-27.0.2-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:f0944d65ba2b872b9fcece08411d6347f15a874c775b4c3baae7f278550da0fb", size = 544639, upload-time = "2025-08-21T04:23:07.279Z" },
+]
+
+[[package]]
+name = "qdrant-client"
+version = "1.16.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "grpcio", version = "1.68.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
+    { name = "grpcio", version = "1.78.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'darwin'" },
+    { name = "httpx", extra = ["http2"] },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "portalocker" },
+    { name = "protobuf", version = "5.29.6", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
+    { name = "protobuf", version = "6.33.5", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'darwin'" },
+    { name = "pydantic" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/68/fec3816a223c0b73b0e0036460be45c61ce2770ffb9197ac371e4f615ddc/qdrant_client-1.16.1.tar.gz", hash = "sha256:676c7c10fd4d4cb2981b8fcb32fd764f5f661b04b7334d024034d07212f971fd", size = 332130, upload-time = "2025-11-25T04:31:54.212Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/e2/60a20d04b0595c641516463168909c5bbcc192d3d6eacb637c1677109c6a/qdrant_client-1.16.1-py3-none-any.whl", hash = "sha256:1eefe89f66e8a468ba0de1680e28b441e69825cfb62e8fb2e457c15e24ce5e3b", size = 378481, upload-time = "2025-11-25T04:31:52.629Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# UPDATE

As per

> @Anush008, We are moving away from adding more sources & sinks in daft. However this seems like something that would be well suited for a community extension. See this discussion for more info https://github.com/Eventual-Inc/Daft/discussions/6852

This PR is now a separate package. Available at https://github.com/qdrant-labs/daft-qdrant.

### Description

This PR adds support for using [Qdrant](https://qdrant.tech/) as a sink destination in Daft.

Qdrant is an open-source vector search engine built for massive-scale and high-performance.

### Related Issues

Resolves #6888

### Testing

I've tested the integration end-to-end against a local Qdrant instance.

### Setup

You can run Qdrant with 

```bash
docker run -p 6333:6333 qdrant/qdrant
```

The dashboard is accessible at http://localhost:6333/dashboard