### PR TITLE
fix(paimon): use dynamic partition overwrite instead of full table delete

### DIFF
--- a/daft/io/paimon/paimon_data_sink.py
+++ b/daft/io/paimon/paimon_data_sink.py
@@ -100,6 +100,9 @@ class PaimonDataSink(DataSink[list[Any]]):
         which are incompatible with ``FileScanner.trim_and_transform_predicate``
         (expects full-table-schema indices).
         """
+        if not commit_messages:
+            return
+
         import time
 
         from pypaimon.common.predicate_builder import PredicateBuilder

--- a/daft/io/paimon/paimon_data_sink.py
+++ b/daft/io/paimon/paimon_data_sink.py
@@ -39,7 +39,7 @@ class PaimonDataSink(DataSink[list[Any]]):
 
         self._target_schema: pa.Schema = PyarrowFieldParser.from_paimon_schema(table.fields)
         self._write_builder = table.new_batch_write_builder()
-        if mode == "overwrite":
+        if mode == "overwrite" and not table.partition_keys:
             self._write_builder.overwrite({})
 
     def name(self) -> str:
@@ -91,14 +91,60 @@ class PaimonDataSink(DataSink[list[Any]]):
             rows_written=total_rows,
         )
 
-    def finalize(self, write_results: list[WriteResult[list[Any]]]) -> MicroPartition:
-        all_commit_messages = [msg for wr in write_results for msg in wr.result]
+    def _commit_dynamic_overwrite(self, commit_messages: list[Any]) -> None:
+        """Overwrite only the partitions touched by the new data.
+
+        Builds an OR-predicate covering all touched partitions, then commits
+        in a single atomic operation.  We bypass pypaimon's ``overwrite()``
+        because it builds the predicate with ``partition_keys_fields`` indices
+        which are incompatible with ``FileScanner.trim_and_transform_predicate``
+        (expects full-table-schema indices).
+        """
+        import time
+
+        from pypaimon.common.predicate_builder import PredicateBuilder
+
+        unique_partitions = {msg.partition for msg in commit_messages}
+
+        predicate_builder = PredicateBuilder(self._table.fields)
+        partition_predicates = []
+        for partition_tuple in unique_partitions:
+            partition_spec = dict(zip(self._table.partition_keys, partition_tuple))
+            sub = [predicate_builder.equal(k, v) for k, v in partition_spec.items()]
+            pred = PredicateBuilder.and_predicates(sub)
+            if pred is not None:
+                partition_predicates.append(pred)
+        partition_filter = PredicateBuilder.or_predicates(partition_predicates)
 
         table_commit = self._write_builder.new_commit()
         try:
-            table_commit.commit(all_commit_messages)
+            fsc = table_commit.file_store_commit
+            commit_id = int(time.time_ns() / 1_000_000)
+            fsc._try_commit(
+                commit_kind="OVERWRITE",
+                commit_identifier=commit_id,
+                commit_entries_plan=lambda snapshot: fsc._generate_overwrite_entries(
+                    snapshot,
+                    partition_filter,
+                    commit_messages,
+                ),
+                detect_conflicts=True,
+                allow_rollback=False,
+            )
         finally:
             table_commit.close()
+
+    def finalize(self, write_results: list[WriteResult[list[Any]]]) -> MicroPartition:
+        all_commit_messages = [msg for wr in write_results for msg in wr.result]
+
+        if self._mode == "overwrite" and self._table.partition_keys:
+            self._commit_dynamic_overwrite(all_commit_messages)
+        else:
+            table_commit = self._write_builder.new_commit()
+            try:
+                table_commit.commit(all_commit_messages)
+            finally:
+                table_commit.close()
 
         operation_label = "OVERWRITE" if self._mode == "overwrite" else "ADD"
         all_files = [f for msg in all_commit_messages for f in msg.new_files]

--- a/daft/io/paimon/paimon_data_sink.py
+++ b/daft/io/paimon/paimon_data_sink.py
@@ -103,9 +103,8 @@ class PaimonDataSink(DataSink[list[Any]]):
         if not commit_messages:
             return
 
-        import time
-
         from pypaimon.common.predicate_builder import PredicateBuilder
+        from pypaimon.write.table_commit import BATCH_COMMIT_IDENTIFIER
 
         unique_partitions = {msg.partition for msg in commit_messages}
 
@@ -122,10 +121,9 @@ class PaimonDataSink(DataSink[list[Any]]):
         table_commit = self._write_builder.new_commit()
         try:
             fsc = table_commit.file_store_commit
-            commit_id = int(time.time_ns() / 1_000_000)
             fsc._try_commit(
                 commit_kind="OVERWRITE",
-                commit_identifier=commit_id,
+                commit_identifier=BATCH_COMMIT_IDENTIFIER,
                 commit_entries_plan=lambda snapshot: fsc._generate_overwrite_entries(
                     snapshot,
                     partition_filter,

--- a/tests/io/paimon/test_paimon_write.py
+++ b/tests/io/paimon/test_paimon_write.py
@@ -106,15 +106,13 @@ def test_write_paimon_roundtrip_native_verify(append_only_table):
 # ---------------------------------------------------------------------------
 
 
-def test_write_paimon_overwrite_full(append_only_table):
-    """mode='overwrite' should replace all existing data."""
-    table, _ = append_only_table
-    initial = daft.from_pydict(
-        {"id": [1, 2], "name": ["a", "b"], "value": [1.0, 2.0], "dt": ["2024-01-01", "2024-01-01"]}
-    )
+def test_write_paimon_overwrite_full_unpartitioned(append_only_table_no_partition):
+    """mode='overwrite' on an unpartitioned table should replace all existing data."""
+    table, _ = append_only_table_no_partition
+    initial = daft.from_pydict({"id": [1, 2], "name": ["a", "b"]})
     initial.write_paimon(table)
 
-    replacement = daft.from_pydict({"id": [100], "name": ["z"], "value": [99.0], "dt": ["2024-06-01"]})
+    replacement = daft.from_pydict({"id": [100], "name": ["z"]})
     result = replacement.write_paimon(table, mode="overwrite")
     result_dict = result.to_pydict()
     assert all(op == "OVERWRITE" for op in result_dict["operation"])
@@ -122,6 +120,30 @@ def test_write_paimon_overwrite_full(append_only_table):
     final = daft.read_paimon(table).to_arrow()
     assert final.num_rows == 1
     assert final.column("id").to_pylist() == [100]
+
+
+def test_write_paimon_overwrite_dynamic_partition(append_only_table):
+    """mode='overwrite' on a partitioned table should only replace touched partitions."""
+    table, _ = append_only_table
+    initial = daft.from_pydict(
+        {
+            "id": [1, 2, 3, 4],
+            "name": ["a", "b", "c", "d"],
+            "value": [1.0, 2.0, 3.0, 4.0],
+            "dt": ["2024-01-01", "2024-01-01", "2024-01-02", "2024-01-02"],
+        }
+    )
+    initial.write_paimon(table)
+    assert daft.read_paimon(table).count_rows() == 4
+
+    replacement = daft.from_pydict({"id": [10], "name": ["x"], "value": [10.0], "dt": ["2024-01-01"]})
+    result = replacement.write_paimon(table, mode="overwrite")
+    result_dict = result.to_pydict()
+    assert all(op == "OVERWRITE" for op in result_dict["operation"])
+
+    final = daft.read_paimon(table).sort("id").to_pydict()
+    assert final["id"] == [3, 4, 10]
+    assert final["dt"] == ["2024-01-02", "2024-01-02", "2024-01-01"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Changes Made
`write_paimon(mode="overwrite")` on partitioned tables passed `overwrite({})` which deletes all partitions, not just the ones being written. 

This fix builds a correct partition-scoped predicate and commits via `file_store_commit._try_commit` directly, bypassing a latent index-mapping bug in pypaimon's `overwrite()`.
<!-- Describe what changes were made and why. Include implementation details if necessary. -->

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
