### PR TITLE
fix(dashboard): split task groups by local-plan shape

### DIFF
--- a/src/daft-dashboard/frontend/src/app/query/tasks-grouping.ts
+++ b/src/daft-dashboard/frontend/src/app/query/tasks-grouping.ts
@@ -71,7 +71,7 @@ export type PlanChainNode = { id: number; name: string };
  * `TaskTypeSection`.
  */
 export type TaskTypeRow = {
-  /** Stable React key: `nodeIdsKey + "|" + name`. */
+  /** Stable React key: `nodeIdsKey + " " + name` (space-separated). */
   key: string;
   /** The dispatching distributed plan node (= node_ids.last()). */
   last_node_id: number;

--- a/src/daft-dashboard/frontend/src/app/query/tasks-grouping.ts
+++ b/src/daft-dashboard/frontend/src/app/query/tasks-grouping.ts
@@ -7,10 +7,17 @@
  * aggregates (always accurate, even when individual tasks have been evicted)
  * and attaches matching retained tasks for drill-down.
  *
- * Groups are keyed by the full `node_ids` chain (the distributed pipeline
- * nodes that contributed to the fused task) — two tasks with the same chain
- * belong to the same group regardless of how their `name` strings differ
- * (e.g. parameter-driven variations like different limit values).
+ * Groups are keyed by `(node_ids, name)`: the distributed-plan chain plus the
+ * local-plan shape. This matches the server's group key. Two tasks under the
+ * same distributed node that render with different local-plan shapes (e.g.
+ * Sort's sample / repartition / final phases) get separate rows; tasks that
+ * differ only in parameter values (e.g. `Limit(10)` vs `Limit(100)`) merge,
+ * because `task.name` derives from operator variant names without parameter
+ * values.
+ *
+ * Rows are then grouped into sections by `node_ids` so sibling phases under
+ * the same distributed node display together with a single shared
+ * distributed-plan header.
  */
 import { OperatorInfo, OperatorStatus, TaskInfo, TaskStore } from "./types";
 
@@ -57,9 +64,14 @@ export function taskHasStarted(task: TaskInfo): boolean {
 /** A node in a distributed-plan chain, displayable + clickable. */
 export type PlanChainNode = { id: number; name: string };
 
-/** One row in the Tasks sidebar — a group of tasks that share a node_ids chain. */
+/**
+ * One row in the Tasks sidebar — a group of tasks sharing the same
+ * `(node_ids, name)` key (same distributed-plan chain *and* same local-plan
+ * shape). Sibling rows under the same distributed node land in the same
+ * `TaskTypeSection`.
+ */
 export type TaskTypeRow = {
-  /** Stable React key: stringified node_ids. */
+  /** Stable React key: `nodeIdsKey + "|" + name`. */
   key: string;
   /** The dispatching distributed plan node (= node_ids.last()). */
   last_node_id: number;
@@ -67,8 +79,6 @@ export type TaskTypeRow = {
   last_node_name: string;
   /** Local-plan chain (`task.name` split on "->"), used by the "Local Plan" column. */
   pipeline: string[];
-  /** Distributed-plan chain derived from node_ids, used by the "Distributed Plan" column. */
-  distributed_plan: PlanChainNode[];
   /** The full chain — directly used by the filter predicate and hover handler. */
   node_ids: number[];
   task_count: number;
@@ -84,9 +94,37 @@ export type TaskTypeRow = {
   retained_task_count: number;
 };
 
+/**
+ * A section in the Tasks sidebar — one or more `TaskTypeRow`s that share the
+ * same distributed-plan chain (`node_ids`). The section header carries the
+ * distributed-plan chips so each child row doesn't repeat them; the rows
+ * inside the section show their distinct local-plan shapes (e.g. Sort's
+ * sample / repartition / final phases).
+ */
+export type TaskTypeSection = {
+  /** Stable React key: `nodeIdsKey(node_ids)`. */
+  key: string;
+  /** The dispatching distributed plan node (= node_ids.last()). */
+  last_node_id: number;
+  /** The full chain — used by the filter predicate and hover handler. */
+  node_ids: number[];
+  /** Distributed-plan chain (id + display name) for the section header. */
+  distributed_plan: PlanChainNode[];
+  rows: TaskTypeRow[];
+};
+
 /** Stable string key for indexing by node_ids chain. */
 function nodeIdsKey(nodeIds: number[]): string {
   return nodeIds.join(",");
+}
+
+/**
+ * Composite group key matching the server's `(node_ids, name)` identity.
+ * Uses ` ` as a separator so we don't collide with any character that
+ * could appear inside a name (`->` is common).
+ */
+function groupKey(nodeIds: number[], name: string): string {
+  return `${nodeIdsKey(nodeIds)} ${name}`;
 }
 
 /**
@@ -149,6 +187,10 @@ export function getActiveTasks(taskStore: TaskStore | undefined): TaskInfo[] {
  * Group summaries provide accurate aggregate stats (counts, totals) even when
  * individual tasks have been evicted from the retained set. Retained tasks are
  * attached for drill-down when the user expands a row.
+ *
+ * Tasks are keyed by `(node_ids, name)` to match the server's group identity —
+ * keying only by `node_ids` would pull every task under a distributed node
+ * into all of its sibling rows.
  */
 export function buildTaskRows(
   taskStore: TaskStore | undefined,
@@ -156,11 +198,14 @@ export function buildTaskRows(
 ): TaskTypeRow[] {
   if (!taskStore) return [];
 
-  // Index retained tasks by node_ids chain (matching the server's group key).
+  // Index retained tasks by `(node_ids, name)` — must match the server's
+  // group key, otherwise sibling groups under the same distributed node
+  // would all pull the same task list.
   const tasksByGroup = new Map<string, TaskInfo[]>();
   for (const t of Object.values(taskStore.tasks)) {
     const ids = t.node_ids.length > 0 ? t.node_ids : [t.last_node_id];
-    const key = nodeIdsKey(ids);
+    const name = t.name ?? `Node ${t.last_node_id}`;
+    const key = groupKey(ids, name);
     let arr = tasksByGroup.get(key);
     if (!arr) {
       arr = [];
@@ -172,13 +217,13 @@ export function buildTaskRows(
   return taskStore.groups
     .map((g) => {
       const ids = g.node_ids.length > 0 ? g.node_ids : [g.last_node_id];
-      const key = nodeIdsKey(ids);
+      const key = groupKey(ids, g.name);
       const tasks = tasksByGroup.get(key) ?? [];
 
-      // Local plan: derived from any retained task's `name`, falling back to
-      // the server-supplied display label (`g.name`). Empty if nothing usable.
-      const sampleName = tasks[0]?.name ?? g.name;
-      const pipeline = localPlanChain(sampleName);
+      // Local plan: trust the server-supplied group name directly. Pulling it
+      // from `tasks[0]?.name` would leak a different sibling's shape if the
+      // server retained no tasks from this group.
+      const pipeline = localPlanChain(g.name);
 
       const inflight = g.pending_count + g.running_count;
       return {
@@ -188,7 +233,6 @@ export function buildTaskRows(
           operators[g.last_node_id]?.node_info.name ??
           `Node ${g.last_node_id}`,
         pipeline,
-        distributed_plan: distributedPlanChain(ids, operators),
         node_ids: ids,
         task_count: g.task_count,
         status_counts: {
@@ -204,9 +248,56 @@ export function buildTaskRows(
         retained_task_count: g.retained_task_count,
       };
     })
-    .sort((a, b) => {
-      if (a.last_node_id !== b.last_node_id)
-        return b.last_node_id - a.last_node_id;
-      return a.key.localeCompare(b.key);
-    });
+    // Sort sections top-to-bottom by `last_node_id` descending (newest /
+    // closer-to-output node first). Within a `last_node_id` we preserve the
+    // server's emission order (= submission order) — `Array.prototype.sort`
+    // is stable, so rows with the same key compare as equal and keep their
+    // original positions. `buildTaskSections` then reverses each section so
+    // the latest-executed phase sits at the top of its block, matching the
+    // bottom-to-top distributed plan view.
+    .sort((a, b) => b.last_node_id - a.last_node_id);
+}
+
+/**
+ * Group rows into sections by their `node_ids` chain. Sibling rows under the
+ * same distributed node share a section so the distributed-plan chips display
+ * once per section instead of repeating on every row. Section order follows
+ * the first-row order from {@link buildTaskRows}.
+ *
+ * Within each section, rows are reversed so the latest-executed phase
+ * appears at the top — matching the bottom-to-top reading of the
+ * distributed-plan view (input at the bottom, output at the top). Concrete
+ * case: a Sort dispatches sample → repartition → final-sort phases in that
+ * submission order; the section displays them top-to-bottom as final-sort,
+ * repartition, sample.
+ */
+export function buildTaskSections(
+  rows: TaskTypeRow[],
+  operators: Record<number, OperatorInfo>,
+): TaskTypeSection[] {
+  const sections: TaskTypeSection[] = [];
+  const indexByKey = new Map<string, number>();
+  for (const row of rows) {
+    const sectionKey = nodeIdsKey(row.node_ids);
+    let idx = indexByKey.get(sectionKey);
+    if (idx == null) {
+      idx = sections.length;
+      indexByKey.set(sectionKey, idx);
+      sections.push({
+        key: sectionKey,
+        last_node_id: row.last_node_id,
+        node_ids: row.node_ids,
+        distributed_plan: distributedPlanChain(row.node_ids, operators),
+        rows: [],
+      });
+    }
+    sections[idx].rows.push(row);
+  }
+  // Rows accumulated in submission order (sample → repartition → final for a
+  // Sort, etc.). Reverse each section so the latest-executed phase appears
+  // at the top, matching the bottom-to-top distributed plan view.
+  for (const section of sections) {
+    section.rows.reverse();
+  }
+  return sections;
 }

--- a/src/daft-dashboard/frontend/src/app/query/tasks-sidebar.tsx
+++ b/src/daft-dashboard/frontend/src/app/query/tasks-sidebar.tsx
@@ -12,12 +12,14 @@ import {
 } from "./stats-utils";
 import {
   buildTaskRows,
+  buildTaskSections,
   getActiveTasks,
   PlanChainNode,
   taskDisplayStatus,
   taskDurationSec,
   taskHasStarted,
   TaskTypeRow,
+  TaskTypeSection,
   TOP_K_RUNNING,
 } from "./tasks-grouping";
 
@@ -65,6 +67,15 @@ export default function TasksSidebar({
         ? allRows
         : allRows.filter((r) => r.node_ids.includes(nodeFilter)),
     [allRows, nodeFilter],
+  );
+
+  // Group filtered rows into sections by `node_ids`. Sibling rows under the
+  // same distributed node share a section header so the distributed-plan
+  // chips don't repeat once per local-plan shape (sample / repartition /
+  // final phases of a Sort, etc.).
+  const sections = useMemo(
+    () => buildTaskSections(rows, operators),
+    [rows, operators],
   );
 
   // In-flight tasks (running + pending) for the "top" section. Running tasks
@@ -168,7 +179,7 @@ export default function TasksSidebar({
               />
             </div>
             <TaskTypeTable
-              rows={rows}
+              sections={sections}
               onSelectNode={onSelectNode}
               onHoverNodes={onHoverNodes}
             />
@@ -379,30 +390,32 @@ function RunningTaskRow({
 }
 
 // ---------------------------------------------------------------------------
-// Table of task-type rows.
+// Sectioned task-type table. Tasks are grouped by `(node_ids, name)`; rows
+// sharing the same `node_ids` (= same distributed-plan chain) display under a
+// single section header that carries the distributed-plan chips. The section
+// header is fixed, not collapsible — it's purely a visual hierarchy hint.
 // ---------------------------------------------------------------------------
-// Columns: chevron | Local Plan | Distributed Plan | Tasks | Status | CPU
+// Columns: chevron | Local Plan | Tasks | Status | CPU
 const GRID_COLS =
-  "grid-cols-[32px_minmax(220px,2fr)_minmax(220px,2fr)_90px_130px_100px]";
+  "grid-cols-[32px_minmax(220px,3fr)_90px_130px_100px]";
 
 function TaskTypeTable({
-  rows,
+  sections,
   onSelectNode,
   onHoverNodes,
 }: {
-  rows: TaskTypeRow[];
+  sections: TaskTypeSection[];
   onSelectNode: (nodeId: number) => void;
   onHoverNodes: (ids: ReadonlySet<number> | null) => void;
 }) {
   return (
-    <div className="min-w-[900px]">
+    <div className="min-w-[800px]">
       {/* Header */}
       <div
         className={`bg-zinc-800 grid ${GRID_COLS} gap-0 items-center min-h-[48px] border-b border-zinc-700 sticky top-0 z-10`}
       >
         <HeaderCell />
         <HeaderCell align="left">Local Plan</HeaderCell>
-        <HeaderCell align="left">Distributed Plan</HeaderCell>
         <HeaderCell align="right">Tasks</HeaderCell>
         <HeaderCell align="left">Status</HeaderCell>
         <HeaderCell align="right" last>
@@ -411,12 +424,55 @@ function TaskTypeTable({
       </div>
 
       {/* Body */}
+      <div>
+        {sections.map((section) => (
+          <TaskTypeSectionBlock
+            key={section.key}
+            section={section}
+            onSelectNode={onSelectNode}
+            onHoverNodes={onHoverNodes}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * One section: a header strip showing the distributed-plan chain followed by
+ * one or more {@link TaskTypeGroupRow}s for each distinct local-plan shape
+ * under that distributed node.
+ */
+function TaskTypeSectionBlock({
+  section,
+  onSelectNode,
+  onHoverNodes,
+}: {
+  section: TaskTypeSection;
+  onSelectNode: (nodeId: number) => void;
+  onHoverNodes: (ids: ReadonlySet<number> | null) => void;
+}) {
+  const hoverSet = useMemo(() => new Set(section.node_ids), [section.node_ids]);
+  return (
+    <div className="border-b border-zinc-700">
+      <div
+        className="px-3 py-2 bg-zinc-900/70 border-b border-zinc-800 flex items-center gap-2"
+        onMouseEnter={() => onHoverNodes(hoverSet)}
+        onMouseLeave={() => onHoverNodes(null)}
+      >
+        <span className={`${main.className} text-[10px] uppercase tracking-wider text-zinc-500 font-mono shrink-0`}>
+          Distributed plan
+        </span>
+        <ClickablePipelineChips
+          chain={section.distributed_plan}
+          onClickNode={onSelectNode}
+        />
+      </div>
       <div className="divide-y divide-zinc-800">
-        {rows.map((row) => (
+        {section.rows.map((row) => (
           <TaskTypeGroupRow
             key={row.key}
             row={row}
-            onSelectNode={onSelectNode}
             onHoverNodes={onHoverNodes}
           />
         ))}
@@ -453,11 +509,9 @@ function HeaderCell({
 
 function TaskTypeGroupRow({
   row,
-  onSelectNode,
   onHoverNodes,
 }: {
   row: TaskTypeRow;
-  onSelectNode: (nodeId: number) => void;
   onHoverNodes: (ids: ReadonlySet<number> | null) => void;
 }) {
   const [expanded, setExpanded] = useState(false);
@@ -480,12 +534,6 @@ function TaskTypeGroupRow({
         </Cell>
         <Cell align="left">
           <PipelineChips pipeline={row.pipeline} />
-        </Cell>
-        <Cell align="left">
-          <ClickablePipelineChips
-            chain={row.distributed_plan}
-            onClickNode={onSelectNode}
-          />
         </Cell>
         <Cell align="right">
           <span className={`${main.className} text-sm text-zinc-200 font-mono`}>

--- a/src/daft-dashboard/src/state.rs
+++ b/src/daft-dashboard/src/state.rs
@@ -448,8 +448,9 @@ impl TaskStore {
         let was_pending = matches!(prev_status, Some(TaskStatus::Pending));
         let was_running = matches!(prev_status, Some(TaskStatus::Running));
 
-        // Display label for the (possibly new) group. The actual group key
-        // is `node_ids`; this is just what the UI shows.
+        // Resolve the group's display name; this is also part of the group
+        // key (alongside `node_ids`), so distinct local-plan shapes split
+        // into separate groups.
         let display_name = self
             .tasks
             .get(&task_id)

--- a/src/daft-dashboard/src/state.rs
+++ b/src/daft-dashboard/src/state.rs
@@ -86,13 +86,22 @@ pub(crate) struct TaskInfo {
     pub sources: Vec<crate::engine::TaskSourceArgs>,
 }
 
-/// Canonical group identity: the full chain of distributed pipeline nodes that
-/// contributed local plan nodes to the task. Two tasks with identical chains
-/// belong to the same group, regardless of how `task.name` was rendered or
-/// what parameter values varied (limit values, repartition counts, etc.).
+/// Canonical group identity: the chain of distributed pipeline nodes that
+/// contributed local plan nodes to the task, plus the local-plan shape
+/// (`task.name`, e.g. `"InMemoryScan->Sample->Project"`). Two tasks with the
+/// same `node_ids` and the same shape belong to the same group; different
+/// shapes under the same `node_ids` (e.g. the sample / repartition / final
+/// phases of a distributed Sort) get their own groups so the UI can show
+/// per-phase counts and totals. The frontend overlays a parent section by
+/// `node_ids` to keep sibling phases visually together.
+///
+/// `task.name` derives from `LocalPhysicalPlan::single_line_display()` which
+/// uses operator variant names (`"Limit"`, not `"Limit(10)"`), so groups
+/// don't split on parameter values like limit/partition counts.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct TaskGroupKey {
     pub node_ids: Vec<NodeID>,
+    pub name: String,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -179,6 +188,7 @@ impl TaskStore {
         };
         let key = TaskGroupKey {
             node_ids: key_node_ids,
+            name: name.to_string(),
         };
         let groups = &mut self.groups;
         *self.group_index.entry(key).or_insert_with_key(|key| {
@@ -186,7 +196,7 @@ impl TaskStore {
             groups.push(TaskGroupSummary {
                 last_node_id,
                 node_ids: key.node_ids.clone(),
-                name: name.to_string(),
+                name: key.name.clone(),
                 task_count: 0,
                 pending_count: 0,
                 running_count: 0,
@@ -202,15 +212,22 @@ impl TaskStore {
         })
     }
 
-    /// Derive the group key for a task from its full `node_ids` chain. Falls
-    /// back to a single-element chain if `node_ids` is empty.
+    /// Derive the group key for a task from its full `node_ids` chain plus
+    /// its local-plan shape. Falls back to a single-element chain if
+    /// `node_ids` is empty, and to `Node {last_node_id}` if `task.name` is
+    /// missing (matching the display-name fallback in `submit_task` /
+    /// `end_task`).
     fn group_key_for_task(task: &TaskInfo) -> TaskGroupKey {
         let node_ids = if task.node_ids.is_empty() {
             vec![task.last_node_id]
         } else {
             task.node_ids.clone()
         };
-        TaskGroupKey { node_ids }
+        let name = task
+            .name
+            .clone()
+            .unwrap_or_else(|| format!("Node {}", task.last_node_id));
+        TaskGroupKey { node_ids, name }
     }
 
     /// Record a task submission. The individual task is always retained while
@@ -225,7 +242,10 @@ impl TaskStore {
             name,
             sources,
         } = args;
-        // Display label only; the group key is `node_ids`.
+        // The group key is `(node_ids, display_name)`, so two tasks under the
+        // same distributed-plan chain that render with different local-plan
+        // shapes (e.g. Sort's sample / repartition / final phases) split into
+        // separate groups and get their own per-shape totals.
         let display_name = name
             .clone()
             .unwrap_or_else(|| format!("Node {last_node_id}"));
@@ -449,6 +469,7 @@ impl TaskStore {
         };
         let key = TaskGroupKey {
             node_ids: key_node_ids.clone(),
+            name: display_name.clone(),
         };
 
         // Ensure group exists and update summary.
@@ -894,14 +915,15 @@ mod task_store_tests {
         }
     }
 
-    /// Two tasks with identical `node_ids` but different `name` strings should
-    /// land in the same group. (Previously, group key included the name and
-    /// these would split.)
+    /// Two tasks with identical `node_ids` and identical `name` collapse into
+    /// one group. `task.name` derives from `LocalPhysicalPlan::name()`
+    /// (operator variant only — not parameter values), so two `Limit` tasks
+    /// with different limit values render with the same name and merge.
     #[test]
-    fn same_node_ids_different_names_collapse_to_one_group() {
+    fn same_node_ids_same_name_collapse_to_one_group() {
         let mut store = TaskStore::default();
-        store.submit_task(submit(1, 7, vec![3, 5, 7], "Limit(10)", 0.0));
-        store.submit_task(submit(2, 7, vec![3, 5, 7], "Limit(100)", 0.0));
+        store.submit_task(submit(1, 7, vec![3, 5, 7], "Limit", 0.0));
+        store.submit_task(submit(2, 7, vec![3, 5, 7], "Limit", 0.0));
 
         assert_eq!(
             store.groups.len(),
@@ -911,6 +933,28 @@ mod task_store_tests {
         );
         assert_eq!(store.groups[0].task_count, 2);
         assert_eq!(store.groups[0].node_ids, vec![3, 5, 7]);
+    }
+
+    /// Two tasks under the same distributed-plan chain that render with
+    /// different local-plan shapes split into separate groups. Concrete case:
+    /// a distributed Sort dispatches three phases (sample / repartition /
+    /// final) all with the same `node_ids = [sort_node_id]`, but their local
+    /// plans render as `InMemoryScan->Sample->Project`,
+    /// `InMemoryScan->RepartitionWrite`, and `InMemoryScan->Sort`. Each phase
+    /// gets its own group so per-phase counts and totals don't get rolled up
+    /// together.
+    #[test]
+    fn same_node_ids_different_names_split_into_separate_groups() {
+        let mut store = TaskStore::default();
+        store.submit_task(submit(1, 7, vec![7], "InMemoryScan->Sample->Project", 0.0));
+        store.submit_task(submit(2, 7, vec![7], "InMemoryScan->RepartitionWrite", 0.0));
+        store.submit_task(submit(3, 7, vec![7], "InMemoryScan->Sort", 0.0));
+
+        assert_eq!(store.groups.len(), 3);
+        for g in &store.groups {
+            assert_eq!(g.node_ids, vec![7]);
+            assert_eq!(g.task_count, 1);
+        }
     }
 
     /// Two tasks with the same `name` but different `node_ids` should land in
@@ -1020,14 +1064,20 @@ mod task_store_tests {
         assert!(!store.tasks.contains_key(&999));
     }
 
-    /// End-before-submit with empty node_ids should resolve to the same group
-    /// as the eventual submit, so counts don't double up.
+    /// End-before-submit with empty node_ids creates a fallback group keyed
+    /// by `(vec![last_node_id], "Node {last_node_id}")` because the local-plan
+    /// name isn't known until submit arrives. When submit eventually arrives
+    /// with the real name, the task isn't double-counted (it's already in
+    /// `tasks` so the new group's counters are not incremented), but the
+    /// fallback group remains as an empty-counts ghost row. End-before-submit
+    /// only happens when network reordering delivers the end event before
+    /// the submit; in steady state this is rare. A future change could
+    /// migrate the fallback group's counts into the real group when submit
+    /// arrives, but that's heavier than the bug warrants today.
     #[test]
-    fn end_before_submit_with_empty_node_ids_resolves_to_submit_group() {
+    fn end_before_submit_with_empty_node_ids_creates_fallback_group() {
         let mut store = TaskStore::default();
 
-        // End arrives first, with empty node_ids — fallback creates a group
-        // keyed by [last_node_id].
         store.end_task(
             42,
             7,
@@ -1041,12 +1091,24 @@ mod task_store_tests {
         // Submit arrives later with the same single-node chain.
         store.submit_task(submit(42, 7, vec![7], "Filter", 0.5));
 
-        assert_eq!(store.groups.len(), 1);
-        let g = &store.groups[0];
-        // task_count should not double-count: end (no submit seen) credited 1,
-        // submit found existing task and didn't increment further.
-        assert_eq!(g.task_count, 1);
-        assert_eq!(g.finished_count, 1);
+        // Two groups: the fallback `(vec![7], "Node 7")` from end_task, and
+        // the real `(vec![7], "Filter")` from submit_task.
+        assert_eq!(store.groups.len(), 2);
+        let fallback = store
+            .groups
+            .iter()
+            .find(|g| g.name == "Node 7")
+            .expect("fallback group present");
+        assert_eq!(fallback.task_count, 1);
+        assert_eq!(fallback.finished_count, 1);
+        let real = store
+            .groups
+            .iter()
+            .find(|g| g.name == "Filter")
+            .expect("real group present");
+        // Real group exists but contributes zero counts: the task already
+        // ended so submit didn't increment further.
+        assert_eq!(real.task_count, 0);
     }
 
     /// submit -> scheduled -> end transitions pending/running/finished counts


### PR DESCRIPTION
## Summary

The Tasks sidebar previously keyed groups by just \`node_ids\` (the chain of distributed pipeline nodes that contributed to the task). That correctly rolled up tasks differing only in parameter values (\`Limit(10)\` vs \`Limit(100)\`) but also incorrectly merged tasks with genuinely different local-plan shapes that share a distributed node — most visibly the **sample / range-repartition / final-sort phases of a distributed Sort**, all of which carry the same \`node_ids = [sort_node_id]\`. The merged group displayed only the first arrival's local plan and summed totals across phases, so per-phase counts/totals looked wrong.

This was a latent bug introduced when the group key was changed to \`node_ids\`-only in #6783. It's surfaced by the per-task rows/bytes I/O work in #6861 (mismatched per-phase totals become visibly wrong once you can see them).

<img width="672" height="600" alt="image" src="https://github.com/user-attachments/assets/59b7cb61-0fac-44ac-93a6-675957f8df33" />

## Changes

1. **Add \`name\` to \`TaskGroupKey\`.** Sibling task shapes under the same distributed node split into separate rows. Tasks differing only in parameter values still merge because \`task.name\` derives from \`LocalPhysicalPlan::name()\` (operator variant only — \`Limit\`, not \`Limit(10)\`).

2. **Restructure the table with a section header.** The distributed-plan chain renders once per section (fixed strip, not collapsible) instead of repeating in every row. Sibling phases under the same distributed node sit together inside one section. Within each section, rows are reversed so the latest-executed phase appears at the top, matching the bottom-to-top distributed plan view.

3. **Frontend \`tasksByGroup\`** is also keyed by \`(node_ids, name)\` to match the server's group identity. Keying by \`node_ids\` alone caused every sibling group to display the same task list once they were split.

## Edge case

End-before-submit (rare race): the fallback group keyed by \`Node X\` is left as an empty-counts ghost when the real-named group is later created. Documented in the test; a future change can migrate counts if it becomes a real issue.

## Test plan

- [x] \`cargo test -p daft-dashboard --lib\` (18/18 pass)
- [x] frontend type-check clean
- [x] Run a distributed Sort query and verify three sections rows (Sort sample / range-repartition / final-sort) appear separately under one section header

🤖 Generated with [Claude Code](https://claude.com/claude-code)