### PR TITLE
feat(iceberg): idempotent commits via daft.idempotence-key snapshot marker

### DIFF
--- a/daft/__init__.py
+++ b/daft/__init__.py
@@ -61,7 +61,7 @@ from daft.catalog import (
     Identifier,
     Table,
 )
-from daft.checkpoint import CheckpointConfig, CheckpointStore, KeyFilteringSettings
+from daft.checkpoint import CheckpointConfig, CheckpointStore, IdempotentCommit, KeyFilteringSettings
 from daft.context import (
     get_context,
     attach_subscriber,
@@ -191,6 +191,7 @@ __all__ = [
     "Expression",
     "File",
     "IOConfig",
+    "IdempotentCommit",
     "Identifier",
     "ImageFile",
     "ImageFormat",

--- a/daft/checkpoint.py
+++ b/daft/checkpoint.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from daft.daft import (
@@ -18,7 +19,7 @@ if TYPE_CHECKING:
     from daft.daft import IOConfig
 
 
-__all__ = ["CheckpointConfig", "CheckpointStore", "KeyFilteringSettings"]
+__all__ = ["CheckpointConfig", "CheckpointStore", "IdempotentCommit", "KeyFilteringSettings"]
 
 
 class CheckpointStore:
@@ -153,3 +154,45 @@ class CheckpointConfig:
 
     def __repr__(self) -> str:
         return f"CheckpointConfig({self._inner!r})"
+
+
+@dataclass(frozen=True)
+class IdempotentCommit:
+    """Per-call idempotent commit configuration for sink writes.
+
+    Bundles a :class:`CheckpointStore` with a stable ``idempotence_key`` that
+    identifies a single logical commit attempt. Pass via ``checkpoint=`` on
+    sinks that support idempotent commits (e.g. :meth:`DataFrame.write_iceberg`).
+
+    Args:
+        store: The :class:`CheckpointStore` backing the commit's staging.
+        idempotence_key: Stable identifier for this logical commit. Stamped
+            on the resulting commit's metadata (e.g. an Iceberg snapshot
+            summary's ``daft.idempotence-key``) so retries — after a crash,
+            network blip, etc. — recognize the prior attempt and don't
+            produce a duplicate. The user is responsible for keeping this
+            stable across retries of the same logical commit and unique
+            across distinct commits.
+
+    Example:
+        >>> store = daft.CheckpointStore("s3://bucket/ckpt", io_config=io)
+        >>> df = daft.read_parquet("s3://input/", checkpoint=daft.CheckpointConfig(store=store, on="file_id"))
+        >>> df.write_iceberg(table, checkpoint=daft.IdempotentCommit(store=store, idempotence_key="run-2026-05-04"))
+
+    Idempotence-key contract — read carefully:
+        - **Same key + different inputs → silent no-op (data loss).** The
+          destination already has a snapshot tagged with the key, so nothing
+          new is written.
+        - **Different key + same retry → duplicate snapshot.** The destination
+          won't recognize the prior attempt and will commit again. Idempotence
+          is broken.
+        - **Recommended source: an orchestrator-supplied run ID.** Stable
+          across task retries and unique across runs by construction.
+    """
+
+    store: CheckpointStore
+    idempotence_key: str
+
+    def __post_init__(self) -> None:
+        if not self.idempotence_key:
+            raise ValueError("idempotence_key must be a non-empty string")

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -67,7 +67,7 @@ if TYPE_CHECKING:
     from sqlalchemy.engine import Connection
 
     from daft.catalog.__unity._client import UnityCatalogTable
-    from daft.checkpoint import CheckpointStore
+    from daft.checkpoint import CheckpointStore, IdempotentCommit
     from daft.execution.metadata import ExecutionMetadata
     from daft.io import DataSink
     from daft.io.lance.rest_config import LanceRestConfig
@@ -1214,7 +1214,7 @@ class DataFrame:
         mode: str = "append",
         io_config: IOConfig | None = None,
         snapshot_properties: dict[str, str] | None = None,
-        checkpoint: "CheckpointStore | None" = None,
+        checkpoint: "IdempotentCommit | None" = None,
     ) -> "DataFrame":
         """Writes the DataFrame to an [Iceberg](https://iceberg.apache.org/docs/nightly/) table, returning a new DataFrame with the operations that occurred.
 
@@ -1224,8 +1224,8 @@ class DataFrame:
             table (pyiceberg.table.Table): Destination [PyIceberg Table](https://py.iceberg.apache.org/reference/pyiceberg/table/#pyiceberg.table.Table) to write dataframe to.
             mode (str, optional): Operation mode of the write. `append` or `overwrite` Iceberg Table. Defaults to `append`.
             io_config (IOConfig, optional): A custom IOConfig to use when accessing Iceberg object storage data. If provided, configurations set in `table` are ignored.
-            snapshot_properties (dict[str, str], optional): Optional snapshot properties to set while writing to the table. Keys with prefix ``daft.checkpoint-`` are reserved when ``checkpoint`` is provided.
-            checkpoint (CheckpointStore, optional): Checkpoint store to make the write idempotent across process restarts. Only ``mode='append'`` is supported. Requires the Ray runner.
+            snapshot_properties (dict[str, str], optional): Optional snapshot properties to set while writing to the table. Keys with prefix ``daft.idempotence-`` are reserved.
+            checkpoint (IdempotentCommit, optional): Bundled checkpoint store + idempotence key for an idempotent commit. When provided, the snapshot summary is tagged with ``daft.idempotence-key`` and retries with the same key recognize the prior attempt without producing a duplicate snapshot. Only ``mode='append'`` is supported. Requires the Ray runner.
 
         Returns:
             DataFrame: The operations that occurred with this write.
@@ -1233,13 +1233,25 @@ class DataFrame:
         Note:
             This call is **blocking** and will execute the DataFrame when called.
 
-            When ``checkpoint`` is provided and ``write_iceberg`` raises *after* the
-            catalog commit landed (e.g. a transient failure during the
-            post-commit ``mark_committed`` bookkeeping), the user data is
-            already durable in Iceberg. The next call to ``write_iceberg`` with
-            the same ``checkpoint`` will detect the snapshot via its markers,
-            finish the bookkeeping, and exit cleanly without producing a
-            duplicate snapshot.
+            When ``checkpoint`` is provided and ``write_iceberg`` raises
+            *after* the catalog commit landed (e.g. a transient failure during
+            the post-commit ``mark_committed`` bookkeeping), the user data is
+            already durable in Iceberg. The next call with the same
+            ``IdempotentCommit`` (same idempotence key) will detect the
+            snapshot via its marker, finish the bookkeeping, and exit cleanly
+            without producing a duplicate snapshot.
+
+            Idempotence-key contract — read carefully:
+
+            - **Same key + different inputs → silent no-op (data loss).** The
+              destination already has a snapshot tagged with the key, so
+              nothing new is written.
+            - **Different key + same retry → duplicate snapshot.** The
+              destination won't recognize the prior attempt and will commit
+              again. Idempotence is broken.
+
+            The orchestrator pattern (run-id supplied from upstream DAG context)
+            avoids both naturally.
 
         Examples:
             >>> import pyiceberg
@@ -1278,11 +1290,11 @@ class DataFrame:
         if checkpoint is not None and parse(pyiceberg.__version__) < parse("0.7.0"):
             raise ValueError("write_iceberg with checkpoint=... requires pyiceberg>=0.7.0")
 
-        if checkpoint is not None and snapshot_properties:
+        if snapshot_properties:
             for key in snapshot_properties:
-                if key.startswith("daft.checkpoint-"):
+                if key.startswith("daft.idempotence-"):
                     raise ValueError(
-                        f"snapshot_properties keys with prefix 'daft.checkpoint-' are reserved; got: {key!r}"
+                        f"snapshot_properties keys with prefix 'daft.idempotence-' are reserved; got: {key!r}"
                     )
 
         io_config = (
@@ -1409,18 +1421,34 @@ class DataFrame:
         table: "pyiceberg.table.Table",
         io_config: IOConfig,
         snapshot_properties: dict[str, str] | None,
-        checkpoint: "CheckpointStore",
+        checkpoint: "IdempotentCommit",
     ) -> "DataFrame":
-        """Idempotent Iceberg commit driven by the checkpoint store.
+        """Idempotent Iceberg commit identified by ``checkpoint.idempotence_key``.
 
-        Files come from `checkpoint.get_checkpointed_files()` (the store is the source
-        of truth — no re-execution after a crash). The snapshot summary carries
-        `daft.checkpoint-store` and `daft.checkpoint-query` markers so a restart can
-        recognize previously-committed work and skip it.
+        Each call produces exactly one Iceberg snapshot per logical commit,
+        tagged in the snapshot summary as ``daft.idempotence-key=<key>``.
+        Retries with the same key are recognized by walking the snapshot
+        history.
 
-        Concurrency assumption: at most one Python process per checkpoint path at a
-        time. The retry loop is defensive against transient `CommitFailedException`,
-        not multi-writer safety.
+        Flow:
+
+        1. Walk Iceberg snapshot history for ``daft.idempotence-key == our key``.
+           Found → previous attempt's commit already landed; mark all
+           ``Checkpointed`` entries → ``Committed`` and bail. **No pipeline run.**
+        2. Not found → run the pipeline. Source filter anti-joins
+           ``Committed ∪ Checkpointed`` keys, so previously-staged work is
+           not reprocessed; SCKO + sink populate the store as new
+           ``Checkpointed`` entries.
+        3. Pull files from ``get_checkpointed_files()`` and commit them in
+           one transaction tagged with ``daft.idempotence-key``. After
+           commit, ``mark_committed`` the entries.
+
+        Files always come from the checkpoint store, never from
+        ``write_df.collect()`` output — the store is the source of truth.
+
+        Concurrency assumption: at most one Python process per logical commit.
+        The retry loop is defensive against transient ``CommitFailedException``,
+        not against concurrent writers.
         """
         import pyarrow as pa
         import pyiceberg
@@ -1429,18 +1457,16 @@ class DataFrame:
 
         from daft import from_pydict
 
+        store = checkpoint.store
+        idempotence_key = checkpoint.idempotence_key
+
         builder = self._builder.write_iceberg(table, io_config)
         write_df = DataFrame(builder)
 
-        pending = [c for c in checkpoint.list_checkpoints() if c.status == CheckpointStatus.Checkpointed]
-        if not pending:
-            # Fresh run: execute the pipeline. SCKO + sink populate the store.
-            write_df.collect()
-            pending = [c for c in checkpoint.list_checkpoints() if c.status == CheckpointStatus.Checkpointed]
+        full_props = dict(snapshot_properties or {})
+        full_props["daft.idempotence-key"] = idempotence_key
 
-        if not pending:
-            # Source filter dropped everything (everything already committed in a
-            # prior run). Nothing to commit; return an empty result.
+        def _empty_result() -> "DataFrame":
             empty = from_pydict(
                 {
                     "operation": pa.array([], type=pa.string()),
@@ -1452,20 +1478,32 @@ class DataFrame:
             empty._metadata = write_df._metadata
             return empty
 
-        # Single-query-id invariant: all pending entries share the run that staged them.
-        our_query_id = pending[0].query_id
-        if not our_query_id or any(c.query_id != our_query_id for c in pending):
-            offending = sorted({c.query_id for c in pending})
-            raise RuntimeError(
-                "Checkpoint store contains pending entries with mismatched or empty query_ids; "
-                f"single-query-id invariant violated (query_ids: {offending}). Possible causes: "
-                "concurrent writers against the same path; the store was reused across "
-                "different destinations (one store per destination — see CheckpointStore docs); "
-                "or pre-feature legacy entries left behind in the store (empty query_id). "
-                "Resolve by using a fresh checkpoint path or clearing the store."
-            )
-        our_ids = [c.id for c in pending]
-        store_path = checkpoint.path
+        def _snapshot_with_our_key_exists() -> bool:
+            for snap in reversed(table.metadata.snapshots):
+                summary = snap.summary
+                if summary is not None and summary.get("daft.idempotence-key") == idempotence_key:
+                    return True
+            return False
+
+        def _pending_ids() -> list[str]:
+            return [c.id for c in store.list_checkpoints() if c.status == CheckpointStatus.Checkpointed]
+
+        # ── 1. Check-first: did a previous attempt already land?
+        table.refresh()
+        if _snapshot_with_our_key_exists():
+            pending_ids = _pending_ids()
+            if pending_ids:
+                store.mark_committed(pending_ids)
+            return _empty_result()
+
+        # ── 2. Run the pipeline. Source filter anti-joins already-Checkpointed
+        #       keys, so this only stages work that hasn't been staged before.
+        write_df.collect()
+
+        # ── 3. Commit-from-store.
+        pending_ids = _pending_ids()
+        if not pending_ids:
+            return _empty_result()
 
         # Pull DataFile objects out of the staged FileMetadata blobs. Each blob
         # is an Arrow IPC stream of a MicroPartition produced by the iceberg
@@ -1473,11 +1511,8 @@ class DataFrame:
         # `BlockingSinkNode::encode_file_metadata`). The MicroPartition has a
         # python-typed `data_file` column whose cells are pickled
         # `pyiceberg.DataFile` instances; the IPC roundtrip preserves them.
-        # If pyiceberg ever changes `DataFile` to be unpicklable the decode
-        # surfaces deep inside MicroPartition with a confusing error — wrap so
-        # the caller sees a clear message naming the contract.
         data_files: list[Any] = []
-        for fm in checkpoint.get_checkpointed_files():
+        for fm in store.get_checkpointed_files():
             try:
                 mp = MicroPartition.from_ipc_stream(fm.data)
                 data_files.extend(mp.to_pydict()["data_file"])
@@ -1489,28 +1524,6 @@ class DataFrame:
                     "Did pyiceberg change the DataFile shape, or is the store from a different "
                     f"writer version? Underlying error: {e}"
                 ) from e
-
-        # Pending entries exist but carry no data files. Happens when the source
-        # filter drops every input row (e.g. re-run after a fully-committed call)
-        # — the sink still seals an empty Checkpointed entry. There is nothing
-        # to commit; mark the empty entries Committed so they don't persist as
-        # pending forever, and return an empty result.
-        if not data_files:
-            checkpoint.mark_committed(our_ids)
-            empty = from_pydict(
-                {
-                    "operation": pa.array([], type=pa.string()),
-                    "rows": pa.array([], type=pa.int64()),
-                    "file_size": pa.array([], type=pa.int64()),
-                    "file_name": pa.array([], type=pa.string()),
-                }
-            )
-            empty._metadata = write_df._metadata
-            return empty
-
-        full_props = dict(snapshot_properties or {})
-        full_props["daft.checkpoint-store"] = store_path
-        full_props["daft.checkpoint-query"] = our_query_id
 
         def _build_result() -> "DataFrame":
             ops: list[str] = []
@@ -1549,17 +1562,12 @@ class DataFrame:
         last_err: Exception | None = None
         for _ in range(max_retries):
             table.refresh()
-            # Recovery check: did a prior attempt (or restart) already land our work?
-            for snap in reversed(table.metadata.snapshots):
-                summary = snap.summary
-                if summary is None:
-                    continue
-                if (
-                    summary.get("daft.checkpoint-store") == store_path
-                    and summary.get("daft.checkpoint-query") == our_query_id
-                ):
-                    checkpoint.mark_committed(our_ids)
-                    return _build_result()
+            # Recheck inside the retry loop — a prior iteration's commit may
+            # have landed despite returning CommitFailedException (rare, but
+            # the post-commit hook can fail in odd ways). Cheap.
+            if _snapshot_with_our_key_exists():
+                store.mark_committed(pending_ids)
+                return _build_result()
 
             try:
                 tx = table.transaction()
@@ -1574,7 +1582,7 @@ class DataFrame:
                     for df_ in data_files:
                         append_files.append_data_file(df_)
                 tx.commit_transaction()
-                checkpoint.mark_committed(our_ids)
+                store.mark_committed(pending_ids)
                 return _build_result()
             except CommitFailedException as e:
                 # Narrow on purpose: only optimistic-concurrency conflicts (the

--- a/src/daft-checkpoint/src/config.rs
+++ b/src/daft-checkpoint/src/config.rs
@@ -131,8 +131,6 @@ pub struct PyCheckpoint {
     pub id: String,
     #[pyo3(get)]
     pub status: PyCheckpointStatus,
-    #[pyo3(get)]
-    pub query_id: String,
 }
 
 impl From<crate::Checkpoint> for PyCheckpoint {
@@ -140,7 +138,6 @@ impl From<crate::Checkpoint> for PyCheckpoint {
         Self {
             id: c.id.to_string(),
             status: c.status.into(),
-            query_id: c.query_id.to_string(),
         }
     }
 }

--- a/src/daft-checkpoint/src/impls/s3.rs
+++ b/src/daft-checkpoint/src/impls/s3.rs
@@ -57,17 +57,12 @@ struct Manifest {
     committed_at: Option<String>,
     num_key_files: usize,
     num_file_files: usize,
-    /// Identifier of the execution that staged this checkpoint. Older manifests
-    /// predate this field; `serde(default)` yields empty on absence.
-    #[serde(default)]
-    query_id: String,
 }
 
 struct StagedEntry {
     num_key_files: usize,
     num_file_files: usize,
     created_at: SystemTime,
-    query_id: String,
     /// In-flight PUTs spawned by `stage_keys` / `stage_files`.
     /// Drained by `checkpoint()`. Aborts on drop (e.g. abandoned checkpoint).
     pending: JoinSet<CheckpointResult<()>>,
@@ -78,12 +73,11 @@ struct StagedEntry {
 }
 
 impl StagedEntry {
-    fn new(query_id: String) -> Self {
+    fn new() -> Self {
         Self {
             num_key_files: 0,
             num_file_files: 0,
             created_at: SystemTime::now(),
-            query_id,
             pending: JoinSet::new(),
             first_error: Arc::new(OnceLock::new()),
         }
@@ -313,7 +307,6 @@ impl S3CheckpointStore {
     async fn reserve_slots(
         &self,
         id: &CheckpointId,
-        query_id: &str,
         update: impl FnOnce(&mut StagedEntry) -> usize,
     ) -> CheckpointResult<usize> {
         {
@@ -335,9 +328,7 @@ impl S3CheckpointStore {
         let mut staged = self.staged.lock().map_err(|e| CheckpointError::Internal {
             message: format!("staged lock poisoned: {e}"),
         })?;
-        let entry = staged
-            .entry(id.clone())
-            .or_insert_with(|| StagedEntry::new(query_id.to_string()));
+        let entry = staged.entry(id.clone()).or_insert_with(StagedEntry::new);
         Ok(update(entry))
     }
 
@@ -485,12 +476,7 @@ impl S3CheckpointStore {
 
 #[async_trait]
 impl CheckpointStore for S3CheckpointStore {
-    async fn stage_keys(
-        &self,
-        id: &CheckpointId,
-        query_id: &str,
-        keys: Series,
-    ) -> CheckpointResult<()> {
+    async fn stage_keys(&self, id: &CheckpointId, keys: Series) -> CheckpointResult<()> {
         self.check_first_error(id)?;
         // Persist under the canonical column name so the on-disk key files
         // are stable across renames of the source column. The scan operator
@@ -498,7 +484,7 @@ impl CheckpointStore for S3CheckpointStore {
         let canonical = keys.rename(common_checkpoint_config::SEALED_KEYS_COLUMN);
         let parquet_bytes = super::keys_codec::write_series_as_parquet(&canonical)?;
         let idx = self
-            .reserve_slots(id, query_id, |e| {
+            .reserve_slots(id, |e| {
                 let i = e.num_key_files;
                 e.num_key_files += 1;
                 i
@@ -510,7 +496,6 @@ impl CheckpointStore for S3CheckpointStore {
     async fn stage_files(
         &self,
         id: &CheckpointId,
-        query_id: &str,
         files: Vec<FileMetadata>,
     ) -> CheckpointResult<()> {
         if files.is_empty() {
@@ -519,7 +504,7 @@ impl CheckpointStore for S3CheckpointStore {
         self.check_first_error(id)?;
         let blob = Self::encode_file_metadata(&files)?;
         let idx = self
-            .reserve_slots(id, query_id, |e| {
+            .reserve_slots(id, |e| {
                 let i = e.num_file_files;
                 e.num_file_files += 1;
                 i
@@ -543,13 +528,12 @@ impl CheckpointStore for S3CheckpointStore {
                     entry.num_key_files,
                     entry.num_file_files,
                     entry.created_at,
-                    entry.query_id.clone(),
                     pending,
                 )
             })
         };
 
-        let (num_key_files, num_file_files, created_at, query_id, pending) = match drain {
+        let (num_key_files, num_file_files, created_at, pending) = match drain {
             Some(data) => data,
             None => {
                 // No in-memory staged entry for this id. Two sub-cases, both
@@ -558,12 +542,10 @@ impl CheckpointStore for S3CheckpointStore {
                 //       read_manifest succeeds; nothing more to do.
                 //   (b) Never staged at all (e.g. 0-row source after the
                 //       anti-join — the sink generated an id but no SCKO or
-                //       sink call ever landed keys/files). There's no query_id
-                //       to record, so we *cannot* write a manifest without
-                //       violating the downstream single-query-id invariant.
-                //       Succeed quietly — consumers using `list_checkpoints`
-                //       simply see no Checkpointed entry for this id, which
-                //       matches the empty-input flow's expected semantics.
+                //       sink call ever landed keys/files). Succeed quietly —
+                //       consumers using `list_checkpoints` simply see no
+                //       Checkpointed entry for this id, which matches the
+                //       empty-input flow's expected semantics.
                 return match self.read_manifest(id).await {
                     Ok(_) => Ok(()),
                     Err(CheckpointError::CheckpointNotFound { .. }) => Ok(()),
@@ -589,7 +571,6 @@ impl CheckpointStore for S3CheckpointStore {
             committed_at: None,
             num_key_files,
             num_file_files,
-            query_id,
         };
         self.write_manifest(id, &manifest).await?;
 
@@ -657,7 +638,6 @@ impl CheckpointStore for S3CheckpointStore {
                 return Ok(Checkpoint::new(
                     id.clone(),
                     CheckpointStatus::Staged,
-                    Arc::from(entry.query_id.as_str()),
                     entry.created_at,
                     None,
                     None,
@@ -676,7 +656,6 @@ impl CheckpointStore for S3CheckpointStore {
         Ok(Checkpoint::new(
             id.clone(),
             status,
-            Arc::from(manifest.query_id.as_str()),
             system_time_from_rfc3339(&manifest.created_at)?,
             Some(system_time_from_rfc3339(&manifest.sealed_at)?),
             manifest
@@ -709,7 +688,6 @@ impl CheckpointStore for S3CheckpointStore {
                 checkpoints.push(Checkpoint::new(
                     id.clone(),
                     CheckpointStatus::Staged,
-                    Arc::from(entry.query_id.as_str()),
                     entry.created_at,
                     None,
                     None,
@@ -726,7 +704,6 @@ impl CheckpointStore for S3CheckpointStore {
             checkpoints.push(Checkpoint::new(
                 id.clone(),
                 status,
-                Arc::from(manifest.query_id.as_str()),
                 system_time_from_rfc3339(&manifest.created_at)?,
                 Some(system_time_from_rfc3339(&manifest.sealed_at)?),
                 manifest
@@ -923,7 +900,6 @@ mod tests {
             committed_at: None,
             num_key_files: 3,
             num_file_files: 1,
-            query_id: "eager-phoenix-a4f821".to_string(),
         };
         let raw = serde_json::to_vec(&manifest).unwrap();
         let decoded: Manifest = serde_json::from_slice(&raw).unwrap();
@@ -934,7 +910,6 @@ mod tests {
         assert_eq!(decoded.committed_at, None);
         assert_eq!(decoded.num_key_files, 3);
         assert_eq!(decoded.num_file_files, 1);
-        assert_eq!(decoded.query_id, "eager-phoenix-a4f821");
     }
 
     #[test]
@@ -948,29 +923,11 @@ mod tests {
             committed_at: Some(now.clone()),
             num_key_files: 1,
             num_file_files: 0,
-            query_id: "swift-otter-1c2b3a".to_string(),
         };
         let raw = serde_json::to_vec(&manifest).unwrap();
         let decoded: Manifest = serde_json::from_slice(&raw).unwrap();
         assert_eq!(decoded.status, ManifestStatus::Committed);
         assert_eq!(decoded.committed_at, Some(now));
-    }
-
-    #[test]
-    fn test_manifest_query_id_default_on_old_payload() {
-        let now = rfc3339_from(SystemTime::now());
-        // Synthetic "old" manifest without the query_id field.
-        let raw = serde_json::json!({
-            "checkpoint_id": "task-0-checkpoint-abc",
-            "status": "checkpointed",
-            "created_at": &now,
-            "sealed_at": &now,
-            "committed_at": null,
-            "num_key_files": 0,
-            "num_file_files": 0,
-        });
-        let decoded: Manifest = serde_json::from_value(raw).unwrap();
-        assert_eq!(decoded.query_id, "");
     }
 
     #[test]

--- a/src/daft-checkpoint/src/scan.rs
+++ b/src/daft-checkpoint/src/scan.rs
@@ -182,29 +182,17 @@ mod tests {
         let (config, store) = make_store(dir.path());
 
         let id1 = CheckpointId::generate(0);
-        store
-            .stage_keys(&id1, "test-query", keys(&["a", "b"]))
-            .await
-            .unwrap();
-        store
-            .stage_keys(&id1, "test-query", keys(&["c"]))
-            .await
-            .unwrap();
+        store.stage_keys(&id1, keys(&["a", "b"])).await.unwrap();
+        store.stage_keys(&id1, keys(&["c"])).await.unwrap();
         store.checkpoint(&id1).await.unwrap();
 
         let id2 = CheckpointId::generate(1);
-        store
-            .stage_keys(&id2, "test-query", keys(&["d"]))
-            .await
-            .unwrap();
+        store.stage_keys(&id2, keys(&["d"])).await.unwrap();
         store.checkpoint(&id2).await.unwrap();
 
         // Staged-only — should be invisible.
         let id3 = CheckpointId::generate(2);
-        store
-            .stage_keys(&id3, "test-query", keys(&["ignored"]))
-            .await
-            .unwrap();
+        store.stage_keys(&id3, keys(&["ignored"])).await.unwrap();
 
         let mut expected_paths = store.sealed_file_paths().await.unwrap();
         expected_paths.sort();

--- a/src/daft-checkpoint/src/store.rs
+++ b/src/daft-checkpoint/src/store.rs
@@ -58,8 +58,6 @@ pub trait CheckpointStore: Send + Sync {
     ///
     /// Implicitly creates a `Staged` checkpoint entry on first call for a
     /// new ID. Subsequent calls for the same ID append to the existing entry.
-    /// The `query_id` is recorded on first call and frozen for the lifetime
-    /// of the checkpoint; later calls' `query_id` is ignored.
     ///
     /// The Series can be any Arrow-compatible type (Utf8, Int64, Struct for
     /// composite keys, etc.). Callers must stage consistent Series types
@@ -72,20 +70,14 @@ pub trait CheckpointStore: Send + Sync {
     /// add cost for no benefit at this layer.
     ///
     /// [`AlreadySealed`]: crate::error::CheckpointError::AlreadySealed
-    async fn stage_keys(
-        &self,
-        id: &CheckpointId,
-        query_id: &str,
-        keys: Series,
-    ) -> CheckpointResult<()>;
+    async fn stage_keys(&self, id: &CheckpointId, keys: Series) -> CheckpointResult<()>;
 
     /// Stage output file metadata into a checkpoint. May be called multiple
     /// times for the same [`CheckpointId`]. Staged files are not visible to
     /// readers until [`checkpoint`](Self::checkpoint) is called.
     ///
     /// Implicitly creates a `Staged` checkpoint entry on first call for a
-    /// new ID, same as [`stage_keys`](Self::stage_keys). The `query_id` is
-    /// recorded on first call and frozen for the lifetime of the checkpoint.
+    /// new ID, same as [`stage_keys`](Self::stage_keys).
     ///
     /// Returns [`AlreadySealed`] if the checkpoint has already been sealed.
     ///
@@ -95,7 +87,6 @@ pub trait CheckpointStore: Send + Sync {
     async fn stage_files(
         &self,
         id: &CheckpointId,
-        query_id: &str,
         files: Vec<FileMetadata>,
     ) -> CheckpointResult<()>;
 

--- a/src/daft-checkpoint/src/test_utils.rs
+++ b/src/daft-checkpoint/src/test_utils.rs
@@ -78,12 +78,9 @@ pub async fn test_lifecycle(store: &dyn CheckpointStore) {
         .unwrap();
     assert!(checkpoints.is_empty());
 
+    store.stage_keys(&id, keys(&["a", "b"])).await.unwrap();
     store
-        .stage_keys(&id, "test-query", keys(&["a", "b"]))
-        .await
-        .unwrap();
-    store
-        .stage_files(&id, "test-query", vec![file(b"file1"), file(b"file2")])
+        .stage_files(&id, vec![file(b"file1"), file(b"file2")])
         .await
         .unwrap();
 
@@ -110,33 +107,15 @@ pub async fn test_multiple_checkpoints_and_partial_commit(store: &dyn Checkpoint
     let id2 = CheckpointId::generate(0);
 
     // Checkpoint 1: single stage call
-    store
-        .stage_keys(&id1, "test-query", keys(&["a"]))
-        .await
-        .unwrap();
-    store
-        .stage_files(&id1, "test-query", vec![file(b"f1")])
-        .await
-        .unwrap();
+    store.stage_keys(&id1, keys(&["a"])).await.unwrap();
+    store.stage_files(&id1, vec![file(b"f1")]).await.unwrap();
     store.checkpoint(&id1).await.unwrap();
 
     // Checkpoint 2: incremental staging (multiple calls)
-    store
-        .stage_keys(&id2, "test-query", keys(&["b"]))
-        .await
-        .unwrap();
-    store
-        .stage_keys(&id2, "test-query", keys(&["c", "d"]))
-        .await
-        .unwrap();
-    store
-        .stage_files(&id2, "test-query", vec![file(b"f2")])
-        .await
-        .unwrap();
-    store
-        .stage_files(&id2, "test-query", vec![file(b"f3")])
-        .await
-        .unwrap();
+    store.stage_keys(&id2, keys(&["b"])).await.unwrap();
+    store.stage_keys(&id2, keys(&["c", "d"])).await.unwrap();
+    store.stage_files(&id2, vec![file(b"f2")]).await.unwrap();
+    store.stage_files(&id2, vec![file(b"f3")]).await.unwrap();
     store.checkpoint(&id2).await.unwrap();
 
     assert_eq!(collect_key_strings(store).await, vec!["a", "b", "c", "d"]);
@@ -156,14 +135,8 @@ pub async fn test_multiple_checkpoints_and_partial_commit(store: &dyn Checkpoint
 pub async fn test_idempotency(store: &dyn CheckpointStore) {
     let id = CheckpointId::generate(0);
 
-    store
-        .stage_keys(&id, "test-query", keys(&["a"]))
-        .await
-        .unwrap();
-    store
-        .stage_files(&id, "test-query", vec![file(b"f1")])
-        .await
-        .unwrap();
+    store.stage_keys(&id, keys(&["a"])).await.unwrap();
+    store.stage_files(&id, vec![file(b"f1")]).await.unwrap();
 
     // Double seal
     store.checkpoint(&id).await.unwrap();
@@ -201,22 +174,13 @@ pub async fn test_error_paths(store: &dyn CheckpointStore) {
 
     // Stage after seal
     let id = CheckpointId::generate(0);
-    store
-        .stage_keys(&id, "test-query", keys(&["a"]))
-        .await
-        .unwrap();
+    store.stage_keys(&id, keys(&["a"])).await.unwrap();
     store.checkpoint(&id).await.unwrap();
 
-    let err = store
-        .stage_keys(&id, "test-query", keys(&["b"]))
-        .await
-        .unwrap_err();
+    let err = store.stage_keys(&id, keys(&["b"])).await.unwrap_err();
     assert!(matches!(err, CheckpointError::AlreadySealed { .. }));
 
-    let err = store
-        .stage_files(&id, "test-query", vec![file(b"f")])
-        .await
-        .unwrap_err();
+    let err = store.stage_files(&id, vec![file(b"f")]).await.unwrap_err();
     assert!(matches!(err, CheckpointError::AlreadySealed { .. }));
 
     // Stage after commit (also AlreadySealed)
@@ -224,18 +188,12 @@ pub async fn test_error_paths(store: &dyn CheckpointStore) {
         .mark_committed(std::slice::from_ref(&id))
         .await
         .unwrap();
-    let err = store
-        .stage_keys(&id, "test-query", keys(&["c"]))
-        .await
-        .unwrap_err();
+    let err = store.stage_keys(&id, keys(&["c"])).await.unwrap_err();
     assert!(matches!(err, CheckpointError::AlreadySealed { .. }));
 
     // mark_committed on staged (not sealed)
     let id2 = CheckpointId::generate(0);
-    store
-        .stage_keys(&id2, "test-query", keys(&["x"]))
-        .await
-        .unwrap();
+    store.stage_keys(&id2, keys(&["x"])).await.unwrap();
     let err = store.mark_committed(&[id2]).await.unwrap_err();
     assert!(matches!(err, CheckpointError::NotCheckpointed { .. }));
 }
@@ -244,22 +202,19 @@ pub async fn test_orphaned_staged_entries(store: &dyn CheckpointStore) {
     // Orphan: staged but never sealed (simulates crash)
     let orphan_id = CheckpointId::generate(0);
     store
-        .stage_keys(&orphan_id, "test-query", keys(&["orphan"]))
+        .stage_keys(&orphan_id, keys(&["orphan"]))
         .await
         .unwrap();
     store
-        .stage_files(&orphan_id, "test-query", vec![file(b"orphan_file")])
+        .stage_files(&orphan_id, vec![file(b"orphan_file")])
         .await
         .unwrap();
 
     // Good: completed successfully
     let good_id = CheckpointId::generate(0);
+    store.stage_keys(&good_id, keys(&["good"])).await.unwrap();
     store
-        .stage_keys(&good_id, "test-query", keys(&["good"]))
-        .await
-        .unwrap();
-    store
-        .stage_files(&good_id, "test-query", vec![file(b"good_file")])
+        .stage_files(&good_id, vec![file(b"good_file")])
         .await
         .unwrap();
     store.checkpoint(&good_id).await.unwrap();
@@ -271,10 +226,7 @@ pub async fn test_orphaned_staged_entries(store: &dyn CheckpointStore) {
 pub async fn test_checkpoint_keys_only(store: &dyn CheckpointStore) {
     let id = CheckpointId::generate(0);
 
-    store
-        .stage_keys(&id, "test-query", keys(&["a"]))
-        .await
-        .unwrap();
+    store.stage_keys(&id, keys(&["a"])).await.unwrap();
     store.checkpoint(&id).await.unwrap();
 
     assert_eq!(collect_key_strings(store).await, vec!["a"]);
@@ -293,10 +245,7 @@ pub async fn test_crud(store: &dyn CheckpointStore) {
     assert!(matches!(err, CheckpointError::CheckpointNotFound { .. }));
 
     // Stage → Sealed → Committed lifecycle via get_checkpoint
-    store
-        .stage_keys(&id1, "test-query", keys(&["a"]))
-        .await
-        .unwrap();
+    store.stage_keys(&id1, keys(&["a"])).await.unwrap();
     let ckpt = store.get_checkpoint(&id1).await.unwrap();
     assert_eq!(ckpt.status, CheckpointStatus::Staged);
     assert!(ckpt.sealed_at.is_none());
@@ -320,10 +269,7 @@ pub async fn test_crud(store: &dyn CheckpointStore) {
     assert!(ckpt.committed_at.unwrap() >= ckpt.sealed_at.unwrap());
 
     // list_checkpoints with mixed states
-    store
-        .stage_keys(&id2, "test-query", keys(&["b"]))
-        .await
-        .unwrap();
+    store.stage_keys(&id2, keys(&["b"])).await.unwrap();
 
     let checkpoints: Vec<_> = store
         .list_checkpoints()
@@ -343,11 +289,8 @@ pub async fn test_empty_inputs(store: &dyn CheckpointStore) {
     let id = CheckpointId::generate(0);
 
     // Empty stage calls
-    store
-        .stage_keys(&id, "test-query", keys(&[]))
-        .await
-        .unwrap();
-    store.stage_files(&id, "test-query", vec![]).await.unwrap();
+    store.stage_keys(&id, keys(&[])).await.unwrap();
+    store.stage_files(&id, vec![]).await.unwrap();
     store.checkpoint(&id).await.unwrap();
 
     assert_eq!(collect_key_strings(store).await, Vec::<String>::new());
@@ -362,17 +305,11 @@ pub async fn test_retry_after_partial_failure(store: &dyn CheckpointStore) {
     let staged_id = CheckpointId::generate(0);
 
     // good_id: fully sealed
-    store
-        .stage_keys(&good_id, "test-query", keys(&["a"]))
-        .await
-        .unwrap();
+    store.stage_keys(&good_id, keys(&["a"])).await.unwrap();
     store.checkpoint(&good_id).await.unwrap();
 
     // staged_id: only staged (not sealed)
-    store
-        .stage_keys(&staged_id, "test-query", keys(&["b"]))
-        .await
-        .unwrap();
+    store.stage_keys(&staged_id, keys(&["b"])).await.unwrap();
 
     // First attempt: partial failure — good_id commits, staged_id errors
     let err = store
@@ -406,10 +343,7 @@ pub async fn test_object_safety(store: &dyn CheckpointStore) {
     // Exercise basic operations through the trait object.
     let id = CheckpointId::generate(0);
 
-    store
-        .stage_keys(&id, "test-query", keys(&["a"]))
-        .await
-        .unwrap();
+    store.stage_keys(&id, keys(&["a"])).await.unwrap();
     store.checkpoint(&id).await.unwrap();
 
     let chunks: Vec<Series> = store

--- a/src/daft-checkpoint/src/types.rs
+++ b/src/daft-checkpoint/src/types.rs
@@ -1,4 +1,4 @@
-use std::{fmt, sync::Arc, time::SystemTime};
+use std::{fmt, time::SystemTime};
 
 // `CheckpointId` lives in `common-checkpoint-config` so that consumers
 // outside the store impls (e.g. `daft-distributed` task metadata) can
@@ -34,11 +34,6 @@ impl fmt::Display for CheckpointStatus {
 pub struct Checkpoint {
     pub id: CheckpointId,
     pub status: CheckpointStatus,
-    /// Identifier of the execution that staged this checkpoint. Set on first
-    /// `stage_keys`/`stage_files` call for the ID, persisted with the manifest,
-    /// returned alongside the checkpoint metadata. Empty for entries created by
-    /// older versions that did not record a query_id.
-    pub query_id: Arc<str>,
     /// When the checkpoint entry was first created (first `stage_keys`/`stage_files` call).
     pub created_at: SystemTime,
     /// When the checkpoint was sealed via `checkpoint()`.
@@ -53,7 +48,6 @@ impl Checkpoint {
     pub fn new(
         id: CheckpointId,
         status: CheckpointStatus,
-        query_id: Arc<str>,
         created_at: SystemTime,
         sealed_at: Option<SystemTime>,
         committed_at: Option<SystemTime>,
@@ -61,7 +55,6 @@ impl Checkpoint {
         Self {
             id,
             status,
-            query_id,
             created_at,
             sealed_at,
             committed_at,

--- a/src/daft-checkpoint/tests/s3_store.rs
+++ b/src/daft-checkpoint/tests/s3_store.rs
@@ -104,12 +104,9 @@ async fn test_lifecycle() {
         .unwrap();
     assert!(checkpoints.is_empty());
 
+    store.stage_keys(&id, keys(&["a", "b"])).await.unwrap();
     store
-        .stage_keys(&id, "test-query", keys(&["a", "b"]))
-        .await
-        .unwrap();
-    store
-        .stage_files(&id, "test-query", vec![file(b"file1"), file(b"file2")])
+        .stage_files(&id, vec![file(b"file1"), file(b"file2")])
         .await
         .unwrap();
 
@@ -142,33 +139,15 @@ async fn test_multiple_checkpoints_and_partial_commit() {
     let id2 = CheckpointId::generate(2);
 
     // Checkpoint 1
-    store
-        .stage_keys(&id1, "test-query", keys(&["a"]))
-        .await
-        .unwrap();
-    store
-        .stage_files(&id1, "test-query", vec![file(b"f1")])
-        .await
-        .unwrap();
+    store.stage_keys(&id1, keys(&["a"])).await.unwrap();
+    store.stage_files(&id1, vec![file(b"f1")]).await.unwrap();
     store.checkpoint(&id1).await.unwrap();
 
     // Checkpoint 2: multiple stage_keys calls → multiple keys/*.parquet files
-    store
-        .stage_keys(&id2, "test-query", keys(&["b"]))
-        .await
-        .unwrap();
-    store
-        .stage_keys(&id2, "test-query", keys(&["c", "d"]))
-        .await
-        .unwrap();
-    store
-        .stage_files(&id2, "test-query", vec![file(b"f2")])
-        .await
-        .unwrap();
-    store
-        .stage_files(&id2, "test-query", vec![file(b"f3")])
-        .await
-        .unwrap();
+    store.stage_keys(&id2, keys(&["b"])).await.unwrap();
+    store.stage_keys(&id2, keys(&["c", "d"])).await.unwrap();
+    store.stage_files(&id2, vec![file(b"f2")]).await.unwrap();
+    store.stage_files(&id2, vec![file(b"f3")]).await.unwrap();
     store.checkpoint(&id2).await.unwrap();
 
     assert_eq!(collect_key_strings(&store).await, vec!["a", "b", "c", "d"]);
@@ -194,14 +173,8 @@ async fn test_idempotency() {
     let (_dir, store) = make_store();
     let id = CheckpointId::generate(0);
 
-    store
-        .stage_keys(&id, "test-query", keys(&["a"]))
-        .await
-        .unwrap();
-    store
-        .stage_files(&id, "test-query", vec![file(b"f1")])
-        .await
-        .unwrap();
+    store.stage_keys(&id, keys(&["a"])).await.unwrap();
+    store.stage_files(&id, vec![file(b"f1")]).await.unwrap();
 
     // Double checkpoint()
     store.checkpoint(&id).await.unwrap();
@@ -245,30 +218,18 @@ async fn test_error_paths() {
 
     // stage_keys after checkpoint() → AlreadySealed
     let id = CheckpointId::generate(0);
-    store
-        .stage_keys(&id, "test-query", keys(&["a"]))
-        .await
-        .unwrap();
+    store.stage_keys(&id, keys(&["a"])).await.unwrap();
     store.checkpoint(&id).await.unwrap();
 
-    let err = store
-        .stage_keys(&id, "test-query", keys(&["b"]))
-        .await
-        .unwrap_err();
+    let err = store.stage_keys(&id, keys(&["b"])).await.unwrap_err();
     assert!(matches!(err, CheckpointError::AlreadySealed { .. }));
 
-    let err = store
-        .stage_files(&id, "test-query", vec![file(b"f")])
-        .await
-        .unwrap_err();
+    let err = store.stage_files(&id, vec![file(b"f")]).await.unwrap_err();
     assert!(matches!(err, CheckpointError::AlreadySealed { .. }));
 
     // mark_committed on staged (not yet checkpointed)
     let id2 = CheckpointId::generate(1);
-    store
-        .stage_keys(&id2, "test-query", keys(&["x"]))
-        .await
-        .unwrap();
+    store.stage_keys(&id2, keys(&["x"])).await.unwrap();
     let err = store.mark_committed(&[id2]).await.unwrap_err();
     assert!(matches!(err, CheckpointError::NotCheckpointed { .. }));
 }
@@ -284,22 +245,19 @@ async fn test_orphaned_staged_entries_invisible() {
     // Orphan: staged but never checkpointed (crash simulation)
     let orphan_id = CheckpointId::generate(0);
     store
-        .stage_keys(&orphan_id, "test-query", keys(&["orphan"]))
+        .stage_keys(&orphan_id, keys(&["orphan"]))
         .await
         .unwrap();
     store
-        .stage_files(&orphan_id, "test-query", vec![file(b"orphan_file")])
+        .stage_files(&orphan_id, vec![file(b"orphan_file")])
         .await
         .unwrap();
 
     // Good: fully checkpointed
     let good_id = CheckpointId::generate(1);
+    store.stage_keys(&good_id, keys(&["good"])).await.unwrap();
     store
-        .stage_keys(&good_id, "test-query", keys(&["good"]))
-        .await
-        .unwrap();
-    store
-        .stage_files(&good_id, "test-query", vec![file(b"good_file")])
+        .stage_files(&good_id, vec![file(b"good_file")])
         .await
         .unwrap();
     store.checkpoint(&good_id).await.unwrap();
@@ -318,10 +276,7 @@ async fn test_checkpoint_keys_only() {
     let (_dir, store) = make_store();
     let id = CheckpointId::generate(0);
 
-    store
-        .stage_keys(&id, "test-query", keys(&["a", "b"]))
-        .await
-        .unwrap();
+    store.stage_keys(&id, keys(&["a", "b"])).await.unwrap();
     store.checkpoint(&id).await.unwrap();
 
     assert_eq!(collect_key_strings(&store).await, vec!["a", "b"]);
@@ -338,7 +293,7 @@ async fn test_checkpoint_files_only() {
     let id = CheckpointId::generate(0);
 
     store
-        .stage_files(&id, "test-query", vec![file(b"data1"), file(b"data2")])
+        .stage_files(&id, vec![file(b"data1"), file(b"data2")])
         .await
         .unwrap();
     store.checkpoint(&id).await.unwrap();
@@ -368,10 +323,7 @@ async fn test_get_checkpoint_and_list() {
     assert!(matches!(err, CheckpointError::CheckpointNotFound { .. }));
 
     // Staged → Checkpointed → Committed via get_checkpoint
-    store
-        .stage_keys(&id1, "test-query", keys(&["a"]))
-        .await
-        .unwrap();
+    store.stage_keys(&id1, keys(&["a"])).await.unwrap();
     let ckpt = store.get_checkpoint(&id1).await.unwrap();
     assert_eq!(ckpt.status, CheckpointStatus::Staged);
     assert!(ckpt.sealed_at.is_none());
@@ -393,10 +345,7 @@ async fn test_get_checkpoint_and_list() {
     assert!(ckpt.committed_at.is_some());
 
     // list_checkpoints: mixed state
-    store
-        .stage_keys(&id2, "test-query", keys(&["b"]))
-        .await
-        .unwrap();
+    store.stage_keys(&id2, keys(&["b"])).await.unwrap();
 
     let checkpoints: Vec<_> = store
         .list_checkpoints()
@@ -421,11 +370,8 @@ async fn test_empty_inputs() {
     let (_dir, store) = make_store();
     let id = CheckpointId::generate(0);
 
-    store
-        .stage_keys(&id, "test-query", keys(&[]))
-        .await
-        .unwrap();
-    store.stage_files(&id, "test-query", vec![]).await.unwrap();
+    store.stage_keys(&id, keys(&[])).await.unwrap();
+    store.stage_files(&id, vec![]).await.unwrap();
     store.checkpoint(&id).await.unwrap();
 
     assert_eq!(collect_key_strings(&store).await, Vec::<String>::new());
@@ -451,10 +397,7 @@ async fn test_stage_keys_renames_to_canonical_column() {
     // on the way in so the on-disk parquet uses the canonical name.
     let source_named = Utf8Array::from_slice("file_id", &["a", "b", "c"]).into_series();
     assert_eq!(source_named.name(), "file_id");
-    store
-        .stage_keys(&id, "test-query", source_named)
-        .await
-        .unwrap();
+    store.stage_keys(&id, source_named).await.unwrap();
     store.checkpoint(&id).await.unwrap();
 
     // Read back via get_checkpointed_keys — every chunk's series field must
@@ -502,8 +445,8 @@ async fn test_stage_keys_round_trip_preserves_int64_dtype_across_batches() {
     assert_eq!(batch1.name(), "src_id");
     assert_eq!(batch2.name(), "src_id");
 
-    store.stage_keys(&id, "test-query", batch1).await.unwrap();
-    store.stage_keys(&id, "test-query", batch2).await.unwrap();
+    store.stage_keys(&id, batch1).await.unwrap();
+    store.stage_keys(&id, batch2).await.unwrap();
     store.checkpoint(&id).await.unwrap();
 
     let chunks: Vec<Series> = store
@@ -549,14 +492,8 @@ async fn test_mark_committed_batch() {
     let ids: Vec<CheckpointId> = (1..=3).map(CheckpointId::generate).collect();
 
     for id in &ids {
-        store
-            .stage_keys(id, "test-query", keys(&["k"]))
-            .await
-            .unwrap();
-        store
-            .stage_files(id, "test-query", vec![file(b"f")])
-            .await
-            .unwrap();
+        store.stage_keys(id, keys(&["k"])).await.unwrap();
+        store.stage_files(id, vec![file(b"f")]).await.unwrap();
         store.checkpoint(id).await.unwrap();
     }
 
@@ -583,10 +520,7 @@ async fn test_mark_committed_idempotent_retry() {
     let (_dir, store) = make_store();
     let id = CheckpointId::generate(0);
 
-    store
-        .stage_keys(&id, "test-query", keys(&["a"]))
-        .await
-        .unwrap();
+    store.stage_keys(&id, keys(&["a"])).await.unwrap();
     store.checkpoint(&id).await.unwrap();
 
     store
@@ -613,18 +547,9 @@ async fn test_multiple_key_batches_become_separate_files() {
     let id = CheckpointId::generate(0);
 
     // 3 separate stage_keys calls → 3 parquet files
-    store
-        .stage_keys(&id, "test-query", keys(&["a"]))
-        .await
-        .unwrap();
-    store
-        .stage_keys(&id, "test-query", keys(&["b", "c"]))
-        .await
-        .unwrap();
-    store
-        .stage_keys(&id, "test-query", keys(&["d"]))
-        .await
-        .unwrap();
+    store.stage_keys(&id, keys(&["a"])).await.unwrap();
+    store.stage_keys(&id, keys(&["b", "c"])).await.unwrap();
+    store.stage_keys(&id, keys(&["d"])).await.unwrap();
     store.checkpoint(&id).await.unwrap();
 
     assert_eq!(collect_key_strings(&store).await, vec!["a", "b", "c", "d"]);
@@ -641,7 +566,7 @@ async fn test_parquet_file_metadata_roundtrip() {
     let parquet_file = FileMetadata::new(FileFormat::Parquet, vec![10, 20, 30]);
 
     store
-        .stage_files(&id, "test-query", vec![parquet_file.clone()])
+        .stage_files(&id, vec![parquet_file.clone()])
         .await
         .unwrap();
     store.checkpoint(&id).await.unwrap();
@@ -672,10 +597,7 @@ async fn test_sealed_file_paths_lifecycle() {
     // Staged only → still no paths (staged-only keys must be invisible so the
     // current run doesn't wrongly skip work that was never durably recorded).
     let id = CheckpointId::generate(0);
-    store
-        .stage_keys(&id, "test-query", keys(&["a", "b"]))
-        .await
-        .unwrap();
+    store.stage_keys(&id, keys(&["a", "b"])).await.unwrap();
     assert!(store.sealed_file_paths().await.unwrap().is_empty());
 
     // Sealed → at least one path.
@@ -702,10 +624,8 @@ async fn test_checkpoint_on_never_staged_id_is_a_noop() {
 
     // Empty-source case: pipeline produced 0 rows after the anti-join, sink
     // generated an id but no SCKO/sink call ever staged keys or files. We
-    // succeed quietly rather than sealing a content-less manifest — that
-    // marker would carry an empty query_id, which violates the downstream
-    // single-query-id invariant for no observable benefit (consumers can
-    // already tell "this id sealed nothing" from the absence of a manifest).
+    // succeed quietly rather than sealing a content-less manifest — consumers
+    // can already tell "this id sealed nothing" from the absence of a manifest.
     store.checkpoint(&id).await.unwrap();
 
     let ckpt = store.get_checkpoint(&id).await;

--- a/src/daft-local-execution/src/intermediate_ops/stage_checkpoint_keys.rs
+++ b/src/daft-local-execution/src/intermediate_ops/stage_checkpoint_keys.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use common_checkpoint_config::CheckpointIdMap;
 use common_error::DaftResult;
-use common_metrics::{QueryID, ops::NodeType};
+use common_metrics::ops::NodeType;
 use daft_checkpoint::CheckpointStoreRef;
 use daft_dsl::{Expr, expr::bound_expr::BoundExpr};
 use daft_micropartition::MicroPartition;
@@ -25,16 +25,10 @@ pub struct StageCheckpointKeysOperator {
     key_expr: BoundExpr,
     store: CheckpointStoreRef,
     id_map: CheckpointIdMap,
-    query_id: QueryID,
 }
 
 impl StageCheckpointKeysOperator {
-    pub fn new(
-        key_expr: BoundExpr,
-        store: CheckpointStoreRef,
-        id_map: CheckpointIdMap,
-        query_id: QueryID,
-    ) -> Self {
+    pub fn new(key_expr: BoundExpr, store: CheckpointStoreRef, id_map: CheckpointIdMap) -> Self {
         // Checkpoint keys must be column references only — no computed expressions.
         assert!(
             matches!(key_expr.inner().as_ref(), Expr::Column(..)),
@@ -44,7 +38,6 @@ impl StageCheckpointKeysOperator {
             key_expr,
             store,
             id_map,
-            query_id,
         }
     }
 }
@@ -65,16 +58,13 @@ impl IntermediateOperator for StageCheckpointKeysOperator {
         let key_expr = self.key_expr.clone();
         let store = self.store.clone();
         let checkpoint_id = self.id_map.get_or_generate(input_id);
-        let query_id = self.query_id.clone();
 
         task_spawner
             .spawn(
                 async move {
                     for rb in input.record_batches() {
                         let key_series = rb.eval_expression(&key_expr)?;
-                        store
-                            .stage_keys(&checkpoint_id, &query_id, key_series)
-                            .await?;
+                        store.stage_keys(&checkpoint_id, key_series).await?;
                     }
                     Ok((state, input))
                 },

--- a/src/daft-local-execution/src/pipeline.rs
+++ b/src/daft-local-execution/src/pipeline.rs
@@ -263,7 +263,6 @@ impl ConcreteTreeNode for Box<dyn PipelineNode> {
 /// It generates a plan_id, and node ids for each plan.
 pub struct BuilderContext {
     index_counter: std::cell::RefCell<usize>,
-    pub query_id: QueryID,
     pub meter: Meter,
     context: HashMap<String, String>,
     shuffle_server: Option<(Arc<ShuffleFlightServer>, String)>,
@@ -289,11 +288,10 @@ impl BuilderContext {
         context: HashMap<String, String>,
         shuffle_server: Option<(Arc<ShuffleFlightServer>, String)>,
     ) -> Self {
-        let meter = Meter::query_scope(query_id.clone(), "daft.execution.local");
+        let meter = Meter::query_scope(query_id, "daft.execution.local");
 
         Self {
             index_counter: std::cell::RefCell::new(0),
-            query_id,
             meter,
             context,
             shuffle_server,
@@ -804,8 +802,7 @@ fn physical_plan_to_pipeline(
 
             ctx.set_checkpoint(store.clone(), id_map.clone(), key_expr.clone());
 
-            let scko =
-                StageCheckpointKeysOperator::new(key_expr, store, id_map, ctx.query_id.clone());
+            let scko = StageCheckpointKeysOperator::new(key_expr, store, id_map);
             IntermediateNode::new(
                 Arc::new(scko),
                 child_node,
@@ -1412,12 +1409,7 @@ fn physical_plan_to_pipeline(
                 context,
             );
             if let Some((store, id_map, _)) = ctx.checkpoint() {
-                node = node.with_checkpoint(
-                    store,
-                    id_map,
-                    daft_checkpoint::FileFormat::Parquet,
-                    ctx.query_id.clone(),
-                );
+                node = node.with_checkpoint(store, id_map, daft_checkpoint::FileFormat::Parquet);
             }
             node.boxed()
         }
@@ -1504,7 +1496,7 @@ fn physical_plan_to_pipeline(
                 context,
             );
             if let Some((store, id_map, _)) = ctx.checkpoint() {
-                node = node.with_checkpoint(store, id_map, ckpt_format, ctx.query_id.clone());
+                node = node.with_checkpoint(store, id_map, ckpt_format);
             }
             node.boxed()
         }

--- a/src/daft-local-execution/src/sinks/blocking_sink.rs
+++ b/src/daft-local-execution/src/sinks/blocking_sink.rs
@@ -8,7 +8,7 @@ use common_checkpoint_config::CheckpointIdMap;
 use common_display::tree::TreeDisplay;
 use common_error::{DaftError, DaftResult};
 use common_metrics::{
-    Meter, QueryID,
+    Meter,
     ops::{NodeCategory, NodeInfo, NodeType},
 };
 use common_runtime::{OrderingAwareJoinSet, get_compute_pool_num_threads, get_compute_runtime};
@@ -155,7 +155,6 @@ pub struct BlockingSinkNode<Op: BlockingSink> {
         CheckpointStoreRef,
         CheckpointIdMap,
         daft_checkpoint::FileFormat,
-        QueryID,
     )>,
 }
 
@@ -187,9 +186,8 @@ impl<Op: BlockingSink + 'static> BlockingSinkNode<Op> {
         store: CheckpointStoreRef,
         id_map: CheckpointIdMap,
         file_format: daft_checkpoint::FileFormat,
-        query_id: QueryID,
     ) -> Self {
-        self.checkpoint = Some((store, id_map, file_format, query_id));
+        self.checkpoint = Some((store, id_map, file_format));
         self
     }
 
@@ -240,28 +238,23 @@ impl<Op: BlockingSink + 'static> BlockingSinkNode<Op> {
             CheckpointStoreRef,
             CheckpointIdMap,
             daft_checkpoint::FileFormat,
-            QueryID,
         )>,
     ) {
         tasks.spawn(async move {
             let checkpoint_id = checkpoint
                 .as_ref()
-                .map(|(_, id_map, _, _)| id_map.get_or_generate(input_id));
+                .map(|(_, id_map, _)| id_map.get_or_generate(input_id));
 
             let output = op.finalize(per_input.states, &finalize_spawner).await??;
             per_input.runtime_stats.increment_num_tasks();
             match output {
                 BlockingSinkOutput::Partitions(partitions) => {
                     // Stage write results as file metadata before sending.
-                    if let Some((ref store, _, file_format, ref query_id)) = checkpoint {
+                    if let Some((ref store, _, file_format)) = checkpoint {
                         let file_metadata = Self::encode_file_metadata(&partitions, file_format)?;
                         if !file_metadata.is_empty() {
                             store
-                                .stage_files(
-                                    checkpoint_id.as_ref().unwrap(),
-                                    query_id,
-                                    file_metadata,
-                                )
+                                .stage_files(checkpoint_id.as_ref().unwrap(), file_metadata)
                                 .await?;
                         }
                     }
@@ -290,7 +283,7 @@ impl<Op: BlockingSink + 'static> BlockingSinkNode<Op> {
                     }
                 }
             }
-            if let Some((store, _, _, _)) = &checkpoint {
+            if let Some((store, _, _)) = &checkpoint {
                 store.checkpoint(checkpoint_id.as_ref().unwrap()).await?;
             }
             let _ = output_tx.send(PipelineMessage::Flush(input_id)).await;
@@ -311,7 +304,6 @@ impl<Op: BlockingSink + 'static> BlockingSinkNode<Op> {
             CheckpointStoreRef,
             CheckpointIdMap,
             daft_checkpoint::FileFormat,
-            QueryID,
         )>,
     ) -> DaftResult<()> {
         let node_id = node_info.id;

--- a/src/daft-local-execution/src/sinks/commit_write.rs
+++ b/src/daft-local-execution/src/sinks/commit_write.rs
@@ -38,9 +38,6 @@ impl CommitWriteState {
     }
 }
 
-// TODO: Catalog commits (Iceberg/Delta) must be idempotent.
-// Iceberg: tag snapshots with `daft.checkpoint-store` + `daft.epoch-id`,
-// skip if duplicate. Delta: use `txn` action with `appId` + `version`.
 pub(crate) struct CommitWriteSink {
     data_schema: SchemaRef,
     file_schema: SchemaRef,

--- a/tests/io/iceberg/test_iceberg_writes_checkpoint.py
+++ b/tests/io/iceberg/test_iceberg_writes_checkpoint.py
@@ -1,14 +1,22 @@
-"""Tests for `write_iceberg(checkpoint=...)` — idempotent commits.
+"""Tests for `write_iceberg(checkpoint=daft.IdempotentCommit(...))`.
 
-The checkpoint-aware source filter (`daft.read_parquet(checkpoint=...)`)
+Idempotence is keyed on the ``idempotence_key`` carried by the
+:class:`daft.IdempotentCommit` passed via ``checkpoint=`` on
+``write_iceberg``. Each logical commit declares its own key; retries of
+the same commit reuse the key. Recovery walks the Iceberg snapshot
+history for ``daft.idempotence-key`` matching the call's key.
+
+Single-snapshot invariant — every test asserts that a logical run lands
+exactly one new Iceberg snapshot tagged with the call's idempotence key.
+
+The checkpoint-aware source filter (``daft.read_parquet(checkpoint=...)``)
 runs only on the Ray runner, so these tests are skipped on the native
-runner. See `tests/checkpoint/test_native_runner_gate.py`.
+runner. See ``tests/checkpoint/test_native_runner_gate.py``.
 """
 
 from __future__ import annotations
 
 import os
-import re
 from unittest.mock import patch
 
 import pytest
@@ -30,6 +38,9 @@ pytestmark = pytest.mark.skipif(
     os.environ.get("DAFT_RUNNER") != "ray",
     reason="checkpoint+write_iceberg requires Ray runner",
 )
+
+
+IDEMPOTENCE_KEY = "test-run-2026-05-04"
 
 
 @pytest.fixture(scope="function")
@@ -67,288 +78,196 @@ def checkpoint_store(tmpdir):
     return daft.CheckpointStore(f"file://{tmpdir}/ckpt")
 
 
-def test_recovery_after_crash_between_commit_and_mark(iceberg_table, parquet_input, checkpoint_store):
-    """Scenario A: crash after commit succeeded but before mark_committed ran.
+@pytest.fixture(scope="function")
+def idempotent_commit(checkpoint_store):
+    return daft.IdempotentCommit(store=checkpoint_store, idempotence_key=IDEMPOTENCE_KEY)
 
-    Catalog has the snapshot with our markers; store still says `Checkpointed`.
-    A fresh call to `write_iceberg(checkpoint=...)` must detect the marker, call
-    `mark_committed`, and NOT produce a second snapshot.
+
+def _assert_single_snapshot_with_key(table, key: str) -> dict[str, str]:
+    """Assert exactly one snapshot exists tagged with the given idempotence key.
+
+    Returns the snapshot summary so the caller can make further assertions.
     """
-    # First call: simulate the crash by patching mark_committed to raise.
+    table.refresh()
+    snapshots = list(table.metadata.snapshots)
+    assert len(snapshots) == 1, f"single-snapshot invariant violated: expected exactly 1 snapshot, got {len(snapshots)}"
+    summary = snapshots[0].summary
+    assert summary["daft.idempotence-key"] == key, (
+        f"snapshot must be tagged with idempotence key {key!r}; got summary={dict(summary)}"
+    )
+    return summary
+
+
+def test_fresh_run_lands_single_snapshot_with_key(iceberg_table, parquet_input, checkpoint_store, idempotent_commit):
+    """Fresh run, no crash. The most-traveled path.
+
+    Pipeline runs, store gets populated, snapshot lands tagged with the
+    idempotence key, ``mark_committed`` runs, all input rows round-trip.
+    """
     df = daft.read_parquet(parquet_input, checkpoint=daft.CheckpointConfig(store=checkpoint_store, on="file_id"))
-    with patch.object(checkpoint_store, "mark_committed", side_effect=RuntimeError("simulated crash")):
-        with pytest.raises(RuntimeError, match="simulated crash"):
-            df.write_iceberg(iceberg_table, checkpoint=checkpoint_store)
+    df.write_iceberg(iceberg_table, checkpoint=idempotent_commit)
 
-    # State: catalog has exactly one snapshot with our markers; store entries are
-    # still in Checkpointed state because mark_committed never ran.
-    iceberg_table.refresh()
-    assert len(iceberg_table.metadata.snapshots) == 1
-    snapshot_id_after_crash = iceberg_table.metadata.snapshots[0].snapshot_id
-    pending_after_crash = [c for c in checkpoint_store.list_checkpoints() if c.status == CheckpointStatus.Checkpointed]
-    assert pending_after_crash, "expected Checkpointed entries to remain after crash"
-    crashed_query_id = pending_after_crash[0].query_id
-
-    # Second call: should hit the recovery path. mark_committed is no longer patched.
-    df2 = daft.read_parquet(parquet_input, checkpoint=daft.CheckpointConfig(store=checkpoint_store, on="file_id"))
-    df2.write_iceberg(iceberg_table, checkpoint=checkpoint_store)
-
-    # Verify: still exactly one snapshot, no double-write.
-    iceberg_table.refresh()
-    assert len(iceberg_table.metadata.snapshots) == 1, "recovery must not produce a second snapshot"
-
-    # Verify: it's the *same* snapshot — recovery did not retire the original
-    # and replace it with a fresh one. The "exactly 1 snapshot" check above
-    # would still pass if recovery had committed a new snapshot whose data
-    # superseded the first; the snapshot_id continuity check rules that out.
-    assert iceberg_table.metadata.snapshots[0].snapshot_id == snapshot_id_after_crash, (
-        "recovery must keep the original snapshot, not replace it with a new one"
-    )
-
-    # Verify: previously-Checkpointed entries are now Committed.
-    still_checkpointed = [c for c in checkpoint_store.list_checkpoints() if c.status == CheckpointStatus.Checkpointed]
-    assert not still_checkpointed, "all entries should be Committed after recovery"
-
-    # Verify: snapshot summary carries the markers in the expected shape. The
-    # query_id assertion catches the empty-string failure mode where the field
-    # is silently defaulted but the marker has no real identity.
-    summary = iceberg_table.metadata.snapshots[0].summary
-    assert summary["daft.checkpoint-store"] == checkpoint_store.path
-    snapshot_query_id = summary["daft.checkpoint-query"]
-    assert snapshot_query_id == crashed_query_id, (
-        "recovery must reuse the crashed run's query_id, not a freshly-generated one"
-    )
-    assert re.match(r"^[a-z]+-[a-z]+-[0-9a-f]{6}$", snapshot_query_id), (
-        f"unexpected query_id shape (caught empty/default failure mode?): {snapshot_query_id!r}"
-    )
-
-    # The recovered snapshot was committed by the *first* call (this scenario
-    # restarts after a successful catalog commit); its summary therefore still
-    # records the original 3 added rows / 1 added data file.
+    summary = _assert_single_snapshot_with_key(iceberg_table, IDEMPOTENCE_KEY)
     assert summary.get("added-records") == "3"
-    assert summary.get("added-data-files") == "1"
 
-    # Verify: the input rows actually round-trip through the table — guards
-    # against a snapshot landing with zero data files (which would still
-    # satisfy the snapshot-count assertion above).
-    rows = daft.read_iceberg(iceberg_table).to_pydict()
-    assert sorted(rows["file_id"]) == ["a", "b", "c"]
-
-
-def test_recovery_after_crash_between_stage_and_commit(iceberg_table, parquet_input, checkpoint_store):
-    """Scenario B: crash after stage_files+checkpoint, before tx.commit_transaction.
-
-    Files exist on object store, file metadata is in the checkpoint store, status
-    is `Checkpointed`. The catalog has no snapshot. A fresh call to
-    `write_iceberg(checkpoint=...)` must skip `write_df.collect()`, pull files
-    out of the store, and commit exactly one snapshot using the original run's
-    query_id (no fresh generation).
-    """
-    # First call: simulate the crash by patching tx.commit_transaction to raise.
-    df = daft.read_parquet(parquet_input, checkpoint=daft.CheckpointConfig(store=checkpoint_store, on="file_id"))
-    with patch.object(Transaction, "commit_transaction", side_effect=RuntimeError("simulated crash")):
-        with pytest.raises(RuntimeError, match="simulated crash"):
-            df.write_iceberg(iceberg_table, checkpoint=checkpoint_store)
-
-    # State: catalog has zero snapshots (commit didn't land); store has Checkpointed
-    # entries with files staged (sink sealed before the commit attempt).
-    iceberg_table.refresh()
-    assert iceberg_table.metadata.snapshots == [], "no snapshot should land when commit raises"
-    pending_after_crash = [c for c in checkpoint_store.list_checkpoints() if c.status == CheckpointStatus.Checkpointed]
-    assert pending_after_crash, "expected Checkpointed entries to remain after crash"
-    crashed_query_id = pending_after_crash[0].query_id
-    assert checkpoint_store.get_checkpointed_files(), "expected staged file metadata in store"
-
-    # Second call: should skip the pipeline, pull files from the store, commit once.
-    df2 = daft.read_parquet(parquet_input, checkpoint=daft.CheckpointConfig(store=checkpoint_store, on="file_id"))
-    df2.write_iceberg(iceberg_table, checkpoint=checkpoint_store)
-
-    # Verify: exactly one snapshot landed.
-    iceberg_table.refresh()
-    assert len(iceberg_table.metadata.snapshots) == 1
-
-    # Verify: previously-Checkpointed entries are now Committed.
-    still_checkpointed = [c for c in checkpoint_store.list_checkpoints() if c.status == CheckpointStatus.Checkpointed]
-    assert not still_checkpointed, "all entries should be Committed after recovery"
-
-    # Verify: the snapshot's query_id matches what was staged before the crash —
-    # i.e. the recovery used the existing entries' query_id, not a freshly
-    # generated one. This is the load-bearing single-query-id-across-restart
-    # invariant.
-    summary = iceberg_table.metadata.snapshots[0].summary
-    assert summary["daft.checkpoint-store"] == checkpoint_store.path
-    assert summary["daft.checkpoint-query"] == crashed_query_id
-
-    # The recovery commit pulled the staged files out of the checkpoint store
-    # (no pipeline re-run); a regression that lands a snapshot with markers but
-    # zero data would pass everything above. This assertion makes that explicit.
-    assert summary.get("added-records") == "3"
-    assert summary.get("added-data-files") == "1"
-
-    # Verify: rows round-trip through the table.
-    rows = daft.read_iceberg(iceberg_table).to_pydict()
-    assert sorted(rows["file_id"]) == ["a", "b", "c"]
-
-
-def test_fresh_run_lands_snapshot_with_markers_and_data(iceberg_table, parquet_input, checkpoint_store):
-    """Scenario C: fresh run with checkpoint, no crash. The most-traveled path.
-
-    Pipeline runs, store gets populated, snapshot lands with markers,
-    `mark_committed` runs. All input rows round-trip through the table.
-    """
-    df = daft.read_parquet(parquet_input, checkpoint=daft.CheckpointConfig(store=checkpoint_store, on="file_id"))
-    df.write_iceberg(iceberg_table, checkpoint=checkpoint_store)
-
-    iceberg_table.refresh()
-    assert len(iceberg_table.metadata.snapshots) == 1
-
-    # Markers present and well-shaped.
-    summary = iceberg_table.metadata.snapshots[0].summary
-    assert summary["daft.checkpoint-store"] == checkpoint_store.path
-    qid = summary["daft.checkpoint-query"]
-    assert re.match(r"^[a-z]+-[a-z]+-[0-9a-f]{6}$", qid), f"unexpected query_id shape: {qid!r}"
-
-    # All entries Committed (no leftover Checkpointed state).
     pending = [c for c in checkpoint_store.list_checkpoints() if c.status == CheckpointStatus.Checkpointed]
     assert not pending
 
-    # Data round-trip.
     rows = daft.read_iceberg(iceberg_table).to_pydict()
     assert sorted(rows["file_id"]) == ["a", "b", "c"]
     assert sorted(rows["x"]) == [1, 2, 3]
 
 
-def test_incremental_writes_dedupe_committed_keys(iceberg_table, tmpdir, checkpoint_store):
-    """Two successive write_iceberg calls; second call's input is a superset.
+def test_recovery_after_crash_between_commit_and_mark(
+    iceberg_table, parquet_input, checkpoint_store, idempotent_commit
+):
+    """Scenario A: crash after commit succeeded but before mark_committed ran.
 
-    The source filter drops keys already Committed by the first call, so
-    snapshot 2 only contains the *new* rows. Each call lands its own
-    snapshot with a distinct query_id; the final table is the input union.
+    Iceberg has the snapshot tagged with our key; store still says Checkpointed.
+    Second call must walk history, find the key, mark Checkpointed → Committed,
+    and NOT produce a second snapshot — and not run the pipeline.
     """
-    # Call 1: input {a, b, c}.
-    inp1 = str(tmpdir / "in1")
-    os.makedirs(inp1, exist_ok=True)
-    daft.from_pydict({"file_id": ["a", "b", "c"], "x": [1, 2, 3]}).write_parquet(inp1)
-    daft.read_parquet(inp1, checkpoint=daft.CheckpointConfig(store=checkpoint_store, on="file_id")).write_iceberg(
-        iceberg_table, checkpoint=checkpoint_store
+    df = daft.read_parquet(parquet_input, checkpoint=daft.CheckpointConfig(store=checkpoint_store, on="file_id"))
+    with patch.object(checkpoint_store, "mark_committed", side_effect=RuntimeError("simulated crash")):
+        with pytest.raises(RuntimeError, match="simulated crash"):
+            df.write_iceberg(iceberg_table, checkpoint=idempotent_commit)
+
+    snapshot_id_after_crash = iceberg_table.metadata.snapshots[0].snapshot_id
+    pending_after_crash = [c for c in checkpoint_store.list_checkpoints() if c.status == CheckpointStatus.Checkpointed]
+    assert pending_after_crash, "expected Checkpointed entries to remain after crash"
+
+    # Second call: recovery path. The pipeline must NOT run.
+    df2 = daft.read_parquet(parquet_input, checkpoint=daft.CheckpointConfig(store=checkpoint_store, on="file_id"))
+    df2.write_iceberg(iceberg_table, checkpoint=idempotent_commit)
+
+    summary = _assert_single_snapshot_with_key(iceberg_table, IDEMPOTENCE_KEY)
+
+    # Same snapshot — recovery did not retire and replace.
+    assert iceberg_table.metadata.snapshots[0].snapshot_id == snapshot_id_after_crash, (
+        "recovery must keep the original snapshot, not replace it"
     )
 
-    iceberg_table.refresh()
-    assert len(iceberg_table.metadata.snapshots) == 1
-    qid_1 = iceberg_table.metadata.snapshots[0].summary["daft.checkpoint-query"]
+    still_checkpointed = [c for c in checkpoint_store.list_checkpoints() if c.status == CheckpointStatus.Checkpointed]
+    assert not still_checkpointed, "all entries should be Committed after recovery"
 
-    # Call 2: input {a, b, c, d, e, f} — superset. Source filter must drop
-    # {a, b, c}; only {d, e, f} should flow through to a new snapshot.
-    inp2 = str(tmpdir / "in2")
-    os.makedirs(inp2, exist_ok=True)
-    daft.from_pydict({"file_id": ["a", "b", "c", "d", "e", "f"], "x": [1, 2, 3, 4, 5, 6]}).write_parquet(inp2)
-    daft.read_parquet(inp2, checkpoint=daft.CheckpointConfig(store=checkpoint_store, on="file_id")).write_iceberg(
-        iceberg_table, checkpoint=checkpoint_store
-    )
+    assert summary.get("added-records") == "3"
+    assert summary.get("added-data-files") == "1"
 
-    iceberg_table.refresh()
-    assert len(iceberg_table.metadata.snapshots) == 2
-    summary_1 = iceberg_table.metadata.snapshots[0].summary
-    summary_2 = iceberg_table.metadata.snapshots[-1].summary
-    qid_2 = summary_2["daft.checkpoint-query"]
-    assert qid_1 != qid_2, "each execution must use its own query_id"
-
-    # Snapshot 1's marker must be unchanged after the second call lands —
-    # nothing in the second-call code path should rewrite earlier snapshot
-    # summaries.
-    assert summary_1["daft.checkpoint-query"] == qid_1
-
-    # Snapshot 2 must contain only the new rows ({d, e, f}). The summary's
-    # `added-records` / `added-data-files` fields are populated by pyiceberg's
-    # fast_append; if the source filter failed to drop {a, b, c} we would see
-    # 6 added records here instead of 3.
-    assert summary_2.get("added-records") == "3", (
-        f"snapshot 2 must add only the new rows; got summary: {dict(summary_2)}"
-    )
-    assert summary_2.get("added-data-files") == "1"
-
-    # All entries Committed across both runs.
-    pending = [c for c in checkpoint_store.list_checkpoints() if c.status == CheckpointStatus.Checkpointed]
-    assert not pending
-
-    # Final table is the union; no duplicates of {a, b, c}.
     rows = daft.read_iceberg(iceberg_table).to_pydict()
-    assert sorted(rows["file_id"]) == ["a", "b", "c", "d", "e", "f"]
+    assert sorted(rows["file_id"]) == ["a", "b", "c"]
 
 
-def test_rerun_after_full_commit_is_noop(iceberg_table, parquet_input, checkpoint_store):
-    """Re-running write_iceberg with already-Committed input is a no-op.
+def test_recovery_after_crash_between_stage_and_commit(
+    iceberg_table, parquet_input, checkpoint_store, idempotent_commit
+):
+    """Scenario B: crash after stage_files+checkpoint, before tx.commit_transaction.
 
-    Call 1 commits everything. Call 2 with the same input: source filter
-    drops every key, the pipeline produces zero pending entries, no second
-    snapshot lands, and the helper returns an empty result.
+    Files staged in store, no snapshot in catalog. Second call sees no
+    matching snapshot, runs the pipeline (filter skips Checkpointed), pulls
+    files from the store, commits exactly once tagged with the idempotence key.
+    """
+    df = daft.read_parquet(parquet_input, checkpoint=daft.CheckpointConfig(store=checkpoint_store, on="file_id"))
+    with patch.object(Transaction, "commit_transaction", side_effect=RuntimeError("simulated crash")):
+        with pytest.raises(RuntimeError, match="simulated crash"):
+            df.write_iceberg(iceberg_table, checkpoint=idempotent_commit)
+
+    iceberg_table.refresh()
+    assert iceberg_table.metadata.snapshots == [], "no snapshot must land when commit raises"
+    pending_after_crash = [c for c in checkpoint_store.list_checkpoints() if c.status == CheckpointStatus.Checkpointed]
+    assert pending_after_crash, "expected Checkpointed entries to remain after crash"
+
+    df2 = daft.read_parquet(parquet_input, checkpoint=daft.CheckpointConfig(store=checkpoint_store, on="file_id"))
+    df2.write_iceberg(iceberg_table, checkpoint=idempotent_commit)
+
+    summary = _assert_single_snapshot_with_key(iceberg_table, IDEMPOTENCE_KEY)
+    assert summary.get("added-records") == "3"
+    assert summary.get("added-data-files") == "1"
+
+    still_checkpointed = [c for c in checkpoint_store.list_checkpoints() if c.status == CheckpointStatus.Checkpointed]
+    assert not still_checkpointed
+
+    rows = daft.read_iceberg(iceberg_table).to_pydict()
+    assert sorted(rows["file_id"]) == ["a", "b", "c"]
+
+
+def test_idempotent_rerun_with_same_key_is_noop(iceberg_table, parquet_input, checkpoint_store, idempotent_commit):
+    """Re-running with the same key on an already-committed table is a no-op.
+
+    First call commits. Second call's check-first path finds the snapshot
+    with our key and bails — no second snapshot, no pipeline run.
     """
     df1 = daft.read_parquet(parquet_input, checkpoint=daft.CheckpointConfig(store=checkpoint_store, on="file_id"))
-    df1.write_iceberg(iceberg_table, checkpoint=checkpoint_store)
+    df1.write_iceberg(iceberg_table, checkpoint=idempotent_commit)
 
-    iceberg_table.refresh()
-    assert len(iceberg_table.metadata.snapshots) == 1
+    _assert_single_snapshot_with_key(iceberg_table, IDEMPOTENCE_KEY)
 
-    # Re-run with identical input — should be a no-op.
     df2 = daft.read_parquet(parquet_input, checkpoint=daft.CheckpointConfig(store=checkpoint_store, on="file_id"))
-    result = df2.write_iceberg(iceberg_table, checkpoint=checkpoint_store)
+    result = df2.write_iceberg(iceberg_table, checkpoint=idempotent_commit)
 
-    iceberg_table.refresh()
-    assert len(iceberg_table.metadata.snapshots) == 1, "no second snapshot should land on a no-op re-run"
-
-    # The result DataFrame for an empty short-circuit is empty.
+    _assert_single_snapshot_with_key(iceberg_table, IDEMPOTENCE_KEY)
     assert result.to_pydict() == {"operation": [], "rows": [], "file_size": [], "file_name": []}
 
 
-def test_overwrite_with_checkpoint_raises(iceberg_table, checkpoint_store):
-    """`mode='overwrite'` + checkpoint is unsupported; must raise NotImplementedError."""
+def test_overwrite_with_checkpoint_raises(iceberg_table, idempotent_commit):
+    """`mode='overwrite'` + checkpoint is unsupported."""
     df = daft.from_pydict({"file_id": ["a"], "x": [1]})
     with pytest.raises(NotImplementedError, match="overwrite"):
-        df.write_iceberg(iceberg_table, mode="overwrite", checkpoint=checkpoint_store)
+        df.write_iceberg(iceberg_table, mode="overwrite", checkpoint=idempotent_commit)
 
 
 @pytest.mark.parametrize(
     "reserved_key",
-    ["daft.checkpoint-store", "daft.checkpoint-query", "daft.checkpoint-foo"],
+    ["daft.idempotence-key", "daft.idempotence-foo"],
 )
-def test_reserved_snapshot_property_key_raises(iceberg_table, checkpoint_store, reserved_key):
-    """Any user-provided `snapshot_properties` key prefixed `daft.checkpoint-` is reserved."""
+def test_reserved_snapshot_property_key_raises(iceberg_table, idempotent_commit, reserved_key):
+    """User-provided `snapshot_properties` keys prefixed `daft.idempotence-` are reserved."""
     df = daft.from_pydict({"file_id": ["a"], "x": [1]})
     with pytest.raises(ValueError, match="reserved"):
         df.write_iceberg(
             iceberg_table,
-            checkpoint=checkpoint_store,
+            checkpoint=idempotent_commit,
             snapshot_properties={reserved_key: "spoofed"},
         )
 
 
-def test_user_snapshot_properties_pass_through(iceberg_table, parquet_input, checkpoint_store):
-    """Non-reserved user snapshot_properties must reach the snapshot summary alongside daft markers."""
+@pytest.mark.parametrize(
+    "reserved_key",
+    ["daft.idempotence-key", "daft.idempotence-foo"],
+)
+def test_reserved_snapshot_property_key_raises_without_checkpoint(iceberg_table, reserved_key):
+    """The `daft.idempotence-` prefix is reserved regardless of `checkpoint=`.
+
+    A future user who lands a snapshot tagged with `daft.idempotence-key`
+    via `snapshot_properties`, then later switches to `checkpoint=...`,
+    would otherwise see "recovery silently misses my prior write". Always
+    reserving the prefix makes this impossible.
+    """
+    df = daft.from_pydict({"file_id": ["a"], "x": [1]})
+    with pytest.raises(ValueError, match="reserved"):
+        df.write_iceberg(
+            iceberg_table,
+            snapshot_properties={reserved_key: "spoofed"},
+        )
+
+
+def test_user_snapshot_properties_pass_through(iceberg_table, parquet_input, checkpoint_store, idempotent_commit):
+    """Non-reserved user snapshot_properties reach the snapshot summary alongside the marker."""
     df = daft.read_parquet(parquet_input, checkpoint=daft.CheckpointConfig(store=checkpoint_store, on="file_id"))
     df.write_iceberg(
         iceberg_table,
-        checkpoint=checkpoint_store,
+        checkpoint=idempotent_commit,
         snapshot_properties={"author": "rohit", "release": "v1"},
     )
 
-    iceberg_table.refresh()
-    summary = iceberg_table.metadata.snapshots[0].summary
-    # User props preserved.
+    summary = _assert_single_snapshot_with_key(iceberg_table, IDEMPOTENCE_KEY)
     assert summary["author"] == "rohit"
     assert summary["release"] == "v1"
-    # Daft markers also injected — user props don't displace them.
-    assert summary["daft.checkpoint-store"] == checkpoint_store.path
-    assert summary.get("daft.checkpoint-query") is not None
 
 
-def test_retry_loop_recovers_from_transient_commit_failure(iceberg_table, parquet_input, checkpoint_store):
-    """The defensive retry loop must recover from a transient commit failure.
-
-    Patch `Transaction.commit_transaction` so the first invocation raises
-    `CommitFailedException` and the second calls through to the real method.
-    The helper's retry loop should swallow attempt 1's failure, loop, and
-    commit successfully on attempt 2 — yielding exactly one snapshot.
-    """
+def test_retry_loop_recovers_from_transient_commit_failure(
+    iceberg_table, parquet_input, checkpoint_store, idempotent_commit
+):
+    """Defensive retry loop recovers from a transient commit failure."""
     original_commit = Transaction.commit_transaction
     call_count = {"n": 0}
 
@@ -360,71 +279,54 @@ def test_retry_loop_recovers_from_transient_commit_failure(iceberg_table, parque
 
     df = daft.read_parquet(parquet_input, checkpoint=daft.CheckpointConfig(store=checkpoint_store, on="file_id"))
     with patch.object(Transaction, "commit_transaction", fail_first_then_succeed):
-        df.write_iceberg(iceberg_table, checkpoint=checkpoint_store)
+        df.write_iceberg(iceberg_table, checkpoint=idempotent_commit)
 
-    # The retry loop must have actually fired — otherwise the test is vacuous.
-    assert call_count["n"] >= 2, "expected at least two commit attempts"
+    assert call_count["n"] >= 2
 
-    iceberg_table.refresh()
-    assert len(iceberg_table.metadata.snapshots) == 1, "exactly one snapshot must land despite the transient failure"
-    pending = [c for c in checkpoint_store.list_checkpoints() if c.status == CheckpointStatus.Checkpointed]
-    assert not pending, "all entries should be Committed after a successful retry"
-
-    summary = iceberg_table.metadata.snapshots[0].summary
-    assert summary["daft.checkpoint-store"] == checkpoint_store.path
+    summary = _assert_single_snapshot_with_key(iceberg_table, IDEMPOTENCE_KEY)
     assert summary.get("added-records") == "3"
+
+    pending = [c for c in checkpoint_store.list_checkpoints() if c.status == CheckpointStatus.Checkpointed]
+    assert not pending
 
     rows = daft.read_iceberg(iceberg_table).to_pydict()
     assert sorted(rows["file_id"]) == ["a", "b", "c"]
 
 
-def test_table_with_pre_existing_legacy_snapshots(iceberg_table, parquet_input, checkpoint_store):
-    """Adopting checkpoint=... on a table that already has snapshots without markers.
+def test_table_with_pre_existing_legacy_snapshots(iceberg_table, parquet_input, checkpoint_store, idempotent_commit):
+    """Adopting checkpoint=... on a table with pre-existing snapshots without the marker.
 
-    The migration path for every existing user. The recovery walk must not
-    false-positive on a legacy snapshot (which has no `daft.checkpoint-*` keys),
-    and the new write must land as a fresh snapshot on top of the existing one.
+    Recovery walk must not false-positive on legacy snapshots; new write
+    lands as a fresh snapshot on top.
     """
-    # Pre-populate the table with a plain non-checkpoint write — produces a
-    # legacy snapshot whose summary has no `daft.checkpoint-*` markers.
     legacy = daft.from_pydict({"file_id": ["x", "y"], "x": [10, 20]})
     legacy.write_iceberg(iceberg_table)
     iceberg_table.refresh()
     assert len(iceberg_table.metadata.snapshots) == 1
     legacy_summary = iceberg_table.metadata.snapshots[0].summary
-    assert legacy_summary.get("daft.checkpoint-store") is None, "legacy snapshot must not carry our markers"
+    assert legacy_summary.get("daft.idempotence-key") is None, "legacy snapshot must not carry our marker"
 
-    # Now enable checkpoint and write new data. Recovery walks history, sees
-    # the legacy snapshot with no matching markers, falls through to commit.
     df = daft.read_parquet(parquet_input, checkpoint=daft.CheckpointConfig(store=checkpoint_store, on="file_id"))
-    df.write_iceberg(iceberg_table, checkpoint=checkpoint_store)
+    df.write_iceberg(iceberg_table, checkpoint=idempotent_commit)
 
     iceberg_table.refresh()
-    assert len(iceberg_table.metadata.snapshots) == 2, (
-        "checkpoint write must land as a new snapshot on top of the legacy one"
-    )
+    snapshots = list(iceberg_table.metadata.snapshots)
+    assert len(snapshots) == 2, "checkpoint write must land as a new snapshot on top of the legacy one"
 
-    new_summary = iceberg_table.metadata.snapshots[-1].summary
-    assert new_summary["daft.checkpoint-store"] == checkpoint_store.path
+    new_summary = snapshots[-1].summary
+    assert new_summary["daft.idempotence-key"] == IDEMPOTENCE_KEY
     assert new_summary.get("added-records") == "3"
 
-    # Final table is the union: legacy {x, y} + new {a, b, c}.
     rows = daft.read_iceberg(iceberg_table).to_pydict()
     assert sorted(rows["file_id"]) == ["a", "b", "c", "x", "y"]
 
 
-def test_empty_input_on_fresh_store(iceberg_table, tmpdir, checkpoint_store):
-    """Writing an empty DataFrame on a fresh store is a clean no-op.
-
-    A scheduled pipeline whose upstream produced zero rows is normal. The
-    feature must not crash (e.g. by sealing an empty checkpoint entry that
-    was never staged), nor land a polluted empty snapshot.
-    """
+def test_empty_input_on_fresh_store(iceberg_table, tmpdir, checkpoint_store, idempotent_commit):
+    """Empty input — no Checkpointed entries, no snapshot lands."""
     import pyarrow as pa
 
     empty_path = str(tmpdir / "empty_in")
     os.makedirs(empty_path, exist_ok=True)
-    # Write a parquet with the right schema but zero rows.
     daft.from_pydict(
         {
             "file_id": pa.array([], type=pa.string()),
@@ -433,71 +335,16 @@ def test_empty_input_on_fresh_store(iceberg_table, tmpdir, checkpoint_store):
     ).write_parquet(empty_path)
 
     df = daft.read_parquet(empty_path, checkpoint=daft.CheckpointConfig(store=checkpoint_store, on="file_id"))
-    df.write_iceberg(iceberg_table, checkpoint=checkpoint_store)
+    df.write_iceberg(iceberg_table, checkpoint=idempotent_commit)
 
     iceberg_table.refresh()
     assert iceberg_table.metadata.snapshots == [], "empty input must not land a snapshot"
     pending = [c for c in checkpoint_store.list_checkpoints() if c.status == CheckpointStatus.Checkpointed]
-    assert not pending, "no Checkpointed entries should remain after an empty write"
+    assert not pending
 
 
-def test_first_write_wins_on_key_collisions(iceberg_table, tmpdir, checkpoint_store):
-    """The `on=` column is checkpoint identity, not a primary key.
-
-    Once a key is committed, subsequent rows with the same key are dropped by
-    the source filter — even if the new row's other columns differ. This
-    codifies first-write-wins semantics so a regression toward upsert-style
-    behavior would fail loudly.
-
-    Also covers duplicates within a single input: both occurrences land on
-    the first call (no within-input dedup), then both are dropped on re-run.
-    """
-    # Call 1: input has a duplicate key 'a'. Both rows must land.
-    inp1 = str(tmpdir / "in1")
-    os.makedirs(inp1, exist_ok=True)
-    daft.from_pydict({"file_id": ["a", "a", "b"], "x": [1, 2, 3]}).write_parquet(inp1)
-    daft.read_parquet(inp1, checkpoint=daft.CheckpointConfig(store=checkpoint_store, on="file_id")).write_iceberg(
-        iceberg_table, checkpoint=checkpoint_store
-    )
-    iceberg_table.refresh()
-    rows_1 = daft.read_iceberg(iceberg_table).to_pydict()
-    pairs_1 = sorted(zip(rows_1["file_id"], rows_1["x"]))
-    assert pairs_1 == [("a", 1), ("a", 2), ("b", 3)], "duplicates within one input must both land"
-
-    # Call 2: same keys 'a' and 'b' with DIFFERENT data, plus a new key 'c'.
-    # First-write-wins: a's and b's new x values are dropped, only 'c' lands.
-    inp2 = str(tmpdir / "in2")
-    os.makedirs(inp2, exist_ok=True)
-    daft.from_pydict({"file_id": ["a", "a", "b", "c"], "x": [100, 200, 300, 4]}).write_parquet(inp2)
-    daft.read_parquet(inp2, checkpoint=daft.CheckpointConfig(store=checkpoint_store, on="file_id")).write_iceberg(
-        iceberg_table, checkpoint=checkpoint_store
-    )
-
-    iceberg_table.refresh()
-    assert len(iceberg_table.metadata.snapshots) == 2
-
-    # Final table: original a, a, b rows preserved with their *first-write*
-    # x values; only c is new. A regression to upsert-semantics would replace
-    # the a rows with x=100, x=200.
-    rows_2 = daft.read_iceberg(iceberg_table).to_pydict()
-    pairs_2 = sorted(zip(rows_2["file_id"], rows_2["x"]))
-    assert pairs_2 == [("a", 1), ("a", 2), ("b", 3), ("c", 4)], f"first-write-wins violated; got {pairs_2}"
-
-
-def test_multi_partition_input_aggregates_into_single_snapshot(iceberg_table, tmpdir, checkpoint_store):
-    """Multi-partition input must aggregate per-partition entries into one snapshot.
-
-    A multi-partition input produces multiple `Checkpointed` entries — one
-    per input partition. A single `write_iceberg` call must aggregate files
-    across all of them into one snapshot, mark every entry Committed, and
-    preserve the single-query-id invariant across all entries.
-
-    The fixed 3-row / 1-data-file shape every other test uses makes the
-    "iterate all entries" code paths trivially correct. This test exercises
-    the aggregation explicitly by writing three separate parquet files into
-    the input directory; `daft.read_parquet` then sees three parquet files
-    and the Ray pipeline distributes them across input partitions.
-    """
+def test_multi_partition_aggregates_into_single_snapshot(iceberg_table, tmpdir, checkpoint_store, idempotent_commit):
+    """Multi-partition input aggregates per-partition entries into one snapshot."""
     inp_dir = str(tmpdir / "multi_in")
     os.makedirs(inp_dir, exist_ok=True)
     parts = [
@@ -510,198 +357,72 @@ def test_multi_partition_input_aggregates_into_single_snapshot(iceberg_table, tm
 
     daft.read_parquet(
         f"{inp_dir}/**", checkpoint=daft.CheckpointConfig(store=checkpoint_store, on="file_id")
-    ).write_iceberg(iceberg_table, checkpoint=checkpoint_store)
+    ).write_iceberg(iceberg_table, checkpoint=idempotent_commit)
 
-    iceberg_table.refresh()
-    assert len(iceberg_table.metadata.snapshots) == 1, "all per-partition entries must aggregate into a single snapshot"
+    summary = _assert_single_snapshot_with_key(iceberg_table, IDEMPOTENCE_KEY)
+    assert int(summary["added-records"]) == 6
+    assert int(summary["added-data-files"]) > 1
 
-    summary = iceberg_table.metadata.snapshots[0].summary
-    # All six rows must land. `added-data-files` should be > 1 — that's the
-    # whole point of this test; if the helper only committed files from the
-    # first entry it iterated, we'd see fewer files than partitions.
-    assert int(summary["added-records"]) == 6, (
-        f"all rows from all partitions must be committed; summary={dict(summary)}"
-    )
-    assert int(summary["added-data-files"]) > 1, (
-        f"expected multiple data files for a multi-partition input; summary={dict(summary)}"
-    )
+    pending = [c for c in checkpoint_store.list_checkpoints() if c.status == CheckpointStatus.Checkpointed]
+    assert not pending
 
-    # Every entry the pipeline staged must transition to Committed — a regression
-    # that marked only the first id Committed would leave the rest pending.
-    all_entries = list(checkpoint_store.list_checkpoints())
-    assert len(all_entries) > 1, "expected multiple per-partition checkpoint entries"
-    pending = [c for c in all_entries if c.status == CheckpointStatus.Checkpointed]
-    assert not pending, "every per-partition entry must be Committed after the write"
-
-    # Single-query-id invariant must hold across all entries — they were all
-    # staged by the same execution, so they all share the same query_id.
-    query_ids = {c.query_id for c in all_entries}
-    assert len(query_ids) == 1, f"all entries from one execution must share one query_id; got {query_ids}"
-
-    # Data round-trip across the union of partitions.
     rows = daft.read_iceberg(iceberg_table).to_pydict()
     assert sorted(rows["file_id"]) == ["a", "b", "c", "d", "e", "f"]
 
 
-def _write_multi_partition_input(parent_dir: str, parts: list[tuple[list[str], list[int]]]) -> str:
-    """Write each (file_ids, xs) pair as its own parquet file under `parent_dir`.
-
-    Returns a glob path suitable for `daft.read_parquet` that picks up every
-    written file as a separate input partition.
-    """
-    os.makedirs(parent_dir, exist_ok=True)
+def test_multi_partition_recovery_after_crash_between_stage_and_commit(
+    iceberg_table, tmpdir, checkpoint_store, idempotent_commit
+):
+    """Scenario B with multi-partition input — recovery aggregates across all entries."""
+    inp_dir = str(tmpdir / "multi_in")
+    os.makedirs(inp_dir, exist_ok=True)
+    parts = [(["a", "b"], [1, 2]), (["c", "d"], [3, 4]), (["e", "f"], [5, 6])]
     for i, (file_ids, xs) in enumerate(parts):
-        daft.from_pydict({"file_id": file_ids, "x": xs}).write_parquet(f"{parent_dir}/part_{i}")
-    return f"{parent_dir}/**"
+        daft.from_pydict({"file_id": file_ids, "x": xs}).write_parquet(f"{inp_dir}/part_{i}")
 
-
-def test_multi_partition_recovery_after_crash_between_stage_and_commit(iceberg_table, tmpdir, checkpoint_store):
-    """Scenario B with multi-partition input.
-
-    The single-partition Scenario B test exercises a single Checkpointed entry
-    on the recovery path. With multiple per-partition entries, the helper must
-    iterate every blob in `get_checkpointed_files()`, decode each one, and
-    aggregate the resulting DataFiles into one commit. A regression that
-    decoded only the first blob, or marked only the first id Committed, would
-    leak files and pending entries.
-    """
-    inp_glob = _write_multi_partition_input(
-        str(tmpdir / "multi_in"),
-        [(["a", "b"], [1, 2]), (["c", "d"], [3, 4]), (["e", "f"], [5, 6])],
-    )
-
-    # First call: crash between sink seal and tx.commit_transaction. Multiple
-    # per-partition entries get sealed before the patched commit raises.
-    df = daft.read_parquet(inp_glob, checkpoint=daft.CheckpointConfig(store=checkpoint_store, on="file_id"))
+    df = daft.read_parquet(f"{inp_dir}/**", checkpoint=daft.CheckpointConfig(store=checkpoint_store, on="file_id"))
     with patch.object(Transaction, "commit_transaction", side_effect=RuntimeError("simulated crash")):
         with pytest.raises(RuntimeError, match="simulated crash"):
-            df.write_iceberg(iceberg_table, checkpoint=checkpoint_store)
+            df.write_iceberg(iceberg_table, checkpoint=idempotent_commit)
 
     iceberg_table.refresh()
-    assert iceberg_table.metadata.snapshots == [], "no snapshot must land when commit raises"
+    assert iceberg_table.metadata.snapshots == []
     pending = [c for c in checkpoint_store.list_checkpoints() if c.status == CheckpointStatus.Checkpointed]
-    assert len(pending) > 1, (
-        f"expected multiple per-partition Checkpointed entries to remain after crash; got {len(pending)}"
-    )
-    crashed_query_id = pending[0].query_id
-    # All staged entries must share the run's query_id (the invariant the
-    # recovery path relies on to read it from any single entry).
-    assert all(c.query_id == crashed_query_id for c in pending), (
-        "single-query-id invariant must hold across all per-partition entries"
-    )
+    assert len(pending) > 1
 
-    # Second call: recovery aggregates files across all staged entries.
-    daft.read_parquet(inp_glob, checkpoint=daft.CheckpointConfig(store=checkpoint_store, on="file_id")).write_iceberg(
-        iceberg_table, checkpoint=checkpoint_store
-    )
+    daft.read_parquet(
+        f"{inp_dir}/**", checkpoint=daft.CheckpointConfig(store=checkpoint_store, on="file_id")
+    ).write_iceberg(iceberg_table, checkpoint=idempotent_commit)
 
-    iceberg_table.refresh()
-    assert len(iceberg_table.metadata.snapshots) == 1
-    summary = iceberg_table.metadata.snapshots[0].summary
-    assert summary["daft.checkpoint-store"] == checkpoint_store.path
-    assert summary["daft.checkpoint-query"] == crashed_query_id
-    assert int(summary["added-records"]) == 6, f"recovery must aggregate every staged entry; summary={dict(summary)}"
-    assert int(summary["added-data-files"]) > 1, "recovery must commit data files from every per-partition entry"
+    summary = _assert_single_snapshot_with_key(iceberg_table, IDEMPOTENCE_KEY)
+    assert int(summary["added-records"]) == 6
+    assert int(summary["added-data-files"]) > 1
 
-    # Every per-partition entry must transition to Committed.
-    still_pending = [c for c in checkpoint_store.list_checkpoints() if c.status == CheckpointStatus.Checkpointed]
-    assert not still_pending
+    pending_after = [c for c in checkpoint_store.list_checkpoints() if c.status == CheckpointStatus.Checkpointed]
+    assert not pending_after
 
     rows = daft.read_iceberg(iceberg_table).to_pydict()
     assert sorted(rows["file_id"]) == ["a", "b", "c", "d", "e", "f"]
 
 
-def test_multi_partition_incremental_writes(iceberg_table, tmpdir, checkpoint_store):
-    """Incremental write with multi-partition inputs on both calls.
-
-    Realistic large-ingest pattern: each call ingests many parquet files at
-    once, and the user re-runs with an overlapping superset. The source
-    filter must drop the prior call's keys per-partition, the helper must
-    aggregate per-partition entries into call 2's snapshot, and the two calls
-    must produce two snapshots with distinct query_ids.
-    """
-    # Call 1: input split across 2 parquet files → 2 partitions, all 4 rows land.
-    inp1_glob = _write_multi_partition_input(
-        str(tmpdir / "in1"),
-        [(["a", "b"], [1, 2]), (["c", "d"], [3, 4])],
-    )
-    daft.read_parquet(inp1_glob, checkpoint=daft.CheckpointConfig(store=checkpoint_store, on="file_id")).write_iceberg(
-        iceberg_table, checkpoint=checkpoint_store
-    )
-
-    iceberg_table.refresh()
-    assert len(iceberg_table.metadata.snapshots) == 1
-    summary_1 = iceberg_table.metadata.snapshots[0].summary
-    qid_1 = summary_1["daft.checkpoint-query"]
-    assert int(summary_1["added-records"]) == 4
-    assert int(summary_1["added-data-files"]) > 1, "call 1 must produce multi-file output"
-
-    # Call 2: superset across 3 parquet files. Two of the partitions overlap
-    # with call 1's keys, one is entirely new — source filter must drop the
-    # overlap, only the new rows land.
-    inp2_glob = _write_multi_partition_input(
-        str(tmpdir / "in2"),
-        [
-            (["a", "b", "g"], [1, 2, 7]),  # 'a','b' overlap; 'g' new
-            (["c", "d", "h"], [3, 4, 8]),  # 'c','d' overlap; 'h' new
-            (["i", "j"], [9, 10]),  # entirely new partition
-        ],
-    )
-    daft.read_parquet(inp2_glob, checkpoint=daft.CheckpointConfig(store=checkpoint_store, on="file_id")).write_iceberg(
-        iceberg_table, checkpoint=checkpoint_store
-    )
-
-    iceberg_table.refresh()
-    assert len(iceberg_table.metadata.snapshots) == 2
-    summary_2 = iceberg_table.metadata.snapshots[-1].summary
-    qid_2 = summary_2["daft.checkpoint-query"]
-    assert qid_1 != qid_2, "each call must have its own query_id"
-
-    # Snapshot 2 must contain only the four new rows. Filter dedup must work
-    # per-partition: each of call 2's partitions had overlap with call 1, but
-    # only the new keys (g, h, i, j) get committed.
-    assert int(summary_2["added-records"]) == 4, f"snapshot 2 must add only the new rows; summary={dict(summary_2)}"
-
-    # Final table is the union; no duplicates of {a, b, c, d}.
-    rows = daft.read_iceberg(iceberg_table).to_pydict()
-    assert sorted(rows["file_id"]) == ["a", "b", "c", "d", "g", "h", "i", "j"]
-
-
-def test_null_keys_are_deduped(iceberg_table, tmpdir, checkpoint_store):
-    """NULL values in the `on=` column are deduped on re-run.
-
-    Daft's anti-join uses NULL-equals-NULL semantics (not SQL's NULL != NULL),
-    so a NULL key gets recorded in the checkpoint store on the first run and
-    matched against on re-runs — same as any other value. This test pins the
-    behavior so a regression toward SQL-style NULL handling would fail.
-    """
-    import pyarrow as pa
-
-    inp = str(tmpdir / "null_in")
+def test_within_input_duplicate_keys_both_land(iceberg_table, tmpdir, checkpoint_store, idempotent_commit):
+    """Duplicates within a single input are not deduped — both rows land."""
+    inp = str(tmpdir / "dup_in")
     os.makedirs(inp, exist_ok=True)
-    # Two non-null keys plus one NULL.
-    daft.from_pydict(
-        {
-            "file_id": pa.array(["a", "b", None], type=pa.string()),
-            "x": pa.array([1, 2, 3], type=pa.int64()),
-        }
-    ).write_parquet(inp)
-
-    # Call 1: all three rows land.
+    daft.from_pydict({"file_id": ["a", "a", "b"], "x": [1, 2, 3]}).write_parquet(inp)
     daft.read_parquet(inp, checkpoint=daft.CheckpointConfig(store=checkpoint_store, on="file_id")).write_iceberg(
-        iceberg_table, checkpoint=checkpoint_store
+        iceberg_table, checkpoint=idempotent_commit
     )
-    iceberg_table.refresh()
-    rows_1 = daft.read_iceberg(iceberg_table).to_pydict()
-    assert len(rows_1["file_id"]) == 3
-    assert sum(1 for fid in rows_1["file_id"] if fid is None) == 1, "first run lands the single NULL-keyed row"
 
-    # Call 2: same input. Filter must drop the NULL row too — same dedup as
-    # for non-null keys.
-    daft.read_parquet(inp, checkpoint=daft.CheckpointConfig(store=checkpoint_store, on="file_id")).write_iceberg(
-        iceberg_table, checkpoint=checkpoint_store
-    )
-    iceberg_table.refresh()
-    rows_2 = daft.read_iceberg(iceberg_table).to_pydict()
-    assert len(rows_2["file_id"]) == 3, f"re-run with same input must not duplicate NULL-keyed rows; got {rows_2}"
-    assert sum(1 for fid in rows_2["file_id"] if fid is None) == 1, "NULL key must be deduped on re-run"
+    summary = _assert_single_snapshot_with_key(iceberg_table, IDEMPOTENCE_KEY)
+    assert int(summary["added-records"]) == 3
+
+    rows = daft.read_iceberg(iceberg_table).to_pydict()
+    pairs = sorted(zip(rows["file_id"], rows["x"]))
+    assert pairs == [("a", 1), ("a", 2), ("b", 3)]
+
+
+def test_idempotent_commit_rejects_empty_key(checkpoint_store):
+    """`IdempotentCommit` constructor rejects empty idempotence_key."""
+    with pytest.raises(ValueError, match="non-empty"):
+        daft.IdempotentCommit(store=checkpoint_store, idempotence_key="")


### PR DESCRIPTION
## Changes Made

`write_iceberg` gains a single optional `checkpoint: IdempotentCommit` kwarg for an idempotent commit. Each call produces exactly one Iceberg snapshot per logical commit, identified by the user-supplied `idempotence_key` written into the snapshot summary as `daft.idempotence-key`. Retries with the same key are recognized by walking the snapshot history.

```python
df.write_iceberg(
    table,
    checkpoint=daft.IdempotentCommit(store=ckpt, idempotence_key="run-1"),
)
```

`IdempotentCommit` is a frozen dataclass bundling the store and key, exported from `daft` and `daft.checkpoint`. `CheckpointStore` is unchanged — pure storage handle.

### Flow

1. Walk Iceberg snapshot history for `daft.idempotence-key == our key`. Found → previous attempt's commit already landed; mark all Checkpointed entries Committed and bail. **No pipeline run.**
2. Not found → run the pipeline. Source filter anti-joins `Committed ∪ Checkpointed` keys; SCKO + sink populate the store as new Checkpointed entries.
3. Pull files from `get_checkpointed_files()` and commit them in one transaction tagged with the idempotence key. Mark Committed.

### API contract

- `idempotence_key` must be a non-empty string (validated in `IdempotentCommit.__post_init__`).
- `snapshot_properties` keys prefixed `daft.idempotence-` raise `ValueError`. Always-reserved, regardless of whether `checkpoint=` is provided — prevents the foot-shotgun of landing a non-idempotent write tagged with the marker, then later switching to `checkpoint=` and having recovery silently miss the prior write.

### Strip — separate refactor commit

The second commit removes per-entry `query_id` from the checkpoint store and pipeline, since nothing reads it under the new design:

- \`daft-checkpoint\`: \`query_id\` removed from \`Checkpoint\`, \`Manifest\` (S3 impl), \`StagedEntry\`, \`PyCheckpoint\`, and the \`stage_keys\` / \`stage_files\` trait signatures.
- \`daft-local-execution\`: \`StageCheckpointKeysOperator\` no longer carries \`QueryID\`; \`BlockingSinkNode\`'s checkpoint tuple shrinks 4→3; \`BuilderContext.query_id\` field removed.

Observability \`query_id\` machinery (runner-side, Meter scope, notifications) is untouched — different purpose.

### Single-snapshot invariant

Every integration test of \`write_iceberg(checkpoint=...)\` asserts exactly one new snapshot tagged with the call's key. Cross-call dedup tests are dropped — under the "one logical commit per key" lifecycle, that's not this feature's scope.

## Related Issues

- Linear: DF-2021 — Idempotent \`write_iceberg(checkpoint=)\` (this PR)
- Linear: DF-2010 — Public launch readiness (parent epic)
- Design doc: \`Work/Checkpointing/Iceberg-Idempotent-Commits-Revised.md\` (in Obsidian)