### PR TITLE
feat: support PostgreSQL as a structured data source via Gravitino

### DIFF
--- a/daft/catalog/__gravitino/_catalog.py
+++ b/daft/catalog/__gravitino/_catalog.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Literal
+from urllib.parse import quote, urlparse
 
 from daft.catalog import Catalog, Function, Identifier, NotFoundError, Properties, Schema, Table
 from daft.catalog.__gravitino._client import GravitinoClient as InnerCatalog
 from daft.catalog.__gravitino._client import GravitinoTable as InnerTable
+from daft.catalog.__gravitino._client import GravitinoTableInfo
 from daft.io._parquet import read_parquet
 from daft.io.iceberg._iceberg import read_iceberg
 
@@ -16,6 +18,7 @@ if TYPE_CHECKING:
 
     from pyiceberg.table import Table as PyIcebergTable
 
+    from daft.catalog.__postgres import PostgresTable
     from daft.dataframe import DataFrame
     from daft.io import IOConfig
     from daft.io.partitioning import PartitionField
@@ -138,6 +141,10 @@ class GravitinoCatalog(Catalog):
             return False
 
 
+class GravitinoTableTypeError(TypeError):
+    pass
+
+
 class GravitinoTable(Table, ABC):
     """Base class for Gravitino table formats."""
 
@@ -155,7 +162,7 @@ class GravitinoTable(Table, ABC):
     def _from_obj(obj: object) -> GravitinoTable:
         """Returns a GravitinoTable if the given object can be adapted so."""
         if isinstance(obj, InnerTable):
-            for impl in (GravitinoIcebergTable, GravitinoParquetTable):
+            for impl in (GravitinoPostgresTable, GravitinoIcebergTable, GravitinoParquetTable):
                 try:
                     return impl._from_inner(obj)
                 except ValueError:
@@ -241,6 +248,35 @@ class GravitinoParquetTable(GravitinoTable):
         raise NotImplementedError("Writing PARQUET format tables is not yet supported")
 
 
+class GravitinoPostgresTable(GravitinoTable):
+    """GravitinoPostgresTable is for Gravitino Postgres tables with provider contains 'postgres'."""
+
+    _postgres_table: PostgresTable
+    _read_options: set[str] = set()
+    _write_options: set[str] = {"enable_rls"}
+
+    @classmethod
+    def _from_inner(cls, inner: InnerTable) -> GravitinoPostgresTable:
+        if "POSTGRES" not in inner.table_info.table_type.upper():
+            raise ValueError(f"""Expected Postgres table, got table_type={inner.table_info.table_type!r}""")
+        t = GravitinoPostgresTable.__new__(GravitinoPostgresTable)
+        t._inner = inner
+        t._postgres_table = _open_postgres_table(inner.table_info)
+        return t
+
+    def read(self, **options: Any) -> DataFrame:
+        Table._validate_options("Gravitino read", options, self._read_options)
+        return self._postgres_table.read()
+
+    def append(self, df: DataFrame, **options: Any) -> None:
+        self._validate_options("Gravitino write", options, self._write_options)
+        self._postgres_table.append(df, **options)
+
+    def overwrite(self, df: DataFrame, **options: Any) -> None:
+        self._validate_options("Gravitino write", options, self._write_options)
+        self._postgres_table.overwrite(df, **options)
+
+
 def _open_iceberg_table(storage_location: str, io_config: IOConfig | None) -> PyIcebergTable:
     """Load a PyIceberg Table from a storage directory via HadoopCatalog."""
     from pyiceberg.catalog.hadoop import HadoopCatalog
@@ -268,6 +304,37 @@ def _io_config_to_pyiceberg_props(io_config: IOConfig | None) -> dict[str, str]:
     if s3.region_name:
         props["s3.region"] = s3.region_name
     return props
+
+
+def _open_postgres_table(table_info: GravitinoTableInfo) -> PostgresTable:
+    from daft.catalog.__postgres import PostgresTable
+
+    required_keys = {"jdbc-url", "jdbc-user", "jdbc-password", "jdbc-database"}
+    if not required_keys.issubset(table_info.properties.keys()):
+        raise GravitinoTableTypeError(
+            "Expected Postgres properties, but jdbc-url, jdbc-user, jdbc-password or jdbc-database is empty."
+        )
+
+    url = table_info.properties.get("jdbc-url", "")
+    user = table_info.properties.get("jdbc-user", "")
+    password = table_info.properties.get("jdbc-password", "")
+    database = table_info.properties.get("jdbc-database", "")
+    extensions = table_info.properties.get("extensions", "").split(",")
+
+    filtered_extensions = [item for item in extensions if item] or None
+    parsed = urlparse(url.replace("jdbc:", "", 1))
+    scheme = parsed.scheme
+    netloc = parsed.netloc
+    pwd = quote(password, safe="")
+    connection = f"{scheme}://{user}:{pwd}@{netloc}/{database}"
+    table_name = f"{table_info.schema}.{table_info.name}"
+
+    catalog = Catalog.from_postgres(connection, extensions=filtered_extensions)
+
+    table = catalog.get_table(table_name)
+    if not isinstance(table, PostgresTable):
+        raise GravitinoTableTypeError(f"Expected PostgresTable, got {type(table).__name__}.")
+    return table
 
 
 def load_gravitino(

--- a/daft/catalog/__gravitino/_client.py
+++ b/daft/catalog/__gravitino/_client.py
@@ -266,14 +266,20 @@ class GravitinoClient:
             if storage_location.startswith("file:/") and not storage_location.startswith("file:///"):
                 storage_location = storage_location.replace("file:/", "file:///", 1)
 
+            table_catalog = self.load_catalog(catalog_name)
+            catalog_properties = table_catalog.properties
+            merged_properties = catalog_properties.copy()
+            merged_properties.update(properties)
+            merged_provider = table_data.get("provider") or table_catalog.provider
+
             table_info = GravitinoTableInfo(
                 name=table_data.get("name", table_name_only),
                 catalog=catalog_name,
                 schema=schema_name,
-                table_type=table_data.get("provider", ""),
+                table_type=merged_provider,
                 storage_location=storage_location,
                 format=properties.get("format", "ICEBERG"),
-                properties=properties,
+                properties=merged_properties,
             )
 
         except requests.exceptions.HTTPError as e:

--- a/tests/catalog/test_gravitino.py
+++ b/tests/catalog/test_gravitino.py
@@ -9,7 +9,7 @@ import requests
 
 from daft.catalog import Identifier, NotFoundError, Schema
 from daft.catalog.__gravitino._catalog import GravitinoCatalog as CatalogWrapper
-from daft.catalog.__gravitino._catalog import GravitinoIcebergTable, GravitinoParquetTable
+from daft.catalog.__gravitino._catalog import GravitinoIcebergTable, GravitinoParquetTable, GravitinoPostgresTable
 from daft.catalog.__gravitino._catalog import GravitinoTable as TableWrapper
 from daft.catalog.__gravitino._client import GravitinoCatalogInfo, GravitinoClient
 from daft.catalog.__gravitino._client import GravitinoTable as InnerTable
@@ -405,8 +405,30 @@ class TestGravitinoTable:
         return mock_table
 
     @pytest.fixture
+    def mock_postgres_inner_table(self):
+        """Create a mock Postgres InnerTable (GravitinoTable from gravitino module) for testing."""
+        mock_table = Mock(spec=InnerTable)
+        mock_table.table_info = Mock()
+        mock_table.table_info.name = "test_table"
+        mock_table.table_info.schema = "test_schema"
+        mock_table.table_info.table_type = "jdbc-postgres"
+        properties = {
+            "jdbc-url": "jdbc:postgresql://localhost:5432/test_db",
+            "jdbc-user": "test_user",
+            "jdbc-password": "test_pwd",
+            "jdbc-database": "test_db",
+        }
+        mock_table.table_info.properties = properties
+        return mock_table
+
+    @pytest.fixture
     def mock_pyiceberg_table(self):
         """Create a mock PyIceberg table."""
+        return Mock()
+
+    @pytest.fixture
+    def mock_postgres_table(self):
+        """Create a mock Postgres table."""
         return Mock()
 
     @pytest.fixture
@@ -414,6 +436,12 @@ class TestGravitinoTable:
         """Create a GravitinoTable instance for testing."""
         with patch("daft.catalog.__gravitino._catalog._open_iceberg_table", return_value=mock_pyiceberg_table):
             return TableWrapper._from_obj(mock_inner_table)
+
+    @pytest.fixture
+    def postgres_gravitino_table(self, mock_postgres_inner_table, mock_postgres_table):
+        """Create a postgres GravitinoTable instance for testing."""
+        with patch("daft.catalog.__gravitino._catalog._open_postgres_table", return_value=mock_postgres_table):
+            return TableWrapper._from_obj(mock_postgres_inner_table)
 
     def test_init_raises_error(self):
         """Test that direct __init__ raises an error (abstract class cannot be instantiated)."""
@@ -434,6 +462,10 @@ class TestGravitinoTable:
         mock_inner_table.table_info.table_type = "hive"
         table = TableWrapper._from_obj(mock_inner_table)
         assert isinstance(table, GravitinoParquetTable)
+
+    def test_from_obj_returns_postgres_table(self, postgres_gravitino_table):
+        """Test _from_obj with a Postgres InnerTable returns GravitinoPostgresTable."""
+        assert isinstance(postgres_gravitino_table, GravitinoPostgresTable)
 
     def test_from_obj_unsupported_format(self, mock_inner_table):
         """Test _from_obj raises ValueError for unsupported formats."""
@@ -509,6 +541,14 @@ class TestGravitinoTable:
             mock_df = Mock()
             mock_read.return_value = mock_df
             result = table.read()
+            assert result is mock_df
+
+    def test_read_postgres_table(self, postgres_gravitino_table):
+        """Test reading a Postgres table."""
+        with patch("daft.catalog.__gravitino._catalog.GravitinoPostgresTable.read") as mock_read:
+            mock_df = Mock()
+            mock_read.return_value = mock_df
+            result = postgres_gravitino_table.read()
             assert result is mock_df
 
     def test_read_with_invalid_option(self, gravitino_table):


### PR DESCRIPTION
## Changes Made

Implement GravitinoPostgresTable to handle PostgreSQL-specific logic.

Parse relevant connection parameters from Gravitino (e.g., host, port, database, table).

Use the extracted parameters to construct PostgreSQL-compatible read and write operations.

This enables Daft to read from and write to PostgreSQL tables through the existing Gravitino interface, extending beyond the current Iceberg/Parquet-only support.


## Related Issues

Closes #6988
