### PR TITLE
fix: align hash implementations with equality

### DIFF
--- a/src/daft-core/src/lit/mod.rs
+++ b/src/daft-core/src/lit/mod.rs
@@ -123,6 +123,7 @@ impl Eq for Literal {}
 
 impl Hash for Literal {
     fn hash<H: Hasher>(&self, state: &mut H) {
+        std::mem::discriminant(self).hash(state);
         match self {
             Self::Null => 1.hash(state),
             Self::Boolean(bool) => bool.hash(state),
@@ -610,9 +611,20 @@ pub trait FromLiteral: Sized {
 
 #[cfg(test)]
 mod test {
+    use std::{
+        collections::hash_map::DefaultHasher,
+        hash::{Hash, Hasher},
+    };
+
     use common_error::DaftResult;
 
     use super::{FromLiteral, Literal};
+
+    fn compute_hash<T: Hash>(value: &T) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        value.hash(&mut hasher);
+        hasher.finish()
+    }
 
     #[test]
     fn test_roundtrip() -> DaftResult<()> {
@@ -637,5 +649,21 @@ mod test {
         roundtrip("test".to_string())?;
 
         Ok(())
+    }
+
+    #[test]
+    fn test_hash_includes_variant_discriminant() {
+        let collision_pairs = [
+            (Literal::Int8(1), Literal::UInt8(1)),
+            (Literal::Int16(1), Literal::UInt16(1)),
+            (Literal::Int32(1), Literal::UInt32(1)),
+            (Literal::Int32(1), Literal::Date(1)),
+            (Literal::Int64(1), Literal::UInt64(1)),
+        ];
+
+        for (left, right) in collision_pairs {
+            assert_ne!(left, right);
+            assert_ne!(compute_hash(&left), compute_hash(&right));
+        }
     }
 }

--- a/src/daft-logical-plan/src/ops/sample.rs
+++ b/src/daft-logical-plan/src/ops/sample.rs
@@ -28,22 +28,22 @@ impl Eq for Sample {}
 
 impl Hash for Sample {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        // Hash the `input` field.
+        self.plan_id.hash(state);
+        self.node_id.hash(state);
         self.input.hash(state);
-
-        // Hash fraction if present (rounded to 6 decimals to avoid tiny differences)
-        if let Some(fraction) = self.fraction {
-            format!("{:.6}", fraction).hash(state);
-        }
-
-        // Hash size if present
-        if let Some(size) = self.size {
-            size.hash(state);
-        }
-
-        // Hash the rest of the fields.
+        self.fraction.map(canonical_fraction_bits).hash(state);
+        self.size.hash(state);
         self.with_replacement.hash(state);
         self.seed.hash(state);
+        self.stats_state.hash(state);
+    }
+}
+
+fn canonical_fraction_bits(fraction: f64) -> u64 {
+    if fraction == 0.0 {
+        0.0f64.to_bits()
+    } else {
+        fraction.to_bits()
     }
 }
 
@@ -106,5 +106,101 @@ impl Sample {
             res.push(format!("Stats = {}", stats));
         }
         res
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::hash_map::DefaultHasher,
+        hash::{Hash, Hasher},
+        sync::Arc,
+    };
+
+    use daft_core::prelude::*;
+    use daft_schema::schema::Schema;
+
+    use super::Sample;
+    use crate::{
+        LogicalPlan,
+        ops::Source,
+        source_info::{InMemoryInfo, SourceInfo},
+        stats::{ApproxStats, PlanStats, StatsState},
+    };
+
+    fn compute_hash<T: Hash>(value: &T) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        value.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    fn dummy_input() -> Arc<LogicalPlan> {
+        let schema = Arc::new(Schema::new(vec![Field::new("x", DataType::Int64)]));
+        let info = InMemoryInfo::new(
+            schema.clone(),
+            "sample_hash_test".to_string(),
+            None,
+            1,
+            0,
+            0,
+            None,
+            None,
+        );
+        let source = Source::new(schema, Arc::new(SourceInfo::InMemory(info)));
+        Arc::new(LogicalPlan::Source(source))
+    }
+
+    fn sample_with_fraction(fraction: f64) -> Sample {
+        Sample::new(dummy_input(), Some(fraction), None, false, Some(42))
+    }
+
+    #[test]
+    fn test_hash_preserves_fraction_precision() {
+        let sample_a = sample_with_fraction(0.1234561);
+        let sample_b = sample_with_fraction(0.1234564);
+
+        assert_ne!(sample_a, sample_b);
+        assert_ne!(compute_hash(&sample_a), compute_hash(&sample_b));
+    }
+
+    #[test]
+    fn test_hash_normalizes_signed_zero_fraction() {
+        let sample_a = sample_with_fraction(-0.0);
+        let sample_b = sample_with_fraction(0.0);
+
+        assert_eq!(sample_a, sample_b);
+        assert_eq!(compute_hash(&sample_a), compute_hash(&sample_b));
+    }
+
+    #[test]
+    fn test_hash_includes_plan_identity_fields() {
+        let input = dummy_input();
+        let sample_a = Sample::new(input.clone(), Some(0.5), None, false, Some(42))
+            .with_plan_id(100)
+            .with_node_id(10);
+        let sample_b = Sample::new(input, Some(0.5), None, false, Some(42))
+            .with_plan_id(200)
+            .with_node_id(20);
+
+        assert_ne!(sample_a, sample_b);
+        assert_ne!(compute_hash(&sample_a), compute_hash(&sample_b));
+    }
+
+    #[test]
+    fn test_hash_includes_stats_materialization_state() {
+        let input = dummy_input();
+        let sample_a = Sample::new(input.clone(), Some(0.5), None, false, Some(42));
+        let mut sample_b = Sample::new(input, Some(0.5), None, false, Some(42));
+        sample_b.stats_state = StatsState::Materialized(
+            PlanStats::new(ApproxStats {
+                num_rows: 10,
+                size_bytes: 80,
+                acc_selectivity: 0.5,
+            })
+            .into(),
+        );
+
+        assert_ne!(sample_a, sample_b);
+        assert_ne!(compute_hash(&sample_a), compute_hash(&sample_b));
     }
 }


### PR DESCRIPTION
## Summary
- Include the `Literal` enum discriminant in its manual `Hash` implementation so unequal cross-variant literals no longer deterministically collide.
- Align `Sample::hash` with the fields compared by `PartialEq`, including plan/node ids and stats materialization state.
- Replace `Sample` fraction string truncation with canonical bit hashing that preserves precision and normalizes signed zero.

Fixes https://github.com/Eventual-Inc/Daft/issues/6954

## Test Plan
- `cargo fmt --all --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/tmp/daft-codex-target cargo test -p daft-core lit::test::test_hash_includes_variant_discriminant -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/daft-codex-target cargo test -p daft-logical-plan ops::sample::tests::test_hash -- --nocapture`

Note: I did not complete `make build` because its default `.venv` setup on this CIFS/NAS checkout hit symlink limitations, and the workaround would sync `--all-extras --all-groups`, pulling very large CUDA/ML wheels. I kept verification to the focused Rust regression tests above.
