### PR TITLE
fix: Handle dtype mismatch error in join_asof join keys

### DIFF
--- a/src/daft-distributed/src/pipeline_node/join/translate_asof_join.rs
+++ b/src/daft-distributed/src/pipeline_node/join/translate_asof_join.rs
@@ -50,19 +50,29 @@ impl LogicalPlanToPipelineNodeTranslator {
         left_node: DistributedPipelineNode,
         right_node: DistributedPipelineNode,
     ) -> DaftResult<DistributedPipelineNode> {
-        // Normalize the by
         let (left_by, right_by) = daft_dsl::join::normalize_join_keys(
             asof_join.left_by.clone(),
             asof_join.right_by.clone(),
             left_node.config().schema.clone(),
             right_node.config().schema.clone(),
         )?;
+        let (left_on_exprs, right_on_exprs) = daft_dsl::join::normalize_join_keys(
+            vec![asof_join.left_on.clone()],
+            vec![asof_join.right_on.clone()],
+            left_node.config().schema.clone(),
+            right_node.config().schema.clone(),
+        )?;
 
-        // Bind keys to schemas
         let left_by = BoundExpr::bind_all(&left_by, &left_node.config().schema)?;
         let right_by = BoundExpr::bind_all(&right_by, &right_node.config().schema)?;
-        let left_on = BoundExpr::try_new(asof_join.left_on.clone(), &left_node.config().schema)?;
-        let right_on = BoundExpr::try_new(asof_join.right_on.clone(), &right_node.config().schema)?;
+        let left_on = BoundExpr::try_new(
+            left_on_exprs.into_iter().next().unwrap(),
+            &left_node.config().schema,
+        )?;
+        let right_on = BoundExpr::try_new(
+            right_on_exprs.into_iter().next().unwrap(),
+            &right_node.config().schema,
+        )?;
 
         self.gen_asof_join_nodes(
             left_node,

--- a/src/daft-dsl/src/join.rs
+++ b/src/daft-dsl/src/join.rs
@@ -1,5 +1,3 @@
-use std::collections::HashSet;
-
 use common_error::DaftResult;
 use daft_core::{prelude::*, utils::supertype::try_get_supertype};
 use indexmap::IndexSet;
@@ -62,61 +60,6 @@ pub fn infer_join_schema(
 
         Ok(Schema::new(fields).into())
     }
-}
-
-/// Infer the output schema for an asof join.
-/// Column order: all left columns in their original schema order, then
-/// right columns not in `right_cols_to_drop` in their original schema order.
-pub fn infer_asof_join_schema(
-    left_schema: &SchemaRef,
-    right_schema: &SchemaRef,
-    right_cols_to_drop: &HashSet<String>,
-) -> DaftResult<SchemaRef> {
-    let mut fields = Vec::new();
-
-    for field in left_schema.into_iter() {
-        fields.push(field.clone());
-    }
-
-    for field in right_schema.into_iter() {
-        if !right_cols_to_drop.contains(field.name.as_ref()) {
-            fields.push(field.clone());
-        }
-    }
-
-    Ok(Schema::new(fields).into())
-}
-
-/// Compute the right key column names to exclude from the asof join output.
-///
-/// For by-keys: all right by columns that are direct column references (not complex expressions) are dropped.
-/// For on-keys: the right on column is dropped only when it has the same name as the left on column.
-///
-/// Returns the set of right column names to drop from the output.
-pub fn get_right_cols_to_drop<E, F>(
-    right_by: &[E],
-    left_on: &E,
-    right_on: &E,
-    extract_name: F,
-) -> HashSet<String>
-where
-    F: Fn(&E) -> Option<String>,
-{
-    let mut right_cols_to_drop = HashSet::new();
-
-    for r in right_by {
-        if let Some(right_name) = extract_name(r) {
-            right_cols_to_drop.insert(right_name);
-        }
-    }
-
-    if let (Some(left_name), Some(right_name)) = (extract_name(left_on), extract_name(right_on))
-        && left_name == right_name
-    {
-        right_cols_to_drop.insert(right_name);
-    }
-
-    right_cols_to_drop
 }
 
 /// Casts join keys to the same types and make their names unique.

--- a/src/daft-local-execution/src/join/asof_join.rs
+++ b/src/daft-local-execution/src/join/asof_join.rs
@@ -15,11 +15,7 @@ use daft_core::{
     kernels::search_sorted::{DynPartialComparator, build_partial_compare_with_nulls},
     prelude::{DataType as DaftDataType, Field, Schema, SchemaRef, Series, UInt64Array},
 };
-use daft_dsl::{
-    Expr,
-    expr::bound_expr::BoundExpr,
-    join::{get_right_cols_to_drop, infer_asof_join_schema},
-};
+use daft_dsl::expr::bound_expr::BoundExpr;
 use daft_groupby::IntoGroups;
 use daft_micropartition::MicroPartition;
 use daft_recordbatch::RecordBatch;
@@ -250,14 +246,15 @@ impl AsofJoinProbeState {
         right_rb: &RecordBatch,
         right_on: &BoundExpr,
         right_by: &[BoundExpr],
-        right_cols_to_drop: &HashSet<String>,
+        join_schema: &SchemaRef,
+        left_schema_len: usize,
     ) -> DaftResult<()> {
         let rb_idx = self.right_rbs_and_on_keys.len();
         let build_state = self.build_contents.clone();
 
         let right_on_arr: Arc<dyn Array> = right_rb.eval_expression(right_on)?.to_arrow()?;
         self.right_rbs_and_on_keys.push((
-            prune_right_batch(right_rb, right_cols_to_drop),
+            prune_right_batch(right_rb, join_schema, left_schema_len),
             right_on_arr.clone(),
         ));
 
@@ -407,13 +404,23 @@ fn forward_fill(global_best: &mut [Option<(u32, u32)>], grouped_sorted_indices: 
     }
 }
 
-fn prune_right_batch(rb: &RecordBatch, right_cols_to_drop: &HashSet<String>) -> RecordBatch {
+fn prune_right_batch(
+    rb: &RecordBatch,
+    join_schema: &SchemaRef,
+    left_schema_len: usize,
+) -> RecordBatch {
+    let right_cols_to_keep: HashSet<&str> = join_schema
+        .fields()
+        .iter()
+        .skip(left_schema_len)
+        .map(|f| f.name.as_ref())
+        .collect();
     let kept_indices: Vec<usize> = rb
         .schema
         .fields()
         .iter()
         .enumerate()
-        .filter_map(|(i, f)| (!right_cols_to_drop.contains(f.name.as_ref())).then_some(i))
+        .filter_map(|(i, f)| right_cols_to_keep.contains(f.name.as_ref()).then_some(i))
         .collect();
     rb.get_columns(&kept_indices)
 }
@@ -469,7 +476,6 @@ pub struct AsofJoinOperator {
     left_on: BoundExpr,
     right_on: BoundExpr,
     left_schema: SchemaRef,
-    right_cols_to_drop: HashSet<String>,
     join_schema: SchemaRef,
 }
 
@@ -480,24 +486,14 @@ impl AsofJoinOperator {
         left_on: BoundExpr,
         right_on: BoundExpr,
         left_schema: SchemaRef,
-        right_schema: SchemaRef,
+        join_schema: SchemaRef,
     ) -> DaftResult<Self> {
-        let right_cols_to_drop = get_right_cols_to_drop(&right_by, &left_on, &right_on, |e| {
-            let (unwrapped, _) = e.inner().clone().unwrap_alias();
-            match unwrapped.as_ref() {
-                Expr::Column(_) => Some(unwrapped.name().to_string()),
-                _ => None,
-            }
-        });
-        let join_schema = infer_asof_join_schema(&left_schema, &right_schema, &right_cols_to_drop)?;
-
         Ok(Self {
             left_by,
             right_by,
             left_on,
             right_on,
             left_schema,
-            right_cols_to_drop,
             join_schema,
         })
     }
@@ -556,7 +552,8 @@ impl JoinOperator for AsofJoinOperator {
     ) -> ProbeResult<Self> {
         let right_on = self.right_on.clone();
         let right_by = self.right_by.clone();
-        let right_cols_to_drop = self.right_cols_to_drop.clone();
+        let join_schema = self.join_schema.clone();
+        let left_schema_len = self.left_schema.len();
 
         spawner
             .spawn(
@@ -569,7 +566,13 @@ impl JoinOperator for AsofJoinOperator {
                         if right_rb.is_empty() {
                             continue;
                         }
-                        state.probe_batch(right_rb, &right_on, &right_by, &right_cols_to_drop)?;
+                        state.probe_batch(
+                            right_rb,
+                            &right_on,
+                            &right_by,
+                            &join_schema,
+                            left_schema_len,
+                        )?;
                     }
                     Ok((state, ProbeOutput::NeedMoreInput(None)))
                 },

--- a/src/daft-local-execution/src/join/asof_join.rs
+++ b/src/daft-local-execution/src/join/asof_join.rs
@@ -246,15 +246,14 @@ impl AsofJoinProbeState {
         right_rb: &RecordBatch,
         right_on: &BoundExpr,
         right_by: &[BoundExpr],
-        join_schema: &SchemaRef,
-        left_schema_len: usize,
+        right_cols_to_keep: &HashSet<String>,
     ) -> DaftResult<()> {
         let rb_idx = self.right_rbs_and_on_keys.len();
         let build_state = self.build_contents.clone();
 
         let right_on_arr: Arc<dyn Array> = right_rb.eval_expression(right_on)?.to_arrow()?;
         self.right_rbs_and_on_keys.push((
-            prune_right_batch(right_rb, join_schema, left_schema_len),
+            prune_right_batch(right_rb, right_cols_to_keep),
             right_on_arr.clone(),
         ));
 
@@ -404,17 +403,7 @@ fn forward_fill(global_best: &mut [Option<(u32, u32)>], grouped_sorted_indices: 
     }
 }
 
-fn prune_right_batch(
-    rb: &RecordBatch,
-    join_schema: &SchemaRef,
-    left_schema_len: usize,
-) -> RecordBatch {
-    let right_cols_to_keep: HashSet<&str> = join_schema
-        .fields()
-        .iter()
-        .skip(left_schema_len)
-        .map(|f| f.name.as_ref())
-        .collect();
+fn prune_right_batch(rb: &RecordBatch, right_cols_to_keep: &HashSet<String>) -> RecordBatch {
     let kept_indices: Vec<usize> = rb
         .schema
         .fields()
@@ -477,6 +466,7 @@ pub struct AsofJoinOperator {
     right_on: BoundExpr,
     left_schema: SchemaRef,
     join_schema: SchemaRef,
+    right_cols_to_keep: HashSet<String>,
 }
 
 impl AsofJoinOperator {
@@ -488,6 +478,12 @@ impl AsofJoinOperator {
         left_schema: SchemaRef,
         join_schema: SchemaRef,
     ) -> DaftResult<Self> {
+        let right_cols_to_keep = join_schema
+            .fields()
+            .iter()
+            .skip(left_schema.len())
+            .map(|f| f.name.to_string())
+            .collect();
         Ok(Self {
             left_by,
             right_by,
@@ -495,6 +491,7 @@ impl AsofJoinOperator {
             right_on,
             left_schema,
             join_schema,
+            right_cols_to_keep,
         })
     }
 }
@@ -552,8 +549,7 @@ impl JoinOperator for AsofJoinOperator {
     ) -> ProbeResult<Self> {
         let right_on = self.right_on.clone();
         let right_by = self.right_by.clone();
-        let join_schema = self.join_schema.clone();
-        let left_schema_len = self.left_schema.len();
+        let right_cols_to_keep = self.right_cols_to_keep.clone();
 
         spawner
             .spawn(
@@ -566,13 +562,7 @@ impl JoinOperator for AsofJoinOperator {
                         if right_rb.is_empty() {
                             continue;
                         }
-                        state.probe_batch(
-                            right_rb,
-                            &right_on,
-                            &right_by,
-                            &join_schema,
-                            left_schema_len,
-                        )?;
+                        state.probe_batch(right_rb, &right_on, &right_by, &right_cols_to_keep)?;
                     }
                     Ok((state, ProbeOutput::NeedMoreInput(None)))
                 },

--- a/src/daft-local-execution/src/pipeline.rs
+++ b/src/daft-local-execution/src/pipeline.rs
@@ -1346,9 +1346,9 @@ fn physical_plan_to_pipeline(
             right_by,
             left_on,
             right_on,
+            schema,
             stats_state,
             context,
-            ..
         }) => {
             let left_node = physical_plan_to_pipeline(left, cfg, ctx, input_senders)?;
             let right_node = physical_plan_to_pipeline(right, cfg, ctx, input_senders)?;
@@ -1359,7 +1359,7 @@ fn physical_plan_to_pipeline(
                 left_on.clone(),
                 right_on.clone(),
                 left.schema().clone(),
-                right.schema().clone(),
+                schema.clone(),
             )
             .with_context(|_| PipelineCreationSnafu {
                 plan_name: "AsofJoin",

--- a/src/daft-local-plan/src/translate.rs
+++ b/src/daft-local-plan/src/translate.rs
@@ -505,10 +505,28 @@ fn translate_helper(
 
             left_inputs.extend(right_inputs);
 
-            let left_by = BoundExpr::bind_all(&asof_join.left_by, left_plan.schema())?;
-            let right_by = BoundExpr::bind_all(&asof_join.right_by, right_plan.schema())?;
-            let left_on = BoundExpr::try_new(asof_join.left_on.clone(), left_plan.schema())?;
-            let right_on = BoundExpr::try_new(asof_join.right_on.clone(), right_plan.schema())?;
+            let (left_by_exprs, right_by_exprs) = normalize_join_keys(
+                asof_join.left_by.clone(),
+                asof_join.right_by.clone(),
+                left_plan.schema().clone(),
+                right_plan.schema().clone(),
+            )?;
+            let left_by = BoundExpr::bind_all(&left_by_exprs, left_plan.schema())?;
+            let right_by = BoundExpr::bind_all(&right_by_exprs, right_plan.schema())?;
+            let (left_on_exprs, right_on_exprs) = normalize_join_keys(
+                vec![asof_join.left_on.clone()],
+                vec![asof_join.right_on.clone()],
+                left_plan.schema().clone(),
+                right_plan.schema().clone(),
+            )?;
+            let left_on = BoundExpr::try_new(
+                left_on_exprs.into_iter().next().unwrap(),
+                left_plan.schema(),
+            )?;
+            let right_on = BoundExpr::try_new(
+                right_on_exprs.into_iter().next().unwrap(),
+                right_plan.schema(),
+            )?;
 
             Ok((
                 LocalPhysicalPlan::asof_join(

--- a/src/daft-logical-plan/src/builder/mod.rs
+++ b/src/daft-logical-plan/src/builder/mod.rs
@@ -17,8 +17,8 @@ use common_treenode::TreeNode;
 use daft_algebra::boolean::combine_conjunction;
 use daft_core::join::{JoinStrategy, JoinType};
 use daft_dsl::{
-    Column, Expr, ExprRef, ResolvedColumn, UnresolvedColumn, WindowSpec, has_agg,
-    join::get_right_cols_to_drop, left_col, resolved_col, right_col, unresolved_col,
+    Column, Expr, ExprRef, ResolvedColumn, UnresolvedColumn, WindowSpec, has_agg, left_col,
+    resolved_col, right_col, unresolved_col,
 };
 use daft_scan::{PhysicalScanInfo, Pushdowns, ScanOperatorRef, Sharder, ShardingStrategy};
 use daft_schema::schema::{Schema, SchemaRef};
@@ -42,7 +42,7 @@ use crate::{
     display::json::JsonVisitor,
     logical_plan::{LogicalPlan, SubqueryAlias},
     ops::{
-        self, Limit, Offset, SetQuantifier, UnionStrategy,
+        self, Limit, Offset, SetQuantifier, UnionStrategy, get_right_cols_to_drop,
         join::{JoinOptions, JoinPredicate},
     },
     optimization::{OptimizerBuilder, OptimizerConfig},

--- a/src/daft-logical-plan/src/logical_plan.rs
+++ b/src/daft-logical-plan/src/logical_plan.rs
@@ -840,7 +840,9 @@ impl LogicalPlan {
                     right_on,
                     ..
                 }) => {
-                    use daft_dsl::{Column, Expr, ResolvedColumn, join::get_right_cols_to_drop};
+                    use daft_dsl::{Column, Expr, ResolvedColumn};
+
+                    use crate::ops::get_right_cols_to_drop;
 
                     let right_cols_to_drop =
                         get_right_cols_to_drop(right_by, left_on, right_on, |e| {

--- a/src/daft-logical-plan/src/ops/asof_join.rs
+++ b/src/daft-logical-plan/src/ops/asof_join.rs
@@ -5,10 +5,7 @@ use std::{
 
 use common_error::DaftResult;
 use common_treenode::{Transformed, TreeNode};
-use daft_dsl::{
-    Column, Expr, ExprRef, UnresolvedColumn, join::infer_asof_join_schema, resolved_col,
-    unresolved_col,
-};
+use daft_dsl::{Column, Expr, ExprRef, UnresolvedColumn, resolved_col, unresolved_col};
 use daft_schema::schema::SchemaRef;
 use serde::{Deserialize, Serialize};
 
@@ -18,6 +15,58 @@ use crate::{
     ops::Project,
     stats::{ApproxStats, PlanStats, StatsState},
 };
+
+/// Infer the output schema for an asof join.
+/// Column order: all left columns in their original schema order, then
+/// right columns not in `right_cols_to_drop` in their original schema order.
+fn infer_asof_join_schema(
+    left_schema: &SchemaRef,
+    right_schema: &SchemaRef,
+    right_cols_to_drop: &HashSet<String>,
+) -> DaftResult<SchemaRef> {
+    let fields: Vec<_> = left_schema
+        .into_iter()
+        .chain(
+            right_schema
+                .into_iter()
+                .filter(|f| !right_cols_to_drop.contains(f.name.as_ref())),
+        )
+        .cloned()
+        .collect();
+    Ok(daft_schema::schema::Schema::new(fields).into())
+}
+
+/// Compute the right key column names to exclude from the asof join output.
+///
+/// For by-keys: all right by columns that are direct column references (not complex expressions) are dropped.
+/// For on-keys: the right on column is dropped only when it has the same name as the left on column.
+///
+/// Returns the set of right column names to drop from the output.
+pub(crate) fn get_right_cols_to_drop<E, F>(
+    right_by: &[E],
+    left_on: &E,
+    right_on: &E,
+    extract_name: F,
+) -> HashSet<String>
+where
+    F: Fn(&E) -> Option<String>,
+{
+    let mut right_cols_to_drop = HashSet::new();
+
+    for r in right_by {
+        if let Some(right_name) = extract_name(r) {
+            right_cols_to_drop.insert(right_name);
+        }
+    }
+
+    if let (Some(left_name), Some(right_name)) = (extract_name(left_on), extract_name(right_on))
+        && left_name == right_name
+    {
+        right_cols_to_drop.insert(right_name);
+    }
+
+    right_cols_to_drop
+}
 
 #[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(debug_assertions, derive(Debug))]

--- a/src/daft-logical-plan/src/ops/mod.rs
+++ b/src/daft-logical-plan/src/ops/mod.rs
@@ -31,6 +31,7 @@ mod window;
 
 pub use agg::Aggregate;
 pub use asof_join::AsofJoin;
+pub(crate) use asof_join::get_right_cols_to_drop;
 pub use concat::Concat;
 pub use distinct::Distinct;
 pub use explode::Explode;

--- a/tests/dataframe/test_asof_join.py
+++ b/tests/dataframe/test_asof_join.py
@@ -661,7 +661,10 @@ class TestAsofJoinTypeMismatches:
         """Time left asof key vs Date right asof key: no supertype exists, should raise."""
         left = daft.from_arrow(pa.table({"ts": pa.array([3_600_000_000_000], type=pa.time64("ns")), "v": [1]}))
         right = daft.from_arrow(pa.table({"ts": pa.array([datetime.date(2021, 1, 1)]), "w": [10]}))
-        with pytest.raises(Exception):
+        with pytest.raises(
+            (daft.exceptions.DaftCoreException, RuntimeError),
+            match="could not determine supertype of Time\\(Nanoseconds\\) and Date",
+        ):
             left.join_asof(right, on="ts").collect()
 
     def test_time_date_by_key_raises(self):
@@ -670,7 +673,10 @@ class TestAsofJoinTypeMismatches:
             pa.table({"g": pa.array([3_600_000_000_000], type=pa.time64("ns")), "ts": [1], "v": [1]})
         )
         right = daft.from_arrow(pa.table({"g": pa.array([datetime.date(2021, 1, 1)]), "ts": [1], "w": [10]}))
-        with pytest.raises(Exception):
+        with pytest.raises(
+            (daft.exceptions.DaftCoreException, RuntimeError),
+            match="could not determine supertype of Time\\(Nanoseconds\\) and Date",
+        ):
             left.join_asof(right, on="ts", by="g").collect()
 
     def test_multiple_by_keys_first_coerces_second_raises(self):
@@ -681,7 +687,10 @@ class TestAsofJoinTypeMismatches:
         right = daft.from_arrow(
             pa.table({"g1": [1.0], "g2": pa.array([datetime.date(2021, 1, 1)]), "ts": [5], "w": [50]})
         )
-        with pytest.raises(Exception):
+        with pytest.raises(
+            (daft.exceptions.DaftCoreException, RuntimeError),
+            match="could not determine supertype of Time\\(Nanoseconds\\) and Date",
+        ):
             left.join_asof(right, on="ts", by=["g1", "g2"]).collect()
 
 

--- a/tests/dataframe/test_asof_join.py
+++ b/tests/dataframe/test_asof_join.py
@@ -189,6 +189,41 @@ class TestAsofJoinKeyPermutations:
         result_list = left.join_asof(right, on="ts", by=["entity"]).sort("ts").to_pydict()
         assert result_str == result_list
 
+    def test_two_left_by_right_by_different_names(self):
+        """Multiple by keys with different column names on left and right sides."""
+        left = daft.from_pydict(
+            {
+                "g1_l": ["A", "A", "B", "B"],
+                "g2_l": [1, 1, 2, 2],
+                "ts": [10, 20, 10, 20],
+                "v": [1, 2, 3, 4],
+            }
+        )
+        right = daft.from_pydict(
+            {
+                "g1_r": ["A", "A", "B", "B"],
+                "g2_r": [1, 1, 2, 2],
+                "ts": [5, 15, 8, 18],
+                "w": [50, 150, 80, 180],
+            }
+        )
+        result = left.join_asof(
+            right,
+            on="ts",
+            left_by=["g1_l", "g2_l"],
+            right_by=["g1_r", "g2_r"],
+        ).sort(["g1_l", "ts"])
+        assert result.column_names == ["g1_l", "g2_l", "ts", "v", "w"]
+        assert result.to_pydict() == {
+            "g1_l": ["A", "A", "B", "B"],
+            "g2_l": [1, 1, 2, 2],
+            "ts": [10, 20, 10, 20],
+            "v": [1, 2, 3, 4],
+            # (A,1)@10 -> right (A,1)@5=50;  (A,1)@20 -> right (A,1)@15=150
+            # (B,2)@10 -> right (B,2)@8=80;  (B,2)@20 -> right (B,2)@18=180
+            "w": [50, 150, 80, 180],
+        }
+
 
 # ---------------------------------------------------------------------------
 # 3. Backward Match Correctness
@@ -582,7 +617,85 @@ class TestAsofJoinIntegration:
 
 
 # ---------------------------------------------------------------------------
-# 8. Distributed Execution
+# 8. Type Mismatches on Join Keys
+# ---------------------------------------------------------------------------
+
+
+class TestAsofJoinTypeMismatches:
+    def test_int_float_asof_key_coercion(self):
+        """Int left asof key and float right asof key coerce to a common type."""
+        left = daft.from_pydict({"ts": [1, 2, 3], "v": [10, 20, 30]})
+        right = daft.from_pydict({"ts": [1.0, 2.0, 3.0], "w": [100, 200, 300]})
+        result = left.join_asof(right, on="ts").sort("ts")
+        assert result.column_names == ["ts", "v", "w"]
+        assert result.to_pydict() == {"ts": [1, 2, 3], "v": [10, 20, 30], "w": [100, 200, 300]}
+
+    def test_int_float_by_key_coercion(self):
+        """Int left by key and float right by key coerce to a common type and group correctly."""
+        left = daft.from_pydict({"g": [1, 2], "ts": [10, 20], "v": [1, 2]})
+        right = daft.from_pydict({"g": [1.0, 2.0], "ts": [5, 4], "w": [50, 60]})
+        result = left.join_asof(right, on="ts", by="g").sort("g")
+        assert result.column_names == ["g", "ts", "v", "w"]
+        assert result.to_pydict() == {"g": [1, 2], "ts": [10, 20], "v": [1, 2], "w": [50, 60]}
+
+    def test_partial_int_str_by_key_coercion(self):
+        """Two by keys: first is int/int (no cast), second is int/str (cast to Utf8). Both match."""
+        left = daft.from_pydict({"g1": [1, 2], "g2": [10, 20], "ts": [1, 2], "v": [10, 20]})
+        right = daft.from_pydict({"g1": [1, 2], "g2": ["10", "20"], "ts": [1, 2], "w": [100, 200]})
+        result = left.join_asof(right, on="ts", by=["g1", "g2"]).sort("g1")
+        assert result.column_names == ["g1", "g2", "ts", "v", "w"]
+        assert result.to_pydict() == {"g1": [1, 2], "g2": [10, 20], "ts": [1, 2], "v": [10, 20], "w": [100, 200]}
+
+    def test_int_float_multiple_by_keys_coercion(self):
+        """Two by keys both with int/float type differences coerce and group correctly."""
+        left = daft.from_pydict({"g1": [1, 2], "g2": [10, 20], "ts": [10, 20], "v": [1, 2]})
+        right = daft.from_pydict({"g1": [1.0, 2.0], "g2": [10.0, 20.0], "ts": [5, 4], "w": [50, 60]})
+        result = left.join_asof(right, on="ts", by=["g1", "g2"]).sort("g1")
+        assert result.column_names == ["g1", "g2", "ts", "v", "w"]
+        assert result.to_pydict() == {"g1": [1, 2], "g2": [10, 20], "ts": [10, 20], "v": [1, 2], "w": [50, 60]}
+
+    def test_time_date_asof_key_raises(self):
+        """Time left asof key vs Date right asof key: no supertype exists, should raise."""
+        import datetime
+
+        import pyarrow as pa
+
+        left = daft.from_arrow(pa.table({"ts": pa.array([3_600_000_000_000], type=pa.time64("ns")), "v": [1]}))
+        right = daft.from_arrow(pa.table({"ts": pa.array([datetime.date(2021, 1, 1)]), "w": [10]}))
+        with pytest.raises(Exception):
+            left.join_asof(right, on="ts").collect()
+
+    def test_time_date_by_key_raises(self):
+        """Time left by key vs Date right by key: no supertype exists, should raise."""
+        import datetime
+
+        import pyarrow as pa
+
+        left = daft.from_arrow(
+            pa.table({"g": pa.array([3_600_000_000_000], type=pa.time64("ns")), "ts": [1], "v": [1]})
+        )
+        right = daft.from_arrow(pa.table({"g": pa.array([datetime.date(2021, 1, 1)]), "ts": [1], "w": [10]}))
+        with pytest.raises(Exception):
+            left.join_asof(right, on="ts", by="g").collect()
+
+    def test_multiple_by_keys_first_coerces_second_raises(self):
+        """Two by keys: first is int/float (coerces), second is Time/Date (no supertype, raises)."""
+        import datetime
+
+        import pyarrow as pa
+
+        left = daft.from_arrow(
+            pa.table({"g1": [1], "g2": pa.array([3_600_000_000_000], type=pa.time64("ns")), "ts": [10], "v": [1]})
+        )
+        right = daft.from_arrow(
+            pa.table({"g1": [1.0], "g2": pa.array([datetime.date(2021, 1, 1)]), "ts": [5], "w": [50]})
+        )
+        with pytest.raises(Exception):
+            left.join_asof(right, on="ts", by=["g1", "g2"]).collect()
+
+
+# ---------------------------------------------------------------------------
+# 9. Distributed Execution
 # ---------------------------------------------------------------------------
 
 

--- a/tests/dataframe/test_asof_join.py
+++ b/tests/dataframe/test_asof_join.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import datetime
+
+import pyarrow as pa
 import pytest
 
 import daft
@@ -656,10 +659,6 @@ class TestAsofJoinTypeMismatches:
 
     def test_time_date_asof_key_raises(self):
         """Time left asof key vs Date right asof key: no supertype exists, should raise."""
-        import datetime
-
-        import pyarrow as pa
-
         left = daft.from_arrow(pa.table({"ts": pa.array([3_600_000_000_000], type=pa.time64("ns")), "v": [1]}))
         right = daft.from_arrow(pa.table({"ts": pa.array([datetime.date(2021, 1, 1)]), "w": [10]}))
         with pytest.raises(Exception):
@@ -667,10 +666,6 @@ class TestAsofJoinTypeMismatches:
 
     def test_time_date_by_key_raises(self):
         """Time left by key vs Date right by key: no supertype exists, should raise."""
-        import datetime
-
-        import pyarrow as pa
-
         left = daft.from_arrow(
             pa.table({"g": pa.array([3_600_000_000_000], type=pa.time64("ns")), "ts": [1], "v": [1]})
         )
@@ -680,10 +675,6 @@ class TestAsofJoinTypeMismatches:
 
     def test_multiple_by_keys_first_coerces_second_raises(self):
         """Two by keys: first is int/float (coerces), second is Time/Date (no supertype, raises)."""
-        import datetime
-
-        import pyarrow as pa
-
         left = daft.from_arrow(
             pa.table({"g1": [1], "g2": pa.array([3_600_000_000_000], type=pa.time64("ns")), "ts": [10], "v": [1]})
         )


### PR DESCRIPTION
Currently as_of joins with mismatched by keys would fail with `mismatch dtype error`. The fix is to

1. normalize and cast the keys to a shared supertype (e..g. int64 and float64 are normalized to float64), which is the same methodology used for the on_key, as well as for the join keys of equality joins.

2. remove the computation of right_cols_to_drop in the local executor, because it does not drop the casted expressions computed during normalization, e.g. Cast(Column("left_on_key"), Utf8), and led to duplicate columns produced in the output (the "left_on_key" column was duplicated in the result). Since we already computed the desired output schema in the logical plan, we can simply use this as the basis to prune columns during execution.
```

left  = {"ts": [1, 3, 5], "v": [...]}   # ts is Int64                           
right = {"ts": [2.0, 4.0], "w": [...]}  # ts is Float64      

# correct output                                                                  
{"ts": [1,    3,   5  ], "v": [10, 30, 50], "w": [None, 20, 40]} 

# without the fix: the second "ts" silently overwrites the first:                               
{"ts": [None, 2.0, 4.0], "v": [10, 30, 50], "w": [None, 20, 40]}                
#  ^^^ left ts [1, 3, 5] is gone — no error raised    
```             

**a more in-depth explanation for the second bug:** 
1. This bug requires three conditions to trigger:
- a join key (meaning it should have been a candidate for right_cols_to_drop)
- that shares a name with the other side (explained later)
- mismatched types on that key (causing normalization to wrap it in a Cast expression, that prevents it from being caught in right_cols_to_drop).

2. Here’s how the bug occurs:
    1. At the logical plan layer, right_cols_to_drop is computed from bare unresolved column expressions — before any normalization has occurred. It is then passed to deduplicate_asof_join_columns, which uses it to determine which right-side columns need to be renamed with a right. prefix. Since the join keys are inside the dropped cols set, the deduplication step skips it since it’s already being dropped.
    2. After translation, at the physical plan layer, AsofJoinOperator::new ignored the output_schema and recomputed right_cols_to_drop from scratch — but by this point, translation had already wrapped bare Column("g") expressions in Cast(Column("g"), Utf8). The extract_name closure used in the recomputation only handled bare column expressions, so it returned None for any cast-wrapped expression,  silently omitting the right key column from right_cols_to_drop.
    4. Without it in the drop set, prune_right_batch kept the column, producing a record batch with duplicate column names. When to_pydict() built a Python dict, the duplicate key caused the right-side values to silently overwrite the left-side values, corrupting the output.                
