### PR TITLE
fix(ai): route OpenAI chat completions parse through beta namespace

### DIFF
--- a/daft/ai/openai/protocols/prompter.py
+++ b/daft/ai/openai/protocols/prompter.py
@@ -311,8 +311,11 @@ class OpenAIPrompter(Prompter):
     async def _prompt_with_chat_completions(self, messages_list: list[dict[str, Any]]) -> Any:
         """Generate responses using the Chat Completions API."""
         if self.return_format is not None:
-            # Use structured outputs with Pydantic model
-            response = await self.llm.chat.completions.parse(
+            # Structured outputs: `.parse()` is only on the `beta` namespace in
+            # older openai SDKs (<1.92); newer versions alias it from `beta` to
+            # the main `chat.completions`. Route through `beta` for compat across
+            # supported openai versions. See issue #5888.
+            response = await self.llm.beta.chat.completions.parse(
                 model=self.model,
                 messages=messages_list,
                 response_format=self.return_format,

--- a/tests/ai/openai/test_openai_prompter.py
+++ b/tests/ai/openai/test_openai_prompter.py
@@ -976,7 +976,7 @@ def test_openai_prompter_chat_completions_structured_output():
         mock_message.parsed = expected_output
         mock_choice.message = mock_message
         mock_response.choices = [mock_choice]
-        mock_client.chat.completions.parse = AsyncMock(return_value=mock_response)
+        mock_client.beta.chat.completions.parse = AsyncMock(return_value=mock_response)
 
         prompter = create_prompter(return_format=SimpleResponse, use_chat_completions=True)
         prompter.llm = mock_client
@@ -986,7 +986,7 @@ def test_openai_prompter_chat_completions_structured_output():
         assert isinstance(result, SimpleResponse)
         assert result.answer == "Yes"
         assert result.confidence == 0.95
-        mock_client.chat.completions.parse.assert_called_once_with(
+        mock_client.beta.chat.completions.parse.assert_called_once_with(
             model="gpt-4o-mini",
             messages=[
                 {
@@ -1125,7 +1125,7 @@ def test_openai_prompter_chat_completions_complex_structured_output():
         mock_message.parsed = expected_output
         mock_choice.message = mock_message
         mock_response.choices = [mock_choice]
-        mock_client.chat.completions.parse = AsyncMock(return_value=mock_response)
+        mock_client.beta.chat.completions.parse = AsyncMock(return_value=mock_response)
 
         prompter = create_prompter(return_format=ComplexResponse, use_chat_completions=True)
         prompter.llm = mock_client
@@ -1136,6 +1136,47 @@ def test_openai_prompter_chat_completions_complex_structured_output():
         assert result.summary == "Test summary"
         assert len(result.key_points) == 3
         assert result.sentiment == "positive"
+
+    run_async(_test())
+
+
+def test_openai_prompter_chat_completions_parse_routes_through_beta_namespace():
+    """Regression for https://github.com/Eventual-Inc/Daft/issues/5888.
+
+    Older openai SDKs (<1.92) only expose `.parse()` under `client.beta.chat.completions`;
+    calling `client.chat.completions.parse` raises AttributeError. The prompter must
+    route structured-output calls through the beta namespace so it works across
+    the openai SDK range the `openai` extra accepts (`openai<2.21.0`).
+    """
+
+    async def _test():
+        from openai import AsyncOpenAI
+
+        # Build a client that simulates the older SDK: `.parse()` exists only on
+        # `beta.chat.completions`, and accessing it on the main namespace raises.
+        mock_client = Mock(spec=AsyncOpenAI)
+        mock_response = Mock()
+        mock_choice = Mock()
+        mock_message = Mock()
+        mock_message.parsed = SimpleResponse(answer="ok", confidence=1.0)
+        mock_choice.message = mock_message
+        mock_response.choices = [mock_choice]
+        mock_response.usage = None
+        mock_client.beta.chat.completions.parse = AsyncMock(return_value=mock_response)
+
+        # If anything tries to touch `client.chat.completions.parse` (the buggy
+        # path), surface it loudly rather than silently returning a Mock.
+        chat_completions = Mock(spec=[])  # spec=[] => no attributes
+        mock_client.chat = Mock()
+        mock_client.chat.completions = chat_completions
+
+        prompter = create_prompter(return_format=SimpleResponse, use_chat_completions=True)
+        prompter.llm = mock_client
+
+        result = await prompter.prompt(("does this route correctly?",))
+
+        assert isinstance(result, SimpleResponse)
+        mock_client.beta.chat.completions.parse.assert_called_once()
 
     run_async(_test())
 
@@ -1172,7 +1213,7 @@ def test_openai_prompter_chat_completions_with_image_structured_output():
         mock_message.parsed = expected_output
         mock_choice.message = mock_message
         mock_response.choices = [mock_choice]
-        mock_client.chat.completions.parse = AsyncMock(return_value=mock_response)
+        mock_client.beta.chat.completions.parse = AsyncMock(return_value=mock_response)
 
         prompter = create_prompter(return_format=ComplexResponse, use_chat_completions=True)
         prompter.llm = mock_client
@@ -1188,7 +1229,7 @@ def test_openai_prompter_chat_completions_with_image_structured_output():
         assert result.sentiment == "positive"
 
         # Verify the call was made with image
-        call_args = mock_client.chat.completions.parse.call_args
+        call_args = mock_client.beta.chat.completions.parse.call_args
         messages = call_args.kwargs["messages"]
         assert len(messages) == 1
         assert isinstance(messages[0]["content"], list)


### PR DESCRIPTION
## Summary
- Structured-output calls (`return_format=...` with `use_chat_completions=True`) crash with `AttributeError: 'AsyncCompletions' object has no attribute 'parse'` on openai SDK <1.92, because `.parse()` only exists under `client.beta.chat.completions` on those versions.
- Daft's `openai` extra is unpinned at the lower end (`openai<2.21.0`), so users on older SDKs hit the bug.
- Route through `beta.chat.completions.parse`, which works on both the old SDKs and the current pin (2.20.0), where it aliases the main namespace.

Fixes #5888

## Test plan
- [x] `pytest tests/ai/openai/test_openai_prompter.py` — 51 tests pass
- [x] Added focused regression test `test_openai_prompter_chat_completions_parse_routes_through_beta_namespace` that simulates the older-SDK shape (`.parse()` absent from main namespace) and verifies the call routes through `beta`. Confirmed it fails with the issue's exact `AttributeError` shape when the fix is reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)