### PR TITLE
feat(temporal): add Spark-style add_months and months_between

### DIFF
--- a/daft/functions/__init__.py
+++ b/daft/functions/__init__.py
@@ -72,6 +72,8 @@ from .datetime import (
     date_add,
     date_sub,
     date_diff,
+    add_months,
+    months_between,
     date_from_unix_date,
     timestamp_seconds,
     timestamp_millis,
@@ -274,6 +276,7 @@ from .window import (
 
 __all__ = [
     "abs",
+    "add_months",
     "any_value",
     "approx_count_distinct",
     "approx_percentiles",
@@ -439,6 +442,7 @@ __all__ = [
     "minute",
     "monotonically_increasing_id",
     "month",
+    "months_between",
     "nanosecond",
     "negate",
     "next_day",

--- a/daft/functions/datetime.py
+++ b/daft/functions/datetime.py
@@ -1353,6 +1353,61 @@ def date_diff(end: Expression, start: Expression) -> Expression:
     return Expression._call_builtin_scalar_fn("date_diff", end, start)
 
 
+def add_months(expr: Expression, months: Expression) -> Expression:
+    """Adds a number of months to a date or timestamp.
+
+    Mirrors Spark's ``add_months``: when the start day exceeds the number of days in
+    the resulting month, the result is clamped to the last day of that month. The
+    return type is always Date, even when the input is a Timestamp (the time-of-day
+    component is dropped before the shift).
+
+    Args:
+        expr: A Date or Timestamp expression.
+        months: An integer expression for the number of months to add (may be negative).
+
+    Returns:
+        Expression: a Date expression shifted by the given number of months.
+
+    Examples:
+        >>> import daft
+        >>> from daft.functions import add_months
+        >>> df = daft.from_pydict({"d": ["2023-01-31", "2024-01-31"], "n": [1, 1]})
+        >>> df = df.with_column("d", df["d"].cast(daft.DataType.date()))
+        >>> df = df.with_column("result", add_months(df["d"], df["n"]))
+        >>> df.schema()["result"].dtype == daft.DataType.date()
+        True
+    """
+    return Expression._call_builtin_scalar_fn("add_months", expr, months)
+
+
+def months_between(end: Expression, start: Expression) -> Expression:
+    """Returns the number of months between two dates or timestamps.
+
+    Mirrors Spark's ``months_between``: returns an integer when both inputs share the
+    same day-of-month or are both the last day of their respective months; otherwise
+    returns ``months_diff + (day1 - day2 + (time1 - time2)/86400) / 31`` rounded to
+    eight decimal places.
+
+    Args:
+        end: The end Date or Timestamp expression.
+        start: The start Date or Timestamp expression.
+
+    Returns:
+        Expression: a Float64 expression with the number of months (end - start).
+
+    Examples:
+        >>> import daft
+        >>> from daft.functions import months_between
+        >>> df = daft.from_pydict({"a": ["1997-02-28"], "b": ["1996-10-30"]})
+        >>> df = df.with_column("a", df["a"].cast(daft.DataType.date()))
+        >>> df = df.with_column("b", df["b"].cast(daft.DataType.date()))
+        >>> df = df.with_column("diff", months_between(df["a"], df["b"]))
+        >>> df.schema()["diff"].dtype == daft.DataType.float64()
+        True
+    """
+    return Expression._call_builtin_scalar_fn("months_between", end, start)
+
+
 def date_from_unix_date(expr: Expression) -> Expression:
     """Converts days since Unix epoch (1970-01-01) to a date.
 

--- a/src/daft-functions-temporal/src/date_arithmetic.rs
+++ b/src/daft-functions-temporal/src/date_arithmetic.rs
@@ -286,18 +286,36 @@ fn is_last_day_of_month(date: NaiveDate) -> bool {
     }
 }
 
+// Number of *complete* months between two dates, matching Java's
+// ChronoUnit.MONTHS.between semantics (truncate toward zero). The naive
+// `(year_diff * 12) + month_diff` is one too large when chrono's end-of-month
+// clamping pushes `start + m_raw months` past `end` — e.g. (2021-02-15,
+// 2020-12-30): start + 2 months clamps to 2021-02-28 which is after 2021-02-15,
+// so only 1 full month fits. The mirror case applies in the negative direction.
+fn months_diff_floor(end: NaiveDate, start: NaiveDate) -> i32 {
+    let m_raw = (end.year() - start.year()) * 12 + (end.month() as i32 - start.month() as i32);
+    match shift_months(start, m_raw) {
+        Some(shifted) if m_raw > 0 && shifted > end => m_raw - 1,
+        Some(shifted) if m_raw < 0 && shifted < end => m_raw + 1,
+        _ => m_raw,
+    }
+}
+
 fn months_between_dt(end: NaiveDateTime, start: NaiveDateTime) -> f64 {
     let end_date = end.date();
     let start_date = start.date();
 
-    let months_diff = (end_date.year() - start_date.year()) * 12
-        + (end_date.month() as i32 - start_date.month() as i32);
-
     let same_day = end_date.day() == start_date.day();
     let both_last_day = is_last_day_of_month(end_date) && is_last_day_of_month(start_date);
     if same_day || both_last_day {
-        return months_diff as f64;
+        // Both fast-path cases align with ChronoUnit.MONTHS.between, so the
+        // naive month delta is exact here.
+        let m = (end_date.year() - start_date.year()) * 12
+            + (end_date.month() as i32 - start_date.month() as i32);
+        return m as f64;
     }
+
+    let months_diff = months_diff_floor(end_date, start_date);
 
     // Seconds-of-day component (Spark normalizes time-of-day to a per-31-day fraction)
     let seconds_per_day = 86_400.0_f64;

--- a/src/daft-functions-temporal/src/date_arithmetic.rs
+++ b/src/daft-functions-temporal/src/date_arithmetic.rs
@@ -228,9 +228,7 @@ impl ScalarUDF for AddMonths {
             .iter()
             .zip(months_arr.iter())
             .map(|(opt_days, opt_months)| match (opt_days, opt_months) {
-                (Some(days), Some(m)) => {
-                    shift_months(days_to_date(days), m).map(date_to_days)
-                }
+                (Some(days), Some(m)) => shift_months(days_to_date(days), m).map(date_to_days),
                 _ => None,
             })
             .collect();
@@ -292,8 +290,8 @@ fn months_between_dt(end: NaiveDateTime, start: NaiveDateTime) -> f64 {
     let end_date = end.date();
     let start_date = start.date();
 
-    let months_diff =
-        (end_date.year() - start_date.year()) * 12 + (end_date.month() as i32 - start_date.month() as i32);
+    let months_diff = (end_date.year() - start_date.year()) * 12
+        + (end_date.month() as i32 - start_date.month() as i32);
 
     let same_day = end_date.day() == start_date.day();
     let both_last_day = is_last_day_of_month(end_date) && is_last_day_of_month(start_date);
@@ -303,10 +301,10 @@ fn months_between_dt(end: NaiveDateTime, start: NaiveDateTime) -> f64 {
 
     // Seconds-of-day component (Spark normalizes time-of-day to a per-31-day fraction)
     let seconds_per_day = 86_400.0_f64;
-    let t_end = end.num_seconds_from_midnight() as f64
-        + (end.nanosecond() as f64) / 1_000_000_000.0;
-    let t_start = start.num_seconds_from_midnight() as f64
-        + (start.nanosecond() as f64) / 1_000_000_000.0;
+    let t_end =
+        end.num_seconds_from_midnight() as f64 + (end.nanosecond() as f64) / 1_000_000_000.0;
+    let t_start =
+        start.num_seconds_from_midnight() as f64 + (start.nanosecond() as f64) / 1_000_000_000.0;
 
     let day_diff = end_date.day() as i32 - start_date.day() as i32;
     let time_diff_days = (t_end - t_start) / seconds_per_day;

--- a/src/daft-functions-temporal/src/date_arithmetic.rs
+++ b/src/daft-functions-temporal/src/date_arithmetic.rs
@@ -1,7 +1,33 @@
-use std::ops::{Add, Sub};
+use std::{
+    ops::{Add, Sub},
+    sync::Arc,
+};
 
-use daft_core::datatypes::Int32Type;
+use arrow_array::{Date32Array, Float64Array};
+use chrono::{Datelike, Months, NaiveDate, NaiveDateTime, Timelike};
+use daft_core::{datatypes::Int32Type, prelude::AsArrow};
 use daft_dsl::functions::prelude::*;
+
+const UNIX_EPOCH: NaiveDate = match NaiveDate::from_ymd_opt(1970, 1, 1) {
+    Some(d) => d,
+    None => unreachable!(),
+};
+
+fn days_to_date(days: i32) -> NaiveDate {
+    UNIX_EPOCH + chrono::Duration::days(days as i64)
+}
+
+fn date_to_days(date: NaiveDate) -> i32 {
+    date.signed_duration_since(UNIX_EPOCH).num_days() as i32
+}
+
+fn shift_months(date: NaiveDate, months: i32) -> Option<NaiveDate> {
+    if months >= 0 {
+        date.checked_add_months(Months::new(months as u32))
+    } else {
+        date.checked_sub_months(Months::new(months.unsigned_abs()))
+    }
+}
 
 // --- DateAdd ---
 
@@ -164,5 +190,205 @@ impl ScalarUDF for DateDiff {
             start_field.dtype
         );
         Ok(Field::new(end_field.name, DataType::Int32))
+    }
+}
+
+// --- AddMonths ---
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct AddMonths;
+
+#[derive(FunctionArgs)]
+struct AddMonthsArgs<T> {
+    input: T,
+    months: T,
+}
+
+#[typetag::serde]
+impl ScalarUDF for AddMonths {
+    fn name(&self) -> &'static str {
+        "add_months"
+    }
+
+    fn call(
+        &self,
+        inputs: FunctionArgs<Series>,
+        _ctx: &daft_dsl::functions::scalar::EvalContext,
+    ) -> DaftResult<Series> {
+        let AddMonthsArgs { input, months } = inputs.try_into()?;
+        let date_series = input.cast(&DataType::Date)?;
+        let months_i32 = months.cast(&DataType::Int32)?;
+        let date_arr = date_series.date()?;
+        let dates = date_arr.as_arrow()?;
+        let months_arr = months_i32
+            .downcast::<daft_core::array::DataArray<Int32Type>>()?
+            .as_arrow()?;
+
+        let values: Vec<Option<i32>> = dates
+            .iter()
+            .zip(months_arr.iter())
+            .map(|(opt_days, opt_months)| match (opt_days, opt_months) {
+                (Some(days), Some(m)) => {
+                    shift_months(days_to_date(days), m).map(date_to_days)
+                }
+                _ => None,
+            })
+            .collect();
+
+        let arrow_arr: arrow_array::ArrayRef = Arc::new(Date32Array::from(values));
+        Series::from_arrow(
+            Arc::new(Field::new(date_arr.name().to_string(), DataType::Date)),
+            arrow_arr,
+        )
+    }
+
+    fn get_return_field(
+        &self,
+        inputs: FunctionArgs<ExprRef>,
+        schema: &Schema,
+    ) -> DaftResult<Field> {
+        let AddMonthsArgs { input, months } = inputs.try_into()?;
+        let input_field = input.to_field(schema)?;
+        let months_field = months.to_field(schema)?;
+        ensure!(
+            matches!(input_field.dtype, DataType::Date | DataType::Timestamp(..)),
+            TypeError: "Expected date or timestamp input, got {}",
+            input_field.dtype
+        );
+        ensure!(
+            months_field.dtype.is_integer(),
+            TypeError: "Expected integer for months, got {}",
+            months_field.dtype
+        );
+        Ok(Field::new(input_field.name, DataType::Date))
+    }
+}
+
+// --- MonthsBetween ---
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct MonthsBetween;
+
+#[derive(FunctionArgs)]
+struct MonthsBetweenArgs<T> {
+    end_date: T,
+    start_date: T,
+}
+
+fn is_last_day_of_month(date: NaiveDate) -> bool {
+    let (year, month) = (date.year(), date.month());
+    let next_month_first = if month == 12 {
+        NaiveDate::from_ymd_opt(year + 1, 1, 1)
+    } else {
+        NaiveDate::from_ymd_opt(year, month + 1, 1)
+    };
+    match next_month_first {
+        Some(d) => date_to_days(d) - date_to_days(date) == 1,
+        None => false,
+    }
+}
+
+fn months_between_dt(end: NaiveDateTime, start: NaiveDateTime) -> f64 {
+    let end_date = end.date();
+    let start_date = start.date();
+
+    let months_diff =
+        (end_date.year() - start_date.year()) * 12 + (end_date.month() as i32 - start_date.month() as i32);
+
+    let same_day = end_date.day() == start_date.day();
+    let both_last_day = is_last_day_of_month(end_date) && is_last_day_of_month(start_date);
+    if same_day || both_last_day {
+        return months_diff as f64;
+    }
+
+    // Seconds-of-day component (Spark normalizes time-of-day to a per-31-day fraction)
+    let seconds_per_day = 86_400.0_f64;
+    let t_end = end.num_seconds_from_midnight() as f64
+        + (end.nanosecond() as f64) / 1_000_000_000.0;
+    let t_start = start.num_seconds_from_midnight() as f64
+        + (start.nanosecond() as f64) / 1_000_000_000.0;
+
+    let day_diff = end_date.day() as i32 - start_date.day() as i32;
+    let time_diff_days = (t_end - t_start) / seconds_per_day;
+
+    let raw = months_diff as f64 + (day_diff as f64 + time_diff_days) / 31.0;
+
+    // Spark rounds to 8 decimal places by default.
+    (raw * 1e8).round() / 1e8
+}
+
+#[typetag::serde]
+impl ScalarUDF for MonthsBetween {
+    fn name(&self) -> &'static str {
+        "months_between"
+    }
+
+    fn call(
+        &self,
+        inputs: FunctionArgs<Series>,
+        _ctx: &daft_dsl::functions::scalar::EvalContext,
+    ) -> DaftResult<Series> {
+        use daft_core::prelude::TimeUnit;
+
+        let MonthsBetweenArgs {
+            end_date,
+            start_date,
+        } = inputs.try_into()?;
+
+        // Cast both inputs to a tz-naive microsecond Timestamp. Casting strips the
+        // timezone label without shifting the underlying i64, so the comparison is
+        // always evaluated in UTC. Daft has no session-timezone concept, so this
+        // matches Spark when the session is UTC.
+        let ts_dtype = DataType::Timestamp(TimeUnit::Microseconds, None);
+        let end_ts = end_date.cast(&ts_dtype)?;
+        let start_ts = start_date.cast(&ts_dtype)?;
+
+        let end_ts_arr = end_ts.timestamp()?;
+        let start_ts_arr = start_ts.timestamp()?;
+        let end_arr = end_ts_arr.as_arrow()?;
+        let start_arr = start_ts_arr.as_arrow()?;
+
+        let values: Vec<Option<f64>> = end_arr
+            .iter()
+            .zip(start_arr.iter())
+            .map(|(opt_e, opt_s)| match (opt_e, opt_s) {
+                (Some(e_us), Some(s_us)) => {
+                    let e_dt = chrono::DateTime::from_timestamp_micros(e_us)?.naive_utc();
+                    let s_dt = chrono::DateTime::from_timestamp_micros(s_us)?.naive_utc();
+                    Some(months_between_dt(e_dt, s_dt))
+                }
+                _ => None,
+            })
+            .collect();
+
+        let arrow_arr: arrow_array::ArrayRef = Arc::new(Float64Array::from(values));
+        Series::from_arrow(
+            Arc::new(Field::new(end_ts_arr.name().to_string(), DataType::Float64)),
+            arrow_arr,
+        )
+    }
+
+    fn get_return_field(
+        &self,
+        inputs: FunctionArgs<ExprRef>,
+        schema: &Schema,
+    ) -> DaftResult<Field> {
+        let MonthsBetweenArgs {
+            end_date,
+            start_date,
+        } = inputs.try_into()?;
+        let end_field = end_date.to_field(schema)?;
+        let start_field = start_date.to_field(schema)?;
+        ensure!(
+            matches!(end_field.dtype, DataType::Date | DataType::Timestamp(..)),
+            TypeError: "Expected date or timestamp for end_date, got {}",
+            end_field.dtype
+        );
+        ensure!(
+            matches!(start_field.dtype, DataType::Date | DataType::Timestamp(..)),
+            TypeError: "Expected date or timestamp for start_date, got {}",
+            start_field.dtype
+        );
+        Ok(Field::new(end_field.name, DataType::Float64))
     }
 }

--- a/src/daft-functions-temporal/src/lib.rs
+++ b/src/daft-functions-temporal/src/lib.rs
@@ -19,7 +19,7 @@ use daft_dsl::{
     ExprRef,
     functions::{FunctionArgs, FunctionModule, FunctionRegistry, ScalarUDF, UnaryArg},
 };
-use date_arithmetic::{DateAdd, DateDiff, DateSub};
+use date_arithmetic::{AddMonths, DateAdd, DateDiff, DateSub, MonthsBetween};
 use date_construction::{MakeDate, MakeTimestamp, MakeTimestampLtz};
 use date_navigation::{LastDay, NextDay};
 use epoch_conversions::{
@@ -129,6 +129,8 @@ impl FunctionModule for TemporalFunctions {
         parent.add_fn(DateAdd);
         parent.add_fn(DateSub);
         parent.add_fn(DateDiff);
+        parent.add_fn(AddMonths);
+        parent.add_fn(MonthsBetween);
         parent.add_fn(DateFromUnixDate);
         parent.add_fn(TimestampSeconds);
         parent.add_fn(TimestampMillis);

--- a/src/daft-sql/src/modules/temporal.rs
+++ b/src/daft-sql/src/modules/temporal.rs
@@ -7,7 +7,7 @@ use daft_dsl::{
 };
 use daft_functions_temporal::{
     current::{CurrentDate, CurrentTimestamp, CurrentTimezone},
-    date_arithmetic::{DateAdd, DateDiff, DateSub},
+    date_arithmetic::{AddMonths, DateAdd, DateDiff, DateSub, MonthsBetween},
     date_construction::{MakeDate, MakeTimestamp, MakeTimestampLtz},
     date_navigation::{LastDay, NextDay},
     epoch_conversions::{
@@ -36,6 +36,8 @@ impl SQLModule for SQLModuleTemporal {
         parent.add_fn("date_add", SQLDateAdd);
         parent.add_fn("date_sub", SQLDateSub);
         parent.add_fn("date_diff", SQLDateDiff);
+        parent.add_fn("add_months", SQLAddMonths);
+        parent.add_fn("months_between", SQLMonthsBetween);
         parent.add_fn("date_from_unix_date", SQLDateFromUnixDate);
         parent.add_fn("timestamp_seconds", SQLTimestampSeconds);
         parent.add_fn("timestamp_millis", SQLTimestampMillis);
@@ -712,5 +714,72 @@ impl SQLFunction for SQLNextDay {
 
     fn arg_names(&self) -> &'static [&'static str] {
         &["date", "day_of_week"]
+    }
+}
+
+// --- AddMonths / MonthsBetween (Spark-style month arithmetic) ---
+
+pub struct SQLAddMonths;
+
+impl SQLFunction for SQLAddMonths {
+    fn to_expr(
+        &self,
+        inputs: &[ast::FunctionArg],
+        planner: &crate::planner::SQLPlanner,
+    ) -> SQLPlannerResult<ExprRef> {
+        if inputs.len() != 2 {
+            invalid_operation_err!("add_months expects 2 arguments, got {}", inputs.len());
+        }
+        let input = planner.plan_function_arg(&inputs[0])?.into_inner();
+        let months = planner.plan_function_arg(&inputs[1])?.into_inner();
+        Ok(BuiltinScalarFn {
+            func: BuiltinScalarFnVariant::Sync(Arc::new(AddMonths)),
+            inputs: FunctionArgs::new_unchecked(vec![
+                FunctionArg::unnamed(input),
+                FunctionArg::unnamed(months),
+            ]),
+        }
+        .into())
+    }
+
+    fn docstrings(&self, _alias: &str) -> String {
+        "Adds a number of months to a date or timestamp, clamping to the last day of the target month if needed."
+            .to_string()
+    }
+
+    fn arg_names(&self) -> &'static [&'static str] {
+        &["input", "months"]
+    }
+}
+
+pub struct SQLMonthsBetween;
+
+impl SQLFunction for SQLMonthsBetween {
+    fn to_expr(
+        &self,
+        inputs: &[ast::FunctionArg],
+        planner: &crate::planner::SQLPlanner,
+    ) -> SQLPlannerResult<ExprRef> {
+        if inputs.len() != 2 {
+            invalid_operation_err!("months_between expects 2 arguments, got {}", inputs.len());
+        }
+        let end_date = planner.plan_function_arg(&inputs[0])?.into_inner();
+        let start_date = planner.plan_function_arg(&inputs[1])?.into_inner();
+        Ok(BuiltinScalarFn {
+            func: BuiltinScalarFnVariant::Sync(Arc::new(MonthsBetween)),
+            inputs: FunctionArgs::new_unchecked(vec![
+                FunctionArg::unnamed(end_date),
+                FunctionArg::unnamed(start_date),
+            ]),
+        }
+        .into())
+    }
+
+    fn docstrings(&self, _alias: &str) -> String {
+        "Returns the number of months between two dates or timestamps as a Float64.".to_string()
+    }
+
+    fn arg_names(&self) -> &'static [&'static str] {
+        &["end_date", "start_date"]
     }
 }

--- a/tests/dataframe/test_temporals.py
+++ b/tests/dataframe/test_temporals.py
@@ -1162,8 +1162,9 @@ def test_months_between_spark_doc_example() -> None:
     assert result == pytest.approx(3.94959677, abs=1e-8)
 
 
-def test_months_between_with_time_component() -> None:
-    # Same date-of-month but different time-of-day should still yield 0 when day matches.
+def test_months_between_same_day_ignores_time_of_day() -> None:
+    # Same calendar day: the same-day fast path returns the integer month diff
+    # regardless of any time-of-day component.
     df = daft.from_pydict(
         {
             "a": [datetime(2021, 6, 15, 12, 0)],
@@ -1172,6 +1173,30 @@ def test_months_between_with_time_component() -> None:
     )
     df = df.with_column("diff", months_between(col("a"), col("b")))
     assert df.to_pydict()["diff"] == [0.0]
+
+
+def test_months_between_clamping_off_by_one() -> None:
+    # start + m_raw months clamps PAST end, so Spark counts only m_raw - 1
+    # complete months. months_between(2021-02-15, 2020-12-30):
+    #   shift_months(2020-12-30, 2) = 2021-02-28 (clamped) > 2021-02-15
+    #   so months_diff_floor = 1, day_diff = 15 - 30 = -15
+    #   result = 1 + (-15)/31 = 0.51612903
+    df = daft.from_pydict({"a": [date(2021, 2, 15)], "b": [date(2020, 12, 30)]})
+    df = df.with_column("diff", months_between(col("a"), col("b")))
+    result = df.to_pydict()["diff"][0]
+    assert result == pytest.approx(0.51612903, abs=1e-8)
+
+
+def test_months_between_negative_clamping() -> None:
+    # Mirror of the previous case in the negative direction.
+    # months_between(2020-12-30, 2021-02-15):
+    #   m_raw = -2; shift_months(2021-02-15, -2) = 2020-12-15 < 2020-12-30
+    #   so months_diff_floor = -1, day_diff = 30 - 15 = 15
+    #   result = -1 + 15/31 = -0.51612903
+    df = daft.from_pydict({"a": [date(2020, 12, 30)], "b": [date(2021, 2, 15)]})
+    df = df.with_column("diff", months_between(col("a"), col("b")))
+    result = df.to_pydict()["diff"][0]
+    assert result == pytest.approx(-0.51612903, abs=1e-8)
 
 
 def test_months_between_negative() -> None:

--- a/tests/dataframe/test_temporals.py
+++ b/tests/dataframe/test_temporals.py
@@ -1213,6 +1213,6 @@ def test_add_months_months_between_sql() -> None:
     add_result = daft.sql("SELECT add_months(start, n) as shifted FROM df").to_pydict()
     assert add_result["shifted"] == [date(2023, 2, 28)]
 
-    between_result = daft.sql("SELECT months_between(\"end\", ref) as diff FROM df").to_pydict()
+    between_result = daft.sql('SELECT months_between("end", ref) as diff FROM df').to_pydict()
     # Pure-date inputs: 4 + (28 - 30) / 31 = 3.93548387
     assert between_result["diff"][0] == pytest.approx(3.93548387, abs=1e-8)

--- a/tests/dataframe/test_temporals.py
+++ b/tests/dataframe/test_temporals.py
@@ -11,6 +11,7 @@ import pytz
 import daft
 from daft import DataType, col
 from daft.functions import (
+    add_months,
     current_date,
     current_timestamp,
     current_timezone,
@@ -23,6 +24,7 @@ from daft.functions import (
     make_date,
     make_timestamp,
     make_timestamp_ltz,
+    months_between,
     next_day,
     timestamp_micros,
     timestamp_millis,
@@ -1061,6 +1063,129 @@ def test_next_day() -> None:
     assert results["Sun"] == [date(2021, 1, 3)] * 3  # next Sun
 
 
+# --- add_months ---
+
+
+def test_add_months_basic() -> None:
+    df = daft.from_pydict(
+        {
+            "d": [date(2021, 1, 15), date(2021, 6, 1), date(2020, 12, 31)],
+            "n": [1, 6, 1],
+        }
+    )
+    df = df.with_column("result", add_months(col("d"), col("n")))
+    assert df.to_pydict()["result"] == [date(2021, 2, 15), date(2021, 12, 1), date(2021, 1, 31)]
+
+
+def test_add_months_end_of_month_clamping() -> None:
+    # Jan 31 + 1 month -> Feb 28 (non-leap)
+    # Jan 31 + 1 month -> Feb 29 (leap year 2024)
+    # Mar 31 - 1 month -> Feb 28
+    df = daft.from_pydict(
+        {
+            "d": [date(2023, 1, 31), date(2024, 1, 31), date(2023, 3, 31)],
+            "n": [1, 1, -1],
+        }
+    )
+    df = df.with_column("result", add_months(col("d"), col("n")))
+    assert df.to_pydict()["result"] == [date(2023, 2, 28), date(2024, 2, 29), date(2023, 2, 28)]
+
+
+def test_add_months_negative_and_year_rollover() -> None:
+    df = daft.from_pydict(
+        {
+            "d": [date(2021, 3, 15), date(2021, 1, 15)],
+            "n": [-5, -1],
+        }
+    )
+    df = df.with_column("result", add_months(col("d"), col("n")))
+    assert df.to_pydict()["result"] == [date(2020, 10, 15), date(2020, 12, 15)]
+
+
+def test_add_months_timestamp_input() -> None:
+    df = daft.from_pydict({"ts": [datetime(2023, 1, 31, 12, 30)], "n": [1]})
+    df = df.with_column("result", add_months(col("ts"), col("n")))
+    assert df.schema()["result"].dtype == DataType.date()
+    assert df.to_pydict()["result"] == [date(2023, 2, 28)]
+
+
+def test_add_months_null_propagation() -> None:
+    df = daft.from_pydict({"d": [date(2021, 1, 15), None, date(2021, 1, 15)], "n": [1, 1, None]})
+    df = df.with_column("result", add_months(col("d"), col("n")))
+    assert df.to_pydict()["result"] == [date(2021, 2, 15), None, None]
+
+
+# --- months_between ---
+
+
+def test_months_between_same_day_of_month() -> None:
+    df = daft.from_pydict(
+        {
+            "a": [date(2021, 6, 15), date(2022, 1, 10)],
+            "b": [date(2021, 1, 15), date(2021, 1, 10)],
+        }
+    )
+    df = df.with_column("diff", months_between(col("a"), col("b")))
+    assert df.to_pydict()["diff"] == [5.0, 12.0]
+
+
+def test_months_between_both_last_day_of_month() -> None:
+    # Last-day-to-last-day should yield an integer regardless of day count.
+    df = daft.from_pydict(
+        {
+            "a": [date(2021, 2, 28), date(2024, 2, 29)],
+            "b": [date(2021, 1, 31), date(2024, 1, 31)],
+        }
+    )
+    df = df.with_column("diff", months_between(col("a"), col("b")))
+    assert df.to_pydict()["diff"] == [1.0, 1.0]
+
+
+def test_months_between_with_day_difference() -> None:
+    # Pure date inputs: 4 months + (28-30)/31 = 3.93548387
+    df = daft.from_pydict({"a": [date(1997, 2, 28)], "b": [date(1996, 10, 30)]})
+    df = df.with_column("diff", months_between(col("a"), col("b")))
+    result = df.to_pydict()["diff"][0]
+    assert result == pytest.approx(3.93548387, abs=1e-8)
+
+
+def test_months_between_spark_doc_example() -> None:
+    # Spark docs: months_between('1997-02-28 10:30:00', '1996-10-30') = 3.94959677
+    df = daft.from_pydict(
+        {
+            "a": [datetime(1997, 2, 28, 10, 30, 0)],
+            "b": [datetime(1996, 10, 30, 0, 0, 0)],
+        }
+    )
+    df = df.with_column("diff", months_between(col("a"), col("b")))
+    result = df.to_pydict()["diff"][0]
+    assert result == pytest.approx(3.94959677, abs=1e-8)
+
+
+def test_months_between_with_time_component() -> None:
+    # Same date-of-month but different time-of-day should still yield 0 when day matches.
+    df = daft.from_pydict(
+        {
+            "a": [datetime(2021, 6, 15, 12, 0)],
+            "b": [datetime(2021, 6, 15, 0, 0)],
+        }
+    )
+    df = df.with_column("diff", months_between(col("a"), col("b")))
+    assert df.to_pydict()["diff"] == [0.0]
+
+
+def test_months_between_negative() -> None:
+    df = daft.from_pydict({"a": [date(2021, 1, 15)], "b": [date(2021, 6, 15)]})
+    df = df.with_column("diff", months_between(col("a"), col("b")))
+    assert df.to_pydict()["diff"] == [-5.0]
+
+
+def test_months_between_null_propagation() -> None:
+    df = daft.from_pydict({"a": [date(2021, 6, 15), None], "b": [None, date(2021, 1, 15)]})
+    df = df.with_column("diff", months_between(col("a"), col("b")))
+    assert df.to_pydict()["diff"] == [None, None]
+
+
 # --- SQL integration ---
 
 
@@ -1074,3 +1199,20 @@ def test_date_construction_sql() -> None:
 
     result = daft.sql("SELECT next_day(make_date(y, m, d), 'Monday') as next_d FROM df").to_pydict()
     assert result["next_d"] == [date(2021, 1, 18)]
+
+
+def test_add_months_months_between_sql() -> None:
+    df = daft.from_pydict(  # noqa: F841
+        {
+            "start": [date(2023, 1, 31)],
+            "end": [date(1997, 2, 28)],
+            "ref": [date(1996, 10, 30)],
+            "n": [1],
+        }
+    )
+    add_result = daft.sql("SELECT add_months(start, n) as shifted FROM df").to_pydict()
+    assert add_result["shifted"] == [date(2023, 2, 28)]
+
+    between_result = daft.sql("SELECT months_between(\"end\", ref) as diff FROM df").to_pydict()
+    # Pure-date inputs: 4 + (28 - 30) / 31 = 3.93548387
+    assert between_result["diff"][0] == pytest.approx(3.93548387, abs=1e-8)


### PR DESCRIPTION
## Summary

Implements two missing functions from issue #3798 by adding Spark-style `add_months` and `months_between` as native Daft temporal expressions.

This PR adds two new scalar UDFs in the temporal module, wires them through the Python and SQL surfaces, and adds regression coverage. Both functions match Spark's documented semantics, including end-of-month clamping in `add_months` and the 8-decimal rounding in `months_between`.

## Why

The issue asks for parity with PySpark's temporal functions. This PR focuses on two practical pieces:

- Calendar-month arithmetic (`add_months`) with correct end-of-month clamping.
- Spark-compatible `months_between` including the same-day / both-last-day fast paths and time-of-day fractional math.

## Changes Made

- Add `AddMonths` and `MonthsBetween` scalar UDFs in `src/daft-functions-temporal/src/date_arithmetic.rs`:
  - `AddMonths` uses `chrono::Months::checked_add_months` / `checked_sub_months` for end-of-month clamping.
  - `MonthsBetween` casts both inputs to `Timestamp(us, None)`, applies same-day / both-last-day shortcuts, and rounds to 8 decimal places.
- Register both UDFs in `src/daft-functions-temporal/src/lib.rs`.
- Add SQL handlers `SQLAddMonths` and `SQLMonthsBetween` in `src/daft-sql/src/modules/temporal.rs` with Spark argument order.
- Add Python wrappers `add_months` and `months_between` in `daft/functions/datetime.py` and export them from `daft/functions/__init__.py`.
- Add focused tests in `tests/dataframe/test_temporals.py`:
  - `add_months` coverage: basic, EOM clamping (incl. leap-year 2024-02-29), negative months, year rollover, Timestamp input, null propagation.
  - `months_between` coverage: same day-of-month, both-last-day, day-difference, time-of-day fraction, Spark doc example (`3.94959677`), negative direction, null propagation.
  - SQL integration test covering both functions.

## Behavior

- `add_months('2023-01-31', 1)` returns `2023-02-28`; `add_months('2024-01-31', 1)` returns `2024-02-29`.
- `add_months` always returns Date, even when the input is a Timestamp.
- `months_between('1997-02-28', '1996-10-30')` returns `3.93548387` (pure-date inputs).
- `months_between('1997-02-28 10:30:00', '1996-10-30')` returns `3.94959677` (Spark doc example).
- `months_between` returns an integer when both inputs share day-of-month or are both the last day of their respective months.
- Null in either input row propagates to null in the output.

## Test Plan

- `cargo check -p daft-functions-temporal -p daft-sql`
- `make build`
- `DAFT_RUNNER=native pytest -q tests/dataframe/test_temporals.py -k "add_months or months_between"`

## Related Issues

- Part of #3798