### PR TITLE
feat: register python data sources

### DIFF
--- a/daft/__init__.py
+++ b/daft/__init__.py
@@ -125,6 +125,7 @@ from daft.session import (
     list_catalogs,
     list_tables,
     load_extension,
+    read_source,
     read_table,
     session,
     set_catalog,
@@ -164,6 +165,7 @@ from daft.file import File, VideoFile, AudioFile, ImageFile
 range = _range  # type: ignore[no-redef,unused-ignore]
 
 from daft import context
+from daft import data_sources
 from daft import io
 from daft import runners
 from daft import datasets
@@ -229,6 +231,7 @@ __all__ = [
     "current_namespace",
     "current_provider",
     "current_session",
+    "data_sources",
     "datasets",
     "detach_catalog",
     "detach_function",
@@ -282,6 +285,7 @@ __all__ = [
     "read_mcap",
     "read_paimon",
     "read_parquet",
+    "read_source",
     "read_sql",
     "read_table",
     "read_text",

--- a/daft/data_sources.py
+++ b/daft/data_sources.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from daft.dataframe import DataFrame
+    from daft.io.source import DataSource
+
+_builtin_list = list
+
+
+def register(data_source: type[DataSource], *, name: str | None = None, replace: bool = False) -> None:
+    """Register a Python ``DataSource`` class on the current session."""
+    from daft.session import current_session
+
+    current_session().register_data_source(data_source, name=name, replace=replace)
+
+
+def unregister(name: str) -> None:
+    """Remove a registered Python ``DataSource`` from the current session."""
+    from daft.session import current_session
+
+    current_session().unregister_data_source(name)
+
+
+def get(name: str) -> type[DataSource]:
+    """Return a registered Python ``DataSource`` class."""
+    from daft.session import current_session
+
+    return current_session().get_data_source(name)
+
+
+def list() -> _builtin_list[str]:
+    """List registered Python ``DataSource`` names."""
+    from daft.session import current_session
+
+    return current_session().list_data_sources()
+
+
+def read(name: str, **options: Any) -> DataFrame:
+    """Read a registered Python ``DataSource`` by name."""
+    from daft.session import current_session
+
+    return current_session().read_source(name, **options)
+
+
+__all__ = [
+    "get",
+    "list",
+    "read",
+    "register",
+    "unregister",
+]

--- a/daft/session.py
+++ b/daft/session.py
@@ -85,11 +85,29 @@ def _data_source_registration_name(data_source: type[DataSource], name: str | No
         source_name_attr = inspect.getattr_static(data_source, "name", None)
         if isinstance(source_name_attr, property):
             try:
-                source_name = data_source().name
-            except TypeError as e:
+                sig: inspect.Signature | None = inspect.signature(data_source)
+            except (TypeError, ValueError):
+                sig = None
+            if sig is not None and any(
+                p.default is inspect.Parameter.empty
+                and p.kind
+                in (
+                    inspect.Parameter.POSITIONAL_ONLY,
+                    inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                    inspect.Parameter.KEYWORD_ONLY,
+                )
+                for p in sig.parameters.values()
+            ):
                 raise ValueError(
-                    "DataSource defines name as an instance property; pass name= explicitly "
-                    "if the source constructor requires arguments"
+                    "DataSource defines name as an instance property and its constructor "
+                    "requires arguments; pass name= explicitly"
+                )
+            try:
+                source_name = data_source().name
+            except Exception as e:
+                raise ValueError(
+                    f"DataSource defines name as an instance property but instantiating it "
+                    f"with no arguments failed: {e}. Pass name= explicitly."
                 ) from e
         else:
             source_name_func = getattr(data_source, "name", None)
@@ -102,10 +120,17 @@ def _data_source_registration_name(data_source: type[DataSource], name: str | No
     return source_name
 
 
-def _read_registered_data_source(name: str, inner: DataSource) -> DataFrame:
+_RegisteredDataSourceCls: type[DataSource] | None = None
+
+
+def _registered_data_source_cls() -> type[DataSource]:
+    global _RegisteredDataSourceCls
+    if _RegisteredDataSourceCls is not None:
+        return _RegisteredDataSourceCls
+
     from daft.io.source import DataSource
 
-    class RegisteredDataSource(DataSource):
+    class _RegisteredDataSource(DataSource):
         def __init__(self, registered_name: str, wrapped: DataSource) -> None:
             self._registered_name = registered_name
             self._wrapped = wrapped
@@ -125,7 +150,13 @@ def _read_registered_data_source(name: str, inner: DataSource) -> DataFrame:
             async for task in self._wrapped.get_tasks(pushdowns):
                 yield task
 
-    return RegisteredDataSource(name, inner).read()
+    _RegisteredDataSourceCls = _RegisteredDataSource
+    return _RegisteredDataSourceCls
+
+
+def _read_registered_data_source(name: str, inner: DataSource) -> DataFrame:
+    registered_data_source_cls: Any = _registered_data_source_cls()
+    return registered_data_source_cls(name, inner).read()
 
 
 def session() -> Session:
@@ -737,7 +768,13 @@ class Session:
         name: str | None = None,
         replace: bool = False,
     ) -> None:
-        """Register a Python ``DataSource`` class with this session."""
+        """Register a Python ``DataSource`` class with this session.
+
+        If ``name`` is omitted and the class declares ``name`` as an instance
+        ``@property``, the class is instantiated with no arguments to read it.
+        Pass ``name=`` explicitly to skip that construction (e.g. when the
+        constructor has side effects or requires arguments).
+        """
         from daft.io.source import DataSource
 
         if not isinstance(data_source, type) or not issubclass(data_source, DataSource):

--- a/daft/session.py
+++ b/daft/session.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ctypes
+import inspect
 import platform
 import types
 import warnings
@@ -20,7 +21,12 @@ from daft.logical.schema import Schema
 from daft.udf import UDF
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
     from types import TracebackType
+
+    from daft.io.partitioning import PartitionField
+    from daft.io.pushdowns import Pushdowns
+    from daft.io.source import DataSource, DataSourceTask
 
 __all__ = [
     "Session",
@@ -58,6 +64,7 @@ __all__ = [
     "list_catalogs",
     "list_namespaces",
     "list_tables",
+    "read_source",
     "read_table",
     "set_catalog",
     "set_model",
@@ -69,6 +76,56 @@ __all__ = [
 
 
 _current_session: ContextVar[Session | None] = ContextVar("current_session", default=None)
+
+
+def _data_source_registration_name(data_source: type[DataSource], name: str | None) -> str:
+    if name is not None:
+        source_name = name
+    else:
+        source_name_attr = inspect.getattr_static(data_source, "name", None)
+        if isinstance(source_name_attr, property):
+            try:
+                source_name = data_source().name
+            except TypeError as e:
+                raise ValueError(
+                    "DataSource defines name as an instance property; pass name= explicitly "
+                    "if the source constructor requires arguments"
+                ) from e
+        else:
+            source_name_func = getattr(data_source, "name", None)
+            if not callable(source_name_func):
+                raise ValueError("DataSource has no callable name; pass name= explicitly")
+            source_name = source_name_func()
+
+    if not isinstance(source_name, str) or not source_name:
+        raise ValueError("DataSource name must be a non-empty string")
+    return source_name
+
+
+def _read_registered_data_source(name: str, inner: DataSource) -> DataFrame:
+    from daft.io.source import DataSource
+
+    class RegisteredDataSource(DataSource):
+        def __init__(self, registered_name: str, wrapped: DataSource) -> None:
+            self._registered_name = registered_name
+            self._wrapped = wrapped
+
+        @property
+        def name(self) -> str:
+            return self._registered_name
+
+        @property
+        def schema(self) -> Schema:
+            return self._wrapped.schema
+
+        def get_partition_fields(self) -> list[PartitionField]:
+            return self._wrapped.get_partition_fields()
+
+        async def get_tasks(self, pushdowns: Pushdowns) -> AsyncIterator[DataSourceTask]:
+            async for task in self._wrapped.get_tasks(pushdowns):
+                yield task
+
+    return RegisteredDataSource(name, inner).read()
 
 
 def session() -> Session:
@@ -111,6 +168,7 @@ class Session:
     def __init__(self) -> None:
         self._session = PySession.empty()
         self._token: Token[Session | None] | None = None
+        self._data_sources: dict[str, type[DataSource]] = {}
 
     ###
     # context manager methods
@@ -138,6 +196,8 @@ class Session:
         """Creates a session from a rust session wrapper."""
         s = Session.__new__(Session)
         s._session = session
+        s._token = None
+        s._data_sources = {}
         return s
 
     @staticmethod
@@ -670,6 +730,48 @@ class Session:
         """
         return self.get_table(identifier).read(**options)
 
+    def register_data_source(
+        self,
+        data_source: type[DataSource],
+        *,
+        name: str | None = None,
+        replace: bool = False,
+    ) -> None:
+        """Register a Python ``DataSource`` class with this session."""
+        from daft.io.source import DataSource
+
+        if not isinstance(data_source, type) or not issubclass(data_source, DataSource):
+            raise TypeError(f"Expected a DataSource class, got {data_source!r}")
+
+        source_name = _data_source_registration_name(data_source, name)
+        if not replace and source_name in self._data_sources:
+            raise ValueError(f"DataSource {source_name!r} is already registered")
+        self._data_sources[source_name] = data_source
+
+    def unregister_data_source(self, name: str) -> None:
+        """Remove a registered Python ``DataSource`` from this session."""
+        try:
+            del self._data_sources[name]
+        except KeyError as e:
+            raise ValueError(f"DataSource {name!r} is not registered") from e
+
+    def get_data_source(self, name: str) -> type[DataSource]:
+        """Return a registered Python ``DataSource`` class."""
+        try:
+            return self._data_sources[name]
+        except KeyError as e:
+            raise ValueError(f"DataSource {name!r} is not registered") from e
+
+    def list_data_sources(self) -> list[str]:
+        """List registered Python ``DataSource`` names."""
+        return sorted(self._data_sources)
+
+    def read_source(self, name: str, **options: Any) -> DataFrame:
+        """Read a registered Python ``DataSource`` by name."""
+        data_source = self.get_data_source(name)
+        source = data_source(**options)
+        return _read_registered_data_source(name, source)
+
     ###
     # set_*
     ###
@@ -995,6 +1097,11 @@ def load_extension(extension: str | types.ModuleType | Path) -> None:
 def read_table(identifier: Identifier | str, **options: Any) -> DataFrame:
     """Returns the table as a DataFrame or raises an exception if it does not exist."""
     return _session().read_table(identifier, **options)
+
+
+def read_source(name: str, **options: Any) -> DataFrame:
+    """Read a registered Python ``DataSource`` by name."""
+    return _session().read_source(name, **options)
 
 
 ###

--- a/docs/api/io.md
+++ b/docs/api/io.md
@@ -84,6 +84,10 @@ Daft offers a variety of approaches to creating a DataFrame from reading various
     options:
         heading_level: 3
 
+::: daft.read_source
+    options:
+        heading_level: 3
+
 ::: daft.sql.sql.sql
     options:
         heading_level: 3
@@ -156,6 +160,26 @@ Daft supports diverse input sources and output sinks, this section covers lower-
 ::: daft.io.source.DataSourceTask
     options:
         filters: ["!^_"]
+        heading_level: 3
+
+::: daft.data_sources.register
+    options:
+        heading_level: 3
+
+::: daft.data_sources.read
+    options:
+        heading_level: 3
+
+::: daft.data_sources.get
+    options:
+        heading_level: 3
+
+::: daft.data_sources.list
+    options:
+        heading_level: 3
+
+::: daft.data_sources.unregister
+    options:
         heading_level: 3
 
 ::: daft.io.sink.DataSink

--- a/docs/api/sessions.md
+++ b/docs/api/sessions.md
@@ -13,3 +13,7 @@ Sessions enable you to attach objects such as catalogs, providers, models, funct
 ::: daft.session.Session
     options:
         filters: ["!^_"]
+
+::: daft.session.read_source
+    options:
+        heading_level: 3

--- a/docs/connectors/custom.md
+++ b/docs/connectors/custom.md
@@ -23,12 +23,13 @@ Create a class that inherits from [`DataSource`](../api/io.md#daft.io.source.Dat
 
 === "🐍 Python"
 ```python
-from collections.abc import Iterator
+from collections.abc import AsyncIterator
 from pathlib import Path
 
 from daft.datatype import DataType
+from daft.io.pushdowns import Pushdowns
 from daft.io import DataSource, DataSourceTask
-from daft.recordbatch import MicroPartition
+from daft.recordbatch import RecordBatch
 from daft.schema import Schema
 
 
@@ -38,6 +39,10 @@ class TextFileDataSource(DataSource):
     Each line in the text file becomes a row in the dataframe.
     """
 
+    @property
+    def name(self) -> str:
+        return "text_file"
+
     def __init__(self, file_paths: list[str]):
         """Initialize the text file data source.
 
@@ -45,11 +50,6 @@ class TextFileDataSource(DataSource):
             file_paths: List of text file paths to read from
         """
         self.file_paths = [Path(path) for path in file_paths]
-
-    @property
-    def name(self) -> str:
-        """Return a descriptive name for this source."""
-        return "Text File Data Source"
 
     @property
     def schema(self) -> Schema:
@@ -62,7 +62,7 @@ class TextFileDataSource(DataSource):
             ("line", DataType.string()),
         ])
 
-    def get_tasks(self, pushdowns) -> Iterator["TextFileDataSourceTask"]:
+    async def get_tasks(self, pushdowns: Pushdowns) -> AsyncIterator["TextFileDataSourceTask"]:
         """Create tasks for each file to enable parallel processing.
 
         Args:
@@ -76,7 +76,7 @@ class TextFileDataSource(DataSource):
 
 
 class TextFileDataSourceTask(DataSourceTask):
-    """A task that reads a single text file and converts it to MicroPartitions."""
+    """A task that reads a single text file and converts it to RecordBatches."""
 
     def __init__(self, file_path: Path):
         """Initialize the task with a specific file path.
@@ -93,27 +93,27 @@ class TextFileDataSourceTask(DataSourceTask):
             ("line", DataType.string()),
         ])
 
-    def get_micro_partitions(self) -> Iterator[MicroPartition]:
-        """Read the text file and yield MicroPartitions.
+    async def read(self) -> AsyncIterator[RecordBatch]:
+        """Read the text file and yield RecordBatches.
 
-        This method reads the file line by line and creates MicroPartitions
+        This method reads the file line by line and creates RecordBatches
         containing the line data.
 
         Yields:
-            MicroPartition: Contains the lines from the text file
+            RecordBatch: Contains the lines from the text file
         """
         lines = []
         with open(self.file_path, encoding='utf-8') as f:
             for line in f:
                 lines.append(line)
 
-        # Create a single MicroPartition with all lines.
-        yield MicroPartition.from_pydict({
+        # Create a single RecordBatch with all lines.
+        yield RecordBatch.from_pydict({
             "line": lines,
         })
 ```
 
-### Step 2: Use Your Custom Data Source to Create a Daft DataFrame
+### Step 2: Register and Read Your Custom Data Source
 
 === "🐍 Python"
 ```python
@@ -128,13 +128,23 @@ with open(sample_file, "w") as f:
     f.write("There was nothing so very remarkable in that;\n")
     f.write("nor did Alice think it so very much out of the way to hear the Rabbit say to itself, 'Oh dear! Oh dear! I shall be late!'\n")
 
-data_source = TextFileDataSource([sample_file])
+daft.data_sources.register(TextFileDataSource, name="text_file")
 
 (
-    data_source
-    .read()
+    daft.read_source("text_file", file_paths=[sample_file])
     .show()
 )
+```
+
+`daft.data_sources.register()` registers the source class on the current session. `daft.read_source()` instantiates the registered source with the keyword arguments you pass and returns a DataFrame. Pass `name=` when the source constructor requires arguments.
+
+You can also register sources on an explicit session:
+
+=== "🐍 Python"
+```python
+with daft.session() as sess:
+    sess.register_data_source(TextFileDataSource, name="text_file")
+    df = sess.read_source("text_file", file_paths=[sample_file])
 ```
 
 **Output:**

--- a/tests/io/test_data_source_registry.py
+++ b/tests/io/test_data_source_registry.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pyarrow as pa
+import pytest
+
+import daft
+from daft.io.pushdowns import Pushdowns
+from daft.io.source import DataSource, DataSourceTask
+from daft.recordbatch import RecordBatch
+from daft.schema import Schema
+
+
+class _TableTask(DataSourceTask):
+    def __init__(self, table: pa.Table) -> None:
+        self._table = table
+
+    @property
+    def schema(self) -> Schema:
+        return Schema.from_pyarrow_schema(self._table.schema)
+
+    async def read(self) -> AsyncIterator[RecordBatch]:
+        for batch in self._table.to_batches():
+            yield RecordBatch.from_arrow_record_batches([batch], self._table.schema)
+
+
+class _SimpleDataSource(DataSource):
+    @classmethod
+    def name(cls) -> str:
+        return "simple"
+
+    def __init__(self, rows: int = 2) -> None:
+        self._rows = rows
+
+    @property
+    def schema(self) -> Schema:
+        return Schema.from_pyarrow_schema(pa.schema([("id", pa.int64()), ("value", pa.string())]))
+
+    async def get_tasks(self, pushdowns: Pushdowns) -> AsyncIterator[DataSourceTask]:
+        del pushdowns
+        yield _TableTask(pa.table({"id": list(range(self._rows)), "value": [f"v{i}" for i in range(self._rows)]}))
+
+
+class _PropertyNameDataSource(DataSource):
+    def __init__(self, x: int = 1) -> None:
+        self._x = x
+
+    @property
+    def name(self) -> str:
+        return "property_name"
+
+    @property
+    def schema(self) -> Schema:
+        return Schema.from_pyarrow_schema(pa.schema([("x", pa.int64())]))
+
+    async def get_tasks(self, pushdowns: Pushdowns) -> AsyncIterator[DataSourceTask]:
+        del pushdowns
+        yield _TableTask(pa.table({"x": [self._x]}))
+
+
+class _RequiredArgPropertyNameDataSource(DataSource):
+    def __init__(self, x: int) -> None:
+        self._x = x
+
+    @property
+    def name(self) -> str:
+        return "required_arg_property_name"
+
+    @property
+    def schema(self) -> Schema:
+        return Schema.from_pyarrow_schema(pa.schema([("x", pa.int64())]))
+
+    async def get_tasks(self, pushdowns: Pushdowns) -> AsyncIterator[DataSourceTask]:
+        del pushdowns
+        yield _TableTask(pa.table({"x": [self._x]}))
+
+
+def test_register_and_read_source():
+    with daft.session() as sess:
+        sess.register_data_source(_SimpleDataSource)
+
+        assert sess.list_data_sources() == ["simple"]
+        assert sess.get_data_source("simple") is _SimpleDataSource
+        assert sess.read_source("simple", rows=3).to_pydict() == {"id": [0, 1, 2], "value": ["v0", "v1", "v2"]}
+
+
+def test_data_sources_module_uses_current_session():
+    with daft.session():
+        daft.data_sources.register(_SimpleDataSource)
+
+        assert daft.data_sources.list() == ["simple"]
+        assert daft.data_sources.read("simple", rows=1).to_pydict() == {"id": [0], "value": ["v0"]}
+        assert daft.read_source("simple", rows=1).to_pydict() == {"id": [0], "value": ["v0"]}
+
+
+def test_register_duplicate_requires_replace():
+    with daft.session() as sess:
+        sess.register_data_source(_SimpleDataSource)
+
+        with pytest.raises(ValueError, match="already registered"):
+            sess.register_data_source(_SimpleDataSource)
+
+        sess.register_data_source(_SimpleDataSource, replace=True)
+
+
+def test_property_name_source_can_be_registered_when_default_constructible():
+    with daft.session() as sess:
+        sess.register_data_source(_PropertyNameDataSource)
+
+        assert sess.read_source("property_name", x=2).to_pydict() == {"x": [2]}
+
+
+def test_property_name_source_with_required_args_uses_explicit_registration_name():
+    with daft.session() as sess:
+        with pytest.raises(ValueError, match="pass name= explicitly"):
+            sess.register_data_source(_RequiredArgPropertyNameDataSource)
+
+        sess.register_data_source(_RequiredArgPropertyNameDataSource, name="required_arg_property_name")
+        assert sess.read_source("required_arg_property_name", x=3).to_pydict() == {"x": [3]}
+
+
+def test_unregister_source():
+    with daft.session() as sess:
+        sess.register_data_source(_SimpleDataSource)
+        sess.unregister_data_source("simple")
+
+        assert sess.list_data_sources() == []
+        with pytest.raises(ValueError, match="not registered"):
+            sess.read_source("simple")
+
+
+def test_get_unknown_source_errors():
+    with daft.session() as sess:
+        with pytest.raises(ValueError, match="not registered"):
+            sess.get_data_source("missing")
+
+
+def test_data_source_registry_is_session_scoped():
+    with daft.session() as outer:
+        outer.register_data_source(_SimpleDataSource)
+
+        with daft.session() as inner:
+            assert inner.list_data_sources() == []
+            inner.register_data_source(_PropertyNameDataSource)
+            assert inner.list_data_sources() == ["property_name"]
+
+        assert outer.list_data_sources() == ["simple"]

--- a/tests/io/test_data_source_registry.py
+++ b/tests/io/test_data_source_registry.py
@@ -120,6 +120,29 @@ def test_property_name_source_with_required_args_uses_explicit_registration_name
         assert sess.read_source("required_arg_property_name", x=3).to_pydict() == {"x": [3]}
 
 
+class _RaisingInitDataSource(DataSource):
+    def __init__(self) -> None:
+        raise RuntimeError("boom")
+
+    @property
+    def name(self) -> str:
+        return "raising"
+
+    @property
+    def schema(self) -> Schema:
+        return Schema.from_pyarrow_schema(pa.schema([("x", pa.int64())]))
+
+    async def get_tasks(self, pushdowns: Pushdowns) -> AsyncIterator[DataSourceTask]:
+        del pushdowns
+        yield _TableTask(pa.table({"x": [0]}))
+
+
+def test_property_name_source_with_failing_init_wraps_error():
+    with daft.session() as sess:
+        with pytest.raises(ValueError, match="instantiating it with no arguments failed.*boom"):
+            sess.register_data_source(_RaisingInitDataSource)
+
+
 def test_unregister_source():
     with daft.session() as sess:
         sess.register_data_source(_SimpleDataSource)


### PR DESCRIPTION
## Summary
- add a session-scoped Python DataSource registry
- expose `daft.data_sources.register(...)` and `daft.read_source(...)`
- document the registry flow in the custom connector guide and API refs

## Validation
- `.venv/bin/ruff check daft/session.py daft/__init__.py daft/data_sources.py tests/io/test_data_source_registry.py`
- `DAFT_RUNNER=native make test EXTRA_ARGS="-q tests/io/test_data_source_registry.py"`

Replaces #6806.