### PR TITLE
ci(demo): expand install-smoke matrix to py 3.11/3.12/3.13

### DIFF
--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -1627,7 +1627,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, Windows]
-        python-version: ["3.10"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         on-main:
         - ${{ github.ref == 'refs/heads/main' }}
         exclude:


### PR DESCRIPTION
**Throwaway PR — do not merge.**

Isolates the matrix-expansion change from #6972 to demonstrate that on `main`'s current (still-buggy) `daft/series.py`, the broader matrix catches the bug class fixed in #6971.

Expected: `test-imports-platform` 3.10 ✅, 3.11/3.12/3.13 ❌ with `ModuleNotFoundError: No module named 'typing_extensions'` on `import daft`.

Will close once CI confirms.