### PR TITLE
feat: Add `DataFrame.to_torch_dataloader`

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -5826,7 +5826,6 @@ class DataFrame:
         self,
         batch_size: int = 1,
         *,
-        drop_last: bool = False,
         pin_memory: bool = False,
         pin_memory_device: str = "",
         prefetch_count: int = 0,
@@ -5840,11 +5839,10 @@ class DataFrame:
         [``sample``][daft.DataFrame.sample] on the DataFrame before calling this method.
 
         Note:
-            Batch sizing is best-effort. The last partition may be smaller than `batch_size` unless `drop_last=True`.
+            Batch sizing is best-effort. Batches may be smaller than `batch_size`.
 
         Args:
             batch_size: Target number of rows per batch.
-            drop_last: If `True`, skip the final partition when it has fewer than `batch_size` rows.
             pin_memory: If `True`, pin memory on returned tensors for faster GPU transfer.
             pin_memory_device: Optional device for pinned memory (PyTorch 2.x).
             prefetch_count: Number of batches loaded in advance. This will increase memory usage, but can
@@ -5870,7 +5868,6 @@ class DataFrame:
         return DaftTorchDataLoader(
             self,
             batch_size,
-            drop_last=drop_last,
             pin_memory=pin_memory,
             pin_memory_device=pin_memory_device,
             prefetch_count=prefetch_count,

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -77,6 +77,7 @@ if TYPE_CHECKING:
     from daft.catalog.__unity._client import UnityCatalogTable
     from daft.checkpoint import IdempotentCommit
     from daft.convert import ArrowStreamExportable
+    from daft.dataframe.to_torch import DaftTorchDataLoader
     from daft.execution.metadata import ExecutionMetadata
     from daft.io import DataSink
     from daft.io.sink import WriteResultType
@@ -601,7 +602,7 @@ class DataFrame:
     ) -> Iterator[Union[MicroPartition, "ray.ObjectRef"]]:
         """Begin executing this dataframe and return an iterator over the partitions.
 
-        Each partition will be returned as a daft.recordbatch object (if using Python runner backend)
+        Each partition will be returned as a daft.MicroPartition object (if using Python runner backend)
         or a ray ObjectRef (if using Ray runner backend).
 
         Args:
@@ -5819,6 +5820,61 @@ class DataFrame:
             df = self
 
         return DaftTorchIterableDataset(df)
+
+    @DataframePublicAPI
+    def to_torch_dataloader(
+        self,
+        batch_size: int = 1,
+        *,
+        drop_last: bool = False,
+        pin_memory: bool = False,
+        pin_memory_device: str = "",
+        prefetch_count: int = 0,
+    ) -> "DaftTorchDataLoader":
+        """Return a DataLoader-like iterator that streams batched partitions for PyTorch training.
+
+        Begins execution of the DataFrame when iterated. Each yielded batch is a dict mapping column
+        names to `torch.Tensor` values (or Python lists for non-numeric columns).
+
+        For row-level shuffling, use [``shuffle``][daft.DataFrame.shuffle] or
+        [``sample``][daft.DataFrame.sample] on the DataFrame before calling this method.
+
+        Note:
+            Batch sizing is best-effort. The last partition may be smaller than `batch_size` unless `drop_last=True`.
+
+        Args:
+            batch_size: Target number of rows per batch.
+            drop_last: If `True`, skip the final partition when it has fewer than `batch_size` rows.
+            pin_memory: If `True`, pin memory on returned tensors for faster GPU transfer.
+            pin_memory_device: Optional device for pinned memory (PyTorch 2.x).
+            prefetch_count: Number of batches loaded in advance. This will increase memory usage, but can
+            improve throughput.
+
+        Returns:
+            DaftTorchDataLoader: Iterable over batch dicts for use as
+            `for batch in df.to_torch_dataloader(batch_size): ...`
+
+        Examples:
+            >>> import daft
+            >>> import torch  # doctest: +SKIP
+            >>> df = daft.from_pydict({"x": [1, 2, 3, 4], "y": [5, 6, 7, 8]})
+            >>> for batch in df.to_torch_dataloader(batch_size=2):  # doctest: +SKIP
+            ...     assert batch["x"].shape == (2,)
+
+        Tip:
+            For the PyTorch `IterableDataset` + `DataLoader` composition, see
+            [``to_torch_iter_dataset``][daft.DataFrame.to_torch_iter_dataset].
+        """
+        from daft.dataframe.to_torch import DaftTorchDataLoader
+
+        return DaftTorchDataLoader(
+            self,
+            batch_size,
+            drop_last=drop_last,
+            pin_memory=pin_memory,
+            pin_memory_device=pin_memory_device,
+            prefetch_count=prefetch_count,
+        )
 
     @DataframePublicAPI
     def to_ray_dataset(self) -> "ray.data.dataset.DataSet":

--- a/daft/dataframe/to_torch.py
+++ b/daft/dataframe/to_torch.py
@@ -3,14 +3,14 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
-from daft.dependencies import torch
+from daft.dependencies import np, torch
 from daft.runners.partitioning import MaterializedResult
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
 
     from daft.dataframe.dataframe import DataFrame
-    from daft.recordbatch.micropartition import MicroPartition
+    from daft.recordbatch import MicroPartition
 
 logger = logging.getLogger(__name__)
 
@@ -68,16 +68,15 @@ class DaftTorchDataLoader:
         df: DataFrame,
         batch_size: int = 1,
         *,
-        drop_last: bool = False,
         pin_memory: bool = False,
         pin_memory_device: str = "",
         prefetch_count: int = 0,
+        # TODO: Add support for drop_last when we have strict into_batches
     ) -> None:
         if batch_size <= 0:
             raise ValueError("batch_size must be greater than 0")
 
         self._batch_size = batch_size
-        self._drop_last = drop_last
         self._pin_memory = pin_memory
         self._pin_memory_device = pin_memory_device if pin_memory_device else None
         self._prefetch_count = prefetch_count
@@ -90,25 +89,21 @@ class DaftTorchDataLoader:
         results = self._batched_df._result
         if results is not None:
             for _, mat_result in results.items():
-                batch = self._partition_to_batch(mat_result.micropartition())
+                batch = self._to_torch_batch(mat_result.micropartition())
                 if batch is not None:
                     yield batch
         else:
+            buffer_size = self._prefetch_count if self._prefetch_count > 0 else None
             partitions_iter: Iterator[MaterializedResult[Any]] = get_or_create_runner().run_iter(
-                self._batched_df._builder, results_buffer_size=self._prefetch_count
+                self._batched_df._builder, results_buffer_size=buffer_size
             )
             for mat_result in partitions_iter:
-                batch = self._partition_to_batch(mat_result.micropartition())
+                batch = self._to_torch_batch(mat_result.micropartition())
                 if batch is not None:
                     yield batch
 
-    def _partition_to_batch(self, partition: MicroPartition) -> dict[str, Any] | None:
-        if self._drop_last and len(partition) < self._batch_size:
-            return None
-        return self._to_torch_batch(partition.to_pydict())
-
-    def _to_torch_batch(self, pydict: dict[str, list[Any]]) -> dict[str, Any]:
-        return {key: self._column_to_tensor(values) for key, values in pydict.items()}
+    def _to_torch_batch(self, batch: MicroPartition) -> dict[str, Any]:
+        return {key: self._column_to_tensor(values) for key, values in batch.to_pydict().items()}
 
     def _column_to_tensor(self, values: list[Any]) -> Any:
         if len(values) == 0:
@@ -119,8 +114,6 @@ class DaftTorchDataLoader:
         if isinstance(first, torch.Tensor):
             return self._pin(torch.stack(values))
         if hasattr(first, "__array__") and not isinstance(first, (str, bytes)):
-            import numpy as np
-
             if isinstance(first, np.ndarray) and first.ndim > 0:
                 return self._pin(torch.stack([torch.as_tensor(v) for v in values]))
             return self._pin(torch.as_tensor(values))

--- a/daft/dataframe/to_torch.py
+++ b/daft/dataframe/to_torch.py
@@ -3,8 +3,14 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
+from daft.dependencies import torch
+from daft.runners.partitioning import MaterializedResult
+
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
+
+    from daft.dataframe.dataframe import DataFrame
+    from daft.recordbatch.micropartition import MicroPartition
 
 logger = logging.getLogger(__name__)
 
@@ -47,3 +53,91 @@ class DaftTorchIterableDataset(ITER_DATASET_CLASS):  # type: ignore
 
     def __iter__(self) -> Iterator[dict[str, Any]]:
         return iter(self.iterable)
+
+
+class DaftTorchDataLoader:
+    """Streams batched partitions from a Daft DataFrame and yields PyTorch-ready batch dicts.
+
+    Note:
+        This simulates the behavior of a PyTorch DataLoader, but does not use the DataLoader class itself.
+        If the underlying DataFrame is already materialized, it will reuse the existing data.
+    """
+
+    def __init__(
+        self,
+        df: DataFrame,
+        batch_size: int = 1,
+        *,
+        drop_last: bool = False,
+        pin_memory: bool = False,
+        pin_memory_device: str = "",
+        prefetch_count: int = 0,
+    ) -> None:
+        if batch_size <= 0:
+            raise ValueError("batch_size must be greater than 0")
+
+        self._batch_size = batch_size
+        self._drop_last = drop_last
+        self._pin_memory = pin_memory
+        self._pin_memory_device = pin_memory_device if pin_memory_device else None
+        self._prefetch_count = prefetch_count
+
+        self._batched_df = df.into_batches(batch_size)
+
+    def __iter__(self) -> Iterator[dict[str, Any]]:
+        from daft.runners import get_or_create_runner
+
+        results = self._batched_df._result
+        if results is not None:
+            for _, mat_result in results.items():
+                batch = self._partition_to_batch(mat_result.micropartition())
+                if batch is not None:
+                    yield batch
+        else:
+            partitions_iter: Iterator[MaterializedResult[Any]] = get_or_create_runner().run_iter(
+                self._batched_df._builder, results_buffer_size=self._prefetch_count
+            )
+            for mat_result in partitions_iter:
+                batch = self._partition_to_batch(mat_result.micropartition())
+                if batch is not None:
+                    yield batch
+
+    def _partition_to_batch(self, partition: MicroPartition) -> dict[str, Any] | None:
+        if self._drop_last and len(partition) < self._batch_size:
+            return None
+        return self._to_torch_batch(partition.to_pydict())
+
+    def _to_torch_batch(self, pydict: dict[str, list[Any]]) -> dict[str, Any]:
+        return {key: self._column_to_tensor(values) for key, values in pydict.items()}
+
+    def _column_to_tensor(self, values: list[Any]) -> Any:
+        if len(values) == 0:
+            return self._pin(torch.tensor([]))
+
+        first = values[0]
+
+        if isinstance(first, torch.Tensor):
+            return self._pin(torch.stack(values))
+        if hasattr(first, "__array__") and not isinstance(first, (str, bytes)):
+            import numpy as np
+
+            if isinstance(first, np.ndarray) and first.ndim > 0:
+                return self._pin(torch.stack([torch.as_tensor(v) for v in values]))
+            return self._pin(torch.as_tensor(values))
+        if isinstance(first, (bool, int, float)):
+            return self._pin(torch.as_tensor(values))
+
+        return values
+
+    def _pin(self, tensor: torch.Tensor) -> torch.Tensor:
+        if not self._pin_memory:
+            return tensor
+
+        # Pinned host memory is only used for async CPU -> CUDA copies.
+        if not torch.cuda.is_available():
+            return tensor
+
+        # If a specific device is provided, use it. Otherwise, use the default device.
+        if self._pin_memory_device:
+            return tensor.pin_memory(device=self._pin_memory_device)
+        return tensor.pin_memory()

--- a/tests/dataframe/test_to_torch.py
+++ b/tests/dataframe/test_to_torch.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("torch")
+import torch
+
+import daft
+from daft.dataframe.to_torch import DaftTorchDataLoader
+
+
+def test_to_torch_dataloader_batches():
+    df = daft.from_pydict({"x": [1, 2, 3, 4], "y": [5, 6, 7, 8]})
+    loader = df.to_torch_dataloader(batch_size=2)
+
+    assert isinstance(loader, DaftTorchDataLoader)
+    assert not isinstance(loader, torch.utils.data.DataLoader)
+
+    batches = list(loader)
+    assert len(batches) == 2
+    for batch in batches:
+        assert set(batch.keys()) == {"x", "y"}
+        assert isinstance(batch["x"], torch.Tensor)
+        assert isinstance(batch["y"], torch.Tensor)
+        assert batch["x"].shape == (2,)
+        assert batch["y"].shape == (2,)
+
+    assert torch.equal(batches[0]["x"], torch.tensor([1, 2]))
+    assert torch.equal(batches[0]["y"], torch.tensor([5, 6]))
+    assert torch.equal(batches[1]["x"], torch.tensor([3, 4]))
+    assert torch.equal(batches[1]["y"], torch.tensor([7, 8]))
+
+
+def test_to_torch_dataloader_drop_last():
+    df = daft.from_pydict({"x": [1, 2, 3]})
+    loader = df.to_torch_dataloader(batch_size=2, drop_last=True)
+
+    batches = list(loader)
+    assert len(batches) == 1
+    assert batches[0]["x"].shape == (2,)
+    assert torch.equal(batches[0]["x"], torch.tensor([1, 2]))
+
+
+def test_to_torch_dataloader_invalid_batch_size():
+    df = daft.from_pydict({"x": [1]})
+    with pytest.raises(ValueError, match="batch_size must be greater than 0"):
+        df.to_torch_dataloader(batch_size=0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="pin_memory requires CUDA")
+def test_to_torch_dataloader_pin_memory():
+    df = daft.from_pydict({"x": [1.0, 2.0]})
+    loader = df.to_torch_dataloader(batch_size=2, pin_memory=True)
+    batch = next(iter(loader))
+    assert batch["x"].is_pinned()

--- a/tests/dataframe/test_to_torch.py
+++ b/tests/dataframe/test_to_torch.py
@@ -31,16 +31,6 @@ def test_to_torch_dataloader_batches():
     assert torch.equal(batches[1]["y"], torch.tensor([7, 8]))
 
 
-def test_to_torch_dataloader_drop_last():
-    df = daft.from_pydict({"x": [1, 2, 3]})
-    loader = df.to_torch_dataloader(batch_size=2, drop_last=True)
-
-    batches = list(loader)
-    assert len(batches) == 1
-    assert batches[0]["x"].shape == (2,)
-    assert torch.equal(batches[0]["x"], torch.tensor([1, 2]))
-
-
 def test_to_torch_dataloader_invalid_batch_size():
     df = daft.from_pydict({"x": [1]})
     with pytest.raises(ValueError, match="batch_size must be greater than 0"):


### PR DESCRIPTION
## Changes Made

Added a torch.DataLoader connection to Daft, since the DataLoader abstraction is closer to what Daft is doing under the hood instead of the torch.DataSet abstraction. We could extend this further in the future by:

- Internally write the data to pinned memory when selected
