### PR TITLE
docs(examples): migrate text-embeddings example to public bucket

### DIFF
--- a/docs/examples/text-embeddings.md
+++ b/docs/examples/text-embeddings.md
@@ -201,7 +201,7 @@ Now we'll execute the complete data processing pipeline:
 
 ```python
 (
-    daft.read_parquet("s3://desmond-demo/text-embedding-dataset.parquet")
+    daft.read_parquet("s3://daft-public-data/text-embedding-dataset.parquet")
     .with_column("sentences", ChunkingUDF(col("text")))
     .explode("sentences")
     .with_column("text", col("sentences")["text"])
@@ -214,7 +214,7 @@ Now we'll execute the complete data processing pipeline:
     )
     .select("id", "url", "language", "source", "text", "embedding")
     .write_turbopuffer(
-        namespace="desmond-scale-experiment6",
+        namespace="text-embeddings-example",
         region="aws-us-west-2",
         id_column="id",
         vector_column="embedding",
@@ -336,7 +336,7 @@ def main():
     )
 
     (
-        daft.read_parquet("s3://desmond-demo/text-embedding-dataset.parquet")
+        daft.read_parquet("s3://daft-public-data/text-embedding-dataset.parquet")
         .with_column("sentences", ChunkingUDF(col("text")))
         .explode("sentences")
         .with_column("text", col("sentences")["text"])
@@ -349,7 +349,7 @@ def main():
         )
         .select("id", "url", "language", "source", "text", "embedding")
         .write_turbopuffer(
-            namespace="desmond-scale-experiment6",
+            namespace="text-embeddings-example",
             region="aws-us-west-2",
             id_column="id",
             vector_column="embedding",


### PR DESCRIPTION
- Updates `docs/examples/text-embeddings.md` to read from `s3://daft-public-data/text-embedding-dataset.parquet` instead of `s3://desmond-demo/...`. The dataset has been copied (1.38 GB, 8 parquet parts) to the public bucket.
- Renames the example's turbopuffer namespace from `desmond-scale-experiment6` to `text-embeddings-example`.