### PR TITLE
docs: add llms-full.txt and update llms.txt sections

### DIFF
--- a/docs/gen_pages/generate_llms_full_txt.py
+++ b/docs/gen_pages/generate_llms_full_txt.py
@@ -1,0 +1,84 @@
+import re
+from pathlib import Path
+
+import mkdocs_gen_files
+
+BASE_URL = "https://docs.daft.ai/en/stable/"
+
+
+def parse_summary():
+    """Parse SUMMARY.md and return an ordered list of (section, name, path) tuples."""
+    summary_path = Path("docs/SUMMARY.md")
+    with open(summary_path, encoding="utf-8") as f:
+        lines = f.readlines()
+
+    entries = []
+    current_section = None
+
+    for line in lines:
+        line = line.rstrip()
+        if not line.strip() or line.strip().startswith("<!--"):
+            continue
+
+        if line.startswith("* "):
+            match = re.search(r"\[([^\]]+)\]\(([^)]+)\)", line)
+            if match and not match.group(2).startswith("http"):
+                name = match.group(1).replace("<sup>↗</sup>", "").strip()
+                entries.append((current_section or "Other", name, match.group(2)))
+            else:
+                current_section = line[2:].strip()
+            continue
+
+        if line.startswith("    ") and current_section:
+            match = re.search(r"\[([^\]]+)\]\(([^)]+)\)", line)
+            if match and not match.group(2).startswith("http"):
+                name = match.group(1).replace("<sup>↗</sup>", "").strip()
+                entries.append((current_section, name, match.group(2)))
+
+    return entries
+
+
+def read_doc(file_path: str) -> str | None:
+    """Read a markdown doc file, returning its content or None."""
+    path = Path("docs") / file_path
+    if path.is_dir():
+        path = path / "index.md"
+    if not path.exists() and not path.suffix:
+        path = path.with_suffix(".md")
+    if not path.exists():
+        return None
+    with open(path, encoding="utf-8") as f:
+        return f.read()
+
+
+def main():
+    entries = parse_summary()
+
+    parts = [
+        "# Daft\n",
+        "> Daft is a high-performance data engine providing simple and reliable data processing "
+        "for any modality and scale, from local to petabyte-scale distributed workloads. "
+        "The core engine is written in Rust and exposes both SQL and Python DataFrame interfaces "
+        "as first-class citizens.\n",
+    ]
+
+    current_section = None
+    for section, name, file_path in entries:
+        if section != current_section:
+            current_section = section
+            parts.append(f"\n---\n\n## {section}\n")
+
+        url = BASE_URL + file_path.replace(".md", "/")
+        content = read_doc(file_path)
+        if content is None:
+            continue
+
+        parts.append(f"\n---\n\n### {name}\n")
+        parts.append(f"Source: {url}\n")
+        parts.append(content)
+
+    with mkdocs_gen_files.open("llms-full.txt", "w") as f:
+        f.write("\n".join(parts))
+
+
+main()

--- a/docs/gen_pages/generate_llms_txt.py
+++ b/docs/gen_pages/generate_llms_txt.py
@@ -15,12 +15,8 @@ def get_doc_structure():
     with open(summary_path, encoding="utf-8") as f:
         content = f.read()
 
-    sections = {
-        "Guide": {"files": []},
-        "Examples": {"files": []},
-        "Python API": {"files": []},
-        "SQL Reference": {"files": []},
-    }
+    section_names = ["Guide", "Examples", "Python API", "SQL Reference", "Contributing"]
+    sections = {name: {"files": []} for name in section_names}
 
     # Parse the markdown structure
     lines = content.split("\n")
@@ -35,17 +31,24 @@ def get_doc_structure():
 
         # Check for main sections (lines starting with *)
         if line.startswith("* "):
+            match = re.search(r"\[([^\]]+)\]\(([^)]+)\)", line)
+            if match and not match.group(2).startswith("http"):
+                # Top-level page not under a named section (e.g. "Daft Skills")
+                name = match.group(1).replace("<sup>↗</sup>", "").strip()
+                file_path = match.group(2)
+                last_section = list(sections.keys())[-1]
+                sections[last_section]["files"].append(
+                    {
+                        "name": name,
+                        "path": file_path,
+                        "url": f"https://docs.daft.ai/en/stable/{file_path.replace('.md', '.txt')}",
+                        "github_url": f"https://raw.githubusercontent.com/Eventual-Inc/Daft/main/docs/{quote(file_path)}",
+                    }
+                )
+                continue
+
             section_name = line[2:].strip()
-            if section_name == "Guide":
-                current_section = "Guide"
-            elif section_name == "Examples":
-                current_section = "Examples"
-            elif section_name == "Python API":
-                current_section = "Python API"
-            elif section_name == "SQL Reference":
-                current_section = "SQL Reference"
-            else:
-                current_section = None
+            current_section = section_name if section_name in sections else None
             continue
 
         # Check for any indented lines (subsections and nested items)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -195,6 +195,7 @@ plugins:
     - docs/gen_pages/gen_function_pages.py
     - docs/gen_pages/gen_txt_files.py
     - docs/gen_pages/generate_llms_txt.py
+    - docs/gen_pages/generate_llms_full_txt.py
 - literate-nav:
     nav_file: SUMMARY.md
 - nav-hide-children:


### PR DESCRIPTION
## Summary
- **`llms.txt` updated**: Now includes the Contributing section (3 pages) and top-level pages like Daft Skills that were previously missing from the generated index
- **`llms-full.txt` added**: New generator that concatenates all 117 doc pages (~884KB) into a single file for full-context LLM ingestion, following the [llmstxt.org](https://llmstxt.org) convention
- Both files are generated at build time via `mkdocs-gen-files` — no manual maintenance needed

## Test plan
- [ ] Verify ReadTheDocs preview build succeeds
- [ ] Check `llms.txt` includes Contributing section and Daft Skills page
- [ ] Check `llms-full.txt` is generated and accessible at `/en/stable/llms-full.txt`
- [ ] Verify existing `llms.txt` links still resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)