### PR TITLE
fix(lance): align partitioned namespace with Lance spec

### DIFF
--- a/daft/io/lance/lance_namespace_scan.py
+++ b/daft/io/lance/lance_namespace_scan.py
@@ -105,7 +105,8 @@ def _build_partition_fields(partition_spec: dict[str, Any], namespace_schema: pa
     for field_def in partition_spec.get("fields", []):
         field_id = field_def["field_id"]
         source_ids = field_def.get("source_ids", [])
-        transform_name = field_def.get("transform", "identity")
+        transform_raw = field_def.get("transform", {"type": "identity"})
+        transform_name = transform_raw["type"] if isinstance(transform_raw, dict) else transform_raw
 
         if source_ids:
             source_idx = source_ids[0]
@@ -137,6 +138,7 @@ def _lancedb_namespace_factory_function(
     limit: int | None = None,
     partition_values: dict[str, Any] | None = None,
     partition_col_types: dict[str, str] | None = None,
+    read_version: int | None = None,
 ) -> Iterator[PyRecordBatch]:
     try:
         import lance
@@ -145,7 +147,10 @@ def _lancedb_namespace_factory_function(
             "Unable to import the `lance` package, please ensure that Daft is installed with the lance extra dependency: `pip install daft[lance]`"
         ) from e
 
-    ds = lance.dataset(ds_uri, **(open_kwargs or {}))
+    kwargs = dict(open_kwargs or {})
+    if read_version is not None:
+        kwargs["version"] = read_version
+    ds = lance.dataset(ds_uri, **kwargs)
 
     non_partition_columns = None
     if required_columns is not None:
@@ -246,9 +251,11 @@ class LanceNamespaceScanOperator(ScanOperator, SupportsPushdownFilters):
         if ns_schema_json and "fields" in ns_schema_json:
             return self._schema_from_json(ns_schema_json)
 
+        from .utils import namespace_physical_path
+
         for i in range(manifest_table.num_rows):
-            path = manifest_table.column("_dataset_path")[i].as_py()
-            ds_uri = self._namespace_uri + "/" + path
+            object_id = manifest_table.column("object_id")[i].as_py()
+            ds_uri = namespace_physical_path(self._namespace_uri, object_id)
             try:
                 import lance
 
@@ -322,6 +329,8 @@ class LanceNamespaceScanOperator(ScanOperator, SupportsPushdownFilters):
         return pushed, remaining
 
     def to_scan_tasks(self, pushdowns: PyPushdowns) -> Iterator[ScanTask]:
+        from .utils import namespace_physical_path
+
         required_columns: list[str] | None
         if pushdowns.columns is None:
             required_columns = None
@@ -337,6 +346,8 @@ class LanceNamespaceScanOperator(ScanOperator, SupportsPushdownFilters):
 
         pushed_arrow_filter = combine_filters_to_arrow(self._pushed_filters)
 
+        has_read_version = "read_version" in self._manifest_table.column_names
+
         for i in range(self._manifest_table.num_rows):
             partition_values = {}
             for field_def in self._partition_spec.get("fields", []):
@@ -349,11 +360,15 @@ class LanceNamespaceScanOperator(ScanOperator, SupportsPushdownFilters):
                 if not self._evaluate_partition_filter(pushdowns.partition_filters, partition_values):
                     continue
 
-            dataset_path = self._manifest_table.column("_dataset_path")[i].as_py()
-            ds_uri = self._namespace_uri + "/" + dataset_path
+            object_id = self._manifest_table.column("object_id")[i].as_py()
+            ds_uri = namespace_physical_path(self._namespace_uri, object_id)
+
+            read_version: int | None = None
+            if has_read_version:
+                read_version = self._manifest_table.column("read_version")[i].as_py()
 
             yield from self._create_scan_tasks_for_partition(
-                ds_uri, partition_values, required_columns, pushed_arrow_filter, pushdowns
+                ds_uri, partition_values, required_columns, pushed_arrow_filter, pushdowns, read_version
             )
 
     def _evaluate_partition_filter(self, partition_filter: PyExpr, partition_values: dict[str, Any]) -> bool:
@@ -389,11 +404,12 @@ class LanceNamespaceScanOperator(ScanOperator, SupportsPushdownFilters):
         required_columns: list[str] | None,
         pushed_arrow_filter: Optional["pa.compute.Expression"],
         pushdowns: PyPushdowns,
+        read_version: int | None = None,
     ) -> Iterator[ScanTask]:
         import lance
 
         try:
-            ds = lance.dataset(ds_uri, storage_options=self._storage_options)
+            ds = lance.dataset(ds_uri, storage_options=self._storage_options, version=read_version)
         except Exception as e:
             logger.warning("Failed to open partition dataset at %s: %s", ds_uri, e)
             return
@@ -419,6 +435,7 @@ class LanceNamespaceScanOperator(ScanOperator, SupportsPushdownFilters):
                     pushdowns.limit,
                     partition_values,
                     self._partition_col_types,
+                    read_version,
                 ),
                 schema=self._schema._schema,
                 num_rows=num_rows,

--- a/daft/io/lance/lance_namespace_scan.py
+++ b/daft/io/lance/lance_namespace_scan.py
@@ -253,7 +253,10 @@ class LanceNamespaceScanOperator(ScanOperator, SupportsPushdownFilters):
 
         from .utils import namespace_physical_path
 
+        has_object_type = "object_type" in manifest_table.column_names
         for i in range(manifest_table.num_rows):
+            if has_object_type and manifest_table.column("object_type")[i].as_py() != "table":
+                continue
             object_id = manifest_table.column("object_id")[i].as_py()
             ds_uri = namespace_physical_path(self._namespace_uri, object_id)
             try:
@@ -348,7 +351,12 @@ class LanceNamespaceScanOperator(ScanOperator, SupportsPushdownFilters):
 
         has_read_version = "read_version" in self._manifest_table.column_names
 
+        has_object_type = "object_type" in self._manifest_table.column_names
+
         for i in range(self._manifest_table.num_rows):
+            if has_object_type and self._manifest_table.column("object_type")[i].as_py() != "table":
+                continue
+
             partition_values = {}
             for field_def in self._partition_spec.get("fields", []):
                 fid = field_def["field_id"]

--- a/daft/io/lance/lance_partitioned_data_sink.py
+++ b/daft/io/lance/lance_partitioned_data_sink.py
@@ -129,8 +129,8 @@ class LancePartitionedDataSink(DataSink[list[tuple[dict[str, Any], str, list[Any
                 {
                     "field_id": spec.field_id,
                     "source_ids": [spec.source_id],
-                    "transform": spec.transform,
-                    "result_type": str(spec.result_type),
+                    "transform": {"type": spec.transform},
+                    "result_type": {"type": str(spec.result_type)},
                 }
             )
         return json.dumps({"id": 1, "fields": fields})
@@ -165,6 +165,7 @@ class LancePartitionedDataSink(DataSink[list[tuple[dict[str, Any], str, list[Any
                 "Use mode='create' to create a new partitioned dataset."
             )
         manifest_table = manifest_ds.to_table()
+        self._existing_read_versions: dict[str, int] = {}
         for i in range(manifest_table.num_rows):
             pv = {}
             for spec in self._partition_field_specs:
@@ -172,11 +173,15 @@ class LancePartitionedDataSink(DataSink[list[tuple[dict[str, Any], str, list[Any
                 if col_name in manifest_table.column_names:
                     pv[spec.field_id] = manifest_table.column(col_name)[i].as_py()
             key = _partition_key(pv)
-            path = manifest_table.column("_dataset_path")[i].as_py()
-            parts = path.split("$")
+            object_id = manifest_table.column("object_id")[i].as_py()
+            parts = object_id.split("$")
             if len(parts) >= 2:
                 self._partition_dirs[key] = parts[1]
                 self._spec_version = parts[0]
+            if "read_version" in manifest_table.column_names:
+                rv = manifest_table.column("read_version")[i].as_py()
+                if rv is not None:
+                    self._existing_read_versions[parts[1]] = rv
 
         self._existing_version = manifest_ds.version
 
@@ -185,6 +190,14 @@ class LancePartitionedDataSink(DataSink[list[tuple[dict[str, Any], str, list[Any
 
     def schema(self) -> Schema:
         return self._schema
+
+    def _object_id_for_dir(self, dir_name: str) -> str:
+        return f"{self._spec_version}${dir_name}$dataset"
+
+    def _physical_path_for_dir(self, dir_name: str) -> str:
+        from daft.io.lance.utils import namespace_physical_path
+
+        return namespace_physical_path(self._table_uri, self._object_id_for_dir(dir_name))
 
     def write(
         self, micropartitions: Iterator[MicroPartition]
@@ -202,7 +215,7 @@ class LancePartitionedDataSink(DataSink[list[tuple[dict[str, Any], str, list[Any
                     self._partition_dirs[key] = _generate_partition_dir_name()
                 dir_name = self._partition_dirs[key]
 
-                dataset_path = self._table_uri.rstrip("/") + f"/{self._spec_version}${dir_name}$dataset"
+                dataset_path = self._physical_path_for_dir(dir_name)
 
                 write_table = group_table.drop_columns(
                     [c for c in self._partition_col_names if c in group_table.column_names]
@@ -254,8 +267,9 @@ class LancePartitionedDataSink(DataSink[list[tuple[dict[str, Any], str, list[Any
                     partition_map[dir_name] = (partition_values, [])
                 partition_map[dir_name][1].extend(fragments)
 
+        partition_versions: dict[str, int] = {}
         for dir_name, (partition_values, fragments) in partition_map.items():
-            dataset_path = self._table_uri.rstrip("/") + f"/{self._spec_version}${dir_name}$dataset"
+            dataset_path = self._physical_path_for_dir(dir_name)
 
             existing_version: int | None = None
             if self._mode == "append":
@@ -267,21 +281,23 @@ class LancePartitionedDataSink(DataSink[list[tuple[dict[str, Any], str, list[Any
 
             if existing_version is not None:
                 operation = lance.LanceOperation.Append(fragments)
-                lance.LanceDataset.commit(
+                committed_ds = lance.LanceDataset.commit(
                     dataset_path,
                     operation,
                     read_version=existing_version,
                     storage_options=self._storage_options,
                 )
+                partition_versions[dir_name] = committed_ds.version
             else:
                 operation = lance.LanceOperation.Overwrite(self._data_schema, fragments)
-                lance.LanceDataset.commit(
+                committed_ds = lance.LanceDataset.commit(
                     dataset_path,
                     operation,
                     storage_options=self._storage_options,
                 )
+                partition_versions[dir_name] = committed_ds.version
 
-        self._write_manifest(lance, partition_map)
+        self._write_manifest(lance, partition_map, partition_versions)
 
         total_fragments = sum(len(frags) for _, frags in partition_map.values())
         return MicroPartition.from_pydict(
@@ -296,18 +312,20 @@ class LancePartitionedDataSink(DataSink[list[tuple[dict[str, Any], str, list[Any
         self,
         lance_module: ModuleType,
         partition_map: dict[str, tuple[dict[str, Any], list[Any]]],
+        partition_versions: dict[str, int],
     ) -> None:
         manifest_uri = self._table_uri.rstrip("/") + "/__manifest"
 
-        all_partitions: dict[str, dict[str, Any]] = {}
+        all_partitions: dict[str, tuple[dict[str, Any], int | None]] = {}
 
         if self._mode == "append":
+            existing_read_versions = getattr(self, "_existing_read_versions", {})
             try:
                 existing_ds = lance_module.dataset(manifest_uri, storage_options=self._storage_options)
                 existing_table = existing_ds.to_table()
                 for i in range(existing_table.num_rows):
-                    path = existing_table.column("_dataset_path")[i].as_py()
-                    parts = path.split("$")
+                    object_id = existing_table.column("object_id")[i].as_py()
+                    parts = object_id.split("$")
                     if len(parts) >= 2:
                         dir_name = parts[1]
                         pv: dict[str, Any] = {}
@@ -315,31 +333,51 @@ class LancePartitionedDataSink(DataSink[list[tuple[dict[str, Any], str, list[Any
                             col = f"partition_field_{spec.field_id}"
                             if col in existing_table.column_names:
                                 pv[spec.source_field] = existing_table.column(col)[i].as_py()
-                        all_partitions[dir_name] = pv
+                        rv = existing_read_versions.get(dir_name)
+                        all_partitions[dir_name] = (pv, rv)
             except (ValueError, FileNotFoundError, OSError):
                 pass
 
         for dir_name, (partition_values, _) in partition_map.items():
-            all_partitions[dir_name] = partition_values
+            all_partitions[dir_name] = (partition_values, partition_versions.get(dir_name))
 
-        columns: dict[str, list[Any]] = {"_dataset_path": []}
+        columns: dict[str, list[Any]] = {
+            "object_id": [],
+            "object_type": [],
+            "metadata": [],
+            "read_version": [],
+            "read_branch": [],
+            "read_tag": [],
+        }
         for spec in self._partition_field_specs:
             columns[f"partition_field_{spec.field_id}"] = []
 
-        for dir_name, partition_values in all_partitions.items():
-            columns["_dataset_path"].append(f"{self._spec_version}${dir_name}$dataset")
+        for dir_name, (partition_values, rv) in all_partitions.items():
+            columns["object_id"].append(self._object_id_for_dir(dir_name))
+            columns["object_type"].append("table")
+            columns["metadata"].append("{}")
+            columns["read_version"].append(rv)
+            columns["read_branch"].append(None)
+            columns["read_tag"].append(None)
             for spec in self._partition_field_specs:
                 columns[f"partition_field_{spec.field_id}"].append(partition_values.get(spec.source_field))
 
-        manifest_fields: list[pa.Field] = [pa.field("_dataset_path", pa.utf8())]
+        manifest_fields: list[pa.Field] = [
+            pa.field("object_id", pa.utf8()),
+            pa.field("object_type", pa.utf8()),
+            pa.field("metadata", pa.utf8()),
+            pa.field("read_version", pa.uint64()),
+            pa.field("read_branch", pa.utf8()),
+            pa.field("read_tag", pa.utf8()),
+        ]
         for spec in self._partition_field_specs:
             manifest_fields.append(pa.field(f"partition_field_{spec.field_id}", spec.result_type))
 
-        metadata: dict[bytes | str, bytes | str] = {
+        schema_metadata: dict[bytes | str, bytes | str] = {
             "partition_spec_v1": self._build_partition_spec_json(),
             "schema": self._build_namespace_schema_json(),
         }
-        manifest_schema = pa.schema(manifest_fields, metadata=metadata)
+        manifest_schema = pa.schema(manifest_fields, metadata=schema_metadata)
 
         arrays = []
         for field in manifest_fields:

--- a/daft/io/lance/lance_partitioned_data_sink.py
+++ b/daft/io/lance/lance_partitioned_data_sink.py
@@ -33,13 +33,9 @@ class _PartitionFieldSpec:
     result_type: pa.DataType
 
 
-def _generate_partition_dir_name() -> str:
+def _generate_random_id() -> str:
     chars = string.ascii_lowercase + string.digits
     return "".join(random.choices(chars, k=16))
-
-
-def _partition_key(values: dict[str, Any]) -> tuple[tuple[str, Any], ...]:
-    return tuple(sorted(values.items()))
 
 
 class LancePartitionedDataSink(DataSink[list[tuple[dict[str, Any], str, list[Any]]]]):
@@ -87,9 +83,15 @@ class LancePartitionedDataSink(DataSink[list[tuple[dict[str, Any], str, list[Any
 
         self._partition_field_specs = self._build_partition_field_specs()
 
-        self._partition_dirs: dict[tuple[tuple[str, Any], ...], str] = {}
-        self._spec_version = "v1"
+        self._spec_id = 1
+        self._spec_version = f"v{self._spec_id}"
         self._existing_version: int = 0
+
+        # Hierarchical namespace ID trie: maps a prefix tuple of partition
+        # values (ordered by _partition_col_names) to its random 16-char ID.
+        # e.g. (2024,) -> "abc123..." and (2024, "US") -> "def456..."
+        self._namespace_ids: dict[tuple[Any, ...], str] = {}
+        self._existing_read_versions: dict[str, int] = {}
 
         if mode == "append":
             self._load_existing_manifest(lance)
@@ -165,23 +167,30 @@ class LancePartitionedDataSink(DataSink[list[tuple[dict[str, Any], str, list[Any
                 "Use mode='create' to create a new partitioned dataset."
             )
         manifest_table = manifest_ds.to_table()
-        self._existing_read_versions: dict[str, int] = {}
+        has_read_version = "read_version" in manifest_table.column_names
+
         for i in range(manifest_table.num_rows):
-            pv = {}
-            for spec in self._partition_field_specs:
-                col_name = f"partition_field_{spec.field_id}"
-                if col_name in manifest_table.column_names:
-                    pv[spec.field_id] = manifest_table.column(col_name)[i].as_py()
-            key = _partition_key(pv)
             object_id = manifest_table.column("object_id")[i].as_py()
+            object_type = manifest_table.column("object_type")[i].as_py()
             parts = object_id.split("$")
-            if len(parts) >= 2:
-                self._partition_dirs[key] = parts[1]
-                self._spec_version = parts[0]
-            if "read_version" in manifest_table.column_names:
-                rv = manifest_table.column("read_version")[i].as_py()
-                if rv is not None:
-                    self._existing_read_versions[parts[1]] = rv
+            self._spec_version = parts[0]
+
+            if object_type == "namespace" and len(parts) >= 2:
+                # Reconstruct namespace ID trie from intermediate rows.
+                # parts = ["v1", id1, id2, ...] for namespace at depth len(parts)-1
+                depth = len(parts) - 1
+                partition_prefix = tuple(
+                    manifest_table.column(f"partition_field_{self._partition_col_names[j]}")[i].as_py()
+                    for j in range(depth)
+                )
+                self._namespace_ids[partition_prefix] = parts[depth]
+
+            elif object_type == "table":
+                table_object_id = object_id
+                if has_read_version:
+                    rv = manifest_table.column("read_version")[i].as_py()
+                    if rv is not None:
+                        self._existing_read_versions[table_object_id] = rv
 
         self._existing_version = manifest_ds.version
 
@@ -191,13 +200,20 @@ class LancePartitionedDataSink(DataSink[list[tuple[dict[str, Any], str, list[Any
     def schema(self) -> Schema:
         return self._schema
 
-    def _object_id_for_dir(self, dir_name: str) -> str:
-        return f"{self._spec_version}${dir_name}$dataset"
+    def _table_object_id(self, partition_values: dict[str, Any]) -> str:
+        segments = [self._spec_version]
+        for i in range(len(self._partition_col_names)):
+            prefix = tuple(partition_values[c] for c in self._partition_col_names[: i + 1])
+            if prefix not in self._namespace_ids:
+                self._namespace_ids[prefix] = _generate_random_id()
+            segments.append(self._namespace_ids[prefix])
+        segments.append("dataset")
+        return "$".join(segments)
 
-    def _physical_path_for_dir(self, dir_name: str) -> str:
+    def _physical_path(self, object_id: str) -> str:
         from daft.io.lance.utils import namespace_physical_path
 
-        return namespace_physical_path(self._table_uri, self._object_id_for_dir(dir_name))
+        return namespace_physical_path(self._table_uri, object_id)
 
     def write(
         self, micropartitions: Iterator[MicroPartition]
@@ -210,12 +226,8 @@ class LancePartitionedDataSink(DataSink[list[tuple[dict[str, Any], str, list[Any
             batch_results = []
 
             for partition_values, group_table in groups:
-                key = _partition_key(partition_values)
-                if key not in self._partition_dirs:
-                    self._partition_dirs[key] = _generate_partition_dir_name()
-                dir_name = self._partition_dirs[key]
-
-                dataset_path = self._physical_path_for_dir(dir_name)
+                table_oid = self._table_object_id(partition_values)
+                dataset_path = self._physical_path(table_oid)
 
                 write_table = group_table.drop_columns(
                     [c for c in self._partition_col_names if c in group_table.column_names]
@@ -228,7 +240,7 @@ class LancePartitionedDataSink(DataSink[list[tuple[dict[str, Any], str, list[Any
                     storage_options=self._storage_options,
                     **self._kwargs,
                 )
-                batch_results.append((partition_values, dir_name, fragments))
+                batch_results.append((partition_values, table_oid, fragments))
 
             yield WriteResult(
                 result=batch_results,
@@ -260,16 +272,17 @@ class LancePartitionedDataSink(DataSink[list[tuple[dict[str, Any], str, list[Any
     def finalize(self, write_results: list[WriteResult[list[tuple[dict[str, Any], str, list[Any]]]]]) -> MicroPartition:
         lance = self._import_lance()
 
+        # partition_map keyed by table object_id (e.g. "v1$abc$def$dataset")
         partition_map: dict[str, tuple[dict[str, Any], list[Any]]] = {}
         for wr in write_results:
-            for partition_values, dir_name, fragments in wr.result:
-                if dir_name not in partition_map:
-                    partition_map[dir_name] = (partition_values, [])
-                partition_map[dir_name][1].extend(fragments)
+            for partition_values, table_oid, fragments in wr.result:
+                if table_oid not in partition_map:
+                    partition_map[table_oid] = (partition_values, [])
+                partition_map[table_oid][1].extend(fragments)
 
         partition_versions: dict[str, int] = {}
-        for dir_name, (partition_values, fragments) in partition_map.items():
-            dataset_path = self._physical_path_for_dir(dir_name)
+        for table_oid, (partition_values, fragments) in partition_map.items():
+            dataset_path = self._physical_path(table_oid)
 
             existing_version: int | None = None
             if self._mode == "append":
@@ -287,7 +300,7 @@ class LancePartitionedDataSink(DataSink[list[tuple[dict[str, Any], str, list[Any
                     read_version=existing_version,
                     storage_options=self._storage_options,
                 )
-                partition_versions[dir_name] = committed_ds.version
+                partition_versions[table_oid] = committed_ds.version
             else:
                 operation = lance.LanceOperation.Overwrite(self._data_schema, fragments)
                 committed_ds = lance.LanceDataset.commit(
@@ -295,7 +308,7 @@ class LancePartitionedDataSink(DataSink[list[tuple[dict[str, Any], str, list[Any
                     operation,
                     storage_options=self._storage_options,
                 )
-                partition_versions[dir_name] = committed_ds.version
+                partition_versions[table_oid] = committed_ds.version
 
         self._write_manifest(lance, partition_map, partition_versions)
 
@@ -316,31 +329,33 @@ class LancePartitionedDataSink(DataSink[list[tuple[dict[str, Any], str, list[Any
     ) -> None:
         manifest_uri = self._table_uri.rstrip("/") + "/__manifest"
 
-        all_partitions: dict[str, tuple[dict[str, Any], int | None]] = {}
+        # Collect all table-level entries: existing (from append) + new writes.
+        # Keyed by table object_id.
+        all_tables: dict[str, tuple[dict[str, Any], int | None]] = {}
 
         if self._mode == "append":
-            existing_read_versions = getattr(self, "_existing_read_versions", {})
             try:
                 existing_ds = lance_module.dataset(manifest_uri, storage_options=self._storage_options)
                 existing_table = existing_ds.to_table()
                 for i in range(existing_table.num_rows):
-                    object_id = existing_table.column("object_id")[i].as_py()
-                    parts = object_id.split("$")
-                    if len(parts) >= 2:
-                        dir_name = parts[1]
-                        pv: dict[str, Any] = {}
-                        for spec in self._partition_field_specs:
-                            col = f"partition_field_{spec.field_id}"
-                            if col in existing_table.column_names:
-                                pv[spec.source_field] = existing_table.column(col)[i].as_py()
-                        rv = existing_read_versions.get(dir_name)
-                        all_partitions[dir_name] = (pv, rv)
+                    oid = existing_table.column("object_id")[i].as_py()
+                    otype = existing_table.column("object_type")[i].as_py()
+                    if otype != "table":
+                        continue
+                    pv: dict[str, Any] = {}
+                    for spec in self._partition_field_specs:
+                        col = f"partition_field_{spec.field_id}"
+                        if col in existing_table.column_names:
+                            pv[spec.source_field] = existing_table.column(col)[i].as_py()
+                    rv = self._existing_read_versions.get(oid)
+                    all_tables[oid] = (pv, rv)
             except (ValueError, FileNotFoundError, OSError):
                 pass
 
-        for dir_name, (partition_values, _) in partition_map.items():
-            all_partitions[dir_name] = (partition_values, partition_versions.get(dir_name))
+        for table_oid, (partition_values, _) in partition_map.items():
+            all_tables[table_oid] = (partition_values, partition_versions.get(table_oid))
 
+        # Build the full manifest with namespace + table rows.
         columns: dict[str, list[Any]] = {
             "object_id": [],
             "object_type": [],
@@ -352,15 +367,45 @@ class LancePartitionedDataSink(DataSink[list[tuple[dict[str, Any], str, list[Any
         for spec in self._partition_field_specs:
             columns[f"partition_field_{spec.field_id}"] = []
 
-        for dir_name, (partition_values, rv) in all_partitions.items():
-            columns["object_id"].append(self._object_id_for_dir(dir_name))
-            columns["object_type"].append("table")
+        def _add_row(
+            oid: str,
+            otype: str,
+            pv: dict[str, Any],
+            rv: int | None = None,
+        ) -> None:
+            columns["object_id"].append(oid)
+            columns["object_type"].append(otype)
             columns["metadata"].append("{}")
             columns["read_version"].append(rv)
             columns["read_branch"].append(None)
             columns["read_tag"].append(None)
             for spec in self._partition_field_specs:
-                columns[f"partition_field_{spec.field_id}"].append(partition_values.get(spec.source_field))
+                columns[f"partition_field_{spec.field_id}"].append(pv.get(spec.source_field))
+
+        # Root namespace row: "v1" with all partition fields NULL
+        _add_row(self._spec_version, "namespace", {})
+
+        # Collect all intermediate namespaces from the namespace_ids trie.
+        # Sort by depth so parents come before children.
+        emitted_ns: set[str] = {self._spec_version}
+        sorted_prefixes = sorted(self._namespace_ids.keys(), key=len)
+        for prefix in sorted_prefixes:
+            segments = [self._spec_version]
+            for depth in range(len(prefix)):
+                sub_prefix = prefix[: depth + 1]
+                segments.append(self._namespace_ids[sub_prefix])
+            ns_oid = "$".join(segments)
+            if ns_oid in emitted_ns:
+                continue
+            emitted_ns.add(ns_oid)
+            ns_pv: dict[str, Any] = {}
+            for j, val in enumerate(prefix):
+                ns_pv[self._partition_col_names[j]] = val
+            _add_row(ns_oid, "namespace", ns_pv)
+
+        # Table rows
+        for table_oid, (partition_values, rv) in all_tables.items():
+            _add_row(table_oid, "table", partition_values, rv)
 
         manifest_fields: list[pa.Field] = [
             pa.field("object_id", pa.utf8()),
@@ -374,7 +419,7 @@ class LancePartitionedDataSink(DataSink[list[tuple[dict[str, Any], str, list[Any
             manifest_fields.append(pa.field(f"partition_field_{spec.field_id}", spec.result_type))
 
         schema_metadata: dict[bytes | str, bytes | str] = {
-            "partition_spec_v1": self._build_partition_spec_json(),
+            f"partition_spec_{self._spec_version}": self._build_partition_spec_json(),
             "schema": self._build_namespace_schema_json(),
         }
         manifest_schema = pa.schema(manifest_fields, metadata=schema_metadata)

--- a/daft/io/lance/utils.py
+++ b/daft/io/lance/utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import zlib
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -11,6 +12,15 @@ if TYPE_CHECKING:
     from daft.dependencies import pa
 
 logger = logging.getLogger(__name__)
+
+
+def namespace_hash_prefix(object_id: str) -> str:
+    return format(zlib.crc32(object_id.encode()) & 0xFFFFFFFF, "08x")
+
+
+def namespace_physical_path(base_uri: str, object_id: str) -> str:
+    prefix = namespace_hash_prefix(object_id)
+    return base_uri.rstrip("/") + f"/{prefix}_{object_id}"
 
 
 def distribute_fragments_balanced(fragments: list[Any], fragment_group_size: int) -> list[dict[str, list[int]]]:

--- a/tests/io/lancedb/test_lance_namespace_partitioning.py
+++ b/tests/io/lancedb/test_lance_namespace_partitioning.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import json
 import os
 import tempfile
+import zlib
 
+import pyarrow as arrow_pa
 import pytest
 
 import daft
@@ -27,6 +29,14 @@ def sample_df():
     )
 
 
+def _table_rows(manifest_table: arrow_pa.Table) -> list[int]:
+    return [i for i in range(manifest_table.num_rows) if manifest_table.column("object_type")[i].as_py() == "table"]
+
+
+def _namespace_rows(manifest_table: arrow_pa.Table) -> list[int]:
+    return [i for i in range(manifest_table.num_rows) if manifest_table.column("object_type")[i].as_py() == "namespace"]
+
+
 class TestPartitionedWrite:
     def test_basic_write(self, namespace_dir, sample_df):
         result = sample_df.write_lance(namespace_dir, partition_cols=["year", "country"], mode="create")
@@ -34,24 +44,42 @@ class TestPartitionedWrite:
         assert result_dict["num_partitions"] == [4]
         assert result_dict["num_fragments"] == [4]
 
-    def test_manifest_created(self, namespace_dir, sample_df):
+    def test_manifest_schema(self, namespace_dir, sample_df):
         sample_df.write_lance(namespace_dir, partition_cols=["year", "country"], mode="create")
         import lance
 
         manifest_ds = lance.dataset(os.path.join(namespace_dir, "__manifest"))
         manifest_table = manifest_ds.to_table()
-        assert manifest_table.num_rows == 4
-        assert "object_id" in manifest_table.column_names
-        assert "object_type" in manifest_table.column_names
-        assert "metadata" in manifest_table.column_names
-        assert "read_version" in manifest_table.column_names
-        assert "read_branch" in manifest_table.column_names
-        assert "read_tag" in manifest_table.column_names
+        for col in ["object_id", "object_type", "metadata", "read_version", "read_branch", "read_tag"]:
+            assert col in manifest_table.column_names
         assert "partition_field_year" in manifest_table.column_names
         assert "partition_field_country" in manifest_table.column_names
-        for i in range(manifest_table.num_rows):
+
+    def test_manifest_namespace_hierarchy(self, namespace_dir, sample_df):
+        """With 2 partition cols and 4 unique combos, expect 11 manifest rows.
+
+        1 root ns + 2 year ns + 4 (year,country) ns + 4 tables = 11 rows.
+        """
+        sample_df.write_lance(namespace_dir, partition_cols=["year", "country"], mode="create")
+        import lance
+
+        manifest_table = lance.dataset(os.path.join(namespace_dir, "__manifest")).to_table()
+        ns_rows = _namespace_rows(manifest_table)
+        tbl_rows = _table_rows(manifest_table)
+        assert len(ns_rows) == 7
+        assert len(tbl_rows) == 4
+        assert manifest_table.num_rows == 11
+
+        # Root namespace
+        root_oids = [manifest_table.column("object_id")[i].as_py() for i in ns_rows]
+        assert "v1" in root_oids
+
+        # Table rows have read_version set and object_type == "table"
+        for i in tbl_rows:
             assert manifest_table.column("object_type")[i].as_py() == "table"
             assert manifest_table.column("read_version")[i].as_py() is not None
+            oid = manifest_table.column("object_id")[i].as_py()
+            assert oid.endswith("$dataset")
 
     def test_manifest_metadata(self, namespace_dir, sample_df):
         sample_df.write_lance(namespace_dir, partition_cols=["year", "country"], mode="create")
@@ -69,23 +97,49 @@ class TestPartitionedWrite:
             assert isinstance(field["result_type"], dict)
             assert "type" in field["result_type"]
 
-    def test_partition_dirs_are_random_base36(self, namespace_dir, sample_df):
-        import zlib
+    def test_hierarchical_object_ids(self, namespace_dir, sample_df):
+        """Two partition cols produce object_ids with 2 intermediate segments.
 
+        Format: v1$<id1>$<id2>$dataset for tables.
+        """
+        sample_df.write_lance(namespace_dir, partition_cols=["year", "country"], mode="create")
+        import lance
+
+        manifest_table = lance.dataset(os.path.join(namespace_dir, "__manifest")).to_table()
+        for i in _table_rows(manifest_table):
+            oid = manifest_table.column("object_id")[i].as_py()
+            parts = oid.split("$")
+            assert len(parts) == 4
+            assert parts[0] == "v1"
+            assert parts[3] == "dataset"
+            for seg in parts[1:3]:
+                assert len(seg) == 16
+                assert all(c in "abcdefghijklmnopqrstuvwxyz0123456789" for c in seg)
+
+    def test_shared_parent_namespaces(self, namespace_dir, sample_df):
+        """Tables sharing a year value should share the same first namespace segment."""
+        sample_df.write_lance(namespace_dir, partition_cols=["year", "country"], mode="create")
+        import lance
+
+        manifest_table = lance.dataset(os.path.join(namespace_dir, "__manifest")).to_table()
+        year_to_seg: dict[int, str] = {}
+        for i in _table_rows(manifest_table):
+            oid = manifest_table.column("object_id")[i].as_py()
+            year = manifest_table.column("partition_field_year")[i].as_py()
+            seg1 = oid.split("$")[1]
+            if year in year_to_seg:
+                assert year_to_seg[year] == seg1, f"Tables with year={year} should share first segment"
+            else:
+                year_to_seg[year] = seg1
+        assert len(year_to_seg) == 2
+
+    def test_hash_prefixed_physical_dirs(self, namespace_dir, sample_df):
         sample_df.write_lance(namespace_dir, partition_cols=["year"], mode="create")
         import lance
 
-        manifest_ds = lance.dataset(os.path.join(namespace_dir, "__manifest"))
-        manifest_table = manifest_ds.to_table()
-        for i in range(manifest_table.num_rows):
+        manifest_table = lance.dataset(os.path.join(namespace_dir, "__manifest")).to_table()
+        for i in _table_rows(manifest_table):
             object_id = manifest_table.column("object_id")[i].as_py()
-            parts = object_id.split("$")
-            assert len(parts) == 3
-            assert parts[0] == "v1"
-            assert parts[2] == "dataset"
-            dir_name = parts[1]
-            assert len(dir_name) == 16
-            assert all(c in "abcdefghijklmnopqrstuvwxyz0123456789" for c in dir_name)
             expected_hash = format(zlib.crc32(object_id.encode()) & 0xFFFFFFFF, "08x")
             physical_dir = f"{expected_hash}_{object_id}"
             assert os.path.exists(os.path.join(namespace_dir, physical_dir))
@@ -96,9 +150,9 @@ class TestPartitionedWrite:
 
         from daft.io.lance.utils import namespace_physical_path
 
-        manifest_ds = lance.dataset(os.path.join(namespace_dir, "__manifest"))
-        manifest_table = manifest_ds.to_table()
-        object_id = manifest_table.column("object_id")[0].as_py()
+        manifest_table = lance.dataset(os.path.join(namespace_dir, "__manifest")).to_table()
+        tbl_idx = _table_rows(manifest_table)[0]
+        object_id = manifest_table.column("object_id")[tbl_idx].as_py()
         ds_uri = namespace_physical_path(namespace_dir, object_id)
         partition_ds = lance.dataset(ds_uri)
         schema_names = set(partition_ds.schema.names)
@@ -111,6 +165,18 @@ class TestPartitionedWrite:
         df = daft.from_pydict({"region": ["east", "west", "east"], "val": [1, 2, 3]})
         result = df.write_lance(namespace_dir, partition_cols=["region"], mode="create")
         assert result.to_pydict()["num_partitions"] == [2]
+
+    def test_single_partition_col_object_id_depth(self, namespace_dir):
+        """Single partition col produces v1$<id>$dataset (3 segments)."""
+        df = daft.from_pydict({"region": ["east", "west", "east"], "val": [1, 2, 3]})
+        df.write_lance(namespace_dir, partition_cols=["region"], mode="create")
+        import lance
+
+        manifest_table = lance.dataset(os.path.join(namespace_dir, "__manifest")).to_table()
+        for i in _table_rows(manifest_table):
+            oid = manifest_table.column("object_id")[i].as_py()
+            parts = oid.split("$")
+            assert len(parts) == 3
 
     def test_create_mode_fails_if_exists(self, namespace_dir, sample_df):
         sample_df.write_lance(namespace_dir, partition_cols=["year"], mode="create")
@@ -134,9 +200,9 @@ class TestPartitionedWrite:
         import lance
 
         manifest = lance.dataset(os.path.join(namespace_dir, "__manifest")).to_table()
-        object_ids = manifest.column("object_id").to_pylist()
-        assert len(object_ids) == len(set(object_ids)), f"Duplicate manifest rows: {object_ids}"
-        assert manifest.num_rows == 3
+        table_oids = [manifest.column("object_id")[i].as_py() for i in _table_rows(manifest)]
+        assert len(table_oids) == len(set(table_oids)), f"Duplicate table rows: {table_oids}"
+        assert len(table_oids) == 3
 
         read_back = daft.read_lance(namespace_dir, namespace_partitioning=True).collect()
         result = read_back.to_pydict()

--- a/tests/io/lancedb/test_lance_namespace_partitioning.py
+++ b/tests/io/lancedb/test_lance_namespace_partitioning.py
@@ -41,9 +41,17 @@ class TestPartitionedWrite:
         manifest_ds = lance.dataset(os.path.join(namespace_dir, "__manifest"))
         manifest_table = manifest_ds.to_table()
         assert manifest_table.num_rows == 4
-        assert "_dataset_path" in manifest_table.column_names
+        assert "object_id" in manifest_table.column_names
+        assert "object_type" in manifest_table.column_names
+        assert "metadata" in manifest_table.column_names
+        assert "read_version" in manifest_table.column_names
+        assert "read_branch" in manifest_table.column_names
+        assert "read_tag" in manifest_table.column_names
         assert "partition_field_year" in manifest_table.column_names
         assert "partition_field_country" in manifest_table.column_names
+        for i in range(manifest_table.num_rows):
+            assert manifest_table.column("object_type")[i].as_py() == "table"
+            assert manifest_table.column("read_version")[i].as_py() is not None
 
     def test_manifest_metadata(self, namespace_dir, sample_df):
         sample_df.write_lance(namespace_dir, partition_cols=["year", "country"], mode="create")
@@ -55,31 +63,44 @@ class TestPartitionedWrite:
         spec = json.loads(metadata[b"partition_spec_v1"])
         assert spec["id"] == 1
         assert len(spec["fields"]) == 2
+        for field in spec["fields"]:
+            assert isinstance(field["transform"], dict)
+            assert "type" in field["transform"]
+            assert isinstance(field["result_type"], dict)
+            assert "type" in field["result_type"]
 
     def test_partition_dirs_are_random_base36(self, namespace_dir, sample_df):
+        import zlib
+
         sample_df.write_lance(namespace_dir, partition_cols=["year"], mode="create")
         import lance
 
         manifest_ds = lance.dataset(os.path.join(namespace_dir, "__manifest"))
         manifest_table = manifest_ds.to_table()
         for i in range(manifest_table.num_rows):
-            path = manifest_table.column("_dataset_path")[i].as_py()
-            parts = path.split("$")
+            object_id = manifest_table.column("object_id")[i].as_py()
+            parts = object_id.split("$")
             assert len(parts) == 3
             assert parts[0] == "v1"
             assert parts[2] == "dataset"
             dir_name = parts[1]
             assert len(dir_name) == 16
             assert all(c in "abcdefghijklmnopqrstuvwxyz0123456789" for c in dir_name)
+            expected_hash = format(zlib.crc32(object_id.encode()) & 0xFFFFFFFF, "08x")
+            physical_dir = f"{expected_hash}_{object_id}"
+            assert os.path.exists(os.path.join(namespace_dir, physical_dir))
 
     def test_partition_columns_stripped_from_data(self, namespace_dir, sample_df):
         sample_df.write_lance(namespace_dir, partition_cols=["year", "country"], mode="create")
         import lance
 
+        from daft.io.lance.utils import namespace_physical_path
+
         manifest_ds = lance.dataset(os.path.join(namespace_dir, "__manifest"))
         manifest_table = manifest_ds.to_table()
-        path = manifest_table.column("_dataset_path")[0].as_py()
-        partition_ds = lance.dataset(os.path.join(namespace_dir, path))
+        object_id = manifest_table.column("object_id")[0].as_py()
+        ds_uri = namespace_physical_path(namespace_dir, object_id)
+        partition_ds = lance.dataset(ds_uri)
         schema_names = set(partition_ds.schema.names)
         assert "year" not in schema_names
         assert "country" not in schema_names
@@ -113,8 +134,8 @@ class TestPartitionedWrite:
         import lance
 
         manifest = lance.dataset(os.path.join(namespace_dir, "__manifest")).to_table()
-        paths = manifest.column("_dataset_path").to_pylist()
-        assert len(paths) == len(set(paths)), f"Duplicate manifest rows: {paths}"
+        object_ids = manifest.column("object_id").to_pylist()
+        assert len(object_ids) == len(set(object_ids)), f"Duplicate manifest rows: {object_ids}"
         assert manifest.num_rows == 3
 
         read_back = daft.read_lance(namespace_dir, namespace_partitioning=True).collect()


### PR DESCRIPTION
## Changes Made

The partitioned lance read/write implementation (PR #6898) diverged from the [Lance Namespace Partitioning Spec](https://lance.org/format/namespace/partitioning-spec/). This brings it into compliance.

**Manifest table schema** — replaced the non-spec `_dataset_path` column with spec-required columns:
- `object_id` (string) — hierarchical `$`-separated namespace path
- `object_type` (string) — `"namespace"` for intermediate levels, `"table"` for leaf datasets
- `metadata` (string) — JSON-encoded properties
- `read_version` (uint64) — dataset version captured after commit for version pinning
- `read_branch` / `read_tag` (string) — nullable, reserved for future use

**Hierarchical namespace object_ids** — each partition field level gets its own random 16-char segment in the object_id. Tables sharing a partition value share the parent namespace segment. For example, with `partition_cols=["year", "country"]`:
- `v1` → root namespace
- `v1$<id_for_2024>` → year=2024 namespace
- `v1$<id_for_2024>$<id_for_US>` → (year=2024, country=US) namespace
- `v1$<id_for_2024>$<id_for_US>$dataset` → leaf table

**Intermediate namespace rows** — the manifest now contains rows for every intermediate namespace level (object_type="namespace"), not just leaf tables.

**Partition spec JSON** — changed `transform` and `result_type` from plain strings to spec-required object format: `{"type": "identity"}` instead of `"identity"`.

**Hash-prefixed physical layout** — directories are named `<crc32>_<object_id>` per spec for object store key distribution.

**Version pinning** — writer captures committed dataset version and stores it in `read_version`. Reader passes `version=read_version` to `lance.dataset()`.

## Related Issues

Follow-up to #6898.