### PR TITLE
fix: handle broadcast of scalars when calling to_struct

### DIFF
--- a/src/daft-functions/src/to_struct.rs
+++ b/src/daft-functions/src/to_struct.rs
@@ -14,7 +14,7 @@ impl ScalarUDF for ToStructFunction {
     fn call(
         &self,
         inputs: daft_dsl::functions::FunctionArgs<Series>,
-        _ctx: &daft_dsl::functions::scalar::EvalContext,
+        ctx: &daft_dsl::functions::scalar::EvalContext,
     ) -> DaftResult<Series> {
         let inputs = inputs.into_inner();
         if inputs.is_empty() {
@@ -22,6 +22,17 @@ impl ScalarUDF for ToStructFunction {
                 "Cannot call struct with no inputs".to_string(),
             ));
         }
+        let target_len = ctx.row_count;
+        let inputs = inputs
+            .into_iter()
+            .map(|s| {
+                if s.len() == 1 && target_len > 1 {
+                    s.broadcast(target_len)
+                } else {
+                    Ok(s)
+                }
+            })
+            .collect::<DaftResult<Vec<_>>>()?;
         let child_fields: Vec<Field> = inputs.iter().map(|s| s.field().clone()).collect();
         let field = Field::new("struct", DataType::Struct(child_fields));
 

--- a/tests/dataframe/test_to_struct.py
+++ b/tests/dataframe/test_to_struct.py
@@ -50,8 +50,6 @@ def test_to_struct_with_literal_inline():
 
 
 def test_to_struct_empty_partition_with_literal():
-    # An empty partition with a literal field: the scalar (len=1) must be sliced
-    # to 0 rows rather than leaking through, producing a 0-row struct column.
     df = daft.from_pydict({"a": []})
     result = df.select(to_struct(col("a"), daft.lit("hello").alias("b"))).to_pydict()
     assert result["struct"] == []

--- a/tests/dataframe/test_to_struct.py
+++ b/tests/dataframe/test_to_struct.py
@@ -26,3 +26,32 @@ def test_to_struct_pushdown():
     df = df.select(to_struct(col("a"), col("b")))
     df = df.select(df["struct"].get("a"))
     assert df.to_pydict() == {"a": [1, 2, 3, 4, None, 6, None]}
+
+
+def test_to_struct_with_literal_materialized():
+    df = daft.from_pydict({"a": [1, 2, 3]})
+    df = df.with_column("b", daft.lit("hello"))
+    result = df.select(to_struct(col("a"), col("b"))).to_pydict()
+    assert result["struct"] == [
+        {"a": 1, "b": "hello"},
+        {"a": 2, "b": "hello"},
+        {"a": 3, "b": "hello"},
+    ]
+
+
+def test_to_struct_with_literal_inline():
+    df = daft.from_pydict({"a": [1, 2, 3]})
+    result = df.select(to_struct(col("a"), daft.lit("hello").alias("b"))).to_pydict()
+    assert result["struct"] == [
+        {"a": 1, "b": "hello"},
+        {"a": 2, "b": "hello"},
+        {"a": 3, "b": "hello"},
+    ]
+
+
+def test_to_struct_empty_partition_with_literal():
+    # An empty partition with a literal field: the scalar (len=1) must be sliced
+    # to 0 rows rather than leaking through, producing a 0-row struct column.
+    df = daft.from_pydict({"a": []})
+    result = df.select(to_struct(col("a"), daft.lit("hello").alias("b"))).to_pydict()
+    assert result["struct"] == []


### PR DESCRIPTION
fix for: https://github.com/Eventual-Inc/Daft/issues/6886

to_struct panicked with StructArray::new expects all children to have the same length when any input was a scalar — either passed inline as daft.lit(...) or materialized via with_column.

Root cause: ToStructFunction::call passed its inputs directly to StructArray::new without broadcasting length-1 series.

Fix: Before constructing the StructArray, broadcast any length-1 input to ctx.row_count (the partition length).