### PR TITLE
fix(sql): omit connection URL from read_sql error messages and __repr__

### DIFF
--- a/daft/sql/sql_connection.py
+++ b/daft/sql/sql_connection.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from typing import TYPE_CHECKING
 from urllib.parse import parse_qsl, urlencode, urlparse
 
@@ -41,12 +42,56 @@ _SENSITIVE_PARAM_KEYWORDS = (
     "apikey",
     "api_key",
     "credential",
+    "signature",
+    "access_key",
 )
 
 
 def _is_sensitive_param(name: str) -> bool:
     lower = name.casefold()
     return any(keyword in lower for keyword in _SENSITIVE_PARAM_KEYWORDS)
+
+
+# Spark-style text-level redaction. Catches `name=value` / `name: value`
+# pairs in arbitrary text where the name contains any of the sensitive
+# substrings above. `_redact_url` handles the URL field we control; this
+# is a defense-in-depth layer for the wrapping error message, which
+# interpolates underlying driver exceptions whose text we don't control
+# (e.g. a JDBC driver echoing back `password=...` from a connection
+# property list).
+_REDACT_TEXT_RE = re.compile(
+    r"""
+    (                                       # group 1: prefix (delim + name + key-value separator)
+        (?:^|[?&;,\s\(\[\{])                # leading delimiter
+        [A-Za-z0-9_\-\.]*                   # name prefix chars
+        (?:                                 # name must contain a sensitive substring
+            password | pwd | secret | token | passphrase
+            | api[._]?key | apikey | credential | signature
+            | access[._]?key
+        )
+        [A-Za-z0-9_\-\.]*                   # name suffix chars
+        \s*[=:]\s*                          # key/value separator
+    )
+    [^\s&;,'"\)\]\}<>]+                      # the value: until next delimiter or quote
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+
+def _redact_text(text: str) -> str:
+    """Redact `name=value` pairs in arbitrary text where the name looks sensitive.
+
+    Mirrors Apache Spark's ``spark.redaction.regex`` approach (configurable
+    log-level redaction by key name), tailored for inline use at error
+    construction sites: wrap the constructed message through this helper so
+    credentials that appear anywhere in the text — including the underlying
+    exception's own message — get replaced before the ``RuntimeError`` is
+    raised.
+
+    For an unparsable URL or a known shape, prefer ``_redact_url``; this
+    function is the catch-all for everything else.
+    """
+    return _REDACT_TEXT_RE.sub(r"\1***", text)
 
 
 def _redact_url(url: str) -> str:
@@ -146,7 +191,7 @@ class SQLConnection:
                 url = connection.engine.url.render_as_string(hide_password=True)
             return cls(conn_factory, driver, dialect, url)
         except Exception as e:
-            raise ValueError(f"Unexpected error while calling the connection factory: {e}") from e
+            raise ValueError(_redact_text(f"Unexpected error while calling the connection factory: {e}")) from e
 
     def read_schema(self, sql: str, infer_schema_length: int) -> Schema:
         if self._should_use_connectorx():
@@ -239,7 +284,13 @@ class SQLConnection:
             table = cx.read_sql(conn=self.conn, query=sql, return_type="arrow")
             return table
         except Exception as e:
-            raise RuntimeError(f"Failed to execute sql: {sql} with url: {_redact_url(self.conn)}, error: {e}") from e
+            # The connection URL is deliberately omitted from the message:
+            # secrets can appear anywhere in it (userinfo, query params,
+            # driver-specific extras), so stripping the URL is the only
+            # robust mitigation. `_redact_text` wraps the rest of the
+            # message as a defense-in-depth pass over the underlying
+            # exception's text in case a driver echoes back credentials.
+            raise RuntimeError(_redact_text(f"Failed to execute sql: {sql}, error: {e}")) from e
 
     def _execute_sql_query_with_sqlalchemy(self, sql: str, schema: pa.Schema | None = None) -> pa.Table:
         from sqlalchemy import create_engine, text
@@ -258,5 +309,7 @@ class SQLConnection:
             pydict = {column_name: [row[i] for row in rows] for i, column_name in enumerate(result.keys())}
             return pa.Table.from_pydict(pydict, schema=schema)
         except Exception as e:
-            connection_str = _redact_url(self.conn) if isinstance(self.conn, str) else self.conn.__name__
-            raise RuntimeError(f"Failed to execute sql: {sql} from connection: {connection_str}, error: {e}") from e
+            # See note in `_execute_sql_query_with_connectorx`: don't echo
+            # back the connection URL — too easy to leak credentials that
+            # live outside the `password` field.
+            raise RuntimeError(_redact_text(f"Failed to execute sql: {sql}, error: {e}")) from e

--- a/daft/sql/sql_connection.py
+++ b/daft/sql/sql_connection.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import re
 from typing import TYPE_CHECKING
 from urllib.parse import parse_qsl, urlencode, urlparse
 
@@ -26,7 +25,7 @@ logger = logging.getLogger(__name__)
 try:
     from sqlalchemy.engine import make_url as _sa_make_url
 except ImportError:
-    _sa_make_url = None  # type: ignore[assignment]
+    _sa_make_url = None
 
 
 # Query-parameter names whose values must be redacted. Substring match,
@@ -50,48 +49,6 @@ _SENSITIVE_PARAM_KEYWORDS = (
 def _is_sensitive_param(name: str) -> bool:
     lower = name.casefold()
     return any(keyword in lower for keyword in _SENSITIVE_PARAM_KEYWORDS)
-
-
-# Spark-style text-level redaction. Catches `name=value` / `name: value`
-# pairs in arbitrary text where the name contains any of the sensitive
-# substrings above. `_redact_url` handles the URL field we control; this
-# is a defense-in-depth layer for the wrapping error message, which
-# interpolates underlying driver exceptions whose text we don't control
-# (e.g. a JDBC driver echoing back `password=...` from a connection
-# property list).
-_REDACT_TEXT_RE = re.compile(
-    r"""
-    (                                       # group 1: prefix (delim + name + key-value separator)
-        (?:^|[?&;,\s\(\[\{])                # leading delimiter
-        [A-Za-z0-9_\-\.]*                   # name prefix chars
-        (?:                                 # name must contain a sensitive substring
-            password | pwd | secret | token | passphrase
-            | api[._]?key | apikey | credential | signature
-            | access[._]?key
-        )
-        [A-Za-z0-9_\-\.]*                   # name suffix chars
-        \s*[=:]\s*                          # key/value separator
-    )
-    [^\s&;,'"\)\]\}<>]+                      # the value: until next delimiter or quote
-    """,
-    re.IGNORECASE | re.VERBOSE,
-)
-
-
-def _redact_text(text: str) -> str:
-    """Redact `name=value` pairs in arbitrary text where the name looks sensitive.
-
-    Mirrors Apache Spark's ``spark.redaction.regex`` approach (configurable
-    log-level redaction by key name), tailored for inline use at error
-    construction sites: wrap the constructed message through this helper so
-    credentials that appear anywhere in the text — including the underlying
-    exception's own message — get replaced before the ``RuntimeError`` is
-    raised.
-
-    For an unparsable URL or a known shape, prefer ``_redact_url``; this
-    function is the catch-all for everything else.
-    """
-    return _REDACT_TEXT_RE.sub(r"\1***", text)
 
 
 def _redact_url(url: str) -> str:
@@ -191,7 +148,7 @@ class SQLConnection:
                 url = connection.engine.url.render_as_string(hide_password=True)
             return cls(conn_factory, driver, dialect, url)
         except Exception as e:
-            raise ValueError(_redact_text(f"Unexpected error while calling the connection factory: {e}")) from e
+            raise ValueError(f"Unexpected error while calling the connection factory: {e}") from e
 
     def read_schema(self, sql: str, infer_schema_length: int) -> Schema:
         if self._should_use_connectorx():
@@ -284,13 +241,12 @@ class SQLConnection:
             table = cx.read_sql(conn=self.conn, query=sql, return_type="arrow")
             return table
         except Exception as e:
-            # The connection URL is deliberately omitted from the message:
+            # The connection URL is deliberately omitted from the error message:
             # secrets can appear anywhere in it (userinfo, query params,
-            # driver-specific extras), so stripping the URL is the only
-            # robust mitigation. `_redact_text` wraps the rest of the
-            # message as a defense-in-depth pass over the underlying
-            # exception's text in case a driver echoes back credentials.
-            raise RuntimeError(_redact_text(f"Failed to execute sql: {sql}, error: {e}")) from e
+            # driver-specific extras), so dropping the URL is the only robust
+            # mitigation. The caller knows which connection they passed in,
+            # so the URL is redundant here.
+            raise RuntimeError(f"Failed to execute sql: {sql}, error: {e}") from e
 
     def _execute_sql_query_with_sqlalchemy(self, sql: str, schema: pa.Schema | None = None) -> pa.Table:
         from sqlalchemy import create_engine, text
@@ -310,6 +266,5 @@ class SQLConnection:
             return pa.Table.from_pydict(pydict, schema=schema)
         except Exception as e:
             # See note in `_execute_sql_query_with_connectorx`: don't echo
-            # back the connection URL — too easy to leak credentials that
-            # live outside the `password` field.
-            raise RuntimeError(_redact_text(f"Failed to execute sql: {sql}, error: {e}")) from e
+            # back the connection URL.
+            raise RuntimeError(f"Failed to execute sql: {sql}, error: {e}") from e

--- a/daft/sql/sql_connection.py
+++ b/daft/sql/sql_connection.py
@@ -16,6 +16,18 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+# SQLAlchemy is an optional dependency (the connectorx-only code path doesn't
+# require it). Try to import `make_url` once at module load so `_redact_url`
+# — which runs on every error message and is meant to be cheap — can take
+# the SA branch without a per-call import lookup. The actual sqlalchemy.engine
+# imports used inside class methods stay inline (they only fire when the SA
+# code path is actually taken).
+try:
+    from sqlalchemy.engine import make_url as _sa_make_url
+except ImportError:
+    _sa_make_url = None  # type: ignore[assignment]
+
+
 # Query-parameter names whose values must be redacted. Substring match,
 # case-insensitive. Covers password / OAuth token / API key / key passphrase
 # styles used by common SQL drivers (Trino JWT auth, Snowflake key auth,
@@ -43,21 +55,21 @@ def _redact_url(url: str) -> str:
     # mis-parses, dropping the password into the fragment/path/query and
     # making it look "absent" — which would otherwise cause this function to
     # return the URL unchanged and leak credentials.
-    try:
-        from sqlalchemy.engine import make_url
-
-        sa_url = make_url(url)
-        sensitive_keys = [k for k in sa_url.query if _is_sensitive_param(k)]
-        if sa_url.password is None and not sensitive_keys:
-            return url
-        if sensitive_keys:
-            new_query = {k: ("***" if _is_sensitive_param(k) else v) for k, v in sa_url.query.items()}
-            sa_url = sa_url.set(query=new_query)
-        # SQLAlchemy percent-encodes '*' to '%2A' in query values; undo that
-        # for the redaction placeholder so the rendered URL stays readable.
-        return sa_url.render_as_string(hide_password=True).replace("%2A%2A%2A", "***")
-    except Exception:
-        pass
+    if _sa_make_url is not None:
+        try:
+            sa_url = _sa_make_url(url)
+            sensitive_keys = [k for k in sa_url.query if _is_sensitive_param(k)]
+            if sa_url.password is None and not sensitive_keys:
+                return url
+            if sensitive_keys:
+                new_query = {k: ("***" if _is_sensitive_param(k) else v) for k, v in sa_url.query.items()}
+                sa_url = sa_url.set(query=new_query)
+            # SQLAlchemy percent-encodes '*' to '%2A' in query values; undo
+            # that for the redaction placeholder so the rendered URL stays
+            # readable in error output.
+            return sa_url.render_as_string(hide_password=True).replace("%2A%2A%2A", "***")
+        except Exception:
+            pass
 
     # Fallback for environments without SQLAlchemy (the connectorx-only path).
     try:
@@ -75,20 +87,24 @@ def _redact_url(url: str) -> str:
             host = parsed.hostname or ""
             if parsed.port is not None:
                 host = f"{host}:{parsed.port}"
-            return parsed._replace(netloc=f"{userinfo}@{host}", query=redacted_query).geturl()
+            return (
+                parsed._replace(netloc=f"{userinfo}@{host}", query=redacted_query).geturl().replace("%2A%2A%2A", "***")
+            )
         if any_sensitive_query:
-            return parsed._replace(query=redacted_query).geturl()
-        # urlparse missed the password — but if there's an "@" before the
-        # path/query/fragment, it's almost certainly userinfo with unescaped
-        # special chars in the password. Over-redact to be safe.
-        if "://" in url:
+            return parsed._replace(query=redacted_query).geturl().replace("%2A%2A%2A", "***")
+        # If urlparse couldn't extract a username but the URL has "@" in the
+        # path-prefix region (before the first "/"), the userinfo almost
+        # certainly contains unescaped URL-special chars in the password
+        # (e.g. "trino://alice:p#ss@host/db" — urlparse stops the netloc at
+        # "#", losing the password). Over-redact to be safe. We deliberately
+        # gate on `username is None` so legitimate no-password URLs like
+        # "mysql://user@host/db" (which urlparse handles fine) pass through
+        # unchanged.
+        if "://" in url and parsed.username is None:
             after_scheme = url.split("://", 1)[1]
-            authority = after_scheme
-            for delim in ("/", "?", "#"):
-                idx = authority.find(delim)
-                if idx != -1:
-                    authority = authority[:idx]
-            if "@" in authority:
+            path_start = after_scheme.find("/")
+            authority_prefix = after_scheme if path_start == -1 else after_scheme[:path_start]
+            if "@" in authority_prefix:
                 return "<redacted>"
         return url
     except Exception:

--- a/daft/sql/sql_connection.py
+++ b/daft/sql/sql_connection.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from typing import TYPE_CHECKING
-from urllib.parse import parse_qsl, urlencode, urlparse
+from urllib.parse import urlparse
 
 from daft.dependencies import pa
 from daft.logical.schema import Schema
@@ -16,103 +16,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-# SQLAlchemy is an optional dependency (the connectorx-only code path doesn't
-# require it). Try to import `make_url` once at module load so `_redact_url`
-# — which runs on every error message and is meant to be cheap — can take
-# the SA branch without a per-call import lookup. The actual sqlalchemy.engine
-# imports used inside class methods stay inline (they only fire when the SA
-# code path is actually taken).
-try:
-    from sqlalchemy.engine import make_url as _sa_make_url
-except ImportError:
-    _sa_make_url = None
-
-
-# Query-parameter names whose values must be redacted. Substring match,
-# case-insensitive. Covers password / OAuth token / API key / key passphrase
-# styles used by common SQL drivers (Trino JWT auth, Snowflake key auth,
-# Databricks PATs, generic API keys, etc.).
-_SENSITIVE_PARAM_KEYWORDS = (
-    "password",
-    "pwd",
-    "secret",
-    "token",
-    "passphrase",
-    "apikey",
-    "api_key",
-    "credential",
-    "signature",
-    "access_key",
-)
-
-
-def _is_sensitive_param(name: str) -> bool:
-    lower = name.casefold()
-    return any(keyword in lower for keyword in _SENSITIVE_PARAM_KEYWORDS)
-
-
-def _redact_url(url: str) -> str:
-    # Prefer SQLAlchemy's URL parser: it handles unescaped URL-special
-    # characters in passwords (e.g. '#', '/', '?') that urllib.parse silently
-    # mis-parses, dropping the password into the fragment/path/query and
-    # making it look "absent" — which would otherwise cause this function to
-    # return the URL unchanged and leak credentials.
-    if _sa_make_url is not None:
-        try:
-            sa_url = _sa_make_url(url)
-            sensitive_keys = [k for k in sa_url.query if _is_sensitive_param(k)]
-            if sa_url.password is None and not sensitive_keys:
-                return url
-            if sensitive_keys:
-                new_query = {k: ("***" if _is_sensitive_param(k) else v) for k, v in sa_url.query.items()}
-                sa_url = sa_url.set(query=new_query)
-            # SQLAlchemy percent-encodes '*' to '%2A' in query values; undo
-            # that for the redaction placeholder so the rendered URL stays
-            # readable in error output.
-            return sa_url.render_as_string(hide_password=True).replace("%2A%2A%2A", "***")
-        except Exception:
-            pass
-
-    # Fallback for environments without SQLAlchemy (the connectorx-only path).
-    try:
-        parsed = urlparse(url)
-        query_pairs = parse_qsl(parsed.query, keep_blank_values=True)
-        any_sensitive_query = any(_is_sensitive_param(k) for k, _ in query_pairs)
-        redacted_query = (
-            urlencode([(k, "***" if _is_sensitive_param(k) else v) for k, v in query_pairs])
-            if any_sensitive_query
-            else parsed.query
-        )
-
-        if parsed.password is not None:
-            userinfo = f"{parsed.username}:***" if parsed.username else "***"
-            host = parsed.hostname or ""
-            if parsed.port is not None:
-                host = f"{host}:{parsed.port}"
-            return (
-                parsed._replace(netloc=f"{userinfo}@{host}", query=redacted_query).geturl().replace("%2A%2A%2A", "***")
-            )
-        if any_sensitive_query:
-            return parsed._replace(query=redacted_query).geturl().replace("%2A%2A%2A", "***")
-        # If urlparse couldn't extract a username but the URL has "@" in the
-        # path-prefix region (before the first "/"), the userinfo almost
-        # certainly contains unescaped URL-special chars in the password
-        # (e.g. "trino://alice:p#ss@host/db" — urlparse stops the netloc at
-        # "#", losing the password). Over-redact to be safe. We deliberately
-        # gate on `username is None` so legitimate no-password URLs like
-        # "mysql://user@host/db" (which urlparse handles fine) pass through
-        # unchanged.
-        if "://" in url and parsed.username is None:
-            after_scheme = url.split("://", 1)[1]
-            path_start = after_scheme.find("/")
-            authority_prefix = after_scheme if path_start == -1 else after_scheme[:path_start]
-            if "@" in authority_prefix:
-                return "<redacted>"
-        return url
-    except Exception:
-        return "<redacted>"
-
-
 class SQLConnection:
     def __init__(self, conn: str | Callable[[], Connection], driver: str, dialect: str, url: str) -> None:
         self.conn = conn
@@ -121,8 +24,10 @@ class SQLConnection:
         self.url = url
 
     def __repr__(self) -> str:
-        conn = _redact_url(self.conn) if isinstance(self.conn, str) else self.conn
-        return f"SQLConnection(conn={conn})"
+        # Deliberately omit the URL: secrets can appear anywhere in a
+        # connection string (userinfo, query params, driver extras), so
+        # the safest mitigation is to not echo it at all.
+        return f"SQLConnection(dialect={self.dialect!r}, driver={self.driver!r})"
 
     @classmethod
     def from_url(cls, url: str) -> SQLConnection:

--- a/daft/sql/sql_connection.py
+++ b/daft/sql/sql_connection.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from typing import TYPE_CHECKING
-from urllib.parse import urlparse
+from urllib.parse import parse_qsl, urlencode, urlparse
 
 from daft.dependencies import pa
 from daft.logical.schema import Schema
@@ -16,16 +16,81 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+# Query-parameter names whose values must be redacted. Substring match,
+# case-insensitive. Covers password / OAuth token / API key / key passphrase
+# styles used by common SQL drivers (Trino JWT auth, Snowflake key auth,
+# Databricks PATs, generic API keys, etc.).
+_SENSITIVE_PARAM_KEYWORDS = (
+    "password",
+    "pwd",
+    "secret",
+    "token",
+    "passphrase",
+    "apikey",
+    "api_key",
+    "credential",
+)
+
+
+def _is_sensitive_param(name: str) -> bool:
+    lower = name.casefold()
+    return any(keyword in lower for keyword in _SENSITIVE_PARAM_KEYWORDS)
+
+
 def _redact_url(url: str) -> str:
+    # Prefer SQLAlchemy's URL parser: it handles unescaped URL-special
+    # characters in passwords (e.g. '#', '/', '?') that urllib.parse silently
+    # mis-parses, dropping the password into the fragment/path/query and
+    # making it look "absent" — which would otherwise cause this function to
+    # return the URL unchanged and leak credentials.
+    try:
+        from sqlalchemy.engine import make_url
+
+        sa_url = make_url(url)
+        sensitive_keys = [k for k in sa_url.query if _is_sensitive_param(k)]
+        if sa_url.password is None and not sensitive_keys:
+            return url
+        if sensitive_keys:
+            new_query = {k: ("***" if _is_sensitive_param(k) else v) for k, v in sa_url.query.items()}
+            sa_url = sa_url.set(query=new_query)
+        # SQLAlchemy percent-encodes '*' to '%2A' in query values; undo that
+        # for the redaction placeholder so the rendered URL stays readable.
+        return sa_url.render_as_string(hide_password=True).replace("%2A%2A%2A", "***")
+    except Exception:
+        pass
+
+    # Fallback for environments without SQLAlchemy (the connectorx-only path).
     try:
         parsed = urlparse(url)
-        if parsed.password is None:
-            return url
-        userinfo = f"{parsed.username}:***" if parsed.username else "***"
-        host = parsed.hostname or ""
-        if parsed.port is not None:
-            host = f"{host}:{parsed.port}"
-        return parsed._replace(netloc=f"{userinfo}@{host}").geturl()
+        query_pairs = parse_qsl(parsed.query, keep_blank_values=True)
+        any_sensitive_query = any(_is_sensitive_param(k) for k, _ in query_pairs)
+        redacted_query = (
+            urlencode([(k, "***" if _is_sensitive_param(k) else v) for k, v in query_pairs])
+            if any_sensitive_query
+            else parsed.query
+        )
+
+        if parsed.password is not None:
+            userinfo = f"{parsed.username}:***" if parsed.username else "***"
+            host = parsed.hostname or ""
+            if parsed.port is not None:
+                host = f"{host}:{parsed.port}"
+            return parsed._replace(netloc=f"{userinfo}@{host}", query=redacted_query).geturl()
+        if any_sensitive_query:
+            return parsed._replace(query=redacted_query).geturl()
+        # urlparse missed the password — but if there's an "@" before the
+        # path/query/fragment, it's almost certainly userinfo with unescaped
+        # special chars in the password. Over-redact to be safe.
+        if "://" in url:
+            after_scheme = url.split("://", 1)[1]
+            authority = after_scheme
+            for delim in ("/", "?", "#"):
+                idx = authority.find(delim)
+                if idx != -1:
+                    authority = authority[:idx]
+            if "@" in authority:
+                return "<redacted>"
+        return url
     except Exception:
         return "<redacted>"
 

--- a/tests/io/test_sql.py
+++ b/tests/io/test_sql.py
@@ -196,6 +196,31 @@ def test_redact_url_redacts_sensitive_query_params(param_name):
     assert "http_scheme=https" in redacted
 
 
+def test_redact_url_fallback_when_sqlalchemy_unavailable(monkeypatch):
+    """Force the urllib.parse fallback by simulating SQLAlchemy being absent.
+
+    The fallback path is what runs in connectorx-only environments. Pin down
+    that it behaves consistently with the primary path for the safe cases
+    (no-password user-only URLs pass through unchanged) and still redacts
+    the leak vectors (sensitive query params, special-char passwords).
+    """
+    from daft.sql import sql_connection as sc
+
+    monkeypatch.setattr(sc, "_sa_make_url", None)
+
+    # No-password user-only URL: must NOT over-redact (Greptile-flagged divergence).
+    assert _redact_url("mysql://user@host/db") == "mysql://user@host/db"
+    # Standard userinfo password — fallback redacts.
+    assert _redact_url("postgresql://user:hunter2@host:5432/db") == "postgresql://user:***@host:5432/db"
+    # Sensitive query param — fallback redacts.
+    redacted = _redact_url("trino://alice@host:443?access_token=SECRET&http_scheme=https")
+    assert "SECRET" not in redacted
+    assert "access_token=***" in redacted
+    # Special-char password — urlparse loses the password into the fragment;
+    # over-redact since we can't safely reconstruct.
+    assert _redact_url("trino://alice:p#ss@host:443/db") == "<redacted>"
+
+
 def test_redact_url_customer_jwt_repro():
     """Customer-reported leak shape: JWT in `access_token=` query parameter, no userinfo password.
 

--- a/tests/io/test_sql.py
+++ b/tests/io/test_sql.py
@@ -112,7 +112,8 @@ def test_sql_partitioned_read_null_partition_col(sqlite_null_partition_db, num_p
             "trino://alice:***@trino.example.com:443/db?param=1",
         ),
         ("postgresql://user:p%40ss@host:5432/db", "postgresql://user:***@host:5432/db"),
-        ("mysql+pymysql://:secret@host/db", "mysql+pymysql://***@host/db"),
+        # Empty username — SQLAlchemy preserves the ':' delimiter.
+        ("mysql+pymysql://:secret@host/db", "mysql+pymysql://:***@host/db"),
         # No password — should be returned unchanged.
         ("sqlite:///my.db", "sqlite:///my.db"),
         ("mysql://user@host/db", "mysql://user@host/db"),
@@ -121,10 +122,91 @@ def test_sql_partitioned_read_null_partition_col(sqlite_null_partition_db, num_p
         # Non-numeric port — parsed.port raises ValueError; must not propagate
         # and must not leak the password.
         ("trino://alice:hunter2@host:badport/db", "<redacted>"),
+        # Unescaped URL-special characters in the password: urllib.parse drops
+        # them into the fragment / path / query and reports password=None, so
+        # the previous implementation returned the URL unchanged — leaking the
+        # password. SQLAlchemy's make_url parses these correctly.
+        ("trino://alice:p#ss@host:443/db", "trino://alice:***@host:443/db"),
+        ("trino://alice:p/ss@host:443/db", "trino://alice:***@host:443/db"),
+        ("trino://alice:p?ss@host:443/db", "trino://alice:***@host:443/db"),
     ],
 )
 def test_redact_url(url, expected):
     assert _redact_url(url) == expected
+
+
+@pytest.mark.parametrize(
+    "password",
+    [
+        "simple",
+        "p@ss",
+        "p:ss",
+        "p#ss",
+        "p/ss",
+        "p?ss",
+        "p&ss",
+        "!@#$%^&*()",
+        "with space",
+    ],
+)
+def test_redact_url_does_not_leak_for_any_password(password):
+    """Regardless of URL-special chars in the password, redaction must not leak it.
+
+    Covers `#`, `/`, `?`, etc. — characters that previously caused urllib.parse
+    to silently mis-parse the URL and skip redaction.
+    """
+    url = f"trino://alice:{password}@host:443/db"
+    redacted = _redact_url(url)
+    assert password not in redacted, f"password leaked in redacted URL: {redacted!r}"
+
+
+@pytest.mark.parametrize(
+    "param_name",
+    [
+        "access_token",
+        "auth_token",
+        "token",
+        "password",
+        "pwd",
+        "secret",
+        "client_secret",
+        "passphrase",
+        "private_key_passphrase",
+        "apikey",
+        "api_key",
+        "credentials",
+        # Case-insensitive matching:
+        "Access_Token",
+        "PASSWORD",
+    ],
+)
+def test_redact_url_redacts_sensitive_query_params(param_name):
+    """Sensitive query-parameter values must be redacted, not just userinfo passwords.
+
+    Drivers like Trino (JWT), Snowflake (key auth), Databricks (PAT), and
+    generic API-key based connectors pass credentials as query parameters,
+    so leaving these in error output leaks credentials.
+    """
+    secret = "SUPER_SECRET_VALUE_DO_NOT_LEAK"
+    url = f"trino://alice@host:443?auth=jwt&{param_name}={secret}&http_scheme=https"
+    redacted = _redact_url(url)
+    assert secret not in redacted, f"{param_name} value leaked in: {redacted!r}"
+    # Non-sensitive params should be preserved.
+    assert "auth=jwt" in redacted
+    assert "http_scheme=https" in redacted
+
+
+def test_redact_url_customer_jwt_repro():
+    """Customer-reported leak shape: JWT in `access_token=` query parameter, no userinfo password.
+
+    The previous fix only handled `user:password@host` style URLs and left
+    the access_token in plaintext in the raised RuntimeError.
+    """
+    secret = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.SECRET_PAYLOAD.SIGNATURE"
+    url = f"trino://alice@trino.example.com:443?auth=jwt&access_token={secret}&http_scheme=https"
+    redacted = _redact_url(url)
+    assert secret not in redacted
+    assert "access_token=***" in redacted
 
 
 def test_execute_sql_error_does_not_leak_password():

--- a/tests/io/test_sql.py
+++ b/tests/io/test_sql.py
@@ -7,7 +7,7 @@ from sqlalchemy import Column, Float, Integer, MetaData, String, Table, create_e
 
 import daft
 from daft.datatype import DataType
-from daft.sql.sql_connection import SQLConnection, _redact_url
+from daft.sql.sql_connection import SQLConnection
 
 
 @pytest.fixture()
@@ -104,158 +104,41 @@ def test_sql_partitioned_read_null_partition_col(sqlite_null_partition_db, num_p
 
 
 @pytest.mark.parametrize(
-    ("url", "expected"),
+    ("url", "secret"),
     [
-        ("trino://alice:hunter2@trino.example.com:443", "trino://alice:***@trino.example.com:443"),
+        # userinfo password
+        ("postgresql+psycopg2://alice:super-secret-pw@127.0.0.1:1/nope", "super-secret-pw"),
+        # query-param token (Trino JWT shape, the customer-reported leak)
         (
-            "trino://alice:hunter2@trino.example.com:443/db?param=1",
-            "trino://alice:***@trino.example.com:443/db?param=1",
+            "trino://alice@127.0.0.1:1?auth=jwt&access_token=SUPER_SECRET_TOKEN&http_scheme=https",
+            "SUPER_SECRET_TOKEN",
         ),
-        ("postgresql://user:p%40ss@host:5432/db", "postgresql://user:***@host:5432/db"),
-        # Empty username — SQLAlchemy preserves the ':' delimiter.
-        ("mysql+pymysql://:secret@host/db", "mysql+pymysql://:***@host/db"),
-        # No password — should be returned unchanged.
-        ("sqlite:///my.db", "sqlite:///my.db"),
-        ("mysql://user@host/db", "mysql://user@host/db"),
-        ("trino://host:443", "trino://host:443"),
-        ("not a url", "not a url"),
-        # Non-numeric port — parsed.port raises ValueError; must not propagate
-        # and must not leak the password.
-        ("trino://alice:hunter2@host:badport/db", "<redacted>"),
-        # Unescaped URL-special characters in the password: urllib.parse drops
-        # them into the fragment / path / query and reports password=None, so
-        # the previous implementation returned the URL unchanged — leaking the
-        # password. SQLAlchemy's make_url parses these correctly.
-        ("trino://alice:p#ss@host:443/db", "trino://alice:***@host:443/db"),
-        ("trino://alice:p/ss@host:443/db", "trino://alice:***@host:443/db"),
-        ("trino://alice:p?ss@host:443/db", "trino://alice:***@host:443/db"),
+        # password with URL-special chars
+        ("postgresql+psycopg2://alice:p#ss@127.0.0.1:1/nope", "p#ss"),
     ],
 )
-def test_redact_url(url, expected):
-    assert _redact_url(url) == expected
-
-
-@pytest.mark.parametrize(
-    "password",
-    [
-        "simple",
-        "p@ss",
-        "p:ss",
-        "p#ss",
-        "p/ss",
-        "p?ss",
-        "p&ss",
-        "!@#$%^&*()",
-        "with space",
-    ],
-)
-def test_redact_url_does_not_leak_for_any_password(password):
-    """Regardless of URL-special chars in the password, redaction must not leak it.
-
-    Covers `#`, `/`, `?`, etc. — characters that previously caused urllib.parse
-    to silently mis-parse the URL and skip redaction.
-    """
-    url = f"trino://alice:{password}@host:443/db"
-    redacted = _redact_url(url)
-    assert password not in redacted, f"password leaked in redacted URL: {redacted!r}"
-
-
-@pytest.mark.parametrize(
-    "param_name",
-    [
-        "access_token",
-        "auth_token",
-        "token",
-        "password",
-        "pwd",
-        "secret",
-        "client_secret",
-        "passphrase",
-        "private_key_passphrase",
-        "apikey",
-        "api_key",
-        "credentials",
-        # Case-insensitive matching:
-        "Access_Token",
-        "PASSWORD",
-    ],
-)
-def test_redact_url_redacts_sensitive_query_params(param_name):
-    """Sensitive query-parameter values must be redacted, not just userinfo passwords.
-
-    Drivers like Trino (JWT), Snowflake (key auth), Databricks (PAT), and
-    generic API-key based connectors pass credentials as query parameters,
-    so leaving these in error output leaks credentials.
-    """
-    secret = "SUPER_SECRET_VALUE_DO_NOT_LEAK"
-    url = f"trino://alice@host:443?auth=jwt&{param_name}={secret}&http_scheme=https"
-    redacted = _redact_url(url)
-    assert secret not in redacted, f"{param_name} value leaked in: {redacted!r}"
-    # Non-sensitive params should be preserved.
-    assert "auth=jwt" in redacted
-    assert "http_scheme=https" in redacted
-
-
-def test_redact_url_fallback_when_sqlalchemy_unavailable(monkeypatch):
-    """Force the urllib.parse fallback by simulating SQLAlchemy being absent.
-
-    The fallback path is what runs in connectorx-only environments. Pin down
-    that it behaves consistently with the primary path for the safe cases
-    (no-password user-only URLs pass through unchanged) and still redacts
-    the leak vectors (sensitive query params, special-char passwords).
-    """
-    from daft.sql import sql_connection as sc
-
-    monkeypatch.setattr(sc, "_sa_make_url", None)
-
-    # No-password user-only URL: must NOT over-redact (Greptile-flagged divergence).
-    assert _redact_url("mysql://user@host/db") == "mysql://user@host/db"
-    # Standard userinfo password — fallback redacts.
-    assert _redact_url("postgresql://user:hunter2@host:5432/db") == "postgresql://user:***@host:5432/db"
-    # Sensitive query param — fallback redacts.
-    redacted = _redact_url("trino://alice@host:443?access_token=SECRET&http_scheme=https")
-    assert "SECRET" not in redacted
-    assert "access_token=***" in redacted
-    # Special-char password — urlparse loses the password into the fragment;
-    # over-redact since we can't safely reconstruct.
-    assert _redact_url("trino://alice:p#ss@host:443/db") == "<redacted>"
-
-
-def test_redact_url_customer_jwt_repro():
-    """Customer-reported leak shape: JWT in `access_token=` query parameter, no userinfo password.
-
-    The previous fix only handled `user:password@host` style URLs and left
-    the access_token in plaintext in the raised RuntimeError.
-    """
-    secret = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.SECRET_PAYLOAD.SIGNATURE"
-    url = f"trino://alice@trino.example.com:443?auth=jwt&access_token={secret}&http_scheme=https"
-    redacted = _redact_url(url)
-    assert secret not in redacted
-    assert "access_token=***" in redacted
-
-
-def test_execute_sql_error_does_not_leak_credentials():
-    """Connection failures must not include the connection URL in the raised error.
+def test_execute_sql_error_does_not_leak_credentials(url, secret):
+    """The raised RuntimeError must not echo any part of the connection URL.
 
     Secrets can appear anywhere in a URL (userinfo, query params, driver
-    extras), so the URL is now omitted from the error message entirely.
+    extras), so the URL is omitted from the error message entirely rather
+    than relying on field-specific redaction.
     """
     pytest.importorskip("psycopg2")
-    password = "super-secret-pw"
-    url = f"postgresql+psycopg2://alice:{password}@127.0.0.1:1/nope"
     conn = SQLConnection.from_url(url)
-
     with pytest.raises(RuntimeError) as exc_info:
         conn.execute_sql_query("SELECT 1")
-
-    message = str(exc_info.value)
-    assert password not in message
-    # The URL itself is not echoed in the error message.
-    assert "127.0.0.1" not in message or "from connection:" not in message
-    assert "alice" not in message
+    assert secret not in str(exc_info.value)
 
 
-def test_repr_does_not_leak_password():
-    password = "super-secret-pw"
-    conn = SQLConnection.from_url(f"postgresql://alice:{password}@host:5432/db")
-    assert password not in repr(conn)
+def test_repr_does_not_leak_url():
+    """SQLConnection.__repr__ must not echo the connection URL.
+
+    Same reasoning as the error-message path. Show only dialect/driver.
+    """
+    secret = "super-secret-token-do-not-leak"
+    conn = SQLConnection.from_url(f"trino://alice@trino.example.com:443?access_token={secret}")
+    r = repr(conn)
+    assert secret not in r
+    assert "trino.example.com" not in r
+    assert "alice" not in r

--- a/tests/io/test_sql.py
+++ b/tests/io/test_sql.py
@@ -7,7 +7,7 @@ from sqlalchemy import Column, Float, Integer, MetaData, String, Table, create_e
 
 import daft
 from daft.datatype import DataType
-from daft.sql.sql_connection import SQLConnection, _redact_text, _redact_url
+from daft.sql.sql_connection import SQLConnection, _redact_url
 
 
 @pytest.fixture()
@@ -232,59 +232,6 @@ def test_redact_url_customer_jwt_repro():
     redacted = _redact_url(url)
     assert secret not in redacted
     assert "access_token=***" in redacted
-
-
-@pytest.mark.parametrize(
-    ("text", "must_not_contain"),
-    [
-        # URL query param style
-        ("?access_token=SUPER_SECRET&http_scheme=https", "SUPER_SECRET"),
-        ("trino://alice@host:443?access_token=SUPER_SECRET&auth=jwt", "SUPER_SECRET"),
-        # JDBC ;-separated property style
-        ("jdbc:trino://host:443;user=alice;password=SUPER_SECRET;ssl=true", "SUPER_SECRET"),
-        # name=value within driver error text
-        ("could not connect: password=SUPER_SECRET host=foo", "SUPER_SECRET"),
-        # Colon separator (common in dict-like reprs)
-        ("kwargs: password: SUPER_SECRET, host: foo", "SUPER_SECRET"),
-        # Case-insensitive name match
-        ("?Access_Token=SUPER_SECRET", "SUPER_SECRET"),
-        ("?PASSWORD=SUPER_SECRET", "SUPER_SECRET"),
-        # Variant names
-        ("?api_key=SUPER_SECRET", "SUPER_SECRET"),
-        ("?apikey=SUPER_SECRET", "SUPER_SECRET"),
-        ("?client_secret=SUPER_SECRET", "SUPER_SECRET"),
-        ("?private_key_passphrase=SUPER_SECRET", "SUPER_SECRET"),
-        ("?signature=SUPER_SECRET", "SUPER_SECRET"),
-        ("?aws_access_key_id=SUPER_SECRET", "SUPER_SECRET"),
-    ],
-)
-def test_redact_text_removes_secret(text, must_not_contain):
-    """`_redact_text` redacts sensitive name=value pairs in arbitrary text.
-
-    The defense-in-depth backstop must catch credentials wherever they
-    appear in the wrapped error message — URL query params, JDBC-style
-    `;`-separated property strings, dict-like reprs, etc. — not just in
-    the URL field we explicitly pass through `_redact_url`.
-    """
-    redacted = _redact_text(text)
-    assert must_not_contain not in redacted, f"secret leaked in: {redacted!r}"
-    assert "***" in redacted
-
-
-@pytest.mark.parametrize(
-    "text",
-    [
-        "auth=jwt",  # auth is a scheme, not a secret
-        "host=trino.example.com",
-        "scheme=https",
-        "port=443",
-        "user=alice",
-        "ssl=true",
-        "[SQL: SELECT * FROM t WHERE k = 'v']",  # SQL embedded — must not get clobbered
-    ],
-)
-def test_redact_text_preserves_non_sensitive(text):
-    assert _redact_text(text) == text
 
 
 def test_execute_sql_error_does_not_leak_credentials():

--- a/tests/io/test_sql.py
+++ b/tests/io/test_sql.py
@@ -7,7 +7,7 @@ from sqlalchemy import Column, Float, Integer, MetaData, String, Table, create_e
 
 import daft
 from daft.datatype import DataType
-from daft.sql.sql_connection import SQLConnection, _redact_url
+from daft.sql.sql_connection import SQLConnection, _redact_text, _redact_url
 
 
 @pytest.fixture()
@@ -234,8 +234,65 @@ def test_redact_url_customer_jwt_repro():
     assert "access_token=***" in redacted
 
 
-def test_execute_sql_error_does_not_leak_password():
-    """Connection failures must not include the password in the raised error."""
+@pytest.mark.parametrize(
+    ("text", "must_not_contain"),
+    [
+        # URL query param style
+        ("?access_token=SUPER_SECRET&http_scheme=https", "SUPER_SECRET"),
+        ("trino://alice@host:443?access_token=SUPER_SECRET&auth=jwt", "SUPER_SECRET"),
+        # JDBC ;-separated property style
+        ("jdbc:trino://host:443;user=alice;password=SUPER_SECRET;ssl=true", "SUPER_SECRET"),
+        # name=value within driver error text
+        ("could not connect: password=SUPER_SECRET host=foo", "SUPER_SECRET"),
+        # Colon separator (common in dict-like reprs)
+        ("kwargs: password: SUPER_SECRET, host: foo", "SUPER_SECRET"),
+        # Case-insensitive name match
+        ("?Access_Token=SUPER_SECRET", "SUPER_SECRET"),
+        ("?PASSWORD=SUPER_SECRET", "SUPER_SECRET"),
+        # Variant names
+        ("?api_key=SUPER_SECRET", "SUPER_SECRET"),
+        ("?apikey=SUPER_SECRET", "SUPER_SECRET"),
+        ("?client_secret=SUPER_SECRET", "SUPER_SECRET"),
+        ("?private_key_passphrase=SUPER_SECRET", "SUPER_SECRET"),
+        ("?signature=SUPER_SECRET", "SUPER_SECRET"),
+        ("?aws_access_key_id=SUPER_SECRET", "SUPER_SECRET"),
+    ],
+)
+def test_redact_text_removes_secret(text, must_not_contain):
+    """`_redact_text` redacts sensitive name=value pairs in arbitrary text.
+
+    The defense-in-depth backstop must catch credentials wherever they
+    appear in the wrapped error message — URL query params, JDBC-style
+    `;`-separated property strings, dict-like reprs, etc. — not just in
+    the URL field we explicitly pass through `_redact_url`.
+    """
+    redacted = _redact_text(text)
+    assert must_not_contain not in redacted, f"secret leaked in: {redacted!r}"
+    assert "***" in redacted
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "auth=jwt",  # auth is a scheme, not a secret
+        "host=trino.example.com",
+        "scheme=https",
+        "port=443",
+        "user=alice",
+        "ssl=true",
+        "[SQL: SELECT * FROM t WHERE k = 'v']",  # SQL embedded — must not get clobbered
+    ],
+)
+def test_redact_text_preserves_non_sensitive(text):
+    assert _redact_text(text) == text
+
+
+def test_execute_sql_error_does_not_leak_credentials():
+    """Connection failures must not include the connection URL in the raised error.
+
+    Secrets can appear anywhere in a URL (userinfo, query params, driver
+    extras), so the URL is now omitted from the error message entirely.
+    """
     pytest.importorskip("psycopg2")
     password = "super-secret-pw"
     url = f"postgresql+psycopg2://alice:{password}@127.0.0.1:1/nope"
@@ -246,7 +303,9 @@ def test_execute_sql_error_does_not_leak_password():
 
     message = str(exc_info.value)
     assert password not in message
-    assert "alice:***@127.0.0.1:1" in message
+    # The URL itself is not echoed in the error message.
+    assert "127.0.0.1" not in message or "from connection:" not in message
+    assert "alice" not in message
 
 
 def test_repr_does_not_leak_password():


### PR DESCRIPTION
## Why

A user reported credentials still leaking in `daft.read_sql` errors on v0.7.11 even after the original redactor in #6902. The URL shape from their stack trace:

```
trino://<USER>@<HOST>:<PORT>?auth=jwt&access_token=<SECRET>&http_scheme=https
```

There's no `user:password@host` here — the secret lives in `access_token=` as a query parameter. The previous fix only redacted userinfo passwords, so the JWT was emitted in plaintext in the `Failed to execute sql: ... from connection: ...` error.

Separately, `urllib.parse.urlparse` silently mis-parses passwords containing `#` / `/` / `?` (it pushes them into the fragment field), so `parsed.password` came back `None` and the old `_redact_url` returned the URL unchanged for inputs like `trino://alice:p#ss@host/db`.

I initially tried to plug both holes inside `_redact_url` (sqlalchemy `make_url` as the parser, plus query-parameter redaction by sensitive-name substring). Reviewers (rchowell) pushed back: *"secrets appear in many places around the connection string and are not limited to query params — we probably shouldn't log it"*. Agreed. Trying to enumerate every shape a credential can take in a connection URL is a losing game.

## What this PR actually does

**Stop echoing the connection URL in error messages and in `SQLConnection.__repr__`.** That's it.

- `RuntimeError(f\"Failed to execute sql: {sql} from connection: {self.conn}, error: {e}\")` → `RuntimeError(f\"Failed to execute sql: {sql}, error: {e}\")`. The caller knows which connection they passed in; the URL is redundant in the message.
- `SQLConnection.__repr__` now returns `SQLConnection(dialect='trino', driver='')` instead of the URL.

Removed alongside: `_redact_url`, `_SENSITIVE_PARAM_KEYWORDS`, `_is_sensitive_param`, the opportunistic SQLAlchemy `make_url` import, and the urllib.parse fallback with its `@`-in-authority heuristic — none of it is needed once the URL itself is not echoed.

## After the fix

```
Failed to execute sql: SELECT * FROM (SELECT * FROM iceberg.namespace.\"table\") AS subquery LIMIT 10,
  error: (trino.exceptions.TrinoConnectionError) failed to execute: HTTPSConnectionPool(...): ...
[SQL: SELECT * FROM (SELECT * FROM iceberg.namespace.\"table\") AS subquery LIMIT 10]
```

No URL, no userinfo, no query parameters.

## Verified end-to-end

Tested locally against the customer's exact URL shape plus two regressions:

| Shape | Secret value | Present in error? |
|---|---|---|
| Trino JWT (`?access_token=<JWT>&auth=jwt`) | the JWT | ✅ No |
| Userinfo password (`alice:hunter2@...`) | `hunter2` | ✅ No |
| Password with `#` (`alice:p#ss@...`) | `p#ss` | ✅ No |

## Tests

`tests/io/test_sql.py`:
- `test_execute_sql_error_does_not_leak_credentials` — parametrized across the three leak shapes; asserts the secret is not in the raised `RuntimeError`.
- `test_repr_does_not_leak_url` — asserts `repr(conn)` contains neither the secret, the host, nor the username.

## Related

Follow-up to #6902 / issue #6903. Customer-reported continued leak after v0.7.11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)