### PR TITLE
feat(shuffle): track rows/bytes/partitions on shuffle write sinks

### DIFF
--- a/src/common/metrics/src/lib.rs
+++ b/src/common/metrics/src/lib.rs
@@ -165,6 +165,17 @@ pub const UNIT_MICROSECONDS: &str = "us";
 pub const UNIT_TASKS: &str = "{task}";
 pub const UNIT_PERCENT: &str = "%";
 
+// Shuffle write metrics
+pub const SHUFFLE_ROWS_IN_KEY: &str = "shuffle.rows_in";
+pub const SHUFFLE_ROWS_WRITTEN_KEY: &str = "shuffle.rows_written";
+
+pub const SHUFFLE_BYTES_IN_KEY: &str = "shuffle.bytes_in";
+pub const SHUFFLE_BYTES_WRITTEN_KEY: &str = "shuffle.bytes_written";
+
+pub const SHUFFLE_PARTITIONS_WRITTEN_KEY: &str = "shuffle.partitions_written";
+
+pub const SHUFFLE_FINALIZE_DURATION_KEY: &str = "shuffle.finalize_duration";
+
 #[cfg(feature = "python")]
 pub fn register_modules(parent: &Bound<PyModule>) -> PyResult<()> {
     use pyo3::types::PyModuleMethods;

--- a/src/common/metrics/src/snapshot.rs
+++ b/src/common/metrics/src/snapshot.rs
@@ -450,10 +450,7 @@ pub struct ShuffleWriteSnapshot {
     #[serde(default)]
     pub bytes_written: u64,
     pub partitions_written: u64,
-    /// Wall time spent inside the sink's `finalize()` call after all input is
-    /// received, including any buffered-data flush, concat, and backend
-    /// write/close work done there. Complements `cpu_us`, which today only
-    /// accumulates time across `sink()` task invocations and excludes finalize.
+    // Wall time inside finalize(); complements cpu_us, which only covers sink() calls.
     pub finalize_duration_us: u64,
     pub num_tasks: u64,
 }
@@ -790,10 +787,7 @@ mod tests {
             stat_for_key(&stats, DURATION_KEY),
             &Stat::Duration(Duration::from_micros(1_000_000))
         );
-        assert_eq!(
-            stat_for_key(&stats, SHUFFLE_ROWS_IN_KEY),
-            &Stat::Count(100)
-        );
+        assert_eq!(stat_for_key(&stats, SHUFFLE_ROWS_IN_KEY), &Stat::Count(100));
         assert_eq!(
             stat_for_key(&stats, SHUFFLE_ROWS_WRITTEN_KEY),
             &Stat::Count(200)
@@ -816,5 +810,4 @@ mod tests {
         );
         assert_eq!(stat_for_key(&stats, NUM_TASKS_KEY), &Stat::Count(5));
     }
-
 }

--- a/src/common/metrics/src/snapshot.rs
+++ b/src/common/metrics/src/snapshot.rs
@@ -10,7 +10,9 @@ use smallvec::SmallVec;
 use crate::{
     BYTES_IN_KEY, BYTES_OUT_KEY, BYTES_READ_KEY, BYTES_WRITTEN_KEY, DURATION_KEY,
     JOIN_BUILD_BYTES_INSERTED_KEY, JOIN_PROBE_BYTES_IN_KEY, JOIN_PROBE_BYTES_OUT_KEY,
-    NUM_TASKS_KEY, ROWS_IN_KEY, ROWS_OUT_KEY, ROWS_WRITTEN_KEY, Stat, Stats,
+    NUM_TASKS_KEY, ROWS_IN_KEY, ROWS_OUT_KEY, ROWS_WRITTEN_KEY, SHUFFLE_BYTES_IN_KEY,
+    SHUFFLE_BYTES_WRITTEN_KEY, SHUFFLE_FINALIZE_DURATION_KEY, SHUFFLE_PARTITIONS_WRITTEN_KEY,
+    SHUFFLE_ROWS_IN_KEY, SHUFFLE_ROWS_WRITTEN_KEY, Stat, Stats,
 };
 
 macro_rules! stats {
@@ -438,6 +440,68 @@ impl WriteSnapshot {
     }
 }
 
+#[derive(Debug, Clone, Encode, Decode, Serialize, Deserialize)]
+pub struct ShuffleWriteSnapshot {
+    pub cpu_us: u64,
+    pub rows_in: u64,
+    pub rows_written: u64,
+    #[serde(default)]
+    pub bytes_in: u64,
+    #[serde(default)]
+    pub bytes_written: u64,
+    pub partitions_written: u64,
+    /// Wall time spent inside the sink's `finalize()` call after all input is
+    /// received, including any buffered-data flush, concat, and backend
+    /// write/close work done there. Complements `cpu_us`, which today only
+    /// accumulates time across `sink()` task invocations and excludes finalize.
+    pub finalize_duration_us: u64,
+    pub num_tasks: u64,
+}
+
+impl StatSnapshotImpl for ShuffleWriteSnapshot {
+    fn duration_us(&self) -> u64 {
+        self.cpu_us
+    }
+
+    fn to_stats(&self) -> Stats {
+        stats![
+            DURATION_KEY; Stat::Duration(Duration::from_micros(self.cpu_us)),
+            SHUFFLE_ROWS_IN_KEY; Stat::Count(self.rows_in),
+            SHUFFLE_ROWS_WRITTEN_KEY; Stat::Count(self.rows_written),
+            SHUFFLE_BYTES_IN_KEY; Stat::Bytes(self.bytes_in),
+            SHUFFLE_BYTES_WRITTEN_KEY; Stat::Bytes(self.bytes_written),
+            SHUFFLE_PARTITIONS_WRITTEN_KEY; Stat::Count(self.partitions_written),
+            SHUFFLE_FINALIZE_DURATION_KEY; Stat::Duration(Duration::from_micros(self.finalize_duration_us)),
+            NUM_TASKS_KEY; Stat::Count(self.num_tasks),
+        ]
+    }
+
+    fn to_message(&self) -> String {
+        format!(
+            "{} rows in, {} rows written, {} written, {} partitions written",
+            HumanCount(self.rows_in),
+            HumanCount(self.rows_written),
+            HumanBytes(self.bytes_written),
+            HumanCount(self.partitions_written),
+        )
+    }
+}
+
+impl ShuffleWriteSnapshot {
+    pub fn merge(self, other: &Self) -> Self {
+        Self {
+            cpu_us: self.cpu_us + other.cpu_us,
+            rows_in: self.rows_in + other.rows_in,
+            rows_written: self.rows_written + other.rows_written,
+            bytes_in: self.bytes_in + other.bytes_in,
+            bytes_written: self.bytes_written + other.bytes_written,
+            partitions_written: self.partitions_written + other.partitions_written,
+            finalize_duration_us: self.finalize_duration_us + other.finalize_duration_us,
+            num_tasks: self.num_tasks + other.num_tasks,
+        }
+    }
+}
+
 #[enum_dispatch(StatSnapshotImpl)]
 #[derive(Debug, Clone, Encode, Decode, Serialize, Deserialize)]
 pub enum StatSnapshot {
@@ -448,6 +512,7 @@ pub enum StatSnapshot {
     Udf(UdfSnapshot),
     Join(JoinSnapshot),
     Write(WriteSnapshot),
+    ShuffleWrite(ShuffleWriteSnapshot),
 }
 
 impl StatSnapshot {
@@ -461,6 +526,7 @@ impl StatSnapshot {
             (Self::Udf(a), Self::Udf(b)) => Self::Udf(a.merge(b)),
             (Self::Join(a), Self::Join(b)) => Self::Join(a.merge(b)),
             (Self::Write(a), Self::Write(b)) => Self::Write(a.merge(b)),
+            (Self::ShuffleWrite(a), Self::ShuffleWrite(b)) => Self::ShuffleWrite(a.merge(b)),
             (s, _) => s,
         }
     }
@@ -482,6 +548,16 @@ mod tests {
                 })
             })
             .expect("num_tasks key should be present in to_stats output")
+    }
+
+    /// Helper for asserting that a `to_stats()` rendering contains an expected key/value.
+    /// Panics with a descriptive message if the key is absent.
+    fn stat_for_key<'a>(stats: &'a Stats, key: &str) -> &'a Stat {
+        stats
+            .iter()
+            .find(|(name, _)| *name == key)
+            .map(|(_, stat)| stat)
+            .unwrap_or_else(|| panic!("expected key {} in stats: {:?}", key, stats))
     }
 
     #[test]
@@ -629,6 +705,29 @@ mod tests {
                 }),
                 3,
             ),
+            (
+                StatSnapshot::ShuffleWrite(ShuffleWriteSnapshot {
+                    num_tasks: 2,
+                    cpu_us: 0,
+                    rows_in: 0,
+                    rows_written: 0,
+                    bytes_in: 0,
+                    bytes_written: 0,
+                    partitions_written: 0,
+                    finalize_duration_us: 0,
+                }),
+                StatSnapshot::ShuffleWrite(ShuffleWriteSnapshot {
+                    num_tasks: 3,
+                    cpu_us: 0,
+                    rows_in: 0,
+                    rows_written: 0,
+                    bytes_in: 0,
+                    bytes_written: 0,
+                    partitions_written: 0,
+                    finalize_duration_us: 0,
+                }),
+                5,
+            ),
         ];
 
         for (a, b, expected) in cases {
@@ -640,4 +739,82 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn shuffle_write_snapshot_merge_sums_all_fields() {
+        let a = ShuffleWriteSnapshot {
+            cpu_us: 1,
+            rows_in: 2,
+            rows_written: 3,
+            bytes_in: 4,
+            bytes_written: 5,
+            partitions_written: 6,
+            finalize_duration_us: 7,
+            num_tasks: 8,
+        };
+        let b = ShuffleWriteSnapshot {
+            cpu_us: 10,
+            rows_in: 20,
+            rows_written: 30,
+            bytes_in: 40,
+            bytes_written: 50,
+            partitions_written: 60,
+            finalize_duration_us: 70,
+            num_tasks: 80,
+        };
+        let merged = a.merge(&b);
+        assert_eq!(merged.cpu_us, 11);
+        assert_eq!(merged.rows_in, 22);
+        assert_eq!(merged.rows_written, 33);
+        assert_eq!(merged.bytes_in, 44);
+        assert_eq!(merged.bytes_written, 55);
+        assert_eq!(merged.partitions_written, 66);
+        assert_eq!(merged.finalize_duration_us, 77);
+        assert_eq!(merged.num_tasks, 88);
+    }
+
+    #[test]
+    fn shuffle_write_snapshot_to_stats_includes_all_fields() {
+        let snap = ShuffleWriteSnapshot {
+            cpu_us: 1_000_000,
+            rows_in: 100,
+            rows_written: 200,
+            bytes_in: 1024,
+            bytes_written: 2048,
+            partitions_written: 4,
+            finalize_duration_us: 750_000,
+            num_tasks: 5,
+        };
+        let stats = snap.to_stats();
+        assert_eq!(
+            stat_for_key(&stats, DURATION_KEY),
+            &Stat::Duration(Duration::from_micros(1_000_000))
+        );
+        assert_eq!(
+            stat_for_key(&stats, SHUFFLE_ROWS_IN_KEY),
+            &Stat::Count(100)
+        );
+        assert_eq!(
+            stat_for_key(&stats, SHUFFLE_ROWS_WRITTEN_KEY),
+            &Stat::Count(200)
+        );
+        assert_eq!(
+            stat_for_key(&stats, SHUFFLE_BYTES_IN_KEY),
+            &Stat::Bytes(1024)
+        );
+        assert_eq!(
+            stat_for_key(&stats, SHUFFLE_BYTES_WRITTEN_KEY),
+            &Stat::Bytes(2048)
+        );
+        assert_eq!(
+            stat_for_key(&stats, SHUFFLE_PARTITIONS_WRITTEN_KEY),
+            &Stat::Count(4)
+        );
+        assert_eq!(
+            stat_for_key(&stats, SHUFFLE_FINALIZE_DURATION_KEY),
+            &Stat::Duration(Duration::from_micros(750_000))
+        );
+        assert_eq!(stat_for_key(&stats, NUM_TASKS_KEY), &Stat::Count(5));
+    }
+
 }

--- a/src/daft-local-execution/src/runtime_stats/mod.rs
+++ b/src/daft-local-execution/src/runtime_stats/mod.rs
@@ -1,5 +1,6 @@
 mod process_stats;
 mod progress_bar;
+mod shuffle;
 mod values;
 
 use std::{
@@ -18,7 +19,7 @@ use daft_context::{
     subscribers::{
         event_header,
         events::{
-            Event, ExecEndEvent, ExecStartEvent, OperatorEndEvent, OperatorMeta,
+            Event, ExecEndEvent, ExecStartEvent, ExecutionConfig, OperatorEndEvent, OperatorMeta,
             OperatorStartEvent, ProcessStatsEvent, StatsEvent, TaskStatsSnapshot,
             TaskStatsUpdateEvent,
         },
@@ -27,6 +28,7 @@ use daft_context::{
 use daft_dsl::common_treenode::{TreeNode, TreeNodeRecursion};
 use daft_local_plan::{ExecutionStats, InputId};
 use progress_bar::{ProgressBar, make_progress_bar_manager};
+pub use shuffle::ShuffleWriteRuntimeStats;
 use tokio::{
     runtime::Handle,
     sync::{mpsc, oneshot},

--- a/src/daft-local-execution/src/runtime_stats/mod.rs
+++ b/src/daft-local-execution/src/runtime_stats/mod.rs
@@ -19,7 +19,7 @@ use daft_context::{
     subscribers::{
         event_header,
         events::{
-            Event, ExecEndEvent, ExecStartEvent, ExecutionConfig, OperatorEndEvent, OperatorMeta,
+            Event, ExecEndEvent, ExecStartEvent, OperatorEndEvent, OperatorMeta,
             OperatorStartEvent, ProcessStatsEvent, StatsEvent, TaskStatsSnapshot,
             TaskStatsUpdateEvent,
         },

--- a/src/daft-local-execution/src/runtime_stats/shuffle.rs
+++ b/src/daft-local-execution/src/runtime_stats/shuffle.rs
@@ -55,13 +55,9 @@ impl RuntimeStats for ShuffleWriteRuntimeStats {
         self.rows_in.add(rows, self.node_kv.as_slice());
     }
 
-    // add_rows_out / add_bytes_out are required by the trait but represent the
-    // generic "node produced output" concept. Shuffle writes track output via
-    // add_rows_written / add_bytes_written, which we override below. The framework
-    // drives all shuffle accounting through the *_written methods directly, so
-    // these stay as no-ops — if some future non-BlockingSink path ever calls
-    // add_rows_out on a ShuffleWriteRuntimeStats, silently dropping the value is
-    // preferable to mis-attributing it against the typed rows_written counter.
+    // Override to no-op so a direct add_rows_out call (bypassing the framework's
+    // add_rows_written path) doesn't mis-attribute into rows_written via the
+    // trait's delegating default.
     fn add_rows_out(&self, _rows: u64) {}
 
     fn add_duration_us(&self, duration_us: u64) {
@@ -132,11 +128,8 @@ mod tests {
         assert_eq!(snap.num_tasks, 2);
     }
 
-    /// Pins the no-op contract documented at the top of the `RuntimeStats` impl:
-    /// `add_rows_out` / `add_bytes_out` must not increment `rows_written` /
-    /// `bytes_written` via the trait's delegating defaults. A future "helpful"
-    /// change that routes generic outputs into the typed counters would silently
-    /// double-count shuffle writes and this test would catch it.
+    // Pins the no-op contract: add_rows_out/add_bytes_out must not route into
+    // rows_written/bytes_written via the trait's delegating defaults.
     #[test]
     fn shuffle_write_add_rows_out_is_noop() {
         let stats = ShuffleWriteRuntimeStats::new(

--- a/src/daft-local-execution/src/runtime_stats/shuffle.rs
+++ b/src/daft-local-execution/src/runtime_stats/shuffle.rs
@@ -1,0 +1,159 @@
+use std::sync::atomic::Ordering;
+
+use common_metrics::{
+    Counter, Meter, SHUFFLE_BYTES_IN_KEY, SHUFFLE_BYTES_WRITTEN_KEY,
+    SHUFFLE_FINALIZE_DURATION_KEY, SHUFFLE_PARTITIONS_WRITTEN_KEY, SHUFFLE_ROWS_IN_KEY,
+    SHUFFLE_ROWS_WRITTEN_KEY, StatSnapshot,
+    ops::NodeInfo,
+    snapshot::ShuffleWriteSnapshot,
+};
+use opentelemetry::KeyValue;
+
+use super::RuntimeStats;
+
+pub struct ShuffleWriteRuntimeStats {
+    duration_us: Counter,
+    rows_in: Counter,
+    rows_written: Counter,
+    bytes_in: Counter,
+    bytes_written: Counter,
+    partitions_written: Counter,
+    finalize_duration_us: Counter,
+    num_tasks: Counter,
+    node_kv: Vec<KeyValue>,
+}
+
+impl RuntimeStats for ShuffleWriteRuntimeStats {
+    fn new(meter: &Meter, node_info: &NodeInfo) -> Self {
+        // duration_us/num_tasks reuse generic per-node metric names shared by all
+        // operators; shuffle-specific counters use the shuffle.* prefix.
+        Self {
+            duration_us: meter.duration_us_metric(),
+            rows_in: meter.u64_counter(SHUFFLE_ROWS_IN_KEY),
+            rows_written: meter.u64_counter(SHUFFLE_ROWS_WRITTEN_KEY),
+            bytes_in: meter.u64_counter(SHUFFLE_BYTES_IN_KEY),
+            bytes_written: meter.u64_counter(SHUFFLE_BYTES_WRITTEN_KEY),
+            partitions_written: meter.u64_counter(SHUFFLE_PARTITIONS_WRITTEN_KEY),
+            finalize_duration_us: meter.u64_counter(SHUFFLE_FINALIZE_DURATION_KEY),
+            num_tasks: meter.num_tasks_metric(),
+            node_kv: node_info.to_key_values(),
+        }
+    }
+
+    fn build_snapshot(&self, ordering: Ordering) -> StatSnapshot {
+        StatSnapshot::ShuffleWrite(ShuffleWriteSnapshot {
+            cpu_us: self.duration_us.load(ordering),
+            rows_in: self.rows_in.load(ordering),
+            rows_written: self.rows_written.load(ordering),
+            bytes_in: self.bytes_in.load(ordering),
+            bytes_written: self.bytes_written.load(ordering),
+            partitions_written: self.partitions_written.load(ordering),
+            finalize_duration_us: self.finalize_duration_us.load(ordering),
+            num_tasks: self.num_tasks.load(ordering),
+        })
+    }
+
+    fn add_rows_in(&self, rows: u64) {
+        self.rows_in.add(rows, self.node_kv.as_slice());
+    }
+
+    // add_rows_out / add_bytes_out are required by the trait but represent the
+    // generic "node produced output" concept. Shuffle writes track output via
+    // add_rows_written / add_bytes_written, which we override below. The framework
+    // drives all shuffle accounting through the *_written methods directly, so
+    // these stay as no-ops — if some future non-BlockingSink path ever calls
+    // add_rows_out on a ShuffleWriteRuntimeStats, silently dropping the value is
+    // preferable to mis-attributing it against the typed rows_written counter.
+    fn add_rows_out(&self, _rows: u64) {}
+
+    fn add_duration_us(&self, duration_us: u64) {
+        self.duration_us.add(duration_us, self.node_kv.as_slice());
+    }
+
+    fn add_bytes_in(&self, bytes: u64) {
+        self.bytes_in.add(bytes, self.node_kv.as_slice());
+    }
+
+    fn add_bytes_out(&self, _bytes: u64) {}
+
+    fn increment_num_tasks(&self) {
+        self.num_tasks.add(1, self.node_kv.as_slice());
+    }
+
+    fn add_rows_written(&self, rows: u64) {
+        self.rows_written.add(rows, self.node_kv.as_slice());
+    }
+
+    fn add_bytes_written(&self, bytes: u64) {
+        self.bytes_written.add(bytes, self.node_kv.as_slice());
+    }
+
+    fn add_partitions_written(&self, partitions: u64) {
+        self.partitions_written
+            .add(partitions, self.node_kv.as_slice());
+    }
+
+    fn add_finalize_duration_us(&self, duration_us: u64) {
+        self.finalize_duration_us
+            .add(duration_us, self.node_kv.as_slice());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use common_metrics::{Meter, StatSnapshot, ops::NodeInfo};
+
+    use super::*;
+
+    #[test]
+    fn shuffle_write_runtime_stats_round_trip() {
+        let stats = ShuffleWriteRuntimeStats::new(
+            &Meter::test_scope("shuffle_write_round_trip"),
+            &NodeInfo::default(),
+        );
+        stats.add_rows_in(120);
+        stats.add_bytes_in(2048);
+        stats.add_rows_written(100);
+        stats.add_bytes_written(1024);
+        stats.add_partitions_written(4);
+        stats.add_finalize_duration_us(750);
+        stats.add_duration_us(900);
+        stats.increment_num_tasks();
+        stats.increment_num_tasks();
+
+        let StatSnapshot::ShuffleWrite(snap) = stats.snapshot() else {
+            panic!("expected ShuffleWrite snapshot");
+        };
+        assert_eq!(snap.rows_in, 120);
+        assert_eq!(snap.bytes_in, 2048);
+        assert_eq!(snap.rows_written, 100);
+        assert_eq!(snap.bytes_written, 1024);
+        assert_eq!(snap.partitions_written, 4);
+        assert_eq!(snap.finalize_duration_us, 750);
+        assert_eq!(snap.cpu_us, 900);
+        assert_eq!(snap.num_tasks, 2);
+    }
+
+    /// Pins the no-op contract documented at the top of the `RuntimeStats` impl:
+    /// `add_rows_out` / `add_bytes_out` must not increment `rows_written` /
+    /// `bytes_written` via the trait's delegating defaults. A future "helpful"
+    /// change that routes generic outputs into the typed counters would silently
+    /// double-count shuffle writes and this test would catch it.
+    #[test]
+    fn shuffle_write_add_rows_out_is_noop() {
+        let stats = ShuffleWriteRuntimeStats::new(
+            &Meter::test_scope("shuffle_write_noop"),
+            &NodeInfo::default(),
+        );
+        stats.add_rows_written(100);
+        stats.add_bytes_written(1024);
+        stats.add_rows_out(999);
+        stats.add_bytes_out(9999);
+
+        let StatSnapshot::ShuffleWrite(snap) = stats.snapshot() else {
+            panic!("expected ShuffleWrite snapshot");
+        };
+        assert_eq!(snap.rows_written, 100);
+        assert_eq!(snap.bytes_written, 1024);
+    }
+}

--- a/src/daft-local-execution/src/runtime_stats/shuffle.rs
+++ b/src/daft-local-execution/src/runtime_stats/shuffle.rs
@@ -1,11 +1,9 @@
 use std::sync::atomic::Ordering;
 
 use common_metrics::{
-    Counter, Meter, SHUFFLE_BYTES_IN_KEY, SHUFFLE_BYTES_WRITTEN_KEY,
-    SHUFFLE_FINALIZE_DURATION_KEY, SHUFFLE_PARTITIONS_WRITTEN_KEY, SHUFFLE_ROWS_IN_KEY,
-    SHUFFLE_ROWS_WRITTEN_KEY, StatSnapshot,
-    ops::NodeInfo,
-    snapshot::ShuffleWriteSnapshot,
+    Counter, Meter, SHUFFLE_BYTES_IN_KEY, SHUFFLE_BYTES_WRITTEN_KEY, SHUFFLE_FINALIZE_DURATION_KEY,
+    SHUFFLE_PARTITIONS_WRITTEN_KEY, SHUFFLE_ROWS_IN_KEY, SHUFFLE_ROWS_WRITTEN_KEY, StatSnapshot,
+    ops::NodeInfo, snapshot::ShuffleWriteSnapshot,
 };
 use opentelemetry::KeyValue;
 

--- a/src/daft-local-execution/src/runtime_stats/values.rs
+++ b/src/daft-local-execution/src/runtime_stats/values.rs
@@ -46,9 +46,6 @@ pub trait RuntimeStats: Send + Sync + std::any::Any {
         self.add_bytes_out(bytes);
     }
     fn add_partitions_written(&self, _partitions: u64) {}
-    /// Wall time spent inside the sink's `finalize()` call after all input is
-    /// received, including any buffered-data flush, concat, and backend
-    /// write/close work done there. Default no-op; sinks that care override.
     fn add_finalize_duration_us(&self, _duration_us: u64) {}
 }
 
@@ -118,11 +115,9 @@ mod tests {
 
     use super::*;
 
-    /// Locks down the trait's delegating defaults: `add_rows_written` lands in
-    /// `rows_out` and `add_bytes_written` lands in `bytes_out`. The framework's
-    /// `BlockingSinkNode::spawn_finalize` calls the `*_written` hooks for all
-    /// blocking-sink outputs; if these defaults silently became no-ops, every
-    /// non-shuffle BlockingSink would lose its rows_out / bytes_out accounting.
+    // Defaults must delegate add_rows_written → rows_out and add_bytes_written →
+    // bytes_out, else non-shuffle BlockingSinks would lose accounting through the
+    // framework's *_written hooks.
     #[test]
     fn default_stats_add_rows_and_bytes_written_delegates() {
         let stats = DefaultRuntimeStats::new(
@@ -139,10 +134,8 @@ mod tests {
         assert_eq!(snap.bytes_out, 2048);
     }
 
-    /// `add_partitions_written` and `add_finalize_duration_us` are no-ops on
-    /// the base trait — `DefaultSnapshot` has no fields for them and shouldn't
-    /// gain any. Confirms calling them on a non-shuffle stats type doesn't
-    /// affect the snapshot's other counters.
+    // add_partitions_written and add_finalize_duration_us are no-ops on the
+    // base trait; DefaultSnapshot has no fields for them.
     #[test]
     fn default_stats_partitions_and_finalize_duration_are_noops() {
         let stats =

--- a/src/daft-local-execution/src/runtime_stats/values.rs
+++ b/src/daft-local-execution/src/runtime_stats/values.rs
@@ -5,7 +5,7 @@ use opentelemetry::KeyValue;
 
 // ----------------------- General Traits for Runtime Stat Collection ----------------------- //
 
-pub trait RuntimeStats: Send + Sync + std::any::Any {
+pub trait RuntimeStats: Send + Sync {
     fn new(meter: &Meter, node_info: &NodeInfo) -> Self
     where
         Self: Sized;
@@ -35,6 +35,21 @@ pub trait RuntimeStats: Send + Sync + std::any::Any {
     /// not directly comparable across operator kinds — interpret relative
     /// to the operator's own scale.
     fn increment_num_tasks(&self);
+
+    /// Optional sink-output hooks. Most nodes do not distinguish generic
+    /// output from materialized writes, so row/byte write defaults delegate
+    /// to generic output counters.
+    fn add_rows_written(&self, rows: u64) {
+        self.add_rows_out(rows);
+    }
+    fn add_bytes_written(&self, bytes: u64) {
+        self.add_bytes_out(bytes);
+    }
+    fn add_partitions_written(&self, _partitions: u64) {}
+    /// Wall time spent inside the sink's `finalize()` call after all input is
+    /// received, including any buffered-data flush, concat, and backend
+    /// write/close work done there. Default no-op; sinks that care override.
+    fn add_finalize_duration_us(&self, _duration_us: u64) {}
 }
 
 pub struct DefaultRuntimeStats {
@@ -94,5 +109,56 @@ impl RuntimeStats for DefaultRuntimeStats {
 
     fn increment_num_tasks(&self) {
         self.num_tasks.add(1, self.node_kv.as_slice());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use common_metrics::ops::NodeInfo;
+
+    use super::*;
+
+    /// Locks down the trait's delegating defaults: `add_rows_written` lands in
+    /// `rows_out` and `add_bytes_written` lands in `bytes_out`. The framework's
+    /// `BlockingSinkNode::spawn_finalize` calls the `*_written` hooks for all
+    /// blocking-sink outputs; if these defaults silently became no-ops, every
+    /// non-shuffle BlockingSink would lose its rows_out / bytes_out accounting.
+    #[test]
+    fn default_stats_add_rows_and_bytes_written_delegates() {
+        let stats = DefaultRuntimeStats::new(
+            &Meter::test_scope("default_delegation"),
+            &NodeInfo::default(),
+        );
+        stats.add_rows_written(100);
+        stats.add_bytes_written(2048);
+
+        let StatSnapshot::Default(snap) = stats.snapshot() else {
+            panic!("expected Default snapshot");
+        };
+        assert_eq!(snap.rows_out, 100);
+        assert_eq!(snap.bytes_out, 2048);
+    }
+
+    /// `add_partitions_written` and `add_finalize_duration_us` are no-ops on
+    /// the base trait — `DefaultSnapshot` has no fields for them and shouldn't
+    /// gain any. Confirms calling them on a non-shuffle stats type doesn't
+    /// affect the snapshot's other counters.
+    #[test]
+    fn default_stats_partitions_and_finalize_duration_are_noops() {
+        let stats = DefaultRuntimeStats::new(
+            &Meter::test_scope("default_noops"),
+            &NodeInfo::default(),
+        );
+        stats.add_rows_in(50);
+        stats.add_partitions_written(42);
+        stats.add_finalize_duration_us(1000);
+
+        let StatSnapshot::Default(snap) = stats.snapshot() else {
+            panic!("expected Default snapshot");
+        };
+        assert_eq!(snap.rows_in, 50);
+        assert_eq!(snap.rows_out, 0);
+        assert_eq!(snap.bytes_out, 0);
+        assert_eq!(snap.cpu_us, 0);
     }
 }

--- a/src/daft-local-execution/src/runtime_stats/values.rs
+++ b/src/daft-local-execution/src/runtime_stats/values.rs
@@ -5,7 +5,7 @@ use opentelemetry::KeyValue;
 
 // ----------------------- General Traits for Runtime Stat Collection ----------------------- //
 
-pub trait RuntimeStats: Send + Sync {
+pub trait RuntimeStats: Send + Sync + std::any::Any {
     fn new(meter: &Meter, node_info: &NodeInfo) -> Self
     where
         Self: Sized;
@@ -145,10 +145,8 @@ mod tests {
     /// affect the snapshot's other counters.
     #[test]
     fn default_stats_partitions_and_finalize_duration_are_noops() {
-        let stats = DefaultRuntimeStats::new(
-            &Meter::test_scope("default_noops"),
-            &NodeInfo::default(),
-        );
+        let stats =
+            DefaultRuntimeStats::new(&Meter::test_scope("default_noops"), &NodeInfo::default());
         stats.add_rows_in(50);
         stats.add_partitions_written(42);
         stats.add_finalize_duration_us(1000);

--- a/src/daft-local-execution/src/sinks/blocking_sink.rs
+++ b/src/daft-local-execution/src/sinks/blocking_sink.rs
@@ -251,11 +251,16 @@ impl<Op: BlockingSink + 'static> BlockingSinkNode<Op> {
             // measurement excludes spawner queue time. Excludes post-finalize
             // framework work like output sending and checkpoint staging, which run
             // after this measurement closes.
+            //
+            // Record the duration before propagating any error so that a slow
+            // finalize that ultimately fails (timeout, OOM, backend error) still
+            // surfaces its wall time in the snapshot.
             let finalize_start = Instant::now();
-            let output = op.finalize(per_input.states, &finalize_spawner).await??;
+            let finalize_result = op.finalize(per_input.states, &finalize_spawner).await;
             per_input
                 .runtime_stats
                 .add_finalize_duration_us(finalize_start.elapsed().as_micros() as u64);
+            let output = finalize_result??;
             per_input.runtime_stats.increment_num_tasks();
             match output {
                 BlockingSinkOutput::Partitions(partitions) => {

--- a/src/daft-local-execution/src/sinks/blocking_sink.rs
+++ b/src/daft-local-execution/src/sinks/blocking_sink.rs
@@ -245,7 +245,17 @@ impl<Op: BlockingSink + 'static> BlockingSinkNode<Op> {
                 .as_ref()
                 .map(|(_, id_map, _)| id_map.get_or_generate(input_id));
 
+            // Wall time spent inside the sink's finalize() call after all input is
+            // received: includes any buffered-data flush, concat, and backend
+            // write/close work done there. Captured inside the spawned task so the
+            // measurement excludes spawner queue time. Excludes post-finalize
+            // framework work like output sending and checkpoint staging, which run
+            // after this measurement closes.
+            let finalize_start = Instant::now();
             let output = op.finalize(per_input.states, &finalize_spawner).await??;
+            per_input
+                .runtime_stats
+                .add_finalize_duration_us(finalize_start.elapsed().as_micros() as u64);
             per_input.runtime_stats.increment_num_tasks();
             match output {
                 BlockingSinkOutput::Partitions(partitions) => {
@@ -259,11 +269,19 @@ impl<Op: BlockingSink + 'static> BlockingSinkNode<Op> {
                         }
                     }
 
+                    let mut rows_written = 0;
+                    let mut bytes_written = 0;
+                    for partition in &partitions {
+                        rows_written += partition.len() as u64;
+                        bytes_written += partition.size_bytes() as u64;
+                    }
+                    per_input.runtime_stats.add_rows_written(rows_written);
+                    per_input.runtime_stats.add_bytes_written(bytes_written);
+                    per_input
+                        .runtime_stats
+                        .add_partitions_written(partitions.len() as u64);
+
                     for partition in partitions {
-                        per_input.runtime_stats.add_rows_out(partition.len() as u64);
-                        per_input
-                            .runtime_stats
-                            .add_bytes_out(partition.size_bytes() as u64);
                         let _ = output_tx
                             .send(PipelineMessage::Morsel {
                                 input_id,
@@ -273,6 +291,18 @@ impl<Op: BlockingSink + 'static> BlockingSinkNode<Op> {
                     }
                 }
                 BlockingSinkOutput::FlightPartitionRefs(partition_refs) => {
+                    let mut rows_written = 0;
+                    let mut bytes_written = 0;
+                    for partition_ref in &partition_refs {
+                        rows_written += partition_ref.num_rows as u64;
+                        bytes_written += partition_ref.size_bytes as u64;
+                    }
+                    per_input.runtime_stats.add_rows_written(rows_written);
+                    per_input.runtime_stats.add_bytes_written(bytes_written);
+                    per_input
+                        .runtime_stats
+                        .add_partitions_written(partition_refs.len() as u64);
+
                     for partition_ref in partition_refs {
                         let _ = output_tx
                             .send(PipelineMessage::FlightPartitionRef {

--- a/src/daft-local-execution/src/sinks/blocking_sink.rs
+++ b/src/daft-local-execution/src/sinks/blocking_sink.rs
@@ -245,16 +245,8 @@ impl<Op: BlockingSink + 'static> BlockingSinkNode<Op> {
                 .as_ref()
                 .map(|(_, id_map, _)| id_map.get_or_generate(input_id));
 
-            // Wall time spent inside the sink's finalize() call after all input is
-            // received: includes any buffered-data flush, concat, and backend
-            // write/close work done there. Captured inside the spawned task so the
-            // measurement excludes spawner queue time. Excludes post-finalize
-            // framework work like output sending and checkpoint staging, which run
-            // after this measurement closes.
-            //
-            // Record the duration before propagating any error so that a slow
-            // finalize that ultimately fails (timeout, OOM, backend error) still
-            // surfaces its wall time in the snapshot.
+            // Record finalize wall time before propagating so a slow-then-failed
+            // finalize (timeout, OOM, backend error) still surfaces its duration.
             let finalize_start = Instant::now();
             let finalize_result = op.finalize(per_input.states, &finalize_spawner).await;
             per_input

--- a/src/daft-local-execution/src/sinks/gather.rs
+++ b/src/daft-local-execution/src/sinks/gather.rs
@@ -17,6 +17,7 @@ use super::blocking_sink::{
 use crate::{
     ExecutionTaskSpawner,
     pipeline::{InputId, NodeName},
+    runtime_stats::ShuffleWriteRuntimeStats,
 };
 
 pub(crate) struct RayGatherState {
@@ -174,6 +175,7 @@ impl GatherSink {
 
 impl BlockingSink for GatherSink {
     type State = GatherState;
+    type Stats = ShuffleWriteRuntimeStats;
 
     #[instrument(skip_all, name = "GatherSink::sink")]
     fn sink(

--- a/src/daft-local-execution/src/sinks/into_partitions.rs
+++ b/src/daft-local-execution/src/sinks/into_partitions.rs
@@ -17,6 +17,7 @@ use super::blocking_sink::{
 use crate::{
     ExecutionTaskSpawner,
     pipeline::{InputId, NodeName},
+    runtime_stats::ShuffleWriteRuntimeStats,
 };
 
 pub(crate) struct RayIntoPartitionsState {
@@ -231,6 +232,7 @@ impl IntoPartitionsSink {
 
 impl BlockingSink for IntoPartitionsSink {
     type State = IntoPartitionsState;
+    type Stats = ShuffleWriteRuntimeStats;
 
     #[instrument(skip_all, name = "IntoPartitionsSink::sink")]
     fn sink(

--- a/src/daft-local-execution/src/sinks/repartition.rs
+++ b/src/daft-local-execution/src/sinks/repartition.rs
@@ -21,6 +21,7 @@ use super::blocking_sink::{
 use crate::{
     ExecutionTaskSpawner,
     pipeline::{InputId, NodeName},
+    runtime_stats::ShuffleWriteRuntimeStats,
 };
 
 // Worst-case buffered memory is `num_workers × num_inputs × threshold` — one
@@ -187,6 +188,7 @@ impl RepartitionSink {
 
 impl BlockingSink for RepartitionSink {
     type State = RepartitionAccState;
+    type Stats = ShuffleWriteRuntimeStats;
 
     #[instrument(skip_all, name = "RepartitionSink::sink")]
     fn sink(


### PR DESCRIPTION
## Changes Made
RepartitionSink, GatherSink, and IntoPartitionsSink previously inherited DefaultRuntimeStats, so the Flight-backed paths produced zero rows_written, bytes_written, and partitions_written on their dashboard snapshots. This left users with no way to diagnose write-side shuffle bottlenecks on Flight, and no comparable visibility across Ray and Flight backends.

Introduce ShuffleWriteRuntimeStats with shuffle-named counters, exposed through a new ShuffleWriteSnapshot variant. Drive the accounting from the BlockingSink framework rather than each sink: BlockingSinkNode::spawn_finalize aggregates rows/bytes/partition counts from both the Partitions and FlightPartitionRefs output variants through new functions (add_rows_written, add_bytes_written, add_partitions_written, add_finalize_duration_us) on the RuntimeStats trait.
