### PR TITLE
feat: add event log config api

### DIFF
--- a/daft/__init__.py
+++ b/daft/__init__.py
@@ -71,6 +71,8 @@ from daft.context import (
     with_subscriber,
     execution_config_ctx,
     planning_config_ctx,
+    set_event_log_config,
+    event_log_ctx,
 )
 from daft.convert import (
     from_arrow,

--- a/daft/context.py
+++ b/daft/context.py
@@ -6,11 +6,19 @@ import threading
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, ClassVar
 
-from daft.daft import IOConfig, PyDaftContext, PyDaftExecutionConfig, PyDaftPlanningConfig, PyQueryResult
+from daft.daft import (
+    IOConfig,
+    PyDaftContext,
+    PyDaftEventLogConfig,
+    PyDaftExecutionConfig,
+    PyDaftPlanningConfig,
+    PyQueryResult,
+)
 from daft.daft import get_context as _get_context
 
 if TYPE_CHECKING:
     from collections.abc import Generator
+    from pathlib import Path
 
     from daft.daft import PyQueryMetadata
     from daft.subscribers import Subscriber
@@ -43,6 +51,10 @@ class DaftContext:
     @property
     def daft_planning_config(self) -> PyDaftPlanningConfig:
         return self._ctx._daft_planning_config
+
+    @property
+    def daft_event_log_config(self) -> PyDaftEventLogConfig:
+        return self._ctx._daft_event_log_config
 
     def attach_subscriber(self, alias: str, subscriber: Subscriber) -> None:
         """Attaches a subscriber to this context.
@@ -327,3 +339,58 @@ def set_execution_config(
 
         ctx._ctx._daft_execution_config = new_daft_execution_config
         return ctx
+
+
+def set_event_log_config(
+    config: PyDaftEventLogConfig | None = None,
+    enabled: bool | None = None,
+    path: str | Path | None = None,
+) -> DaftContext:
+    """Globally sets configuration parameters which control Daft event logging.
+
+    These configuration values are used to control whether Daft emits event logs during query execution and
+    where those event logs are written.
+
+    This is an experimental feature.
+
+    Args:
+        config: A PyDaftEventLogConfig object to set the config to, before applying other kwargs. Defaults to None
+            which indicates that the old (current) config should be used.
+        enabled: Whether event logging should be enabled. Defaults to None, which leaves the current setting unchanged.
+        path: Directory where event logs should be written. Defaults to None, which leaves the current path unchanged.
+    """
+    ctx = get_context()
+    old_config = ctx.daft_event_log_config if config is None else config
+    kwargs: dict[str, Any] = {"enabled": enabled}
+    if path is not None:
+        kwargs["path"] = str(path)
+
+    new_config = old_config.with_config_values(**kwargs)
+    ctx._ctx._daft_event_log_config = new_config
+    return ctx
+
+
+@contextlib.contextmanager
+def event_log_ctx(
+    path: str | Path | None = None,
+    *,
+    enabled: bool = True,
+) -> Generator[None, None, None]:
+    """Context manager that temporarily sets event logging configuration.
+
+    This is an experimental feature.
+
+    Args:
+        path: Directory where event logs should be written while inside the context. Defaults to None, which leaves
+            the current path unchanged.
+        enabled: Whether event logging should be enabled while inside the context. Defaults to True.
+    """
+    original_config = get_context().daft_event_log_config
+    try:
+        kwargs: dict[str, Any] = {"enabled": enabled}
+        if path is not None:
+            kwargs["path"] = path
+        set_event_log_config(**kwargs)
+        yield
+    finally:
+        set_event_log_config(config=original_config)

--- a/daft/context.py
+++ b/daft/context.py
@@ -360,14 +360,15 @@ def set_event_log_config(
         path: Directory where event logs should be written. Defaults to None, which leaves the current path unchanged.
     """
     ctx = get_context()
-    old_config = ctx.daft_event_log_config if config is None else config
-    kwargs: dict[str, Any] = {"enabled": enabled}
-    if path is not None:
-        kwargs["path"] = str(path)
+    with ctx._lock:
+        old_config = ctx.daft_event_log_config if config is None else config
+        kwargs: dict[str, Any] = {"enabled": enabled}
+        if path is not None:
+            kwargs["path"] = str(path)
 
-    new_config = old_config.with_config_values(**kwargs)
-    ctx._ctx._daft_event_log_config = new_config
-    return ctx
+        new_config = old_config.with_config_values(**kwargs)
+        ctx._ctx._daft_event_log_config = new_config
+        return ctx
 
 
 @contextlib.contextmanager

--- a/daft/daft/__init__.pyi
+++ b/daft/daft/__init__.pyi
@@ -2527,6 +2527,19 @@ class PyDaftPlanningConfig:
     @property
     def enable_strict_filter_pushdown(self) -> bool: ...
 
+class PyDaftEventLogConfig:
+    @staticmethod
+    def from_env() -> PyDaftEventLogConfig: ...
+    def with_config_values(
+        self,
+        enabled: bool | None = None,
+        path: str | None = None,
+    ) -> PyDaftEventLogConfig: ...
+    @property
+    def enabled(self) -> bool: ...
+    @property
+    def path(self) -> str: ...
+
 class StatType(Enum):
     COUNT = 0
     BYTES = 1
@@ -2572,11 +2585,14 @@ class PyDaftContext:
 
     _daft_execution_config: PyDaftExecutionConfig
     _daft_planning_config: PyDaftPlanningConfig
+    _daft_event_log_config: PyDaftEventLogConfig
 
     @property
     def daft_execution_config(self) -> PyDaftExecutionConfig: ...
     @property
     def daft_planning_config(self) -> PyDaftPlanningConfig: ...
+    @property
+    def daft_event_log_config(self) -> PyDaftEventLogConfig: ...
 
     # Subscriber methods
     def attach_subscriber(self, alias: str, subscriber: Subscriber) -> None: ...

--- a/src/common/daft-config/src/lib.rs
+++ b/src/common/daft-config/src/lib.rs
@@ -292,11 +292,51 @@ impl DaftExecutionConfig {
     }
 }
 
+/// Configurations for Daft Event Logging to use during the execution of a Dataframe
+///  Note that this should be immutable for a given end-to-end execution of a logical plan.
+#[derive(Clone, Serialize, Deserialize)]
+#[cfg_attr(debug_assertions, derive(Debug))]
+pub struct DaftEventLogConfig {
+    pub enabled: bool,
+    pub path: String,
+}
+
+impl Default for DaftEventLogConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            path: "~/.daft/events".to_string(),
+        }
+    }
+}
+
+impl DaftEventLogConfig {
+    const ENV_DAFT_EVENT_LOG_ENABLED: &'static str = "DAFT_EVENT_LOG_ENABLED";
+    const ENV_DAFT_EVENT_LOG_DIR: &'static str = "DAFT_EVENT_LOG_DIR";
+
+    pub fn from_env() -> Self {
+        let mut config = Self::default();
+
+        if let Some(enabled) = parse_bool_from_env(Self::ENV_DAFT_EVENT_LOG_ENABLED) {
+            config.enabled = enabled;
+        }
+
+        if let Some(path) = parse_string_from_env(Self::ENV_DAFT_EVENT_LOG_DIR, true) {
+            config.enabled = true;
+            config.path = path;
+        }
+
+        config
+    }
+}
+
 #[cfg(feature = "python")]
 mod python;
 
 #[cfg(feature = "python")]
 use pyo3::prelude::*;
+#[cfg(feature = "python")]
+pub use python::PyDaftEventLogConfig;
 #[cfg(feature = "python")]
 pub use python::PyDaftExecutionConfig;
 #[cfg(feature = "python")]
@@ -306,6 +346,7 @@ pub use python::PyDaftPlanningConfig;
 pub fn register_modules(parent: &Bound<PyModule>) -> PyResult<()> {
     parent.add_class::<python::PyDaftExecutionConfig>()?;
     parent.add_class::<python::PyDaftPlanningConfig>()?;
+    parent.add_class::<python::PyDaftEventLogConfig>()?;
 
     Ok(())
 }

--- a/src/common/daft-config/src/python.rs
+++ b/src/common/daft-config/src/python.rs
@@ -5,7 +5,7 @@ use common_py_serde::impl_bincode_py_state_serialization;
 use pyo3::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use crate::{DaftExecutionConfig, DaftPlanningConfig};
+use crate::{DaftEventLogConfig, DaftExecutionConfig, DaftPlanningConfig};
 
 #[derive(Clone, Default, Serialize, Deserialize)]
 #[pyclass(module = "daft.daft", from_py_object)]
@@ -478,3 +478,53 @@ impl PyDaftExecutionConfig {
 }
 
 impl_bincode_py_state_serialization!(PyDaftExecutionConfig);
+
+#[derive(Clone, Default, Serialize, Deserialize)]
+#[pyclass(module = "daft.daft", from_py_object)]
+pub struct PyDaftEventLogConfig {
+    pub config: DaftEventLogConfig,
+}
+
+#[pymethods]
+impl PyDaftEventLogConfig {
+    #[new]
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    #[staticmethod]
+    #[must_use]
+    pub fn from_env() -> Self {
+        Self {
+            config: DaftEventLogConfig::from_env(),
+        }
+    }
+
+    #[pyo3(signature = (enabled=None, path=None))]
+    fn with_config_values(&self, enabled: Option<bool>, path: Option<String>) -> PyResult<Self> {
+        let mut config = self.config.clone();
+
+        if let Some(enabled) = enabled {
+            config.enabled = enabled;
+        }
+
+        if let Some(path) = path {
+            config.path = path;
+        }
+
+        Ok(Self { config })
+    }
+
+    #[getter(enabled)]
+    fn enabled(&self) -> bool {
+        self.config.enabled
+    }
+
+    #[getter(path)]
+    fn path(&self) -> String {
+        self.config.path.clone()
+    }
+}
+
+impl_bincode_py_state_serialization!(PyDaftEventLogConfig);

--- a/src/daft-context/src/lib.rs
+++ b/src/daft-context/src/lib.rs
@@ -8,7 +8,7 @@ use std::{
     sync::{Arc, OnceLock, RwLock},
 };
 
-use common_daft_config::{DaftExecutionConfig, DaftPlanningConfig, IOConfig};
+use common_daft_config::{DaftEventLogConfig, DaftExecutionConfig, DaftPlanningConfig, IOConfig};
 use common_error::{DaftError, DaftResult};
 use common_metrics::{QueryID, QueryPlan};
 #[cfg(feature = "python")]
@@ -29,6 +29,7 @@ use crate::subscribers::{
 pub struct Config {
     pub execution: Arc<DaftExecutionConfig>,
     pub planning: Arc<DaftPlanningConfig>,
+    pub event_log: DaftEventLogConfig,
 }
 
 impl Config {
@@ -36,6 +37,7 @@ impl Config {
         Self {
             execution: Arc::new(DaftExecutionConfig::from_env()),
             planning: Arc::new(DaftPlanningConfig::from_env()),
+            event_log: DaftEventLogConfig::from_env(),
         }
     }
 }
@@ -106,8 +108,17 @@ impl DaftContext {
         self.with_state_mut(|state| state.config.planning = config);
     }
 
+    /// set the event log config
+    pub fn set_event_log_config(&self, config: DaftEventLogConfig) {
+        self.with_state_mut(|state| state.config.event_log = config);
+    }
+
     pub fn io_config(&self) -> IOConfig {
         self.with_state(|state| state.config.planning.default_io_config.clone())
+    }
+
+    pub fn event_log_config(&self) -> DaftEventLogConfig {
+        self.with_state(|state| state.config.event_log.clone())
     }
 
     pub fn subscribers(&self) -> Vec<Arc<dyn Subscriber>> {

--- a/src/daft-context/src/python.rs
+++ b/src/daft-context/src/python.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, sync::Arc};
 
-use common_daft_config::{PyDaftExecutionConfig, PyDaftPlanningConfig};
+use common_daft_config::{PyDaftEventLogConfig, PyDaftExecutionConfig, PyDaftPlanningConfig};
 use common_metrics::QueryEndState;
 use daft_core::python::PySchema;
 use pyo3::prelude::*;
@@ -205,6 +205,22 @@ impl PyDaftContext {
     #[setter(_daft_planning_config)]
     pub fn set_daft_planning_config(&self, py: Python, config: PyDaftPlanningConfig) {
         py.detach(|| self.inner.set_planning_config(config.config));
+    }
+
+    #[getter(_daft_event_log_config)]
+    pub fn get_daft_event_log_config(&self, py: Python) -> PyResult<PyDaftEventLogConfig> {
+        let config = py.detach(|| self.inner.event_log_config());
+        Ok(PyDaftEventLogConfig { config })
+    }
+
+    #[setter(_daft_event_log_config)]
+    pub fn set_daft_event_log_config(
+        &self,
+        py: Python,
+        config: PyDaftEventLogConfig,
+    ) -> PyResult<()> {
+        py.detach(|| self.inner.set_event_log_config(config.config));
+        Ok(())
     }
 
     pub fn attach_subscriber(&self, py: Python, alias: String, subscriber: Py<PyAny>) {


### PR DESCRIPTION
## Changes Made
This adds an event log config api to the context. A follow PR will be added to attach and detach the event log subscriber based on this config. This removes all the global variables in the python event log file.

## Related Issues

https://github.com/Eventual-Inc/Daft/issues/6720


examples
```
daft.set_event_log_config(enabled=True)
daft.set_event_log_config(enabled=True, path="/tmp/events")

with daft.event_log_ctx("/tmp/events"):
  df.collect()
```