### PR TITLE
feat(iceberg): auto-configure IOConfig for Alibaba Cloud OSS

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -1309,7 +1309,7 @@ class DataFrame:
         import pyiceberg
         from packaging.version import parse
 
-        from daft.io.iceberg._iceberg import _convert_iceberg_file_io_properties_to_io_config
+        from daft.io.iceberg._iceberg import _convert_iceberg_file_io_properties_to_io_config, _enable_oss_io_config
 
         if len(table.spec().fields) > 0 and parse(pyiceberg.__version__) < parse("0.7.0"):
             raise ValueError("pyiceberg>=0.7.0 is required to write to a partitioned table")
@@ -1341,7 +1341,11 @@ class DataFrame:
                     )
 
         io_config = (
-            _convert_iceberg_file_io_properties_to_io_config(table.io.properties) if io_config is None else io_config
+            _enable_oss_io_config(
+                _convert_iceberg_file_io_properties_to_io_config(table.io.properties), table.location()
+            )
+            if io_config is None
+            else io_config
         )
         io_config = get_context().daft_planning_config.default_io_config if io_config is None else io_config
 

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -1309,7 +1309,7 @@ class DataFrame:
         import pyiceberg
         from packaging.version import parse
 
-        from daft.io.iceberg._iceberg import _convert_iceberg_file_io_properties_to_io_config, _enable_oss_io_config
+        from daft.io.iceberg._iceberg import _convert_iceberg_file_io_properties_to_io_config
 
         if len(table.spec().fields) > 0 and parse(pyiceberg.__version__) < parse("0.7.0"):
             raise ValueError("pyiceberg>=0.7.0 is required to write to a partitioned table")
@@ -1341,9 +1341,7 @@ class DataFrame:
                     )
 
         io_config = (
-            _enable_oss_io_config(
-                _convert_iceberg_file_io_properties_to_io_config(table.io.properties), table.location()
-            )
+            _convert_iceberg_file_io_properties_to_io_config(table.io.properties, table.location())
             if io_config is None
             else io_config
         )

--- a/daft/io/iceberg/_iceberg.py
+++ b/daft/io/iceberg/_iceberg.py
@@ -8,6 +8,7 @@ from daft import context, runners
 from daft.api_annotations import PublicAPI
 from daft.daft import IOConfig, ScanOperatorHandle, StorageConfig
 from daft.dataframe import DataFrame
+from daft.filesystem import get_protocol_from_path
 from daft.io._checkpoint import attach_checkpoint
 from daft.logical.builder import LogicalPlanBuilder
 
@@ -66,14 +67,15 @@ def _enable_oss_io_config(io_config: IOConfig | None, location: str | None) -> I
     ``s3`` and enabling virtual-hosted-style addressing lets the existing S3
     filesystem resolve ``oss://`` paths -- no OSS-specific backend is involved.
 
-    Applied only to the IOConfig derived from the table; pass an explicit
-    ``io_config`` to ``read_iceberg``/``write_iceberg`` to opt out.
+    Runs on the IOConfig Daft derives from the table, or a fresh one when the
+    table exposes no IO properties (e.g. environment-variable credentials).
+    Pass an explicit ``io_config`` to ``read_iceberg``/``write_iceberg`` to opt out.
     """
-    from daft.filesystem import get_protocol_from_path
-
-    if io_config is None or location is None or get_protocol_from_path(location) != "oss":
+    if location is None or get_protocol_from_path(location) != "oss":
         return io_config
-    logger.debug("oss:// table detected; applying S3-compatible settings to the derived IOConfig")
+    if io_config is None:
+        io_config = IOConfig()
+    logger.debug("oss:// table detected; applying S3-compatible settings to the IOConfig")
     return io_config.replace(
         s3=io_config.s3.replace(force_virtual_addressing=True),
         protocol_aliases={"oss": "s3"},

--- a/daft/io/iceberg/_iceberg.py
+++ b/daft/io/iceberg/_iceberg.py
@@ -1,6 +1,7 @@
 # ruff: noqa: I002
 # isort: dont-add-import: from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Any, Union
 
 from daft import context, runners
@@ -14,6 +15,9 @@ if TYPE_CHECKING:
     from pyiceberg.table import Table as PyIcebergTable
 
     from daft.checkpoint import CheckpointConfig
+
+
+logger = logging.getLogger(__name__)
 
 
 def _convert_iceberg_file_io_properties_to_io_config(props: dict[str, Any]) -> IOConfig | None:
@@ -53,6 +57,27 @@ def _convert_iceberg_file_io_properties_to_io_config(props: dict[str, Any]) -> I
     )
 
     return io_config if any_props_set else None
+
+
+def _enable_oss_io_config(io_config: IOConfig | None, location: str | None) -> IOConfig | None:
+    """Apply the S3-compatible settings an ``oss://`` table needs to ``io_config``.
+
+    The ``oss://`` scheme (Alibaba Cloud OSS) is S3-compatible: aliasing it to
+    ``s3`` and enabling virtual-hosted-style addressing lets the existing S3
+    filesystem resolve ``oss://`` paths -- no OSS-specific backend is involved.
+
+    Applied only to the IOConfig derived from the table; pass an explicit
+    ``io_config`` to ``read_iceberg``/``write_iceberg`` to opt out.
+    """
+    from daft.filesystem import get_protocol_from_path
+
+    if io_config is None or location is None or get_protocol_from_path(location) != "oss":
+        return io_config
+    logger.debug("oss:// table detected; applying S3-compatible settings to the derived IOConfig")
+    return io_config.replace(
+        s3=io_config.s3.replace(force_virtual_addressing=True),
+        protocol_aliases={"oss": "s3"},
+    )
 
 
 @PublicAPI
@@ -107,7 +132,9 @@ def read_iceberg(
         table = StaticTable.from_metadata(metadata_location=table)
 
     io_config = (
-        _convert_iceberg_file_io_properties_to_io_config(table.io.properties) if io_config is None else io_config
+        _enable_oss_io_config(_convert_iceberg_file_io_properties_to_io_config(table.io.properties), table.location())
+        if io_config is None
+        else io_config
     )
     io_config = context.get_context().daft_planning_config.default_io_config if io_config is None else io_config
 

--- a/daft/io/iceberg/_iceberg.py
+++ b/daft/io/iceberg/_iceberg.py
@@ -21,8 +21,15 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _convert_iceberg_file_io_properties_to_io_config(props: dict[str, Any]) -> IOConfig | None:
-    """Property keys defined here: https://github.com/apache/iceberg-python/blob/main/pyiceberg/io/__init__.py."""
+def _convert_iceberg_file_io_properties_to_io_config(
+    props: dict[str, Any], location: str | None = None
+) -> IOConfig | None:
+    """Property keys defined here: https://github.com/apache/iceberg-python/blob/main/pyiceberg/io/__init__.py.
+
+    For an ``oss://`` ``location`` (Alibaba Cloud OSS, S3-compatible), the IOConfig gets
+    virtual-hosted addressing and an ``oss``->``s3`` alias so the S3 filesystem resolves
+    ``oss://`` paths -- applied even with no IO properties (e.g. env-var credentials).
+    """
     from daft.io import AzureConfig, GCSConfig, IOConfig, S3Config
 
     any_props_set = False
@@ -35,6 +42,8 @@ def _convert_iceberg_file_io_properties_to_io_config(props: dict[str, Any]) -> I
                 return property_value
         return None
 
+    is_oss = location is not None and get_protocol_from_path(location) == "oss"
+
     io_config = IOConfig(
         s3=S3Config(
             endpoint_url=get_first_property_value("s3.endpoint"),
@@ -42,6 +51,7 @@ def _convert_iceberg_file_io_properties_to_io_config(props: dict[str, Any]) -> I
             key_id=get_first_property_value("s3.access-key-id", "client.access-key-id"),
             access_key=get_first_property_value("s3.secret-access-key", "client.secret-access-key"),
             session_token=get_first_property_value("s3.session-token", "client.session-token"),
+            force_virtual_addressing=True if is_oss else None,
         ),
         azure=AzureConfig(
             storage_account=get_first_property_value("adls.account-name", "adlfs.account-name"),
@@ -55,31 +65,13 @@ def _convert_iceberg_file_io_properties_to_io_config(props: dict[str, Any]) -> I
             project_id=get_first_property_value("gcs.project-id"),
             token=get_first_property_value("gcs.oauth2.token"),
         ),
+        protocol_aliases={"oss": "s3"} if is_oss else None,
     )
 
-    return io_config if any_props_set else None
-
-
-def _enable_oss_io_config(io_config: IOConfig | None, location: str | None) -> IOConfig | None:
-    """Apply the S3-compatible settings an ``oss://`` table needs to ``io_config``.
-
-    The ``oss://`` scheme (Alibaba Cloud OSS) is S3-compatible: aliasing it to
-    ``s3`` and enabling virtual-hosted-style addressing lets the existing S3
-    filesystem resolve ``oss://`` paths -- no OSS-specific backend is involved.
-
-    Runs on the IOConfig Daft derives from the table, or a fresh one when the
-    table exposes no IO properties (e.g. environment-variable credentials).
-    Pass an explicit ``io_config`` to ``read_iceberg``/``write_iceberg`` to opt out.
-    """
-    if location is None or get_protocol_from_path(location) != "oss":
+    if is_oss:
+        logger.debug("oss:// table detected; applying S3-compatible settings to the IOConfig")
         return io_config
-    if io_config is None:
-        io_config = IOConfig()
-    logger.debug("oss:// table detected; applying S3-compatible settings to the IOConfig")
-    return io_config.replace(
-        s3=io_config.s3.replace(force_virtual_addressing=True),
-        protocol_aliases={"oss": "s3"},
-    )
+    return io_config if any_props_set else None
 
 
 @PublicAPI
@@ -134,7 +126,7 @@ def read_iceberg(
         table = StaticTable.from_metadata(metadata_location=table)
 
     io_config = (
-        _enable_oss_io_config(_convert_iceberg_file_io_properties_to_io_config(table.io.properties), table.location())
+        _convert_iceberg_file_io_properties_to_io_config(table.io.properties, table.location())
         if io_config is None
         else io_config
     )

--- a/tests/io/iceberg/test_iceberg_io_config.py
+++ b/tests/io/iceberg/test_iceberg_io_config.py
@@ -1,38 +1,56 @@
 from __future__ import annotations
 
-from daft.io import IOConfig, S3Config
-from daft.io.iceberg._iceberg import _enable_oss_io_config
+from daft.io.iceberg._iceberg import _convert_iceberg_file_io_properties_to_io_config
 
 
-def test_enable_oss_io_config_oss_location():
+def test_oss_location_applies_settings():
     """An oss:// table location enables virtual-hosted addressing and the oss->s3 alias."""
-    io_config = IOConfig(s3=S3Config(endpoint_url="http://oss-cn-hangzhou.aliyuncs.com", key_id="ak"))
-    result = _enable_oss_io_config(io_config, "oss://my-bucket/warehouse/db/table")
+    props = {"s3.endpoint": "http://oss-cn-hangzhou.aliyuncs.com", "s3.access-key-id": "ak"}
+    result = _convert_iceberg_file_io_properties_to_io_config(props, "oss://my-bucket/warehouse/db/table")
     assert result is not None
     assert result.s3.force_virtual_addressing is True
     assert result.protocol_aliases == {"oss": "s3"}
-    # Unrelated S3 settings are preserved.
+    # Table properties are still applied.
     assert result.s3.endpoint_url == "http://oss-cn-hangzhou.aliyuncs.com"
     assert result.s3.key_id == "ak"
 
 
-def test_enable_oss_io_config_oss_location_no_derived_config():
-    """An oss:// table with no derived IOConfig still gets the OSS settings.
+def test_oss_location_no_props():
+    """An oss:// table with no IO properties still gets the OSS settings.
 
     Covers credentials supplied via the environment rather than table properties.
     """
-    result = _enable_oss_io_config(None, "oss://my-bucket/warehouse/db/table")
+    result = _convert_iceberg_file_io_properties_to_io_config({}, "oss://my-bucket/warehouse/db/table")
     assert result is not None
     assert result.s3.force_virtual_addressing is True
     assert result.protocol_aliases == {"oss": "s3"}
 
 
-def test_enable_oss_io_config_non_oss_location_unchanged():
-    """A non-oss:// table location leaves the IOConfig untouched."""
-    io_config = IOConfig(s3=S3Config(endpoint_url="https://s3.us-west-2.amazonaws.com"))
-    assert _enable_oss_io_config(io_config, "s3://my-bucket/warehouse/db/table") is io_config
+def test_non_oss_location_with_props():
+    """A non-oss:// location with properties leaves the OSS settings off."""
+    props = {"s3.endpoint": "https://s3.us-west-2.amazonaws.com"}
+    result = _convert_iceberg_file_io_properties_to_io_config(props, "s3://my-bucket/warehouse/db/table")
+    assert result is not None
+    assert result.s3.force_virtual_addressing is False
+    assert result.protocol_aliases == {}
+    assert result.s3.endpoint_url == "https://s3.us-west-2.amazonaws.com"
 
 
-def test_enable_oss_io_config_non_oss_location_none_passthrough():
-    """A non-oss:// location with no IOConfig passes None through unchanged."""
-    assert _enable_oss_io_config(None, "s3://my-bucket/warehouse/db/table") is None
+def test_non_oss_location_no_props_returns_none():
+    """A non-oss:// location with no properties yields no IOConfig."""
+    assert _convert_iceberg_file_io_properties_to_io_config({}, "s3://my-bucket/warehouse/db/table") is None
+
+
+def test_no_location_with_props():
+    """With no location (default), properties still convert and OSS settings stay off."""
+    props = {"s3.endpoint": "https://s3.us-west-2.amazonaws.com"}
+    result = _convert_iceberg_file_io_properties_to_io_config(props)
+    assert result is not None
+    assert result.s3.force_virtual_addressing is False
+    assert result.protocol_aliases == {}
+    assert result.s3.endpoint_url == "https://s3.us-west-2.amazonaws.com"
+
+
+def test_no_location_no_props_returns_none():
+    """With no location (default) and no properties, no IOConfig is produced."""
+    assert _convert_iceberg_file_io_properties_to_io_config({}) is None

--- a/tests/io/iceberg/test_iceberg_io_config.py
+++ b/tests/io/iceberg/test_iceberg_io_config.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from daft.io import IOConfig, S3Config
+from daft.io.iceberg._iceberg import _enable_oss_io_config
+
+
+def test_enable_oss_io_config_oss_location():
+    """An oss:// table location enables virtual-hosted addressing and the oss->s3 alias."""
+    io_config = IOConfig(s3=S3Config(endpoint_url="http://oss-cn-hangzhou.aliyuncs.com", key_id="ak"))
+    result = _enable_oss_io_config(io_config, "oss://my-bucket/warehouse/db/table")
+    assert result is not None
+    assert result.s3.force_virtual_addressing is True
+    assert result.protocol_aliases == {"oss": "s3"}
+    # Unrelated S3 settings are preserved.
+    assert result.s3.endpoint_url == "http://oss-cn-hangzhou.aliyuncs.com"
+    assert result.s3.key_id == "ak"
+
+
+def test_enable_oss_io_config_non_oss_location_unchanged():
+    """A non-oss:// table location leaves the IOConfig untouched."""
+    io_config = IOConfig(s3=S3Config(endpoint_url="https://s3.us-west-2.amazonaws.com"))
+    assert _enable_oss_io_config(io_config, "s3://my-bucket/warehouse/db/table") is io_config
+
+
+def test_enable_oss_io_config_none():
+    """A None IOConfig passes through unchanged."""
+    assert _enable_oss_io_config(None, "oss://my-bucket/table") is None

--- a/tests/io/iceberg/test_iceberg_io_config.py
+++ b/tests/io/iceberg/test_iceberg_io_config.py
@@ -16,12 +16,23 @@ def test_enable_oss_io_config_oss_location():
     assert result.s3.key_id == "ak"
 
 
+def test_enable_oss_io_config_oss_location_no_derived_config():
+    """An oss:// table with no derived IOConfig still gets the OSS settings.
+
+    Covers credentials supplied via the environment rather than table properties.
+    """
+    result = _enable_oss_io_config(None, "oss://my-bucket/warehouse/db/table")
+    assert result is not None
+    assert result.s3.force_virtual_addressing is True
+    assert result.protocol_aliases == {"oss": "s3"}
+
+
 def test_enable_oss_io_config_non_oss_location_unchanged():
     """A non-oss:// table location leaves the IOConfig untouched."""
     io_config = IOConfig(s3=S3Config(endpoint_url="https://s3.us-west-2.amazonaws.com"))
     assert _enable_oss_io_config(io_config, "s3://my-bucket/warehouse/db/table") is io_config
 
 
-def test_enable_oss_io_config_none():
-    """A None IOConfig passes through unchanged."""
-    assert _enable_oss_io_config(None, "oss://my-bucket/table") is None
+def test_enable_oss_io_config_non_oss_location_none_passthrough():
+    """A non-oss:// location with no IOConfig passes None through unchanged."""
+    assert _enable_oss_io_config(None, "s3://my-bucket/warehouse/db/table") is None


### PR DESCRIPTION
## Changes Made
OSS is S3-compatible; it just needs `force_virtual_addressing` plus an `oss`→`s3`protocol alias. `_convert_iceberg_file_io_properties_to_io_config` now applies these when the table `location` is `oss://`, routing it through the existing S3 path — same approach as PyIceberg's `_initialize_oss_fs`. No new backend. Works even with no table properties (env-var creds). Pass an explicit `io_config` to opt out. Scoped to the Iceberg connector.