### PR TITLE
Dispatch TaskStart event when execution loop dequeues task

### DIFF
--- a/src/daft-local-execution/src/run.rs
+++ b/src/daft-local-execution/src/run.rs
@@ -89,6 +89,16 @@ fn get_global_runtime() -> &'static Handle {
     })
 }
 
+/// Event + subscribers to dispatch when a task actually begins executing.
+///
+/// Carried on the `EnqueueInputMessage` so the event fires inside
+/// `run_execution_loop` at the moment the task's inputs are dispatched into
+/// the running pipeline — not when the message was placed in the channel.
+pub(crate) struct TaskStartDispatch {
+    event: Event,
+    subscribers: Vec<Arc<dyn Subscriber>>,
+}
+
 /// Message sent to the execution task to enqueue inputs
 pub(crate) struct EnqueueInputMessage {
     /// The input_id for this enqueue operation
@@ -97,6 +107,10 @@ pub(crate) struct EnqueueInputMessage {
     inputs: HashMap<SourceId, Input>,
     /// Sender for results of this input_id
     result_sender: UnboundedSender<ExecutionEngineResultItem>,
+    /// If set, dispatched when the execution loop picks up this message —
+    /// i.e., when the task truly begins executing rather than when it was
+    /// merely accepted onto the per-plan enqueue channel.
+    on_dequeue: Option<TaskStartDispatch>,
 }
 
 /// Routes pipeline messages to per-input_id channels.
@@ -353,7 +367,13 @@ async fn run_execution_loop(
                 }
             }
             enqueue_msg = enqueue_input_rx.recv(), if !input_exhausted => {
-                if let Some(EnqueueInputMessage { input_id, inputs, result_sender }) = enqueue_msg {
+                if let Some(EnqueueInputMessage { input_id, inputs, result_sender, on_dequeue }) = enqueue_msg {
+                    // Fire the TaskStart event now — the task is no longer
+                    // merely queued on the per-plan enqueue channel; we are
+                    // about to push its inputs into the running pipeline.
+                    if let Some(TaskStartDispatch { event, subscribers }) = on_dequeue {
+                        dispatch_task_start_event(&subscribers, &event);
+                    }
                     message_router.insert_output_sender(input_id, result_sender);
                     let senders = input_senders.as_ref().unwrap();
                     for (key, plan_input) in inputs {
@@ -455,8 +475,8 @@ impl NativeExecutor {
             && task_events_enabled()
             && let Some(task_id) = task_id
         {
-            Some((
-                Event::TaskStart(TaskStartEvent {
+            Some(TaskStartDispatch {
+                event: Event::TaskStart(TaskStartEvent {
                     header: event_header(query_id.clone()),
                     task: Arc::new(TaskInfo {
                         id: task_id,
@@ -467,8 +487,8 @@ impl NativeExecutor {
                     }),
                     worker_id: None, // TODO: propagate worker id
                 }),
-                subscribers.clone(),
-            ))
+                subscribers: subscribers.clone(),
+            })
         } else {
             None
         };
@@ -533,16 +553,12 @@ impl NativeExecutor {
                     input_id,
                     inputs,
                     result_sender: result_tx,
+                    on_dequeue: task_start_dispatch,
                 };
                 if enqueue_input_sender.send(enqueue_msg).await.is_err() {
                     return Err(common_error::DaftError::InternalError(
                         "Plan execution task has died; cannot enqueue new input".to_string(),
                     ));
-                }
-
-                // Send the event after the task has been enqueued for execution
-                if let Some((event, subscribers)) = task_start_dispatch {
-                    dispatch_task_start_event(&subscribers, &event);
                 }
 
                 Ok(ExecutionEngineResult {


### PR DESCRIPTION
## Changes Made

Refactored the timing of `TaskStart` event dispatch to occur when the execution loop actually begins processing a task, rather than when the task is enqueued to the channel.

### Implementation Details

- Created a new `TaskStartDispatch` struct to carry both the event and subscribers together
- Added an `on_dequeue` field to `EnqueueInputMessage` to transport the dispatch information through the channel
- Moved event dispatch from the enqueue call site to inside `run_execution_loop`, immediately before the task's inputs are pushed into the running pipeline
- This ensures the event fires at the moment the task truly begins executing, not just when it was accepted onto the per-plan enqueue channel

This change provides more accurate timing for task execution monitoring and event-driven systems that depend on knowing when a task actually starts running.

## Related Issues

<!-- Link to related GitHub issues if applicable -->

https://claude.ai/code/session_01QJ9jBxiSq9dPc1kdJHmr46