### PR TITLE
fix(distributed): emit empty downstream task for limit(0)

### DIFF
--- a/src/daft-distributed/src/pipeline_node/limit.rs
+++ b/src/daft-distributed/src/pipeline_node/limit.rs
@@ -165,6 +165,22 @@ impl LimitNode {
         }
     }
 
+    /// Build a single empty-input scan task with this node's output schema.
+    /// Used to keep downstream blocking sinks (notably ungrouped aggregates)
+    /// running when no rows reach them — e.g. when the limit is 0 or when
+    /// every input row is skipped — so they still emit their finalize output.
+    fn build_empty_scan_task(self: &Arc<Self>) -> SwordfishTaskBuilder {
+        let empty_plan = LocalPhysicalPlan::in_memory_scan(
+            self.node_id(),
+            self.config.schema.clone(),
+            0,
+            StatsState::Materialized(PlanStats::empty().into()),
+            LocalNodeContext::new(Some(self.node_id() as usize)),
+        );
+        SwordfishTaskBuilder::new(empty_plan, self.as_ref(), self.node_id())
+            .with_psets(self.node_id(), vec![])
+    }
+
     fn process_materialized_output(
         self: &Arc<Self>,
         materialized_output: MaterializedOutput,
@@ -271,6 +287,15 @@ impl LimitNode {
 
         let mut input = std::pin::pin!(input.peekable());
 
+        // Limit=0 (with no offset to skip) yields no rows. Emit a single empty
+        // scan task so downstream blocking sinks like ungrouped aggregates
+        // still finalize and produce their one-row null result, then bail out
+        // without consuming the input.
+        if limit_state.is_take_done() && limit_state.is_skip_done() {
+            let _ = result_tx.send(self.build_empty_scan_task()).await;
+            return Ok(());
+        }
+
         // Try to estimate initial concurrency from scan task metadata (e.g. Parquet row counts).
         // This avoids the bottleneck of running one task sequentially just to measure output size.
         if let Some(first) = input.as_mut().peek().await
@@ -322,17 +347,7 @@ impl LimitNode {
                     if next_tasks.is_empty() {
                         // If all rows need to be skipped, send an empty scan task to allow downstream tasks to
                         // continue running, such as aggregate tasks
-                        let empty_plan = LocalPhysicalPlan::in_memory_scan(
-                            self.node_id(),
-                            self.config.schema.clone(),
-                            0,
-                            StatsState::Materialized(PlanStats::empty().into()),
-                            LocalNodeContext::new(Some(self.node_id() as usize)),
-                        );
-                        let empty_scan_builder =
-                            SwordfishTaskBuilder::new(empty_plan, self.as_ref(), self.node_id())
-                                .with_psets(self.node_id(), vec![]);
-                        if result_tx.send(empty_scan_builder).await.is_err() {
+                        if result_tx.send(self.build_empty_scan_task()).await.is_err() {
                             return Ok(());
                         }
                     } else {
@@ -536,6 +551,23 @@ mod tests {
 
         let stats = run_pipeline_and_get_stats(&pipeline, &meter).await?;
         assert_limit_rows_out(&stats, 7);
+        Ok(())
+    }
+
+    /// Limit = 0 on a non-empty `InMemorySource`: the execution loop must
+    /// still emit a single empty downstream task (rather than producing zero
+    /// tasks) so blocking ops like ungrouped aggregates downstream still
+    /// finalize and emit their one-row null result. Verifies `rows_out == 0`
+    /// and the pipeline completes without hanging.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_limit_zero_emits_empty_task() -> DaftResult<()> {
+        let meter = Meter::test_scope("test_limit_zero_emits_empty_task");
+        let (source, plan_config) =
+            build_in_memory_source(0, vec![make_partition(&[1, 2, 3, 4, 5])], &meter);
+        let pipeline = wrap_with_limit(source, &plan_config, 0, &meter);
+
+        let stats = run_pipeline_and_get_stats(&pipeline, &meter).await?;
+        assert_limit_rows_out(&stats, 0);
         Ok(())
     }
 

--- a/src/daft-distributed/src/pipeline_node/limit.rs
+++ b/src/daft-distributed/src/pipeline_node/limit.rs
@@ -531,6 +531,24 @@ mod tests {
         }
     }
 
+    /// Assert the limit node ran exactly `expected` downstream tasks.
+    /// `num_tasks` is incremented per task instance executed on a worker,
+    /// keyed by the emitting node's id, so this directly verifies how many
+    /// SwordfishTaskBuilders the limit node sent downstream.
+    fn assert_limit_num_tasks(
+        stats: &[(Arc<common_metrics::ops::NodeInfo>, StatSnapshot)],
+        expected: u64,
+    ) {
+        let (_, snapshot) = stats
+            .iter()
+            .find(|(i, _)| i.id == 1)
+            .expect("limit node stats");
+        match snapshot {
+            StatSnapshot::Default(s) => assert_eq!(s.num_tasks, expected),
+            other => panic!("expected Default snapshot for limit, got: {other:?}"),
+        }
+    }
+
     /// Limit on an `InMemorySource`: input task builders carry `psets` rather
     /// than scan tasks, so `estimated_num_rows()` returns `None` and the
     /// execution loop takes the fallback `max_concurrent_tasks = 1` branch.
@@ -557,8 +575,12 @@ mod tests {
     /// Limit = 0 on a non-empty `InMemorySource`: the execution loop must
     /// still emit a single empty downstream task (rather than producing zero
     /// tasks) so blocking ops like ungrouped aggregates downstream still
-    /// finalize and emit their one-row null result. Verifies `rows_out == 0`
-    /// and the pipeline completes without hanging.
+    /// finalize and emit their one-row null result.
+    ///
+    /// Asserts `num_tasks == 1` directly — without the short-circuit fix the
+    /// execution loop emits zero tasks (max_concurrent_tasks collapses to 0
+    /// because total_remaining is 0), so `rows_out == 0` alone wouldn't
+    /// distinguish the buggy path from the fixed one.
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn test_limit_zero_emits_empty_task() -> DaftResult<()> {
         let meter = Meter::test_scope("test_limit_zero_emits_empty_task");
@@ -568,6 +590,7 @@ mod tests {
 
         let stats = run_pipeline_and_get_stats(&pipeline, &meter).await?;
         assert_limit_rows_out(&stats, 0);
+        assert_limit_num_tasks(&stats, 1);
         Ok(())
     }
 


### PR DESCRIPTION
## Changes Made

`LimitNode` in the Flotilla pipeline computes `max_concurrent_tasks = total_remaining().div_ceil(estimated_num_rows)`. For `limit=0` against any input source carrying row-count metadata (e.g. `InMemoryScan`), this collapses to 0, the submission loop never runs, and **no downstream task is ever emitted**. Blocking sinks downstream — notably ungrouped aggregates — then have 0 input tasks, never finalize, and produce 0 output rows.

The native runner doesn't have a Limit pipeline node, and its `AggregateSink::finalize` always runs once even with zero input states, which is why the native path was unaffected.

### Fix

Short-circuit `is_take_done() && is_skip_done()` at the top of `limit_execution_loop` by emitting one empty scan task and returning — so downstream blocking sinks still finalize and produce their conventional one-row null result. Pulled the empty-scan construction into a private `build_empty_scan_task` helper to dedupe with the existing "all rows skipped" code path.

### Repro (before fix)

```python
import daft
from daft import col
df = daft.from_pydict({"values": [1.0, 2.0]}).limit(0)
df.agg(col("values").sum().alias("s")).collect().to_pydict()
# Ray:    {"s": []}      ← bug
# Native: {"s": [None]}
```

### Tests

- New unit test `test_limit_zero_emits_empty_task` in `src/daft-distributed/src/pipeline_node/limit.rs` covering the limit=0 path.
- Verified locally: `tests/dataframe/test_percentile.py` all 14 tests pass on Ray, and `tests/dataframe/test_limit_offset.py` all 199 tests pass on Ray.

## Related Issues

Unblocks the v0.7.11 release — `test_percentile_empty_input` was failing on the Ray test job: https://github.com/Eventual-Inc/Daft/actions/runs/25575457827/job/75087986460

The test was added in #6153 (percentile/median ops). It exposed this latent `limit=0` bug in the distributed limit node; the bug also affects `sum`, `count`, `mean`, and any other ungrouped aggregation over `limit(0)`-empty input on the Ray runner.

## Test plan

- [ ] CI green
- [ ] `test_percentile_empty_input` passes on Ray
- [ ] `test_limit_offset.py` suite stays green on Ray

🤖 Generated with [Claude Code](https://claude.com/claude-code)