### PR TITLE
fix(distributed): implement accurate operator wall time tracking

### DIFF
--- a/src/daft-distributed/src/statistics/mod.rs
+++ b/src/daft-distributed/src/statistics/mod.rs
@@ -189,7 +189,11 @@ impl StatisticsManager {
                 }
             }
             TaskEvent::Completed { context, .. }
-            | TaskEvent::Failed { context, .. }
+            | TaskEvent::Failed {
+                context,
+                retryable: false,
+                ..
+            }
             | TaskEvent::Cancelled { context } => {
                 for node_id in &context.node_ids {
                     let mgr = self
@@ -201,6 +205,9 @@ impl StatisticsManager {
                     }
                 }
             }
+            TaskEvent::Failed {
+                retryable: true, ..
+            } => {}
             TaskEvent::Scheduled { .. } => {}
         }
 
@@ -278,11 +285,18 @@ impl StatisticsManager {
     /// Collects accumulated stats from each node manager and returns them as an
     /// ExecutionEngineFinalResult for export to the driver (e.g. after the partition stream is done).
     pub fn export_metrics(&self) -> ExecutionStats {
+        let mut wall_times: HashMap<u32, u64> = HashMap::new();
+
         let nodes: Vec<(Arc<NodeInfo>, _)> = self
             .runtime_node_managers
             .values()
-            .map(RuntimeNodeManager::export_snapshot)
+            .map(|manager| {
+                if let Some(wall_time) = manager.wall_time_us() {
+                    wall_times.insert(manager.node_id() as u32, wall_time);
+                }
+                manager.export_snapshot()
+            })
             .collect();
-        ExecutionStats::new("".into(), nodes)
+        ExecutionStats::new("".into(), nodes).with_wall_times(wall_times)
     }
 }

--- a/src/daft-distributed/src/statistics/stats.rs
+++ b/src/daft-distributed/src/statistics/stats.rs
@@ -1,4 +1,7 @@
-use std::sync::{Arc, Mutex, atomic::Ordering};
+use std::{
+    sync::{Arc, Mutex, atomic::Ordering},
+    time::Instant,
+};
 
 use common_metrics::{
     Counter, Meter, StatSnapshot, TASK_ACTIVE_KEY, TASK_CANCELLED_KEY, TASK_COMPLETED_KEY,
@@ -57,6 +60,8 @@ struct OperatorLifecycle {
     /// Together with `phase == Started` and `pending_tasks == 0`, this
     /// triggers the `Ended` transition.
     produce_complete: bool,
+    started_at: Option<Instant>,
+    wall_time_us: Option<u64>,
 }
 
 pub struct RuntimeNodeManager {
@@ -116,6 +121,7 @@ impl RuntimeNodeManager {
         s.pending_tasks += 1;
         if s.phase == LifecyclePhase::Pending {
             s.phase = LifecyclePhase::Started;
+            s.started_at = Some(Instant::now());
             true
         } else {
             false
@@ -146,7 +152,7 @@ impl RuntimeNodeManager {
     /// fired) or `Ended` (terminal).
     fn maybe_end(s: &mut OperatorLifecycle) -> bool {
         if s.phase == LifecyclePhase::Started && s.produce_complete && s.pending_tasks == 0 {
-            s.phase = LifecyclePhase::Ended;
+            Self::mark_ended(s);
             true
         } else {
             false
@@ -162,10 +168,19 @@ impl RuntimeNodeManager {
     pub fn force_end(&self) -> bool {
         let mut s = self.lifecycle.lock().unwrap();
         if s.phase == LifecyclePhase::Started {
-            s.phase = LifecyclePhase::Ended;
+            Self::mark_ended(&mut s);
             true
         } else {
             false
+        }
+    }
+
+    fn mark_ended(s: &mut OperatorLifecycle) {
+        s.phase = LifecyclePhase::Ended;
+        if s.wall_time_us.is_none()
+            && let Some(started_at) = s.started_at
+        {
+            s.wall_time_us = Some(started_at.elapsed().as_micros().min(u64::MAX as u128) as u64);
         }
     }
 
@@ -248,6 +263,10 @@ impl RuntimeNodeManager {
             }
             TaskEvent::Submitted { .. } => (), // We don't track submitted tasks
         }
+    }
+
+    pub fn wall_time_us(&self) -> Option<u64> {
+        self.lifecycle.lock().unwrap().wall_time_us
     }
 }
 
@@ -605,5 +624,34 @@ mod tests {
                 case.name
             );
         }
+    }
+
+    #[test]
+    fn wall_time_is_recorded_only_when_lifecycle_ends() {
+        let mgr = runtime_node_manager(42);
+
+        assert_eq!(mgr.wall_time_us(), None);
+
+        assert!(mgr.on_task_submitted());
+        assert_eq!(mgr.wall_time_us(), None);
+
+        assert!(!mgr.on_task_finished());
+        assert_eq!(mgr.wall_time_us(), None);
+
+        assert!(mgr.on_produce_complete());
+        assert!(mgr.wall_time_us().is_some());
+    }
+
+    #[test]
+    fn force_end_records_wall_time_for_started_operator() {
+        let mgr = runtime_node_manager(42);
+
+        assert!(!mgr.force_end());
+
+        assert!(mgr.on_task_submitted());
+        assert!(mgr.force_end());
+        assert!(mgr.wall_time_us().is_some());
+
+        assert!(!mgr.force_end());
     }
 }

--- a/src/daft-local-plan/src/results.rs
+++ b/src/daft-local-plan/src/results.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use arrow_array::{
     ArrayRef,
@@ -8,16 +8,21 @@ use arrow_array::{
     },
 };
 use common_error::{DaftError, DaftResult};
-use common_metrics::{QueryID, StatSnapshot, ops::NodeInfo, snapshot::StatSnapshotImpl};
+use common_metrics::{
+    DURATION_KEY, QueryID, Stat, StatSnapshot, ops::NodeInfo, snapshot::StatSnapshotImpl,
+};
 use daft_core::prelude::{DataType, Field, Schema, TimeUnit};
 use daft_recordbatch::RecordBatch;
 use serde::{Deserialize, Serialize};
+
+const EXECUTION_TIME_TOTAL_KEY: &str = "execution_time_total";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExecutionStats {
     pub query_id: QueryID,
     pub query_plan: Option<serde_json::Value>,
     pub nodes: Vec<(Arc<NodeInfo>, StatSnapshot)>,
+    pub wall_times: HashMap<u32, u64>,
 }
 
 impl ExecutionStats {
@@ -27,6 +32,7 @@ impl ExecutionStats {
             query_id,
             query_plan: None,
             nodes,
+            wall_times: HashMap::new(),
         }
     }
 
@@ -35,7 +41,16 @@ impl ExecutionStats {
         self
     }
 
+    pub fn with_wall_times(mut self, wall_times: HashMap<u32, u64>) -> Self {
+        self.wall_times = wall_times;
+        self
+    }
+
     /// Encode the ExecutionStats into a binary format for transmission to scheduler
+    ///
+    /// Only `nodes` are serialized: runner-level fields such as distributed
+    /// lifecycle wall time are attached later by the scheduler's final
+    /// `StatisticsManager::export_metrics()` path.
     pub fn encode(&self) -> Vec<u8> {
         bincode::encode_to_vec(&self.nodes, bincode::config::legacy())
             .expect("Failed to encode ExecutionStats")
@@ -53,6 +68,7 @@ impl ExecutionStats {
             query_id: "".into(),
             query_plan: None,
             nodes,
+            wall_times: HashMap::new(),
         }
     }
 
@@ -95,8 +111,26 @@ impl ExecutionStats {
             names.append_value(&node_info.name);
             types.append_value(node_info.node_type.to_string());
             categories.append_value(node_info.node_category.to_string());
-            duration_values.append_value((stat_snapshot.duration_us() / 1000) as i64);
+
+            // The top-level duration column is the user-facing operator duration. Use
+            // runner-provided wall-clock lifecycle time when available; otherwise fall back
+            // to the accumulated execution duration from the snapshot for runners that do
+            // not yet report lifecycle wall time.
+            let execution_time_total = stat_snapshot.duration_us();
+            let node_id = node_info.id as u32;
+            let duration_us = self
+                .wall_times
+                .get(&node_id)
+                .copied()
+                .unwrap_or(execution_time_total);
+            duration_values.append_value((duration_us / 1000) as i64);
             for (name, value) in stat_snapshot.to_stats() {
+                // duration is promoted to the top-level column above.
+                // keep the stats map from carrying a second, differently-defined duration.
+                // the accumulated snapshot duration is exposed as `execution_time_total` instead.
+                if name.as_ref() == DURATION_KEY {
+                    continue;
+                }
                 stats.keys().append_value(name);
                 let values = stats.values();
                 let (value, unit) = value.into_f64_and_unit();
@@ -110,6 +144,24 @@ impl ExecutionStats {
                     .append_option(unit);
                 values.append(true);
             }
+
+            // preserve the accumulated execution duration that snapshots report. In
+            // distributed runners this can exceed wall-clock duration because it sums work
+            // across concurrent tasks/work units.
+            stats.keys().append_value(EXECUTION_TIME_TOTAL_KEY);
+            let values = stats.values();
+            let (value, unit) =
+                Stat::Duration(Duration::from_micros(execution_time_total)).into_f64_and_unit();
+            values
+                .field_builder::<Float64Builder>(0)
+                .unwrap()
+                .append_value(value);
+            values
+                .field_builder::<LargeStringBuilder>(1)
+                .unwrap()
+                .append_option(unit);
+            values.append(true);
+
             stats.append(true)?;
         }
 


### PR DESCRIPTION
## Changes Made
This PR fixes operator duration reporting in distributed execution. Previously, the `duration` column in `ExecutionStats` represented the accumulated CPU time across all tasks, which is misleading for distributed operators where tasks run in parallel.

-  Distributed Statistics: Added `started_at` and `wall_time_us` to `OperatorLifecycle` to track the actual wall-clock duration of an operator (from first task submission to last task completion).
- ExecutionStats Update: Updated `ExecutionStats` to carry a map of operator wall times.
- RecordBatch Export: Modified `to_recordbatch` to:
         - Use the new wall-clock duration for the primary `duration` column.
        - Expose the accumulated CPU time as a new metric `execution_time_total` in the stats map.
        - Maintain fallback logic to CPU time for runners that do not yet report wall time.