### PR TITLE
fix(stats): close race in RuntimeStatsManager shutdown

### DIFF
--- a/src/daft-local-execution/src/runtime_stats/mod.rs
+++ b/src/daft-local-execution/src/runtime_stats/mod.rs
@@ -184,6 +184,73 @@ impl std::fmt::Debug for RuntimeStatsManager {
 }
 
 impl RuntimeStatsManager {
+    /// Apply a single channel message to the manager's mutable state. Used both
+    /// from the main `select!` branch and from the post-finish drain so late
+    /// `RegisterRuntimeStats` / `TakeInputSnapshot` messages aren't lost when
+    /// `finish_rx` wins the race against a still-queued `node_rx` message.
+    #[allow(clippy::too_many_arguments)]
+    fn handle_message(
+        msg: StatsManagerMessage,
+        input_stats: &mut HashMap<(NodeID, InputId), Arc<dyn RuntimeStats>>,
+        active_nodes: &mut HashSet<NodeID>,
+        query_id: &QueryID,
+        query_plan: &serde_json::Value,
+        progress_bar: Option<&dyn ProgressBar>,
+        subscribers: &[Arc<dyn Subscriber>],
+        operators: &HashMap<NodeID, Arc<OperatorMeta>>,
+        node_info_map: &HashMap<NodeID, Arc<NodeInfo>>,
+    ) {
+        match msg {
+            StatsManagerMessage::NodeEvent(node_id, is_initialize) => {
+                if is_initialize && active_nodes.insert(node_id) {
+                    if let Some(progress_bar) = progress_bar {
+                        progress_bar.initialize_node(node_id);
+                    }
+
+                    let Some(operator_meta) = operators.get(&node_id) else {
+                        log::warn!(
+                            "Unknown node_id {node_id} in operators during on_start, skipping subscriber notification"
+                        );
+                        return;
+                    };
+
+                    let event = Event::OperatorStart(OperatorStartEvent {
+                        header: event_header(query_id.clone()),
+                        operator: operator_meta.clone(),
+                    });
+                    dispatch_event(subscribers, &event, "notify operator start");
+                } else if !is_initialize && active_nodes.remove(&node_id) {
+                    Self::flush_and_finalize_node(
+                        query_id,
+                        node_id,
+                        input_stats,
+                        progress_bar,
+                        subscribers,
+                        "finalize node",
+                        operators,
+                    );
+                }
+            }
+            StatsManagerMessage::RegisterRuntimeStats(node_id, input_id, stats) => {
+                input_stats.insert((node_id, input_id), stats);
+            }
+            StatsManagerMessage::TakeInputSnapshot(input_id, respond_tx) => {
+                let mut result = Vec::new();
+                for (&(node_id, iid), stats) in input_stats.iter() {
+                    if iid == input_id
+                        && let Some(node_info) = node_info_map.get(&node_id)
+                    {
+                        result.push((node_info.clone(), stats.flush()));
+                    }
+                }
+                let _ = respond_tx.send(
+                    ExecutionStats::new(query_id.clone(), result)
+                        .with_query_plan(query_plan.clone()),
+                );
+            }
+        }
+    }
+
     fn flush_and_finalize_node(
         query_id: &QueryID,
         node_id: NodeID,
@@ -317,70 +384,21 @@ impl RuntimeStatsManager {
             // Reuse container for ticks
             let mut snapshot_container = Vec::with_capacity(node_info_map.len());
 
-            // Handle a single channel message. Shared between the main `select!`
-            // branch and the post-finish drain below so late `RegisterRuntimeStats`
-            // messages aren't lost when `finish_rx` wins the race against a still-
-            // queued node_rx message.
-            let handle_message =
-                |msg: StatsManagerMessage,
-                 input_stats: &mut HashMap<(NodeID, InputId), Arc<dyn RuntimeStats>>,
-                 active_nodes: &mut HashSet<NodeID>| {
-                    match msg {
-                        StatsManagerMessage::NodeEvent(node_id, is_initialize) => {
-                            if is_initialize && active_nodes.insert(node_id) {
-                                if let Some(progress_bar) = &progress_bar {
-                                    progress_bar.initialize_node(node_id);
-                                }
-
-                                let Some(operator_meta) = operators.get(&node_id) else {
-                                    log::warn!(
-                                        "Unknown node_id {node_id} in operators during on_start, skipping subscriber notification"
-                                    );
-                                    return;
-                                };
-
-                                let event = Event::OperatorStart(OperatorStartEvent {
-                                    header: event_header(query_id.clone()),
-                                    operator: operator_meta.clone(),
-                                });
-                                dispatch_event(&subscribers, &event, "notify operator start");
-                            } else if !is_initialize && active_nodes.remove(&node_id) {
-                                Self::flush_and_finalize_node(
-                                    &query_id,
-                                    node_id,
-                                    input_stats,
-                                    progress_bar.as_deref(),
-                                    &subscribers,
-                                    "finalize node",
-                                    &operators,
-                                );
-                            }
-                        }
-                        StatsManagerMessage::RegisterRuntimeStats(node_id, input_id, stats) => {
-                            input_stats.insert((node_id, input_id), stats);
-                        }
-                        StatsManagerMessage::TakeInputSnapshot(input_id, respond_tx) => {
-                            let mut result = Vec::new();
-                            for (&(node_id, iid), stats) in input_stats.iter() {
-                                if iid == input_id
-                                    && let Some(node_info) = node_info_map.get(&node_id)
-                                {
-                                    result.push((node_info.clone(), stats.flush()));
-                                }
-                            }
-                            let _ = respond_tx.send(
-                                ExecutionStats::new(query_id.clone(), result)
-                                    .with_query_plan(query_plan.clone()),
-                            );
-                        }
-                    }
-                };
-
             loop {
                 tokio::select! {
                     biased;
                     Some(msg) = node_rx.recv() => {
-                        handle_message(msg, &mut input_stats, &mut active_nodes);
+                        Self::handle_message(
+                            msg,
+                            &mut input_stats,
+                            &mut active_nodes,
+                            &query_id,
+                            &query_plan,
+                            progress_bar.as_deref(),
+                            &subscribers,
+                            &operators,
+                            &node_info_map,
+                        );
                     }
 
                     _ = &mut finish_rx => {
@@ -390,7 +408,17 @@ impl RuntimeStatsManager {
                         // finish branch, leaving `input_stats` missing entries and
                         // `take_input_snapshot` returning empty stats.
                         while let Ok(msg) = node_rx.try_recv() {
-                            handle_message(msg, &mut input_stats, &mut active_nodes);
+                            Self::handle_message(
+                                msg,
+                                &mut input_stats,
+                                &mut active_nodes,
+                                &query_id,
+                                &query_plan,
+                                progress_bar.as_deref(),
+                                &subscribers,
+                                &operators,
+                                &node_info_map,
+                            );
                         }
                         // Queries that terminate early (e.g. LIMIT) may still have active upstream nodes.
                         // Flush and finalize those nodes so subscribers and progress bars end in a consistent state.

--- a/src/daft-local-execution/src/runtime_stats/mod.rs
+++ b/src/daft-local-execution/src/runtime_stats/mod.rs
@@ -321,7 +321,7 @@ impl RuntimeStatsManager {
             // branch and the post-finish drain below so late `RegisterRuntimeStats`
             // messages aren't lost when `finish_rx` wins the race against a still-
             // queued node_rx message.
-            let mut handle_message = |msg: StatsManagerMessage,
+            let handle_message = |msg: StatsManagerMessage,
                                       input_stats: &mut HashMap<(NodeID, InputId), Arc<dyn RuntimeStats>>,
                                       active_nodes: &mut HashSet<NodeID>| {
                 match msg {

--- a/src/daft-local-execution/src/runtime_stats/mod.rs
+++ b/src/daft-local-execution/src/runtime_stats/mod.rs
@@ -321,54 +321,60 @@ impl RuntimeStatsManager {
             // branch and the post-finish drain below so late `RegisterRuntimeStats`
             // messages aren't lost when `finish_rx` wins the race against a still-
             // queued node_rx message.
-            let handle_message = |msg: StatsManagerMessage,
-                                      input_stats: &mut HashMap<(NodeID, InputId), Arc<dyn RuntimeStats>>,
-                                      active_nodes: &mut HashSet<NodeID>| {
-                match msg {
-                    StatsManagerMessage::NodeEvent(node_id, is_initialize) => {
-                        if is_initialize && active_nodes.insert(node_id) {
-                            if let Some(progress_bar) = &progress_bar {
-                                progress_bar.initialize_node(node_id);
+            let handle_message =
+                |msg: StatsManagerMessage,
+                 input_stats: &mut HashMap<(NodeID, InputId), Arc<dyn RuntimeStats>>,
+                 active_nodes: &mut HashSet<NodeID>| {
+                    match msg {
+                        StatsManagerMessage::NodeEvent(node_id, is_initialize) => {
+                            if is_initialize && active_nodes.insert(node_id) {
+                                if let Some(progress_bar) = &progress_bar {
+                                    progress_bar.initialize_node(node_id);
+                                }
+
+                                let Some(operator_meta) = operators.get(&node_id) else {
+                                    log::warn!(
+                                        "Unknown node_id {node_id} in operators during on_start, skipping subscriber notification"
+                                    );
+                                    return;
+                                };
+
+                                let event = Event::OperatorStart(OperatorStartEvent {
+                                    header: event_header(query_id.clone()),
+                                    operator: operator_meta.clone(),
+                                });
+                                dispatch_event(&subscribers, &event, "notify operator start");
+                            } else if !is_initialize && active_nodes.remove(&node_id) {
+                                Self::flush_and_finalize_node(
+                                    &query_id,
+                                    node_id,
+                                    input_stats,
+                                    progress_bar.as_deref(),
+                                    &subscribers,
+                                    "finalize node",
+                                    &operators,
+                                );
                             }
-
-                            let Some(operator_meta) = operators.get(&node_id) else {
-                                log::warn!("Unknown node_id {node_id} in operators during on_start, skipping subscriber notification");
-                                return;
-                            };
-
-                            let event = Event::OperatorStart(OperatorStartEvent {
-                                header: event_header(query_id.clone()),
-                                operator: operator_meta.clone(),
-                            });
-                            dispatch_event(&subscribers, &event, "notify operator start");
-                        } else if !is_initialize && active_nodes.remove(&node_id) {
-                            Self::flush_and_finalize_node(
-                                &query_id,
-                                node_id,
-                                input_stats,
-                                progress_bar.as_deref(),
-                                &subscribers,
-                                "finalize node",
-                                &operators,
+                        }
+                        StatsManagerMessage::RegisterRuntimeStats(node_id, input_id, stats) => {
+                            input_stats.insert((node_id, input_id), stats);
+                        }
+                        StatsManagerMessage::TakeInputSnapshot(input_id, respond_tx) => {
+                            let mut result = Vec::new();
+                            for (&(node_id, iid), stats) in input_stats.iter() {
+                                if iid == input_id
+                                    && let Some(node_info) = node_info_map.get(&node_id)
+                                {
+                                    result.push((node_info.clone(), stats.flush()));
+                                }
+                            }
+                            let _ = respond_tx.send(
+                                ExecutionStats::new(query_id.clone(), result)
+                                    .with_query_plan(query_plan.clone()),
                             );
                         }
                     }
-                    StatsManagerMessage::RegisterRuntimeStats(node_id, input_id, stats) => {
-                        input_stats.insert((node_id, input_id), stats);
-                    }
-                    StatsManagerMessage::TakeInputSnapshot(input_id, respond_tx) => {
-                        let mut result = Vec::new();
-                        for (&(node_id, iid), stats) in input_stats.iter() {
-                            if iid == input_id
-                                && let Some(node_info) = node_info_map.get(&node_id)
-                            {
-                                result.push((node_info.clone(), stats.flush()));
-                            }
-                        }
-                        let _ = respond_tx.send(ExecutionStats::new(query_id.clone(), result).with_query_plan(query_plan.clone()));
-                    }
-                }
-            };
+                };
 
             loop {
                 tokio::select! {

--- a/src/daft-local-execution/src/runtime_stats/mod.rs
+++ b/src/daft-local-execution/src/runtime_stats/mod.rs
@@ -120,30 +120,48 @@ impl RuntimeStatsManagerHandle {
     /// plans do not retain metrics for completed inputs indefinitely.
     #[allow(dead_code)]
     pub async fn take_input_snapshot(&self, input_id: InputId) -> DaftResult<ExecutionStats> {
-        if let Some(stats) = self
-            .finished_snapshots
-            .lock()
-            .expect("finished_snapshots lock poisoned")
-            .as_mut()
-            .and_then(|snapshots| snapshots.remove(&input_id))
-        {
+        if let Some(stats) = self.take_finished_snapshot(input_id) {
             return Ok(stats);
         }
 
         let (tx, rx) = oneshot::channel();
-        self.tx
+        if self
+            .tx
             .send(StatsManagerMessage::TakeInputSnapshot(input_id, tx))
-            .map_err(|_| {
+            .is_err()
+        {
+            // Manager already shut down its receiver. The shutdown path publishes
+            // `finished_snapshots` before exiting, so check there.
+            return self.take_finished_snapshot(input_id).ok_or_else(|| {
                 common_error::DaftError::InternalError(
                     "RuntimeStatsManager was already finished; cannot take input snapshot"
                         .to_string(),
                 )
-            })?;
-        rx.await.map_err(|_| {
-            common_error::DaftError::InternalError(
-                "RuntimeStatsManager task ended before responding to snapshot request".to_string(),
-            )
-        })
+            });
+        }
+        match rx.await {
+            Ok(stats) => Ok(stats),
+            Err(_) => {
+                // The manager dropped the responder before answering — typically
+                // because it broke out of its event loop (and stopped reading
+                // node_rx) right when our request was queued. Fall back to the
+                // finalized snapshots, which the manager publishes before exit.
+                self.take_finished_snapshot(input_id).ok_or_else(|| {
+                    common_error::DaftError::InternalError(
+                        "RuntimeStatsManager task ended before responding to snapshot request"
+                            .to_string(),
+                    )
+                })
+            }
+        }
+    }
+
+    fn take_finished_snapshot(&self, input_id: InputId) -> Option<ExecutionStats> {
+        self.finished_snapshots
+            .lock()
+            .expect("finished_snapshots lock poisoned")
+            .as_mut()
+            .and_then(|snapshots| snapshots.remove(&input_id))
     }
 }
 
@@ -299,57 +317,75 @@ impl RuntimeStatsManager {
             // Reuse container for ticks
             let mut snapshot_container = Vec::with_capacity(node_info_map.len());
 
+            // Handle a single channel message. Shared between the main `select!`
+            // branch and the post-finish drain below so late `RegisterRuntimeStats`
+            // messages aren't lost when `finish_rx` wins the race against a still-
+            // queued node_rx message.
+            let mut handle_message = |msg: StatsManagerMessage,
+                                      input_stats: &mut HashMap<(NodeID, InputId), Arc<dyn RuntimeStats>>,
+                                      active_nodes: &mut HashSet<NodeID>| {
+                match msg {
+                    StatsManagerMessage::NodeEvent(node_id, is_initialize) => {
+                        if is_initialize && active_nodes.insert(node_id) {
+                            if let Some(progress_bar) = &progress_bar {
+                                progress_bar.initialize_node(node_id);
+                            }
+
+                            let Some(operator_meta) = operators.get(&node_id) else {
+                                log::warn!("Unknown node_id {node_id} in operators during on_start, skipping subscriber notification");
+                                return;
+                            };
+
+                            let event = Event::OperatorStart(OperatorStartEvent {
+                                header: event_header(query_id.clone()),
+                                operator: operator_meta.clone(),
+                            });
+                            dispatch_event(&subscribers, &event, "notify operator start");
+                        } else if !is_initialize && active_nodes.remove(&node_id) {
+                            Self::flush_and_finalize_node(
+                                &query_id,
+                                node_id,
+                                input_stats,
+                                progress_bar.as_deref(),
+                                &subscribers,
+                                "finalize node",
+                                &operators,
+                            );
+                        }
+                    }
+                    StatsManagerMessage::RegisterRuntimeStats(node_id, input_id, stats) => {
+                        input_stats.insert((node_id, input_id), stats);
+                    }
+                    StatsManagerMessage::TakeInputSnapshot(input_id, respond_tx) => {
+                        let mut result = Vec::new();
+                        for (&(node_id, iid), stats) in input_stats.iter() {
+                            if iid == input_id
+                                && let Some(node_info) = node_info_map.get(&node_id)
+                            {
+                                result.push((node_info.clone(), stats.flush()));
+                            }
+                        }
+                        let _ = respond_tx.send(ExecutionStats::new(query_id.clone(), result).with_query_plan(query_plan.clone()));
+                    }
+                }
+            };
+
             loop {
                 tokio::select! {
                     biased;
                     Some(msg) = node_rx.recv() => {
-                        match msg {
-                            StatsManagerMessage::NodeEvent(node_id, is_initialize) => {
-                                if is_initialize && active_nodes.insert(node_id) {
-                                    if let Some(progress_bar) = &progress_bar {
-                                        progress_bar.initialize_node(node_id);
-                                    }
-
-                                    let Some(operator_meta) = operators.get(&node_id) else {
-                                        log::warn!("Unknown node_id {node_id} in operators during on_start, skipping subscriber notification");
-                                        continue;
-                                    };
-
-                                    let event = Event::OperatorStart(OperatorStartEvent {
-                                        header: event_header(query_id.clone()),
-                                        operator: operator_meta.clone(),
-                                    });
-                                    dispatch_event(&subscribers, &event, "notify operator start");
-                                } else if !is_initialize && active_nodes.remove(&node_id) {
-                                    Self::flush_and_finalize_node(
-                                        &query_id,
-                                        node_id,
-                                        &input_stats,
-                                        progress_bar.as_deref(),
-                                    &subscribers,
-                                    "finalize node",
-                                    &operators,
-                                    );
-                                }
-                            }
-                            StatsManagerMessage::RegisterRuntimeStats(node_id, input_id, stats) => {
-                                input_stats.insert((node_id, input_id), stats);
-                            }
-                            StatsManagerMessage::TakeInputSnapshot(input_id, respond_tx) => {
-                                let mut result = Vec::new();
-                                for (&(node_id, iid), stats) in &input_stats {
-                                    if iid == input_id
-                                        && let Some(node_info) = node_info_map.get(&node_id)
-                                    {
-                                        result.push((node_info.clone(), stats.flush()));
-                                    }
-                                }
-                                let _ = respond_tx.send(ExecutionStats::new(query_id.clone(), result).with_query_plan(query_plan.clone()));
-                            }
-                        }
+                        handle_message(msg, &mut input_stats, &mut active_nodes);
                     }
 
                     _ = &mut finish_rx => {
+                        // Drain any messages queued before the finish signal but not yet
+                        // processed. Without this, a `RegisterRuntimeStats` send that
+                        // races with `finish_tx.send` can be lost when `select!` picks the
+                        // finish branch, leaving `input_stats` missing entries and
+                        // `take_input_snapshot` returning empty stats.
+                        while let Ok(msg) = node_rx.try_recv() {
+                            handle_message(msg, &mut input_stats, &mut active_nodes);
+                        }
                         // Queries that terminate early (e.g. LIMIT) may still have active upstream nodes.
                         // Flush and finalize those nodes so subscribers and progress bars end in a consistent state.
                         for node_id in active_nodes.drain() {
@@ -363,6 +399,35 @@ impl RuntimeStatsManager {
                                 &operators,
                             );
                         }
+                        // Publish finalized snapshots BEFORE exiting the select loop so a
+                        // `take_input_snapshot` call that races with manager shutdown finds
+                        // the data via `finished_snapshots` rather than a closed channel.
+                        // (Setting it post-loop leaves a window between break and assignment
+                        // during which channel sends silently queue but are never read.)
+                        let mut snapshots_by_input: HashMap<InputId, Vec<(Arc<NodeInfo>, StatSnapshot)>> =
+                            HashMap::new();
+                        for ((node_id, input_id), stats) in &input_stats {
+                            if let Some(node_info) = node_info_map.get(node_id) {
+                                snapshots_by_input
+                                    .entry(*input_id)
+                                    .or_default()
+                                    .push((node_info.clone(), stats.flush()));
+                            }
+                        }
+                        let finished = snapshots_by_input
+                            .into_iter()
+                            .map(|(input_id, mut nodes)| {
+                                nodes.sort_by_key(|(node_info, _)| node_info.id);
+                                (
+                                    input_id,
+                                    ExecutionStats::new(query_id.clone(), nodes)
+                                        .with_query_plan(query_plan.clone()),
+                                )
+                            })
+                            .collect();
+                        *finished_snapshots_for_task
+                            .lock()
+                            .expect("finished_snapshots lock poisoned") = Some(finished);
                         break;
                     }
 
@@ -406,36 +471,6 @@ impl RuntimeStatsManager {
             {
                 log::warn!("Failed to finish progress bar: {}", e);
             }
-
-            let mut snapshots_by_input: HashMap<InputId, Vec<(Arc<NodeInfo>, StatSnapshot)>> =
-                HashMap::new();
-
-            for ((node_id, input_id), stats) in input_stats {
-                if let Some(node_info) = node_info_map.get(&node_id) {
-                    snapshots_by_input
-                        .entry(input_id)
-                        .or_default()
-                        .push((node_info.clone(), stats.flush()));
-                }
-            }
-
-            let finished = snapshots_by_input
-                .into_iter()
-                .map(|(input_id, mut nodes)| {
-                    nodes.sort_by_key(|(node_info, _)| node_info.id);
-                    (
-                        input_id,
-                        ExecutionStats::new(query_id.clone(), nodes)
-                            .with_query_plan(query_plan.clone()),
-                    )
-                })
-                .collect();
-
-            // Publish finalized snapshots before exiting so callers can retrieve per-input
-            // metrics after the stats manager task has shut down.
-            *finished_snapshots_for_task
-                .lock()
-                .expect("finished_snapshots lock poisoned") = Some(finished);
 
             let exec_end_event = Event::ExecEnd(ExecEndEvent {
                 header: event_header(query_id.clone()),


### PR DESCRIPTION
## Summary

`take_input_snapshot` could return empty stats for fast-finishing pipelines (e.g. a hit `LIMIT`), surfacing as the flaky `test_limit_without_estimated_rows` failure on `rust-tests-platform`.

## Race

When a pipeline finishes early, `run_execution_loop` fires `finish_tx`. The manager's biased `select!` could pick `finish_rx` over still-queued `RegisterRuntimeStats` / `TakeInputSnapshot` messages on `node_rx`, then break the loop and only build `finished_snapshots` *after* the break. A concurrent `take_input_snapshot` landing in that window saw `finished_snapshots == None`, sent on a channel the manager no longer read, and got `Err` back — empty stats.

## Fix (`src/daft-local-execution/src/runtime_stats/mod.rs`)

- Drain `node_rx` (`try_recv`) inside the `finish_rx` arm so late register messages aren't dropped.
- Build & publish `finished_snapshots` *before* `break`, so it's visible the moment the loop exits.
- In `take_input_snapshot`, fall back to `finished_snapshots` after a channel send/recv failure.

Locally repro'd at ~10% on the test pre-fix; 0/100 with the fix.

https://claude.ai/code/session_01NVUu3zCZwk3rdaiXpPnYKD