### PR TITLE
docs: add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,3 +26,13 @@
 
 - Titles: Conventional Commits format; enforced by `.github/workflows/pr-labeller.yml`.
 - Descriptions: follow `.github/pull_request_template.md`.
+
+## Cursor Cloud specific instructions
+
+- **Daft is a Python+Rust library, not a web service.** There are no long-running services to start. The development loop is: `make .venv` → `make build` → run tests/scripts.
+- The Rust build (`make build`) takes ~4-5 minutes on a fresh compile. Incremental rebuilds after small Rust changes are much faster.
+- The `make build` target uses `maturin develop --uv`, which compiles the Rust extension and installs it into the venv in-place. A `patchelf` warning may appear — it is harmless and can be ignored.
+- Always use `DAFT_RUNNER=native` for tests unless specifically testing distributed/Ray functionality. Example: `DAFT_RUNNER=native make test EXTRA_ARGS="-v tests/dataframe/test_select.py"`.
+- Lint commands: `ruff check daft/` for Python, `cargo clippy --all-features` for Rust. The full pre-commit suite is available via `make check-format`.
+- `make doctests` runs docstring examples; useful for verifying API doc correctness.
+- The `uv` package manager and Python 3.11 must be on `$PATH`. If using the update script, `$HOME/.local/bin` is added to PATH for this purpose.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Changes Made

Added a `## Cursor Cloud specific instructions` section to `AGENTS.md` with non-obvious development environment notes for future Cloud Agents:

- Clarifies Daft is a library (no services to start)
- Documents Rust build time expectations and the harmless `patchelf` warning
- Notes the required `DAFT_RUNNER=native` env var for tests
- Lists lint commands for both Python (ruff) and Rust (clippy)
- Documents that `uv` and Python 3.11 must be on `$PATH`

## Related Issues

N/A — environment setup documentation for Cloud Agents.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2e48c2a6-84bc-4cb8-8116-a4cc5b3b826b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e48c2a6-84bc-4cb8-8116-a4cc5b3b826b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

