### PR TITLE
fix(dashbaord): highlight failed operators for queries

### DIFF
--- a/src/daft-dashboard/frontend/src/app/layout.tsx
+++ b/src/daft-dashboard/frontend/src/app/layout.tsx
@@ -25,7 +25,7 @@ export default function RootLayout({
               <div className="flex flex-col h-full">
                 <AppNavbar />
                 <main className="flex-1 overflow-auto">
-                  <div className="p-[20px]">{children}</div>
+                  <div className="pt-[20px]">{children}</div>
                 </main>
               </div>
             </TooltipProvider>

--- a/src/daft-dashboard/frontend/src/app/query/page.tsx
+++ b/src/daft-dashboard/frontend/src/app/query/page.tsx
@@ -197,11 +197,6 @@ function QueryPageInner() {
     query.state.status === "Optimizing" ||
     query.state.status === "Setup" ||
     query.state.status === "Executing";
-  const queryIsTerminal =
-    query.state.status === "Finished" ||
-    query.state.status === "Failed" ||
-    query.state.status === "Canceled" ||
-    query.state.status === "Dead";
   const last_heartbeat_sec = isActive || query.state.status === "Dead"
     ? query.last_heartbeat_sec
     : null;
@@ -328,7 +323,7 @@ function QueryPageInner() {
                       onViewTasks={isFlotilla ? handleViewTasksForNode : undefined}
                       tasksOpen={isFlotilla && tasksOpen}
                       onOpenTasks={isFlotilla ? handleOpenTasks : undefined}
-                      queryIsTerminal={queryIsTerminal}
+                      queryStatus={query.state.status}
                     />
                   </div>
                   {isFlotilla && tasksOpen && queryId && (

--- a/src/daft-dashboard/frontend/src/app/query/page.tsx
+++ b/src/daft-dashboard/frontend/src/app/query/page.tsx
@@ -28,14 +28,16 @@ const MetaField = ({
   href,
   mono,
   title,
+  align = "left",
 }: {
   label: string;
   value: string;
   href?: string;
   mono?: boolean;
   title?: string;
+  align?: "left" | "right";
 }) => (
-  <div className="min-w-0">
+  <div className={`min-w-0 ${align === "right" ? "text-right" : ""}`}>
     <p className={`${main.className} text-[10px] uppercase tracking-wider text-zinc-500 leading-none mb-1`}>
       {label}
     </p>
@@ -50,8 +52,8 @@ const MetaField = ({
       </a>
     ) : (
       <p
-        className={`${main.className} text-base ${mono ? "font-mono" : ""} text-zinc-100`}
-        title={title}
+        className={`${main.className} text-base ${mono ? "font-mono" : ""} text-zinc-100 truncate`}
+        title={title ?? value}
       >
         {value}
       </p>
@@ -195,6 +197,11 @@ function QueryPageInner() {
     query.state.status === "Optimizing" ||
     query.state.status === "Setup" ||
     query.state.status === "Executing";
+  const queryIsTerminal =
+    query.state.status === "Finished" ||
+    query.state.status === "Failed" ||
+    query.state.status === "Canceled" ||
+    query.state.status === "Dead";
   const last_heartbeat_sec = isActive || query.state.status === "Dead"
     ? query.last_heartbeat_sec
     : null;
@@ -203,7 +210,7 @@ function QueryPageInner() {
     <div className="h-full flex flex-col">
       {/* Compact Header */}
       <div className="flex-shrink-0">
-        <div className="px-6 pt-0 pb-1">
+        <div className="px-6 pb-1">
           <Breadcrumb>
             <BreadcrumbList>
               <BreadcrumbItem>
@@ -226,7 +233,7 @@ function QueryPageInner() {
 
         <div className="w-full flex items-stretch">
           {/* Status — fixed width so the divider never shifts during execution */}
-          <div className="w-52 flex-shrink-0 px-6 py-5 flex items-center justify-start">
+          <div className="w-52 flex-shrink-0 px-6 py-3 flex items-center justify-start">
             <Status
               status={query.state.status}
               start_sec={query.start_sec}
@@ -239,12 +246,12 @@ function QueryPageInner() {
           <div className="w-px bg-zinc-800 my-4 flex-shrink-0" />
 
           {/* Metadata — 4 columns, 2 rows */}
-          <div className="flex-1 px-6 py-5 grid grid-cols-4 gap-x-8 gap-y-3 content-center overflow-hidden">
+          <div className="flex-1 px-6 py-3 grid grid-cols-4 gap-x-8 gap-y-3 content-center overflow-hidden">
             {/* Row 1 */}
             <MetaField label="Query ID" value={query.id} mono />
             <MetaField label="Engine" value={getEngineName(query.runner)} mono />
             <MetaField label="Start Time" value={toHumanReadableDate(query.start_sec)} mono />
-            <MetaField label="End Time" value={end_sec ? toHumanReadableDate(end_sec) : "—"} mono />
+            <MetaField label="End Time" value={end_sec ? toHumanReadableDate(end_sec) : "—"} mono align="right" />
 
             {/* Row 2 */}
             <MetaField label="Entrypoint" value={query.entrypoint || "—"} mono title={query.entrypoint} />
@@ -263,6 +270,7 @@ function QueryPageInner() {
                 label="Versions"
                 value={[query.python_version && `Python ${query.python_version}`, query.ray_version && `Ray ${query.ray_version}`].filter(Boolean).join(" | ")}
                 mono
+                align="right"
               />
             ) : (
               <div />
@@ -278,7 +286,7 @@ function QueryPageInner() {
           onValueChange={handleTabChange}
           className="w-full h-full flex flex-col"
         >
-          <TabsList className="flex w-full flex-shrink-0 justify-start gap-x-0 rounded-none bg-transparent p-0 border-b border-zinc-800">
+          <TabsList className="flex w-full flex-shrink-0 justify-start gap-x-0 rounded-none bg-transparent px-6 py-0 border-b border-zinc-800">
             <TabsTrigger
               value="progress-table"
               disabled={
@@ -307,9 +315,9 @@ function QueryPageInner() {
 
           <TabsContent
             value="progress-table"
-            className="mt-4 flex-1 overflow-hidden"
+            className="flex-1 overflow-hidden"
           >
-            <div className="bg-zinc-900 h-full flex">
+            <div className="h-full flex">
               {"exec_info" in query.state && query.state.exec_info !== null ? (
                 <>
                   <div className="flex-1 min-w-0 h-full">
@@ -320,6 +328,7 @@ function QueryPageInner() {
                       onViewTasks={isFlotilla ? handleViewTasksForNode : undefined}
                       tasksOpen={isFlotilla && tasksOpen}
                       onOpenTasks={isFlotilla ? handleOpenTasks : undefined}
+                      queryIsTerminal={queryIsTerminal}
                     />
                   </div>
                   {isFlotilla && tasksOpen && queryId && (
@@ -347,7 +356,7 @@ function QueryPageInner() {
 
           <TabsContent
             value="optimized-plan"
-            className="mt-4 flex-1 overflow-auto"
+            className="flex-1 overflow-auto"
           >
             {query.state.status === "Pending" ? (
               <div className="bg-zinc-900 p-4">
@@ -368,7 +377,7 @@ function QueryPageInner() {
 
           <TabsContent
             value="unoptimized-plan"
-            className="mt-4 flex-1 overflow-auto"
+            className="flex-1 overflow-auto"
           >
             <PlanVisualizer planJson={query.unoptimized_plan} />
           </TabsContent>

--- a/src/daft-dashboard/frontend/src/app/query/physical-plan-tree.tsx
+++ b/src/daft-dashboard/frontend/src/app/query/physical-plan-tree.tsx
@@ -3,9 +3,11 @@
 import { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import { ListChecks, PanelRightOpen } from "lucide-react";
 import { main } from "@/lib/utils";
-import { ExecutingState, OperatorInfo, OperatorStatus, PhysicalPlanNode } from "./types";
+import { ExecutingState, OperatorInfo, OperatorStatus, PhysicalPlanNode, TaskStore } from "./types";
+import { QueryStatusName } from "@/hooks/use-queries";
 import {
   getStatusIcon,
+  getEffectiveStatus,
   formatStatValue,
   formatDuration,
   statNumericValue,
@@ -18,8 +20,7 @@ import {
 import ProgressTable from "./progress-table";
 import TreeLayout from "./tree-layout";
 import EdgeLabel from "./edge-label";
-import { getHeatmapStyle, FINISHED_STYLE, FAILED_STYLE } from "./tree-colors";
-import { TaskStore } from "./types";
+import { getHeatmapStyle, FINISHED_STYLE, FAILED_STYLE, CANCELED_STYLE } from "./tree-colors";
 
 function getCpuSec(operator?: OperatorInfo): number {
   if (!operator) return 0;
@@ -111,26 +112,6 @@ function useWallClockDuration(operator?: OperatorInfo): string | null {
   return formatDuration(Math.max(0, end - operator.start_sec));
 }
 
-function getEffectiveStatus(
-  operator: OperatorInfo | undefined,
-  nodeId: number,
-  taskStore: TaskStore | undefined,
-): OperatorStatus {
-  if (!operator) return "Pending";
-
-  if (taskStore) {
-    const hasFailed = taskStore.groups.some(
-      (g) => g.node_ids.includes(nodeId) && g.failed_count > 0,
-    );
-    if (hasFailed) return "Failed";
-  }
-
-  // Marked Finished by the backend but never actually started → never ran
-  if (operator.status === "Finished" && !operator.start_sec) return "Pending";
-
-  return operator.status;
-}
-
 function PhysicalNodeCard({
   node,
   operator,
@@ -138,7 +119,7 @@ function PhysicalNodeCard({
   effectiveStatus,
   isHighlighted,
   isHovered,
-  queryIsTerminal,
+  queryStatus,
   onViewTasks,
 }: {
   node: PhysicalPlanNode;
@@ -149,18 +130,18 @@ function PhysicalNodeCard({
   isHighlighted: boolean;
   /** Transient hover preview — set when the user hovers a task row in the sidebar. */
   isHovered: boolean;
-  queryIsTerminal: boolean;
+  queryStatus: QueryStatusName;
   /** If provided, shows a "View Tasks" affordance on the card. Flotilla only. */
   onViewTasks?: (nodeId: number) => void;
 }) {
   const [expanded, setExpanded] = useState(false);
+  const isTerminal = queryStatus === "Finished" || queryStatus === "Failed" || queryStatus === "Canceled" || queryStatus === "Dead";
   const wallClock = useWallClockDuration(operator);
   const cardStyle: React.CSSProperties =
-    effectiveStatus === "Failed"
-      ? FAILED_STYLE
-      : effectiveStatus === "Finished"
-        ? FINISHED_STYLE
-        : getHeatmapStyle(intensity);
+    effectiveStatus === "Failed"   ? FAILED_STYLE :
+    effectiveStatus === "Finished" ? FINISHED_STYLE :
+    effectiveStatus === "Canceled" ? CANCELED_STYLE :
+    getHeatmapStyle(intensity);
 
   // Scroll into view only when the *sticky* (click-driven) highlight becomes
   // active — scrubbing the sidebar via hover shouldn't jump the plan around.
@@ -212,7 +193,7 @@ function PhysicalNodeCard({
     >
       {/* Header: status icon + name */}
       <div className="flex items-center gap-2">
-        {getStatusIcon(effectiveStatus, queryIsTerminal)}
+        {getStatusIcon(effectiveStatus, isTerminal)}
         <span
           className={`${main.className} text-zinc-100 text-sm font-bold tracking-wide truncate`}
         >
@@ -301,7 +282,7 @@ export default function PhysicalPlanTree({
   onViewTasks,
   tasksOpen,
   onOpenTasks,
-  queryIsTerminal,
+  queryStatus,
 }: {
   exec_state: ExecutingState;
   /** Sticky highlight — driven by the URL/node filter (click-to-filter). */
@@ -313,7 +294,7 @@ export default function PhysicalPlanTree({
   tasksOpen?: boolean;
   /** If provided, renders a toolbar button that opens the tasks sidebar (unfiltered). */
   onOpenTasks?: () => void;
-  queryIsTerminal: boolean;
+  queryStatus: QueryStatusName;
 }) {
   const [viewMode, setViewMode] = useState<"tree" | "table" | "json">("tree");
 
@@ -430,7 +411,7 @@ export default function PhysicalPlanTree({
                   node.type,
                   maxCpuSec,
                 );
-                const effectiveStatus = getEffectiveStatus(op, node.id, taskStore);
+                const effectiveStatus = getEffectiveStatus(op, node.id, taskStore, queryStatus);
                 return (
                   <PhysicalNodeCard
                     node={node}
@@ -439,7 +420,7 @@ export default function PhysicalPlanTree({
                     effectiveStatus={effectiveStatus}
                     isHighlighted={highlightedNodeId === node.id}
                     isHovered={hoveredNodeIds?.has(node.id) ?? false}
-                    queryIsTerminal={queryIsTerminal}
+                    queryStatus={queryStatus}
                     onViewTasks={onViewTasks}
                   />
                 );
@@ -454,7 +435,7 @@ export default function PhysicalPlanTree({
             {JSON.stringify(plan, null, 2)}
           </pre>
         ) : (
-          <ProgressTable exec_state={exec_state} queryIsTerminal={queryIsTerminal} />
+          <ProgressTable exec_state={exec_state} queryStatus={queryStatus} />
         )}
       </div>
     </div>

--- a/src/daft-dashboard/frontend/src/app/query/physical-plan-tree.tsx
+++ b/src/daft-dashboard/frontend/src/app/query/physical-plan-tree.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import { ListChecks, PanelRightOpen } from "lucide-react";
 import { main } from "@/lib/utils";
-import { ExecutingState, OperatorInfo, PhysicalPlanNode } from "./types";
+import { ExecutingState, OperatorInfo, OperatorStatus, PhysicalPlanNode } from "./types";
 import {
   getStatusIcon,
   formatStatValue,
@@ -18,7 +18,8 @@ import {
 import ProgressTable from "./progress-table";
 import TreeLayout from "./tree-layout";
 import EdgeLabel from "./edge-label";
-import { getHeatmapStyle, FINISHED_STYLE } from "./tree-colors";
+import { getHeatmapStyle, FINISHED_STYLE, FAILED_STYLE } from "./tree-colors";
+import { TaskStore } from "./types";
 
 function getCpuSec(operator?: OperatorInfo): number {
   if (!operator) return 0;
@@ -110,29 +111,56 @@ function useWallClockDuration(operator?: OperatorInfo): string | null {
   return formatDuration(Math.max(0, end - operator.start_sec));
 }
 
+function getEffectiveStatus(
+  operator: OperatorInfo | undefined,
+  nodeId: number,
+  taskStore: TaskStore | undefined,
+): OperatorStatus {
+  if (!operator) return "Pending";
+
+  if (taskStore) {
+    const hasFailed = taskStore.groups.some(
+      (g) => g.node_ids.includes(nodeId) && g.failed_count > 0,
+    );
+    if (hasFailed) return "Failed";
+  }
+
+  // Marked Finished by the backend but never actually started → never ran
+  if (operator.status === "Finished" && !operator.start_sec) return "Pending";
+
+  return operator.status;
+}
+
 function PhysicalNodeCard({
   node,
   operator,
   intensity,
+  effectiveStatus,
   isHighlighted,
   isHovered,
+  queryIsTerminal,
   onViewTasks,
 }: {
   node: PhysicalPlanNode;
   operator?: OperatorInfo;
   intensity: number;
+  effectiveStatus: OperatorStatus;
   /** Sticky highlight — typically set by the URL/node filter from the Tasks sidebar. */
   isHighlighted: boolean;
   /** Transient hover preview — set when the user hovers a task row in the sidebar. */
   isHovered: boolean;
+  queryIsTerminal: boolean;
   /** If provided, shows a "View Tasks" affordance on the card. Flotilla only. */
   onViewTasks?: (nodeId: number) => void;
 }) {
   const [expanded, setExpanded] = useState(false);
-  const status = operator?.status ?? "Pending";
   const wallClock = useWallClockDuration(operator);
   const cardStyle: React.CSSProperties =
-    status === "Finished" ? FINISHED_STYLE : getHeatmapStyle(intensity);
+    effectiveStatus === "Failed"
+      ? FAILED_STYLE
+      : effectiveStatus === "Finished"
+        ? FINISHED_STYLE
+        : getHeatmapStyle(intensity);
 
   // Scroll into view only when the *sticky* (click-driven) highlight becomes
   // active — scrubbing the sidebar via hover shouldn't jump the plan around.
@@ -184,7 +212,7 @@ function PhysicalNodeCard({
     >
       {/* Header: status icon + name */}
       <div className="flex items-center gap-2">
-        {getStatusIcon(status)}
+        {getStatusIcon(effectiveStatus, queryIsTerminal)}
         <span
           className={`${main.className} text-zinc-100 text-sm font-bold tracking-wide truncate`}
         >
@@ -273,6 +301,7 @@ export default function PhysicalPlanTree({
   onViewTasks,
   tasksOpen,
   onOpenTasks,
+  queryIsTerminal,
 }: {
   exec_state: ExecutingState;
   /** Sticky highlight — driven by the URL/node filter (click-to-filter). */
@@ -284,6 +313,7 @@ export default function PhysicalPlanTree({
   tasksOpen?: boolean;
   /** If provided, renders a toolbar button that opens the tasks sidebar (unfiltered). */
   onOpenTasks?: () => void;
+  queryIsTerminal: boolean;
 }) {
   const [viewMode, setViewMode] = useState<"tree" | "table" | "json">("tree");
 
@@ -298,6 +328,7 @@ export default function PhysicalPlanTree({
   }
 
   const operators = exec_state.exec_info.operators;
+  const taskStore = exec_state.exec_info.task_store;
   const maxCpuSec = Math.max(
     0.001,
     ...Object.values(operators).map(getCpuSec),
@@ -335,9 +366,9 @@ export default function PhysicalPlanTree({
   );
 
   return (
-    <div className="bg-zinc-900 h-full flex flex-col">
+    <div className="h-full flex flex-col">
       {/* View toggle */}
-      <div className="flex items-center gap-2 px-4 pt-3 pb-2 border-b border-zinc-800">
+      <div className="flex items-center gap-2 px-6 pt-3 pb-2 border-b border-zinc-800">
         {plan && (
           <button
             onClick={() => setViewMode("tree")}
@@ -399,13 +430,16 @@ export default function PhysicalPlanTree({
                   node.type,
                   maxCpuSec,
                 );
+                const effectiveStatus = getEffectiveStatus(op, node.id, taskStore);
                 return (
                   <PhysicalNodeCard
                     node={node}
                     operator={op}
                     intensity={intensity}
+                    effectiveStatus={effectiveStatus}
                     isHighlighted={highlightedNodeId === node.id}
                     isHovered={hoveredNodeIds?.has(node.id) ?? false}
+                    queryIsTerminal={queryIsTerminal}
                     onViewTasks={onViewTasks}
                   />
                 );
@@ -420,7 +454,7 @@ export default function PhysicalPlanTree({
             {JSON.stringify(plan, null, 2)}
           </pre>
         ) : (
-          <ProgressTable exec_state={exec_state} />
+          <ProgressTable exec_state={exec_state} queryIsTerminal={queryIsTerminal} />
         )}
       </div>
     </div>

--- a/src/daft-dashboard/frontend/src/app/query/plan-visualizer.tsx
+++ b/src/daft-dashboard/frontend/src/app/query/plan-visualizer.tsx
@@ -110,7 +110,7 @@ export default function PlanVisualizer({ planJson }: { planJson: string }) {
     plan = parsePlan(planJson);
   } catch {
     return (
-      <div className="bg-zinc-900 p-4">
+      <div className="p-4">
         <pre
           className={`${main.className} text-sm font-mono text-zinc-300 whitespace-pre-wrap`}
         >
@@ -121,9 +121,9 @@ export default function PlanVisualizer({ planJson }: { planJson: string }) {
   }
 
   return (
-    <div className="bg-zinc-900 h-full flex flex-col">
+    <div className="h-full flex flex-col">
       {/* View toggle */}
-      <div className="flex items-center gap-2 px-4 pt-3 pb-2 border-b border-zinc-800">
+      <div className="flex items-center gap-2 px-6 pt-3 pb-2 border-b border-zinc-800">
         <button
           onClick={() => setViewMode("tree")}
           className={`${main.className} text-xs px-3 py-1 rounded-md transition-colors ${

--- a/src/daft-dashboard/frontend/src/app/query/progress-table.tsx
+++ b/src/daft-dashboard/frontend/src/app/query/progress-table.tsx
@@ -1,9 +1,11 @@
 import { useState, useEffect } from "react";
 import { ExecutingState, OperatorInfo } from "./types";
+import { QueryStatusName } from "@/hooks/use-queries";
 import {
   getStatusIcon,
   getStatusText,
   getStatusColor,
+  getEffectiveStatus,
   formatStatValue,
   formatBytes,
   formatDuration,
@@ -33,11 +35,12 @@ function OperatorDuration({ operator }: { operator: OperatorInfo }) {
 
 export default function ProgressTable({
   exec_state,
-  queryIsTerminal,
+  queryStatus,
 }: {
   exec_state: ExecutingState;
-  queryIsTerminal: boolean;
+  queryStatus: QueryStatusName;
 }) {
+  const isTerminal = queryStatus === "Finished" || queryStatus === "Failed" || queryStatus === "Canceled" || queryStatus === "Dead";
   return (
     <div className="overflow-auto h-full px-6 py-4">
       <div className="min-w-[1130px]">
@@ -78,6 +81,12 @@ export default function ProgressTable({
           {Object.entries(exec_state.exec_info.operators)
             .sort(([a], [b]) => parseInt(a) - parseInt(b))
             .map(([operatorId, operator]) => {
+              const effectiveStatus = getEffectiveStatus(
+                operator,
+                operator.node_info.id,
+                exec_state.exec_info.task_store,
+                queryStatus,
+              );
               const name = operator.node_info.name;
               const rowsIn = operator.stats[ROWS_IN_STAT_KEY]?.value || 0;
               const rowsOut = operator.stats[ROWS_OUT_STAT_KEY]?.value || 0;
@@ -108,14 +117,14 @@ export default function ProgressTable({
                   className="grid grid-cols-[50px_60px_100px_200px_120px_120px_120px_120px_100px_1fr] gap-0 items-center min-h-[55px] transition-colors hover:bg-zinc-800/50"
                 >
                   <div className="px-3 py-4 flex items-center justify-end border-r border-zinc-700 h-full">
-                    {getStatusIcon(operator.status, queryIsTerminal)}
+                    {getStatusIcon(effectiveStatus, isTerminal)}
                   </div>
                   <div className="px-3 py-4 text-center text-sm text-zinc-400 font-mono border-r border-zinc-700 h-full flex items-center justify-center">
                     {operatorId}
                   </div>
                   <div className="pr-3 py-4 text-right text-sm border-r border-zinc-700 h-full flex items-center justify-end">
-                    <span className={getStatusColor(operator.status)}>
-                      {getStatusText(operator.status)}
+                    <span className={getStatusColor(effectiveStatus)}>
+                      {getStatusText(effectiveStatus)}
                     </span>
                   </div>
                   <div

--- a/src/daft-dashboard/frontend/src/app/query/progress-table.tsx
+++ b/src/daft-dashboard/frontend/src/app/query/progress-table.tsx
@@ -33,11 +33,13 @@ function OperatorDuration({ operator }: { operator: OperatorInfo }) {
 
 export default function ProgressTable({
   exec_state,
+  queryIsTerminal,
 }: {
   exec_state: ExecutingState;
+  queryIsTerminal: boolean;
 }) {
   return (
-    <div className="overflow-auto h-full">
+    <div className="overflow-auto h-full px-6 py-4">
       <div className="min-w-[1130px]">
         {/* Table Headers */}
         <div className="bg-zinc-800 grid grid-cols-[50px_60px_100px_200px_120px_120px_120px_120px_100px_1fr] gap-0 items-center min-h-[55px] border-b border-zinc-700">
@@ -106,7 +108,7 @@ export default function ProgressTable({
                   className="grid grid-cols-[50px_60px_100px_200px_120px_120px_120px_120px_100px_1fr] gap-0 items-center min-h-[55px] transition-colors hover:bg-zinc-800/50"
                 >
                   <div className="px-3 py-4 flex items-center justify-end border-r border-zinc-700 h-full">
-                    {getStatusIcon(operator.status)}
+                    {getStatusIcon(operator.status, queryIsTerminal)}
                   </div>
                   <div className="px-3 py-4 text-center text-sm text-zinc-400 font-mono border-r border-zinc-700 h-full flex items-center justify-center">
                     {operatorId}

--- a/src/daft-dashboard/frontend/src/app/query/stats-utils.tsx
+++ b/src/daft-dashboard/frontend/src/app/query/stats-utils.tsx
@@ -44,12 +44,12 @@ export const formatBytes = (bytes: number): string => {
   }
 };
 
-export const getStatusIcon = (status: OperatorStatus) => {
+export const getStatusIcon = (status: OperatorStatus, isTerminal = false) => {
   switch (status) {
     case "Finished":
-      return <Naruto />;
+      return <Naruto animated={!isTerminal} />;
     case "Executing":
-      return <AnimatedFish />;
+      return <AnimatedFish animated={!isTerminal} />;
     case "Failed":
       return (
         <div className="w-5 h-5 flex items-center justify-center">
@@ -61,7 +61,7 @@ export const getStatusIcon = (status: OperatorStatus) => {
     case "Pending":
     default:
       return (
-        <div className="w-5 h-5 shrink-0 border-2 border-zinc-400 border-t-transparent rounded-full animate-spin"></div>
+        <div className={`w-5 h-5 shrink-0 border-2 border-zinc-400 border-t-transparent rounded-full ${isTerminal ? "" : "animate-spin"}`}></div>
       );
   }
 };

--- a/src/daft-dashboard/frontend/src/app/query/stats-utils.tsx
+++ b/src/daft-dashboard/frontend/src/app/query/stats-utils.tsx
@@ -1,5 +1,6 @@
 import { AnimatedFish, Naruto } from "@/components/icons";
-import { OperatorStatus, Stat } from "./types";
+import { OperatorInfo, OperatorStatus, Stat, TaskStore } from "./types";
+import { QueryStatusName } from "@/hooks/use-queries";
 
 export const ROWS_IN_STAT_KEY = "rows.in";
 export const ROWS_OUT_STAT_KEY = "rows.out";
@@ -44,6 +45,41 @@ export const formatBytes = (bytes: number): string => {
   }
 };
 
+/**
+ * Resolves the status to display for an operator, taking Flotilla task-level
+ * failures into account. A "Finished" operator is never overridden — retried
+ * tasks leave a non-zero failed_count even after the operator succeeds.
+ */
+export function getEffectiveStatus(
+  operator: OperatorInfo | undefined,
+  nodeId: number,
+  taskStore: TaskStore | undefined,
+  queryStatus: QueryStatusName = "Executing",
+): OperatorStatus {
+  if (!operator) return "Pending";
+
+  if (taskStore) {
+    const group = taskStore.groups.find((g) => g.node_ids.includes(nodeId));
+    if (group) {
+      // On a successful query, failed_count may be non-zero from Flotilla task
+      // retries that ultimately succeeded — don't override the Finished status.
+      if (group.failed_count > 0 && queryStatus !== "Finished") return "Failed";
+
+      // When Daft terminates the query externally (Failed/Dead), tasks that
+      // were still running never recorded an outcome — treat them as failed.
+      if (group.running_count > 0 && (queryStatus === "Failed" || queryStatus === "Dead")) return "Failed";
+
+      // Tasks cancelled as part of a user-initiated cancellation → gray.
+      if (group.cancelled_count > 0 && queryStatus === "Canceled") return "Canceled";
+    }
+  }
+
+  // Marked Finished by the backend but never actually started → never ran
+  if (operator.status === "Finished" && !operator.start_sec) return "Pending";
+
+  return operator.status;
+}
+
 export const getStatusIcon = (status: OperatorStatus, isTerminal = false) => {
   switch (status) {
     case "Finished":
@@ -58,6 +94,14 @@ export const getStatusIcon = (status: OperatorStatus, isTerminal = false) => {
           </div>
         </div>
       );
+    case "Canceled":
+      return (
+        <div className="w-5 h-5 flex items-center justify-center">
+          <div className="w-4 h-4 bg-zinc-600 rounded-full flex items-center justify-center">
+            <span className="text-zinc-300 text-[10px] font-bold">−</span>
+          </div>
+        </div>
+      );
     case "Pending":
     default:
       return (
@@ -67,28 +111,22 @@ export const getStatusIcon = (status: OperatorStatus, isTerminal = false) => {
 };
 
 export const getStatusText = (status: OperatorStatus) => {
-  if (status === "Finished") {
-    return "Finished";
-  } else if (status === "Executing") {
-    return "Running";
-  } else if (status === "Failed") {
-    return "Failed";
-  } else {
-    return "Pending";
+  switch (status) {
+    case "Finished":  return "Finished";
+    case "Executing": return "Running";
+    case "Failed":    return "Failed";
+    case "Canceled":  return "Canceled";
+    default:          return "Pending";
   }
 };
 
 export const getStatusColor = (status: OperatorStatus) => {
   switch (status) {
-    case "Finished":
-      return "text-green-500";
-    case "Executing":
-      return "text-(--daft-accent)";
-    case "Failed":
-      return "text-red-500";
-    case "Pending":
-    default:
-      return "text-zinc-400";
+    case "Finished":  return "text-green-500";
+    case "Executing": return "text-(--daft-accent)";
+    case "Failed":    return "text-red-500";
+    case "Canceled":  return "text-zinc-400";
+    default:          return "text-zinc-400";
   }
 };
 
@@ -130,14 +168,10 @@ export const formatDuration = (seconds: number): string => {
 
 export const getStatusBorderColor = (status: OperatorStatus) => {
   switch (status) {
-    case "Finished":
-      return "border-green-600";
-    case "Executing":
-      return "border-orange-500";
-    case "Failed":
-      return "border-red-600";
-    case "Pending":
-    default:
-      return "border-zinc-600";
+    case "Finished":  return "border-green-600";
+    case "Executing": return "border-orange-500";
+    case "Failed":    return "border-red-600";
+    case "Canceled":  return "border-zinc-600";
+    default:          return "border-zinc-600";
   }
 };

--- a/src/daft-dashboard/frontend/src/app/query/stats-utils.tsx
+++ b/src/daft-dashboard/frontend/src/app/query/stats-utils.tsx
@@ -61,6 +61,12 @@ export function getEffectiveStatus(
   if (taskStore) {
     const group = taskStore.groups.find((g) => g.node_ids.includes(nodeId));
     if (group) {
+      // Tasks cancelled as part of a user-initiated cancellation → gray.
+      // Must come before the failed_count check: a task can have both
+      // failed_count > 0 and cancelled_count > 0 if some tasks failed before
+      // the cancellation arrived, and cancellation should win.
+      if (group.cancelled_count > 0 && queryStatus === "Canceled") return "Canceled";
+
       // On a successful query, failed_count may be non-zero from Flotilla task
       // retries that ultimately succeeded — don't override the Finished status.
       if (group.failed_count > 0 && queryStatus !== "Finished") return "Failed";
@@ -68,9 +74,6 @@ export function getEffectiveStatus(
       // When Daft terminates the query externally (Failed/Dead), tasks that
       // were still running never recorded an outcome — treat them as failed.
       if (group.running_count > 0 && (queryStatus === "Failed" || queryStatus === "Dead")) return "Failed";
-
-      // Tasks cancelled as part of a user-initiated cancellation → gray.
-      if (group.cancelled_count > 0 && queryStatus === "Canceled") return "Canceled";
     }
   }
 

--- a/src/daft-dashboard/frontend/src/app/query/status.tsx
+++ b/src/daft-dashboard/frontend/src/app/query/status.tsx
@@ -112,20 +112,19 @@ export function Status({
 
   return (
     <div className="flex flex-col gap-y-1.5">
-      <div className="flex items-center gap-x-2 whitespace-nowrap">
+      <div className="flex items-center gap-x-2">
         {icon}
         <span className={`${main.className} ${textColor} font-bold text-base`}>
           {label}
         </span>
-        <span className="text-zinc-600">·</span>
-        {end_sec != null ? (
-          <span className={`${main.className} text-sm font-mono text-zinc-400`}>
-            {toHumanReadableDuration(end_sec - start_sec)}
-          </span>
-        ) : (
-          <Timer start_sec={start_sec} />
-        )}
       </div>
+      {end_sec != null ? (
+        <span className={`${main.className} text-sm font-mono text-zinc-400`}>
+          {toHumanReadableDuration(end_sec - start_sec)}
+        </span>
+      ) : (
+        <Timer start_sec={start_sec} />
+      )}
       {last_heartbeat_sec && <LastHeartbeat last_heartbeat_sec={last_heartbeat_sec} />}
       {status === "Failed" && errorMessage && (
         <ErrorModal message={errorMessage} />

--- a/src/daft-dashboard/frontend/src/app/query/status.tsx
+++ b/src/daft-dashboard/frontend/src/app/query/status.tsx
@@ -89,7 +89,7 @@ const STATUS_CONFIG: Record<QueryStatusName, { icon: ReactNode; label: string; t
   Setup:      { icon: <LoaderCircle size={15} strokeWidth={3} className="text-magenta-500 animate-spin" />,label: "Setting Up Runner",  textColor: "text-magenta-500" },
   Executing:  { icon: <AnimatedFish />,                                                                     label: "Running",            textColor: "text-(--daft-accent)" },
   Finalizing: { icon: <LoaderCircle size={15} strokeWidth={3} className="text-blue-500 animate-spin" />,   label: "Finalizing",         textColor: "text-blue-500" },
-  Finished:   { icon: <Naruto />,                                                                           label: "Finished",           textColor: "text-green-500" },
+  Finished:   { icon: <Naruto animated={false} />,                                                          label: "Finished",           textColor: "text-green-500" },
   Failed:     { icon: <CircleX size={15} strokeWidth={3} className="text-red-500" />,                      label: "Failed",             textColor: "text-red-500" },
   Canceled:   { icon: <Ban size={15} strokeWidth={3} className="text-zinc-500" />,                         label: "Canceled",           textColor: "text-zinc-400" },
   Dead:       { icon: <Skull size={15} strokeWidth={3} className="text-zinc-500" />,                       label: "Dead",               textColor: "text-zinc-400" },

--- a/src/daft-dashboard/frontend/src/app/query/tree-colors.ts
+++ b/src/daft-dashboard/frontend/src/app/query/tree-colors.ts
@@ -69,6 +69,13 @@ export const FAILED_STYLE: HeatmapStyle = {
   borderWidth: "2px",
 };
 
+/** Discrete style for an operator whose tasks were cancelled. */
+export const CANCELED_STYLE: HeatmapStyle = {
+  backgroundColor: "rgb(24, 24, 27)",
+  borderColor: "rgb(82, 82, 91)",
+  borderWidth: "2px",
+};
+
 /**
  * Thresholds at which an edge's bytes-out / bytes-in ratio is considered
  * meaningful enough to badge. Shared with EdgeLabel so both files agree on

--- a/src/daft-dashboard/frontend/src/app/query/tree-colors.ts
+++ b/src/daft-dashboard/frontend/src/app/query/tree-colors.ts
@@ -62,6 +62,13 @@ export const FINISHED_STYLE: HeatmapStyle = {
   borderWidth: "2px",
 };
 
+/** Discrete style for an operator with failed tasks. */
+export const FAILED_STYLE: HeatmapStyle = {
+  backgroundColor: "rgb(28, 16, 16)",
+  borderColor: "rgb(220, 38, 38)",
+  borderWidth: "2px",
+};
+
 /**
  * Thresholds at which an edge's bytes-out / bytes-in ratio is considered
  * meaningful enough to badge. Shared with EdgeLabel so both files agree on

--- a/src/daft-dashboard/frontend/src/app/query/types.ts
+++ b/src/daft-dashboard/frontend/src/app/query/types.ts
@@ -4,7 +4,7 @@ export type PlanInfo = {
   optimized_plan: string;
 };
 
-export type OperatorStatus = "Pending" | "Executing" | "Finished" | "Failed";
+export type OperatorStatus = "Pending" | "Executing" | "Finished" | "Failed" | "Canceled";
 
 export type NodeInfo = {
   name: string;

--- a/src/daft-dashboard/frontend/src/components/icons.tsx
+++ b/src/daft-dashboard/frontend/src/components/icons.tsx
@@ -2,19 +2,19 @@ import Image from "next/image";
 import { Fish } from "lucide-react";
 import FishCake from "@/public/fish-cake-filled.svg";
 
-export function AnimatedFish() {
+export function AnimatedFish({ animated = true }: { animated?: boolean }) {
   return (
-    <div className="fish-container">
-      <Fish size={20} strokeWidth={2} className="fish-swim" />
+    <div className={animated ? "fish-container" : ""}>
+      <Fish size={20} strokeWidth={2} className={animated ? "fish-swim" : ""} />
     </div>
   );
 }
 
-export const Naruto = () => (
+export const Naruto = ({ animated = true }: { animated?: boolean }) => (
   <Image
     src={FishCake}
     alt="Fish Cake"
-    className="animate-[spin_5s_linear_none]"
+    className={animated ? "animate-[spin_5s_linear_none]" : ""}
     height={20}
     width={20}
   />


### PR DESCRIPTION
## Changes Made

* Stop all icon animations (fish, naruto, spinner) when query is terminal (Finished/Failed/Canceled/Dead)
* Detect failed tasks from task store and apply red FAILED_STYLE to operator cards
* Fix "Finished" operator with no start_sec incorrectly showing as finished instead of pending
* Layout polish: consistent px-6 horizontal padding, status duration on its own line, MetaField right-align support


<img width="1479" height="797" alt="Screenshot 2026-05-13 at 9 35 44 AM" src="https://github.com/user-attachments/assets/8dd40383-5745-485d-ad00-7475c087ddae" />
