### PR TITLE
feat(dashboard): surface query failure details in query view

### DIFF
--- a/src/daft-dashboard/frontend/src/app/queries/status.tsx
+++ b/src/daft-dashboard/frontend/src/app/queries/status.tsx
@@ -14,9 +14,7 @@ import {
   PlanningStatus,
   ExecutingStatus,
   FinishedStatus,
-  FailedStatus,
   CanceledStatus,
-  DeadStatus
 } from "@/hooks/use-queries";
 import { AnimatedFish, Naruto } from "@/components/icons";
 
@@ -160,12 +158,11 @@ const Canceled = ({ state }: { state: CanceledStatus }) => (
   />
 );
 
-const Failed = ({ state }: { state: FailedStatus }) => (
+const Failed = () => (
   <StatusBadgeInner
     icon={<CircleX size={16} strokeWidth={3} className="text-red-500" />}
     label="Failed"
     textColor="text-red-500"
-    tooltipText={state.message}
   />
 );
 
@@ -227,7 +224,7 @@ export default function Status({ state, showDuration = true }: StatusBadgeProps)
     case "Finished":
       return <Finished state={state} showDuration={showDuration} />;
     case "Failed":
-      return <Failed state={state} />;
+      return <Failed />;
     case "Canceled":
       return <Canceled state={state} />;
     case "Dead":

--- a/src/daft-dashboard/frontend/src/app/query/page.tsx
+++ b/src/daft-dashboard/frontend/src/app/query/page.tsx
@@ -194,6 +194,7 @@ function QueryPageInner() {
               start_sec={query.start_sec}
               end_sec={end_sec}
               last_heartbeat_sec={last_heartbeat_sec}
+              errorMessage={query.state.status === "Failed" ? query.state.message : undefined}
             />
           </div>
           <div className="flex-1 px-6 py-4">

--- a/src/daft-dashboard/frontend/src/app/query/status.tsx
+++ b/src/daft-dashboard/frontend/src/app/query/status.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from "react";
 import { main, toHumanReadableDuration, toHumanReadableDate } from "@/lib/utils";
-import { Ban, CircleX, LoaderCircle, Skull } from "lucide-react";
+import { AlertTriangle, Ban, CircleX, LoaderCircle, Skull, X } from "lucide-react";
 import { QueryStatusName } from "@/hooks/use-queries";
 import { AnimatedFish, Naruto } from "@/components/icons";
+import * as Dialog from "@radix-ui/react-dialog";
 
 const Timer = ({ start_sec }: { start_sec: number }) => {
   const [currentTime, setCurrentTime] = useState(() => Date.now());
@@ -157,16 +158,51 @@ const LastHeartbeat = ({
   );
 };
 
+const ErrorModal = ({ message }: { message: string }) => {
+  return (
+    <Dialog.Root>
+      <Dialog.Trigger asChild>
+        <button className="flex items-center gap-x-1.5 px-2.5 py-1 rounded border border-red-700 text-red-400 hover:bg-red-950 hover:border-red-500 transition-colors text-xs font-mono">
+          <AlertTriangle size={12} />
+          View Error
+        </button>
+      </Dialog.Trigger>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/70 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 z-50 w-full max-w-2xl -translate-x-1/2 -translate-y-1/2 rounded-lg border border-zinc-700 bg-zinc-900 p-6 shadow-xl data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95">
+          <div className="flex items-center justify-between mb-4">
+            <Dialog.Title className={`${main.className} flex items-center gap-x-2 text-red-400 font-semibold text-base`}>
+              <CircleX size={16} strokeWidth={2.5} />
+              Query Error
+            </Dialog.Title>
+            <Dialog.Close className="rounded opacity-70 hover:opacity-100 transition-opacity text-zinc-400 hover:text-white">
+              <X size={16} />
+              <span className="sr-only">Close</span>
+            </Dialog.Close>
+          </div>
+          <Dialog.Description asChild>
+            <pre className={`${main.className} whitespace-pre-wrap break-words text-xs text-zinc-300 bg-zinc-950 rounded border border-zinc-800 p-4 max-h-96 overflow-y-auto`}>
+              {message}
+            </pre>
+          </Dialog.Description>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+};
+
 export function Status({
   status,
   start_sec,
   end_sec,
   last_heartbeat_sec,
+  errorMessage,
 }: {
   status: QueryStatusName;
   start_sec: number;
   end_sec: number | null;
   last_heartbeat_sec: number | null;
+  errorMessage?: string;
 }) {
   return (
     <div className="flex flex-col items-center justify-center h-full space-y-4">
@@ -179,6 +215,9 @@ export function Status({
         </div>
       ) : (
         <Timer start_sec={start_sec} />
+      )}
+      {status === "Failed" && errorMessage && (
+        <ErrorModal message={errorMessage} />
       )}
       {last_heartbeat_sec ? (
         <LastHeartbeat last_heartbeat_sec={last_heartbeat_sec} />


### PR DESCRIPTION
## Changes Made
Move failed query error details out of the queries list status tooltip and show them from the query detail status panel instead. This keeps the overview compact while making the full error easier to inspect on the query page.

<img width="1566" height="940" alt="Screenshot 2026-05-07 at 11 19 38 AM" src="https://github.com/user-attachments/assets/476708a1-4901-4517-a50a-3589db0729d0" />
<img width="1561" height="933" alt="Screenshot 2026-05-07 at 11 19 49 AM" src="https://github.com/user-attachments/assets/429677f3-f9e2-4494-ad10-5e7920df7753" />
