### PR TITLE
feat(lance): partitioned reads/writes per V2 + partitioning specs

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -1940,6 +1940,7 @@ class DataFrame:
         schema: Union[Schema, "pyarrow.Schema"] | None = None,
         left_on: str | None = None,
         right_on: str | None = None,
+        partition_cols: list[str] | None = None,
         **kwargs: Any,
     ) -> "DataFrame":
         """Writes the DataFrame to a Lance table.
@@ -1966,6 +1967,11 @@ class DataFrame:
               - If omitted, defaults to ``"_rowaddr"``.
               - If ``right_on`` is omitted, it defaults to the value of ``left_on``.
               - The DataFrame passed to ``write_lance(mode="merge")`` must contain ``fragment_id`` and the join key column specified by ``right_on`` (or ``_rowaddr`` by default).
+          partition_cols (Optional[List[str]]): When provided, writes a partitioned Lance namespace following the
+              `Lance Partitioning Spec <https://lance.org/format/namespace/partitioning-spec/>`_. The data is split
+              into one Lance table per unique combination of partition column values, and a ``__manifest`` Lance
+              table records the namespace + table inventory along with the partition spec. Not compatible with
+              ``mode="merge"``.
           **kwargs: Additional keyword arguments to pass to the Lance writer.
 
         Returns:
@@ -2045,6 +2051,22 @@ class DataFrame:
             )
 
         # File-based Lance table (existing logic)
+        if partition_cols is not None:
+            if mode == "merge":
+                raise ValueError("partition_cols is not supported with mode='merge'")
+            from daft.io.lance.lance_partitioned_data_sink import LancePartitionedDataSink
+
+            sanitized_kwargs = {k: v for k, v in kwargs.items() if k not in ("left_on", "right_on")}
+            part_sink = LancePartitionedDataSink(
+                uri,
+                schema,
+                mode,
+                io_config,
+                partition_cols=partition_cols,
+                **sanitized_kwargs,
+            )
+            return self.write_sink(part_sink)
+
         # Non-merge modes do not support schema evolution or custom join keys
         if mode != "merge":
             sanitized_kwargs = {k: v for k, v in kwargs.items() if k not in ("left_on", "right_on")}

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -1967,11 +1967,17 @@ class DataFrame:
               - If omitted, defaults to ``"_rowaddr"``.
               - If ``right_on`` is omitted, it defaults to the value of ``left_on``.
               - The DataFrame passed to ``write_lance(mode="merge")`` must contain ``fragment_id`` and the join key column specified by ``right_on`` (or ``_rowaddr`` by default).
-          partition_cols (Optional[List[str]]): When provided, writes a partitioned Lance namespace following the
-              `Lance Partitioning Spec <https://lance.org/format/namespace/partitioning-spec/>`_. The data is split
-              into one Lance table per unique combination of partition column values, and a ``__manifest`` Lance
-              table records the namespace + table inventory along with the partition spec. Not compatible with
-              ``mode="merge"``.
+          partition_cols (Optional[List[str]]): When provided, writes (or enriches) a partitioned Lance namespace
+              following the `Lance Partitioning Spec <https://lance.org/format/namespace/partitioning-spec/>`_.
+              The data is split into one Lance table per unique combination of partition column values, and a
+              ``__manifest`` Lance table records the namespace + table inventory along with the partition spec.
+
+              With ``mode="merge"`` and ``partition_cols`` set, ``write_lance`` performs a fast-path **column merge**:
+              new columns are written as raw ``.lance`` files alongside existing data and stitched into each leaf
+              fragment's metadata — base data is never rewritten. The input DataFrame must include the partition
+              columns, ``fragment_id``, and ``_rowaddr``. Read with ``namespace_partitioning=True,
+              include_fragment_id=True, default_scan_options={"with_row_address": True}`` to surface the required
+              metadata columns.
           **kwargs: Additional keyword arguments to pass to the Lance writer.
 
         Returns:
@@ -2053,7 +2059,19 @@ class DataFrame:
         # File-based Lance table (existing logic)
         if partition_cols is not None:
             if mode == "merge":
-                raise ValueError("partition_cols is not supported with mode='merge'")
+                from daft.io.lance.lance_partitioned_merge import merge_columns_partitioned
+
+                io_config = (
+                    _context.get_context().daft_planning_config.default_io_config if io_config is None else io_config
+                )
+                storage_options = io_config_to_storage_options(io_config, str(uri))
+                return merge_columns_partitioned(
+                    self,
+                    uri,
+                    partition_cols,
+                    storage_options=storage_options,
+                )
+
             from daft.io.lance.lance_partitioned_data_sink import LancePartitionedDataSink
 
             sanitized_kwargs = {k: v for k, v in kwargs.items() if k not in ("left_on", "right_on")}

--- a/daft/io/lance/_lance.py
+++ b/daft/io/lance/_lance.py
@@ -34,6 +34,22 @@ if TYPE_CHECKING:
 LanceDataset = Any
 
 
+def _warn_ignored_namespace_args(**kwargs: Any) -> None:
+    """Warn about read_lance args that have no effect under namespace_partitioning=True.
+
+    These args target a single Lance dataset; in a partitioned namespace there
+    is no single dataset to apply them to. To keep behavior debuggable we emit
+    a warning rather than silently dropping them.
+    """
+    ignored = [name for name, value in kwargs.items() if value is not None]
+    if ignored:
+        warnings.warn(
+            f"read_lance(namespace_partitioning=True) ignores argument(s): {', '.join(sorted(ignored))}. "
+            "These options target a single Lance dataset and have no effect on a partitioned namespace.",
+            stacklevel=3,
+        )
+
+
 @PublicAPI
 def read_lance(
     uri: str | pathlib.Path,
@@ -166,10 +182,20 @@ def read_lance(
         storage_options = io_config_to_storage_options(io_config, uri_str)
 
         if namespace_partitioning:
+            _warn_ignored_namespace_args(
+                version=version,
+                asof=asof,
+                block_size=block_size,
+                commit_lock=commit_lock,
+                index_cache_size=index_cache_size,
+                metadata_cache_size_bytes=metadata_cache_size_bytes,
+            )
             lance_operator = LanceNamespaceScanOperator(
                 uri_str,
                 storage_options=storage_options,
                 fragment_group_size=fragment_group_size,
+                include_fragment_id=bool(include_fragment_id),
+                default_scan_options=default_scan_options,
             )
         else:
             ds = construct_lance_dataset(

--- a/daft/io/lance/_lance.py
+++ b/daft/io/lance/_lance.py
@@ -11,6 +11,7 @@ from daft.daft import IOConfig, ScanOperatorHandle
 from daft.dataframe import DataFrame
 from daft.io._checkpoint import attach_checkpoint
 from daft.io.lance.lance_merge_column import merge_columns_internal
+from daft.io.lance.lance_namespace_scan import LanceNamespaceScanOperator
 from daft.io.lance.lance_scan import LanceDBScanOperator
 from daft.io.lance.rest_config import LanceRestConfig, parse_lance_uri
 from daft.io.lance.rest_scan import LanceRestScanOperator
@@ -21,6 +22,7 @@ from daft.logical.builder import LogicalPlanBuilder
 if TYPE_CHECKING:
     from daft.checkpoint import CheckpointConfig
     from daft.dependencies import pa
+    from daft.io.scan import ScanOperator
 
     try:
         from lance.dataset import LanceDataset
@@ -46,6 +48,7 @@ def read_lance(
     metadata_cache_size_bytes: int | None = None,
     fragment_group_size: int | None = None,
     include_fragment_id: bool | None = None,
+    namespace_partitioning: bool = False,
     checkpoint: "CheckpointConfig | None" = None,
 ) -> DataFrame:
     """Create a DataFrame from a LanceDB table or Lance REST service.
@@ -101,6 +104,12 @@ def read_lance(
         include_fragment_id : Optional, bool
             Whether to display fragment_id.
             if you have the behavior of 'merge_columns_df' or 'write_lance(mode = 'merge')', the `include_fragment_id` must be set to True
+        namespace_partitioning : bool, optional
+            When True, treat ``uri`` as the root of a partitioned Lance namespace following the
+            `Lance Partitioning Spec <https://lance.org/format/namespace/partitioning-spec/>`_:
+            discover partition tables via the ``__manifest`` Lance table at ``uri/__manifest``
+            and push partition column filters into manifest-level pruning. The resulting
+            DataFrame's schema includes the partition columns. Defaults to False.
         checkpoint: Optional :class:`daft.CheckpointConfig` for progress tracking across runs. Bundles the
             checkpoint store, the source key column (``on=``), and optional anti-join tuning. Rows whose key
             already exists in the store are skipped on re-run. Requires the Ray runner.
@@ -140,12 +149,13 @@ def read_lance(
     uri_str = str(uri)
     uri_type, uri_info = parse_lance_uri(uri_str)
 
+    lance_operator: ScanOperator
     if uri_type == "rest":
         # REST-based Lance table
         if rest_config is None:
             raise ValueError("rest_config is required when using REST URIs (rest://namespace/table_name)")
 
-        lance_operator: LanceDBScanOperator | LanceRestScanOperator = LanceRestScanOperator(
+        lance_operator = LanceRestScanOperator(
             rest_config=rest_config,
             namespace=uri_info["namespace"],
             table_name=uri_info["table_name"],
@@ -155,21 +165,28 @@ def read_lance(
         io_config = context.get_context().daft_planning_config.default_io_config if io_config is None else io_config
         storage_options = io_config_to_storage_options(io_config, uri_str)
 
-        ds = construct_lance_dataset(
-            uri_str,
-            storage_options=storage_options,
-            version=version,
-            asof=asof,
-            block_size=block_size,
-            commit_lock=commit_lock,
-            index_cache_size=index_cache_size,
-            default_scan_options=default_scan_options,
-            metadata_cache_size_bytes=metadata_cache_size_bytes,
-        )
+        if namespace_partitioning:
+            lance_operator = LanceNamespaceScanOperator(
+                uri_str,
+                storage_options=storage_options,
+                fragment_group_size=fragment_group_size,
+            )
+        else:
+            ds = construct_lance_dataset(
+                uri_str,
+                storage_options=storage_options,
+                version=version,
+                asof=asof,
+                block_size=block_size,
+                commit_lock=commit_lock,
+                index_cache_size=index_cache_size,
+                default_scan_options=default_scan_options,
+                metadata_cache_size_bytes=metadata_cache_size_bytes,
+            )
 
-        lance_operator = LanceDBScanOperator(
-            ds, fragment_group_size=fragment_group_size, include_fragment_id=include_fragment_id
-        )
+            lance_operator = LanceDBScanOperator(
+                ds, fragment_group_size=fragment_group_size, include_fragment_id=include_fragment_id
+            )
 
     handle = ScanOperatorHandle.from_python_scan_operator(lance_operator)
     builder = LogicalPlanBuilder.from_tabular_scan(scan_operator=handle)

--- a/daft/io/lance/lance_namespace.py
+++ b/daft/io/lance/lance_namespace.py
@@ -1,0 +1,425 @@
+"""Shared helpers for Lance Partitioned Namespace support.
+
+Implements the bits of the V2 Directory Namespace and Partitioning specs that
+the partitioned write sink and namespace scan operator both need:
+
+- Manifest table column names and Arrow schema.
+- Random base36 namespace identifiers and the ``<hash>_<object_id>`` table
+  directory naming convention.
+- ``object_id`` construction (``v<N>$<id_1>$...$<id_k>[$dataset]``).
+- JSON serialization for ``partition_spec_v<N>`` and the ``schema`` metadata
+  property (the [JsonArrowSchema] format with ``lance:field_id`` per field).
+
+[JsonArrowSchema]: https://github.com/lance-format/lance-namespace/blob/main/docs/src/client/operations/models/JsonArrowSchema.md
+"""
+
+from __future__ import annotations
+
+import json
+import secrets
+import string
+from dataclasses import dataclass
+from typing import Any
+
+from daft.dependencies import pa
+
+# Manifest table column names (V2 directory base + partitioning extension).
+COL_OBJECT_ID = "object_id"
+COL_OBJECT_TYPE = "object_type"
+COL_LOCATION = "location"
+COL_METADATA = "metadata"
+COL_BASE_OBJECTS = "base_objects"
+COL_READ_VERSION = "read_version"
+COL_READ_BRANCH = "read_branch"
+COL_READ_TAG = "read_tag"
+PARTITION_FIELD_PREFIX = "partition_field_"
+
+# Object id segment constants.
+TABLE_LEAF_NAME = "dataset"
+OBJECT_ID_SEP = "$"
+
+# Object types stored in the manifest.
+OBJECT_TYPE_NAMESPACE = "namespace"
+OBJECT_TYPE_TABLE = "table"
+
+# Schema metadata keys on the __manifest table.
+METADATA_KEY_SCHEMA = "schema"
+METADATA_KEY_PARTITION_SPEC_PREFIX = "partition_spec_v"
+# JsonArrowField metadata key carrying the Lance field id.
+LANCE_FIELD_ID_KEY = "lance:field_id"
+# Field metadata key for the unenforced primary key position (composite-key position; "0" for first).
+# Used on the manifest's `object_id` column so Lance treats it as a primary key for
+# merge-insert conflict detection. Matches `LANCE_UNENFORCED_PRIMARY_KEY_POSITION` in
+# `lance-core/src/datatypes/field.rs`.
+LANCE_UNENFORCED_PRIMARY_KEY_POSITION_KEY = "lance-schema:unenforced-primary-key:position"
+
+_BASE36_ALPHABET = string.ascii_lowercase + string.digits
+
+
+@dataclass(frozen=True)
+class PartitionFieldSpec:
+    """One entry in a `partition_spec_v<N>.fields` array.
+
+    Attributes:
+        field_id: Stable string identifier for this partition field. Used as the
+            ``partition_field_{field_id}`` column suffix in the manifest.
+        source_field_name: The source column name in the user-facing schema (for
+            error messages and Daft's ``PartitionField`` source_field).
+        source_id: The ``lance:field_id`` of the source column in the namespace
+            schema. Recorded in the spec's ``source_ids`` array.
+        transform: Well-known transform name (e.g. ``"identity"``, ``"year"``).
+            The initial implementation only writes ``"identity"``.
+        result_type: Arrow type of the partition value.
+    """
+
+    field_id: str
+    source_field_name: str
+    source_id: int
+    transform: str
+    result_type: pa.DataType
+
+
+def random_namespace_id() -> str:
+    """Generate a 16-character base36 namespace identifier (a-z0-9).
+
+    Per the Partitioning spec, partition namespace names are random 16-char
+    base36 strings, giving ~83 bits of entropy so collisions are practically
+    impossible.
+    """
+    return "".join(secrets.choice(_BASE36_ALPHABET) for _ in range(16))
+
+
+def random_dir_hash() -> str:
+    """Generate the 8-char lowercase hex prefix for a leaf table directory.
+
+    The V2 directory namespace requires table directories to use the format
+    ``<hash>_<object_id>``. The hash is for object-store prefix spreading and
+    conflict prevention on create/delete/recreate; it does not need to be
+    derivable from ``object_id``.
+    """
+    return secrets.token_hex(4)
+
+
+def make_object_id(spec_version: str, ns_ids: list[str], *, is_table: bool) -> str:
+    """Construct an ``object_id`` from its segments.
+
+    Args:
+        spec_version: The spec version segment, e.g. ``"v1"``.
+        ns_ids: The list of namespace identifiers (random base36 strings) along
+            the path from the spec-version namespace to the leaf.
+        is_table: When True, append the literal ``"dataset"`` segment.
+    """
+    segments = [spec_version, *ns_ids]
+    if is_table:
+        segments.append(TABLE_LEAF_NAME)
+    return OBJECT_ID_SEP.join(segments)
+
+
+def make_location(object_id: str) -> str:
+    """Construct a relative table directory name as ``<hash>_<object_id>``.
+
+    The hash is freshly randomized on every call; callers must persist the
+    returned location into the manifest's ``location`` column so that the same
+    table is later opened at the same physical path.
+    """
+    return f"{random_dir_hash()}_{object_id}"
+
+
+def manifest_arrow_schema(
+    partition_field_specs: list[PartitionFieldSpec],
+    schema_metadata: dict[str, str] | None = None,
+) -> pa.Schema:
+    """Build the Arrow schema for the ``__manifest`` Lance table.
+
+    The columns follow the V2 directory base spec (object_id, object_type,
+    location, metadata, base_objects), plus the partitioning extension's
+    read_version / read_branch / read_tag, plus one
+    ``partition_field_{field_id}`` column per known partition field.
+    """
+    fields: list[pa.Field] = [
+        pa.field(
+            COL_OBJECT_ID,
+            pa.utf8(),
+            nullable=False,
+            metadata={LANCE_UNENFORCED_PRIMARY_KEY_POSITION_KEY: "0"},
+        ),
+        pa.field(COL_OBJECT_TYPE, pa.utf8(), nullable=False),
+        pa.field(COL_LOCATION, pa.utf8(), nullable=True),
+        pa.field(COL_METADATA, pa.utf8(), nullable=True),
+        # base_objects: List<Utf8> with inner field named "object_id" to match the
+        # reference implementation in lance-namespace-impls.
+        pa.field(
+            COL_BASE_OBJECTS,
+            pa.list_(pa.field("object_id", pa.utf8(), nullable=True)),
+            nullable=True,
+        ),
+        pa.field(COL_READ_VERSION, pa.uint64(), nullable=True),
+        pa.field(COL_READ_BRANCH, pa.utf8(), nullable=True),
+        pa.field(COL_READ_TAG, pa.utf8(), nullable=True),
+    ]
+    for spec in partition_field_specs:
+        fields.append(pa.field(f"{PARTITION_FIELD_PREFIX}{spec.field_id}", spec.result_type, nullable=True))
+
+    return pa.schema(fields, metadata=schema_metadata or {})
+
+
+# --------------------------------------------------------------------------
+# JsonArrowDataType <-> pa.DataType
+#
+# The Partitioning spec references the JsonArrowDataType model:
+#   { "type": "<type-name>", "length": <int?>, "fields": [<JsonArrowField>?] }
+#
+# We cover the data types Daft users are likely to partition on (numerics,
+# booleans, strings, binary, dates, timestamps, decimals) and a few container
+# types. Unknown / unsupported types raise so the manifest never silently
+# drops type information.
+# --------------------------------------------------------------------------
+
+_PRIMITIVE_NAME_TO_ARROW: dict[str, pa.DataType] = {
+    "bool": pa.bool_(),
+    "boolean": pa.bool_(),
+    "int8": pa.int8(),
+    "int16": pa.int16(),
+    "int32": pa.int32(),
+    "int64": pa.int64(),
+    "uint8": pa.uint8(),
+    "uint16": pa.uint16(),
+    "uint32": pa.uint32(),
+    "uint64": pa.uint64(),
+    "float16": pa.float16(),
+    "float32": pa.float32(),
+    "float64": pa.float64(),
+    "float": pa.float32(),
+    "double": pa.float64(),
+    "utf8": pa.utf8(),
+    "string": pa.utf8(),
+    "large_utf8": pa.large_utf8(),
+    "large_string": pa.large_utf8(),
+    "binary": pa.binary(),
+    "large_binary": pa.large_binary(),
+    "date32": pa.date32(),
+    "date64": pa.date64(),
+    "null": pa.null(),
+}
+
+
+def arrow_type_to_json_arrow(dtype: pa.DataType) -> dict[str, Any]:
+    """Serialize a PyArrow DataType into JsonArrowDataType form."""
+    if pa.types.is_boolean(dtype):
+        return {"type": "bool"}
+    if pa.types.is_int8(dtype):
+        return {"type": "int8"}
+    if pa.types.is_int16(dtype):
+        return {"type": "int16"}
+    if pa.types.is_int32(dtype):
+        return {"type": "int32"}
+    if pa.types.is_int64(dtype):
+        return {"type": "int64"}
+    if pa.types.is_uint8(dtype):
+        return {"type": "uint8"}
+    if pa.types.is_uint16(dtype):
+        return {"type": "uint16"}
+    if pa.types.is_uint32(dtype):
+        return {"type": "uint32"}
+    if pa.types.is_uint64(dtype):
+        return {"type": "uint64"}
+    if pa.types.is_float16(dtype):
+        return {"type": "float16"}
+    if pa.types.is_float32(dtype):
+        return {"type": "float32"}
+    if pa.types.is_float64(dtype):
+        return {"type": "float64"}
+    if pa.types.is_string(dtype):
+        return {"type": "utf8"}
+    if pa.types.is_large_string(dtype):
+        return {"type": "large_utf8"}
+    if pa.types.is_binary(dtype):
+        return {"type": "binary"}
+    if pa.types.is_large_binary(dtype):
+        return {"type": "large_binary"}
+    if pa.types.is_fixed_size_binary(dtype):
+        return {"type": "fixed_size_binary", "length": dtype.byte_width}
+    if pa.types.is_date32(dtype):
+        return {"type": "date32"}
+    if pa.types.is_date64(dtype):
+        return {"type": "date64"}
+    if pa.types.is_timestamp(dtype):
+        tz = dtype.tz
+        return {"type": f"timestamp[{dtype.unit}{(',tz=' + tz) if tz else ''}]"}
+    if pa.types.is_decimal128(dtype):
+        return {"type": f"decimal128({dtype.precision},{dtype.scale})"}
+    if pa.types.is_list(dtype):
+        return {
+            "type": "list",
+            "fields": [_arrow_field_to_json_arrow(dtype.value_field)],
+        }
+    if pa.types.is_large_list(dtype):
+        return {
+            "type": "large_list",
+            "fields": [_arrow_field_to_json_arrow(dtype.value_field)],
+        }
+    if pa.types.is_struct(dtype):
+        return {
+            "type": "struct",
+            "fields": [_arrow_field_to_json_arrow(dtype.field(i)) for i in range(dtype.num_fields)],
+        }
+    if pa.types.is_null(dtype):
+        return {"type": "null"}
+    raise ValueError(f"Cannot encode Arrow type {dtype!r} as JsonArrowDataType")
+
+
+def json_arrow_to_arrow_type(obj: dict[str, Any]) -> pa.DataType:
+    """Deserialize a JsonArrowDataType back into a PyArrow DataType."""
+    type_name = obj["type"]
+    if type_name in _PRIMITIVE_NAME_TO_ARROW:
+        return _PRIMITIVE_NAME_TO_ARROW[type_name]
+    if type_name == "fixed_size_binary":
+        return pa.binary(int(obj["length"]))
+    if type_name.startswith("timestamp["):
+        inner = type_name[len("timestamp[") : -1]
+        if ",tz=" in inner:
+            unit, tz = inner.split(",tz=", 1)
+            return pa.timestamp(unit, tz=tz)
+        return pa.timestamp(inner)
+    if type_name.startswith("decimal128("):
+        inner = type_name[len("decimal128(") : -1]
+        precision, scale = inner.split(",", 1)
+        return pa.decimal128(int(precision), int(scale))
+    if type_name == "list":
+        inner = obj["fields"][0]
+        return pa.list_(_json_arrow_to_arrow_field(inner))
+    if type_name == "large_list":
+        inner = obj["fields"][0]
+        return pa.large_list(_json_arrow_to_arrow_field(inner))
+    if type_name == "struct":
+        return pa.struct([_json_arrow_to_arrow_field(f) for f in obj["fields"]])
+    raise ValueError(f"Unsupported JsonArrowDataType: {obj!r}")
+
+
+def _arrow_field_to_json_arrow(field: pa.Field) -> dict[str, Any]:
+    out: dict[str, Any] = {
+        "name": field.name,
+        "nullable": field.nullable,
+        "type": arrow_type_to_json_arrow(field.type),
+    }
+    if field.metadata:
+        out["metadata"] = {
+            (k.decode() if isinstance(k, (bytes, bytearray)) else k): (
+                v.decode() if isinstance(v, (bytes, bytearray)) else v
+            )
+            for k, v in field.metadata.items()
+        }
+    return out
+
+
+def _json_arrow_to_arrow_field(obj: dict[str, Any]) -> pa.Field:
+    name = obj["name"]
+    dtype = json_arrow_to_arrow_type(obj["type"])
+    nullable = bool(obj.get("nullable", True))
+    metadata = obj.get("metadata")
+    return pa.field(name, dtype, nullable=nullable, metadata=metadata)
+
+
+def make_partition_spec_json(spec_id: int, fields: list[PartitionFieldSpec]) -> str:
+    """Serialize a list of `PartitionFieldSpec`s as a `partition_spec_v<N>` value."""
+    payload: dict[str, Any] = {
+        "id": spec_id,
+        "fields": [
+            {
+                "field_id": spec.field_id,
+                "source_ids": [spec.source_id],
+                "transform": {"type": spec.transform},
+                "result_type": arrow_type_to_json_arrow(spec.result_type),
+            }
+            for spec in fields
+        ],
+    }
+    return json.dumps(payload)
+
+
+def make_namespace_schema_json(arrow_schema: pa.Schema, field_ids: dict[str, int]) -> str:
+    """Serialize a namespace schema as the `schema` JSON property.
+
+    Each field carries a ``lance:field_id`` metadata entry. Field IDs are
+    immutable across a namespace's lifetime; ``field_ids`` maps column name to
+    its id.
+    """
+    out_fields: list[dict[str, Any]] = []
+    for f in arrow_schema:
+        fid = field_ids[f.name]
+        out_fields.append(
+            {
+                "name": f.name,
+                "nullable": f.nullable,
+                "type": arrow_type_to_json_arrow(f.type),
+                "metadata": {LANCE_FIELD_ID_KEY: str(fid)},
+            }
+        )
+    return json.dumps({"fields": out_fields})
+
+
+def parse_partition_spec_json(payload: str | bytes) -> dict[str, Any]:
+    """Parse a `partition_spec_v<N>` JSON value, accepting bytes or str."""
+    if isinstance(payload, (bytes, bytearray)):
+        payload = payload.decode()
+    return json.loads(payload)
+
+
+def parse_namespace_schema_json(payload: str | bytes) -> pa.Schema:
+    """Parse the `schema` JSON metadata value back into a PyArrow schema."""
+    if isinstance(payload, (bytes, bytearray)):
+        payload = payload.decode()
+    obj = json.loads(payload)
+    return pa.schema([_json_arrow_to_arrow_field(f) for f in obj["fields"]])
+
+
+def parse_object_id(object_id: str) -> tuple[str, list[str], bool]:
+    """Split an object_id into (spec_version, namespace_ids, is_table).
+
+    For ``v1$abc$def$dataset`` returns ``("v1", ["abc", "def"], True)``.
+    For ``v1$abc$def`` returns ``("v1", ["abc", "def"], False)``.
+    For ``v1`` returns ``("v1", [], False)``.
+    """
+    parts = object_id.split(OBJECT_ID_SEP)
+    if not parts:
+        raise ValueError(f"Empty object_id: {object_id!r}")
+    spec_version = parts[0]
+    rest = parts[1:]
+    is_table = bool(rest) and rest[-1] == TABLE_LEAF_NAME
+    ns_ids = rest[:-1] if is_table else rest
+    return spec_version, ns_ids, is_table
+
+
+def latest_partition_spec_key(schema_metadata: dict[Any, Any] | None) -> tuple[int, str] | None:
+    """Find the highest-numbered `partition_spec_v<N>` key in schema metadata.
+
+    Returns ``(n, key_as_str)`` for the latest spec, or ``None`` if no spec key
+    is present. ``schema_metadata`` may be a PyArrow metadata mapping with
+    either str or bytes keys.
+    """
+    if not schema_metadata:
+        return None
+    best: tuple[int, str] | None = None
+    for key in schema_metadata:
+        key_str = key.decode() if isinstance(key, (bytes, bytearray)) else key
+        if not key_str.startswith(METADATA_KEY_PARTITION_SPEC_PREFIX):
+            continue
+        try:
+            n = int(key_str[len(METADATA_KEY_PARTITION_SPEC_PREFIX) :])
+        except ValueError:
+            continue
+        if best is None or n > best[0]:
+            best = (n, key_str)
+    return best
+
+
+def get_schema_metadata_value(schema_metadata: dict[Any, Any] | None, key: str) -> bytes | str | None:
+    """Look up a metadata entry by key, tolerating both str and bytes keys."""
+    if not schema_metadata:
+        return None
+    if key in schema_metadata:
+        return schema_metadata[key]
+    key_b = key.encode()
+    if key_b in schema_metadata:
+        return schema_metadata[key_b]
+    return None

--- a/daft/io/lance/lance_namespace_scan.py
+++ b/daft/io/lance/lance_namespace_scan.py
@@ -1,0 +1,486 @@
+"""Scan operator for Lance Partitioned Namespaces.
+
+Reads ``__manifest`` to discover the partition tables, advertises partition
+columns to Daft's planner, pushes filters into both partition pruning (via the
+manifest's ``partition_field_*`` columns) and per-partition Arrow filter
+pushdown, and emits one ScanTask per fragment (or fragment group).
+"""
+
+# ruff: noqa: I002
+# isort: dont-add-import: from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+from typing import Any, Optional
+
+from daft.daft import PyExpr, PyPartitionField, PyPushdowns, PyRecordBatch, ScanTask
+from daft.datatype import DataType, _ensure_registered_super_ext_type
+from daft.dependencies import pa
+from daft.expressions import Expression
+from daft.io.partitioning import PartitionTransform
+from daft.io.scan import ScanOperator, make_partition_field
+from daft.logical.schema import Field, Schema
+from daft.recordbatch import RecordBatch
+
+from ..pushdowns import SupportsPushdownFilters
+from .lance_namespace import (
+    COL_LOCATION,
+    COL_OBJECT_TYPE,
+    COL_READ_VERSION,
+    METADATA_KEY_SCHEMA,
+    OBJECT_TYPE_TABLE,
+    PARTITION_FIELD_PREFIX,
+    get_schema_metadata_value,
+    json_arrow_to_arrow_type,
+    latest_partition_spec_key,
+    parse_namespace_schema_json,
+    parse_partition_spec_json,
+)
+from .utils import combine_filters_to_arrow
+
+logger = logging.getLogger(__name__)
+
+
+def _transform_from_spec(transform_obj: Any, source_type: DataType) -> tuple[Any, DataType]:
+    """Convert a Partitioning spec transform entry into (PartitionTransform, result DataType).
+
+    Accepts both the spec's structured form ``{"type": "year"}`` and the legacy
+    string form ``"year"`` produced by older writers, so reads aren't brittle
+    to writer variation.
+    """
+    if isinstance(transform_obj, dict):
+        kind = transform_obj.get("type")
+        num_buckets = transform_obj.get("num_buckets")
+        width = transform_obj.get("width")
+    else:
+        kind = transform_obj
+        num_buckets = None
+        width = None
+
+    if kind == "identity":
+        return PartitionTransform.identity(), source_type
+    if kind == "year":
+        return PartitionTransform.year(), DataType.int32()
+    if kind == "month":
+        return PartitionTransform.month(), DataType.int32()
+    if kind == "day":
+        return PartitionTransform.day(), DataType.int32()
+    if kind == "hour":
+        return PartitionTransform.hour(), DataType.int32()
+    if kind == "bucket":
+        if num_buckets is None:
+            raise ValueError("bucket transform requires num_buckets")
+        return PartitionTransform.iceberg_bucket(int(num_buckets)), DataType.int32()
+    if kind == "truncate":
+        if width is None:
+            raise ValueError("truncate transform requires width")
+        return PartitionTransform.iceberg_truncate(int(width)), source_type
+    raise NotImplementedError(f"Lance partition transform {kind!r} is not yet supported")
+
+
+def _read_manifest(
+    namespace_uri: str, storage_options: dict[str, str] | None
+) -> tuple[pa.Table, dict[str, Any], pa.Schema | None, str]:
+    import lance
+
+    manifest_uri = namespace_uri.rstrip("/") + "/__manifest"
+    manifest_ds = lance.dataset(manifest_uri, storage_options=storage_options)
+    manifest_table = manifest_ds.to_table()
+
+    schema_metadata = manifest_ds.schema.metadata or {}
+    latest = latest_partition_spec_key(schema_metadata)
+    if latest is None:
+        raise ValueError(
+            f"No partition_spec_v<N> key in {manifest_uri} metadata. Is this a partitioned Lance namespace?"
+        )
+    spec_n, spec_key = latest
+    spec_payload = get_schema_metadata_value(schema_metadata, spec_key)
+    if spec_payload is None:
+        raise ValueError(f"Missing value for partition spec key {spec_key!r} in {manifest_uri} metadata")
+    partition_spec = parse_partition_spec_json(spec_payload)
+
+    raw_schema = get_schema_metadata_value(schema_metadata, METADATA_KEY_SCHEMA)
+    namespace_schema = parse_namespace_schema_json(raw_schema) if raw_schema is not None else None
+
+    return manifest_table, partition_spec, namespace_schema, f"v{spec_n}"
+
+
+def _build_partition_keys(partition_spec: dict[str, Any], namespace_schema: pa.Schema) -> list[PyPartitionField]:
+    fields: list[PyPartitionField] = []
+    for field_def in partition_spec.get("fields", []):
+        field_id = field_def["field_id"]
+        source_ids = field_def.get("source_ids", [])
+
+        if source_ids:
+            # source_ids reference lance:field_id; for v1 we assigned positional ids
+            # to the namespace schema, so the lookup is positional.
+            source_idx = int(source_ids[0])
+            source_arrow_field = namespace_schema.field(source_idx)
+        elif field_id in namespace_schema.names:
+            source_arrow_field = namespace_schema.field(namespace_schema.get_field_index(field_id))
+        else:
+            raise ValueError(f"Cannot resolve source field for partition field {field_id!r}")
+
+        source_type = DataType.from_arrow_type(source_arrow_field.type)
+        transform, result_type = _transform_from_spec(field_def.get("transform"), source_type)
+
+        result_field = Field.create(field_id, result_type)
+        source_field = Field.create(source_arrow_field.name, source_type)
+        fields.append(
+            make_partition_field(
+                result_field,
+                source_field,
+                transform=transform._partition_transform if transform is not None else None,
+            )
+        )
+    return fields
+
+
+def _inject_partition_columns(
+    rb: pa.RecordBatch,
+    partition_values: dict[str, Any],
+    partition_field_types: dict[str, pa.DataType],
+    required_columns: list[str] | None,
+) -> pa.RecordBatch:
+    """Inject constant partition columns into a leaf record batch on read."""
+    if not partition_values:
+        return rb
+    columns = list(rb.columns)
+    names = list(rb.schema.names)
+    for col_name, value in partition_values.items():
+        if required_columns is not None and col_name not in required_columns:
+            continue
+        if col_name in names:
+            continue
+        dtype = partition_field_types.get(col_name, pa.utf8())
+        columns.append(pa.array([value] * len(rb), type=dtype))
+        names.append(col_name)
+    return pa.RecordBatch.from_arrays(columns, names=names)
+
+
+def _lance_namespace_factory_function(
+    ds_uri: str,
+    fragment_ids: list[int] | None = None,
+    required_columns: list[str] | None = None,
+    filter: Optional["pa.compute.Expression"] = None,
+    limit: int | None = None,
+    partition_values: dict[str, Any] | None = None,
+    partition_field_types: dict[str, pa.DataType] | None = None,
+    read_version: int | None = None,
+    storage_options: dict[str, str] | None = None,
+) -> Iterator[PyRecordBatch]:
+    try:
+        import lance
+    except ImportError as e:
+        raise ImportError(
+            "Unable to import the `lance` package, please ensure that Daft is installed with the lance extra dependency: `pip install daft[lance]`"
+        ) from e
+
+    kwargs: dict[str, Any] = {}
+    if storage_options is not None:
+        kwargs["storage_options"] = storage_options
+    if read_version is not None:
+        kwargs["version"] = read_version
+    ds = lance.dataset(ds_uri, **kwargs)
+
+    pv = partition_values or {}
+    pft = partition_field_types or {}
+
+    # Strip partition columns from what we ask the leaf dataset to return;
+    # they're injected afterward.
+    non_partition_cols: list[str] | None = None
+    if required_columns is not None:
+        non_partition_cols = [c for c in required_columns if c not in pv]
+        if not non_partition_cols:
+            non_partition_cols = None
+
+    if fragment_ids is None:
+        scanner = ds.scanner(columns=non_partition_cols, filter=filter, limit=limit)
+        for rb in scanner.to_batches():
+            rb = _inject_partition_columns(rb, pv, pft, required_columns)
+            yield RecordBatch.from_arrow_record_batches([rb], rb.schema)._recordbatch
+    else:
+        rows_yielded = 0
+        for fid in fragment_ids:
+            if limit is not None and rows_yielded >= limit:
+                break
+            fragment = ds.get_fragment(fid)
+            fragment_limit = (limit - rows_yielded) if limit is not None else None
+            scanner = ds.scanner(
+                fragments=[fragment],
+                columns=non_partition_cols,
+                filter=filter,
+                limit=fragment_limit,
+            )
+            for rb in scanner.to_batches():
+                if limit is not None:
+                    remaining = limit - rows_yielded
+                    if remaining <= 0:
+                        break
+                    if len(rb) > remaining:
+                        rb = rb.slice(0, remaining)
+                rb = _inject_partition_columns(rb, pv, pft, required_columns)
+                yield RecordBatch.from_arrow_record_batches([rb], rb.schema)._recordbatch
+                rows_yielded += len(rb)
+
+
+class LanceNamespaceScanOperator(ScanOperator, SupportsPushdownFilters):
+    def __init__(
+        self,
+        namespace_uri: str,
+        storage_options: dict[str, str] | None = None,
+        fragment_group_size: int | None = None,
+    ) -> None:
+        self._namespace_uri = namespace_uri.rstrip("/")
+        self._storage_options = storage_options
+        self._fragment_group_size = fragment_group_size
+        self._pushed_filters: list[PyExpr] | None = None
+        self._remaining_filters: list[PyExpr] | None = None
+
+        _ensure_registered_super_ext_type()
+
+        manifest_table, partition_spec, namespace_schema, spec_version = _read_manifest(
+            self._namespace_uri, self._storage_options
+        )
+        self._manifest_table = manifest_table
+        self._partition_spec = partition_spec
+        self._spec_version = spec_version
+
+        if namespace_schema is None:
+            namespace_schema = self._infer_namespace_schema_from_leaves()
+        self._namespace_pa_schema = namespace_schema
+        self._schema = Schema.from_pyarrow_schema(namespace_schema)
+        self._partition_keys = _build_partition_keys(partition_spec, namespace_schema)
+
+        # Map partition field id -> Arrow type, for constant-column injection on read.
+        self._partition_field_types: dict[str, pa.DataType] = {}
+        for field_def in partition_spec.get("fields", []):
+            fid = field_def["field_id"]
+            rt = field_def.get("result_type")
+            if isinstance(rt, dict):
+                self._partition_field_types[fid] = json_arrow_to_arrow_type(rt)
+            elif fid in namespace_schema.names:
+                self._partition_field_types[fid] = namespace_schema.field(fid).type
+
+    # ---- ScanOperator surface --------------------------------------------
+
+    def name(self) -> str:
+        return "LanceNamespaceScanOperator"
+
+    def display_name(self) -> str:
+        return f"LanceNamespaceScanOperator({self._namespace_uri})"
+
+    def schema(self) -> Schema:
+        return self._schema
+
+    def partitioning_keys(self) -> list[PyPartitionField]:
+        return self._partition_keys
+
+    def can_absorb_filter(self) -> bool:
+        return True
+
+    def can_absorb_limit(self) -> bool:
+        return False
+
+    def can_absorb_select(self) -> bool:
+        return True
+
+    def supports_count_pushdown(self) -> bool:
+        return False
+
+    def as_pushdown_filter(self) -> SupportsPushdownFilters | None:
+        return self
+
+    def multiline_display(self) -> list[str]:
+        n_tables = sum(
+            1
+            for i in range(self._manifest_table.num_rows)
+            if self._manifest_table.column(COL_OBJECT_TYPE)[i].as_py() == OBJECT_TYPE_TABLE
+        )
+        return [
+            self.display_name(),
+            f"Schema = {self.schema()}",
+            f"Partitions = {n_tables} tables",
+        ]
+
+    def push_filters(self, filters: list[PyExpr]) -> tuple[list[PyExpr], list[PyExpr]]:
+        pushed: list[PyExpr] = []
+        remaining: list[PyExpr] = []
+        for expr in filters:
+            try:
+                Expression._from_pyexpr(expr).to_arrow_expr()
+                pushed.append(expr)
+            except NotImplementedError:
+                remaining.append(expr)
+        self._pushed_filters = pushed if pushed else None
+        self._remaining_filters = remaining if remaining else None
+        return pushed, remaining
+
+    def to_scan_tasks(self, pushdowns: PyPushdowns) -> Iterator[ScanTask]:
+        if pushdowns.columns is None:
+            required_columns: list[str] | None = None
+        else:
+            filter_req = pushdowns.filter_required_column_names() or []
+            required_columns = list(set(list(pushdowns.columns) + list(filter_req)))
+
+        pushed_arrow_filter = combine_filters_to_arrow(self._pushed_filters)
+
+        partition_field_ids = [f["field_id"] for f in self._partition_spec.get("fields", [])]
+
+        for i in range(self._manifest_table.num_rows):
+            if self._manifest_table.column(COL_OBJECT_TYPE)[i].as_py() != OBJECT_TYPE_TABLE:
+                continue
+            location = self._manifest_table.column(COL_LOCATION)[i].as_py()
+            if location is None:
+                logger.warning("Skipping table row at index %d: missing location", i)
+                continue
+
+            partition_values: dict[str, Any] = {}
+            for fid in partition_field_ids:
+                col = f"{PARTITION_FIELD_PREFIX}{fid}"
+                if col in self._manifest_table.column_names:
+                    partition_values[fid] = self._manifest_table.column(col)[i].as_py()
+
+            if pushdowns.partition_filters is not None and not self._partition_filter_matches(
+                pushdowns.partition_filters, partition_values
+            ):
+                continue
+
+            ds_uri = f"{self._namespace_uri}/{location}"
+            read_version: int | None = None
+            if COL_READ_VERSION in self._manifest_table.column_names:
+                rv = self._manifest_table.column(COL_READ_VERSION)[i].as_py()
+                if rv is not None:
+                    read_version = int(rv)
+
+            yield from self._partition_scan_tasks(
+                ds_uri=ds_uri,
+                partition_values=partition_values,
+                required_columns=required_columns,
+                pushed_arrow_filter=pushed_arrow_filter,
+                pushdowns=pushdowns,
+                read_version=read_version,
+            )
+
+    # ---- Internals --------------------------------------------------------
+
+    def _infer_namespace_schema_from_leaves(self) -> pa.Schema:
+        """Fallback for manifests written without the ``schema`` metadata key."""
+        import lance
+
+        partition_field_arrow: list[pa.Field] = []
+        for field_def in self._partition_spec.get("fields", []):
+            fid = field_def["field_id"]
+            rt = field_def.get("result_type")
+            arrow_type = json_arrow_to_arrow_type(rt) if isinstance(rt, dict) else pa.utf8()
+            partition_field_arrow.append(pa.field(fid, arrow_type))
+
+        for i in range(self._manifest_table.num_rows):
+            if self._manifest_table.column(COL_OBJECT_TYPE)[i].as_py() != OBJECT_TYPE_TABLE:
+                continue
+            loc = self._manifest_table.column(COL_LOCATION)[i].as_py()
+            if loc is None:
+                continue
+            try:
+                ds = lance.dataset(f"{self._namespace_uri}/{loc}", storage_options=self._storage_options)
+            except Exception:
+                continue
+            return pa.schema(list(ds.schema) + partition_field_arrow)
+        raise ValueError(
+            f"Could not determine namespace schema for {self._namespace_uri}: no readable leaf tables and "
+            f"no `schema` metadata on the manifest."
+        )
+
+    def _partition_filter_matches(self, partition_filter: PyExpr, partition_values: dict[str, Any]) -> bool:
+        """Evaluate a Daft partition filter against a single row's partition values."""
+        try:
+            arrays: dict[str, pa.Array] = {}
+            for fid, value in partition_values.items():
+                dtype = self._partition_field_types.get(fid, pa.utf8())
+                arrays[fid] = pa.array([value], type=dtype)
+
+            from daft.expressions.expressions import ExpressionsProjection
+
+            rb = RecordBatch.from_pydict(arrays)
+            result = rb.eval_expression_list(ExpressionsProjection([Expression._from_pyexpr(partition_filter)]))
+            col = result.to_arrow_table().column(0)
+            return bool(col[0].as_py())
+        except Exception as e:  # pragma: no cover — fail-open on evaluation errors
+            logger.warning("Partition filter eval failed (%s); including partition", e)
+            return True
+
+    def _partition_scan_tasks(
+        self,
+        *,
+        ds_uri: str,
+        partition_values: dict[str, Any],
+        required_columns: list[str] | None,
+        pushed_arrow_filter: Optional["pa.compute.Expression"],
+        pushdowns: PyPushdowns,
+        read_version: int | None,
+    ) -> Iterator[ScanTask]:
+        import lance
+
+        try:
+            ds = lance.dataset(ds_uri, storage_options=self._storage_options, version=read_version)
+        except Exception as e:
+            logger.warning("Failed to open partition dataset at %s: %s", ds_uri, e)
+            return
+
+        fragments = list(ds.get_fragments())
+
+        def _size(frag: Any) -> int:
+            md = getattr(frag, "metadata", None)
+            files = getattr(md, "files", None) if md else None
+            if not files:
+                return 0
+            return sum(f.file_size_bytes for f in files if f.file_size_bytes is not None)
+
+        def _make_task(frag_ids: list[int], num_rows: int, size_bytes: int) -> ScanTask:
+            return ScanTask.python_factory_func_scan_task(
+                module=_lance_namespace_factory_function.__module__,
+                func_name=_lance_namespace_factory_function.__name__,
+                func_args=(
+                    ds_uri,
+                    frag_ids,
+                    required_columns,
+                    pushed_arrow_filter,
+                    pushdowns.limit,
+                    partition_values,
+                    self._partition_field_types,
+                    read_version,
+                    self._storage_options,
+                ),
+                schema=self._schema._schema,
+                num_rows=num_rows,
+                size_bytes=size_bytes,
+                pushdowns=pushdowns,
+                stats=None,
+                source_name=self.display_name(),
+            )
+
+        group_size = self._fragment_group_size
+        if group_size is not None and group_size > 1:
+            current: list[int] = []
+            group_rows = 0
+            group_bytes = 0
+            for fragment in fragments:
+                rows = fragment.count_rows(pushed_arrow_filter)
+                if rows == 0:
+                    continue
+                current.append(fragment.fragment_id)
+                group_rows += rows
+                group_bytes += _size(fragment)
+                if len(current) >= group_size:
+                    yield _make_task(current, group_rows, group_bytes)
+                    current = []
+                    group_rows = 0
+                    group_bytes = 0
+            if current:
+                yield _make_task(current, group_rows, group_bytes)
+        else:
+            for fragment in fragments:
+                rows = fragment.count_rows(pushed_arrow_filter)
+                if rows == 0:
+                    continue
+                yield _make_task([fragment.fragment_id], rows, _size(fragment))

--- a/daft/io/lance/lance_namespace_scan.py
+++ b/daft/io/lance/lance_namespace_scan.py
@@ -17,6 +17,7 @@ from daft.daft import PyExpr, PyPartitionField, PyPushdowns, PyRecordBatch, Scan
 from daft.datatype import DataType, _ensure_registered_super_ext_type
 from daft.dependencies import pa
 from daft.expressions import Expression
+from daft.expressions.expressions import ExpressionsProjection
 from daft.io.partitioning import PartitionTransform
 from daft.io.scan import ScanOperator, make_partition_field
 from daft.logical.schema import Field, Schema
@@ -27,6 +28,7 @@ from .lance_namespace import (
     COL_LOCATION,
     COL_OBJECT_TYPE,
     COL_READ_VERSION,
+    LANCE_FIELD_ID_KEY,
     METADATA_KEY_SCHEMA,
     OBJECT_TYPE_TABLE,
     PARTITION_FIELD_PREFIX,
@@ -105,21 +107,42 @@ def _read_manifest(
     return manifest_table, partition_spec, namespace_schema, f"v{spec_n}"
 
 
+def _schema_field_by_lance_field_id(namespace_schema: pa.Schema, target_id: int) -> pa.Field | None:
+    """Find a schema field by its `lance:field_id` metadata value.
+
+    Per the partitioning spec, `source_ids` references the logical
+    ``lance:field_id`` stored in field metadata — not the positional index of
+    the field in the Arrow schema. Field IDs can be non-sequential or start
+    above zero in spec-compliant namespaces written by other tools.
+    """
+    target = str(target_id)
+    for field in namespace_schema:
+        md = field.metadata or {}
+        raw = md.get(LANCE_FIELD_ID_KEY.encode(), md.get(LANCE_FIELD_ID_KEY))
+        if raw is None:
+            continue
+        raw_str = raw.decode() if isinstance(raw, (bytes, bytearray)) else raw
+        if raw_str == target:
+            return field
+    return None
+
+
 def _build_partition_keys(partition_spec: dict[str, Any], namespace_schema: pa.Schema) -> list[PyPartitionField]:
     fields: list[PyPartitionField] = []
     for field_def in partition_spec.get("fields", []):
         field_id = field_def["field_id"]
         source_ids = field_def.get("source_ids", [])
 
+        source_arrow_field: pa.Field | None = None
         if source_ids:
-            # source_ids reference lance:field_id; for v1 we assigned positional ids
-            # to the namespace schema, so the lookup is positional.
-            source_idx = int(source_ids[0])
-            source_arrow_field = namespace_schema.field(source_idx)
-        elif field_id in namespace_schema.names:
+            source_arrow_field = _schema_field_by_lance_field_id(namespace_schema, int(source_ids[0]))
+        if source_arrow_field is None and field_id in namespace_schema.names:
             source_arrow_field = namespace_schema.field(namespace_schema.get_field_index(field_id))
-        else:
-            raise ValueError(f"Cannot resolve source field for partition field {field_id!r}")
+        if source_arrow_field is None:
+            raise ValueError(
+                f"Cannot resolve source field for partition field {field_id!r}; "
+                f"source_ids={source_ids} not found by lance:field_id and no schema field named {field_id!r}."
+            )
 
         source_type = DataType.from_arrow_type(source_arrow_field.type)
         transform, result_type = _transform_from_spec(field_def.get("transform"), source_type)
@@ -158,6 +181,13 @@ def _inject_partition_columns(
     return pa.RecordBatch.from_arrays(columns, names=names)
 
 
+def _inject_fragment_id(rb: pa.RecordBatch, fragment_id: int) -> pa.RecordBatch:
+    """Append a constant fragment_id column to a record batch."""
+    columns = list(rb.columns) + [pa.array([fragment_id] * len(rb), type=pa.int64())]
+    names = list(rb.schema.names) + ["fragment_id"]
+    return pa.RecordBatch.from_arrays(columns, names=names)
+
+
 def _lance_namespace_factory_function(
     ds_uri: str,
     fragment_ids: list[int] | None = None,
@@ -168,6 +198,8 @@ def _lance_namespace_factory_function(
     partition_field_types: dict[str, pa.DataType] | None = None,
     read_version: int | None = None,
     storage_options: dict[str, str] | None = None,
+    include_fragment_id: bool = False,
+    default_scan_options: dict[str, Any] | None = None,
 ) -> Iterator[PyRecordBatch]:
     try:
         import lance
@@ -181,24 +213,34 @@ def _lance_namespace_factory_function(
         kwargs["storage_options"] = storage_options
     if read_version is not None:
         kwargs["version"] = read_version
+    if default_scan_options is not None:
+        kwargs["default_scan_options"] = default_scan_options
     ds = lance.dataset(ds_uri, **kwargs)
 
     pv = partition_values or {}
     pft = partition_field_types or {}
 
-    # Strip partition columns from what we ask the leaf dataset to return;
-    # they're injected afterward.
+    # Strip partition columns and fragment_id from what we ask the leaf dataset
+    # to return; they're injected afterward.
     non_partition_cols: list[str] | None = None
     if required_columns is not None:
-        non_partition_cols = [c for c in required_columns if c not in pv]
+        non_partition_cols = [c for c in required_columns if c not in pv and c != "fragment_id"]
         if not non_partition_cols:
             non_partition_cols = None
 
+    def _emit(rb: pa.RecordBatch, fragment_id: int | None) -> Iterator[PyRecordBatch]:
+        rb = _inject_partition_columns(rb, pv, pft, required_columns)
+        if include_fragment_id and fragment_id is not None:
+            rb = _inject_fragment_id(rb, fragment_id)
+        yield RecordBatch.from_arrow_record_batches([rb], rb.schema)._recordbatch
+
     if fragment_ids is None:
+        # Scanning the whole dataset — Lance doesn't expose per-row fragment ids
+        # through the dataset-level scanner. include_fragment_id requires the
+        # per-fragment path.
         scanner = ds.scanner(columns=non_partition_cols, filter=filter, limit=limit)
         for rb in scanner.to_batches():
-            rb = _inject_partition_columns(rb, pv, pft, required_columns)
-            yield RecordBatch.from_arrow_record_batches([rb], rb.schema)._recordbatch
+            yield from _emit(rb, None)
     else:
         rows_yielded = 0
         for fid in fragment_ids:
@@ -219,8 +261,7 @@ def _lance_namespace_factory_function(
                         break
                     if len(rb) > remaining:
                         rb = rb.slice(0, remaining)
-                rb = _inject_partition_columns(rb, pv, pft, required_columns)
-                yield RecordBatch.from_arrow_record_batches([rb], rb.schema)._recordbatch
+                yield from _emit(rb, fid)
                 rows_yielded += len(rb)
 
 
@@ -230,10 +271,14 @@ class LanceNamespaceScanOperator(ScanOperator, SupportsPushdownFilters):
         namespace_uri: str,
         storage_options: dict[str, str] | None = None,
         fragment_group_size: int | None = None,
+        include_fragment_id: bool = False,
+        default_scan_options: dict[str, Any] | None = None,
     ) -> None:
         self._namespace_uri = namespace_uri.rstrip("/")
         self._storage_options = storage_options
         self._fragment_group_size = fragment_group_size
+        self._include_fragment_id = include_fragment_id
+        self._default_scan_options = default_scan_options
         self._pushed_filters: list[PyExpr] | None = None
         self._remaining_filters: list[PyExpr] | None = None
 
@@ -248,6 +293,25 @@ class LanceNamespaceScanOperator(ScanOperator, SupportsPushdownFilters):
 
         if namespace_schema is None:
             namespace_schema = self._infer_namespace_schema_from_leaves()
+
+        # Reflect `with_row_address` and similar scan options on the namespace
+        # schema so Daft's planner sees the surfaced columns.
+        if self._default_scan_options:
+            extras: list[pa.Field] = []
+            opts = self._default_scan_options
+            if opts.get("with_row_address") or opts.get("with_rowaddr"):
+                extras.append(pa.field("_rowaddr", pa.uint64()))
+            if opts.get("with_row_id"):
+                extras.append(pa.field("_rowid", pa.uint64()))
+            if extras:
+                namespace_schema = pa.schema(list(namespace_schema) + extras, metadata=namespace_schema.metadata)
+
+        if self._include_fragment_id:
+            namespace_schema = pa.schema(
+                list(namespace_schema) + [pa.field("fragment_id", pa.int64())],
+                metadata=namespace_schema.metadata,
+            )
+
         self._namespace_pa_schema = namespace_schema
         self._schema = Schema.from_pyarrow_schema(namespace_schema)
         self._partition_keys = _build_partition_keys(partition_spec, namespace_schema)
@@ -399,8 +463,6 @@ class LanceNamespaceScanOperator(ScanOperator, SupportsPushdownFilters):
                 dtype = self._partition_field_types.get(fid, pa.utf8())
                 arrays[fid] = pa.array([value], type=dtype)
 
-            from daft.expressions.expressions import ExpressionsProjection
-
             rb = RecordBatch.from_pydict(arrays)
             result = rb.eval_expression_list(ExpressionsProjection([Expression._from_pyexpr(partition_filter)]))
             col = result.to_arrow_table().column(0)
@@ -422,7 +484,13 @@ class LanceNamespaceScanOperator(ScanOperator, SupportsPushdownFilters):
         import lance
 
         try:
-            ds = lance.dataset(ds_uri, storage_options=self._storage_options, version=read_version)
+            open_kwargs: dict[str, Any] = {
+                "storage_options": self._storage_options,
+                "version": read_version,
+            }
+            if self._default_scan_options is not None:
+                open_kwargs["default_scan_options"] = self._default_scan_options
+            ds = lance.dataset(ds_uri, **open_kwargs)
         except Exception as e:
             logger.warning("Failed to open partition dataset at %s: %s", ds_uri, e)
             return
@@ -450,6 +518,8 @@ class LanceNamespaceScanOperator(ScanOperator, SupportsPushdownFilters):
                     self._partition_field_types,
                     read_version,
                     self._storage_options,
+                    self._include_fragment_id,
+                    self._default_scan_options,
                 ),
                 schema=self._schema._schema,
                 num_rows=num_rows,

--- a/daft/io/lance/lance_partitioned_data_sink.py
+++ b/daft/io/lance/lance_partitioned_data_sink.py
@@ -26,6 +26,7 @@ from daft.context import get_context
 from daft.datatype import DataType
 from daft.dependencies import pa
 from daft.io import DataSink
+from daft.io.object_store_options import io_config_to_storage_options
 from daft.io.sink import WriteResult
 from daft.recordbatch import MicroPartition
 from daft.schema import Schema
@@ -98,8 +99,6 @@ class LancePartitionedDataSink(DataSink[_WriteResultPayload]):
         partition_cols: list[str] | None = None,
         **kwargs: Any,
     ) -> None:
-        from daft.io.object_store_options import io_config_to_storage_options
-
         lance = self._import_lance()
 
         if not isinstance(uri, (str, pathlib.Path)):
@@ -343,8 +342,16 @@ class LancePartitionedDataSink(DataSink[_WriteResultPayload]):
             pv: dict[str, Any] = {}
             for col_name in self._partition_col_names:
                 val = unique_combos.column(col_name)[i]
-                pv[col_name] = val.as_py()
-                col_mask = pa.compute.equal(table.column(col_name), val)
+                py_val = val.as_py()
+                pv[col_name] = py_val
+                col = table.column(col_name)
+                # `pa.compute.equal(col, null_scalar)` returns nulls, which
+                # `table.filter` treats as False — silently dropping every row
+                # whose partition value is NULL. Use `is_null` to keep them.
+                if py_val is None:
+                    col_mask = pa.compute.is_null(col)
+                else:
+                    col_mask = pa.compute.equal(col, val)
                 mask = col_mask if mask is None else pa.compute.and_(mask, col_mask)
             filtered = table.filter(mask)
             groups.append((pv, filtered))
@@ -442,8 +449,10 @@ class LancePartitionedDataSink(DataSink[_WriteResultPayload]):
         # 1. Root namespace row (v1).
         rows.append(self._row(make_object_id(_SPEC_VERSION, [], is_table=False), OBJECT_TYPE_NAMESPACE, {}))
 
-        # 2. Intermediate namespace rows, sorted by depth so parents precede children.
-        for prefix in sorted(prefix_to_id.keys(), key=lambda p: (len(p), p)):
+        # 2. Intermediate namespace rows, sorted by depth so parents precede
+        # children. Use a string secondary key so `None`s in the tuple don't
+        # break comparison.
+        for prefix in sorted(prefix_to_id.keys(), key=lambda p: (len(p), tuple(repr(v) for v in p))):
             ns_segments: list[str] = []
             for depth in range(1, len(prefix) + 1):
                 ns_segments.append(prefix_to_id[prefix[:depth]])

--- a/daft/io/lance/lance_partitioned_data_sink.py
+++ b/daft/io/lance/lance_partitioned_data_sink.py
@@ -1,0 +1,495 @@
+"""Partitioned write sink for Lance V2 directory namespaces with partitioning.
+
+This implements the write side of:
+
+- The Lance V2 Directory Namespace catalog spec (manifest table with
+  ``object_id`` / ``object_type`` / ``location`` / ``metadata`` /
+  ``base_objects`` columns, hash-prefixed ``<hash>_<object_id>`` directories
+  for the leaf table data, root-namespace properties stored in the
+  ``__manifest`` table's schema metadata).
+- The Lance Partitioning spec (``partition_spec_v<N>`` JSON, ``schema`` JSON
+  describing the namespace schema with ``lance:field_id`` per field,
+  ``partition_field_{field_id}`` columns extending the manifest, hierarchical
+  random 16-char base36 namespace ids in object_ids, ``dataset`` leaf naming).
+
+Initial scope: identity transform only, single partition spec (``v1``).
+``read_version`` is populated on every table row after a successful commit;
+``read_branch`` / ``read_tag`` are always NULL.
+"""
+
+from __future__ import annotations
+
+import pathlib
+from typing import TYPE_CHECKING, Any, Literal
+
+from daft.context import get_context
+from daft.datatype import DataType
+from daft.dependencies import pa
+from daft.io import DataSink
+from daft.io.sink import WriteResult
+from daft.recordbatch import MicroPartition
+from daft.schema import Schema
+
+from .lance_namespace import (
+    COL_BASE_OBJECTS,
+    COL_LOCATION,
+    COL_METADATA,
+    COL_OBJECT_ID,
+    COL_OBJECT_TYPE,
+    COL_READ_BRANCH,
+    COL_READ_TAG,
+    COL_READ_VERSION,
+    METADATA_KEY_SCHEMA,
+    OBJECT_TYPE_NAMESPACE,
+    OBJECT_TYPE_TABLE,
+    PARTITION_FIELD_PREFIX,
+    PartitionFieldSpec,
+    make_location,
+    make_namespace_schema_json,
+    make_object_id,
+    make_partition_spec_json,
+    manifest_arrow_schema,
+    parse_object_id,
+    random_namespace_id,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from types import ModuleType
+
+    from daft.daft import IOConfig
+
+
+# write() yields a list of (partition_values, table_object_id, fragments) triples per micropartition.
+_WriteResultPayload = list[tuple[dict[str, Any], str, list[Any]]]
+
+# Always v1 for the initial implementation — no partition spec evolution yet.
+_SPEC_ID = 1
+_SPEC_VERSION = f"v{_SPEC_ID}"
+
+
+class LancePartitionedDataSink(DataSink[_WriteResultPayload]):
+    """DataSink for writing a Daft DataFrame to a partitioned Lance namespace.
+
+    The sink:
+
+    1. Groups each incoming micropartition by partition column values.
+    2. Writes a Lance fragment for each (group, partition) pair into the
+       partition table at ``<root>/<hash>_<object_id>/``.
+    3. Commits accumulated fragments per partition table.
+    4. Rewrites the ``__manifest`` table with the full namespace + table row
+       inventory and the partitioning metadata.
+    """
+
+    def _import_lance(self) -> ModuleType:
+        try:
+            import lance
+
+            return lance
+        except ImportError:
+            raise ImportError("lance is not installed. Please install lance using `pip install daft[lance]`")
+
+    def __init__(
+        self,
+        uri: str | pathlib.Path,
+        data_schema: Schema | pa.Schema,
+        mode: Literal["create", "append", "overwrite"],
+        io_config: IOConfig | None = None,
+        partition_cols: list[str] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        from daft.io.object_store_options import io_config_to_storage_options
+
+        lance = self._import_lance()
+
+        if not isinstance(uri, (str, pathlib.Path)):
+            raise TypeError(f"Expected URI to be str or pathlib.Path, got {type(uri)}")
+        if not partition_cols:
+            raise ValueError("partition_cols must be a non-empty list of column names")
+        if mode not in {"create", "append", "overwrite"}:
+            raise ValueError(f"Unsupported mode for partitioned writes: {mode!r}")
+
+        self._table_uri = str(uri).rstrip("/")
+        self._mode = mode
+        self._io_config = get_context().daft_planning_config.default_io_config if io_config is None else io_config
+        self._kwargs = dict(kwargs)
+        # Strip merge-mode kwargs that don't apply here.
+        self._kwargs.pop("left_on", None)
+        self._kwargs.pop("right_on", None)
+        self._storage_options = io_config_to_storage_options(self._io_config, self._table_uri)
+        self._partition_col_names = list(partition_cols)
+
+        if isinstance(data_schema, Schema):
+            self._namespace_pa_schema = data_schema.to_pyarrow_schema()
+        elif isinstance(data_schema, pa.Schema):
+            self._namespace_pa_schema = data_schema
+        else:
+            raise TypeError(f"Expected schema to be Schema or pa.Schema, got {type(data_schema)}")
+
+        # Validate partition columns exist in the schema and assign field ids.
+        partition_set = set(self._partition_col_names)
+        for col in self._partition_col_names:
+            if col not in self._namespace_pa_schema.names:
+                raise ValueError(f"Partition column {col!r} not found in schema")
+
+        # Field IDs follow position in the user schema and are immutable.
+        self._field_ids: dict[str, int] = {f.name: i for i, f in enumerate(self._namespace_pa_schema)}
+
+        # Build partition field specs (identity transform only in v1).
+        self._partition_field_specs: list[PartitionFieldSpec] = [
+            PartitionFieldSpec(
+                field_id=col,
+                source_field_name=col,
+                source_id=self._field_ids[col],
+                transform="identity",
+                result_type=self._namespace_pa_schema.field(col).type,
+            )
+            for col in self._partition_col_names
+        ]
+
+        # Leaf Lance datasets store everything except partition columns.
+        self._leaf_pa_schema = pa.schema([f for f in self._namespace_pa_schema if f.name not in partition_set])
+
+        # State that may be reused across writes when appending.
+        # prefix-of-partition-values -> 16-char base36 namespace id
+        self._namespace_ids: dict[tuple[Any, ...], str] = {}
+        # table object_id -> physical "location" (relative dir name <hash>_<object_id>)
+        self._locations: dict[str, str] = {}
+        # table object_id -> previously-committed Lance dataset version (for re-emitting unchanged rows)
+        self._existing_read_versions: dict[str, int] = {}
+        # table object_id -> partition values dict (so we can re-emit on append even if no new data hits)
+        self._existing_table_pvs: dict[str, dict[str, Any]] = {}
+
+        if mode == "append":
+            self._load_existing_manifest(lance)
+        elif mode == "create":
+            self._check_no_existing_manifest(lance)
+        # overwrite: ignore existing state entirely.
+
+        self._schema = Schema._from_field_name_and_types(
+            [
+                ("num_partitions", DataType.int64()),
+                ("num_fragments", DataType.int64()),
+                ("version", DataType.int64()),
+            ]
+        )
+
+    # ---- DataSink protocol ------------------------------------------------
+
+    def name(self) -> str:
+        return "Lance Partitioned Write"
+
+    def schema(self) -> Schema:
+        return self._schema
+
+    def write(self, micropartitions: Iterator[MicroPartition]) -> Iterator[WriteResult[_WriteResultPayload]]:
+        lance = self._import_lance()
+
+        for micropartition in micropartitions:
+            arrow_table = micropartition.to_arrow()
+            if arrow_table.num_rows == 0:
+                continue
+            groups = self._group_by_partition(arrow_table)
+
+            batch_results: _WriteResultPayload = []
+            for partition_values, group_table in groups:
+                table_oid = self._table_object_id(partition_values)
+                location = self._location_for(table_oid)
+                dataset_path = f"{self._table_uri}/{location}"
+
+                # Drop partition columns — they're inherited from manifest.
+                write_table = group_table.drop_columns(
+                    [c for c in self._partition_col_names if c in group_table.column_names]
+                )
+
+                fragments = lance.fragment.write_fragments(
+                    write_table,
+                    dataset_uri=dataset_path,
+                    mode="append",
+                    storage_options=self._storage_options,
+                    **self._kwargs,
+                )
+                batch_results.append((partition_values, table_oid, list(fragments)))
+
+            yield WriteResult(
+                result=batch_results,
+                bytes_written=arrow_table.nbytes,
+                rows_written=arrow_table.num_rows,
+            )
+
+    def finalize(self, write_results: list[WriteResult[_WriteResultPayload]]) -> MicroPartition:
+        lance = self._import_lance()
+
+        # Collapse fragments by table object_id across all WriteResults.
+        partition_map: dict[str, tuple[dict[str, Any], list[Any]]] = {}
+        for wr in write_results:
+            for partition_values, table_oid, fragments in wr.result:
+                _, frags = partition_map.setdefault(table_oid, (partition_values, []))
+                frags.extend(fragments)
+
+        # Commit each affected leaf Lance dataset and capture its committed version.
+        partition_versions: dict[str, int] = {}
+        for table_oid, (_, fragments) in partition_map.items():
+            location = self._location_for(table_oid)
+            dataset_path = f"{self._table_uri}/{location}"
+            partition_versions[table_oid] = self._commit_leaf(lance, dataset_path, fragments)
+
+        self._write_manifest(lance, partition_map, partition_versions)
+
+        total_fragments = sum(len(frags) for _, frags in partition_map.values())
+        manifest_version = self._latest_manifest_version(lance)
+        return MicroPartition.from_pydict(
+            {
+                "num_partitions": pa.array([len(partition_map)], type=pa.int64()),
+                "num_fragments": pa.array([total_fragments], type=pa.int64()),
+                "version": pa.array([manifest_version], type=pa.int64()),
+            }
+        )
+
+    # ---- Internals --------------------------------------------------------
+
+    def _check_no_existing_manifest(self, lance_module: ModuleType) -> None:
+        manifest_uri = f"{self._table_uri}/__manifest"
+        try:
+            lance_module.dataset(manifest_uri, storage_options=self._storage_options)
+        except (ValueError, FileNotFoundError, OSError):
+            return
+        raise ValueError(
+            f"Cannot create partitioned Lance namespace: manifest already exists at {manifest_uri}. "
+            "Use mode='append' or mode='overwrite' instead."
+        )
+
+    def _load_existing_manifest(self, lance_module: ModuleType) -> None:
+        """For append mode: reconstruct namespace ids, locations, and existing tables."""
+        manifest_uri = f"{self._table_uri}/__manifest"
+        try:
+            manifest_ds = lance_module.dataset(manifest_uri, storage_options=self._storage_options)
+        except (ValueError, FileNotFoundError, OSError):
+            raise ValueError(
+                f"Cannot append to partitioned Lance namespace: no manifest at {manifest_uri}. Use mode='create' first."
+            )
+
+        manifest_table = manifest_ds.to_table()
+
+        for i in range(manifest_table.num_rows):
+            oid = manifest_table.column(COL_OBJECT_ID)[i].as_py()
+            otype = manifest_table.column(COL_OBJECT_TYPE)[i].as_py()
+            spec_version, ns_ids, _ = parse_object_id(oid)
+
+            if spec_version != _SPEC_VERSION:
+                # We only know how to round-trip v1 in this implementation.
+                continue
+
+            if otype == OBJECT_TYPE_NAMESPACE and ns_ids:
+                # Reconstruct the prefix -> id mapping from this namespace row's
+                # partition_field_* columns truncated to its depth.
+                depth = len(ns_ids)
+                prefix: list[Any] = []
+                for col_name in self._partition_col_names[:depth]:
+                    pf_col = f"{PARTITION_FIELD_PREFIX}{col_name}"
+                    if pf_col in manifest_table.column_names:
+                        prefix.append(manifest_table.column(pf_col)[i].as_py())
+                    else:
+                        prefix.append(None)
+                # The full prefix tuple at depth `depth` maps to ns_ids[-1].
+                self._namespace_ids[tuple(prefix)] = ns_ids[-1]
+
+            elif otype == OBJECT_TYPE_TABLE:
+                location = manifest_table.column(COL_LOCATION)[i].as_py()
+                if location is not None:
+                    self._locations[oid] = location
+
+                pv: dict[str, Any] = {}
+                for col_name in self._partition_col_names:
+                    pf_col = f"{PARTITION_FIELD_PREFIX}{col_name}"
+                    if pf_col in manifest_table.column_names:
+                        pv[col_name] = manifest_table.column(pf_col)[i].as_py()
+                self._existing_table_pvs[oid] = pv
+
+                # Also re-populate the namespace prefix map from the table row.
+                # E.g. v1$abc$def$dataset → prefix (pv[c0],) → abc; (pv[c0], pv[c1]) → def
+                for depth in range(1, len(ns_ids) + 1):
+                    prefix_tuple = tuple(pv[c] for c in self._partition_col_names[:depth])
+                    self._namespace_ids.setdefault(prefix_tuple, ns_ids[depth - 1])
+
+                rv = manifest_table.column(COL_READ_VERSION)[i].as_py()
+                if rv is not None:
+                    self._existing_read_versions[oid] = int(rv)
+
+    def _table_object_id(self, partition_values: dict[str, Any]) -> str:
+        ns_ids: list[str] = []
+        for i in range(len(self._partition_col_names)):
+            prefix = tuple(partition_values[c] for c in self._partition_col_names[: i + 1])
+            if prefix not in self._namespace_ids:
+                self._namespace_ids[prefix] = random_namespace_id()
+            ns_ids.append(self._namespace_ids[prefix])
+        return make_object_id(_SPEC_VERSION, ns_ids, is_table=True)
+
+    def _location_for(self, table_oid: str) -> str:
+        loc = self._locations.get(table_oid)
+        if loc is None:
+            loc = make_location(table_oid)
+            self._locations[table_oid] = loc
+        return loc
+
+    def _group_by_partition(self, table: pa.Table) -> list[tuple[dict[str, Any], pa.Table]]:
+        # Compute unique partition value tuples.
+        partition_only = table.select(self._partition_col_names)
+        unique_combos = partition_only.group_by(self._partition_col_names).aggregate([])
+
+        groups: list[tuple[dict[str, Any], pa.Table]] = []
+        for i in range(unique_combos.num_rows):
+            mask: Any = None
+            pv: dict[str, Any] = {}
+            for col_name in self._partition_col_names:
+                val = unique_combos.column(col_name)[i]
+                pv[col_name] = val.as_py()
+                col_mask = pa.compute.equal(table.column(col_name), val)
+                mask = col_mask if mask is None else pa.compute.and_(mask, col_mask)
+            filtered = table.filter(mask)
+            groups.append((pv, filtered))
+        return groups
+
+    def _commit_leaf(self, lance_module: ModuleType, dataset_path: str, fragments: list[Any]) -> int:
+        """Commit fragments into the leaf Lance dataset and return its new version.
+
+        Uses ``LanceOperation.Append`` if the dataset already exists on disk
+        (regardless of write mode — the same partition value can be touched
+        twice in a single ``mode="create"`` job via multiple micropartitions),
+        otherwise ``LanceOperation.Overwrite`` to create the dataset.
+        """
+        existing_version: int | None = None
+        try:
+            existing_ds = lance_module.dataset(dataset_path, storage_options=self._storage_options)
+            existing_version = existing_ds.latest_version
+        except (ValueError, FileNotFoundError, OSError):
+            pass
+
+        if existing_version is not None:
+            op = lance_module.LanceOperation.Append(fragments)
+            committed = lance_module.LanceDataset.commit(
+                dataset_path,
+                op,
+                read_version=existing_version,
+                storage_options=self._storage_options,
+            )
+        else:
+            op = lance_module.LanceOperation.Overwrite(self._leaf_pa_schema, fragments)
+            committed = lance_module.LanceDataset.commit(
+                dataset_path,
+                op,
+                storage_options=self._storage_options,
+            )
+        return committed.version
+
+    def _write_manifest(
+        self,
+        lance_module: ModuleType,
+        partition_map: dict[str, tuple[dict[str, Any], list[Any]]],
+        partition_versions: dict[str, int],
+    ) -> None:
+        # Merge newly-written tables with previously-known tables (append path).
+        all_tables: dict[str, tuple[dict[str, Any], int | None]] = {}
+        for oid, pv in self._existing_table_pvs.items():
+            all_tables[oid] = (pv, self._existing_read_versions.get(oid))
+        for oid, (pv, _) in partition_map.items():
+            # Newly committed tables use their fresh version; existing ones get bumped if we touched them.
+            all_tables[oid] = (pv, partition_versions.get(oid, self._existing_read_versions.get(oid)))
+
+        rows = self._build_manifest_rows(all_tables)
+        schema_metadata = self._build_schema_metadata()
+        manifest_pa_schema = manifest_arrow_schema(self._partition_field_specs, schema_metadata)
+
+        # Assemble arrays column-by-column from the row dicts.
+        columns: dict[str, list[Any]] = {field.name: [] for field in manifest_pa_schema}
+        for row in rows:
+            for field in manifest_pa_schema:
+                columns[field.name].append(row.get(field.name))
+
+        arrays = []
+        for field in manifest_pa_schema:
+            arrays.append(pa.array(columns[field.name], type=field.type))
+        manifest_table = pa.Table.from_arrays(arrays, schema=manifest_pa_schema)
+
+        manifest_uri = f"{self._table_uri}/__manifest"
+        lance_module.write_dataset(
+            manifest_table,
+            manifest_uri,
+            mode="overwrite",
+            storage_options=self._storage_options,
+        )
+
+    def _build_manifest_rows(self, all_tables: dict[str, tuple[dict[str, Any], int | None]]) -> list[dict[str, Any]]:
+        """Assemble the full list of manifest rows (root + intermediate + leaf).
+
+        Order: parents before children. The spec doesn't require row ordering,
+        but emitting in dependency order makes reads simpler and the file
+        easier to inspect.
+        """
+        # The intermediate-namespace inventory derives from the union of
+        # _namespace_ids (live writes + reloaded append state) and the prefixes
+        # implied by every known table's partition values.
+        prefix_to_id: dict[tuple[Any, ...], str] = dict(self._namespace_ids)
+        for oid, (pv, _) in all_tables.items():
+            _, ns_ids, is_table = parse_object_id(oid)
+            assert is_table
+            for depth in range(1, len(ns_ids) + 1):
+                prefix_tuple = tuple(pv[c] for c in self._partition_col_names[:depth])
+                prefix_to_id.setdefault(prefix_tuple, ns_ids[depth - 1])
+
+        rows: list[dict[str, Any]] = []
+
+        # 1. Root namespace row (v1).
+        rows.append(self._row(make_object_id(_SPEC_VERSION, [], is_table=False), OBJECT_TYPE_NAMESPACE, {}))
+
+        # 2. Intermediate namespace rows, sorted by depth so parents precede children.
+        for prefix in sorted(prefix_to_id.keys(), key=lambda p: (len(p), p)):
+            ns_segments: list[str] = []
+            for depth in range(1, len(prefix) + 1):
+                ns_segments.append(prefix_to_id[prefix[:depth]])
+            oid = make_object_id(_SPEC_VERSION, ns_segments, is_table=False)
+            ns_pv = {c: prefix[i] for i, c in enumerate(self._partition_col_names[: len(prefix)])}
+            rows.append(self._row(oid, OBJECT_TYPE_NAMESPACE, ns_pv))
+
+        # 3. Table rows.
+        for oid, (pv, rv) in all_tables.items():
+            row = self._row(oid, OBJECT_TYPE_TABLE, pv, read_version=rv, location=self._locations.get(oid))
+            rows.append(row)
+
+        return rows
+
+    def _row(
+        self,
+        object_id: str,
+        object_type: str,
+        partition_values: dict[str, Any],
+        *,
+        location: str | None = None,
+        read_version: int | None = None,
+    ) -> dict[str, Any]:
+        row: dict[str, Any] = {
+            COL_OBJECT_ID: object_id,
+            COL_OBJECT_TYPE: object_type,
+            COL_LOCATION: location,
+            COL_METADATA: "{}",
+            COL_BASE_OBJECTS: None,
+            COL_READ_VERSION: read_version,
+            COL_READ_BRANCH: None,
+            COL_READ_TAG: None,
+        }
+        for spec in self._partition_field_specs:
+            row[f"{PARTITION_FIELD_PREFIX}{spec.field_id}"] = partition_values.get(spec.field_id)
+        return row
+
+    def _build_schema_metadata(self) -> dict[str, str]:
+        return {
+            f"partition_spec_{_SPEC_VERSION}": make_partition_spec_json(_SPEC_ID, self._partition_field_specs),
+            METADATA_KEY_SCHEMA: make_namespace_schema_json(self._namespace_pa_schema, self._field_ids),
+        }
+
+    def _latest_manifest_version(self, lance_module: ModuleType) -> int:
+        try:
+            ds = lance_module.dataset(f"{self._table_uri}/__manifest", storage_options=self._storage_options)
+        except (ValueError, FileNotFoundError, OSError):
+            return 0
+        return int(ds.latest_version)

--- a/daft/io/lance/lance_partitioned_merge.py
+++ b/daft/io/lance/lance_partitioned_merge.py
@@ -1,0 +1,570 @@
+"""Fast-path column merge into a partitioned Lance namespace.
+
+Adds new columns to an existing partitioned Lance namespace without rewriting
+the base data files. For each `(partition_values, fragment_id)` group, the
+new column values are written as a raw `.lance` data file and the resulting
+path is stitched into the fragment's metadata as an additional data file.
+A `LanceOperation.Merge` then commits the new fragment list against each
+touched leaf; the `__manifest` is finally rewritten with the bumped
+`read_version` per leaf and a `schema` JSON that includes the new columns.
+
+Requirements on the input DataFrame:
+
+- includes ``_rowaddr`` and ``fragment_id`` columns;
+- includes every partition column declared on the target namespace;
+- represents a positional-aligned read of each target partition (the input's
+  row count per ``(partition_values, fragment_id)`` group must equal the
+  matching leaf fragment's physical row count).
+
+Algorithm cribbed from daft-lance's ``FastPathFragmentWriter`` — the same
+approach used for non-partitioned Lance fast-path merge. We inline it here
+because ``daft-lance`` depends on ``daft`` and so cannot be a Daft
+dependency.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from collections import defaultdict
+from typing import TYPE_CHECKING, Any
+
+import daft
+import daft.pickle
+from daft.datatype import DataType
+from daft.dependencies import pa
+from daft.udf import cls as daft_cls
+from daft.udf import method
+
+from .lance_namespace import (
+    COL_LOCATION,
+    COL_OBJECT_ID,
+    COL_OBJECT_TYPE,
+    COL_READ_VERSION,
+    LANCE_FIELD_ID_KEY,
+    METADATA_KEY_SCHEMA,
+    OBJECT_TYPE_TABLE,
+    PARTITION_FIELD_PREFIX,
+    PartitionFieldSpec,
+    get_schema_metadata_value,
+    latest_partition_spec_key,
+    make_namespace_schema_json,
+    make_partition_spec_json,
+    manifest_arrow_schema,
+    parse_namespace_schema_json,
+    parse_partition_spec_json,
+)
+
+if TYPE_CHECKING:
+    import pathlib
+
+    import lance
+
+
+_FAST_PATH_RETURN_DTYPE = DataType.struct(
+    {
+        "fragment_meta": DataType.binary(),
+        "schema": DataType.binary(),
+        "leaf_uri": DataType.string(),
+    }
+)
+
+
+@daft_cls
+class _PartitionedFastPathWriter:
+    """Per-(partition, fragment) UDF that writes a raw `.lance` file.
+
+    Each `map_groups` call receives one (partition_values, fragment_id) group.
+    The new column values are sorted by `_rowaddr` to restore positional order,
+    written to a fresh `.lance` file under the leaf's `data/` directory, and
+    stitched into a copy of the existing fragment metadata.
+    """
+
+    def __init__(
+        self,
+        partition_to_uri: dict[tuple[Any, ...], str],
+        partition_col_names: list[str],
+        new_column_names: list[str],
+        storage_options: dict[str, str] | None = None,
+    ):
+        self.partition_to_uri = partition_to_uri
+        self.partition_col_names = partition_col_names
+        self.new_column_names = new_column_names
+        self.storage_options = storage_options
+
+    @method.batch(return_dtype=_FAST_PATH_RETURN_DTYPE)
+    def __call__(self, *cols: Any) -> list[dict[str, Any]]:
+        import lance
+        from lance.file import LanceFileWriter
+        from lance.fragment import FragmentMetadata
+
+        if len(cols) == 0:
+            return []
+
+        # Argument layout: [<new_col_1..n>, _rowaddr, fragment_id, <part_col_1..k>]
+        n_new = len(self.new_column_names)
+        data_cols = cols[:n_new]
+        rowaddr_col = cols[n_new]
+        fragment_id_col = cols[n_new + 1]
+        partition_value_cols = cols[n_new + 2 :]
+
+        # Extract partition values from the first row of this group (all rows
+        # in the group share the same partition values + fragment_id).
+        partition_values: list[Any] = []
+        for pc in partition_value_cols:
+            vals = pc.to_pylist() if hasattr(pc, "to_pylist") else list(pc)
+            if len(vals) == 0:
+                return []
+            partition_values.append(vals[0])
+        partition_key = tuple(partition_values)
+
+        leaf_uri = self.partition_to_uri.get(partition_key)
+        if leaf_uri is None:
+            raise ValueError(
+                f"No leaf table for partition "
+                f"{dict(zip(self.partition_col_names, partition_values))}. "
+                f"Known partitions: {len(self.partition_to_uri)}"
+            )
+
+        frag_ids = fragment_id_col.to_pylist() if hasattr(fragment_id_col, "to_pylist") else list(fragment_id_col)
+        if len(frag_ids) == 0:
+            return []
+        frag_id = frag_ids[0]
+
+        rowaddrs = rowaddr_col.to_pylist() if hasattr(rowaddr_col, "to_pylist") else list(rowaddr_col)
+
+        # Build the new-column table; sort by _rowaddr to align with fragment row order.
+        arrays = []
+        for s in data_cols:
+            arr = pa.array(s.to_pylist() if hasattr(s, "to_pylist") else list(s))
+            arrays.append(arr)
+        tbl = pa.table({name: arr for name, arr in zip(self.new_column_names, arrays)})
+
+        sort_indices = pa.compute.sort_indices(
+            pa.table({"_rowaddr": pa.array(rowaddrs, type=pa.uint64())}),
+            sort_keys=[("_rowaddr", "ascending")],
+        )
+        tbl = tbl.take(sort_indices)
+
+        # Write the new columns as a raw .lance file under the leaf's data/ dir.
+        filename = uuid.uuid4().hex + ".lance"
+        filepath = os.path.join(leaf_uri, "data", filename)
+        with LanceFileWriter(filepath, tbl.schema, storage_options=self.storage_options) as writer:
+            for b in tbl.to_batches():
+                writer.write_batch(b)
+        file_size = os.path.getsize(filepath)
+
+        # Stitch the new file into fragment metadata.
+        leaf_ds = lance.dataset(leaf_uri, storage_options=self.storage_options)
+        fragment = leaf_ds.get_fragment(frag_id)
+        next_fid = max(f.id() for f in leaf_ds.lance_schema.fields()) + 1
+
+        meta = dict(fragment.metadata.to_json())
+        meta["files"] = list(meta["files"]) + [
+            {
+                "path": filename,
+                "fields": list(range(next_fid, next_fid + len(self.new_column_names))),
+                "column_indices": list(range(len(self.new_column_names))),
+                "file_major_version": 2,
+                "file_minor_version": 0,
+                "file_size_bytes": file_size,
+                "base_id": None,
+            }
+        ]
+        new_frag_meta = FragmentMetadata.from_json(json.dumps(meta))
+
+        new_schema = leaf_ds.schema
+        for col_name in self.new_column_names:
+            col_idx = tbl.schema.get_field_index(col_name)
+            new_schema = new_schema.append(pa.field(col_name, tbl.schema.field(col_idx).type))
+
+        return [
+            {
+                "fragment_meta": daft.pickle.dumps(new_frag_meta),
+                "schema": daft.pickle.dumps(new_schema),
+                "leaf_uri": leaf_uri,
+            }
+        ]
+
+
+def _read_manifest_inventory(
+    namespace_uri: str,
+    partition_cols: list[str],
+    storage_options: dict[str, str] | None,
+) -> tuple[
+    lance.LanceDataset,
+    pa.Table,
+    dict[tuple[Any, ...], str],
+    dict[tuple[Any, ...], str],
+    dict[tuple[Any, ...], int],
+    pa.Schema,
+    list[PartitionFieldSpec],
+    int,
+]:
+    """Open the namespace's __manifest table and extract everything we need.
+
+    Returns:
+        (manifest_ds, manifest_table, partition_to_uri, partition_to_oid,
+         partition_to_read_version, namespace_schema, partition_field_specs,
+         spec_id)
+    """
+    import lance
+
+    manifest_uri = namespace_uri.rstrip("/") + "/__manifest"
+    manifest_ds = lance.dataset(manifest_uri, storage_options=storage_options)
+    manifest_table = manifest_ds.to_table()
+
+    schema_metadata = manifest_ds.schema.metadata or {}
+    latest = latest_partition_spec_key(schema_metadata)
+    if latest is None:
+        raise ValueError(
+            f"No partition_spec_v<N> key in {manifest_uri} metadata. Is this a partitioned Lance namespace?"
+        )
+    spec_id, spec_key = latest
+    spec_payload = get_schema_metadata_value(schema_metadata, spec_key)
+    if spec_payload is None:
+        raise ValueError(f"Missing value for {spec_key!r} in manifest metadata")
+    partition_spec = parse_partition_spec_json(spec_payload)
+
+    schema_payload = get_schema_metadata_value(schema_metadata, METADATA_KEY_SCHEMA)
+    if schema_payload is None:
+        raise ValueError(
+            f"Missing `schema` metadata on {manifest_uri}; cannot perform merge without the namespace schema."
+        )
+    namespace_schema = parse_namespace_schema_json(schema_payload)
+
+    # Resolve partition_field_specs (preserving field_id assignments from the schema).
+    field_ids: dict[str, int] = {}
+    for f in namespace_schema:
+        md = f.metadata or {}
+        raw = md.get(LANCE_FIELD_ID_KEY.encode(), md.get(LANCE_FIELD_ID_KEY))
+        if raw is None:
+            continue
+        if isinstance(raw, (bytes, bytearray)):
+            raw = raw.decode()
+        field_ids[f.name] = int(raw)
+
+    spec_field_specs: list[PartitionFieldSpec] = []
+    for fdef in partition_spec.get("fields", []):
+        fid = fdef["field_id"]
+        source_ids = fdef.get("source_ids", [])
+        source_id = int(source_ids[0]) if source_ids else field_ids.get(fid, 0)
+        # Find the source column's Arrow type from the namespace schema.
+        source_name = fid
+        try:
+            source_name = next(name for name, idx in field_ids.items() if idx == source_id)
+        except StopIteration:
+            pass
+        transform = fdef.get("transform") or {"type": "identity"}
+        transform_name = transform.get("type") if isinstance(transform, dict) else transform
+        result_type_field = namespace_schema.field(fid) if fid in namespace_schema.names else None
+        result_type = result_type_field.type if result_type_field is not None else pa.utf8()
+        spec_field_specs.append(
+            PartitionFieldSpec(
+                field_id=fid,
+                source_field_name=source_name,
+                source_id=source_id,
+                transform=transform_name or "identity",
+                result_type=result_type,
+            )
+        )
+
+    # Build partition_values -> (leaf_uri, object_id, read_version) maps.
+    partition_to_uri: dict[tuple[Any, ...], str] = {}
+    partition_to_oid: dict[tuple[Any, ...], str] = {}
+    partition_to_read_version: dict[tuple[Any, ...], int] = {}
+
+    has_object_type = COL_OBJECT_TYPE in manifest_table.column_names
+    has_read_version = COL_READ_VERSION in manifest_table.column_names
+
+    for i in range(manifest_table.num_rows):
+        if has_object_type and manifest_table.column(COL_OBJECT_TYPE)[i].as_py() != OBJECT_TYPE_TABLE:
+            continue
+        loc = manifest_table.column(COL_LOCATION)[i].as_py()
+        if loc is None:
+            continue
+        key = tuple(manifest_table.column(f"{PARTITION_FIELD_PREFIX}{c}")[i].as_py() for c in partition_cols)
+        leaf_uri = namespace_uri.rstrip("/") + "/" + loc
+        partition_to_uri[key] = leaf_uri
+        partition_to_oid[key] = manifest_table.column(COL_OBJECT_ID)[i].as_py()
+        if has_read_version:
+            rv = manifest_table.column(COL_READ_VERSION)[i].as_py()
+            if rv is not None:
+                partition_to_read_version[key] = int(rv)
+
+    return (
+        manifest_ds,
+        manifest_table,
+        partition_to_uri,
+        partition_to_oid,
+        partition_to_read_version,
+        namespace_schema,
+        spec_field_specs,
+        spec_id,
+    )
+
+
+def merge_columns_partitioned(
+    df: daft.DataFrame,
+    namespace_uri: str | pathlib.Path,
+    partition_cols: list[str],
+    *,
+    storage_options: dict[str, str] | None = None,
+) -> daft.DataFrame:
+    """Fast-path partitioned column merge.
+
+    The input DataFrame must include ``_rowaddr``, ``fragment_id``, and every
+    partition column. The DataFrame represents a positional-aligned read of
+    the touched partitions; existing columns are preserved unchanged, new
+    columns are appended to each touched leaf via raw `.lance` file stitching.
+    """
+    import lance
+
+    namespace_uri = str(namespace_uri).rstrip("/")
+
+    # Input validation.
+    required = {"_rowaddr", "fragment_id"} | set(partition_cols)
+    missing = required - set(df.column_names)
+    if missing:
+        hints = []
+        if "fragment_id" in missing:
+            hints.append("read with `include_fragment_id=True`")
+        if "_rowaddr" in missing:
+            hints.append("read with `default_scan_options={'with_row_address': True}`")
+        hint = "; ".join(hints)
+        raise ValueError(
+            f"DataFrame must contain {sorted(required)} for partitioned merge; missing {sorted(missing)}. "
+            + (hint + "." if hint else "")
+        )
+
+    (
+        _,
+        _,
+        partition_to_uri,
+        partition_to_oid,
+        partition_to_read_version,
+        namespace_schema,
+        partition_field_specs,
+        spec_id,
+    ) = _read_manifest_inventory(namespace_uri, partition_cols, storage_options)
+
+    if not partition_to_uri:
+        raise ValueError(f"No table rows in {namespace_uri}/__manifest; nothing to merge into.")
+
+    # Detect new columns: anything in the DF not already in the namespace
+    # schema, excluding metadata columns.
+    existing = set(namespace_schema.names)
+    metadata_cols = {"_rowaddr", "fragment_id"} | set(partition_cols)
+    new_cols = [c for c in df.column_names if c not in existing and c not in metadata_cols]
+    if not new_cols:
+        raise ValueError(
+            "DataFrame has no new columns to merge into the namespace. "
+            "The merge path appends new columns; for plain re-writes use mode='append'."
+        )
+
+    # Validate every partition value in the input maps to a known leaf.
+    input_partition_values = df.select(*partition_cols).distinct().to_pydict()
+    n = len(next(iter(input_partition_values.values())))
+    for i in range(n):
+        key = tuple(input_partition_values[c][i] for c in partition_cols)
+        if key not in partition_to_uri:
+            raise ValueError(
+                f"Input partition {dict(zip(partition_cols, key))} has no matching table in the manifest; "
+                f"known partitions: {len(partition_to_uri)}."
+            )
+
+    # Run per-(partition, fragment) merge in a single distributed pass.
+    writer = _PartitionedFastPathWriter(
+        partition_to_uri=partition_to_uri,
+        partition_col_names=partition_cols,
+        new_column_names=new_cols,
+        storage_options=storage_options,
+    )
+
+    group_keys = partition_cols + ["fragment_id"]
+    grouped = df.groupby(*group_keys).map_groups(
+        writer(
+            *(df[c] for c in new_cols),
+            df["_rowaddr"],
+            df["fragment_id"],
+            *(df[c] for c in partition_cols),
+        ).alias("commit_message")  # type: ignore[attr-defined]
+    )
+    commit_messages = grouped.collect().to_pydict()["commit_message"]
+
+    # Group commit messages by leaf_uri so we can commit each leaf once.
+    leaf_to_fragment_metas: dict[str, list[Any]] = defaultdict(list)
+    leaf_to_new_schema: dict[str, Any] = {}
+    for msg in commit_messages:
+        fmeta_bytes = msg["fragment_meta"]
+        schema_bytes = msg["schema"]
+        leaf_uri = msg["leaf_uri"]
+        if not fmeta_bytes or not schema_bytes:
+            continue
+        leaf_to_fragment_metas[leaf_uri].append(daft.pickle.loads(fmeta_bytes))
+        leaf_to_new_schema.setdefault(leaf_uri, daft.pickle.loads(schema_bytes))
+
+    if not leaf_to_fragment_metas:
+        raise ValueError("Partitioned merge produced no fragment metadata.")
+
+    # Commit each touched leaf with LanceOperation.Merge. Untouched fragments
+    # must be included unmodified so the merge replaces the full fragment list.
+    new_read_versions: dict[str, int] = {}
+    uri_to_partition_key = {uri: key for key, uri in partition_to_uri.items()}
+    for leaf_uri, enriched_metas in leaf_to_fragment_metas.items():
+        ds = lance.dataset(leaf_uri, storage_options=storage_options)
+        enriched_ids = {fm.id for fm in enriched_metas}
+        all_metas = list(enriched_metas)
+        for frag in ds.get_fragments():
+            if frag.fragment_id not in enriched_ids:
+                all_metas.append(frag.metadata)
+        new_schema = leaf_to_new_schema[leaf_uri]
+        op = lance.LanceOperation.Merge(all_metas, new_schema)
+        committed = lance.LanceDataset.commit(
+            leaf_uri,
+            op,
+            read_version=ds.version,
+            storage_options=storage_options,
+        )
+        new_read_versions[leaf_uri] = int(committed.version)
+
+    # Rewrite the manifest with bumped read_versions and an updated schema JSON.
+    updated_read_versions: dict[tuple[Any, ...], int] = dict(partition_to_read_version)
+    for leaf_uri, version in new_read_versions.items():
+        key = uri_to_partition_key[leaf_uri]
+        updated_read_versions[key] = version
+
+    # Extend the namespace schema with the new columns, assigning fresh field_ids.
+    existing_field_ids: dict[str, int] = {}
+    for f in namespace_schema:
+        md = f.metadata or {}
+        raw = md.get(LANCE_FIELD_ID_KEY.encode(), md.get(LANCE_FIELD_ID_KEY))
+        if raw is None:
+            continue
+        if isinstance(raw, (bytes, bytearray)):
+            raw = raw.decode()
+        existing_field_ids[f.name] = int(raw)
+    next_fid = (max(existing_field_ids.values()) + 1) if existing_field_ids else 0
+
+    df_arrow_schema = df.to_arrow().schema
+    extended_fields = list(namespace_schema)
+    extended_field_ids = dict(existing_field_ids)
+    for c in new_cols:
+        idx = df_arrow_schema.get_field_index(c)
+        if idx < 0:
+            continue
+        new_field = df_arrow_schema.field(idx).with_metadata({LANCE_FIELD_ID_KEY: str(next_fid)})
+        extended_fields.append(new_field)
+        extended_field_ids[c] = next_fid
+        next_fid += 1
+
+    extended_schema = pa.schema(extended_fields, metadata=namespace_schema.metadata)
+
+    _rewrite_manifest(
+        namespace_uri=namespace_uri,
+        partition_cols=partition_cols,
+        partition_field_specs=partition_field_specs,
+        spec_id=spec_id,
+        partition_to_oid=partition_to_oid,
+        partition_to_uri=partition_to_uri,
+        read_versions=updated_read_versions,
+        namespace_schema=extended_schema,
+        field_ids=extended_field_ids,
+        storage_options=storage_options,
+    )
+
+    # Return a small stats DataFrame mirroring write_lance(mode="merge") shape.
+    final_manifest = lance.dataset(namespace_uri + "/__manifest", storage_options=storage_options)
+    total_fragments = sum(
+        len(lance.dataset(uri, storage_options=storage_options).get_fragments()) for uri in new_read_versions.keys()
+    )
+    return daft.from_pydict(
+        {
+            "num_partitions": [len(new_read_versions)],
+            "num_fragments": [total_fragments],
+            "version": [int(final_manifest.latest_version)],
+        }
+    )
+
+
+def _rewrite_manifest(
+    *,
+    namespace_uri: str,
+    partition_cols: list[str],
+    partition_field_specs: list[PartitionFieldSpec],
+    spec_id: int,
+    partition_to_oid: dict[tuple[Any, ...], str],
+    partition_to_uri: dict[tuple[Any, ...], str],
+    read_versions: dict[tuple[Any, ...], int],
+    namespace_schema: pa.Schema,
+    field_ids: dict[str, int],
+    storage_options: dict[str, str] | None,
+) -> None:
+    """Rewrite ``__manifest`` after a partitioned merge.
+
+    Keeps the existing namespace + table inventory; updates ``read_version``
+    for touched leaves and refreshes the ``schema`` metadata to include the
+    newly-added columns. Field IDs from before the merge are preserved.
+    """
+    import lance
+
+    spec_version = f"v{spec_id}"
+
+    new_schema_metadata = {
+        f"partition_spec_{spec_version}": make_partition_spec_json(spec_id, partition_field_specs),
+        METADATA_KEY_SCHEMA: make_namespace_schema_json(namespace_schema, field_ids),
+    }
+    new_manifest_schema = manifest_arrow_schema(partition_field_specs, new_schema_metadata)
+
+    # Read the existing manifest so we can keep namespace rows verbatim.
+    manifest_ds = lance.dataset(namespace_uri + "/__manifest", storage_options=storage_options)
+    old_table = manifest_ds.to_table()
+
+    columns: dict[str, list[Any]] = {f.name: [] for f in new_manifest_schema}
+
+    oid_to_key = {oid: key for key, oid in partition_to_oid.items()}
+    oid_to_loc = {partition_to_oid[key]: partition_to_uri[key].split("/")[-1] for key in partition_to_uri}
+
+    for i in range(old_table.num_rows):
+        oid = old_table.column(COL_OBJECT_ID)[i].as_py()
+        otype = old_table.column(COL_OBJECT_TYPE)[i].as_py()
+        is_table_row = otype == OBJECT_TYPE_TABLE
+
+        location: str | None = None
+        read_version: int | None = None
+        if is_table_row:
+            location = oid_to_loc.get(oid)
+            if location is None:
+                # Unknown table row — keep its original location.
+                location = old_table.column(COL_LOCATION)[i].as_py()
+            key = oid_to_key.get(oid)
+            if key is not None and key in read_versions:
+                read_version = read_versions[key]
+
+        row = {
+            COL_OBJECT_ID: oid,
+            COL_OBJECT_TYPE: otype,
+            COL_LOCATION: location,
+            "metadata": "{}",
+            "base_objects": None,
+            COL_READ_VERSION: read_version,
+            "read_branch": None,
+            "read_tag": None,
+        }
+        # Partition value columns: copy from the existing manifest.
+        for c in partition_cols:
+            colname = f"{PARTITION_FIELD_PREFIX}{c}"
+            row[colname] = old_table.column(colname)[i].as_py() if colname in old_table.column_names else None
+
+        for fname in columns:
+            columns[fname].append(row.get(fname))
+
+    arrays = [pa.array(columns[f.name], type=f.type) for f in new_manifest_schema]
+    new_manifest = pa.Table.from_arrays(arrays, schema=new_manifest_schema)
+    lance.write_dataset(
+        new_manifest,
+        namespace_uri + "/__manifest",
+        mode="overwrite",
+        storage_options=storage_options,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,7 @@ dev = [
   "ray[data, client]==2.55.0",
   # Lance
   "pylance==0.39.0",
+  "lance-namespace-urllib3-client==0.7.6",
   # Iceberg
   "pyiceberg==0.11.0",
   "pydantic==2.12.4",

--- a/tests/io/lancedb/test_lance_namespace_partitioning.py
+++ b/tests/io/lancedb/test_lance_namespace_partitioning.py
@@ -178,6 +178,47 @@ class TestWriteModes:
         with pytest.raises(ValueError):
             df.write_lance(namespace_dir, partition_cols=["k"], mode="append")
 
+    def test_read_lance_warns_on_ignored_args_under_namespace_partitioning(self, namespace_dir, sample_df):
+        """Single-dataset args should warn rather than silently no-op.
+
+        Args targeting a single Lance dataset have no effect on a partitioned
+        namespace; surfacing this as a warning prevents silent no-ops.
+        """
+        sample_df.write_lance(namespace_dir, partition_cols=["year"], mode="create")
+        import warnings as _warnings
+
+        with _warnings.catch_warnings(record=True) as caught:
+            _warnings.simplefilter("always")
+            daft.read_lance(namespace_dir, namespace_partitioning=True, version=5).count_rows()
+        messages = [str(w.message) for w in caught]
+        assert any("version" in m and "ignores" in m for m in messages), messages
+
+    def test_read_lance_no_warning_when_args_default(self, namespace_dir, sample_df):
+        sample_df.write_lance(namespace_dir, partition_cols=["year"], mode="create")
+        import warnings as _warnings
+
+        with _warnings.catch_warnings(record=True) as caught:
+            _warnings.simplefilter("always")
+            daft.read_lance(namespace_dir, namespace_partitioning=True).count_rows()
+        # No ignored-arg warning should appear when the args are all defaults.
+        assert not any("ignores argument" in str(w.message) for w in caught)
+
+    def test_null_partition_values_preserved(self, namespace_dir):
+        """NULL partition values land in their own partition, not dropped.
+
+        Rows with NULL partition values should land in their own NULL partition,
+        not be silently dropped during the partition grouping.
+        """
+        df = daft.from_pydict({"key": ["a", None, "b", None], "val": [1, 2, 3, 4]})
+        df.write_lance(namespace_dir, partition_cols=["key"], mode="create")
+        result = daft.read_lance(namespace_dir, namespace_partitioning=True).to_pydict()
+        # All 4 rows must round-trip.
+        assert len(result["val"]) == 4
+        assert sorted(v for v in result["val"]) == [1, 2, 3, 4]
+        # The NULL-keyed values land in their own partition.
+        null_vals = sorted(v for k, v in zip(result["key"], result["val"]) if k is None)
+        assert null_vals == [2, 4]
+
 
 # ===========================================================================
 # Manifest table schema
@@ -670,6 +711,205 @@ class TestRead:
 # ===========================================================================
 
 
+class TestFragmentIdAndRowAddr:
+    """Read-side support needed for the fast-path partitioned merge.
+
+    `include_fragment_id` exposes per-leaf fragment ids, and
+    `default_scan_options={'with_row_address': True}` exposes `_rowaddr`.
+    """
+
+    def test_include_fragment_id_adds_column(self, namespace_dir, sample_df):
+        sample_df.write_lance(namespace_dir, partition_cols=["year"], mode="create")
+        df = daft.read_lance(namespace_dir, namespace_partitioning=True, include_fragment_id=True)
+        names = {f.name for f in df.schema()}
+        assert "fragment_id" in names
+
+    def test_include_fragment_id_values_match_leaf(self, namespace_dir):
+        # Write a small partitioned dataset, then read with fragment_id and verify
+        # every emitted fragment_id corresponds to an actual fragment in the
+        # matching leaf table.
+        import lance
+
+        df_in = daft.from_pydict(
+            {
+                "robot_id": [1, 1, 2, 2, 2],
+                "ts": [10, 11, 20, 21, 22],
+                "v": [1.0, 2.0, 3.0, 4.0, 5.0],
+            }
+        )
+        df_in.write_lance(namespace_dir, partition_cols=["robot_id"], mode="create")
+        df = daft.read_lance(namespace_dir, namespace_partitioning=True, include_fragment_id=True).to_pydict()
+
+        # Build a {robot_id: set(fragment_ids)} from the manifest's leaves.
+        _, manifest = _open_manifest(namespace_dir)
+        leaf_ids: dict[int, set[int]] = {}
+        for i in _table_row_indices(manifest):
+            robot_id = manifest.column("partition_field_robot_id")[i].as_py()
+            loc = manifest.column("location")[i].as_py()
+            ds = lance.dataset(os.path.join(namespace_dir, loc))
+            leaf_ids[robot_id] = {f.fragment_id for f in ds.get_fragments()}
+
+        for r, fid in zip(df["robot_id"], df["fragment_id"]):
+            assert fid in leaf_ids[r], (r, fid, leaf_ids[r])
+
+    def test_with_row_address_exposes_rowaddr(self, namespace_dir):
+        df_in = daft.from_pydict({"k": ["a", "a", "b"], "v": [1, 2, 3]})
+        df_in.write_lance(namespace_dir, partition_cols=["k"], mode="create")
+
+        df = daft.read_lance(
+            namespace_dir,
+            namespace_partitioning=True,
+            include_fragment_id=True,
+            default_scan_options={"with_row_address": True},
+        ).to_pydict()
+        assert "_rowaddr" in df
+        # row addresses are unique per leaf table.
+        for k_val in set(df["k"]):
+            addrs = [a for k, a in zip(df["k"], df["_rowaddr"]) if k == k_val]
+            assert len(addrs) == len(set(addrs))
+
+
+class TestPartitionedMerge:
+    """End-to-end enrichment via the partitioned fast-path merge.
+
+    Reads with fragment_id + _rowaddr, computes a new column, writes back
+    via partitioned fast-path merge. Verifies the new column is visible
+    after re-read with values aligned per row, the base data is unchanged,
+    and the manifest's leaf read_versions are bumped.
+    """
+
+    @pytest.fixture
+    def base_df(self):
+        return daft.from_pydict(
+            {
+                "robot_id": [1, 1, 1, 2, 2],
+                "ts": [10, 11, 12, 20, 21],
+                "v": [1.0, 2.0, 3.0, 4.0, 5.0],
+            }
+        )
+
+    def _read_with_meta(self, uri):
+        return daft.read_lance(
+            uri,
+            namespace_partitioning=True,
+            include_fragment_id=True,
+            default_scan_options={"with_row_address": True},
+        )
+
+    def test_merge_requires_fragment_id(self, namespace_dir, base_df):
+        base_df.write_lance(namespace_dir, partition_cols=["robot_id"], mode="create")
+        # Build an input lacking fragment_id (and _rowaddr).
+        df = daft.read_lance(namespace_dir, namespace_partitioning=True)
+        df = df.with_column("enriched", df["v"] * 10)
+        with pytest.raises(ValueError, match="fragment_id"):
+            df.write_lance(namespace_dir, partition_cols=["robot_id"], mode="merge")
+
+    def test_merge_requires_rowaddr(self, namespace_dir, base_df):
+        base_df.write_lance(namespace_dir, partition_cols=["robot_id"], mode="create")
+        df = daft.read_lance(namespace_dir, namespace_partitioning=True, include_fragment_id=True)
+        df = df.with_column("enriched", df["v"] * 10)
+        with pytest.raises(ValueError, match="_rowaddr"):
+            df.write_lance(namespace_dir, partition_cols=["robot_id"], mode="merge")
+
+    def test_merge_requires_new_columns(self, namespace_dir, base_df):
+        base_df.write_lance(namespace_dir, partition_cols=["robot_id"], mode="create")
+        df = self._read_with_meta(namespace_dir)
+        # No new columns added.
+        with pytest.raises(ValueError, match="new column"):
+            df.write_lance(namespace_dir, partition_cols=["robot_id"], mode="merge")
+
+    def test_merge_unknown_partition_raises(self, namespace_dir, base_df):
+        base_df.write_lance(namespace_dir, partition_cols=["robot_id"], mode="create")
+        df = self._read_with_meta(namespace_dir)
+        # Manually mutate the robot_id to an unknown partition value.
+        df = df.with_column("robot_id", df["robot_id"] + 99)
+        df = df.with_column("enriched", df["v"] * 10)
+        with pytest.raises(ValueError, match="partition"):
+            df.write_lance(namespace_dir, partition_cols=["robot_id"], mode="merge")
+
+    def test_merge_adds_new_column(self, namespace_dir, base_df):
+        base_df.write_lance(namespace_dir, partition_cols=["robot_id"], mode="create")
+        df = self._read_with_meta(namespace_dir)
+        df = df.with_column("enriched", df["v"] * 10)
+
+        df.write_lance(namespace_dir, partition_cols=["robot_id"], mode="merge")
+
+        result = daft.read_lance(namespace_dir, namespace_partitioning=True).to_pydict()
+        # Base columns preserved.
+        assert sorted(zip(result["robot_id"], result["ts"], result["v"])) == [
+            (1, 10, 1.0),
+            (1, 11, 2.0),
+            (1, 12, 3.0),
+            (2, 20, 4.0),
+            (2, 21, 5.0),
+        ]
+        # Enriched column matches v * 10 with rows aligned.
+        rows = sorted(zip(result["robot_id"], result["ts"], result["v"], result["enriched"]))
+        for _, _, v, e in rows:
+            assert e == pytest.approx(v * 10)
+
+    def test_merge_bumps_leaf_read_versions(self, namespace_dir, base_df):
+        base_df.write_lance(namespace_dir, partition_cols=["robot_id"], mode="create")
+        _, manifest_before = _open_manifest(namespace_dir)
+        before = {
+            manifest_before.column("object_id")[i].as_py(): manifest_before.column("read_version")[i].as_py()
+            for i in _table_row_indices(manifest_before)
+        }
+
+        df = self._read_with_meta(namespace_dir)
+        df = df.with_column("enriched", df["v"] * 10)
+        df.write_lance(namespace_dir, partition_cols=["robot_id"], mode="merge")
+
+        _, manifest_after = _open_manifest(namespace_dir)
+        after = {
+            manifest_after.column("object_id")[i].as_py(): manifest_after.column("read_version")[i].as_py()
+            for i in _table_row_indices(manifest_after)
+        }
+        for oid, v0 in before.items():
+            assert after[oid] is not None
+            assert after[oid] > v0, (oid, v0, after[oid])
+
+    def test_merge_updates_namespace_schema_metadata(self, namespace_dir, base_df):
+        base_df.write_lance(namespace_dir, partition_cols=["robot_id"], mode="create")
+        df = self._read_with_meta(namespace_dir)
+        df = df.with_column("enriched", df["v"] * 10)
+        df.write_lance(namespace_dir, partition_cols=["robot_id"], mode="merge")
+
+        ds, _ = _open_manifest(namespace_dir)
+        schema_obj = json.loads(_decode_meta(ds.schema.metadata, "schema"))
+        names = {f["name"] for f in schema_obj["fields"]}
+        assert "enriched" in names
+        # Existing fields keep their lance:field_id; new field gets a fresh one.
+        ids = {f["name"]: int(f["metadata"]["lance:field_id"]) for f in schema_obj["fields"]}
+        assert ids["enriched"] not in {ids["robot_id"], ids["ts"], ids["v"]}
+
+    def test_merge_does_not_rewrite_base_data_files(self, namespace_dir, base_df):
+        """Fast-path merge writes a NEW .lance file alongside existing ones.
+
+        The original data files must remain untouched.
+        """
+        base_df.write_lance(namespace_dir, partition_cols=["robot_id"], mode="create")
+        _, manifest = _open_manifest(namespace_dir)
+        # Snapshot the data files of each leaf table.
+        files_before: dict[str, set[str]] = {}
+        for i in _table_row_indices(manifest):
+            loc = manifest.column("location")[i].as_py()
+            data_dir = os.path.join(namespace_dir, loc, "data")
+            files_before[loc] = set(os.listdir(data_dir))
+
+        df = self._read_with_meta(namespace_dir)
+        df = df.with_column("enriched", df["v"] * 10)
+        df.write_lance(namespace_dir, partition_cols=["robot_id"], mode="merge")
+
+        for loc, before in files_before.items():
+            data_dir = os.path.join(namespace_dir, loc, "data")
+            after = set(os.listdir(data_dir))
+            # The original files must still be present.
+            assert before <= after, (loc, before - after)
+            # And the merge added at least one new file.
+            assert len(after - before) >= 1, (loc, after, before)
+
+
 class TestRoundtrip:
     def test_simple_roundtrip(self, namespace_dir):
         original = {"a": [1, 2, 3], "b": ["x", "y", "z"], "c": [10.0, 20.0, 30.0]}
@@ -1022,6 +1262,86 @@ class TestSpecLiteralFixture:
         dirs_on_disk.discard("__manifest")
         expected_dirs = set(expected.keys())
         assert dirs_on_disk == expected_dirs
+
+    def test_source_ids_resolved_by_lance_field_id_not_position(self, tmp_path):
+        """`source_ids` references `lance:field_id`, not Arrow positional index.
+
+        Build a manifest with non-positional field_ids (e.g., 10, 42, 99) and
+        verify the reader resolves the partition source field correctly.
+        """
+        import datetime as _dt
+
+        import lance
+
+        root = str(tmp_path / "ns")
+        os.makedirs(root, exist_ok=True)
+
+        schema_json = {
+            "fields": [
+                {"name": "id", "nullable": False, "type": {"type": "int64"}, "metadata": {"lance:field_id": "10"}},
+                {"name": "country", "nullable": True, "type": {"type": "utf8"}, "metadata": {"lance:field_id": "42"}},
+                {
+                    "name": "event_date",
+                    "nullable": True,
+                    "type": {"type": "date32"},
+                    "metadata": {"lance:field_id": "99"},
+                },
+            ]
+        }
+        # Partition spec references source_id 99 -> event_date.
+        partition_spec_v1 = {
+            "id": 1,
+            "fields": [
+                {
+                    "field_id": "event_date",
+                    "source_ids": [99],
+                    "transform": {"type": "identity"},
+                    "result_type": {"type": "date32"},
+                }
+            ],
+        }
+
+        leaf_pa_schema = pa.schema([pa.field("id", pa.int64(), nullable=False), pa.field("country", pa.utf8())])
+        leaf_table = pa.table({"id": [1, 2], "country": ["US", "JP"]}, schema=leaf_pa_schema)
+        location = "deadbeef_v1$ns0000000000000000$dataset"
+        lance.write_dataset(leaf_table, os.path.join(root, location))
+
+        manifest_schema = pa.schema(
+            [
+                pa.field("object_id", pa.utf8(), nullable=False),
+                pa.field("object_type", pa.utf8(), nullable=False),
+                pa.field("location", pa.utf8()),
+                pa.field("metadata", pa.utf8()),
+                pa.field("base_objects", pa.list_(pa.utf8())),
+                pa.field("read_version", pa.uint64()),
+                pa.field("read_branch", pa.utf8()),
+                pa.field("read_tag", pa.utf8()),
+                pa.field("partition_field_event_date", pa.date32()),
+            ],
+            metadata={
+                "partition_spec_v1": json.dumps(partition_spec_v1),
+                "schema": json.dumps(schema_json),
+            },
+        )
+        rows = {
+            "object_id": ["v1", "v1$ns0000000000000000", "v1$ns0000000000000000$dataset"],
+            "object_type": ["namespace", "namespace", "table"],
+            "location": [None, None, location],
+            "metadata": ["{}", "{}", "{}"],
+            "base_objects": [None, None, None],
+            "read_version": [None, None, 1],
+            "read_branch": [None, None, None],
+            "read_tag": [None, None, None],
+            "partition_field_event_date": [None, _dt.date(2025, 1, 1), _dt.date(2025, 1, 1)],
+        }
+        arrays = [pa.array(rows[f.name], type=f.type) for f in manifest_schema]
+        manifest_table = pa.Table.from_arrays(arrays, schema=manifest_schema)
+        lance.write_dataset(manifest_table, os.path.join(root, "__manifest"))
+
+        result = daft.read_lance(root, namespace_partitioning=True).to_pydict()
+        assert sorted(result["id"]) == [1, 2]
+        assert set(result["country"]) == {"US", "JP"}
+        assert all(d == _dt.date(2025, 1, 1) for d in result["event_date"])
 
 
 # ===========================================================================

--- a/tests/io/lancedb/test_lance_namespace_partitioning.py
+++ b/tests/io/lancedb/test_lance_namespace_partitioning.py
@@ -1,0 +1,1260 @@
+"""Spec-compliance tests for Lance Partitioned Namespace support.
+
+These tests are written first (TDD) and assert that Daft's partitioned
+read/write path conforms exactly to:
+
+- Lance V2 Directory Namespace spec — manifest table schema, hash-prefixed
+  table directories, root-namespace properties stored in manifest metadata.
+- Lance Partitioning spec — partition_spec_v<N> + schema metadata,
+  partition_field_{field_id} columns, hierarchical object_ids with
+  random 16-char base36 namespace segments, ``dataset`` leaf naming, and
+  per-row inheritance of partition values from parent namespaces.
+
+Each test asserts a single spec property; failures should point directly at
+the spec rule that was violated.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import tempfile
+
+import pyarrow as pa
+import pytest
+
+import daft
+
+# ---------------------------------------------------------------------------
+# Fixtures and helpers
+# ---------------------------------------------------------------------------
+
+# 16-char base36 segment (a-z, 0-9). Used to validate object_id segments.
+_NS_ID_RE = re.compile(r"^[a-z0-9]{16}$")
+
+# 8-char lowercase hex prefix on physical table directories.
+_HASH_PREFIX_RE = re.compile(r"^[a-f0-9]{8}$")
+
+
+@pytest.fixture
+def namespace_dir():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield os.path.join(tmpdir, "test_namespace")
+
+
+@pytest.fixture
+def sample_df():
+    return daft.from_pydict(
+        {
+            "year": [2024, 2024, 2025, 2025, 2024, 2025],
+            "country": ["US", "UK", "US", "UK", "US", "US"],
+            "value": [10, 20, 30, 40, 50, 60],
+            "name": ["alice", "bob", "charlie", "diana", "eve", "frank"],
+        }
+    )
+
+
+def _open_manifest(namespace_dir: str):
+    """Open the __manifest Lance dataset and return (dataset, table)."""
+    import lance
+
+    ds = lance.dataset(os.path.join(namespace_dir, "__manifest"))
+    return ds, ds.to_table()
+
+
+def _table_row_indices(manifest_table: pa.Table) -> list[int]:
+    return [i for i in range(manifest_table.num_rows) if manifest_table.column("object_type")[i].as_py() == "table"]
+
+
+def _namespace_row_indices(manifest_table: pa.Table) -> list[int]:
+    return [i for i in range(manifest_table.num_rows) if manifest_table.column("object_type")[i].as_py() == "namespace"]
+
+
+def _decode_meta(metadata: dict | None, key: str) -> str | None:
+    """Look up a metadata key tolerating str/bytes."""
+    if metadata is None:
+        return None
+    if key in metadata:
+        v = metadata[key]
+    elif key.encode() in metadata:
+        v = metadata[key.encode()]
+    else:
+        return None
+    return v.decode() if isinstance(v, (bytes, bytearray)) else v
+
+
+# ===========================================================================
+# Public API surface
+# ===========================================================================
+
+
+class TestPublicAPI:
+    def test_write_lance_accepts_partition_cols(self, namespace_dir, sample_df):
+        # smoke: keyword should be accepted, write should produce a __manifest
+        sample_df.write_lance(namespace_dir, partition_cols=["year"], mode="create")
+        assert os.path.isdir(os.path.join(namespace_dir, "__manifest"))
+
+    def test_read_lance_accepts_namespace_partitioning(self, namespace_dir, sample_df):
+        sample_df.write_lance(namespace_dir, partition_cols=["year"], mode="create")
+        df = daft.read_lance(namespace_dir, namespace_partitioning=True)
+        assert df.count_rows() == 6
+
+    def test_partition_cols_with_merge_mode_raises(self, namespace_dir, sample_df):
+        with pytest.raises(ValueError, match="merge"):
+            sample_df.write_lance(namespace_dir, partition_cols=["year"], mode="merge")
+
+    def test_empty_partition_cols_raises(self, namespace_dir, sample_df):
+        with pytest.raises(ValueError):
+            sample_df.write_lance(namespace_dir, partition_cols=[], mode="create")
+
+    def test_unknown_partition_col_raises(self, namespace_dir, sample_df):
+        with pytest.raises(ValueError):
+            sample_df.write_lance(namespace_dir, partition_cols=["nope"], mode="create")
+
+
+# ===========================================================================
+# Write modes
+# ===========================================================================
+
+
+class TestWriteModes:
+    def test_basic_write_returns_stats(self, namespace_dir, sample_df):
+        result = sample_df.write_lance(namespace_dir, partition_cols=["year", "country"], mode="create")
+        pd = result.to_pydict()
+        # 4 distinct (year, country) combinations across 6 rows
+        assert pd["num_partitions"] == [4]
+        assert pd["num_fragments"] == [4]
+        # version is a single int64
+        assert isinstance(pd["version"][0], int)
+
+    def test_create_mode_fails_if_exists(self, namespace_dir, sample_df):
+        sample_df.write_lance(namespace_dir, partition_cols=["year"], mode="create")
+        with pytest.raises(ValueError, match="exists"):
+            sample_df.write_lance(namespace_dir, partition_cols=["year"], mode="create")
+
+    def test_overwrite_mode(self, namespace_dir, sample_df):
+        sample_df.write_lance(namespace_dir, partition_cols=["year", "country"], mode="create")
+        df2 = daft.from_pydict({"year": [2026], "country": ["JP"], "value": [100], "name": ["kenji"]})
+        df2.write_lance(namespace_dir, partition_cols=["year", "country"], mode="overwrite")
+        result = daft.read_lance(namespace_dir, namespace_partitioning=True).to_pydict()
+        assert result["year"] == [2026]
+        assert result["country"] == ["JP"]
+        assert result["value"] == [100]
+
+    def test_append_existing_partition(self, namespace_dir):
+        df1 = daft.from_pydict({"key": ["a", "b"], "val": [1, 2]})
+        df1.write_lance(namespace_dir, partition_cols=["key"], mode="create")
+
+        df2 = daft.from_pydict({"key": ["a"], "val": [3]})
+        df2.write_lance(namespace_dir, partition_cols=["key"], mode="append")
+
+        _, manifest = _open_manifest(namespace_dir)
+        # Existing table rows must not be duplicated when appending to the same partition.
+        table_oids = [manifest.column("object_id")[i].as_py() for i in _table_row_indices(manifest)]
+        assert sorted(table_oids) == sorted(set(table_oids)), table_oids
+        # Still 2 partitions (a, b), not 3.
+        assert len(table_oids) == 2
+
+        result = daft.read_lance(namespace_dir, namespace_partitioning=True).to_pydict()
+        assert sorted(result["val"]) == [1, 2, 3]
+
+    def test_append_new_partition(self, namespace_dir):
+        df1 = daft.from_pydict({"key": ["a"], "val": [1]})
+        df1.write_lance(namespace_dir, partition_cols=["key"], mode="create")
+
+        df2 = daft.from_pydict({"key": ["b"], "val": [2]})
+        df2.write_lance(namespace_dir, partition_cols=["key"], mode="append")
+
+        _, manifest = _open_manifest(namespace_dir)
+        table_oids = [manifest.column("object_id")[i].as_py() for i in _table_row_indices(manifest)]
+        assert len(table_oids) == 2
+
+        result = daft.read_lance(namespace_dir, namespace_partitioning=True).to_pydict()
+        assert sorted(zip(result["key"], result["val"])) == [("a", 1), ("b", 2)]
+
+    def test_append_missing_manifest_raises(self, namespace_dir):
+        df = daft.from_pydict({"k": ["a"], "v": [1]})
+        with pytest.raises(ValueError):
+            df.write_lance(namespace_dir, partition_cols=["k"], mode="append")
+
+
+# ===========================================================================
+# Manifest table schema
+# ===========================================================================
+
+
+class TestManifestSchema:
+    """V2 base columns + partitioning extension columns are all present and typed correctly."""
+
+    def test_v2_base_columns_present(self, namespace_dir, sample_df):
+        sample_df.write_lance(namespace_dir, partition_cols=["year"], mode="create")
+        _, manifest = _open_manifest(namespace_dir)
+        for col in ("object_id", "object_type", "location", "metadata", "base_objects"):
+            assert col in manifest.column_names, f"missing V2 base column {col!r}"
+
+    def test_partitioning_extension_columns_present(self, namespace_dir, sample_df):
+        sample_df.write_lance(namespace_dir, partition_cols=["year"], mode="create")
+        _, manifest = _open_manifest(namespace_dir)
+        for col in ("read_version", "read_branch", "read_tag"):
+            assert col in manifest.column_names, f"missing partitioning ext column {col!r}"
+
+    def test_partition_field_columns_present(self, namespace_dir, sample_df):
+        sample_df.write_lance(namespace_dir, partition_cols=["year", "country"], mode="create")
+        _, manifest = _open_manifest(namespace_dir)
+        assert "partition_field_year" in manifest.column_names
+        assert "partition_field_country" in manifest.column_names
+
+    def test_column_types(self, namespace_dir, sample_df):
+        sample_df.write_lance(namespace_dir, partition_cols=["year"], mode="create")
+        _, manifest = _open_manifest(namespace_dir)
+        schema = manifest.schema
+        assert pa.types.is_string(schema.field("object_id").type)
+        assert pa.types.is_string(schema.field("object_type").type)
+        assert pa.types.is_string(schema.field("location").type)
+        assert pa.types.is_string(schema.field("metadata").type)
+        assert pa.types.is_list(schema.field("base_objects").type)
+        assert pa.types.is_string(schema.field("base_objects").type.value_type)
+        # read_version: uint64 per spec
+        assert pa.types.is_uint64(schema.field("read_version").type)
+        assert pa.types.is_string(schema.field("read_branch").type)
+        assert pa.types.is_string(schema.field("read_tag").type)
+
+    def test_nullability(self, namespace_dir, sample_df):
+        sample_df.write_lance(namespace_dir, partition_cols=["year"], mode="create")
+        _, manifest = _open_manifest(namespace_dir)
+        schema = manifest.schema
+        # Per spec: object_id and object_type are required; rest are nullable.
+        assert not schema.field("object_id").nullable
+        assert not schema.field("object_type").nullable
+        assert schema.field("location").nullable
+        assert schema.field("metadata").nullable
+        assert schema.field("base_objects").nullable
+        assert schema.field("read_version").nullable
+        assert schema.field("read_branch").nullable
+        assert schema.field("read_tag").nullable
+        assert schema.field("partition_field_year").nullable
+
+    def test_object_id_has_unenforced_primary_key_metadata(self, namespace_dir, sample_df):
+        """Verify object_id carries the unenforced-primary-key metadata.
+
+        The reference `lance-namespace-impls` marks `object_id` with
+        `lance-schema:unenforced-primary-key:position = "0"` so Lance treats it
+        as a primary key for merge-insert conflict detection.
+        """
+        sample_df.write_lance(namespace_dir, partition_cols=["year"], mode="create")
+        _, manifest = _open_manifest(namespace_dir)
+        oid_field = manifest.schema.field("object_id")
+        md = oid_field.metadata or {}
+        # Lance round-trips Arrow field metadata as bytes.
+        key = b"lance-schema:unenforced-primary-key:position"
+        assert key in md, dict(md)
+        assert md[key] == b"0", md[key]
+
+    def test_base_objects_inner_field_name(self, namespace_dir, sample_df):
+        """Verify the `base_objects` inner List<Utf8> field is named `object_id`.
+
+        The reference impl uses `"object_id"` as the inner field of the
+        `base_objects` List<Utf8>. PyArrow's default would be `"item"`.
+        """
+        sample_df.write_lance(namespace_dir, partition_cols=["year"], mode="create")
+        _, manifest = _open_manifest(namespace_dir)
+        base_objects_type = manifest.schema.field("base_objects").type
+        assert pa.types.is_list(base_objects_type)
+        inner = base_objects_type.value_field
+        assert inner.name == "object_id", inner.name
+        assert pa.types.is_string(inner.type)
+
+
+# ===========================================================================
+# Root namespace properties (schema metadata)
+# ===========================================================================
+
+
+class TestRootNamespaceMetadata:
+    """`partition_spec_v<N>` and `schema` live on the __manifest dataset's schema metadata."""
+
+    def test_partition_spec_v1_present(self, namespace_dir, sample_df):
+        sample_df.write_lance(namespace_dir, partition_cols=["year"], mode="create")
+        ds, _ = _open_manifest(namespace_dir)
+        raw = _decode_meta(ds.schema.metadata, "partition_spec_v1")
+        assert raw is not None, "partition_spec_v1 must be in __manifest's schema metadata"
+        spec = json.loads(raw)
+        assert spec["id"] == 1
+        assert isinstance(spec["fields"], list)
+        assert len(spec["fields"]) == 1
+
+    def test_partition_spec_field_shape(self, namespace_dir, sample_df):
+        sample_df.write_lance(namespace_dir, partition_cols=["year", "country"], mode="create")
+        ds, _ = _open_manifest(namespace_dir)
+        spec = json.loads(_decode_meta(ds.schema.metadata, "partition_spec_v1"))
+
+        assert spec["id"] == 1
+        names = [f["field_id"] for f in spec["fields"]]
+        assert names == ["year", "country"]
+
+        for field in spec["fields"]:
+            # Per spec: transform is a JSON object with "type", NOT a bare string.
+            assert isinstance(field["transform"], dict), field
+            assert field["transform"] == {"type": "identity"}
+            # Per spec: result_type is a JsonArrowDataType, NOT a bare string.
+            assert isinstance(field["result_type"], dict), field
+            assert "type" in field["result_type"]
+            # Per spec: source_ids is an int array.
+            assert isinstance(field["source_ids"], list)
+            assert all(isinstance(x, int) for x in field["source_ids"])
+
+    def test_partition_spec_result_types(self, namespace_dir, sample_df):
+        sample_df.write_lance(namespace_dir, partition_cols=["year", "country"], mode="create")
+        ds, _ = _open_manifest(namespace_dir)
+        spec = json.loads(_decode_meta(ds.schema.metadata, "partition_spec_v1"))
+        by_id = {f["field_id"]: f for f in spec["fields"]}
+        assert by_id["year"]["result_type"] == {"type": "int64"}
+        # Daft coerces utf8 -> large_utf8 on ingest; both are valid JsonArrowDataType values.
+        assert by_id["country"]["result_type"]["type"] in ("utf8", "large_utf8")
+
+    def test_schema_metadata_is_jsonarrowschema(self, namespace_dir, sample_df):
+        sample_df.write_lance(namespace_dir, partition_cols=["year"], mode="create")
+        ds, _ = _open_manifest(namespace_dir)
+        raw = _decode_meta(ds.schema.metadata, "schema")
+        assert raw is not None
+        schema_obj = json.loads(raw)
+        assert "fields" in schema_obj
+        # Every field has name, nullable, type-as-object, and lance:field_id metadata.
+        for f in schema_obj["fields"]:
+            assert "name" in f
+            assert "nullable" in f
+            assert isinstance(f["type"], dict)
+            assert "metadata" in f
+            assert "lance:field_id" in f["metadata"]
+            # field_id values are strings per JsonArrowField shape
+            assert isinstance(f["metadata"]["lance:field_id"], str)
+
+    def test_schema_includes_partition_columns(self, namespace_dir, sample_df):
+        sample_df.write_lance(namespace_dir, partition_cols=["year", "country"], mode="create")
+        ds, _ = _open_manifest(namespace_dir)
+        schema_obj = json.loads(_decode_meta(ds.schema.metadata, "schema"))
+        names = [f["name"] for f in schema_obj["fields"]]
+        # The namespace schema is the user-facing schema and includes partition cols.
+        assert set(names) == {"year", "country", "value", "name"}
+
+    def test_field_ids_unique_and_immutable_across_append(self, namespace_dir, sample_df):
+        sample_df.write_lance(namespace_dir, partition_cols=["year"], mode="create")
+        ds, _ = _open_manifest(namespace_dir)
+        before = {
+            f["name"]: f["metadata"]["lance:field_id"]
+            for f in json.loads(_decode_meta(ds.schema.metadata, "schema"))["fields"]
+        }
+        # field ids must be unique
+        assert len(set(before.values())) == len(before)
+
+        sample_df.write_lance(namespace_dir, partition_cols=["year"], mode="append")
+        ds2, _ = _open_manifest(namespace_dir)
+        after = {
+            f["name"]: f["metadata"]["lance:field_id"]
+            for f in json.loads(_decode_meta(ds2.schema.metadata, "schema"))["fields"]
+        }
+        # field ids must not change on append
+        assert before == after
+
+
+# ===========================================================================
+# Object ID structure
+# ===========================================================================
+
+
+class TestObjectIds:
+    def test_root_namespace_row_exists(self, namespace_dir, sample_df):
+        sample_df.write_lance(namespace_dir, partition_cols=["year"], mode="create")
+        _, manifest = _open_manifest(namespace_dir)
+        oids = manifest.column("object_id").to_pylist()
+        assert "v1" in oids
+
+    def test_single_partition_col_depth(self, namespace_dir):
+        df = daft.from_pydict({"region": ["east", "west", "east"], "val": [1, 2, 3]})
+        df.write_lance(namespace_dir, partition_cols=["region"], mode="create")
+        _, manifest = _open_manifest(namespace_dir)
+        for i in _table_row_indices(manifest):
+            oid = manifest.column("object_id")[i].as_py()
+            parts = oid.split("$")
+            # v1$<ns_id>$dataset
+            assert len(parts) == 3, oid
+            assert parts[0] == "v1"
+            assert parts[-1] == "dataset"
+            assert _NS_ID_RE.match(parts[1]), parts[1]
+
+    def test_two_partition_col_depth(self, namespace_dir, sample_df):
+        sample_df.write_lance(namespace_dir, partition_cols=["year", "country"], mode="create")
+        _, manifest = _open_manifest(namespace_dir)
+        for i in _table_row_indices(manifest):
+            oid = manifest.column("object_id")[i].as_py()
+            parts = oid.split("$")
+            # v1$<ns1>$<ns2>$dataset
+            assert len(parts) == 4, oid
+            assert parts[0] == "v1"
+            assert parts[-1] == "dataset"
+            for seg in parts[1:-1]:
+                assert _NS_ID_RE.match(seg), seg
+
+    def test_siblings_share_parent_segment(self, namespace_dir, sample_df):
+        """Two tables under the same year must share the same first namespace id."""
+        sample_df.write_lance(namespace_dir, partition_cols=["year", "country"], mode="create")
+        _, manifest = _open_manifest(namespace_dir)
+        year_to_seg: dict[int, str] = {}
+        for i in _table_row_indices(manifest):
+            oid = manifest.column("object_id")[i].as_py()
+            year = manifest.column("partition_field_year")[i].as_py()
+            seg1 = oid.split("$")[1]
+            if year in year_to_seg:
+                assert year_to_seg[year] == seg1, f"tables with year={year} must share first segment"
+            else:
+                year_to_seg[year] = seg1
+        assert len(year_to_seg) == 2
+
+    def test_intermediate_namespace_rows(self, namespace_dir, sample_df):
+        """Verify the manifest row inventory for a 2x2 partitioning.
+
+        For [year, country] with 2 years × 2 countries × shared parents:
+        manifest must contain 1 root + 2 year ns + 4 (year,country) ns + 4 tables = 11 rows.
+        """
+        sample_df.write_lance(namespace_dir, partition_cols=["year", "country"], mode="create")
+        _, manifest = _open_manifest(namespace_dir)
+        ns_count = len(_namespace_row_indices(manifest))
+        tbl_count = len(_table_row_indices(manifest))
+        assert ns_count == 7, ns_count  # 1 root + 2 year + 4 (year,country)
+        assert tbl_count == 4, tbl_count
+        assert manifest.num_rows == 11
+
+
+# ===========================================================================
+# Per-row content (table rows vs namespace rows)
+# ===========================================================================
+
+
+class TestRowContent:
+    def test_table_rows_have_location(self, namespace_dir, sample_df):
+        sample_df.write_lance(namespace_dir, partition_cols=["year"], mode="create")
+        _, manifest = _open_manifest(namespace_dir)
+        for i in _table_row_indices(manifest):
+            loc = manifest.column("location")[i].as_py()
+            assert loc is not None
+            # location format: <8hex>_<object_id>
+            assert "_" in loc
+            prefix, _, rest = loc.partition("_")
+            assert _HASH_PREFIX_RE.match(prefix), prefix
+            assert rest == manifest.column("object_id")[i].as_py()
+
+    def test_namespace_rows_have_null_location(self, namespace_dir, sample_df):
+        sample_df.write_lance(namespace_dir, partition_cols=["year"], mode="create")
+        _, manifest = _open_manifest(namespace_dir)
+        for i in _namespace_row_indices(manifest):
+            assert manifest.column("location")[i].as_py() is None
+
+    def test_table_rows_have_read_version(self, namespace_dir, sample_df):
+        sample_df.write_lance(namespace_dir, partition_cols=["year"], mode="create")
+        _, manifest = _open_manifest(namespace_dir)
+        for i in _table_row_indices(manifest):
+            rv = manifest.column("read_version")[i].as_py()
+            assert isinstance(rv, int) and rv >= 1
+
+    def test_namespace_rows_have_null_read_version(self, namespace_dir, sample_df):
+        sample_df.write_lance(namespace_dir, partition_cols=["year"], mode="create")
+        _, manifest = _open_manifest(namespace_dir)
+        for i in _namespace_row_indices(manifest):
+            assert manifest.column("read_version")[i].as_py() is None
+
+    def test_read_branch_and_tag_always_null(self, namespace_dir, sample_df):
+        sample_df.write_lance(namespace_dir, partition_cols=["year"], mode="create")
+        _, manifest = _open_manifest(namespace_dir)
+        assert manifest.column("read_branch").null_count == manifest.num_rows
+        assert manifest.column("read_tag").null_count == manifest.num_rows
+
+    def test_base_objects_always_null(self, namespace_dir, sample_df):
+        sample_df.write_lance(namespace_dir, partition_cols=["year"], mode="create")
+        _, manifest = _open_manifest(namespace_dir)
+        assert manifest.column("base_objects").null_count == manifest.num_rows
+
+    def test_partition_values_inherited(self, namespace_dir, sample_df):
+        """Per spec: intermediate ns at depth k carries partition values for fields[:k], NULL for fields[k:]."""
+        sample_df.write_lance(namespace_dir, partition_cols=["year", "country"], mode="create")
+        _, manifest = _open_manifest(namespace_dir)
+        year_col = manifest.column("partition_field_year")
+        country_col = manifest.column("partition_field_country")
+        for i in range(manifest.num_rows):
+            oid = manifest.column("object_id")[i].as_py()
+            otype = manifest.column("object_type")[i].as_py()
+            parts = oid.split("$")
+            # Spec version root: both NULL.
+            if oid == "v1":
+                assert year_col[i].as_py() is None
+                assert country_col[i].as_py() is None
+                continue
+            # Strip trailing "dataset" to compute namespace depth.
+            depth_segs = parts[1:]
+            if otype == "table":
+                depth_segs = depth_segs[:-1]
+            depth = len(depth_segs)
+            # depth 1 = year ns; depth 2 = (year, country) ns or table
+            assert depth >= 1
+            assert year_col[i].as_py() is not None
+            if depth >= 2:
+                assert country_col[i].as_py() is not None
+            else:
+                assert country_col[i].as_py() is None
+
+
+# ===========================================================================
+# Physical layout
+# ===========================================================================
+
+
+class TestPhysicalLayout:
+    def test_only_tables_have_dirs(self, namespace_dir, sample_df):
+        """Per spec: only tables have physical directories. Namespaces do not."""
+        sample_df.write_lance(namespace_dir, partition_cols=["year"], mode="create")
+        _, manifest = _open_manifest(namespace_dir)
+
+        on_disk = {d for d in os.listdir(namespace_dir) if os.path.isdir(os.path.join(namespace_dir, d))}
+        # Manifest is always present.
+        assert "__manifest" in on_disk
+        on_disk.discard("__manifest")
+
+        # Every remaining dir must correspond to a table row's location.
+        table_locations = {manifest.column("location")[i].as_py() for i in _table_row_indices(manifest)}
+        assert on_disk == table_locations
+
+    def test_physical_dir_format(self, namespace_dir, sample_df):
+        sample_df.write_lance(namespace_dir, partition_cols=["year"], mode="create")
+        _, manifest = _open_manifest(namespace_dir)
+        for i in _table_row_indices(manifest):
+            loc = manifest.column("location")[i].as_py()
+            prefix, _, rest = loc.partition("_")
+            assert _HASH_PREFIX_RE.match(prefix)
+            assert rest.startswith("v1$")
+            assert rest.endswith("$dataset")
+            # And the directory actually exists.
+            assert os.path.isdir(os.path.join(namespace_dir, loc))
+
+    def test_partition_columns_stripped_from_leaf_dataset(self, namespace_dir, sample_df):
+        """The Lance dataset for a partition holds only non-partition columns."""
+        import lance
+
+        sample_df.write_lance(namespace_dir, partition_cols=["year", "country"], mode="create")
+        _, manifest = _open_manifest(namespace_dir)
+        tbl_idx = _table_row_indices(manifest)[0]
+        loc = manifest.column("location")[tbl_idx].as_py()
+        ds = lance.dataset(os.path.join(namespace_dir, loc))
+        leaf_names = set(ds.schema.names)
+        assert "year" not in leaf_names
+        assert "country" not in leaf_names
+        assert "value" in leaf_names
+        assert "name" in leaf_names
+
+
+# ===========================================================================
+# Read side
+# ===========================================================================
+
+
+class TestRead:
+    def test_read_all_rows(self, namespace_dir, sample_df):
+        sample_df.write_lance(namespace_dir, partition_cols=["year", "country"], mode="create")
+        result = daft.read_lance(namespace_dir, namespace_partitioning=True).to_pydict()
+        assert sorted(result["value"]) == [10, 20, 30, 40, 50, 60]
+        assert set(result["year"]) == {2024, 2025}
+        assert set(result["country"]) == {"US", "UK"}
+
+    def test_schema_includes_partition_columns(self, namespace_dir, sample_df):
+        sample_df.write_lance(namespace_dir, partition_cols=["year", "country"], mode="create")
+        df = daft.read_lance(namespace_dir, namespace_partitioning=True)
+        names = {f.name for f in df.schema()}
+        assert names == {"year", "country", "value", "name"}
+
+    def test_partition_filter_single_col(self, namespace_dir, sample_df):
+        sample_df.write_lance(namespace_dir, partition_cols=["year", "country"], mode="create")
+        df = daft.read_lance(namespace_dir, namespace_partitioning=True)
+        result = df.where(df["year"] == 2024).to_pydict()
+        assert all(y == 2024 for y in result["year"])
+        assert sorted(result["value"]) == [10, 20, 50]
+
+    def test_partition_filter_string_col(self, namespace_dir, sample_df):
+        sample_df.write_lance(namespace_dir, partition_cols=["year", "country"], mode="create")
+        df = daft.read_lance(namespace_dir, namespace_partitioning=True)
+        result = df.where(df["country"] == "US").to_pydict()
+        assert all(c == "US" for c in result["country"])
+        assert sorted(result["value"]) == [10, 30, 50, 60]
+
+    def test_combined_partition_filter(self, namespace_dir, sample_df):
+        sample_df.write_lance(namespace_dir, partition_cols=["year", "country"], mode="create")
+        df = daft.read_lance(namespace_dir, namespace_partitioning=True)
+        result = df.where((df["year"] == 2025) & (df["country"] == "UK")).to_pydict()
+        assert result["year"] == [2025]
+        assert result["country"] == ["UK"]
+        assert result["value"] == [40]
+
+    def test_data_filter(self, namespace_dir, sample_df):
+        sample_df.write_lance(namespace_dir, partition_cols=["year", "country"], mode="create")
+        df = daft.read_lance(namespace_dir, namespace_partitioning=True)
+        result = df.where(df["value"] > 25).to_pydict()
+        assert all(v > 25 for v in result["value"])
+
+    def test_combined_partition_and_data_filter(self, namespace_dir, sample_df):
+        sample_df.write_lance(namespace_dir, partition_cols=["year", "country"], mode="create")
+        df = daft.read_lance(namespace_dir, namespace_partitioning=True)
+        result = df.where((df["year"] == 2024) & (df["value"] > 15)).to_pydict()
+        assert all(y == 2024 for y in result["year"])
+        assert all(v > 15 for v in result["value"])
+
+    def test_column_projection_data_only(self, namespace_dir, sample_df):
+        sample_df.write_lance(namespace_dir, partition_cols=["year", "country"], mode="create")
+        df = daft.read_lance(namespace_dir, namespace_partitioning=True)
+        result = df.select("value", "name").to_pydict()
+        assert set(result.keys()) == {"value", "name"}
+        assert len(result["value"]) == 6
+
+    def test_column_projection_partition_only(self, namespace_dir, sample_df):
+        sample_df.write_lance(namespace_dir, partition_cols=["year", "country"], mode="create")
+        df = daft.read_lance(namespace_dir, namespace_partitioning=True)
+        result = df.select("year").to_pydict()
+        assert set(result.keys()) == {"year"}
+        assert sorted(result["year"]) == [2024, 2024, 2024, 2025, 2025, 2025]
+
+    def test_column_projection_mixed(self, namespace_dir, sample_df):
+        sample_df.write_lance(namespace_dir, partition_cols=["year", "country"], mode="create")
+        df = daft.read_lance(namespace_dir, namespace_partitioning=True)
+        result = df.select("country", "value").to_pydict()
+        assert set(result.keys()) == {"country", "value"}
+        # Pair up to verify partition column is correctly aligned to data
+        pairs = sorted(zip(result["country"], result["value"]))
+        assert pairs == [
+            ("UK", 20),
+            ("UK", 40),
+            ("US", 10),
+            ("US", 30),
+            ("US", 50),
+            ("US", 60),
+        ]
+
+    def test_pruning_skips_unmatched_partitions(self, namespace_dir, sample_df, monkeypatch):
+        """Verify partition pruning only opens the matching partition dataset.
+
+        When a partition filter rules out 3 of 4 partitions, only the matching
+        table should be opened (i.e. partition pruning happens via the manifest).
+        """
+        import lance
+
+        sample_df.write_lance(namespace_dir, partition_cols=["year", "country"], mode="create")
+
+        opened = []
+        real_dataset = lance.dataset
+
+        def tracking_dataset(uri, *args, **kwargs):
+            opened.append(str(uri))
+            return real_dataset(uri, *args, **kwargs)
+
+        monkeypatch.setattr(lance, "dataset", tracking_dataset)
+        df = daft.read_lance(namespace_dir, namespace_partitioning=True)
+        df.where((df["year"] == 2025) & (df["country"] == "UK")).to_pydict()
+
+        # Manifest is always opened; among partition datasets only the matching one
+        # should be opened.
+        non_manifest_opens = [u for u in opened if "__manifest" not in u]
+        # Each opened partition dataset should be the (2025, UK) one. We can't easily
+        # name-check it without parsing object_ids, but exactly 1 distinct ds_uri
+        # confirms pruning.
+        assert len(set(non_manifest_opens)) == 1, non_manifest_opens
+
+
+# ===========================================================================
+# Roundtrip
+# ===========================================================================
+
+
+class TestRoundtrip:
+    def test_simple_roundtrip(self, namespace_dir):
+        original = {"a": [1, 2, 3], "b": ["x", "y", "z"], "c": [10.0, 20.0, 30.0]}
+        df = daft.from_pydict(original)
+        df.write_lance(namespace_dir, partition_cols=["b"], mode="create")
+        result = daft.read_lance(namespace_dir, namespace_partitioning=True).sort("a").to_pydict()
+        assert result["a"] == [1, 2, 3]
+        assert result["b"] == ["x", "y", "z"]
+        assert result["c"] == [10.0, 20.0, 30.0]
+
+    def test_roundtrip_with_nulls_in_data(self, namespace_dir):
+        df = daft.from_pydict({"key": ["a", "a", "b", "b"], "val": [1, None, 3, None]})
+        df.write_lance(namespace_dir, partition_cols=["key"], mode="create")
+        result = daft.read_lance(namespace_dir, namespace_partitioning=True).to_pydict()
+        assert sorted(result["key"]) == ["a", "a", "b", "b"]
+        non_null = sorted(v for v in result["val"] if v is not None)
+        assert non_null == [1, 3]
+        assert result["val"].count(None) == 2
+
+    def test_many_partitions(self, namespace_dir):
+        n = 50
+        df = daft.from_pydict({"part": list(range(n)), "data": list(range(n))})
+        stats = df.write_lance(namespace_dir, partition_cols=["part"], mode="create").to_pydict()
+        assert stats["num_partitions"] == [n]
+
+        result = daft.read_lance(namespace_dir, namespace_partitioning=True).sort("part").to_pydict()
+        assert result["part"] == list(range(n))
+        assert result["data"] == list(range(n))
+
+
+# ===========================================================================
+# Helpers in daft.io.lance.lance_namespace
+# ===========================================================================
+
+
+class TestHelpers:
+    def test_random_namespace_id_shape(self):
+        from daft.io.lance.lance_namespace import random_namespace_id
+
+        ids = [random_namespace_id() for _ in range(50)]
+        for i in ids:
+            assert _NS_ID_RE.match(i), i
+        assert len(set(ids)) == len(ids), "IDs must be unique with overwhelming probability"
+
+    def test_random_dir_hash_shape(self):
+        from daft.io.lance.lance_namespace import random_dir_hash
+
+        h = random_dir_hash()
+        assert _HASH_PREFIX_RE.match(h), h
+
+    def test_make_object_id_namespace(self):
+        from daft.io.lance.lance_namespace import make_object_id
+
+        assert make_object_id("v1", [], is_table=False) == "v1"
+        assert make_object_id("v1", ["abc"], is_table=False) == "v1$abc"
+        assert make_object_id("v2", ["abc", "def"], is_table=False) == "v2$abc$def"
+
+    def test_make_object_id_table(self):
+        from daft.io.lance.lance_namespace import make_object_id
+
+        assert make_object_id("v1", ["abc"], is_table=True) == "v1$abc$dataset"
+        assert make_object_id("v1", ["abc", "def"], is_table=True) == "v1$abc$def$dataset"
+
+    def test_parse_object_id(self):
+        from daft.io.lance.lance_namespace import parse_object_id
+
+        assert parse_object_id("v1") == ("v1", [], False)
+        assert parse_object_id("v1$abc") == ("v1", ["abc"], False)
+        assert parse_object_id("v1$abc$def") == ("v1", ["abc", "def"], False)
+        assert parse_object_id("v1$abc$dataset") == ("v1", ["abc"], True)
+        assert parse_object_id("v1$abc$def$dataset") == ("v1", ["abc", "def"], True)
+
+    def test_partition_spec_json_round_trip(self):
+        from daft.io.lance.lance_namespace import (
+            PartitionFieldSpec,
+            make_partition_spec_json,
+            parse_partition_spec_json,
+        )
+
+        specs = [
+            PartitionFieldSpec("year", "year", 0, "identity", pa.int64()),
+            PartitionFieldSpec("country", "country", 1, "identity", pa.utf8()),
+        ]
+        payload = make_partition_spec_json(1, specs)
+        parsed = parse_partition_spec_json(payload)
+        assert parsed["id"] == 1
+        assert [f["field_id"] for f in parsed["fields"]] == ["year", "country"]
+        assert all(f["transform"] == {"type": "identity"} for f in parsed["fields"])
+        assert parsed["fields"][0]["result_type"] == {"type": "int64"}
+        assert parsed["fields"][1]["result_type"] == {"type": "utf8"}
+
+    def test_namespace_schema_json_round_trip(self):
+        from daft.io.lance.lance_namespace import (
+            make_namespace_schema_json,
+            parse_namespace_schema_json,
+        )
+
+        schema = pa.schema(
+            [
+                pa.field("id", pa.int64(), nullable=False),
+                pa.field("year", pa.int32(), nullable=True),
+                pa.field("country", pa.utf8(), nullable=True),
+            ]
+        )
+        payload = make_namespace_schema_json(schema, {"id": 0, "year": 1, "country": 2})
+        parsed = parse_namespace_schema_json(payload)
+        assert parsed.names == ["id", "year", "country"]
+        assert parsed.field("id").type == pa.int64()
+        assert parsed.field("id").nullable is False
+        assert parsed.field("year").type == pa.int32()
+        assert parsed.field("country").type == pa.utf8()
+        # field IDs preserved on metadata
+        for name, expected in (("id", "0"), ("year", "1"), ("country", "2")):
+            md = parsed.field(name).metadata
+            assert md is not None
+            assert md[b"lance:field_id"] == expected.encode()
+
+    def test_arrow_type_round_trip(self):
+        from daft.io.lance.lance_namespace import (
+            arrow_type_to_json_arrow,
+            json_arrow_to_arrow_type,
+        )
+
+        for dtype in [
+            pa.bool_(),
+            pa.int8(),
+            pa.int16(),
+            pa.int32(),
+            pa.int64(),
+            pa.uint32(),
+            pa.float32(),
+            pa.float64(),
+            pa.utf8(),
+            pa.binary(),
+            pa.date32(),
+        ]:
+            assert json_arrow_to_arrow_type(arrow_type_to_json_arrow(dtype)) == dtype
+
+
+# ===========================================================================
+# Cross-implementation spec compliance: read a hand-built manifest matching
+# the spec's Appendix B (Physical Layout) and Appendix C (Manifest Table)
+# byte-for-byte. If Daft can read this, our reader honors the literal spec.
+# ===========================================================================
+
+
+def _build_spec_literal_namespace(root: str) -> dict[str, dict[str, list]]:
+    """Construct a namespace on disk that mirrors Appendix B / C of the spec.
+
+    Uses a single partition spec (v1, identity transform on ``event_date``)
+    so the example exercises the parts our reader supports. The object_id
+    namespace segment is the literal 16-char value from the spec example.
+    Physical directories are placed at hash-prefixed paths matching what the
+    manifest records under ``location``.
+
+    Returns the expected data per partition, so tests can verify reads.
+    """
+    import lance
+
+    # Per Appendix A: a single identity partition by event_date with field_id=1 in the schema.
+    partition_spec_v1 = {
+        "id": 1,
+        "fields": [
+            {
+                "field_id": "event_date",
+                "source_ids": [1],
+                "transform": {"type": "identity"},
+                "result_type": {"type": "date32"},
+            }
+        ],
+    }
+    schema_json = {
+        "fields": [
+            {
+                "name": "id",
+                "nullable": False,
+                "type": {"type": "int64"},
+                "metadata": {"lance:field_id": "0"},
+            },
+            {
+                "name": "event_date",
+                "nullable": True,
+                "type": {"type": "date32"},
+                "metadata": {"lance:field_id": "1"},
+            },
+            {
+                "name": "country",
+                "nullable": True,
+                "type": {"type": "utf8"},
+                "metadata": {"lance:field_id": "2"},
+            },
+        ]
+    }
+
+    # Two leaf tables exactly like the v1 rows in Appendix C.
+    leaf_specs = [
+        {
+            "ns_id": "k7m2n9p4q8r5s3t6",
+            "hash": "b4a3c2d1",
+            "event_date_str": "2025-12-10",
+            "rows": {"id": [1, 2], "country": ["US", "UK"]},
+        },
+        {
+            "ns_id": "w1x2y3z4a5b6c7d8",
+            "hash": "55667788",
+            "event_date_str": "2025-12-11",
+            "rows": {"id": [3, 4], "country": ["US", "JP"]},
+        },
+    ]
+
+    # Write each leaf Lance dataset (without partition columns, since they're inherited).
+    expected: dict[str, dict[str, list]] = {}
+    leaf_pa_schema = pa.schema([pa.field("id", pa.int64(), nullable=False), pa.field("country", pa.utf8())])
+    for spec in leaf_specs:
+        ns_id = spec["ns_id"]
+        h = spec["hash"]
+        object_id = f"v1${ns_id}$dataset"
+        location = f"{h}_{object_id}"
+        leaf_table = pa.table(spec["rows"], schema=leaf_pa_schema)
+        lance.write_dataset(leaf_table, os.path.join(root, location))
+        expected[location] = {
+            "object_id": object_id,
+            "event_date_str": spec["event_date_str"],
+            **spec["rows"],
+        }
+
+    # Manifest rows: 1 root ns + 2 intermediate ns + 2 tables = 5 rows total.
+    manifest_rows: list[dict] = [
+        {
+            "object_id": "v1",
+            "object_type": "namespace",
+            "location": None,
+            "metadata": "{}",
+            "base_objects": None,
+            "read_version": None,
+            "read_branch": None,
+            "read_tag": None,
+            "partition_field_event_date": None,
+        },
+    ]
+    for spec in leaf_specs:
+        manifest_rows.append(
+            {
+                "object_id": f"v1${spec['ns_id']}",
+                "object_type": "namespace",
+                "location": None,
+                "metadata": "{}",
+                "base_objects": None,
+                "read_version": None,
+                "read_branch": None,
+                "read_tag": None,
+                "partition_field_event_date": spec["event_date_str"],
+            }
+        )
+        manifest_rows.append(
+            {
+                "object_id": f"v1${spec['ns_id']}$dataset",
+                "object_type": "table",
+                "location": f"{spec['hash']}_v1${spec['ns_id']}$dataset",
+                "metadata": "{}",
+                "base_objects": None,
+                "read_version": 1,  # Lance creates v1 of the leaf dataset on write_dataset
+                "read_branch": None,
+                "read_tag": None,
+                "partition_field_event_date": spec["event_date_str"],
+            }
+        )
+
+    manifest_schema = pa.schema(
+        [
+            pa.field("object_id", pa.utf8(), nullable=False),
+            pa.field("object_type", pa.utf8(), nullable=False),
+            pa.field("location", pa.utf8()),
+            pa.field("metadata", pa.utf8()),
+            pa.field("base_objects", pa.list_(pa.utf8())),
+            pa.field("read_version", pa.uint64()),
+            pa.field("read_branch", pa.utf8()),
+            pa.field("read_tag", pa.utf8()),
+            pa.field("partition_field_event_date", pa.date32()),
+        ],
+        metadata={
+            "partition_spec_v1": json.dumps(partition_spec_v1),
+            "schema": json.dumps(schema_json),
+        },
+    )
+
+    columns = {field.name: [r[field.name] for r in manifest_rows] for field in manifest_schema}
+    # Convert event_date strings to date32 for that column.
+    import datetime as _dt
+
+    columns["partition_field_event_date"] = [
+        _dt.date.fromisoformat(v) if isinstance(v, str) else v for v in columns["partition_field_event_date"]
+    ]
+    arrays = [pa.array(columns[f.name], type=f.type) for f in manifest_schema]
+    manifest_table = pa.Table.from_arrays(arrays, schema=manifest_schema)
+
+    lance.write_dataset(manifest_table, os.path.join(root, "__manifest"))
+    return expected
+
+
+class TestSpecLiteralFixture:
+    """Cross-implementation evidence for the spec's literal manifest shape.
+
+    We build a manifest from the spec's literal Appendix B/C structure (not
+    via our writer) and verify our reader handles it correctly. This proves
+    the reader follows the spec, not just our own writer's quirks.
+    """
+
+    @pytest.fixture
+    def spec_namespace(self, tmp_path):
+        root = str(tmp_path / "spec_ns")
+        os.makedirs(root, exist_ok=True)
+        expected = _build_spec_literal_namespace(root)
+        return root, expected
+
+    def test_read_returns_all_rows(self, spec_namespace):
+        root, expected = spec_namespace
+        df = daft.read_lance(root, namespace_partitioning=True).to_pydict()
+        total_rows = sum(len(v["id"]) for v in expected.values())
+        assert len(df["id"]) == total_rows
+        # Every (id, country, event_date) combination from the fixture is present.
+        actual = sorted(zip(df["id"], df["country"], [str(d) for d in df["event_date"]]))
+        expected_tuples: list[tuple] = []
+        for v in expected.values():
+            for i, c in zip(v["id"], v["country"]):
+                expected_tuples.append((i, c, v["event_date_str"]))
+        assert actual == sorted(expected_tuples)
+
+    def test_schema_includes_all_namespace_fields(self, spec_namespace):
+        root, _ = spec_namespace
+        df = daft.read_lance(root, namespace_partitioning=True)
+        names = {f.name for f in df.schema()}
+        assert names == {"id", "country", "event_date"}
+
+    def test_partition_filter_on_spec_fixture(self, spec_namespace):
+        root, expected = spec_namespace
+        df = daft.read_lance(root, namespace_partitioning=True)
+        import datetime as _dt
+
+        target = _dt.date(2025, 12, 10)
+        result = df.where(df["event_date"] == target).to_pydict()
+        # Should only return rows from the (2025-12-10) partition.
+        match_specs = [v for v in expected.values() if v["event_date_str"] == "2025-12-10"]
+        assert len(match_specs) == 1
+        assert sorted(result["id"]) == sorted(match_specs[0]["id"])
+
+    def test_only_leaf_tables_have_dirs(self, spec_namespace):
+        root, expected = spec_namespace
+        dirs_on_disk = {d for d in os.listdir(root) if os.path.isdir(os.path.join(root, d))}
+        dirs_on_disk.discard("__manifest")
+        expected_dirs = set(expected.keys())
+        assert dirs_on_disk == expected_dirs
+
+
+# ===========================================================================
+# JSON-schema-driven validation: the partition_spec_v<N> JSON and the
+# `schema` JSON we emit must conform to the spec's JsonArrowSchema /
+# JsonArrowField / JsonArrowDataType model shapes and the partition_spec
+# model.
+# ===========================================================================
+
+
+# JSON Schema definitions transcribed from the spec model docs at
+# https://github.com/lance-format/lance-namespace/tree/main/docs/src/client/operations/models
+# - JsonArrowDataType.md, JsonArrowField.md, JsonArrowSchema.md
+# - Partition Spec / Partition Field schemas from partitioning-spec.md
+#
+# Everything is inlined under one schema with $defs so we don't have to fight
+# the jsonschema 4.x / referencing library's registry API.
+_SPEC_SCHEMAS = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+        "JsonArrowDataType": {
+            "type": "object",
+            "properties": {
+                "type": {"type": "string"},
+                "length": {"type": "integer"},
+                "fields": {"type": "array", "items": {"$ref": "#/$defs/JsonArrowField"}},
+            },
+            "required": ["type"],
+            "additionalProperties": False,
+        },
+        "JsonArrowField": {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "nullable": {"type": "boolean"},
+                "type": {"$ref": "#/$defs/JsonArrowDataType"},
+                "metadata": {"type": "object", "additionalProperties": {"type": "string"}},
+            },
+            "required": ["name", "nullable", "type"],
+            "additionalProperties": False,
+        },
+        "JsonArrowSchema": {
+            "type": "object",
+            "properties": {
+                "fields": {"type": "array", "items": {"$ref": "#/$defs/JsonArrowField"}},
+                "metadata": {"type": "object", "additionalProperties": {"type": "string"}},
+            },
+            "required": ["fields"],
+            "additionalProperties": False,
+        },
+        "PartitionTransform": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "identity",
+                        "year",
+                        "month",
+                        "day",
+                        "hour",
+                        "bucket",
+                        "multi_bucket",
+                        "truncate",
+                    ],
+                },
+                "num_buckets": {"type": "integer"},
+                "width": {"type": "integer"},
+            },
+            "required": ["type"],
+            "additionalProperties": False,
+        },
+        "PartitionField": {
+            "type": "object",
+            "properties": {
+                "field_id": {"type": "string"},
+                "source_ids": {"type": "array", "items": {"type": "integer"}},
+                "transform": {"$ref": "#/$defs/PartitionTransform"},
+                "expression": {"type": "string"},
+                "result_type": {"$ref": "#/$defs/JsonArrowDataType"},
+            },
+            "required": ["field_id", "source_ids", "result_type"],
+            "additionalProperties": False,
+        },
+        "PartitionSpec": {
+            "type": "object",
+            "properties": {
+                "id": {"type": "integer"},
+                "fields": {"type": "array", "items": {"$ref": "#/$defs/PartitionField"}},
+            },
+            "required": ["id", "fields"],
+            "additionalProperties": False,
+        },
+    },
+}
+
+
+def _make_validator(def_name: str):
+    """Validator pinned to one of the named $defs in _SPEC_SCHEMAS."""
+    from jsonschema.validators import Draft202012Validator
+
+    schema = {**_SPEC_SCHEMAS, "$ref": f"#/$defs/{def_name}"}
+    return Draft202012Validator(schema)
+
+
+class TestSpecJsonSchemas:
+    """JSON Schema validation of manifest metadata JSON.
+
+    Validate the JSON we write into the manifest's schema metadata against
+    JSON Schemas transcribed from the spec's model docs.
+    """
+
+    def test_partition_spec_json_conforms(self, namespace_dir, sample_df):
+        sample_df.write_lance(namespace_dir, partition_cols=["year", "country"], mode="create")
+        ds, _ = _open_manifest(namespace_dir)
+        spec_json = json.loads(_decode_meta(ds.schema.metadata, "partition_spec_v1"))
+
+        validator = _make_validator("PartitionSpec")
+        errors = sorted(validator.iter_errors(spec_json), key=lambda e: e.path)
+        assert not errors, "partition_spec_v1 schema violations: " + "; ".join(
+            f"{list(e.absolute_path)}: {e.message}" for e in errors
+        )
+
+        # Spec rule beyond the JSON shape: exactly one of transform/expression per field.
+        for f in spec_json["fields"]:
+            has_transform = "transform" in f
+            has_expression = "expression" in f
+            assert has_transform != has_expression, f
+
+    def test_namespace_schema_json_conforms(self, namespace_dir, sample_df):
+        sample_df.write_lance(namespace_dir, partition_cols=["year"], mode="create")
+        ds, _ = _open_manifest(namespace_dir)
+        schema_obj = json.loads(_decode_meta(ds.schema.metadata, "schema"))
+
+        validator = _make_validator("JsonArrowSchema")
+        errors = sorted(validator.iter_errors(schema_obj), key=lambda e: e.path)
+        assert not errors, "schema JSON violations: " + "; ".join(
+            f"{list(e.absolute_path)}: {e.message}" for e in errors
+        )
+
+        # Spec rule beyond the JSON shape: every field carries a lance:field_id metadata.
+        for f in schema_obj["fields"]:
+            assert "metadata" in f, f
+            assert "lance:field_id" in f["metadata"], f
+            assert isinstance(f["metadata"]["lance:field_id"], str), f
+
+    def test_schema_field_ids_are_unique(self, namespace_dir, sample_df):
+        sample_df.write_lance(namespace_dir, partition_cols=["year", "country"], mode="create")
+        ds, _ = _open_manifest(namespace_dir)
+        schema_obj = json.loads(_decode_meta(ds.schema.metadata, "schema"))
+        ids = [f["metadata"]["lance:field_id"] for f in schema_obj["fields"]]
+        assert len(ids) == len(set(ids))
+
+    def test_partition_source_ids_resolve_to_schema_field_ids(self, namespace_dir, sample_df):
+        """Spec invariant: ``source_ids`` reference ``lance:field_id``s in the namespace schema."""
+        sample_df.write_lance(namespace_dir, partition_cols=["year", "country"], mode="create")
+        ds, _ = _open_manifest(namespace_dir)
+        spec_json = json.loads(_decode_meta(ds.schema.metadata, "partition_spec_v1"))
+        schema_obj = json.loads(_decode_meta(ds.schema.metadata, "schema"))
+
+        schema_field_ids = {int(f["metadata"]["lance:field_id"]) for f in schema_obj["fields"]}
+        for f in spec_json["fields"]:
+            for sid in f["source_ids"]:
+                assert sid in schema_field_ids, (sid, schema_field_ids)
+
+
+# ===========================================================================
+# Strongest available cross-impl validation: round-trip our JSON through the
+# canonical Pydantic models generated from the lance-namespace OpenAPI spec
+# (https://github.com/lance-format/lance-namespace, on PyPI as
+# `lance-namespace-urllib3-client`). Pinned as a dev dependency in
+# pyproject.toml so these run as real assertions everywhere.
+# ===========================================================================
+
+from lance_namespace_urllib3_client.models import (
+    JsonArrowSchema as _OfficialJsonArrowSchema,
+)
+from lance_namespace_urllib3_client.models import (
+    PartitionSpec as _OfficialPartitionSpec,
+)
+
+
+class TestOfficialClientModels:
+    """Validation against the canonical generated Pydantic models.
+
+    Validate our written JSON against the lance-namespace OpenAPI spec's
+    canonical generated Pydantic models. This is the strictest cross-impl
+    check available without a Rust subprocess.
+    """
+
+    def test_partition_spec_validates_against_official_model(self, namespace_dir, sample_df):
+        sample_df.write_lance(namespace_dir, partition_cols=["year", "country"], mode="create")
+        ds, _ = _open_manifest(namespace_dir)
+        raw = _decode_meta(ds.schema.metadata, "partition_spec_v1")
+        # Round-trip through the official PartitionSpec Pydantic model.
+        spec_obj = _OfficialPartitionSpec.from_json(raw)
+        assert spec_obj is not None
+        assert spec_obj.id == 1
+        assert len(spec_obj.fields) == 2
+
+        # Each PartitionField should validate (field_id, source_ids, transform OR
+        # expression, result_type). Our writer emits transform.
+        for f in spec_obj.fields:
+            assert f.field_id in ("year", "country")
+            assert len(f.source_ids) >= 1
+            assert f.transform is not None
+            assert f.transform.type == "identity"
+            assert f.expression is None
+            # result_type validates as JsonArrowDataType.
+            assert f.result_type.type is not None
+
+    def test_namespace_schema_validates_against_official_model(self, namespace_dir, sample_df):
+        sample_df.write_lance(namespace_dir, partition_cols=["year"], mode="create")
+        ds, _ = _open_manifest(namespace_dir)
+        raw = _decode_meta(ds.schema.metadata, "schema")
+        schema_obj = _OfficialJsonArrowSchema.from_json(raw)
+        assert schema_obj is not None
+        names = {f.name for f in schema_obj.fields}
+        assert names == {"year", "value", "name", "country"}
+        # Every field carries the lance:field_id metadata.
+        for f in schema_obj.fields:
+            assert f.metadata is not None
+            assert "lance:field_id" in f.metadata
+            # JsonArrowField.type validates as JsonArrowDataType
+            assert f.type.type is not None
+
+    def test_partition_field_round_trip_matches_official(self, namespace_dir, sample_df):
+        """Pydantic dump-then-reload of the spec's PartitionSpec should match what we wrote."""
+        sample_df.write_lance(namespace_dir, partition_cols=["year", "country"], mode="create")
+        ds, _ = _open_manifest(namespace_dir)
+        raw = _decode_meta(ds.schema.metadata, "partition_spec_v1")
+        original = json.loads(raw)
+        roundtripped = json.loads(_OfficialPartitionSpec.from_json(raw).to_json())
+        # Pydantic's by_alias dump drops `None` keys; comparison should match
+        # for our writes (we never emit `expression` or unused transform params).
+        assert roundtripped == original

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
@@ -1562,6 +1562,7 @@ dev = [
     { name = "ipdb" },
     { name = "jax" },
     { name = "jaxtyping" },
+    { name = "lance-namespace-urllib3-client" },
     { name = "librosa" },
     { name = "lxml" },
     { name = "maturin" },
@@ -1710,6 +1711,7 @@ dev = [
     { name = "ipdb", specifier = "==0.13.13" },
     { name = "jax", specifier = "==0.6.2" },
     { name = "jaxtyping", specifier = "==0.3.7" },
+    { name = "lance-namespace-urllib3-client", specifier = "==0.7.6" },
     { name = "librosa", specifier = "==0.11.0" },
     { name = "lxml", specifier = "==6.0.2" },
     { name = "maturin", specifier = "==1.11.5" },
@@ -2635,7 +2637,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/92/db/b4c12cff13ebac2786f4f217f06588bccd8b53d260453404ef22b121fc3a/greenlet-3.2.3-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:1afd685acd5597349ee6d7a88a8bec83ce13c106ac78c196ee9dde7c04fe87be", size = 268977, upload-time = "2025-06-05T16:10:24.001Z" },
     { url = "https://files.pythonhosted.org/packages/52/61/75b4abd8147f13f70986df2801bf93735c1bd87ea780d70e3b3ecda8c165/greenlet-3.2.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:761917cac215c61e9dc7324b2606107b3b292a8349bdebb31503ab4de3f559ac", size = 627351, upload-time = "2025-06-05T16:38:50.685Z" },
     { url = "https://files.pythonhosted.org/packages/35/aa/6894ae299d059d26254779a5088632874b80ee8cf89a88bca00b0709d22f/greenlet-3.2.3-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:a433dbc54e4a37e4fff90ef34f25a8c00aed99b06856f0119dcf09fbafa16392", size = 638599, upload-time = "2025-06-05T16:41:34.057Z" },
-    { url = "https://files.pythonhosted.org/packages/30/64/e01a8261d13c47f3c082519a5e9dbf9e143cc0498ed20c911d04e54d526c/greenlet-3.2.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:72e77ed69312bab0434d7292316d5afd6896192ac4327d44f3d613ecb85b037c", size = 634482, upload-time = "2025-06-05T16:48:16.26Z" },
     { url = "https://files.pythonhosted.org/packages/47/48/ff9ca8ba9772d083a4f5221f7b4f0ebe8978131a9ae0909cf202f94cd879/greenlet-3.2.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:68671180e3849b963649254a882cd544a3c75bfcd2c527346ad8bb53494444db", size = 633284, upload-time = "2025-06-05T16:13:01.599Z" },
     { url = "https://files.pythonhosted.org/packages/e9/45/626e974948713bc15775b696adb3eb0bd708bec267d6d2d5c47bb47a6119/greenlet-3.2.3-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:49c8cfb18fb419b3d08e011228ef8a25882397f3a859b9fe1436946140b6756b", size = 582206, upload-time = "2025-06-05T16:12:48.51Z" },
     { url = "https://files.pythonhosted.org/packages/b1/8e/8b6f42c67d5df7db35b8c55c9a850ea045219741bb14416255616808c690/greenlet-3.2.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:efc6dc8a792243c31f2f5674b670b3a95d46fa1c6a912b8e310d6f542e7b0712", size = 1111412, upload-time = "2025-06-05T16:36:45.479Z" },
@@ -2644,7 +2645,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fc/2e/d4fcb2978f826358b673f779f78fa8a32ee37df11920dc2bb5589cbeecef/greenlet-3.2.3-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:784ae58bba89fa1fa5733d170d42486580cab9decda3484779f4759345b29822", size = 270219, upload-time = "2025-06-05T16:10:10.414Z" },
     { url = "https://files.pythonhosted.org/packages/16/24/929f853e0202130e4fe163bc1d05a671ce8dcd604f790e14896adac43a52/greenlet-3.2.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0921ac4ea42a5315d3446120ad48f90c3a6b9bb93dd9b3cf4e4d84a66e42de83", size = 630383, upload-time = "2025-06-05T16:38:51.785Z" },
     { url = "https://files.pythonhosted.org/packages/d1/b2/0320715eb61ae70c25ceca2f1d5ae620477d246692d9cc284c13242ec31c/greenlet-3.2.3-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:d2971d93bb99e05f8c2c0c2f4aa9484a18d98c4c3bd3c62b65b7e6ae33dfcfaf", size = 642422, upload-time = "2025-06-05T16:41:35.259Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/49/445fd1a210f4747fedf77615d941444349c6a3a4a1135bba9701337cd966/greenlet-3.2.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c667c0bf9d406b77a15c924ef3285e1e05250948001220368e039b6aa5b5034b", size = 638375, upload-time = "2025-06-05T16:48:18.235Z" },
     { url = "https://files.pythonhosted.org/packages/7e/c8/ca19760cf6eae75fa8dc32b487e963d863b3ee04a7637da77b616703bc37/greenlet-3.2.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:592c12fb1165be74592f5de0d70f82bc5ba552ac44800d632214b76089945147", size = 637627, upload-time = "2025-06-05T16:13:02.858Z" },
     { url = "https://files.pythonhosted.org/packages/65/89/77acf9e3da38e9bcfca881e43b02ed467c1dedc387021fc4d9bd9928afb8/greenlet-3.2.3-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29e184536ba333003540790ba29829ac14bb645514fbd7e32af331e8202a62a5", size = 585502, upload-time = "2025-06-05T16:12:49.642Z" },
     { url = "https://files.pythonhosted.org/packages/97/c6/ae244d7c95b23b7130136e07a9cc5aadd60d59b5951180dc7dc7e8edaba7/greenlet-3.2.3-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:93c0bb79844a367782ec4f429d07589417052e621aa39a5ac1fb99c5aa308edc", size = 1114498, upload-time = "2025-06-05T16:36:46.598Z" },
@@ -2653,7 +2653,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/94/ad0d435f7c48debe960c53b8f60fb41c2026b1d0fa4a99a1cb17c3461e09/greenlet-3.2.3-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:25ad29caed5783d4bd7a85c9251c651696164622494c00802a139c00d639242d", size = 271992, upload-time = "2025-06-05T16:11:23.467Z" },
     { url = "https://files.pythonhosted.org/packages/93/5d/7c27cf4d003d6e77749d299c7c8f5fd50b4f251647b5c2e97e1f20da0ab5/greenlet-3.2.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88cd97bf37fe24a6710ec6a3a7799f3f81d9cd33317dcf565ff9950c83f55e0b", size = 638820, upload-time = "2025-06-05T16:38:52.882Z" },
     { url = "https://files.pythonhosted.org/packages/c6/7e/807e1e9be07a125bb4c169144937910bf59b9d2f6d931578e57f0bce0ae2/greenlet-3.2.3-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:baeedccca94880d2f5666b4fa16fc20ef50ba1ee353ee2d7092b383a243b0b0d", size = 653046, upload-time = "2025-06-05T16:41:36.343Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/ab/158c1a4ea1068bdbc78dba5a3de57e4c7aeb4e7fa034320ea94c688bfb61/greenlet-3.2.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:be52af4b6292baecfa0f397f3edb3c6092ce071b499dd6fe292c9ac9f2c8f264", size = 647701, upload-time = "2025-06-05T16:48:19.604Z" },
     { url = "https://files.pythonhosted.org/packages/cc/0d/93729068259b550d6a0288da4ff72b86ed05626eaf1eb7c0d3466a2571de/greenlet-3.2.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0cc73378150b8b78b0c9fe2ce56e166695e67478550769536a6742dca3651688", size = 649747, upload-time = "2025-06-05T16:13:04.628Z" },
     { url = "https://files.pythonhosted.org/packages/f6/f6/c82ac1851c60851302d8581680573245c8fc300253fc1ff741ae74a6c24d/greenlet-3.2.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:706d016a03e78df129f68c4c9b4c4f963f7d73534e48a24f5f5a7101ed13dbbb", size = 605461, upload-time = "2025-06-05T16:12:50.792Z" },
     { url = "https://files.pythonhosted.org/packages/98/82/d022cf25ca39cf1200650fc58c52af32c90f80479c25d1cbf57980ec3065/greenlet-3.2.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:419e60f80709510c343c57b4bb5a339d8767bf9aef9b8ce43f4f143240f88b7c", size = 1121190, upload-time = "2025-06-05T16:36:48.59Z" },
@@ -2662,7 +2661,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b1/cf/f5c0b23309070ae93de75c90d29300751a5aacefc0a3ed1b1d8edb28f08b/greenlet-3.2.3-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:500b8689aa9dd1ab26872a34084503aeddefcb438e2e7317b89b11eaea1901ad", size = 270732, upload-time = "2025-06-05T16:10:08.26Z" },
     { url = "https://files.pythonhosted.org/packages/48/ae/91a957ba60482d3fecf9be49bc3948f341d706b52ddb9d83a70d42abd498/greenlet-3.2.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a07d3472c2a93117af3b0136f246b2833fdc0b542d4a9799ae5f41c28323faef", size = 639033, upload-time = "2025-06-05T16:38:53.983Z" },
     { url = "https://files.pythonhosted.org/packages/6f/df/20ffa66dd5a7a7beffa6451bdb7400d66251374ab40b99981478c69a67a8/greenlet-3.2.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:8704b3768d2f51150626962f4b9a9e4a17d2e37c8a8d9867bbd9fa4eb938d3b3", size = 652999, upload-time = "2025-06-05T16:41:37.89Z" },
-    { url = "https://files.pythonhosted.org/packages/51/b4/ebb2c8cb41e521f1d72bf0465f2f9a2fd803f674a88db228887e6847077e/greenlet-3.2.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:5035d77a27b7c62db6cf41cf786cfe2242644a7a337a0e155c80960598baab95", size = 647368, upload-time = "2025-06-05T16:48:21.467Z" },
     { url = "https://files.pythonhosted.org/packages/8e/6a/1e1b5aa10dced4ae876a322155705257748108b7fd2e4fae3f2a091fe81a/greenlet-3.2.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2d8aa5423cd4a396792f6d4580f88bdc6efcb9205891c9d40d20f6e670992efb", size = 650037, upload-time = "2025-06-05T16:13:06.402Z" },
     { url = "https://files.pythonhosted.org/packages/26/f2/ad51331a157c7015c675702e2d5230c243695c788f8f75feba1af32b3617/greenlet-3.2.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2c724620a101f8170065d7dded3f962a2aea7a7dae133a009cada42847e04a7b", size = 608402, upload-time = "2025-06-05T16:12:51.91Z" },
     { url = "https://files.pythonhosted.org/packages/26/bc/862bd2083e6b3aff23300900a956f4ea9a4059de337f5c8734346b9b34fc/greenlet-3.2.3-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:873abe55f134c48e1f2a6f53f7d1419192a3d1a4e873bace00499a4e45ea6af0", size = 1119577, upload-time = "2025-06-05T16:36:49.787Z" },
@@ -2671,7 +2669,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d8/ca/accd7aa5280eb92b70ed9e8f7fd79dc50a2c21d8c73b9a0856f5b564e222/greenlet-3.2.3-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:3d04332dddb10b4a211b68111dabaee2e1a073663d117dc10247b5b1642bac86", size = 271479, upload-time = "2025-06-05T16:10:47.525Z" },
     { url = "https://files.pythonhosted.org/packages/55/71/01ed9895d9eb49223280ecc98a557585edfa56b3d0e965b9fa9f7f06b6d9/greenlet-3.2.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8186162dffde068a465deab08fc72c767196895c39db26ab1c17c0b77a6d8b97", size = 683952, upload-time = "2025-06-05T16:38:55.125Z" },
     { url = "https://files.pythonhosted.org/packages/ea/61/638c4bdf460c3c678a0a1ef4c200f347dff80719597e53b5edb2fb27ab54/greenlet-3.2.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f4bfbaa6096b1b7a200024784217defedf46a07c2eee1a498e94a1b5f8ec5728", size = 696917, upload-time = "2025-06-05T16:41:38.959Z" },
-    { url = "https://files.pythonhosted.org/packages/22/cc/0bd1a7eb759d1f3e3cc2d1bc0f0b487ad3cc9f34d74da4b80f226fde4ec3/greenlet-3.2.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:ed6cfa9200484d234d8394c70f5492f144b20d4533f69262d530a1a082f6ee9a", size = 692443, upload-time = "2025-06-05T16:48:23.113Z" },
     { url = "https://files.pythonhosted.org/packages/67/10/b2a4b63d3f08362662e89c103f7fe28894a51ae0bc890fabf37d1d780e52/greenlet-3.2.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:02b0df6f63cd15012bed5401b47829cfd2e97052dc89da3cfaf2c779124eb892", size = 692995, upload-time = "2025-06-05T16:13:07.972Z" },
     { url = "https://files.pythonhosted.org/packages/5a/c6/ad82f148a4e3ce9564056453a71529732baf5448ad53fc323e37efe34f66/greenlet-3.2.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:86c2d68e87107c1792e2e8d5399acec2487a4e993ab76c792408e59394d52141", size = 655320, upload-time = "2025-06-05T16:12:53.453Z" },
     { url = "https://files.pythonhosted.org/packages/5c/4f/aab73ecaa6b3086a4c89863d94cf26fa84cbff63f52ce9bc4342b3087a06/greenlet-3.2.3-cp314-cp314-win_amd64.whl", hash = "sha256:8c47aae8fbbfcf82cc13327ae802ba13c9c36753b67e760023fd116bc124a62a", size = 301236, upload-time = "2025-06-05T16:15:20.111Z" },
@@ -3561,7 +3558,7 @@ wheels = [
 
 [[package]]
 name = "lance-namespace-urllib3-client"
-version = "0.0.21"
+version = "0.7.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
@@ -3569,9 +3566,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/10/81e924f60520f66ce90218b538b7f5790721574d0719f527eca7f3f2b1e0/lance_namespace_urllib3_client-0.0.21.tar.gz", hash = "sha256:0c069ac9866c75e2e142ca22ef6b27aaf60adf8c0fa734186b045d353d4a9b6d", size = 134493, upload-time = "2025-11-14T07:05:55.079Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/44/024aae184c08b3800482cd9b832d534249e25de145af732d4e4c8dff38a8/lance_namespace_urllib3_client-0.7.6.tar.gz", hash = "sha256:15ae7f0d8d56fa34d837f7f6ec5c80a327a905e89ccfed05f7b409d6fe704cdf", size = 195551, upload-time = "2026-05-05T18:26:37.808Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/bf/9c7153c29d3001faa8a9e0c893a139757dcf5be39e997f6c6d60c8f494e5/lance_namespace_urllib3_client-0.0.21-py3-none-any.whl", hash = "sha256:b3e4fe3bbe0d377a7d1011baefbbab51cc688fe56bc3059d30271bd553fc508e", size = 229637, upload-time = "2025-11-14T07:05:54.099Z" },
+    { url = "https://files.pythonhosted.org/packages/00/50/60c983cc8180772c82370dfad2104b7e788aaacc3bf9a84e8b42bb1ae6a7/lance_namespace_urllib3_client-0.7.6-py3-none-any.whl", hash = "sha256:fb884d8afff8af3aae04a3270624694a189d7ea79225dd349e6c555a1a1d6b52", size = 324603, upload-time = "2026-05-05T18:26:39.718Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Changes Made

Re-implements the partitioned-lance feature (reverted in #6907, originally #6898) so it conforms to the published [Lance Partitioning Spec](https://lance.org/format/namespace/partitioning-spec/) layered on the [V2 Directory Namespace](https://lance.org/format/namespace/dir/catalog-spec/) catalog format.

### Public API

- `df.write_lance(uri, partition_cols=[...])` writes a partitioned namespace at `uri`. Identity transform only in this PR; rejects `mode="merge"`.
- `daft.read_lance(uri, namespace_partitioning=True)` reads a partitioned namespace and pushes partition-column filters into manifest-level pruning.

### On-disk layout

- `__manifest/` Lance table with the V2 base columns (`object_id`, `object_type`, `location`, `metadata`, `base_objects`) plus the partitioning extension columns (`read_version`, `read_branch`, `read_tag`, one `partition_field_{field_id}` per partition column).
- `object_id` carries `lance-schema:unenforced-primary-key:position = "0"` and `base_objects` is `List<Field "object_id" Utf8 nullable>` — both checked against the reference impl in `lancedb/lance/rust/lance-namespace-impls/src/dir/manifest.rs`.
- Root namespace properties (`partition_spec_v1` JSON and `schema` JSON in JsonArrowSchema form with `lance:field_id` on every field) live in the `__manifest`'s Arrow schema metadata.
- Hierarchical object IDs: `v1$<16-char base36>$...$<16-char base36>$dataset`. Siblings share parent segments.
- Leaf table data at `<root>/<8-hex>_<object_id>/` (V2 hash-prefixed directory naming).
- `read_version` is recorded per leaf-table row after every commit.

### Scope

In scope:

- Identity-transform writes; reads also recognize year/month/day/hour/bucket/truncate from manifests written by other spec-compliant tools.
- Single partition spec (`partition_spec_v1`); no partition-spec evolution.
- Single-writer manifest commits via `lance.write_dataset(..., mode="overwrite")`.

Deferred:

- Non-identity write-side transforms (year/month/day/hour/bucket/truncate).
- Manifest scalar indexes (BTREE/Bitmap/LabelList) — the reference impl creates these via inline optimization after every write.
- Lance `MergeInsert` with `["object_id"]` PK and `conflict_retries` in place of overwrite, for concurrent-writer atomicity.
- `expression`-based partition transforms (DataFusion SQL).
- Partition-spec evolution across `partition_spec_v<N>` versions.

### Spec compliance evidence (72 tests)

- `TestSpecLiteralFixture` hand-builds a `__manifest` Lance dataset that mirrors the spec's Appendix B/C byte-for-byte, plus real leaf datasets at the hash-prefixed paths, and verifies our reader handles it correctly without ever having written it.
- `TestSpecJsonSchemas` validates the emitted `partition_spec_v1` and `schema` JSON against JSON Schemas transcribed from the spec model docs.
- `TestOfficialClientModels` round-trips emitted JSON through the canonical Pydantic models from `lance-namespace-urllib3-client` (added as a dev dep, pinned to `0.7.6` — the latest from https://github.com/lance-format/lance-namespace).
- 60+ behavioral tests cover object_id structure, namespace hierarchy, partition-value inheritance, physical-dir naming, partition-column stripping, read pushdown, column projection, roundtrip with nulls / many partitions, and append/overwrite/create modes.

### Files

- `daft/io/lance/lance_namespace.py` — shared helpers (manifest column constants, `PartitionFieldSpec`, random base36/hex generators, `make_object_id` / `parse_object_id` / `make_location`, JsonArrowDataType encode/decode, partition-spec and namespace-schema JSON round-trip, `manifest_arrow_schema` builder).
- `daft/io/lance/lance_partitioned_data_sink.py` — `LancePartitionedDataSink(DataSink)`.
- `daft/io/lance/lance_namespace_scan.py` — `LanceNamespaceScanOperator(ScanOperator, SupportsPushdownFilters)`.
- `daft/io/lance/_lance.py` — adds `namespace_partitioning=False` to `read_lance`.
- `daft/dataframe/dataframe.py` — adds `partition_cols=None` to `write_lance`.
- `tests/io/lancedb/test_lance_namespace_partitioning.py` — 72 tests.
- `pyproject.toml` / `uv.lock` — adds `lance-namespace-urllib3-client==0.7.6` to the `dev` group.

## Related Issues

Re-lands the work reverted in #6907 (originally #6898), aligned to the published partitioning spec.