### PR TITLE
docs: Update API references and fix code examples

### DIFF
--- a/docs/connectors/custom.md
+++ b/docs/connectors/custom.md
@@ -23,12 +23,13 @@ Create a class that inherits from [`DataSource`](../api/io.md#daft.io.source.Dat
 
 === "🐍 Python"
 ```python
-from collections.abc import Iterator
+from collections.abc import AsyncIterator
 from pathlib import Path
 
 from daft.datatype import DataType
 from daft.io import DataSource, DataSourceTask
-from daft.recordbatch import MicroPartition
+from daft.io.pushdowns import Pushdowns
+from daft.recordbatch import RecordBatch
 from daft.schema import Schema
 
 
@@ -62,7 +63,7 @@ class TextFileDataSource(DataSource):
             ("line", DataType.string()),
         ])
 
-    def get_tasks(self, pushdowns) -> Iterator["TextFileDataSourceTask"]:
+    async def get_tasks(self, pushdowns: Pushdowns) -> AsyncIterator["TextFileDataSourceTask"]:
         """Create tasks for each file to enable parallel processing.
 
         Args:
@@ -76,7 +77,7 @@ class TextFileDataSource(DataSource):
 
 
 class TextFileDataSourceTask(DataSourceTask):
-    """A task that reads a single text file and converts it to MicroPartitions."""
+    """A task that reads a single text file and converts it to RecordBatches."""
 
     def __init__(self, file_path: Path):
         """Initialize the task with a specific file path.
@@ -93,22 +94,22 @@ class TextFileDataSourceTask(DataSourceTask):
             ("line", DataType.string()),
         ])
 
-    def get_micro_partitions(self) -> Iterator[MicroPartition]:
-        """Read the text file and yield MicroPartitions.
+    async def read(self) -> AsyncIterator[RecordBatch]:
+        """Read the text file and yield RecordBatches.
 
-        This method reads the file line by line and creates MicroPartitions
+        This method reads the file line by line and creates RecordBatches
         containing the line data.
 
         Yields:
-            MicroPartition: Contains the lines from the text file
+            RecordBatch: Contains the lines from the text file
         """
         lines = []
         with open(self.file_path, encoding='utf-8') as f:
             for line in f:
                 lines.append(line)
 
-        # Create a single MicroPartition with all lines.
-        yield MicroPartition.from_pydict({
+        # Create a single RecordBatch with all lines.
+        yield RecordBatch.from_pydict({
             "line": lines,
         })
 ```

--- a/docs/connectors/unity_catalog.md
+++ b/docs/connectors/unity_catalog.md
@@ -106,7 +106,7 @@ Daft supports downloading from Unity Catalog volumes using [`Expression.download
 
     # explicitly specify the unity catalog
     io_config = unity.to_io_config()
-    data_df = df.select("vol+dbfs:" + df["files"].download(io_config=io_config))
+    data_df = df.select(("vol+dbfs:" + df["files"]).download(io_config=io_config))
     data_df.show()
 
     # use the global session

--- a/docs/modalities/audio.md
+++ b/docs/modalities/audio.md
@@ -290,7 +290,7 @@ df_transcript = (
     # Unpack Results
     .select("path", daft.col("result").unnest())
     .explode("segments")
-    .select("path", "info", "transcript", daft.unnest(daft.col("segments")))
+    .select("path", "info", "transcript", daft.functions.unnest(daft.col("segments")))
 )
 
 df_transcript.show(3, format="fancy", max_width=40)

--- a/docs/modalities/audio.md
+++ b/docs/modalities/audio.md
@@ -282,7 +282,7 @@ df_transcript = (
     daft.from_glob_path(SOURCE_URI)
 
     # Wrap the path as a daft.File
-    .with_column("audio_file", file(col("path")))
+    .with_column("audio_file", file(daft.col("path")))
 
     # Transcribe the audio file with Voice Activity Detection (VAD) using Faster Whisper
     .with_column("result", fwt.transcribe(daft.col("audio_file")))
@@ -290,7 +290,7 @@ df_transcript = (
     # Unpack Results
     .select("path", daft.col("result").unnest())
     .explode("segments")
-    .select("path", "info", "transcript", unnest(daft.col("segments")))
+    .select("path", "info", "transcript", daft.unnest(daft.col("segments")))
 )
 
 df_transcript.show(3, format="fancy", max_width=40)

--- a/docs/modalities/images.md
+++ b/docs/modalities/images.md
@@ -544,9 +544,12 @@ This is necessary because multimodal data such as images, videos, and audio file
 === "🐍 Python"
     ```python
     # Each operation uses different batch sizes automatically
-    df = daft.read_parquet("metadata.parquet") # Large batches
-          .with_column("image_data", col("urls").download())  # Small batches
-          .with_column("resized", col("image_data").resize(224, 224))  # Medium batches
+    df = (
+        daft.read_parquet("metadata.parquet")  # Large batches
+        .with_column("image_data", col("urls").download())  # Small batches
+        .with_column("image", col("image_data").decode_image())  # Decode to image
+        .with_column("resized", col("image").resize(224, 224))  # Medium batches
+    )
     ```
 
 This approach allows processing of datasets larger than available memory, while maintaining optimal performance for each operation type.


### PR DESCRIPTION
Fixes critical doc issues from the [documentation audit](https://eventualgroup.slack.com/archives/C0ARMCJKZCN/p1778780482358339?thread_ts=1778746580.784789&cid=C0ARMCJKZCN):

- **custom.md**: Use async `get_tasks`/`read` and `RecordBatch` instead of deprecated sync `get_micro_partitions`/`MicroPartition`
- **unity_catalog.md**: Fix operator precedence so URL prefix is added before download
- **images.md**: Add missing `decode_image()` between download and resize
- **audio.md**: Fix undefined `col` and `unnest` references

https://claude.ai/code/session_01LNzvmX91kjcWo7htEmEQM7