### PR TITLE
feat: configurable flight shuffle compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,6 +400,8 @@ dependencies = [
  "arrow-schema 57.3.0",
  "arrow-select",
  "flatbuffers",
+ "lz4_flex",
+ "zstd",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -249,7 +249,7 @@ arrow-buffer = "57.1.0"
 arrow-csv = "57.1.0"
 arrow-data = "57.1.0"
 arrow-flight = "57.1.0"
-arrow-ipc = "57.1.0"
+arrow-ipc = {version = "57.1.0", features = ["lz4", "zstd"]}
 arrow-json = "57.1.0"
 arrow-row = "57.1.0"
 arrow-schema = "57.1.0"

--- a/daft/context.py
+++ b/daft/context.py
@@ -243,6 +243,7 @@ def set_execution_config(
     enable_dynamic_batching: bool | None = None,
     dynamic_batching_strategy: str | None = None,
     flight_shuffle_dirs: list[str] | None = None,
+    flight_shuffle_compression: str | None = None,
     enable_multi_glob_path_tasks: bool | None = None,
 ) -> DaftContext:
     """Globally sets various configuration parameters which control various aspects of Daft execution.
@@ -292,6 +293,7 @@ def set_execution_config(
         enable_dynamic_batching: Whether to enable dynamic batching. Defaults to False.
         dynamic_batching_strategy: The strategy to use for dynamic batching. Defaults to 'auto'.
         flight_shuffle_dirs: Directories to use for flight shuffle. Defaults to ["/tmp"]. Must not be empty.
+        flight_shuffle_compression: Arrow IPC compression for flight shuffle spill files. One of "lz4", "zstd", or "none". Defaults to None (uncompressed).
         enable_multi_glob_path_tasks: Whether to create multiple glob path tasks in Ray Runner to achieve parallel glob. Defaults to False.
     """
     # Replace values in the DaftExecutionConfig with user-specified overrides
@@ -334,6 +336,7 @@ def set_execution_config(
             enable_dynamic_batching=enable_dynamic_batching,
             dynamic_batching_strategy=dynamic_batching_strategy,
             flight_shuffle_dirs=flight_shuffle_dirs,
+            flight_shuffle_compression=flight_shuffle_compression,
             enable_multi_glob_path_tasks=enable_multi_glob_path_tasks,
         )
 

--- a/daft/daft/__init__.pyi
+++ b/daft/daft/__init__.pyi
@@ -2482,6 +2482,7 @@ class PyDaftExecutionConfig:
         enable_dynamic_batching: bool | None = None,
         dynamic_batching_strategy: str | None = None,
         flight_shuffle_dirs: list[str] | None = None,
+        flight_shuffle_compression: str | None = None,
         enable_multi_glob_path_tasks: bool | None = None,
     ) -> PyDaftExecutionConfig: ...
     @property
@@ -2548,6 +2549,8 @@ class PyDaftExecutionConfig:
     def dynamic_batching_strategy(self) -> str: ...
     @property
     def flight_shuffle_dirs(self) -> list[str]: ...
+    @property
+    def flight_shuffle_compression(self) -> str | None: ...
     @property
     def enable_multi_glob_path_tasks(self) -> bool: ...
     @property

--- a/src/common/daft-config/src/lib.rs
+++ b/src/common/daft-config/src/lib.rs
@@ -152,6 +152,7 @@ pub struct DaftExecutionConfig {
     pub enable_dynamic_batching: bool,
     pub dynamic_batching_strategy: String,
     pub flight_shuffle_dirs: Vec<String>,
+    pub flight_shuffle_compression: Option<String>,
     pub enable_multi_glob_path_tasks: bool,
 }
 
@@ -199,6 +200,7 @@ impl Default for DaftExecutionConfig {
             enable_dynamic_batching: false,
             dynamic_batching_strategy: "auto".to_string(),
             flight_shuffle_dirs: vec!["/tmp".to_string()],
+            flight_shuffle_compression: None,
             enable_multi_glob_path_tasks: false,
         }
     }

--- a/src/common/daft-config/src/python.rs
+++ b/src/common/daft-config/src/python.rs
@@ -123,6 +123,7 @@ impl PyDaftExecutionConfig {
         enable_dynamic_batching=None,
         dynamic_batching_strategy=None,
         flight_shuffle_dirs=None,
+        flight_shuffle_compression=None,
         enable_multi_glob_path_tasks=None,
     ))]
     fn with_config_values(
@@ -161,6 +162,7 @@ impl PyDaftExecutionConfig {
         enable_dynamic_batching: Option<bool>,
         dynamic_batching_strategy: Option<&str>,
         flight_shuffle_dirs: Option<Vec<String>>,
+        flight_shuffle_compression: Option<&str>,
         enable_multi_glob_path_tasks: Option<bool>,
     ) -> PyResult<Self> {
         let mut config = self.config.as_ref().clone();
@@ -302,6 +304,19 @@ impl PyDaftExecutionConfig {
                 ));
             }
             config.flight_shuffle_dirs = flight_shuffle_dirs;
+        }
+
+        if let Some(flight_shuffle_compression) = flight_shuffle_compression {
+            config.flight_shuffle_compression = match flight_shuffle_compression {
+                "" | "none" => None,
+                "lz4" | "zstd" => Some(flight_shuffle_compression.to_string()),
+                other => {
+                    return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                        "flight_shuffle_compression must be 'lz4', 'zstd', or 'none' (got '{}')",
+                        other
+                    )));
+                }
+            };
         }
 
         if let Some(enable_multi_glob_path_tasks) = enable_multi_glob_path_tasks {
@@ -474,6 +489,11 @@ impl PyDaftExecutionConfig {
     #[getter]
     fn enable_multi_glob_path_tasks(&self) -> PyResult<bool> {
         Ok(self.config.enable_multi_glob_path_tasks)
+    }
+
+    #[getter]
+    fn flight_shuffle_compression(&self) -> PyResult<Option<&str>> {
+        Ok(self.config.flight_shuffle_compression.as_deref())
     }
 }
 

--- a/src/daft-distributed/src/pipeline_node/shuffles/translate_shuffle.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/translate_shuffle.rs
@@ -27,6 +27,7 @@ impl LogicalPlanToPipelineNodeTranslator {
         if self.plan_config.config.shuffle_algorithm.as_str() == "flight_shuffle" {
             DistributedShuffleBackend::Flight(FlightShuffleBackendConfig {
                 shuffle_dirs: self.plan_config.config.flight_shuffle_dirs.clone(),
+                compression: self.plan_config.config.flight_shuffle_compression.clone(),
                 ..Default::default()
             })
         } else {


### PR DESCRIPTION
## Changes Made

Adds a new `flight_shuffle_compression` knob to `DaftExecutionConfig`, letting users opt into Arrow IPC compression for flight-shuffle spill files:

```python
daft.context.set_execution_config(
    shuffle_algorithm="flight_shuffle",
    flight_shuffle_dirs=["/mnt/ssd"],
    flight_shuffle_compression="zstd",  # "lz4" | "zstd" | "none" (default)
)
```

## Related Issues

n/a