### PR TITLE
test(checkpoint): optional real-S3 routing for checkpoint test suites

### DIFF
--- a/tests/io/_s3_helpers.py
+++ b/tests/io/_s3_helpers.py
@@ -1,0 +1,53 @@
+"""Shared helpers for routing the checkpoint test suites through real S3.
+
+Importing this module activates the routing if ``CHECKPOINTING_TEST_BUCKET``
+is set:
+
+* ``AWS_REGION`` is ensured in env (deltalake-rs reads it for storage routing).
+* Daft's default planning IO config is set to point at the bucket's region,
+  so test-body calls that don't pass ``io_config=`` still talk to S3.
+
+Without the env var, importing is a no-op — fixtures fall back to the local
+filesystem (the default ``make test`` flow).
+
+Only the iceberg + delta checkpoint test suites import this module, so the
+side effects are scoped to those suites' pytest sessions.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import daft
+
+S3_BUCKET = os.environ.get("CHECKPOINTING_TEST_BUCKET")
+S3_REGION = os.environ.get("AWS_REGION", "us-east-2")
+
+
+def s3_uri(sink: str, *parts: str) -> str:
+    """Build an ``s3://`` URI under a per-call uuid prefix.
+
+    ``sink`` ("iceberg" or "delta") namespaces the prefix so the two
+    suites don't collide. Each call gets a fresh prefix, so individual
+    test invocations stay isolated even when reusing the same bucket.
+    """
+    run = f"checkpointing-suite/{sink}/{uuid.uuid4().hex[:8]}"
+    return f"s3://{S3_BUCKET}/{run}/" + "/".join(parts)
+
+
+def s3_io_config() -> daft.io.IOConfig:
+    return daft.io.IOConfig(s3=daft.io.S3Config(region_name=S3_REGION))
+
+
+def delta_storage_options() -> dict[str, str]:
+    return {"AWS_REGION": S3_REGION}
+
+
+if S3_BUCKET:
+    # Ensure deltalake-rs picks up the region from env in test-body calls
+    # that don't pass explicit ``storage_options=``.
+    os.environ.setdefault("AWS_REGION", S3_REGION)
+    # Make daft's default IO config S3-aware so test bodies that don't pass
+    # ``io_config=`` still talk to S3 correctly.
+    daft.set_planning_config(default_io_config=s3_io_config())

--- a/tests/io/delta_lake/test_deltalake_writes_checkpoint.py
+++ b/tests/io/delta_lake/test_deltalake_writes_checkpoint.py
@@ -12,6 +12,10 @@ exactly one new Delta commit tagged with the call's idempotence key.
 The checkpoint-aware source filter (``daft.read_parquet(checkpoint=...)``)
 runs only on the Ray runner, so these tests are skipped on the native
 runner.
+
+Optional: set ``CHECKPOINTING_TEST_BUCKET`` (and ensure ``AWS_REGION`` /
+AWS auth are exported) to route fixtures through real S3 instead of the
+local filesystem. CI defaults to local; S3 is opt-in.
 """
 
 from __future__ import annotations
@@ -26,6 +30,7 @@ import daft
 deltalake = pytest.importorskip("deltalake")
 
 from daft.daft import CheckpointStatus
+from tests.io._s3_helpers import S3_BUCKET, delta_storage_options, s3_io_config, s3_uri
 
 pytestmark = pytest.mark.skipif(
     os.environ.get("DAFT_RUNNER") != "ray",
@@ -39,6 +44,8 @@ IDEMPOTENCE_KEY = "test-run-2026-05-08"
 @pytest.fixture(scope="function")
 def delta_table_path(tmpdir):
     """Path for a Delta table that doesn't exist yet (fresh-table path)."""
+    if S3_BUCKET:
+        return s3_uri("delta", "delta_table")
     return str(tmpdir / "delta_table")
 
 
@@ -48,21 +55,33 @@ def delta_table(delta_table_path):
     import pyarrow as pa
 
     schema = pa.schema([("file_id", pa.string()), ("x", pa.int64())])
-    deltalake.write_deltalake(delta_table_path, pa.table({"file_id": [], "x": []}).cast(schema))
+    empty = pa.table({"file_id": [], "x": []}).cast(schema)
+    if S3_BUCKET:
+        opts = delta_storage_options()
+        deltalake.write_deltalake(delta_table_path, empty, storage_options=opts)
+        return deltalake.DeltaTable(delta_table_path, storage_options=opts)
+    deltalake.write_deltalake(delta_table_path, empty)
     return deltalake.DeltaTable(delta_table_path)
 
 
 @pytest.fixture(scope="function")
 def parquet_input(tmpdir):
     """A small parquet input directory we can read with checkpoint=."""
+    df = daft.from_pydict({"file_id": ["a", "b", "c"], "x": [1, 2, 3]})
+    if S3_BUCKET:
+        path = s3_uri("delta", "input")
+        df.write_parquet(path, io_config=s3_io_config())
+        return path
     path = str(tmpdir / "input")
     os.makedirs(path, exist_ok=True)
-    daft.from_pydict({"file_id": ["a", "b", "c"], "x": [1, 2, 3]}).write_parquet(path)
+    df.write_parquet(path)
     return path
 
 
 @pytest.fixture(scope="function")
 def checkpoint_store(tmpdir):
+    if S3_BUCKET:
+        return daft.CheckpointStore(s3_uri("delta", "ckpt"), io_config=s3_io_config())
     return daft.CheckpointStore(f"file://{tmpdir}/ckpt")
 
 
@@ -72,6 +91,8 @@ def idempotent_commit(checkpoint_store):
 
 
 def _read_delta_rows(table_path: str) -> dict:
+    if S3_BUCKET:
+        return daft.read_deltalake(table_path, io_config=s3_io_config()).to_pydict()
     return daft.read_deltalake(table_path).to_pydict()
 
 

--- a/tests/io/iceberg/test_iceberg_writes_checkpoint.py
+++ b/tests/io/iceberg/test_iceberg_writes_checkpoint.py
@@ -12,6 +12,10 @@ exactly one new Iceberg snapshot tagged with the call's idempotence key.
 The checkpoint-aware source filter (``daft.read_parquet(checkpoint=...)``)
 runs only on the Ray runner, so these tests are skipped on the native
 runner. See ``tests/checkpoint/test_native_runner_gate.py``.
+
+Optional: set ``CHECKPOINTING_TEST_BUCKET`` (and ensure ``AWS_REGION`` /
+AWS auth are exported) to route fixtures through real S3 instead of the
+local filesystem. CI defaults to local; S3 is opt-in.
 """
 
 from __future__ import annotations
@@ -33,6 +37,7 @@ from pyiceberg.table import Transaction
 from pyiceberg.types import LongType, NestedField, StringType
 
 from daft.daft import CheckpointStatus
+from tests.io._s3_helpers import S3_BUCKET, S3_REGION, s3_io_config, s3_uri
 
 pytestmark = pytest.mark.skipif(
     os.environ.get("DAFT_RUNNER") != "ray",
@@ -45,11 +50,19 @@ IDEMPOTENCE_KEY = "test-run-2026-05-04"
 
 @pytest.fixture(scope="function")
 def local_catalog(tmpdir):
-    catalog = SqlCatalog(
-        "default",
-        uri=f"sqlite:///{tmpdir}/pyiceberg_catalog.db",
-        warehouse=f"file://{tmpdir}",
-    )
+    if S3_BUCKET:
+        catalog = SqlCatalog(
+            "default",
+            uri=f"sqlite:///{tmpdir}/pyiceberg_catalog.db",
+            warehouse=s3_uri("iceberg", "warehouse"),
+            **{"s3.region": S3_REGION},
+        )
+    else:
+        catalog = SqlCatalog(
+            "default",
+            uri=f"sqlite:///{tmpdir}/pyiceberg_catalog.db",
+            warehouse=f"file://{tmpdir}",
+        )
     catalog.create_namespace("default")
     yield catalog
     catalog.engine.dispose()
@@ -83,14 +96,21 @@ def partitioned_iceberg_table(local_catalog):
 @pytest.fixture(scope="function")
 def parquet_input(tmpdir):
     """A small parquet input directory we can read with checkpoint=."""
+    df = daft.from_pydict({"file_id": ["a", "b", "c"], "x": [1, 2, 3]})
+    if S3_BUCKET:
+        path = s3_uri("iceberg", "input")
+        df.write_parquet(path, io_config=s3_io_config())
+        return path
     path = str(tmpdir / "input")
     os.makedirs(path, exist_ok=True)
-    daft.from_pydict({"file_id": ["a", "b", "c"], "x": [1, 2, 3]}).write_parquet(path)
+    df.write_parquet(path)
     return path
 
 
 @pytest.fixture(scope="function")
 def checkpoint_store(tmpdir):
+    if S3_BUCKET:
+        return daft.CheckpointStore(s3_uri("iceberg", "ckpt"), io_config=s3_io_config())
     return daft.CheckpointStore(f"file://{tmpdir}/ckpt")
 
 


### PR DESCRIPTION
## Changes Made

Adds opt-in S3 routing to the iceberg + delta checkpoint test suites. When `CHECKPOINTING_TEST_BUCKET` is set, fixtures route warehouses, parquet inputs, and checkpoint stores through real S3. When absent, behavior is unchanged — local filesystem, the CI default.

Shared helpers in `tests/io/_s3_helpers.py`. Side effects on daft's planning config + `AWS_REGION` env var fire at module import time, so only the two suites that import them are affected.

Run command:

```
eval "$(aws configure export-credentials --profile <profile> --format env)"
CHECKPOINTING_TEST_BUCKET=<bucket> \
AWS_REGION=us-east-2 \
DAFT_RUNNER=ray \
make test EXTRA_ARGS="-v tests/io/iceberg/test_iceberg_writes_checkpoint.py tests/io/delta_lake/test_deltalake_writes_checkpoint.py"
```

## Related Issues

Stacked on top of #6932.