### PR TITLE
feat(iceberg): honor table-level write.target-file-size-bytes property

### DIFF
--- a/src/daft-writers/src/lib.rs
+++ b/src/daft-writers/src/lib.rs
@@ -48,6 +48,8 @@ pub use lance::make_lance_writer_factory;
 use partition::PartitionedWriterFactory;
 use physical::PhysicalWriterFactory;
 #[cfg(feature = "python")]
+use pyo3::prelude::*;
+#[cfg(feature = "python")]
 pub use sink::make_data_sink_writer_factory;
 
 pub const RETURN_PATHS_COLUMN_NAME: &str = "path";
@@ -264,27 +266,24 @@ pub fn make_catalog_writer_factory(
     // Honor Iceberg-spec table-level write properties:
     // https://iceberg.apache.org/docs/latest/configuration/#write-properties
     let (target_file_size, target_row_group_size) = match catalog_info {
-        daft_logical_plan::CatalogType::Iceberg(info) => {
-            use pyo3::prelude::*;
-            Python::attach(|py| {
-                let props = info.iceberg_properties.bind(py);
-                let read = |key: &str, default: usize| {
-                    props
-                        .get_item(key)
-                        .ok()
-                        .and_then(|v| v.extract::<String>().ok())
-                        .and_then(|s| s.parse().ok())
-                        .unwrap_or(default)
-                };
-                (
-                    read("write.target-file-size-bytes", cfg.parquet_target_filesize),
-                    read(
-                        "write.parquet.row-group-size-bytes",
-                        cfg.parquet_target_row_group_size,
-                    ),
-                )
-            })
-        }
+        daft_logical_plan::CatalogType::Iceberg(info) => Python::attach(|py| {
+            let props = info.iceberg_properties.bind(py);
+            let read = |key: &str, default: usize| {
+                props
+                    .get_item(key)
+                    .ok()
+                    .and_then(|v| v.extract::<String>().ok())
+                    .and_then(|s| s.parse::<usize>().ok().filter(|&v| v > 0))
+                    .unwrap_or(default)
+            };
+            (
+                read("write.target-file-size-bytes", cfg.parquet_target_filesize),
+                read(
+                    "write.parquet.row-group-size-bytes",
+                    cfg.parquet_target_row_group_size,
+                ),
+            )
+        }),
         _ => (
             cfg.parquet_target_filesize,
             cfg.parquet_target_row_group_size,

--- a/src/daft-writers/src/lib.rs
+++ b/src/daft-writers/src/lib.rs
@@ -261,15 +261,40 @@ pub fn make_catalog_writer_factory(
 
     let base_writer_factory = CatalogWriterFactory::new(catalog_info.clone());
 
-    let file_size_calculator = TargetInMemorySizeBytesCalculator::new(
-        cfg.parquet_target_filesize,
-        cfg.parquet_inflation_factor,
-    );
-    let row_group_size_calculator = TargetInMemorySizeBytesCalculator::new(
-        min(
-            cfg.parquet_target_row_group_size,
+    // Honor Iceberg-spec table-level write properties:
+    // https://iceberg.apache.org/docs/latest/configuration/#write-properties
+    let (target_file_size, target_row_group_size) = match catalog_info {
+        daft_logical_plan::CatalogType::Iceberg(info) => {
+            use pyo3::prelude::*;
+            Python::attach(|py| {
+                let props = info.iceberg_properties.bind(py);
+                let read = |key: &str, default: usize| {
+                    props
+                        .get_item(key)
+                        .ok()
+                        .and_then(|v| v.extract::<String>().ok())
+                        .and_then(|s| s.parse().ok())
+                        .unwrap_or(default)
+                };
+                (
+                    read("write.target-file-size-bytes", cfg.parquet_target_filesize),
+                    read(
+                        "write.parquet.row-group-size-bytes",
+                        cfg.parquet_target_row_group_size,
+                    ),
+                )
+            })
+        }
+        _ => (
             cfg.parquet_target_filesize,
+            cfg.parquet_target_row_group_size,
         ),
+    };
+
+    let file_size_calculator =
+        TargetInMemorySizeBytesCalculator::new(target_file_size, cfg.parquet_inflation_factor);
+    let row_group_size_calculator = TargetInMemorySizeBytesCalculator::new(
+        min(target_row_group_size, target_file_size),
         cfg.parquet_inflation_factor,
     );
     let row_group_writer_factory = TargetBatchWriterFactory::new(

--- a/tests/integration/iceberg/test_iceberg_writes.py
+++ b/tests/integration/iceberg/test_iceberg_writes.py
@@ -125,3 +125,24 @@ def test_daft_custom_location(local_iceberg_catalog):
             assert file_path.startswith(custom_data_location), f"File found outside custom location: {file_path}"
     finally:
         local_pyiceberg_catalog.drop_table(table_name)
+
+
+@pytest.mark.integration()
+def test_write_iceberg_target_file_size(local_iceberg_catalog):
+    """write_iceberg respects the write.target-file-size-bytes table property."""
+    _, local_pyiceberg_catalog = local_iceberg_catalog
+    schema = pa.schema([("x", pa.int64())])
+    arrow_table = pa.Table.from_pydict({"x": list(range(1_000))}, schema=schema)
+
+    table_name = "pyiceberg.target_file_size_test"
+    try:
+        table = local_pyiceberg_catalog.create_table(
+            table_name,
+            schema=schema,
+            # 1 KB target forces the ~8 KB of data to split across multiple files.
+            properties={"write.target-file-size-bytes": "1024"},
+        )
+        files_written = daft.from_arrow(arrow_table).write_iceberg(table, mode="overwrite")
+        assert len(files_written) > 1
+    finally:
+        local_pyiceberg_catalog.drop_table(table_name)

--- a/tests/integration/iceberg/test_iceberg_writes.py
+++ b/tests/integration/iceberg/test_iceberg_writes.py
@@ -130,9 +130,10 @@ def test_daft_custom_location(local_iceberg_catalog):
 @pytest.mark.integration()
 def test_write_iceberg_target_file_size(local_iceberg_catalog):
     """write_iceberg respects the write.target-file-size-bytes table property."""
-    _, local_pyiceberg_catalog = local_iceberg_catalog
+    catalog_name, local_pyiceberg_catalog = local_iceberg_catalog
+    data = {"x": list(range(1_000))}
     schema = pa.schema([("x", pa.int64())])
-    arrow_table = pa.Table.from_pydict({"x": list(range(1_000))}, schema=schema)
+    arrow_table = pa.Table.from_pydict(data, schema=schema)
 
     table_name = "pyiceberg.target_file_size_test"
     try:
@@ -144,5 +145,8 @@ def test_write_iceberg_target_file_size(local_iceberg_catalog):
         )
         files_written = daft.from_arrow(arrow_table).write_iceberg(table, mode="overwrite")
         assert len(files_written) > 1
+
+        read_back = daft.read_table(f"{catalog_name}.{table_name}").sort("x").to_pydict()
+        assert read_back == data
     finally:
         local_pyiceberg_catalog.drop_table(table_name)


### PR DESCRIPTION
## Changes Made

`make_catalog_writer_factory` (in `src/daft-writers/src/lib.rs`) created the file-size-rotating writer using only Daft's global `parquet_target_filesize`execution config, ignoring the table-level Iceberg-spec properties:
- `write.target-file-size-bytes`
- `write.parquet.row-group-size-bytes`

This PR reads those properties from the table at writer-factory construction time, falling back to Daft's execution config when unset. Daft's defaults already match the Iceberg spec defaults (512MB / 128MB), so the fallback chain is consistent and backwards-compatible.

A new integration test (`test_write_iceberg_target_file_size`) verifies that setting `write.target-file-size-bytes=1024` on a table splits 1000 int64 rows(~8KB raw) across multiple files. 

## Related Issues

Closes #3823.
