### PR TITLE
feat(dashboard): make header smaller in query details

### DIFF
--- a/src/daft-dashboard/frontend/src/app/query/page.tsx
+++ b/src/daft-dashboard/frontend/src/app/query/page.tsx
@@ -20,10 +20,40 @@ import PhysicalPlanTree from "./physical-plan-tree";
 import PlanVisualizer from "./plan-visualizer";
 import TasksSidebar from "./tasks-sidebar";
 
-/**
- * Query detail page component
- * Displays details for a specific query by ID using query parameters
- */
+const TAB_TRIGGER_CLS = "rounded-none bg-transparent px-4 py-2.5 text-sm font-medium text-zinc-400 shadow-none transition-colors hover:text-zinc-100 data-[state=active]:bg-transparent data-[state=active]:text-white data-[state=active]:shadow-none data-[state=active]:border-b-2 data-[state=active]:border-white data-[state=active]:-mb-px disabled:opacity-30";
+
+const MetaField = ({
+  label,
+  value,
+  href,
+  mono,
+}: {
+  label: string;
+  value: string;
+  href?: string;
+  mono?: boolean;
+}) => (
+  <div className="min-w-0">
+    <p className={`${main.className} text-[10px] uppercase tracking-wider text-zinc-500 leading-none mb-1`}>
+      {label}
+    </p>
+    {href ? (
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={`${main.className} text-base ${mono ? "font-mono" : ""} text-blue-400 hover:underline`}
+      >
+        {value}
+      </a>
+    ) : (
+      <p className={`${main.className} text-base ${mono ? "font-mono" : ""} text-zinc-100`}>
+        {value}
+      </p>
+    )}
+  </div>
+);
+
 function QueryPageInner() {
   const searchParams = useSearchParams();
   const router = useRouter();
@@ -166,29 +196,32 @@ function QueryPageInner() {
 
   return (
     <div className="h-full flex flex-col">
-      {/* Fixed Header Section */}
-      <div className="flex-shrink-0 space-y-4">
-        <Breadcrumb>
-          <BreadcrumbList>
-            <BreadcrumbItem>
-              <BreadcrumbLink
-                asChild
-                className="text-lg font-mono text-zinc-400 hover:text-white"
-              >
-                <Link href="/queries">All Queries</Link>
-              </BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbSeparator />
-            <BreadcrumbItem>
-              <BreadcrumbLink asChild className="text-lg font-mono font-bold">
-                <p>Query {queryId}</p>
-              </BreadcrumbLink>
-            </BreadcrumbItem>
-          </BreadcrumbList>
-        </Breadcrumb>
+      {/* Compact Header */}
+      <div className="flex-shrink-0">
+        <div className="px-6 pt-0 pb-1">
+          <Breadcrumb>
+            <BreadcrumbList>
+              <BreadcrumbItem>
+                <BreadcrumbLink
+                  asChild
+                  className="text-xs font-mono text-zinc-500 hover:text-white"
+                >
+                  <Link href="/queries">All Queries</Link>
+                </BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbSeparator />
+              <BreadcrumbItem>
+                <BreadcrumbLink asChild className="text-xs font-mono text-zinc-300">
+                  <p>Query {queryId}</p>
+                </BreadcrumbLink>
+              </BreadcrumbItem>
+            </BreadcrumbList>
+          </Breadcrumb>
+        </div>
 
-        <div className="w-full flex border-b border-zinc-800">
-          <div className="w-1/4 border-r border-zinc-800 px-6 py-4">
+        <div className="w-full flex items-stretch">
+          {/* Status — fixed width so the divider never shifts during execution */}
+          <div className="w-52 flex-shrink-0 px-6 py-5 flex items-center justify-start">
             <Status
               status={query.state.status}
               start_sec={query.start_sec}
@@ -197,113 +230,40 @@ function QueryPageInner() {
               errorMessage={query.state.status === "Failed" ? query.state.message : undefined}
             />
           </div>
-          <div className="flex-1 px-6 py-4">
-            <div className="grid grid-cols-2 gap-6">
-              <div className="space-y-3">
-                <div>
-                  <h3
-                    className={`${main.className} text-sm font-semibold text-zinc-400 mb-1`}
-                  >
-                    Query ID
-                  </h3>
-                  <p className={`${main.className} text-lg font-mono text-zinc-100`}>
-                    {query.id}
-                  </p>
-                </div>
-                <div>
-                  <h3
-                    className={`${main.className} text-sm font-semibold text-zinc-400 mb-1`}
-                  >
-                    Start Time
-                  </h3>
-                  <p className={`${main.className} text-lg font-mono text-zinc-100`}>
-                    {toHumanReadableDate(query.start_sec)}
-                  </p>
-                </div>
-                <div>
-                  <h3 className={`${main.className} text-sm font-semibold text-zinc-400 mb-1`}>
-                    Entrypoint
-                  </h3>
-                  <p className={`${main.className} text-sm font-mono break-all text-zinc-100`} title={query.entrypoint || ""}>
-                    {query.entrypoint || "-"}
-                  </p>
-                </div>
-              </div>
-              <div className="space-y-3">
-                <div>
-                  <h3
-                    className={`${main.className} text-sm font-semibold text-zinc-400 mb-1`}
-                  >
-                    Engine
-                  </h3>
-                  <p className={`${main.className} text-lg font-mono text-zinc-100`}>
-                    {getEngineName(query.runner)}
-                  </p>
-                </div>
-                <div>
-                  <h3
-                    className={`${main.className} text-sm font-semibold text-zinc-400 mb-1`}
-                  >
-                    End Time
-                  </h3>
-                  <p className={`${main.className} text-lg font-mono text-zinc-100`}>
-                    {end_sec ? toHumanReadableDate(end_sec) : "..."}
-                  </p>
-                </div>
-                {query.ray_dashboard_url && (
-                  <div>
-                    <h3 className={`${main.className} text-sm font-semibold text-zinc-400 mb-1`}>
-                      Ray Dashboard
-                    </h3>
-                    <a
-                      href={query.ray_dashboard_url.startsWith("http") ? query.ray_dashboard_url : `http://${query.ray_dashboard_url}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className={`${main.className} text-sm font-mono text-blue-500 hover:underline`}
-                    >
-                      Open in Ray
-                    </a>
-                  </div>
-                )}
-              </div>
-              {(query.daft_version || query.python_version || query.ray_version) && (
-              <div className="space-y-3">
-                {query.daft_version && (
-                  <div>
-                    <h3 className={`${main.className} text-sm font-semibold text-zinc-400 mb-1`}>
-                      Daft Version
-                    </h3>
-                    <p className={`${main.className} text-lg font-mono text-zinc-100`}>
-                      {query.daft_version}
-                    </p>
-                  </div>
-                )}
-                {query.python_version && (
-                  <div>
-                    <h3 className={`${main.className} text-sm font-semibold text-zinc-400 mb-1`}>
-                      Python Version
-                    </h3>
-                    <p className={`${main.className} text-lg font-mono text-zinc-100`}>
-                      {query.python_version}
-                    </p>
-                  </div>
-                )}
-                {query.ray_version && (
-                  <div>
-                    <h3 className={`${main.className} text-sm font-semibold text-zinc-400 mb-1`}>
-                      Ray Version
-                    </h3>
-                    <p className={`${main.className} text-lg font-mono text-zinc-100`}>
-                      {query.ray_version}
-                    </p>
-                  </div>
-                )}
-              </div>
-              )}
-            </div>
+
+          <div className="w-px bg-zinc-800 my-4 flex-shrink-0" />
+
+          {/* Metadata — 4 columns, 2 rows */}
+          <div className="flex-1 px-6 py-5 grid grid-cols-4 gap-x-8 gap-y-3 content-center overflow-hidden">
+            {/* Row 1 */}
+            <MetaField label="Query ID" value={query.id} mono />
+            <MetaField label="Engine" value={getEngineName(query.runner)} mono />
+            <MetaField label="Start Time" value={toHumanReadableDate(query.start_sec)} mono />
+            <MetaField label="End Time" value={end_sec ? toHumanReadableDate(end_sec) : "—"} mono />
+
+            {/* Row 2 */}
+            <MetaField label="Entrypoint" value={query.entrypoint || "—"} mono />
+            <MetaField label="Daft Version" value={query.daft_version || "—"} mono />
+            {query.ray_dashboard_url ? (
+              <MetaField
+                label="Ray Dashboard"
+                href={query.ray_dashboard_url.startsWith("http") ? query.ray_dashboard_url : `http://${query.ray_dashboard_url}`}
+                value="Open in Ray"
+              />
+            ) : (
+              <div />
+            )}
+            {(query.python_version || query.ray_version) ? (
+              <MetaField
+                label="Versions"
+                value={[query.python_version && `Python ${query.python_version}`, query.ray_version && `Ray ${query.ray_version}`].filter(Boolean).join(" | ")}
+                mono
+              />
+            ) : (
+              <div />
+            )}
           </div>
         </div>
-        <div className="w-full h-[20px] flex"></div>
       </div>
 
       {/* Scrollable Content Section */}
@@ -313,7 +273,7 @@ function QueryPageInner() {
           onValueChange={handleTabChange}
           className="w-full h-full flex flex-col"
         >
-          <TabsList className="grid w-full flex-shrink-0 grid-cols-3">
+          <TabsList className="flex w-full flex-shrink-0 justify-start gap-x-0 rounded-none bg-transparent p-0 border-b border-zinc-800">
             <TabsTrigger
               value="progress-table"
               disabled={
@@ -321,16 +281,23 @@ function QueryPageInner() {
                 query.state.status === "Optimizing" ||
                 query.state.status === "Setup"
               }
+              className={TAB_TRIGGER_CLS}
             >
               Execution
             </TabsTrigger>
             <TabsTrigger
               value="optimized-plan"
               disabled={!("plan_info" in query.state && query.state.plan_info)}
+              className={TAB_TRIGGER_CLS}
             >
               Optimized Plan
             </TabsTrigger>
-            <TabsTrigger value="unoptimized-plan">Unoptimized Plan</TabsTrigger>
+            <TabsTrigger
+              value="unoptimized-plan"
+              className={TAB_TRIGGER_CLS}
+            >
+              Unoptimized Plan
+            </TabsTrigger>
           </TabsList>
 
           <TabsContent

--- a/src/daft-dashboard/frontend/src/app/query/page.tsx
+++ b/src/daft-dashboard/frontend/src/app/query/page.tsx
@@ -27,11 +27,13 @@ const MetaField = ({
   value,
   href,
   mono,
+  title,
 }: {
   label: string;
   value: string;
   href?: string;
   mono?: boolean;
+  title?: string;
 }) => (
   <div className="min-w-0">
     <p className={`${main.className} text-[10px] uppercase tracking-wider text-zinc-500 leading-none mb-1`}>
@@ -47,7 +49,10 @@ const MetaField = ({
         {value}
       </a>
     ) : (
-      <p className={`${main.className} text-base ${mono ? "font-mono" : ""} text-zinc-100`}>
+      <p
+        className={`${main.className} text-base ${mono ? "font-mono" : ""} text-zinc-100`}
+        title={title}
+      >
         {value}
       </p>
     )}
@@ -242,7 +247,7 @@ function QueryPageInner() {
             <MetaField label="End Time" value={end_sec ? toHumanReadableDate(end_sec) : "—"} mono />
 
             {/* Row 2 */}
-            <MetaField label="Entrypoint" value={query.entrypoint || "—"} mono />
+            <MetaField label="Entrypoint" value={query.entrypoint || "—"} mono title={query.entrypoint} />
             <MetaField label="Daft Version" value={query.daft_version || "—"} mono />
             {query.ray_dashboard_url ? (
               <MetaField

--- a/src/daft-dashboard/frontend/src/app/query/status.tsx
+++ b/src/daft-dashboard/frontend/src/app/query/status.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { main, toHumanReadableDuration, toHumanReadableDate } from "@/lib/utils";
 import { AlertTriangle, Ban, CircleX, LoaderCircle, Skull, X } from "lucide-react";
 import { QueryStatusName } from "@/hooks/use-queries";
@@ -83,7 +83,7 @@ const ErrorModal = ({ message }: { message: string }) => (
   </Dialog.Root>
 );
 
-const STATUS_CONFIG: Record<QueryStatusName, { icon: React.ReactNode; label: string; textColor: string }> = {
+const STATUS_CONFIG: Record<QueryStatusName, { icon: ReactNode; label: string; textColor: string }> = {
   Pending:    { icon: <LoaderCircle size={15} strokeWidth={3} className="text-chart-1 animate-spin" />,   label: "Waiting to Start",   textColor: "text-chart-1" },
   Optimizing: { icon: <LoaderCircle size={15} strokeWidth={3} className="text-orange-500 animate-spin" />, label: "Optimizing",         textColor: "text-orange-500" },
   Setup:      { icon: <LoaderCircle size={15} strokeWidth={3} className="text-magenta-500 animate-spin" />,label: "Setting Up Runner",  textColor: "text-magenta-500" },

--- a/src/daft-dashboard/frontend/src/app/query/status.tsx
+++ b/src/daft-dashboard/frontend/src/app/query/status.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect, useState } from "react";
 import { main, toHumanReadableDuration, toHumanReadableDate } from "@/lib/utils";
 import { AlertTriangle, Ban, CircleX, LoaderCircle, Skull, X } from "lucide-react";
@@ -14,118 +16,14 @@ const Timer = ({ start_sec }: { start_sec: number }) => {
     return () => clearInterval(interval);
   }, []);
 
-  const currDuration = Math.round(currentTime / 1000 - start_sec);
   return (
-    <div className={`${main.className} text-sm font-mono text-zinc-400`}>
-      {toHumanReadableDuration(currDuration)}
-    </div>
+    <span className={`${main.className} text-sm font-mono text-zinc-400`}>
+      {toHumanReadableDuration(Math.round(currentTime / 1000 - start_sec))}
+    </span>
   );
 };
 
-// Custom status component that shows only status without duration text
-const StatusIcon = ({ status }: { status: QueryStatusName }) => {
-  const getStatusDisplay = () => {
-    switch (status) {
-      case "Pending":
-        return {
-          icon: (
-            <LoaderCircle size={16} strokeWidth={3} className="text-chart-1" />
-          ),
-          label: "Waiting to Start",
-          textColor: "text-chart-1",
-        };
-      case "Optimizing":
-        return {
-          icon: (
-            <LoaderCircle
-              size={16}
-              strokeWidth={3}
-              className="text-orange-500"
-            />
-          ),
-          label: "Optimizing",
-          textColor: "text-orange-500",
-        };
-      case "Setup":
-        return {
-          icon: (
-            <LoaderCircle
-              size={16}
-              strokeWidth={3}
-              className="text-magenta-500"
-            />
-          ),
-          label: "Setting Up Runner",
-          textColor: "text-magenta-500",
-        };
-      case "Executing":
-        return {
-          icon: <AnimatedFish />,
-          label: "Running",
-          textColor: "text-(--daft-accent)",
-        };
-      case "Finalizing":
-        return {
-          icon: (
-            <LoaderCircle size={16} strokeWidth={3} className="text-blue-500" />
-          ),
-          label: "Finalizing Query",
-          textColor: "text-blue-500",
-        };
-      case "Finished":
-        return {
-          icon: <Naruto />,
-          label: "Finished",
-          textColor: "text-green-500",
-        };
-      case "Failed":
-        return {
-          icon: <CircleX size={16} strokeWidth={3} className="text-red-500" />,
-          label: "Failed",
-          textColor: "text-red-500",
-        };
-      case "Canceled":
-        return {
-          icon: <Ban size={16} strokeWidth={3} className="text-gray-500" />,
-          label: "Canceled",
-          textColor: "text-gray-500",
-        };
-      case "Dead":
-        return {
-          icon: <Skull size={16} strokeWidth={3} className="text-gray-500" />,
-          label: "Dead",
-          textColor: "text-gray-500",
-        };
-      default:
-        return {
-          icon: (
-            <LoaderCircle size={16} strokeWidth={3} className="text-chart-2" />
-          ),
-          label: "Unknown",
-          textColor: "text-chart-2",
-        };
-    }
-  };
-
-  const statusDisplay = getStatusDisplay();
-
-  return (
-    <div className="flex items-center justify-center gap-x-4 w-full">
-      <div className="scale-150">{statusDisplay.icon}</div>
-      <span
-        className={`${main.className} ${statusDisplay.textColor} font-bold text-4xl`}
-      >
-        {statusDisplay.label}
-      </span>
-    </div>
-  );
-};
-
-const LastHeartbeat = ({
-  last_heartbeat_sec,
-}: {
-  last_heartbeat_sec: number;
-}) => {
+const LastHeartbeat = ({ last_heartbeat_sec }: { last_heartbeat_sec: number }) => {
   const [currentTime, setCurrentTime] = useState(() => Date.now());
   useEffect(() => {
     const interval = setInterval(() => {
@@ -134,11 +32,7 @@ const LastHeartbeat = ({
     return () => clearInterval(interval);
   }, []);
 
-  // Note this is may be inaccurate if the browser's and dashboard server's
-  // clocks are out of sync, since currentTime uses the browser's clock whereas
-  // last_heartbeat_sec uses the server's clock.
-  // However it should be unaffected by time zone differences since both timestamps
-  // are just seconds-since-epoch.
+  // Note: may be inaccurate if browser and dashboard server clocks are out of sync.
   const ago = Math.round(currentTime / 1000 - last_heartbeat_sec);
 
   if (ago < 10) return null;
@@ -146,49 +40,59 @@ const LastHeartbeat = ({
   if (ago > 30) {
     return (
       <div className={`${main.className} text-xs font-mono text-red-400`}>
-        Query unresponsive (last heartbeat: {toHumanReadableDate(last_heartbeat_sec)})
+        unresponsive (last heartbeat: {toHumanReadableDate(last_heartbeat_sec)})
       </div>
     );
   }
 
   return (
     <div className={`${main.className} text-xs font-mono text-zinc-500`}>
-      Last heartbeat: {toHumanReadableDuration(ago)} ago
+      heartbeat {toHumanReadableDuration(ago)} ago
     </div>
   );
 };
 
-const ErrorModal = ({ message }: { message: string }) => {
-  return (
-    <Dialog.Root>
-      <Dialog.Trigger asChild>
-        <button className="flex items-center gap-x-1.5 px-2.5 py-1 rounded border border-red-700 text-red-400 hover:bg-red-950 hover:border-red-500 transition-colors text-xs font-mono">
-          <AlertTriangle size={12} />
-          View Error
-        </button>
-      </Dialog.Trigger>
-      <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/70 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
-        <Dialog.Content className="fixed left-1/2 top-1/2 z-50 w-full max-w-2xl -translate-x-1/2 -translate-y-1/2 rounded-lg border border-zinc-700 bg-zinc-900 p-6 shadow-xl data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95">
-          <div className="flex items-center justify-between mb-4">
-            <Dialog.Title className={`${main.className} flex items-center gap-x-2 text-red-400 font-semibold text-base`}>
-              <CircleX size={16} strokeWidth={2.5} />
-              Query Error
-            </Dialog.Title>
-            <Dialog.Close className="rounded opacity-70 hover:opacity-100 transition-opacity text-zinc-400 hover:text-white">
-              <X size={16} />
-              <span className="sr-only">Close</span>
-            </Dialog.Close>
-          </div>
-          <Dialog.Description asChild>
-            <pre className={`${main.className} whitespace-pre-wrap break-words text-xs text-zinc-300 bg-zinc-950 rounded border border-zinc-800 p-4 max-h-96 overflow-y-auto`}>
-              {message}
-            </pre>
-          </Dialog.Description>
-        </Dialog.Content>
-      </Dialog.Portal>
-    </Dialog.Root>
-  );
+const ErrorModal = ({ message }: { message: string }) => (
+  <Dialog.Root>
+    <Dialog.Trigger asChild>
+      <button className="w-fit flex items-center gap-x-1.5 px-2 py-0.5 rounded border border-red-700 text-red-400 hover:bg-red-950 hover:border-red-500 transition-colors text-xs font-mono">
+        <AlertTriangle size={11} />
+        View Error
+      </button>
+    </Dialog.Trigger>
+    <Dialog.Portal>
+      <Dialog.Overlay className="fixed inset-0 z-50 bg-black/70 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+      <Dialog.Content className="fixed left-1/2 top-1/2 z-50 w-full max-w-2xl -translate-x-1/2 -translate-y-1/2 rounded-lg border border-zinc-700 bg-zinc-900 p-6 shadow-xl data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95">
+        <div className="flex items-center justify-between mb-4">
+          <Dialog.Title className={`${main.className} flex items-center gap-x-2 text-red-400 font-semibold text-base`}>
+            <CircleX size={16} strokeWidth={2.5} />
+            Query Error
+          </Dialog.Title>
+          <Dialog.Close className="rounded opacity-70 hover:opacity-100 transition-opacity text-zinc-400 hover:text-white">
+            <X size={16} />
+            <span className="sr-only">Close</span>
+          </Dialog.Close>
+        </div>
+        <Dialog.Description asChild>
+          <pre className={`${main.className} whitespace-pre-wrap break-words text-xs text-zinc-300 bg-zinc-950 rounded border border-zinc-800 p-4 max-h-96 overflow-y-auto`}>
+            {message}
+          </pre>
+        </Dialog.Description>
+      </Dialog.Content>
+    </Dialog.Portal>
+  </Dialog.Root>
+);
+
+const STATUS_CONFIG: Record<QueryStatusName, { icon: React.ReactNode; label: string; textColor: string }> = {
+  Pending:    { icon: <LoaderCircle size={15} strokeWidth={3} className="text-chart-1 animate-spin" />,   label: "Waiting to Start",   textColor: "text-chart-1" },
+  Optimizing: { icon: <LoaderCircle size={15} strokeWidth={3} className="text-orange-500 animate-spin" />, label: "Optimizing",         textColor: "text-orange-500" },
+  Setup:      { icon: <LoaderCircle size={15} strokeWidth={3} className="text-magenta-500 animate-spin" />,label: "Setting Up Runner",  textColor: "text-magenta-500" },
+  Executing:  { icon: <AnimatedFish />,                                                                     label: "Running",            textColor: "text-(--daft-accent)" },
+  Finalizing: { icon: <LoaderCircle size={15} strokeWidth={3} className="text-blue-500 animate-spin" />,   label: "Finalizing",         textColor: "text-blue-500" },
+  Finished:   { icon: <Naruto />,                                                                           label: "Finished",           textColor: "text-green-500" },
+  Failed:     { icon: <CircleX size={15} strokeWidth={3} className="text-red-500" />,                      label: "Failed",             textColor: "text-red-500" },
+  Canceled:   { icon: <Ban size={15} strokeWidth={3} className="text-zinc-500" />,                         label: "Canceled",           textColor: "text-zinc-400" },
+  Dead:       { icon: <Skull size={15} strokeWidth={3} className="text-zinc-500" />,                       label: "Dead",               textColor: "text-zinc-400" },
 };
 
 export function Status({
@@ -204,24 +108,28 @@ export function Status({
   last_heartbeat_sec: number | null;
   errorMessage?: string;
 }) {
+  const { icon, label, textColor } = STATUS_CONFIG[status] ?? STATUS_CONFIG.Pending;
+
   return (
-    <div className="flex flex-col items-center justify-center h-full space-y-4">
-      <StatusIcon status={status} />
-      {end_sec ? (
-        <div
-          className={`${main.className} text-md font-mono text-bold text-zinc-300`}
-        >
-          {toHumanReadableDuration(end_sec - start_sec)}
-        </div>
-      ) : (
-        <Timer start_sec={start_sec} />
-      )}
+    <div className="flex flex-col gap-y-1.5">
+      <div className="flex items-center gap-x-2 whitespace-nowrap">
+        {icon}
+        <span className={`${main.className} ${textColor} font-bold text-base`}>
+          {label}
+        </span>
+        <span className="text-zinc-600">·</span>
+        {end_sec != null ? (
+          <span className={`${main.className} text-sm font-mono text-zinc-400`}>
+            {toHumanReadableDuration(end_sec - start_sec)}
+          </span>
+        ) : (
+          <Timer start_sec={start_sec} />
+        )}
+      </div>
+      {last_heartbeat_sec && <LastHeartbeat last_heartbeat_sec={last_heartbeat_sec} />}
       {status === "Failed" && errorMessage && (
         <ErrorModal message={errorMessage} />
       )}
-      {last_heartbeat_sec ? (
-        <LastHeartbeat last_heartbeat_sec={last_heartbeat_sec} />
-      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Changes Made
This compresses the header in the query details to make more space for the plan and other information.

<img width="1579" height="941" alt="Screenshot 2026-05-07 at 2 37 26 PM" src="https://github.com/user-attachments/assets/6f5bf24c-4b48-411f-a9c9-1ea22f640ea4" />
