### PR TITLE
test: re-enable Iceberg map-type round-trip test

### DIFF
--- a/tests/integration/iceberg/test_iceberg_writes.py
+++ b/tests/integration/iceberg/test_iceberg_writes.py
@@ -60,7 +60,6 @@ def test_pyiceberg_written_catalog(local_iceberg_catalog):
 
 
 @pytest.mark.integration()
-@pytest.mark.skip
 def test_daft_written_catalog(local_iceberg_catalog):
     catalog_name, local_pyiceberg_catalog = local_iceberg_catalog
     with table_written_by_daft(local_pyiceberg_catalog) as catalog_table_name:


### PR DESCRIPTION
## Changes Made

Removes @pytest.mark.skip from test_daft_written_catalog, which round-trips a map<int, string> column through df.write_iceberg(...) and reads it back via both Daft and PyIceberg.

The skip was originally added because Map-type round-trip failed at write time due to a type-conversion bug. That bug has since been fixed, and the test now passes on both runners against the full Docker stack used by CI:

DAFT_RUNNER=native pytest -m integration tests/integration/iceberg → 419 passed, 5 skipped (unrelated), 0 failed
DAFT_RUNNER=ray pytest -m integration tests/integration/iceberg → 419 passed, 5 skipped (unrelated), 0 failed

## Related Issues

Closes #2459.
