### PR TITLE
fix(daft-distributed): remove unused hash_map_macro feature gate

### DIFF
--- a/src/daft-distributed/src/lib.rs
+++ b/src/daft-distributed/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(hash_map_macro)]
-
 mod pipeline_node;
 mod plan;
 #[cfg(feature = "python")]


### PR DESCRIPTION
## What

Remove the `#![feature(hash_map_macro)]` feature gate from `daft-distributed/src/lib.rs`.

## Why

The `hash_map_macro` feature was [removed from Rust after 1.91](https://github.com/rust-lang/rust/issues/87853) and does not exist in stable Rust 1.95.0+. `daft-distributed` declares the feature gate but never uses the `hash_map!` macro anywhere in the crate, so the gate can be safely removed.

This eliminates one unnecessary nightly-only feature gate, making it easier to compile daft on stable Rust.

## Testing

- Verified that `hash_map!` is not used anywhere in `daft-distributed`:
  ```
  grep -rn "hash_map!" src/daft-distributed/ # no results
  ```
  
  We've also built 0.7.14 with Rust 1.95 in our own build system.