### PR TITLE
docs(observability): add Grafana dashboard starter

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -78,6 +78,7 @@
         * [Progress Indicators](observability/progress-indicators.md)
         * [Logging](observability/logging.md)
         * [Telemetry](observability/telemetry.md)
+        * [Grafana Dashboard](observability/grafana.md)
     * [Sessions, Catalogs, and Tables](configuration/sessions-usage.md)
     * [Roadmap](roadmap.md)
     * [Benchmarks](benchmarks/index.md)

--- a/docs/observability/grafana.md
+++ b/docs/observability/grafana.md
@@ -1,0 +1,99 @@
+# Grafana Dashboard
+
+Daft ships an importable Grafana dashboard for visualizing query execution metrics alongside the rest of your infrastructure observability. The dashboard reads Daft's OTel-exported metrics via Prometheus and renders five panels covering throughput, bytes flow, task lifecycle, operator hot spots, and failed-task counts.
+
+This is a complement to the [in-process Daft Dashboard](dashboard.md), not a replacement. The in-process dashboard is the front door for live per-query debugging — plan tree, tasks view, heatmap, event log replay. The Grafana dashboard is the on-call surface — fleet-level metrics, time-series, alerting, SLO tracking — aggregated alongside your other services.
+
+
+## Prerequisites
+
+Three pieces of infrastructure need to be wired up before any panel will render data:
+
+1. **Daft with OTel export enabled.** Telemetry is off by default. Set an OTLP endpoint when launching your script. See [Telemetry](telemetry.md) for the full environment variable matrix.
+   ```bash
+   export OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
+   python my-daft-script.py
+   ```
+2. **A Prometheus instance scraping Daft's OTel metrics.** Either through the OTel Collector's Prometheus exporter, or by pointing Prometheus directly at the OTel `/metrics` endpoint.
+3. **A Grafana instance with the Prometheus datasource configured.** The dashboard uses a `${DS_PROMETHEUS}` datasource variable so it imports cleanly against any Prometheus datasource.
+
+!!! info
+    The dashboard is designed for Grafana 10+ (schema version 39). Earlier Grafana versions may need adjustments to panel configurations.
+
+
+## Importing the dashboard
+
+Download [daft-dashboard.json](grafana/daft-dashboard.json) and import via the Grafana UI or API.
+
+**Via the Grafana UI:**
+
+1. Navigate to **Dashboards** → **New** → **Import**
+2. Upload `daft-dashboard.json` or paste its contents into the import dialog
+3. Select your Prometheus datasource when prompted
+4. Click **Import**
+
+**Via the Grafana HTTP API:**
+
+```bash
+curl -X POST \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $GRAFANA_API_TOKEN" \
+  -d @daft-dashboard.json \
+  https://your-grafana-host/api/dashboards/db
+```
+
+
+## Panels
+
+| Panel | What it shows |
+| --- | --- |
+| **Rows/sec by operator type** | Rate of rows emitted per operator type. Spikes show heavy producers; flat lines after a high rate often indicate a downstream bottleneck. |
+| **Bytes flow — read vs written** | Bytes read from sources vs bytes written to sinks. The gap between the two is approximately the work the engine is doing in-memory. |
+| **Task lifecycle** | Active, completed, failed, and cancelled task counters. Failed counter is highlighted in red when non-zero. |
+| **Top 10 operators by cumulative duration** | Operators ranked by accumulated CPU time. Use this to find hot spots, then cross-reference with the [in-process dashboard's](dashboard.md) heatmap for the plan context. |
+| **Failed tasks** | Single-stat panel with a red threshold above zero. The quick "is anything broken?" view for on-call dashboards. |
+
+
+## Metric naming convention
+
+Daft emits OTel metrics with dot-separated names. The Prometheus convention converts dots to underscores and adds `_total` to counters — the OTel Collector's Prometheus exporter handles this automatically. The dashboard's queries assume this convention.
+
+| OTel name | Prometheus query name | Type |
+| --- | --- | --- |
+| `daft.rows.in` | `daft_rows_in_total` | counter |
+| `daft.rows.out` | `daft_rows_out_total` | counter |
+| `daft.bytes.read` | `daft_bytes_read_total` | counter |
+| `daft.bytes.written` | `daft_bytes_written_total` | counter |
+| `daft.duration` | `daft_duration_total` | counter (µs) |
+| `daft.task.active` | `daft_task_active` | gauge |
+| `daft.task.completed` | `daft_task_completed_total` | counter |
+| `daft.task.failed` | `daft_task_failed_total` | counter |
+| `daft.task.cancelled` | `daft_task_cancelled_total` | counter |
+
+Labels: `node.id` and `node.type` become `node_id` and `node_type` in Prometheus queries.
+
+!!! info
+    Several metrics are emitted only in distributed (Ray) execution: `daft_bytes_read_total`, `daft_task_active`, `daft_task_cancelled_total`, `daft_task_completed_total`, `daft_task_failed_total`. Native-runner-only workloads will see empty panels for those — the rows, bytes-written, and duration panels work in both modes.
+
+
+## What's not yet covered
+
+The current dashboard focuses on metrics that are documented and stable as of Daft v0.7.x. Several additional metrics are landing in the observability work — when their Prometheus exposure stabilizes, panels can be added:
+
+- **Process-level memory and CPU.** Per-process memory and CPU stats land as OTel metrics in distributed execution. Once the exposed metric names are confirmed against a real scrape, a "process resources" panel row makes sense.
+- **Per-operator memory attribution.** `bytes_in` / `bytes_out` and inflation/deflation ratios are exposed in the in-process dashboard. Verifying their Prometheus name shape will let those panels land in Grafana too.
+- **Peak resident state for stateful operators.** Coming in [#6883](https://github.com/Eventual-Inc/Daft/pull/6883). Will need a dedicated panel for accumulating-operator memory.
+
+Panel additions are mechanical once the metric names are confirmed — same query shape, different metric name.
+
+
+## Adapting the dashboard
+
+The dashboard is a starting point. Real production setups often want:
+
+- **Per-job filtering.** Add a `job_id` or `query_id` template variable if you're labeling metrics with one.
+- **Aggregation windows.** The default `rate([1m])` is fine for interactive debugging; longer windows (`[5m]`, `[15m]`) give cleaner trend lines for SLO dashboards.
+- **Alerts.** The `Failed tasks` panel is a natural alerting hook — set `sum(daft_task_failed_total) > 0` as a trigger.
+- **Cluster topology.** If you're running multiple Daft jobs on shared infrastructure, group panels by `cluster` or `service` labels that your OTel collector adds.
+
+Submit improvements via PRs — the dashboard belongs to the community.

--- a/docs/observability/grafana/daft-dashboard.json
+++ b/docs/observability/grafana/daft-dashboard.json
@@ -1,0 +1,254 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Daft query overview — operator throughput, bytes flow, task lifecycle, and operator hot spots. Reads OTel-exported Daft metrics via Prometheus. See engine/canon/observability/grafana/README.md for setup.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [
+    {
+      "title": "Daft Observability Docs",
+      "type": "link",
+      "url": "https://docs.daft.ai/en/stable/observability/telemetry/",
+      "targetBlank": true
+    }
+  ],
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Rows/sec by operator type",
+      "description": "Rate of rows emitted by each operator type. Spikes show heavy producers; flat lines after a high rate often indicate a downstream bottleneck.",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "sum by (node_type) (rate(daft_rows_out_total[1m]))",
+          "legendFormat": "{{node_type}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "rows/sec",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10,
+            "stacking": { "mode": "none", "group": "A" }
+          }
+        }
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "right", "showLegend": true, "calcs": ["mean", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      }
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Bytes flow — read vs written",
+      "description": "Bytes read from sources and bytes written to sinks. The gap is roughly the work the engine is doing in-memory.",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "sum(rate(daft_bytes_read_total[1m]))",
+          "legendFormat": "Read",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(daft_bytes_written_total[1m]))",
+          "legendFormat": "Written",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10
+          }
+        }
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      }
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Task lifecycle",
+      "description": "Currently-active tasks and totals across the lifecycle. Distributed (Ray) execution only — native runner does not emit these task metrics.",
+      "gridPos": { "h": 6, "w": 12, "x": 0, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "sum(daft_task_active)",
+          "legendFormat": "Active",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(daft_task_completed_total)",
+          "legendFormat": "Completed",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(daft_task_failed_total)",
+          "legendFormat": "Failed",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(daft_task_cancelled_total)",
+          "legendFormat": "Cancelled",
+          "refId": "D"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          },
+          "mappings": []
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Failed" },
+            "properties": [
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    { "color": "green", "value": null },
+                    { "color": "red", "value": 1 }
+                  ]
+                }
+              },
+              { "id": "color", "value": { "mode": "thresholds" } }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "reduceOptions": { "values": false, "calcs": ["lastNotNull"], "fields": "" },
+        "orientation": "horizontal",
+        "textMode": "value_and_name",
+        "colorMode": "background_solid",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 4,
+      "type": "bargauge",
+      "title": "Top 10 operators by cumulative duration",
+      "description": "Operators ranked by accumulated CPU time across all tasks. The longest bars are your hot spots — look for them on the dashboard's heatmap to see the plan context.",
+      "gridPos": { "h": 6, "w": 12, "x": 12, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "topk(10, sum by (node_type, node_id) (daft_duration_total))",
+          "legendFormat": "{{node_type}} ({{node_id}})",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "µs",
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "blue", "value": null }]
+          }
+        }
+      },
+      "options": {
+        "orientation": "horizontal",
+        "displayMode": "gradient",
+        "showUnfilled": true,
+        "reduceOptions": { "values": false, "calcs": ["lastNotNull"], "fields": "" }
+      }
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "Failed tasks",
+      "description": "Total failed tasks since the query started. Non-zero = something needs attention in the dashboard's failure view.",
+      "gridPos": { "h": 4, "w": 8, "x": 0, "y": 14 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "sum(daft_task_failed_total)",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          },
+          "color": { "mode": "thresholds" }
+        }
+      },
+      "options": {
+        "reduceOptions": { "values": false, "calcs": ["lastNotNull"], "fields": "" },
+        "textMode": "auto",
+        "colorMode": "background_solid",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      }
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "tags": ["daft", "observability"],
+  "templating": {
+    "list": [
+      {
+        "current": { "selected": false, "text": "Prometheus", "value": "Prometheus" },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": { "from": "now-15m", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Daft — Query Overview",
+  "uid": "daft-query-overview",
+  "version": 1,
+  "weekStart": ""
+}


### PR DESCRIPTION
## Summary

Adds an importable Grafana dashboard for Daft observability, built on the OTel metrics already documented in [`docs/observability/telemetry.md`](docs/observability/telemetry.md). 5 panels: rows/sec by operator type, bytes flow, task lifecycle, top operators by cumulative duration, and a failed-tasks stat panel.

**Companion to the in-process Daft Dashboard** (`daft dashboard start`):
- In-process dashboard → live per-query debugging (plan tree, tasks view, heatmap, event log replay)
- Grafana dashboard → fleet monitoring / on-call / SLO tracking alongside your existing infra observability

## Why a draft

Shipped **untested end-to-end**. I built this from the documented metric surface but haven't run it against a live Daft + OTel + Prometheus + Grafana stack. The metric query shapes assume the standard OTel Collector → Prometheus exporter naming convention (`daft.X.Y` → `daft_x_y_total`); this should be verified against an actual scrape before users follow the docs.

## Files

- `docs/observability/grafana.md` — new docs page (prerequisites, import instructions, panel reference, metric naming convention, "what's not covered yet", adaptation tips)
- `docs/observability/grafana/daft-dashboard.json` — the dashboard JSON (Grafana 10+, schema v39, `$DS_PROMETHEUS` datasource variable)
- `docs/SUMMARY.md` — adds "Grafana Dashboard" entry under Observability nav, after Telemetry

## Test plan

- [ ] Import `daft-dashboard.json` into a real Grafana instance pointed at a Prometheus scraping OTel-exported Daft metrics
- [ ] @samstokes / @cckellogg / @universalmind303 — verify metric query names against actual Prometheus output (`daft_rows_out_total`, `daft_duration_total`, `daft_task_*`, etc.)
- [ ] @desmondcheongzx — confirm the process-level memory + CPU metrics (PR #6428) are visible via Prometheus and what their names are, so a future PR can add a "process resources" panel row
- [ ] Verify `Top 10 operators by cumulative duration` query (`topk(10, sum by (node_type, node_id) (daft_duration_total))`) returns expected shape — the µs counter may need to be rescaled in the panel display
- [ ] Confirm the "distributed-only" caveat in the docs page matches reality (we list `daft_bytes_read_total`, `daft_task_active`, `daft_task_*` as distributed-only per `telemetry.md`)
- [ ] When @samstokes' peak resident state PR (#6883) lands, add a memory-attribution panel
- [ ] Once per-operator `bytes_in` / `bytes_out` Prometheus exposure is confirmed, add inflation/deflation panels

## Context

This started as a marketing-repo canon artifact (`Eventual-Inc/marketing#360`) supporting the W21 observability launch. Moved here because:

1. Daft repo can actually test it end-to-end against a real stack
2. Users reading `docs.daft.ai/observability/` will find it where they're already looking
3. Engineering reviews the metric queries against actual scraper output before users import it

The marketing PR (#360 in `Eventual-Inc/marketing`) will be closed in favor of this one.