### PR TITLE
fix: update code for nightly-2026-01-08 toolchain

### DIFF
--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -138,7 +138,7 @@ jobs:
       if: matrix.coverage != false
       uses: taiki-e/install-action@cargo-llvm-cov
       with:
-        tool: cargo-llvm-cov@0.7.1
+        tool: cargo-llvm-cov@0.8.7
 
     - name: install llvm tools
       if: matrix.coverage != false

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2025-09-03"
+channel = "nightly-2026-01-08"
 components = ["rustfmt", "clippy"]
 profile = "minimal"

--- a/src/common/treenode/src/lib.rs
+++ b/src/common/treenode/src/lib.rs
@@ -960,7 +960,7 @@ mod tests {
 
     #[derive(PartialEq, Debug)]
     struct TestTreeNode<T> {
-        children: Vec<TestTreeNode<T>>,
+        children: Vec<Self>,
         data: T,
     }
 

--- a/src/daft-core/src/lit/mod.rs
+++ b/src/daft-core/src/lit/mod.rs
@@ -97,7 +97,7 @@ pub enum Literal {
     #[cfg(feature = "python")]
     Python(PyObjectWrapper),
     /// TODO chore: audit struct literal vs. struct expression support.
-    Struct(IndexMap<String, Literal>),
+    Struct(IndexMap<String, Self>),
     File(FileReference),
     /// A tensor
     Tensor {

--- a/src/daft-dashboard/src/engine.rs
+++ b/src/daft-dashboard/src/engine.rs
@@ -210,7 +210,7 @@ struct PlanJsonConfig {
     #[serde(rename = "type")]
     pub node_type: Arc<str>,
     pub category: Arc<str>,
-    pub children: Option<Vec<PlanJsonConfig>>,
+    pub children: Option<Vec<Self>>,
 }
 
 fn parse_physical_plan(physical_plan: &QueryPlan) -> OperatorInfos {

--- a/src/daft-distributed/src/pipeline_node/mod.rs
+++ b/src/daft-distributed/src/pipeline_node/mod.rs
@@ -327,7 +327,7 @@ pub(crate) trait PipelineNodeImpl: Send + Sync {
 pub(crate) struct DistributedPipelineNode {
     op: Arc<dyn PipelineNodeImpl>,
     runtime_stats: RuntimeStatsRef,
-    children: Vec<DistributedPipelineNode>,
+    children: Vec<Self>,
 }
 
 impl DistributedPipelineNode {

--- a/src/daft-ext/src/abi/arrow.rs
+++ b/src/daft-ext/src/abi/arrow.rs
@@ -32,9 +32,9 @@ pub struct ArrowSchema {
     pub metadata: *const c_char,
     pub flags: i64,
     pub n_children: i64,
-    pub children: *mut *mut ArrowSchema,
-    pub dictionary: *mut ArrowSchema,
-    pub release: Option<unsafe extern "C" fn(schema: *mut ArrowSchema)>,
+    pub children: *mut *mut Self,
+    pub dictionary: *mut Self,
+    pub release: Option<unsafe extern "C" fn(schema: *mut Self)>,
     pub private_data: *mut c_void,
 }
 
@@ -178,9 +178,9 @@ pub struct ArrowArray {
     pub n_buffers: i64,
     pub n_children: i64,
     pub buffers: *mut *const c_void,
-    pub children: *mut *mut ArrowArray,
-    pub dictionary: *mut ArrowArray,
-    pub release: Option<unsafe extern "C" fn(array: *mut ArrowArray)>,
+    pub children: *mut *mut Self,
+    pub dictionary: *mut Self,
+    pub release: Option<unsafe extern "C" fn(array: *mut Self)>,
     pub private_data: *mut c_void,
 }
 
@@ -476,28 +476,25 @@ pub struct ArrowArrayStream {
     ///
     /// On success, writes to `*out` and returns 0.
     /// On error, returns non-zero; caller may call `get_last_error`.
-    pub get_schema:
-        Option<unsafe extern "C" fn(stream: *mut ArrowArrayStream, out: *mut ArrowSchema) -> c_int>,
+    pub get_schema: Option<unsafe extern "C" fn(stream: *mut Self, out: *mut ArrowSchema) -> c_int>,
 
     /// Get the next record batch.
     ///
     /// On success, writes to `*out` and returns 0.
     /// End-of-stream is signaled by writing a released array (release == None).
     /// On error, returns non-zero; caller may call `get_last_error`.
-    pub get_next:
-        Option<unsafe extern "C" fn(stream: *mut ArrowArrayStream, out: *mut ArrowArray) -> c_int>,
+    pub get_next: Option<unsafe extern "C" fn(stream: *mut Self, out: *mut ArrowArray) -> c_int>,
 
     /// Get a human-readable error message for the last error.
     ///
     /// Returns a pointer to a null-terminated string, or null if no error.
     /// The pointer is valid until the next call on this stream or until release.
-    pub get_last_error:
-        Option<unsafe extern "C" fn(stream: *mut ArrowArrayStream) -> *const c_char>,
+    pub get_last_error: Option<unsafe extern "C" fn(stream: *mut Self) -> *const c_char>,
 
     /// Release the stream and all associated resources.
     ///
     /// After calling, the stream is in a released state (all pointers None/null).
-    pub release: Option<unsafe extern "C" fn(stream: *mut ArrowArrayStream)>,
+    pub release: Option<unsafe extern "C" fn(stream: *mut Self)>,
 
     /// Opaque producer-specific data.
     pub private_data: *mut c_void,
@@ -537,9 +534,9 @@ mod tests {
         metadata: *const c_char,
         flags: i64,
         n_children: i64,
-        children: *mut *mut FakeSchema,
-        dictionary: *mut FakeSchema,
-        release: Option<unsafe extern "C" fn(schema: *mut FakeSchema)>,
+        children: *mut *mut Self,
+        dictionary: *mut Self,
+        release: Option<unsafe extern "C" fn(schema: *mut Self)>,
         private_data: *mut c_void,
     }
 
@@ -552,9 +549,9 @@ mod tests {
         n_buffers: i64,
         n_children: i64,
         buffers: *mut *const c_void,
-        children: *mut *mut FakeArray,
-        dictionary: *mut FakeArray,
-        release: Option<unsafe extern "C" fn(array: *mut FakeArray)>,
+        children: *mut *mut Self,
+        dictionary: *mut Self,
+        release: Option<unsafe extern "C" fn(array: *mut Self)>,
         private_data: *mut c_void,
     }
 

--- a/src/daft-io/src/huggingface.rs
+++ b/src/daft-io/src/huggingface.rs
@@ -304,6 +304,7 @@ impl HFSource {
         .into())
     }
 
+    #[allow(clippy::self_only_used_in_recursion)]
     #[async_recursion]
     async fn request(
         &self,

--- a/src/daft-io/src/lib.rs
+++ b/src/daft-io/src/lib.rs
@@ -168,6 +168,7 @@ pub enum Error {
     JoinError { source: tokio::task::JoinError },
 
     #[snafu(display("Cached error: {}", source))]
+    #[allow(clippy::use_self)]
     CachedError { source: Arc<Error> },
 }
 

--- a/src/daft-io/src/tos.rs
+++ b/src/daft-io/src/tos.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::result_large_err)]
+
 use std::{
     any::Any,
     borrow::Cow,

--- a/src/daft-io/src/utils.rs
+++ b/src/daft-io/src/utils.rs
@@ -204,7 +204,7 @@ mod tests {
 
     #[test]
     fn test_group_glob_paths() {
-        let groups = group_glob_paths(&vec![
+        let groups = group_glob_paths(&[
             "/data1/2026/**/*.parquet".to_string(),
             "s3://ai/data/2026/**/[x,y,z].json".to_string(),
             "/data1/2026/01/*.parquet".to_string(),

--- a/src/daft-json/src/deserializer.rs
+++ b/src/daft-json/src/deserializer.rs
@@ -13,7 +13,7 @@ pub enum Value<'value> {
     /// string type
     String(Cow<'value, str>),
     /// array type
-    Array(Vec<Value<'value>>),
+    Array(Vec<Self>),
     /// object type
     Object(Object<'value>),
 }

--- a/src/daft-local-execution/src/dynamic_batching/latency_constrained_strategy.rs
+++ b/src/daft-local-execution/src/dynamic_batching/latency_constrained_strategy.rs
@@ -214,13 +214,16 @@ impl BatchingStrategy for LatencyConstrainedBatchingStrategy {
             );
 
         // else if ¯𝜏 < 𝐷SLA − 𝜖D
-        } else if t < delta_sla - self.latency_tolerance {
+        } else if t < delta_sla.checked_sub(self.latency_tolerance).unwrap() {
             // Latency good, expand search space
             log::debug!(
                 "[{}] LATENCY GOOD (𝜏={}ms < 𝐷SLA={}ms), expanding search space",
                 std::thread::current().name().unwrap_or("unknown"),
                 t.as_millis(),
-                (delta_sla - self.latency_tolerance).as_millis(),
+                delta_sla
+                    .checked_sub(self.latency_tolerance)
+                    .unwrap()
+                    .as_millis(),
             );
             // 𝑏low 𝑡 ← min{ ¯𝑏, 𝑏high 𝑡 −1 − 𝛼}
             state.b_low = usize::max(

--- a/src/daft-logical-plan/src/optimization/rules/eliminate_offsets.rs
+++ b/src/daft-logical-plan/src/optimization/rules/eliminate_offsets.rs
@@ -29,7 +29,7 @@ impl OptimizerRule for EliminateOffsets {
 }
 
 impl EliminateOffsets {
-    #[allow(clippy::only_used_in_recursion)]
+    #[allow(clippy::self_only_used_in_recursion)]
     fn try_optimize_node(
         &self,
         plan: Arc<LogicalPlan>,

--- a/src/daft-logical-plan/src/optimization/rules/materialize_scans.rs
+++ b/src/daft-logical-plan/src/optimization/rules/materialize_scans.rs
@@ -23,7 +23,7 @@ impl OptimizerRule for MaterializeScans {
 }
 
 impl MaterializeScans {
-    #[allow(clippy::only_used_in_recursion)]
+    #[allow(clippy::self_only_used_in_recursion)]
     fn try_optimize_node(
         &self,
         plan: Arc<LogicalPlan>,

--- a/src/daft-logical-plan/src/optimization/rules/push_down_filter.rs
+++ b/src/daft-logical-plan/src/optimization/rules/push_down_filter.rs
@@ -40,7 +40,7 @@ impl OptimizerRule for PushDownFilter {
 }
 
 impl PushDownFilter {
-    #[allow(clippy::only_used_in_recursion)]
+    #[allow(clippy::self_only_used_in_recursion)]
     fn try_optimize_node(
         &self,
         plan: Arc<LogicalPlan>,

--- a/src/daft-logical-plan/src/optimization/rules/push_down_limit.rs
+++ b/src/daft-logical-plan/src/optimization/rules/push_down_limit.rs
@@ -41,7 +41,7 @@ impl OptimizerRule for PushDownLimit {
 }
 
 impl PushDownLimit {
-    #[allow(clippy::only_used_in_recursion)]
+    #[allow(clippy::self_only_used_in_recursion)]
     fn try_optimize_node(
         &self,
         plan: Arc<LogicalPlan>,

--- a/src/daft-logical-plan/src/optimization/rules/push_down_shard.rs
+++ b/src/daft-logical-plan/src/optimization/rules/push_down_shard.rs
@@ -23,7 +23,7 @@ impl OptimizerRule for PushDownShard {
 }
 
 impl PushDownShard {
-    #[allow(clippy::only_used_in_recursion)]
+    #[allow(clippy::self_only_used_in_recursion)]
     fn try_optimize_node(
         &self,
         plan: Arc<LogicalPlan>,

--- a/src/daft-logical-plan/src/optimization/rules/reorder_joins/join_graph.rs
+++ b/src/daft-logical-plan/src/optimization/rules/reorder_joins/join_graph.rs
@@ -28,13 +28,8 @@ use crate::{
 #[derive(Clone)]
 #[cfg_attr(debug_assertions, derive(Debug))]
 pub(super) enum JoinOrderTree {
-    Relation(usize, usize), // (ID, cardinality).
-    Join(
-        Box<JoinOrderTree>,
-        Box<JoinOrderTree>,
-        Vec<JoinCondition>,
-        usize,
-    ), // (subtree, subtree, join conditions, cardinality).
+    Relation(usize, usize),                                // (ID, cardinality).
+    Join(Box<Self>, Box<Self>, Vec<JoinCondition>, usize), // (subtree, subtree, join conditions, cardinality).
 }
 
 impl JoinOrderTree {

--- a/src/daft-logical-plan/src/optimization/rules/rewrite_offset.rs
+++ b/src/daft-logical-plan/src/optimization/rules/rewrite_offset.rs
@@ -27,7 +27,7 @@ impl OptimizerRule for RewriteOffset {
 }
 
 impl RewriteOffset {
-    #[allow(clippy::only_used_in_recursion)]
+    #[allow(clippy::self_only_used_in_recursion)]
     fn try_optimize_node(
         &self,
         plan: Arc<LogicalPlan>,

--- a/src/daft-logical-plan/src/optimization/rules/shard_scans.rs
+++ b/src/daft-logical-plan/src/optimization/rules/shard_scans.rs
@@ -24,7 +24,7 @@ impl OptimizerRule for ShardScans {
 }
 
 impl ShardScans {
-    #[allow(clippy::only_used_in_recursion)]
+    #[allow(clippy::self_only_used_in_recursion)]
     fn try_optimize_node(plan: Arc<LogicalPlan>) -> DaftResult<Transformed<Arc<LogicalPlan>>> {
         match &*plan {
             LogicalPlan::Source(source) => match source.source_info.as_ref() {

--- a/src/daft-minhash/src/lib.rs
+++ b/src/daft-minhash/src/lib.rs
@@ -325,10 +325,8 @@ pub fn minhash_in(
         simd_permute_and_min_batch(chunk_simd, perm_a_simd, perm_b_simd, &mut min_hash_values);
     }
 
-    if let Some(remainder) = chunks.into_remainder() {
-        for hash in remainder {
-            simd_permute_and_min_single(hash, perm_a_simd, perm_b_simd, &mut min_hash_values);
-        }
+    for hash in chunks.into_remainder() {
+        simd_permute_and_min_single(hash, perm_a_simd, perm_b_simd, &mut min_hash_values);
     }
 
     // Convert SIMD results to a flat vector of u32 values

--- a/src/daft-parquet/src/lib.rs
+++ b/src/daft-parquet/src/lib.rs
@@ -101,6 +101,7 @@ pub enum Error {
     /// type must be `Clone`, so we keep `Arc<Error>` internally and surface the
     /// typed source to every consumer.
     #[snafu(display("Remote parquet fetch failed for {path}: {source}"))]
+    #[allow(clippy::use_self)]
     RemoteFetchFailed {
         path: String,
         source: std::sync::Arc<Error>,

--- a/src/daft-recordbatch/src/column/mod.rs
+++ b/src/daft-recordbatch/src/column/mod.rs
@@ -374,8 +374,8 @@ mod tests {
     #[test]
     fn scalar_column_materialize_cached() {
         let sc = ScalarColumn::new(Arc::from("c"), DataType::Int64, Literal::Int64(1), 5);
-        let ptr1 = sc.as_materialized_series() as *const Series;
-        let ptr2 = sc.as_materialized_series() as *const Series;
+        let ptr1 = std::ptr::from_ref::<Series>(sc.as_materialized_series());
+        let ptr2 = std::ptr::from_ref::<Series>(sc.as_materialized_series());
         assert_eq!(ptr1, ptr2);
     }
 

--- a/src/daft-recordbatch/src/preview.rs
+++ b/src/daft-recordbatch/src/preview.rs
@@ -19,10 +19,11 @@ pub struct Preview {
 }
 
 /// The .show() table format for box drawing.
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum PreviewFormat {
     /// Fancy box drawing.
+    #[default]
     Fancy,
     /// No box drawing.
     Plain,
@@ -126,12 +127,6 @@ impl TryFrom<&str> for PreviewFormat {
                 "Unknown preview format: {s}"
             ))),
         }
-    }
-}
-
-impl Default for PreviewFormat {
-    fn default() -> Self {
-        Self::Fancy
     }
 }
 

--- a/src/daft-schema/src/dtype.rs
+++ b/src/daft-schema/src/dtype.rs
@@ -103,26 +103,26 @@ pub enum DataType {
     Utf8,
 
     /// A list of some logical data type with a fixed number of elements.
-    FixedSizeList(Box<DataType>, usize),
+    FixedSizeList(Box<Self>, usize),
 
     /// A list of some logical data type whose offsets are represented as [`i64`].
-    List(Box<DataType>),
+    List(Box<Self>),
 
     /// A nested [`DataType`] with a given number of [`Field`]s.
     Struct(Vec<Field>),
 
     /// A nested [`DataType`] that is represented as List<entries: Struct<key: K, value: V>>.
     Map {
-        key: Box<DataType>,
-        value: Box<DataType>,
+        key: Box<Self>,
+        value: Box<Self>,
     },
 
     /// Extension type.
-    Extension(String, Box<DataType>, Option<String>),
+    Extension(String, Box<Self>, Option<String>),
 
     // Non-ArrowTypes:
     /// A logical type for embeddings.
-    Embedding(Box<DataType>, usize),
+    Embedding(Box<Self>, usize),
 
     /// A logical type for images with variable shapes.
     Image(Option<ImageMode>),
@@ -131,16 +131,16 @@ pub enum DataType {
     FixedShapeImage(ImageMode, u32, u32),
 
     /// A logical type for tensors with variable shapes.
-    Tensor(Box<DataType>),
+    Tensor(Box<Self>),
 
     /// A logical type for tensors with the same shape.
-    FixedShapeTensor(Box<DataType>, Vec<u64>),
+    FixedShapeTensor(Box<Self>, Vec<u64>),
 
     /// A logical type for sparse tensors with variable shapes.
-    SparseTensor(Box<DataType>, bool),
+    SparseTensor(Box<Self>, bool),
 
     /// A logical type for sparse tensors with the same shape.
-    FixedShapeSparseTensor(Box<DataType>, Vec<u64>, bool),
+    FixedShapeSparseTensor(Box<Self>, Vec<u64>, bool),
 
     #[cfg(feature = "python")]
     Python,

--- a/src/daft-sql/src/functions.rs
+++ b/src/daft-sql/src/functions.rs
@@ -524,8 +524,8 @@ impl SQLPlanner<'_> {
             }
         };
 
-        if func.over.is_some() {
-            let window_spec = Arc::new(self.parse_window_spec(func.over.as_ref().unwrap())?);
+        if let Some(over) = &func.over {
+            let window_spec = Arc::new(self.parse_window_spec(over)?);
             let window_fn = fn_match.to_expr(&args, self)?;
             Ok(match &*window_fn {
                 Expr::Agg(agg_expr) => {

--- a/src/daft-sql/src/planner.rs
+++ b/src/daft-sql/src/planner.rs
@@ -166,7 +166,7 @@ pub struct SQLPlanner<'sess> {
     /// Shared context for all planners
     pub(crate) context: Rc<RefCell<PlannerContext>>,
     /// Planner for the outer scope
-    parent: Option<&'sess SQLPlanner<'sess>>,
+    parent: Option<&'sess Self>,
     /// In-scope bindings introduced by the current relation's schema
     pub(crate) current_plan: Option<LogicalPlanBuilder>,
     /// Plan that will be used as the right side of the join, used for planning join predicates


### PR DESCRIPTION
## What

Bump rust nightly toolchain from nightly-2025-09-03 to nightly-2026-01-08.
This picks up the ArrayChunks::into_remainder() return type change
(rust-lang/rust#149127) while staying before the cargo --timings=html
removal (rust-lang/cargo#16420), which CI still relies on.

Changes to accommodate the new nightly:
- Fix into_remainder() call in daft-minhash to match new return type
  (no longer wrapped in Option) (This enables distributions to build
  with Rust 1.93 stable and newer when RUSTC_BOOTSTRAP is set.)
- Upgrade cargo-llvm-cov from 0.7.1 to 0.8.7 to fix corrupt profraw
  files due to LLVM profdata format incompatibility

Clippy lint fixes for newer nightly:
- Fix use_self by replacing self-referential type names with Self
  across multiple enum/struct definitions
- Allow clippy::use_self on snafu-derived Error variants that use
  Arc<Error> (snafu macro generates code with concrete type names,
  incompatible with Self): daft-io CachedError, daft-parquet
  RemoteFetchFailed
- Allow clippy::result_large_err in daft-io/src/tos.rs (IO error
  types are inherently large)
- Rename clippy::only_used_in_recursion allow attributes to
  clippy::self_only_used_in_recursion (lint renamed in newer clippy)
- Fix ref_as_ptr by using std::ptr::from_ref
- Fix unnecessary_unwrap in daft-sql by using if-let
- Fix unchecked_time_subtraction by using checked_sub().unwrap()
- Fix useless_vec in daft-io test
- Fix derivable_impls on PreviewFormat by using #[derive(Default)]

## Why

`Iterator::array_chunks().into_remainder()` returns `IntoIter<T, N>` directly in stable Rust 1.93 and later, not `Option<IntoIter<T, N>>` as in daft's current target nightly (2025-09-03). The current code does not compile on stable Rust 1.95.0 because of this API difference.

We are successfully building daft with stable Rust 1.95.0 (using `RUSTC_BOOTSTRAP=1` to accept nightly feature gates) in our internal build system, and this is the one call site that needs updating.

## Testing

- Verified this is the only call site of `into_remainder()` in the codebase
- Confirmed the replacement compiles and works correctly on stable Rust 1.95.0

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>