### PR TITLE
ci: catch undeclared runtime imports via TC strict + py version matrix

### DIFF
--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -1627,7 +1627,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, Windows]
-        python-version: ["3.10"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         on-main:
         - ${{ github.ref == 'refs/heads/main' }}
         exclude:

--- a/daft/.ruff.toml
+++ b/daft/.ruff.toml
@@ -6,9 +6,19 @@ extend-select = [
   "TID253",  # banned-module-level-imports, derived from flake8-tidy-imports
   "TCH"  # flake8-type-checking
 ]
+# TC001/TC003 (first-party/stdlib annotation-only imports) have ~160 existing
+# violations and are cosmetic; leave for a follow-up. TC002 is the bug-class
+# rule: it catches third-party imports used only in annotations, which forces
+# undeclared/conditional deps to be installed at runtime.
+extend-ignore = ["TC001", "TC003"]
 
 [lint.flake8-tidy-imports]
 # Ban certain modules from being imported at module level, instead requiring
 # that they're imported lazily (e.g., within a function definition,
 # with daft.lazy_import.LazyImport, or with TYPE_CHECKING).
 banned-module-level-imports = ["daft.catalog.__unity._client", "fsspec", "numpy", "pandas", "PIL", "pyarrow", "ray", "xml"]
+
+[lint.flake8-type-checking]
+# Required for TC rules to fire on files with `from __future__ import annotations`.
+# Without this, the typing_extensions/Self class of bug slips through.
+strict = true

--- a/daft/ai/openai/protocols/text_embedder.py
+++ b/daft/ai/openai/protocols/text_embedder.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 from openai import AsyncOpenAI, OpenAIError, RateLimitError
 from openai import OpenAI as OpenAIClient
-from openai._types import Omit, omit
+from openai._types import omit
 from openai.types.create_embedding_response import Usage
 
 from daft import DataType
@@ -18,6 +18,7 @@ from daft.ai.utils import merge_provider_and_api_options
 from daft.dependencies import np
 
 if TYPE_CHECKING:
+    from openai._types import Omit
     from openai.types import EmbeddingModel
     from openai.types.create_embedding_response import CreateEmbeddingResponse
 

--- a/daft/ai/transformers/protocols/text_classifier.py
+++ b/daft/ai/transformers/protocols/text_classifier.py
@@ -5,7 +5,6 @@ import threading
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, TypedDict
 
-import transformers
 from transformers import pipeline
 
 if sys.version_info < (3, 11):
@@ -21,6 +20,8 @@ from daft.ai.utils import get_gpu_udf_options, get_torch_device
 _model_loading_lock = threading.Lock()
 
 if TYPE_CHECKING:
+    import transformers
+
     from daft.ai.typing import Label, Options, UDFOptions
 
 

--- a/daft/catalog/__iceberg.py
+++ b/daft/catalog/__iceberg.py
@@ -11,7 +11,6 @@ from pyiceberg.io.pyarrow import _pyarrow_to_schema_without_ids
 from pyiceberg.partitioning import PartitionField as PyIcebergPartitionField
 from pyiceberg.partitioning import PartitionSpec as PyIcebergPartitionSpec
 from pyiceberg.partitioning import _PartitionNameGenerator
-from pyiceberg.schema import Schema as PyIcebergSchema
 from pyiceberg.schema import assign_fresh_schema_ids
 from pyiceberg.table import Table as InnerTable
 from pyiceberg.transforms import (
@@ -29,6 +28,8 @@ from daft.io.iceberg._iceberg import read_iceberg
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+    from pyiceberg.schema import Schema as PyIcebergSchema
 
     from daft.dataframe import DataFrame
     from daft.io.partitioning import PartitionField

--- a/daft/io/huggingface/sink.py
+++ b/daft/io/huggingface/sink.py
@@ -17,7 +17,7 @@ from daft.utils import get_arrow_version
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
-    from huggingface_hub import CommitOperationAdd, HfApi
+    from huggingface_hub import CommitOperation, CommitOperationAdd, HfApi
 
     from daft.daft import HuggingFaceConfig
 
@@ -167,7 +167,7 @@ class HuggingFaceSink(DataSink[CommitOperationAddWrapper]):
                     yield flush(writer)
 
     def finalize(self, write_results: list[WriteResult[CommitOperationAddWrapper]]) -> MicroPartition:
-        from huggingface_hub import CommitOperation, CommitOperationAdd, CommitOperationCopy, CommitOperationDelete
+        from huggingface_hub import CommitOperationAdd, CommitOperationCopy, CommitOperationDelete
         from huggingface_hub.hf_api import RepoFile, RepoFolder
 
         additions = [res.result.inner for res in write_results]

--- a/daft/io/iceberg/_metadata.py
+++ b/daft/io/iceberg/_metadata.py
@@ -18,9 +18,6 @@ from pyiceberg.transforms import (
 from pyiceberg.transforms import (
     MonthTransform as IcebergMonthTransform,
 )
-from pyiceberg.transforms import (
-    Transform as IcebergTransform,
-)
 from pyiceberg.transforms import TruncateTransform as IcebergTruncateTransform
 from pyiceberg.transforms import YearTransform as IcebergYearTransform
 
@@ -32,6 +29,7 @@ if TYPE_CHECKING:
     from pyiceberg.partitioning import PartitionSpec as IcebergPartitionSpec
     from pyiceberg.schema import Schema as IcebergSchema
     from pyiceberg.table import TableMetadata as IcebergTableMetadata
+    from pyiceberg.transforms import Transform as IcebergTransform
     from pyiceberg.types import IcebergType
 
 

--- a/daft/io/iceberg/iceberg_scan.py
+++ b/daft/io/iceberg/iceberg_scan.py
@@ -4,7 +4,6 @@ import logging
 import warnings
 from typing import TYPE_CHECKING
 
-from pyiceberg.schema import Schema as IcebergSchema
 from pyiceberg.schema import visit
 
 import daft
@@ -35,6 +34,7 @@ if TYPE_CHECKING:
 
     from pyiceberg.partitioning import PartitionField as IcebergPartitionField
     from pyiceberg.partitioning import PartitionSpec as IcebergPartitionSpec
+    from pyiceberg.schema import Schema as IcebergSchema
     from pyiceberg.table import Table
     from pyiceberg.typedef import Record
 

--- a/daft/io/iceberg/schema_field_id_mapping_visitor.py
+++ b/daft/io/iceberg/schema_field_id_mapping_visitor.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from pyiceberg.io.pyarrow import schema_to_pyarrow
-from pyiceberg.schema import Schema, SchemaVisitor
+from pyiceberg.schema import SchemaVisitor
 
 from daft import DataType
 from daft.daft import PyField
 
 if TYPE_CHECKING:
+    from pyiceberg.schema import Schema
     from pyiceberg.types import ListType, MapType, NestedField, PrimitiveType, StructType
 
 FieldIdMapping = dict[int, PyField]

--- a/daft/series.py
+++ b/daft/series.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Literal, TypeVar
 
-from typing_extensions import Self
-
 import daft.daft as native
 from daft.daft import CountMode, ImageFormat, ImageMode, PyRecordBatch, PySeries, PySeriesIterator
 from daft.datatype import DataType, TimeUnit, _ensure_registered_super_ext_type
@@ -13,6 +11,8 @@ from daft.schema import Field
 if TYPE_CHECKING:
     import builtins
     from collections.abc import Callable
+
+    from typing_extensions import Self
 
     from daft.daft import PyDataType
 


### PR DESCRIPTION
## Changes Made

Follow-up to #6971. Defends against the bug class it fixed — a module-level import of a runtime dep that isn't always declared (in that case, `typing_extensions` on Python 3.11+).

After this PR:

- **CI** verifies `pip install daft` + `import daft` on Python 3.10/3.11/3.12/3.13 (was 3.10 only). The existing `test-imports-platform` job was the right design; its matrix was the gap.
- **Lint** (ruff `flake8-type-checking`, `strict = true`) fails pre-commit on misplaced annotation-only imports. The headline catch is TC002 (third-party imports at module top, the #6971 pattern); TC004–TC010 (misplaced TYPE_CHECKING imports, runtime cast/alias issues) are also live. TC001/TC003 (first-party/stdlib) are deferred via `extend-ignore` — 163 existing cosmetic violations, follow-up territory. Existing TC002 offenders fixed.

No user-visible behavior change; the wheel and the public API are identical.

## Related Issues

Follow-up to #6971.

🤖 Generated with [Claude Code](https://claude.com/claude-code)