### PR TITLE
feat(checkpoint): idempotent write_deltalake + cross-sink helpers

### DIFF
--- a/daft/checkpoint.py
+++ b/daft/checkpoint.py
@@ -33,7 +33,7 @@ class CheckpointStore:
         io_config: Optional IO configuration for the object store backend.
 
     Example:
-        >>> store = daft.CheckpointStore("s3://bucket/ckpt", io_config=io)
+        >>> store = daft.CheckpointStore("s3://bucket/ckpt")
         >>> config = daft.CheckpointConfig(store=store, on="file_id")
         >>> df = daft.read_parquet("s3://input/", checkpoint=config)
     """
@@ -93,7 +93,7 @@ class CheckpointConfig:
             to engine-chosen values when omitted.
 
     Example:
-        >>> store = daft.CheckpointStore("s3://bucket/ckpt", io_config=io)
+        >>> store = daft.CheckpointStore("s3://bucket/ckpt")
         >>> config = daft.CheckpointConfig(
         ...     store=store,
         ...     on="file_id",
@@ -175,15 +175,15 @@ class IdempotentCommit:
             across distinct commits.
 
     Example:
-        >>> store = daft.CheckpointStore("s3://bucket/ckpt", io_config=io)
+        >>> store = daft.CheckpointStore("s3://bucket/ckpt")
         >>> df = daft.read_parquet("s3://input/", checkpoint=daft.CheckpointConfig(store=store, on="file_id"))
         >>> df.write_iceberg(table, checkpoint=daft.IdempotentCommit(store=store, idempotence_key="run-2026-05-04"))
 
     Idempotence-key contract — read carefully:
         - **Same key + different inputs → silent no-op (data loss).** The
-          destination already has a snapshot tagged with the key, so nothing
+          destination already has a commit tagged with the key, so nothing
           new is written.
-        - **Different key + same retry → duplicate snapshot.** The destination
+        - **Different key + same retry → duplicate commit.** The destination
           won't recognize the prior attempt and will commit again. Idempotence
           is broken.
         - **Recommended source: an orchestrator-supplied run ID.** Stable

--- a/daft/dataframe/_checkpoint_commit.py
+++ b/daft/dataframe/_checkpoint_commit.py
@@ -1,0 +1,76 @@
+"""Lightweight utilities for checkpoint-based idempotent catalog commits.
+
+Each connector (Iceberg, Delta Lake) keeps its commit logic inline;
+these helpers factor out the repeated bookkeeping so connectors don't
+duplicate the same patterns. Sink-agnostic — connector-specific decoding
+of the pickled-object payloads is steered by the ``column_name`` parameter.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from daft.checkpoint import CheckpointStore
+    from daft.dataframe.dataframe import DataFrame
+
+
+def decode_file_metadata(store: CheckpointStore, column_name: str) -> list[Any]:
+    """Decode pickled Python objects from staged FileMetadata blobs.
+
+    Each FileMetadata entry in the checkpoint store is an Arrow IPC stream
+    of a MicroPartition produced by the connector's writer. The MicroPartition
+    has a single python-typed column whose cells are pickled objects of the
+    connector's choosing (``pyiceberg.DataFile`` for Iceberg,
+    ``deltalake.AddAction`` for Delta). The IPC roundtrip preserves them via pickle.
+
+    Args:
+        store: the live checkpoint store.
+        column_name: name of the python-typed column to extract from each blob.
+
+    Returns:
+        Flattened list of decoded Python objects in store iteration order.
+
+    Raises:
+        RuntimeError: if any blob fails to decode (writer-version mismatch,
+            store corruption, etc.). Wraps the underlying error with context
+            naming the expected on-disk shape.
+    """
+    from daft.recordbatch import MicroPartition
+
+    files: list[Any] = []
+    for fm in store.get_checkpointed_files():
+        try:
+            mp = MicroPartition.from_ipc_stream(fm.data)
+            files.extend(mp.to_pydict()[column_name])
+        except Exception as e:
+            raise RuntimeError(
+                f"failed to decode {column_name!r} payloads from a checkpoint store FileMetadata blob; "
+                "expected an Arrow IPC stream of a MicroPartition with a python-typed "
+                f"`{column_name}` column carrying pickled objects. "
+                f"Underlying error: {e}"
+            ) from e
+    return files
+
+
+def empty_write_result(write_df: DataFrame) -> DataFrame:
+    """Build an empty write-result DataFrame preserving ``write_df``'s metadata.
+
+    Used by checkpoint-aware write helpers when nothing needs to be committed
+    (recovery short-circuit, fully-committed re-run, source filter dropped
+    everything).
+    """
+    import pyarrow as pa
+
+    from daft import from_pydict
+
+    empty = from_pydict(
+        {
+            "operation": pa.array([], type=pa.string()),
+            "rows": pa.array([], type=pa.int64()),
+            "file_size": pa.array([], type=pa.int64()),
+            "file_name": pa.array([], type=pa.string()),
+        }
+    )
+    empty._metadata = write_df._metadata
+    return empty

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -67,7 +67,7 @@ if TYPE_CHECKING:
     from sqlalchemy.engine import Connection
 
     from daft.catalog.__unity._client import UnityCatalogTable
-    from daft.checkpoint import CheckpointStore, IdempotentCommit
+    from daft.checkpoint import IdempotentCommit
     from daft.convert import ArrowStreamExportable
     from daft.execution.metadata import ExecutionMetadata
     from daft.io import DataSink
@@ -109,6 +109,17 @@ def to_logical_plan_builder(*parts: MicroPartition) -> LogicalPlanBuilder:
     return LogicalPlanBuilder.from_in_memory_scan(
         cache_entry, parts[0].schema(), result_pset.num_partitions(), size_bytes, num_rows=num_rows
     )
+
+
+def _create_delta_metadata_param(metadata: dict[str, str] | None) -> Any:
+    """Wrap commit metadata as a ``CommitProperties`` for ``create_write_transaction``.
+
+    Shared between :meth:`DataFrame.write_deltalake` (non-checkpoint path) and
+    :meth:`DataFrame._write_deltalake_with_checkpoint`.
+    """
+    from deltalake import CommitProperties
+
+    return CommitProperties(custom_metadata=metadata)
 
 
 def _utc_now() -> datetime:
@@ -1248,6 +1259,10 @@ class DataFrame:
             snapshot via its marker, finish the bookkeeping, and exit cleanly
             without producing a duplicate snapshot.
 
+            The returned DataFrame reflects only this call's writes — empty
+            (0 rows) on a recovery short-circuit, populated when a new
+            snapshot lands. Useful for run-to-run diffing.
+
             Idempotence-key contract — read carefully:
 
             - **Same key + different inputs → silent no-op (data loss).** The
@@ -1259,6 +1274,11 @@ class DataFrame:
 
             The orchestrator pattern (run-id supplied from upstream DAG context)
             avoids both naturally.
+
+            Crashed runs leave orphan data files at the warehouse location.
+            Iceberg writes stage data files before the snapshot commit, so
+            files from crashed attempts are not referenced by any snapshot
+            but the bytes remain on disk.
 
         Examples:
             >>> import pyiceberg
@@ -1458,11 +1478,10 @@ class DataFrame:
         not against concurrent writers.
         """
         import pyarrow as pa
-        import pyiceberg
-        from packaging.version import parse
         from pyiceberg.exceptions import CommitFailedException
 
         from daft import from_pydict
+        from daft.dataframe._checkpoint_commit import decode_file_metadata
 
         store = checkpoint.store
         idempotence_key = checkpoint.idempotence_key
@@ -1472,18 +1491,6 @@ class DataFrame:
 
         full_props = dict(snapshot_properties or {})
         full_props["daft.idempotence-key"] = idempotence_key
-
-        def _empty_result() -> "DataFrame":
-            empty = from_pydict(
-                {
-                    "operation": pa.array([], type=pa.string()),
-                    "rows": pa.array([], type=pa.int64()),
-                    "file_size": pa.array([], type=pa.int64()),
-                    "file_name": pa.array([], type=pa.string()),
-                }
-            )
-            empty._metadata = write_df._metadata
-            return empty
 
         def _snapshot_with_our_key_exists() -> bool:
             for snap in reversed(table.metadata.snapshots):
@@ -1495,44 +1502,16 @@ class DataFrame:
         def _pending_ids() -> list[str]:
             return [c.id for c in store.list_checkpoints() if c.status == CheckpointStatus.Checkpointed]
 
-        # ── 1. Check-first: did a previous attempt already land?
-        table.refresh()
-        if _snapshot_with_our_key_exists():
-            pending_ids = _pending_ids()
-            if pending_ids:
-                store.mark_committed(pending_ids)
-            return _empty_result()
-
-        # ── 2. Run the pipeline. Source filter anti-joins already-Checkpointed
-        #       keys, so this only stages work that hasn't been staged before.
-        write_df.collect()
-
-        # ── 3. Commit-from-store.
-        pending_ids = _pending_ids()
-        if not pending_ids:
-            return _empty_result()
-
-        # Pull DataFile objects out of the staged FileMetadata blobs. Each blob
-        # is an Arrow IPC stream of a MicroPartition produced by the iceberg
-        # writer (see `IcebergWriteVisitors.to_metadata` and the encode side in
-        # `BlockingSinkNode::encode_file_metadata`). The MicroPartition has a
-        # python-typed `data_file` column whose cells are pickled
-        # `pyiceberg.DataFile` instances; the IPC roundtrip preserves them.
-        data_files: list[Any] = []
-        for fm in store.get_checkpointed_files():
-            try:
-                mp = MicroPartition.from_ipc_stream(fm.data)
-                data_files.extend(mp.to_pydict()["data_file"])
-            except Exception as e:
-                raise RuntimeError(
-                    "failed to decode iceberg DataFile metadata from the checkpoint store; "
-                    "the on-disk format is an Arrow IPC stream of a MicroPartition with a "
-                    "python `data_file` column carrying pickled pyiceberg.DataFile objects. "
-                    "Did pyiceberg change the DataFile shape, or is the store from a different "
-                    f"writer version? Underlying error: {e}"
-                ) from e
-
-        def _build_result() -> "DataFrame":
+        def _build_result(data_files: list[Any]) -> "DataFrame":
+            # Mirror the non-checkpoint write_iceberg result shape: include a
+            # `partitioning` struct column on partitioned tables so callers
+            # don't see the column disappear when they flip `checkpoint=` on.
+            # Called with `[]` on recovery short-circuits so the empty-branch
+            # schema matches the populated-branch schema (no column-count drift).
+            schema = table.schema()
+            partitioning: dict[str, list[Any]] = {
+                schema.find_field(field.source_id).name: [] for field in table.spec().fields
+            }
             ops: list[str] = []
             paths: list[str] = []
             row_counts: list[int] = []
@@ -1542,39 +1521,66 @@ class DataFrame:
                 paths.append(df_.file_path)
                 row_counts.append(df_.record_count)
                 sizes.append(df_.file_size_in_bytes)
-            result = from_pydict(
-                {
-                    "operation": pa.array(ops, type=pa.string()),
-                    "rows": pa.array(row_counts, type=pa.int64()),
-                    "file_size": pa.array(sizes, type=pa.int64()),
-                    "file_name": pa.array(paths, type=pa.string()),
-                }
-            )
+                for field in partitioning:
+                    partitioning[field].append(getattr(df_.partition, field, None))
+            with_operations = {
+                "operation": pa.array(ops, type=pa.string()),
+                "rows": pa.array(row_counts, type=pa.int64()),
+                "file_size": pa.array(sizes, type=pa.int64()),
+                "file_name": pa.array(paths, type=pa.string()),
+            }
+            if partitioning:
+                with_operations["partitioning"] = pa.StructArray.from_arrays(
+                    list(partitioning.values()), names=list(partitioning.keys())
+                )
+            result = from_pydict(with_operations)
             result._metadata = write_df._metadata
             return result
+
+        # ── 1. Check-first: did a previous attempt already land?
+        table.refresh()
+        if _snapshot_with_our_key_exists():
+            pending_ids = _pending_ids()
+            if pending_ids:
+                store.mark_committed(pending_ids)
+            return _build_result([])
+
+        # ── 2. Run the pipeline. Source filter anti-joins already-Checkpointed
+        #       keys, so this only stages work that hasn't been staged before.
+        write_df.collect()
+
+        # ── 3. Commit-from-store.
+        pending_ids = _pending_ids()
+        if not pending_ids:
+            return _build_result([])
+
+        # Pull DataFile objects out of the staged FileMetadata blobs. Each blob
+        # is an Arrow IPC stream of a MicroPartition produced by the iceberg
+        # writer (see `IcebergWriteVisitors.to_metadata` and the encode side in
+        # `BlockingSinkNode::encode_file_metadata`); cells are pickled
+        # `pyiceberg.DataFile` instances.
+        data_files: list[Any] = decode_file_metadata(store, "data_file")
 
         # Honor the table's `commit.manifest-merge.enabled` property the same
         # way the non-checkpoint branch does — users who set it expect manifest
         # merging regardless of whether they pass `checkpoint=`.
         from pyiceberg.table import TableProperties
+        from pyiceberg.utils.properties import property_as_bool
 
-        if parse(pyiceberg.__version__) >= parse("0.8.0"):
-            from pyiceberg.utils.properties import property_as_bool
-        else:
-            from pyiceberg.table import PropertyUtil
-
-            property_as_bool = PropertyUtil.property_as_bool
-
-        max_retries = 2  # defensive only; transient catalog errors
+        max_retries = 2  # defensive — transient CommitFailedException only
         last_err: Exception | None = None
+        # Step 1's `table.refresh()` (above) gives iter 1 the current view;
+        # subsequent iters refresh only after a CommitFailedException. The
+        # pre-loop view stays valid for iter 1 because under the concurrency
+        # assumption ("at most one Python process per logical commit") no
+        # snapshot carrying our marker can land between step 1 and iter 1.
         for _ in range(max_retries):
-            table.refresh()
-            # Recheck inside the retry loop — a prior iteration's commit may
-            # have landed despite returning CommitFailedException (rare, but
+            # Recheck the marker — a prior iteration's commit may have
+            # landed despite returning CommitFailedException (rare, but
             # the post-commit hook can fail in odd ways). Cheap.
             if _snapshot_with_our_key_exists():
                 store.mark_committed(pending_ids)
-                return _build_result()
+                return _build_result(data_files)
 
             try:
                 tx = table.transaction()
@@ -1590,14 +1596,16 @@ class DataFrame:
                         append_files.append_data_file(df_)
                 tx.commit_transaction()
                 store.mark_committed(pending_ids)
-                return _build_result()
+                return _build_result(data_files)
             except CommitFailedException as e:
-                # Narrow on purpose: only optimistic-concurrency conflicts (the
-                # catalog raised because the branch head moved) retry. Other
-                # transient catalog errors — REST/network 5xx, auth blips,
-                # pyiceberg internals — propagate to the caller, who can wrap
-                # this whole `write_iceberg` in their own retry policy.
+                # Narrow to CommitFailedException on purpose: catalog-raised
+                # conflicts (concurrent commit, lock-acquisition contention)
+                # retry. Other exception types — REST 5xx, network blips,
+                # auth, pyiceberg internals — propagate to the caller, who
+                # can wrap this whole `write_iceberg` in their own retry
+                # policy. Broadening tracked separately.
                 last_err = e
+                table.refresh()
                 continue
 
         raise last_err or CommitFailedException(f"write_iceberg with checkpoint exhausted {max_retries} retries")
@@ -1654,7 +1662,7 @@ class DataFrame:
         dynamo_table_name: str | None = None,
         allow_unsafe_rename: bool = False,
         io_config: IOConfig | None = None,
-        checkpoint: "CheckpointStore | None" = None,
+        checkpoint: "IdempotentCommit | None" = None,
     ) -> "DataFrame":
         """Writes the DataFrame to a [Delta Lake](https://docs.delta.io/latest/index.html) table, returning a new DataFrame with the operations that occurred.
 
@@ -1666,16 +1674,46 @@ class DataFrame:
             name (str, optional): User-provided identifier for this table.
             description (str, optional): User-provided description for this table.
             configuration (Mapping[str, Optional[str]], optional): A map containing configuration options for the metadata action.
-            custom_metadata (Dict[str, str], optional): Custom metadata to add to the commit info.
+            custom_metadata (Dict[str, str], optional): Custom metadata to add to the commit info. Keys with prefix ``daft.idempotence-`` are reserved.
             dynamo_table_name (str, optional): Name of the DynamoDB table to be used as the locking provider if writing to S3.
             allow_unsafe_rename (bool, optional): Whether to allow unsafe rename when writing to S3 or local disk. Defaults to False.
             io_config (IOConfig, optional): configurations to use when interacting with remote storage.
+            checkpoint (IdempotentCommit, optional): Bundled checkpoint store + idempotence key for an idempotent commit. When provided, the Delta commit's ``custom_metadata`` is tagged with ``daft.idempotence-key`` and retries with the same key recognize the prior attempt without producing a duplicate commit. Only ``mode='append'`` is supported. Requires the Ray runner.
 
         Returns:
             DataFrame: The operations that occurred with this write.
 
         Note:
-            This call is **blocking** and will execute the DataFrame when called
+            This call is **blocking** and will execute the DataFrame when called.
+
+            When ``checkpoint`` is provided and ``write_deltalake`` raises
+            *after* the Delta commit landed (e.g. a transient failure during
+            the post-commit ``mark_committed`` bookkeeping), the user data is
+            already durable in Delta. The next call with the same
+            ``IdempotentCommit`` (same idempotence key) will detect the
+            commit via its marker, finish the bookkeeping, and exit cleanly
+            without producing a duplicate commit.
+
+            The returned DataFrame reflects only this call's writes — empty
+            (0 rows) on a recovery short-circuit, populated when a new
+            commit lands. Useful for run-to-run diffing.
+
+            Idempotence-key contract — read carefully:
+
+            - **Same key + different inputs → silent no-op (data loss).** The
+              destination already has a commit tagged with the key, so
+              nothing new is written.
+            - **Different key + same retry → duplicate commit.** The
+              destination won't recognize the prior attempt and will commit
+              again. Idempotence is broken.
+
+            The orchestrator pattern (run-id supplied from upstream DAG context)
+            avoids both naturally.
+
+            Crashed runs leave orphan data files at the table location.
+            Delta writes parquet files before the commit, so files from
+            crashed attempts are not referenced by any commit but the
+            bytes remain on disk.
 
         Examples:
             >>> import daft
@@ -1701,27 +1739,26 @@ class DataFrame:
         )
         from daft.io.object_store_options import io_config_to_storage_options
 
-        def _create_metadata_param(metadata: dict[str, str] | None) -> Any:
-            """From deltalake>=0.20.0 onwards, custom_metadata has to be passed as CommitProperties.
-
-            Args:
-                metadata
-
-            Returns:
-                DataFrame: metadata for deltalake<0.20.0, otherwise CommitProperties with custom_metadata
-            """
-            if parse(deltalake.__version__) < parse("0.20.0"):
-                return metadata
-            else:
-                from deltalake import CommitProperties
-
-                return CommitProperties(custom_metadata=metadata)
-
         if schema_mode == "merge":
             raise ValueError("Schema mode' merge' is not currently supported for write_deltalake.")
 
         if parse(deltalake.__version__) < parse("0.14.0"):
             raise ValueError(f"Write delta lake is only supported on deltalake>=0.14.0, found {deltalake.__version__}")
+
+        # Reserved-prefix guard. Fires regardless of `checkpoint=` so a user
+        # can't land a `daft.idempotence-*` marker via custom_metadata
+        # without going through the idempotent flow — that would let a
+        # future `checkpoint=` call walk into a confused recovery branch.
+        if custom_metadata:
+            for key in custom_metadata:
+                if key.startswith("daft.idempotence-"):
+                    raise ValueError(f"custom_metadata keys with prefix 'daft.idempotence-' are reserved; got: {key!r}")
+
+        if checkpoint is not None and mode != "append":
+            raise NotImplementedError(
+                f"write_deltalake with checkpoint=... currently supports mode='append' only; "
+                f"got mode={mode!r}. overwrite/error/ignore + checkpoint are tracked separately."
+            )
 
         io_config = get_context().daft_planning_config.default_io_config if io_config is None else io_config
 
@@ -1813,6 +1850,24 @@ class DataFrame:
                 if self.schema()[c].dtype == DataType.binary():
                     raise NotImplementedError("Binary partition columns are not yet supported for Delta Lake writes")
 
+        if checkpoint is not None:
+            return self._write_deltalake_with_checkpoint(
+                table=table,
+                table_uri=table_uri,
+                storage_options=storage_options,
+                delta_schema=delta_schema,
+                partition_cols=partition_cols,
+                mode=mode,
+                version=version,
+                large_dtypes=large_dtypes,
+                io_config=io_config,
+                name=name,
+                description=description,
+                configuration=configuration,
+                custom_metadata=custom_metadata,
+                checkpoint=checkpoint,
+            )
+
         builder = self._builder.write_deltalake(
             table_uri,
             mode,
@@ -1863,7 +1918,7 @@ class DataFrame:
                     rows.append(old_actions_dict["num_records"][i])
                     sizes.append(old_actions_dict["size_bytes"][i])
 
-            metadata_param = _create_metadata_param(custom_metadata)
+            metadata_param = _create_delta_metadata_param(custom_metadata)
             if parse(deltalake.__version__) < parse("1.0.0"):
                 table._table.create_write_transaction(
                     add_actions, mode, partition_cols or [], delta_schema, None, metadata_param
@@ -1879,13 +1934,6 @@ class DataFrame:
                 )
             table.update_incremental()
 
-        # Mark all checkpointed entries as committed after successful catalog commit.
-        if checkpoint is not None:
-            ckpts = checkpoint.list_checkpoints()
-            ids = [c.id for c in ckpts if c.status == CheckpointStatus.Checkpointed]
-            if ids:
-                checkpoint.mark_committed(ids)
-
         with_operations = from_pydict(
             {
                 "operation": pa.array(operations, type=pa.string()),
@@ -1896,6 +1944,191 @@ class DataFrame:
         )
         with_operations._metadata = write_df._metadata
         return with_operations
+
+    def _write_deltalake_with_checkpoint(
+        self,
+        table: "deltalake.DeltaTable | None",
+        table_uri: str,
+        storage_options: dict[str, str],
+        delta_schema: "pyarrow.Schema",
+        partition_cols: list[str] | None,
+        mode: str,
+        version: int,
+        large_dtypes: bool,
+        io_config: IOConfig,
+        name: str | None,
+        description: str | None,
+        configuration: "Mapping[str, str | None] | None",
+        custom_metadata: dict[str, str] | None,
+        checkpoint: "IdempotentCommit",
+    ) -> "DataFrame":
+        """Idempotent Delta Lake commit identified by ``checkpoint.idempotence_key``.
+
+        Mirrors :meth:`_write_iceberg_with_checkpoint`:
+
+        1. Walk Delta commit history for our ``daft.idempotence-key``
+           marker. Found → previous attempt's commit already landed;
+           mark all Checkpointed entries Committed and bail.
+           **No pipeline run.**
+        2. Not found → run the pipeline. Source filter anti-joins
+           ``Committed ∪ Checkpointed`` keys; SCKO + sink populate the
+           store as new Checkpointed entries.
+        3. Pull ``AddAction`` payloads from ``get_checkpointed_files()``
+           and commit them in one transaction tagged with
+           ``daft.idempotence-key`` in ``custom_metadata``. Mark Committed.
+           Call ``update_incremental()`` so passed-in ``DeltaTable``
+           instances aren't stale on return.
+
+        Concurrency assumption: at most one Python process per logical commit.
+        The retry loop is defensive against transient ``CommitFailedError``,
+        not against concurrent writers.
+        """
+        import json
+
+        import deltalake
+        import pyarrow as pa
+        from deltalake.exceptions import CommitFailedError, TableNotFoundError
+
+        from daft import from_pydict
+        from daft.dataframe._checkpoint_commit import decode_file_metadata, empty_write_result
+        from daft.io.delta_lake.delta_lake_write import AddAction, create_table_with_add_actions
+
+        store = checkpoint.store
+        idempotence_key = checkpoint.idempotence_key
+
+        builder = self._builder.write_deltalake(
+            table_uri,
+            mode,
+            version,
+            large_dtypes,
+            io_config=io_config,
+            partition_cols=partition_cols,
+        )
+        write_df = DataFrame(builder)
+
+        full_meta = dict(custom_metadata or {})
+        full_meta["daft.idempotence-key"] = idempotence_key
+
+        def _resolve_table() -> "deltalake.DeltaTable | None":
+            if table is not None:
+                return table
+            try:
+                return deltalake.DeltaTable(table_uri, storage_options=storage_options)
+            except TableNotFoundError:
+                return None
+
+        def _commit_with_our_key_exists(t: "deltalake.DeltaTable | None") -> bool:
+            """Walk Delta commits for our marker.
+
+            Unbounded by design — pyiceberg's parallel symmetric walk is
+            in-memory; deltalake's ``history()`` is already ~32-way parallel
+            internally (``num_cpus * 4`` via ``.buffered()``).
+            """
+            if t is None:
+                return False
+            t.update_incremental()
+            for entry in t.history():
+                if entry.get("daft.idempotence-key") == idempotence_key:
+                    return True
+            return False
+
+        def _pending_ids() -> list[str]:
+            return [c.id for c in store.list_checkpoints() if c.status == CheckpointStatus.Checkpointed]
+
+        # ── 1. Check-first: did a previous attempt already land?
+        resolved = _resolve_table()
+        if _commit_with_our_key_exists(resolved):
+            pending_ids = _pending_ids()
+            if pending_ids:
+                store.mark_committed(pending_ids)
+            return empty_write_result(write_df)
+
+        # ── 2. Run the pipeline. Source filter anti-joins already-Checkpointed
+        #       keys, so this only stages work that hasn't been staged before.
+        write_df.collect()
+
+        # ── 3. Commit-from-store.
+        pending_ids = _pending_ids()
+        if not pending_ids:
+            return empty_write_result(write_df)
+
+        add_actions: list[AddAction] = decode_file_metadata(store, "add_action")
+
+        def _build_result() -> "DataFrame":
+            operations: list[str] = []
+            paths: list[str] = []
+            row_counts: list[int] = []
+            sizes: list[int] = []
+            for aa in add_actions:
+                stats = json.loads(aa.stats)
+                operations.append("ADD")
+                paths.append(os.path.basename(aa.path))
+                row_counts.append(stats["numRecords"])
+                sizes.append(aa.size)
+            result = from_pydict(
+                {
+                    "operation": pa.array(operations, type=pa.string()),
+                    "rows": pa.array(row_counts, type=pa.int64()),
+                    "file_size": pa.array(sizes, type=pa.int64()),
+                    "file_name": pa.array(paths, type=pa.string()),
+                }
+            )
+            result._metadata = write_df._metadata
+            return result
+
+        # Defensive retry — parity with iceberg's max_retries = 2. We narrow
+        # to deltalake's CommitFailedError so schema mismatches, decode bugs,
+        # and metadata-construction errors propagate immediately instead of
+        # masquerading as transient commit conflicts.
+        max_retries = 2
+        last_err: Exception | None = None
+        # `resolved` carried over from step 1; refresh only after a commit
+        # failure. Iter 1's view stays valid because under the concurrency
+        # assumption ("at most one Python process per logical commit") no
+        # commit carrying our marker can land between step 1 and iter 1.
+        for _ in range(max_retries):
+            # Recheck the marker in case a previous iteration's commit
+            # actually landed despite raising (rare, but cheap to check).
+            if _commit_with_our_key_exists(resolved):
+                store.mark_committed(pending_ids)
+                return _build_result()
+
+            try:
+                if resolved is None:
+                    create_table_with_add_actions(
+                        table_uri,
+                        delta_schema,
+                        add_actions,
+                        mode,
+                        partition_cols or [],
+                        name,
+                        description,
+                        configuration,
+                        storage_options,
+                        full_meta,
+                    )
+                else:
+                    metadata_param = _create_delta_metadata_param(full_meta)
+                    resolved._table.create_write_transaction(
+                        add_actions,
+                        mode,
+                        partition_cols or [],
+                        deltalake.Schema.from_arrow(delta_schema),
+                        None,
+                        metadata_param,
+                    )
+                    resolved.update_incremental()
+                store.mark_committed(pending_ids)
+                return _build_result()
+            except CommitFailedError as e:
+                last_err = e
+                if resolved is None:
+                    resolved = _resolve_table()  # fresh-table case
+                else:
+                    resolved.update_incremental()  # incremental refresh
+                continue
+
+        raise last_err or RuntimeError(f"write_deltalake with checkpoint exhausted {max_retries} retries")
 
     @DataframePublicAPI
     def write_sink(self, sink: "DataSink[WriteResultType]") -> "DataFrame":

--- a/tests/dataframe/test_checkpoint_commit_helpers.py
+++ b/tests/dataframe/test_checkpoint_commit_helpers.py
@@ -1,0 +1,119 @@
+"""Direct unit tests for ``daft.dataframe._checkpoint_commit`` helpers.
+
+The helpers are sink-agnostic and load-bearing for both
+``write_iceberg(checkpoint=)`` and ``write_deltalake(checkpoint=)``.
+Integration coverage through those write paths is Ray-only and slow;
+these unit tests pin the helper contracts directly so a future
+refactor gets fast, runner-independent feedback.
+"""
+
+from __future__ import annotations
+
+import io
+from typing import Any
+
+import pyarrow as pa
+import pytest
+
+import daft
+from daft.dataframe._checkpoint_commit import decode_file_metadata, empty_write_result
+from daft.recordbatch import MicroPartition
+
+
+def _ipc_bytes(column_name: str, values: list[Any]) -> bytes:
+    """Build the Arrow IPC stream shape that ``decode_file_metadata`` expects.
+
+    Mirrors what ``BlockingSinkNode.spawn_finalize`` writes when staging file
+    metadata: an IPC stream of a MicroPartition with a single python-typed
+    column whose cells are pickled Python objects.
+    """
+    mp = MicroPartition.from_pydict({column_name: values})
+    tbl = mp.to_arrow()
+    sink = io.BytesIO()
+    with pa.ipc.new_stream(sink, tbl.schema) as writer:
+        writer.write_table(tbl)
+    return sink.getvalue()
+
+
+class _MockFileMetadata:
+    def __init__(self, data: bytes):
+        self.data = data
+
+
+class _MockStore:
+    """Minimal duck-typed CheckpointStore exposing only ``get_checkpointed_files``."""
+
+    def __init__(self, blobs: list[bytes]):
+        self._blobs = blobs
+
+    def get_checkpointed_files(self) -> list[_MockFileMetadata]:
+        return [_MockFileMetadata(b) for b in self._blobs]
+
+
+# ── empty_write_result ────────────────────────────────────────────────────────
+
+
+def test_empty_write_result_returns_empty_dataframe_with_expected_schema():
+    df = daft.from_pydict({"x": [1, 2, 3]})
+    result = empty_write_result(df)
+    rows = result.to_pydict()
+
+    assert rows == {"operation": [], "rows": [], "file_size": [], "file_name": []}
+
+
+def test_empty_write_result_preserves_metadata():
+    df = daft.from_pydict({"x": [1]})
+    sentinel = {"run_id": "test-2026-05-12"}
+    df._metadata = sentinel
+
+    result = empty_write_result(df)
+    assert result._metadata is sentinel
+
+
+# ── decode_file_metadata ──────────────────────────────────────────────────────
+
+
+class _Payload:
+    """Stand-in for ``pyiceberg.DataFile`` / ``deltalake.AddAction``."""
+
+    def __init__(self, label: str):
+        self.label = label
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, _Payload) and self.label == other.label
+
+    def __hash__(self) -> int:
+        return hash(("_Payload", self.label))
+
+
+def test_decode_file_metadata_empty_store_returns_empty_list():
+    assert decode_file_metadata(_MockStore([]), "data_file") == []
+
+
+def test_decode_file_metadata_happy_path_roundtrips_python_objects():
+    payloads_a = [_Payload("a1"), _Payload("a2")]
+    payloads_b = [_Payload("b1")]
+    store = _MockStore(
+        [
+            _ipc_bytes("data_file", payloads_a),
+            _ipc_bytes("data_file", payloads_b),
+        ]
+    )
+
+    decoded = decode_file_metadata(store, "data_file")
+
+    assert decoded == payloads_a + payloads_b
+
+
+def test_decode_file_metadata_wrong_column_raises_runtime_error_with_column_in_message():
+    store = _MockStore([_ipc_bytes("data_file", [_Payload("x")])])
+
+    with pytest.raises(RuntimeError, match="'add_action'"):
+        decode_file_metadata(store, "add_action")
+
+
+def test_decode_file_metadata_corrupted_bytes_raises_runtime_error_with_context():
+    store = _MockStore([b"not a valid Arrow IPC stream"])
+
+    with pytest.raises(RuntimeError, match="failed to decode 'data_file' payloads"):
+        decode_file_metadata(store, "data_file")

--- a/tests/io/delta_lake/test_deltalake_writes_checkpoint.py
+++ b/tests/io/delta_lake/test_deltalake_writes_checkpoint.py
@@ -1,0 +1,555 @@
+"""Tests for ``write_deltalake(checkpoint=daft.IdempotentCommit(...))``.
+
+Idempotence is keyed on the ``idempotence_key`` carried by the
+:class:`daft.IdempotentCommit` passed via ``checkpoint=`` on
+``write_deltalake``. Each logical commit declares its own key; retries of
+the same commit reuse the key. Recovery walks Delta commit history for
+``daft.idempotence-key`` matching the call's key.
+
+Single-commit invariant — every test asserts that a logical run lands
+exactly one new Delta commit tagged with the call's idempotence key.
+
+The checkpoint-aware source filter (``daft.read_parquet(checkpoint=...)``)
+runs only on the Ray runner, so these tests are skipped on the native
+runner.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+import daft
+
+deltalake = pytest.importorskip("deltalake")
+
+from daft.daft import CheckpointStatus
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("DAFT_RUNNER") != "ray",
+    reason="checkpoint+write_deltalake requires Ray runner",
+)
+
+
+IDEMPOTENCE_KEY = "test-run-2026-05-08"
+
+
+@pytest.fixture(scope="function")
+def delta_table_path(tmpdir):
+    """Path for a Delta table that doesn't exist yet (fresh-table path)."""
+    return str(tmpdir / "delta_table")
+
+
+@pytest.fixture(scope="function")
+def delta_table(delta_table_path):
+    """Create an empty Delta table at delta_table_path with the test schema."""
+    import pyarrow as pa
+
+    schema = pa.schema([("file_id", pa.string()), ("x", pa.int64())])
+    deltalake.write_deltalake(delta_table_path, pa.table({"file_id": [], "x": []}).cast(schema))
+    return deltalake.DeltaTable(delta_table_path)
+
+
+@pytest.fixture(scope="function")
+def parquet_input(tmpdir):
+    """A small parquet input directory we can read with checkpoint=."""
+    path = str(tmpdir / "input")
+    os.makedirs(path, exist_ok=True)
+    daft.from_pydict({"file_id": ["a", "b", "c"], "x": [1, 2, 3]}).write_parquet(path)
+    return path
+
+
+@pytest.fixture(scope="function")
+def checkpoint_store(tmpdir):
+    return daft.CheckpointStore(f"file://{tmpdir}/ckpt")
+
+
+@pytest.fixture(scope="function")
+def idempotent_commit(checkpoint_store):
+    return daft.IdempotentCommit(store=checkpoint_store, idempotence_key=IDEMPOTENCE_KEY)
+
+
+def _read_delta_rows(table_path: str) -> dict:
+    return daft.read_deltalake(table_path).to_pydict()
+
+
+def _make_crash_wrapper(real_table):
+    """Build a wrapper around a RawDeltaTable that raises on commit attempts.
+
+    PyO3's RawDeltaTable methods are read-only at the instance level, so
+    ``patch.object(delta_table._table, "create_write_transaction", ...)``
+    fails with ``AttributeError: ... is read-only``. The DeltaTable's
+    ``_table`` attribute itself, however, is a plain Python instance
+    attribute that we can swap out. This wrapper proxies all attribute
+    access to the real table except ``create_write_transaction``, which
+    raises — simulating a mid-commit crash.
+    """
+
+    class _CrashTableWrapper:
+        def create_write_transaction(self, *args, **kwargs):
+            raise RuntimeError("simulated crash")
+
+        def __getattr__(self, name):
+            return getattr(real_table, name)
+
+    return _CrashTableWrapper()
+
+
+def _commits_with_key(table: deltalake.DeltaTable, key: str) -> int:
+    """Count commits in Delta history tagged with our idempotence key."""
+    table.update_incremental()
+    return sum(1 for entry in table.history(limit=50) if entry.get("daft.idempotence-key") == key)
+
+
+def _assert_single_commit_with_key(table: deltalake.DeltaTable, key: str) -> dict:
+    """Assert exactly one commit in history tagged with the given key.
+
+    Returns the matching commit entry so callers can make further assertions.
+    """
+    table.update_incremental()
+    matches = [entry for entry in table.history(limit=50) if entry.get("daft.idempotence-key") == key]
+    assert len(matches) == 1, (
+        f"single-commit invariant violated: expected exactly 1 commit tagged {key!r}, got {len(matches)}"
+    )
+    return matches[0]
+
+
+def test_fresh_run_lands_single_commit_with_key(delta_table, parquet_input, checkpoint_store, idempotent_commit):
+    """Fresh run with an existing (empty) Delta table — the most-traveled path."""
+    df = daft.read_parquet(parquet_input, checkpoint=daft.CheckpointConfig(store=checkpoint_store, on="file_id"))
+    df.write_deltalake(delta_table, checkpoint=idempotent_commit)
+
+    _assert_single_commit_with_key(delta_table, IDEMPOTENCE_KEY)
+
+    pending = [c for c in checkpoint_store.list_checkpoints() if c.status == CheckpointStatus.Checkpointed]
+    assert not pending
+
+    rows = _read_delta_rows(delta_table.table_uri)
+    assert sorted(rows["file_id"]) == ["a", "b", "c"]
+    assert sorted(rows["x"]) == [1, 2, 3]
+
+
+def test_fresh_table_path(delta_table_path, parquet_input, checkpoint_store, idempotent_commit):
+    """Fresh-table path (table=None) — `create_table_with_add_actions` route.
+
+    Pass a string URI rather than a constructed DeltaTable. The helper takes
+    the create-fresh path. Result: one commit with our marker on a brand-new
+    table.
+    """
+    df = daft.read_parquet(parquet_input, checkpoint=daft.CheckpointConfig(store=checkpoint_store, on="file_id"))
+    df.write_deltalake(delta_table_path, checkpoint=idempotent_commit)
+
+    table = deltalake.DeltaTable(delta_table_path)
+    _assert_single_commit_with_key(table, IDEMPOTENCE_KEY)
+
+    rows = _read_delta_rows(delta_table_path)
+    assert sorted(rows["file_id"]) == ["a", "b", "c"]
+
+
+def test_recovery_after_crash_between_commit_and_mark(delta_table, parquet_input, checkpoint_store, idempotent_commit):
+    """Scenario A: crash post-commit, pre-mark.
+
+    Delta log has the commit tagged with our key; store says Checkpointed.
+    Second call must walk history, find the key, mark Committed, NOT produce
+    a second commit, NOT run the pipeline.
+    """
+    df = daft.read_parquet(parquet_input, checkpoint=daft.CheckpointConfig(store=checkpoint_store, on="file_id"))
+    with patch.object(checkpoint_store, "mark_committed", side_effect=RuntimeError("simulated crash")):
+        with pytest.raises(RuntimeError, match="simulated crash"):
+            df.write_deltalake(delta_table, checkpoint=idempotent_commit)
+
+    delta_table.update_incremental()
+    version_after_crash = delta_table.version()
+    pending_after_crash = [c for c in checkpoint_store.list_checkpoints() if c.status == CheckpointStatus.Checkpointed]
+    assert pending_after_crash, "expected Checkpointed entries to remain after crash"
+
+    df2 = daft.read_parquet(parquet_input, checkpoint=daft.CheckpointConfig(store=checkpoint_store, on="file_id"))
+    df2.write_deltalake(delta_table, checkpoint=idempotent_commit)
+
+    # No new commit; the version unchanged.
+    delta_table.update_incremental()
+    assert delta_table.version() == version_after_crash, "recovery must not produce a second commit"
+    _assert_single_commit_with_key(delta_table, IDEMPOTENCE_KEY)
+
+    # All Checkpointed entries graduated to Committed.
+    still_checkpointed = [c for c in checkpoint_store.list_checkpoints() if c.status == CheckpointStatus.Checkpointed]
+    assert not still_checkpointed
+
+
+def test_recovery_after_crash_between_stage_and_commit(delta_table, parquet_input, checkpoint_store, idempotent_commit):
+    """Scenario B: crash post-stage, pre-commit.
+
+    Files staged in store, no commit landed. Second call sees no matching
+    commit, runs pipeline (filter skips Checkpointed), pulls AddActions
+    from store, commits exactly once tagged with the key.
+    """
+    df = daft.read_parquet(parquet_input, checkpoint=daft.CheckpointConfig(store=checkpoint_store, on="file_id"))
+
+    # PyO3's RawDeltaTable.create_write_transaction is read-only at the
+    # instance level, so `patch.object` fails. Swap `_table` (a regular
+    # instance attribute on DeltaTable) for a wrapper that raises on
+    # create_write_transaction and proxies everything else.
+    real_table = delta_table._table
+    crash_wrapper = _make_crash_wrapper(real_table)
+    delta_table._table = crash_wrapper
+    try:
+        with pytest.raises(RuntimeError, match="simulated crash"):
+            df.write_deltalake(delta_table, checkpoint=idempotent_commit)
+    finally:
+        delta_table._table = real_table
+
+    # State after crash: no commit landed but pending Checkpointed entries exist.
+    delta_table.update_incremental()
+    version_pre_crash = delta_table.version()
+    pending_after_crash = [c for c in checkpoint_store.list_checkpoints() if c.status == CheckpointStatus.Checkpointed]
+    assert pending_after_crash
+
+    # Second call lands the commit cleanly.
+    df2 = daft.read_parquet(parquet_input, checkpoint=daft.CheckpointConfig(store=checkpoint_store, on="file_id"))
+    df2.write_deltalake(delta_table, checkpoint=idempotent_commit)
+
+    delta_table.update_incremental()
+    assert delta_table.version() == version_pre_crash + 1
+    _assert_single_commit_with_key(delta_table, IDEMPOTENCE_KEY)
+
+    still_checkpointed = [c for c in checkpoint_store.list_checkpoints() if c.status == CheckpointStatus.Checkpointed]
+    assert not still_checkpointed
+
+    rows = _read_delta_rows(delta_table.table_uri)
+    assert sorted(rows["file_id"]) == ["a", "b", "c"]
+
+
+def test_idempotent_rerun_with_same_key_is_noop(delta_table, parquet_input, checkpoint_store, idempotent_commit):
+    """Re-running with the same key after a successful commit is a no-op.
+
+    First call commits. Second call's check-first finds the marker and bails;
+    no second commit, no pipeline run.
+    """
+    df1 = daft.read_parquet(parquet_input, checkpoint=daft.CheckpointConfig(store=checkpoint_store, on="file_id"))
+    df1.write_deltalake(delta_table, checkpoint=idempotent_commit)
+
+    delta_table.update_incremental()
+    version_after_first = delta_table.version()
+
+    df2 = daft.read_parquet(parquet_input, checkpoint=daft.CheckpointConfig(store=checkpoint_store, on="file_id"))
+    result = df2.write_deltalake(delta_table, checkpoint=idempotent_commit)
+
+    delta_table.update_incremental()
+    assert delta_table.version() == version_after_first
+    _assert_single_commit_with_key(delta_table, IDEMPOTENCE_KEY)
+    assert result.to_pydict() == {"operation": [], "rows": [], "file_size": [], "file_name": []}
+
+
+@pytest.mark.parametrize("mode", ["overwrite", "error", "ignore"])
+def test_unsupported_mode_with_checkpoint_raises(delta_table, idempotent_commit, mode):
+    """Only ``mode='append'`` is supported with ``checkpoint=``.
+
+    The guard runs before the existing-table dispatch — otherwise
+    ``mode='error'`` would assert and ``mode='ignore'`` would silently
+    short-circuit, both bypassing the idempotent recovery flow.
+    """
+    df = daft.from_pydict({"file_id": ["a"], "x": [1]})
+    with pytest.raises(NotImplementedError, match="mode='append' only"):
+        df.write_deltalake(delta_table, mode=mode, checkpoint=idempotent_commit)
+
+
+def test_non_commit_error_propagates_without_retry(delta_table, parquet_input, checkpoint_store, idempotent_commit):
+    """A non-``CommitFailedError`` raised during the commit phase propagates immediately.
+
+    The retry loop is for ``deltalake.exceptions.CommitFailedError`` — concurrent
+    commits from another writer. Schema mismatches, decode bugs, and other
+    surprise exceptions should not be silently retried.
+    """
+    df = daft.read_parquet(parquet_input, checkpoint=daft.CheckpointConfig(store=checkpoint_store, on="file_id"))
+
+    real_table = delta_table._table
+
+    class _NonCommitFailureWrapper:
+        calls = 0
+
+        def create_write_transaction(self, *args, **kwargs):
+            type(self).calls += 1
+            raise ValueError("definitely not a commit conflict")
+
+        def __getattr__(self, name):
+            return getattr(real_table, name)
+
+    wrapper = _NonCommitFailureWrapper()
+    delta_table._table = wrapper
+    try:
+        with pytest.raises(ValueError, match="definitely not a commit conflict"):
+            df.write_deltalake(delta_table, checkpoint=idempotent_commit)
+    finally:
+        delta_table._table = real_table
+
+    # Exactly one commit attempt — the narrow except didn't swallow + retry.
+    assert wrapper.calls == 1
+
+
+@pytest.mark.parametrize(
+    "reserved_key",
+    ["daft.idempotence-key", "daft.idempotence-foo"],
+)
+def test_reserved_custom_metadata_key_raises(delta_table, idempotent_commit, reserved_key):
+    """User-provided `custom_metadata` keys prefixed `daft.idempotence-` are reserved."""
+    df = daft.from_pydict({"file_id": ["a"], "x": [1]})
+    with pytest.raises(ValueError, match="reserved"):
+        df.write_deltalake(
+            delta_table,
+            checkpoint=idempotent_commit,
+            custom_metadata={reserved_key: "spoofed"},
+        )
+
+
+@pytest.mark.parametrize(
+    "reserved_key",
+    ["daft.idempotence-key", "daft.idempotence-foo"],
+)
+def test_reserved_custom_metadata_key_raises_without_checkpoint(delta_table, reserved_key):
+    """The `daft.idempotence-` prefix is reserved regardless of `checkpoint=`.
+
+    Closes the spoofing path: a future user could otherwise land a
+    non-idempotent write tagged with the marker, then later switch to
+    `checkpoint=...` and have recovery silently miss the prior commit.
+    """
+    df = daft.from_pydict({"file_id": ["a"], "x": [1]})
+    with pytest.raises(ValueError, match="reserved"):
+        df.write_deltalake(
+            delta_table,
+            custom_metadata={reserved_key: "spoofed"},
+        )
+
+
+def test_user_custom_metadata_pass_through(delta_table, parquet_input, checkpoint_store, idempotent_commit):
+    """Non-reserved user `custom_metadata` flows through to the commit."""
+    df = daft.read_parquet(parquet_input, checkpoint=daft.CheckpointConfig(store=checkpoint_store, on="file_id"))
+    df.write_deltalake(
+        delta_table,
+        checkpoint=idempotent_commit,
+        custom_metadata={"author": "rohit", "release": "v1"},
+    )
+
+    entry = _assert_single_commit_with_key(delta_table, IDEMPOTENCE_KEY)
+    assert entry.get("author") == "rohit"
+    assert entry.get("release") == "v1"
+
+
+def test_retry_loop_recovers_from_transient_commit_failure(
+    delta_table, parquet_input, checkpoint_store, idempotent_commit
+):
+    """Defensive retry loop recovers from a transient ``CommitFailedError``.
+
+    Iter 1 raises (e.g. concurrent writer landed a snapshot between our
+    check and our commit); iter 2 succeeds. Asserts exactly one commit
+    lands tagged with our key and the second attempt was actually made.
+    """
+    from deltalake.exceptions import CommitFailedError
+
+    real_table = delta_table._table
+    call_count = {"n": 0}
+
+    class _TransientFailureWrapper:
+        def create_write_transaction(self, *args, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise CommitFailedError("simulated transient catalog conflict")
+            return real_table.create_write_transaction(*args, **kwargs)
+
+        def __getattr__(self, name):
+            return getattr(real_table, name)
+
+    df = daft.read_parquet(parquet_input, checkpoint=daft.CheckpointConfig(store=checkpoint_store, on="file_id"))
+
+    delta_table._table = _TransientFailureWrapper()
+    try:
+        df.write_deltalake(delta_table, checkpoint=idempotent_commit)
+    finally:
+        delta_table._table = real_table
+
+    assert call_count["n"] >= 2
+
+    _assert_single_commit_with_key(delta_table, IDEMPOTENCE_KEY)
+
+    pending = [c for c in checkpoint_store.list_checkpoints() if c.status == CheckpointStatus.Checkpointed]
+    assert not pending
+
+    rows = _read_delta_rows(delta_table.table_uri)
+    assert sorted(rows["file_id"]) == ["a", "b", "c"]
+
+
+def test_table_with_pre_existing_legacy_commits(delta_table, parquet_input, checkpoint_store, idempotent_commit):
+    """Adopting `checkpoint=...` on a table with pre-existing untagged commits.
+
+    Recovery walk must not false-positive on legacy commits (no marker);
+    new write lands as a fresh commit on top.
+    """
+    # The fixture's delta_table already has one initial empty commit (version 0).
+    # That's our "legacy" commit.
+    delta_table.update_incremental()
+    legacy_version = delta_table.version()
+    legacy_history = list(delta_table.history(limit=50))
+    assert all(entry.get("daft.idempotence-key") is None for entry in legacy_history), (
+        "legacy commits must not carry our marker"
+    )
+
+    df = daft.read_parquet(parquet_input, checkpoint=daft.CheckpointConfig(store=checkpoint_store, on="file_id"))
+    df.write_deltalake(delta_table, checkpoint=idempotent_commit)
+
+    delta_table.update_incremental()
+    assert delta_table.version() == legacy_version + 1
+    _assert_single_commit_with_key(delta_table, IDEMPOTENCE_KEY)
+
+
+def test_empty_input_on_fresh_store(delta_table, tmpdir, checkpoint_store, idempotent_commit):
+    """Empty input — no Checkpointed entries are sealed, no commit lands."""
+    import pyarrow as pa
+
+    empty_path = str(tmpdir / "empty_in")
+    os.makedirs(empty_path, exist_ok=True)
+    daft.from_pydict(
+        {
+            "file_id": pa.array([], type=pa.string()),
+            "x": pa.array([], type=pa.int64()),
+        }
+    ).write_parquet(empty_path)
+
+    delta_table.update_incremental()
+    version_before = delta_table.version()
+
+    df = daft.read_parquet(empty_path, checkpoint=daft.CheckpointConfig(store=checkpoint_store, on="file_id"))
+    df.write_deltalake(delta_table, checkpoint=idempotent_commit)
+
+    delta_table.update_incremental()
+    assert delta_table.version() == version_before, "empty input must not land a new commit"
+    pending = [c for c in checkpoint_store.list_checkpoints() if c.status == CheckpointStatus.Checkpointed]
+    assert not pending
+
+
+def test_multi_partition_aggregates_into_single_commit(delta_table, tmpdir, checkpoint_store, idempotent_commit):
+    """Multi-partition input aggregates per-partition entries into one Delta commit."""
+    inp_dir = str(tmpdir / "multi_in")
+    os.makedirs(inp_dir, exist_ok=True)
+    parts = [
+        (["a", "b"], [1, 2]),
+        (["c", "d"], [3, 4]),
+        (["e", "f"], [5, 6]),
+    ]
+    for i, (file_ids, xs) in enumerate(parts):
+        daft.from_pydict({"file_id": file_ids, "x": xs}).write_parquet(f"{inp_dir}/part_{i}")
+
+    delta_table.update_incremental()
+    version_before = delta_table.version()
+
+    daft.read_parquet(
+        f"{inp_dir}/**", checkpoint=daft.CheckpointConfig(store=checkpoint_store, on="file_id")
+    ).write_deltalake(delta_table, checkpoint=idempotent_commit)
+
+    delta_table.update_incremental()
+    assert delta_table.version() == version_before + 1, "multi-partition must aggregate into a single commit"
+    _assert_single_commit_with_key(delta_table, IDEMPOTENCE_KEY)
+
+    pending = [c for c in checkpoint_store.list_checkpoints() if c.status == CheckpointStatus.Checkpointed]
+    assert not pending
+
+    rows = _read_delta_rows(delta_table.table_uri)
+    assert sorted(rows["file_id"]) == ["a", "b", "c", "d", "e", "f"]
+
+
+def test_multi_partition_recovery_after_crash_between_stage_and_commit(
+    delta_table, tmpdir, checkpoint_store, idempotent_commit
+):
+    """Scenario B with multi-partition input — recovery aggregates across all entries."""
+    inp_dir = str(tmpdir / "multi_in")
+    os.makedirs(inp_dir, exist_ok=True)
+    parts = [(["a", "b"], [1, 2]), (["c", "d"], [3, 4]), (["e", "f"], [5, 6])]
+    for i, (file_ids, xs) in enumerate(parts):
+        daft.from_pydict({"file_id": file_ids, "x": xs}).write_parquet(f"{inp_dir}/part_{i}")
+
+    df = daft.read_parquet(f"{inp_dir}/**", checkpoint=daft.CheckpointConfig(store=checkpoint_store, on="file_id"))
+
+    # See test_recovery_after_crash_between_stage_and_commit for why we wrap
+    # `_table` rather than patching the method directly.
+    real_table = delta_table._table
+    delta_table._table = _make_crash_wrapper(real_table)
+    try:
+        with pytest.raises(RuntimeError, match="simulated crash"):
+            df.write_deltalake(delta_table, checkpoint=idempotent_commit)
+    finally:
+        delta_table._table = real_table
+
+    delta_table.update_incremental()
+    version_pre_crash = delta_table.version()
+    pending = [c for c in checkpoint_store.list_checkpoints() if c.status == CheckpointStatus.Checkpointed]
+    assert len(pending) > 1
+
+    daft.read_parquet(
+        f"{inp_dir}/**", checkpoint=daft.CheckpointConfig(store=checkpoint_store, on="file_id")
+    ).write_deltalake(delta_table, checkpoint=idempotent_commit)
+
+    delta_table.update_incremental()
+    assert delta_table.version() == version_pre_crash + 1
+    _assert_single_commit_with_key(delta_table, IDEMPOTENCE_KEY)
+
+    pending_after = [c for c in checkpoint_store.list_checkpoints() if c.status == CheckpointStatus.Checkpointed]
+    assert not pending_after
+
+    rows = _read_delta_rows(delta_table.table_uri)
+    assert sorted(rows["file_id"]) == ["a", "b", "c", "d", "e", "f"]
+
+
+def test_within_input_duplicate_keys_both_land(delta_table, tmpdir, checkpoint_store, idempotent_commit):
+    """Duplicates within a single input are not deduped — both rows land."""
+    inp = str(tmpdir / "dup_in")
+    os.makedirs(inp, exist_ok=True)
+    daft.from_pydict({"file_id": ["a", "a", "b"], "x": [1, 2, 3]}).write_parquet(inp)
+    daft.read_parquet(inp, checkpoint=daft.CheckpointConfig(store=checkpoint_store, on="file_id")).write_deltalake(
+        delta_table, checkpoint=idempotent_commit
+    )
+
+    _assert_single_commit_with_key(delta_table, IDEMPOTENCE_KEY)
+
+    rows = _read_delta_rows(delta_table.table_uri)
+    pairs = sorted(zip(rows["file_id"], rows["x"]))
+    assert pairs == [("a", 1), ("a", 2), ("b", 3)]
+
+
+def test_incremental_writes_dedupe_committed_keys(delta_table, tmpdir, checkpoint_store):
+    """Two successive write_deltalake calls with distinct keys against the same store.
+
+    Different ``idempotence_key`` per call — each commits its own version —
+    but the source-side filter drops keys already Committed by the first
+    call, so commit 2 only contains the *new* rows. Pins the source filter
+    behavior across logical commits.
+    """
+    inp1 = str(tmpdir / "in1")
+    os.makedirs(inp1, exist_ok=True)
+    daft.from_pydict({"file_id": ["a", "b", "c"], "x": [1, 2, 3]}).write_parquet(inp1)
+    daft.read_parquet(inp1, checkpoint=daft.CheckpointConfig(store=checkpoint_store, on="file_id")).write_deltalake(
+        delta_table,
+        checkpoint=daft.IdempotentCommit(store=checkpoint_store, idempotence_key="run-1"),
+    )
+
+    delta_table.update_incremental()
+    version_after_first = delta_table.version()
+    assert _commits_with_key(delta_table, "run-1") == 1
+
+    inp2 = str(tmpdir / "in2")
+    os.makedirs(inp2, exist_ok=True)
+    daft.from_pydict({"file_id": ["a", "b", "c", "d", "e", "f"], "x": [1, 2, 3, 4, 5, 6]}).write_parquet(inp2)
+    daft.read_parquet(inp2, checkpoint=daft.CheckpointConfig(store=checkpoint_store, on="file_id")).write_deltalake(
+        delta_table,
+        checkpoint=daft.IdempotentCommit(store=checkpoint_store, idempotence_key="run-2"),
+    )
+
+    delta_table.update_incremental()
+    assert delta_table.version() == version_after_first + 1
+    assert _commits_with_key(delta_table, "run-1") == 1
+    assert _commits_with_key(delta_table, "run-2") == 1
+
+    pending = [c for c in checkpoint_store.list_checkpoints() if c.status == CheckpointStatus.Checkpointed]
+    assert not pending
+
+    rows = _read_delta_rows(delta_table.table_uri)
+    assert sorted(rows["file_id"]) == ["a", "b", "c", "d", "e", "f"]

--- a/tests/io/iceberg/test_iceberg_writes_checkpoint.py
+++ b/tests/io/iceberg/test_iceberg_writes_checkpoint.py
@@ -65,6 +65,22 @@ def iceberg_table(local_catalog):
 
 
 @pytest.fixture(scope="function")
+def partitioned_iceberg_table(local_catalog):
+    """Identity-partitioned on ``file_id`` — one partition per distinct key."""
+    from pyiceberg.partitioning import PartitionField, PartitionSpec
+    from pyiceberg.transforms import IdentityTransform
+
+    schema = Schema(
+        NestedField(field_id=1, name="file_id", type=StringType()),
+        NestedField(field_id=2, name="x", type=LongType()),
+    )
+    partition_spec = PartitionSpec(
+        PartitionField(source_id=1, field_id=1000, transform=IdentityTransform(), name="file_id")
+    )
+    return local_catalog.create_table("default.partitioned_idempotent_test", schema, partition_spec=partition_spec)
+
+
+@pytest.fixture(scope="function")
 def parquet_input(tmpdir):
     """A small parquet input directory we can read with checkpoint=."""
     path = str(tmpdir / "input")
@@ -264,6 +280,54 @@ def test_user_snapshot_properties_pass_through(iceberg_table, parquet_input, che
     assert summary["release"] == "v1"
 
 
+def test_partitioned_table_result_includes_partitioning_column(
+    partitioned_iceberg_table, parquet_input, checkpoint_store, idempotent_commit
+):
+    """Result includes ``partitioning`` struct column on partitioned tables.
+
+    Same shape as non-checkpoint ``write_iceberg``. Regression for C1 from
+    code review: an earlier version of
+    ``_write_iceberg_with_checkpoint._build_result()`` omitted partitioning,
+    silently dropping the column when users flipped ``checkpoint=`` on a
+    partitioned table.
+
+    Pins schema-level presence only. Value-level correctness of partition
+    extraction is inherited from the non-checkpoint path's ``getattr``
+    against ``data_file.partition`` and is a pyiceberg-internals concern.
+    """
+    df = daft.read_parquet(parquet_input, checkpoint=daft.CheckpointConfig(store=checkpoint_store, on="file_id"))
+    result = df.write_iceberg(partitioned_iceberg_table, checkpoint=idempotent_commit)
+
+    cols = set(result.schema().column_names())
+    assert {"operation", "rows", "file_size", "file_name", "partitioning"} <= cols, (
+        f"expected partitioned-table result columns to include `partitioning`; got {cols}"
+    )
+
+
+def test_partitioned_table_recovery_branch_result_includes_partitioning_column(
+    partitioned_iceberg_table, parquet_input, checkpoint_store, idempotent_commit
+):
+    """Recovery-branch empty result has the same schema as the populated branch.
+
+    Regression for CC1 from code review: the recovery short-circuit used to
+    call the shared ``empty_write_result()`` which always returned 4 columns,
+    while the populated branch returns 5 cols (with ``partitioning``) on a
+    partitioned table. ``pa.concat`` over runs would break on the mismatch.
+    """
+    df = daft.read_parquet(parquet_input, checkpoint=daft.CheckpointConfig(store=checkpoint_store, on="file_id"))
+    populated = df.write_iceberg(partitioned_iceberg_table, checkpoint=idempotent_commit)
+
+    # Second call with same key → step 1 marker-found short-circuit → empty result.
+    df2 = daft.read_parquet(parquet_input, checkpoint=daft.CheckpointConfig(store=checkpoint_store, on="file_id"))
+    empty = df2.write_iceberg(partitioned_iceberg_table, checkpoint=idempotent_commit)
+
+    assert empty.schema().column_names() == populated.schema().column_names(), (
+        f"recovery-branch result schema must match populated-branch on partitioned tables; "
+        f"got empty={empty.schema().column_names()} vs populated={populated.schema().column_names()}"
+    )
+    assert empty.count_rows() == 0
+
+
 def test_retry_loop_recovers_from_transient_commit_failure(
     iceberg_table, parquet_input, checkpoint_store, idempotent_commit
 ):
@@ -426,3 +490,56 @@ def test_idempotent_commit_rejects_empty_key(checkpoint_store):
     """`IdempotentCommit` constructor rejects empty idempotence_key."""
     with pytest.raises(ValueError, match="non-empty"):
         daft.IdempotentCommit(store=checkpoint_store, idempotence_key="")
+
+
+def test_incremental_writes_dedupe_committed_keys(iceberg_table, tmpdir, checkpoint_store):
+    """Two successive write_iceberg calls with distinct keys against the same store.
+
+    Different ``idempotence_key`` per call — each commits its own snapshot —
+    but the source-side filter drops keys already Committed by the first
+    call, so snapshot 2 only contains the *new* rows. Pins the source filter
+    behavior across logical commits (this is *not* same-key dedup; it's
+    different-key cross-call dedup via the source anti-join, which is a
+    legitimate part of the feature surface).
+    """
+    # Call 1: input {a, b, c}.
+    inp1 = str(tmpdir / "in1")
+    os.makedirs(inp1, exist_ok=True)
+    daft.from_pydict({"file_id": ["a", "b", "c"], "x": [1, 2, 3]}).write_parquet(inp1)
+    daft.read_parquet(inp1, checkpoint=daft.CheckpointConfig(store=checkpoint_store, on="file_id")).write_iceberg(
+        iceberg_table,
+        checkpoint=daft.IdempotentCommit(store=checkpoint_store, idempotence_key="run-1"),
+    )
+
+    iceberg_table.refresh()
+    assert len(iceberg_table.metadata.snapshots) == 1
+    assert iceberg_table.metadata.snapshots[0].summary["daft.idempotence-key"] == "run-1"
+
+    # Call 2: input {a, b, c, d, e, f} — superset.
+    inp2 = str(tmpdir / "in2")
+    os.makedirs(inp2, exist_ok=True)
+    daft.from_pydict({"file_id": ["a", "b", "c", "d", "e", "f"], "x": [1, 2, 3, 4, 5, 6]}).write_parquet(inp2)
+    daft.read_parquet(inp2, checkpoint=daft.CheckpointConfig(store=checkpoint_store, on="file_id")).write_iceberg(
+        iceberg_table,
+        checkpoint=daft.IdempotentCommit(store=checkpoint_store, idempotence_key="run-2"),
+    )
+
+    iceberg_table.refresh()
+    snapshots = list(iceberg_table.metadata.snapshots)
+    assert len(snapshots) == 2
+
+    # Snapshot 1's marker unchanged.
+    assert snapshots[0].summary["daft.idempotence-key"] == "run-1"
+    # Snapshot 2 carries the new key.
+    assert snapshots[-1].summary["daft.idempotence-key"] == "run-2"
+    # Snapshot 2 only adds the *new* rows; the source filter drops {a,b,c}.
+    assert int(snapshots[-1].summary["added-records"]) == 3
+    assert int(snapshots[-1].summary["added-data-files"]) == 1
+
+    # All entries Committed.
+    pending = [c for c in checkpoint_store.list_checkpoints() if c.status == CheckpointStatus.Checkpointed]
+    assert not pending
+
+    # Final table is the union; no duplicates.
+    rows = daft.read_iceberg(iceberg_table).to_pydict()
+    assert sorted(rows["file_id"]) == ["a", "b", "c", "d", "e", "f"]


### PR DESCRIPTION
## Changes Made

* `write_deltalake(checkpoint=daft.IdempotentCommit(store, key))` produces exactly one Delta commit per logical commit, tagged with `daft.idempotence-key` in `custom_metadata`. Retries with the same key short-circuit via Delta history walk.
* Shared helpers extracted to `daft/dataframe/_checkpoint_commit.py` (sink-agnostic `decode_file_metadata` + `empty_write_result`), used by both the new delta path and the existing iceberg path.
* Iceberg refactor: route through shared helpers; partitioning struct column included on partitioned tables.

Co-authored with ChengHui Chen.

## Related Issues

Supersedes #6872.