### PR TITLE
fix: short-circuit on empty micropartitions

### DIFF
--- a/daft/io/writer.py
+++ b/daft/io/writer.py
@@ -4,11 +4,13 @@ import uuid
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
+from daft.datatype import DataType
 from daft.dependencies import pa, pacsv, pafs, pq
 from daft.filesystem import (
     _resolve_paths_and_filesystem,
     get_protocol_from_path,
 )
+from daft.io.common import _get_schema_from_dict
 from daft.io.delta_lake.delta_lake_write import (
     make_deltalake_add_action,
     make_deltalake_fs,
@@ -167,14 +169,14 @@ class ParquetFileWriter(FileWriterBase):
         return bytes_written
 
     def close(self) -> RecordBatch:
-        if self.current_writer is not None:
-            self.current_writer.close()
-
         self.is_closed = True
-        metadata = {"path": Series.from_pylist([self.full_path])}
+        metadata: dict[str, Series] = {"path": Series.from_pylist([self.full_path])}
         if self.partition_values is not None:
             for column in self.partition_values.columns():
                 metadata[column.name()] = column
+        if self.current_writer is None:
+            return RecordBatch.from_pydict(metadata).slice(0, 0)
+        self.current_writer.close()
         return RecordBatch.from_pydict(metadata)
 
 
@@ -260,15 +262,14 @@ class CSVFileWriter(FileWriterBase):
         return bytes_written
 
     def close(self) -> RecordBatch:
-        if self.current_writer is not None:
-            self.current_writer.close()
-
         self.is_closed = True
-        metadata = {"path": Series.from_pylist([self.full_path])}
+        metadata: dict[str, Series] = {"path": Series.from_pylist([self.full_path])}
         if self.partition_values is not None:
             for column in self.partition_values.columns():
                 metadata[column.name()] = column
-
+        if self.current_writer is None:
+            return RecordBatch.from_pydict(metadata).slice(0, 0)
+        self.current_writer.close()
         return RecordBatch.from_pydict(metadata)
 
 
@@ -319,9 +320,10 @@ class IcebergWriter(ParquetFileWriter):
         return bytes_written
 
     def close(self) -> RecordBatch:
-        if self.current_writer is not None:
-            self.current_writer.close()
         self.is_closed = True
+        if self.current_writer is None:
+            return RecordBatch.empty(_get_schema_from_dict({"data_file": DataType.python()}))
+        self.current_writer.close()
 
         assert self.metadata_collector is not None
         metadata = self.metadata_collector[0]
@@ -385,9 +387,10 @@ class DeltalakeWriter(ParquetFileWriter):
         return bytes_written
 
     def close(self) -> RecordBatch:
-        if self.current_writer is not None:
-            self.current_writer.close()
         self.is_closed = True
+        if self.current_writer is None:
+            return RecordBatch.empty(_get_schema_from_dict({"add_action": DataType.python()}))
+        self.current_writer.close()
 
         assert self.metadata_collector is not None
         metadata = self.metadata_collector[0]

--- a/daft/io/writer.py
+++ b/daft/io/writer.py
@@ -155,6 +155,8 @@ class ParquetFileWriter(FileWriterBase):
 
     def write(self, table: MicroPartition) -> int:
         assert not self.is_closed, "Cannot write to a closed ParquetFileWriter"
+        if len(table) == 0:
+            return 0
         if self.current_writer is None:
             self.current_writer = self._create_writer(table.schema().to_pyarrow_schema())
         self.current_writer.write_table(table.to_arrow(), row_group_size=len(table))
@@ -240,6 +242,8 @@ class CSVFileWriter(FileWriterBase):
 
     def write(self, table: MicroPartition) -> int:
         assert not self.is_closed, "Cannot write to a closed CSVFileWriter"
+        if len(table) == 0:
+            return 0
         arrow_table = table.to_arrow()
 
         # Apply custom date/timestamp formatting if specified
@@ -302,6 +306,8 @@ class IcebergWriter(ParquetFileWriter):
 
     def write(self, table: MicroPartition) -> int:
         assert not self.is_closed, "Cannot write to a closed IcebergFileWriter"
+        if len(table) == 0:
+            return 0
         if self.current_writer is None:
             self.current_writer = self._create_writer(self.file_schema)
         casted = coerce_pyarrow_table_to_schema(table.to_arrow(), self.file_schema)
@@ -361,6 +367,8 @@ class DeltalakeWriter(ParquetFileWriter):
 
     def write(self, table: MicroPartition) -> int:
         assert not self.is_closed, "Cannot write to a closed DeltalakeFileWriter"
+        if len(table) == 0:
+            return 0
 
         converted_arrow_table = sanitize_table_for_deltalake(
             table,

--- a/tests/io/delta_lake/test_delta_lake_writer.py
+++ b/tests/io/delta_lake/test_delta_lake_writer.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import pyarrow as pa
+import pytest
+
+pytest.importorskip("deltalake")
+
+from daft.io.writer import DeltalakeWriter
+from daft.recordbatch.micropartition import MicroPartition
+
+
+def test_deltalake_writer_empty_micropartition(tmp_path):
+    empty = MicroPartition.from_arrow(pa.table({"x": pa.array([], type=pa.int64())}))
+    writer = DeltalakeWriter(
+        root_dir=str(tmp_path),
+        file_idx=0,
+        version=1,
+        large_dtypes=False,
+    )
+    bytes_written = writer.write(empty)
+    assert bytes_written == 0
+    # Must not IndexError on metadata_collector[0] when no file was opened.
+    result = writer.close()
+    assert len(result) == 0
+    assert "add_action" in result.schema().column_names()
+    assert not (tmp_path / writer.file_name).exists()

--- a/tests/io/iceberg/test_iceberg_writes.py
+++ b/tests/io/iceberg/test_iceberg_writes.py
@@ -15,7 +15,6 @@ from tests.conftest import get_tests_daft_runner_name
 
 pyiceberg = pytest.importorskip("pyiceberg")
 
-
 from pyiceberg.catalog.sql import SqlCatalog
 from pyiceberg.partitioning import UNPARTITIONED_PARTITION_SPEC, PartitionField, PartitionSpec
 from pyiceberg.schema import Schema
@@ -42,8 +41,11 @@ from pyiceberg.types import (
     StructType,
     TimestampType,
 )
+from pyiceberg.types import NestedField as _NestedField
 
 import daft
+from daft.io.writer import IcebergWriter
+from daft.recordbatch.micropartition import MicroPartition
 
 
 @pytest.fixture(scope="function", params=[False, True], ids=["no_mock", "with_mock"])
@@ -290,6 +292,25 @@ def test_read_after_write_with_empty_partition(local_catalog):
     assert as_dict["rows"] == [1, 1, 1]
     read_back = daft.read_iceberg(table)
     assert as_arrow == read_back.to_arrow()
+
+
+def test_iceberg_writer_empty_micropartition(tmp_path):
+    iceberg_schema = Schema(_NestedField(field_id=1, name="x", field_type=LongType(), required=False))
+    empty = MicroPartition.from_arrow(pa.table({"x": pa.array([], type=pa.int64())}))
+    writer = IcebergWriter(
+        root_dir=str(tmp_path),
+        file_idx=0,
+        schema=iceberg_schema,
+        properties={},
+        partition_spec_id=UNPARTITIONED_PARTITION_SPEC.spec_id,
+    )
+    bytes_written = writer.write(empty)
+    assert bytes_written == 0
+    # Must not IndexError on metadata_collector[0] when no file was opened.
+    result = writer.close()
+    assert len(result) == 0
+    assert "data_file" in result.schema().column_names()
+    assert not (tmp_path / writer.file_name).exists()
 
 
 @pytest.fixture

--- a/tests/io/test_csv.py
+++ b/tests/io/test_csv.py
@@ -8,6 +8,8 @@ import pytest
 
 import daft
 from daft import DataType, TimeUnit
+from daft.io.writer import CSVFileWriter
+from daft.recordbatch.micropartition import MicroPartition
 
 
 @pytest.mark.parametrize(
@@ -433,3 +435,11 @@ def test_pyarrow_csv_writer_custom_formats(tmp_path):
     # Check timestamp formatting (YYYY-MM-DD HH:MM:SS)
     assert "2024-01-15 10:30:45" in text
     assert "2024-12-31 23:59:59" in text
+
+
+def test_csv_file_writer_empty_micropartition(tmp_path):
+    empty = MicroPartition.from_arrow(pa.table({"id": pa.array([], type=pa.int64())}))
+    writer = CSVFileWriter(root_dir=str(tmp_path), file_idx=0)
+    bytes_written = writer.write(empty)
+    assert bytes_written == 0
+    writer.close()

--- a/tests/io/test_csv.py
+++ b/tests/io/test_csv.py
@@ -442,4 +442,8 @@ def test_csv_file_writer_empty_micropartition(tmp_path):
     writer = CSVFileWriter(root_dir=str(tmp_path), file_idx=0)
     bytes_written = writer.write(empty)
     assert bytes_written == 0
-    writer.close()
+    result = writer.close()
+
+    # Empty micropartition should result in an empty record batch.
+    assert len(result) == 0
+    assert "path" in result.schema().column_names()

--- a/tests/io/test_parquet_roundtrip.py
+++ b/tests/io/test_parquet_roundtrip.py
@@ -13,6 +13,8 @@ import pytest
 import daft
 from daft import DataType, Series, TimeUnit
 from daft.context import execution_config_ctx
+from daft.io.writer import ParquetFileWriter
+from daft.recordbatch.micropartition import MicroPartition
 from tests.conftest import get_tests_daft_runner_name
 
 
@@ -227,6 +229,14 @@ def test_roundtrip_arrow_extension_type(tmp_path, uuid_ext_type, native_parquet_
     ba = before.to_arrow()
     aa = after.to_arrow()
     assert ba.equals(aa, check_metadata=False)
+
+
+def test_parquet_file_writer_empty_micropartition(tmp_path):
+    empty = MicroPartition.from_arrow(pa.table({"id": pa.array([], type=pa.int64())}))
+    writer = ParquetFileWriter(root_dir=str(tmp_path), file_idx=0)
+    bytes_written = writer.write(empty)
+    assert bytes_written == 0
+    writer.close()
 
 
 # TODO: reading/writing:

--- a/tests/io/test_parquet_roundtrip.py
+++ b/tests/io/test_parquet_roundtrip.py
@@ -236,7 +236,11 @@ def test_parquet_file_writer_empty_micropartition(tmp_path):
     writer = ParquetFileWriter(root_dir=str(tmp_path), file_idx=0)
     bytes_written = writer.write(empty)
     assert bytes_written == 0
-    writer.close()
+    result = writer.close()
+
+    # Empty micropartition should result in an empty record batch.
+    assert len(result) == 0
+    assert "path" in result.schema().column_names()
 
 
 # TODO: reading/writing:


### PR DESCRIPTION
## Changes Made

Calling .to_arrow() on an empty micropartition triggers a ValueError because of empty row groups. This short-circuits the write for empty micropartitions. 

## Related Issues

- Closes #6927