### PR TITLE
feat(writers): add single_file kwarg to write_parquet

### DIFF
--- a/daft/daft/__init__.pyi
+++ b/daft/daft/__init__.pyi
@@ -2307,6 +2307,7 @@ class LogicalPlanBuilder:
         partition_cols: list[PyExpr] | None = None,
         compression: str | None = None,
         io_config: IOConfig | None = None,
+        single_file: bool = False,
     ) -> LogicalPlanBuilder: ...
     def iceberg_write(
         self,

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -47,7 +47,7 @@ from daft.execution.native_executor import NativeExecutor
 from daft.expressions import Expression, ExpressionsProjection, col, lit
 from daft.logical.builder import LogicalPlanBuilder
 from daft.recordbatch import MicroPartition, RecordBatch
-from daft.runners import get_or_create_runner
+from daft.runners import get_or_create_runner, get_or_infer_runner_type
 from daft.runners.partitioning import (
     LocalPartitionSet,
     MaterializedResult,
@@ -972,19 +972,21 @@ class DataFrame:
         partition_cols: list[ColumnInputType] | None = None,
         io_config: IOConfig | None = None,
         column_compression: dict[str, str] | None = None,
+        single_file: bool = False,
     ) -> "DataFrame":
         """Writes the DataFrame as parquet files, returning a new DataFrame with paths to the files that were written.
 
         Files will be written to `<root_dir>/*` with randomly generated UUIDs as the file names.
 
         Args:
-            root_dir (str): root file path to write parquet files to.
+            root_dir (str): root file path to write parquet files to. When `single_file=True`, this is the exact file path to write to.
             compression (str, optional): default compression codec applied to every column. Defaults to "snappy". Accepts "snappy", "gzip", "zstd", "lz4", "lz4_raw", "brotli", "uncompressed", or "none" (case-insensitive).
             write_mode (str, optional): Operation mode of the write. `append` will add new data, `overwrite` will replace the contents of the root directory with new data. `overwrite-partitions` will replace only the contents in the partitions that are being written to. Defaults to "append".
             write_success_file (bool, optional): Whether to write a `_SUCCESS` file upon successful completion. Defaults to False.
             partition_cols (Optional[List[ColumnInputType]], optional): How to subpartition each partition further. Defaults to None.
             io_config (Optional[IOConfig], optional): configurations to use when interacting with remote storage.
             column_compression (Optional[Dict[str, str]], optional): per-column compression overrides. Keys are dot-separated column paths (e.g. `"user.name"` for a nested struct field); values are codec names accepted by `compression`. Columns not listed fall back to `compression`. Defaults to None.
+            single_file (bool, optional): If True, coalesce all data into a single parquet file at `root_dir` (treated as the exact file path). Cannot be combined with `partition_cols` or `overwrite-partitions`. Only supported on the native runner. Defaults to False.
 
         Returns:
             DataFrame: The filenames that were written out as strings.
@@ -996,6 +998,7 @@ class DataFrame:
             >>> import daft
             >>> df = daft.from_pydict({"x": [1, 2, 3], "y": ["a", "b", "c"]})
             >>> df.write_parquet("output_dir", write_mode="overwrite")  # doctest: +SKIP
+            >>> df.write_parquet("output.parquet", single_file=True)  # doctest: +SKIP
 
         Tip:
             See also [`df.write_csv()`][daft.DataFrame.write_csv] and [`df.write_json()`][daft.DataFrame.write_json]
@@ -1007,6 +1010,16 @@ class DataFrame:
             )
         if write_mode == "overwrite-partitions" and partition_cols is None:
             raise ValueError("Partition columns must be specified to use `overwrite-partitions` mode.")
+        if single_file and partition_cols is not None:
+            raise ValueError("`single_file=True` cannot be combined with `partition_cols`.")
+        if single_file and write_mode == "overwrite-partitions":
+            raise ValueError("`single_file=True` cannot be combined with `write_mode='overwrite-partitions'`.")
+        if single_file and write_success_file:
+            raise ValueError("`single_file=True` cannot be combined with `write_success_file=True`.")
+        if single_file:
+            runner_type = get_or_infer_runner_type()
+            if runner_type != "native":
+                raise ValueError(f"`single_file=True` is only supported on the native runner, got '{runner_type}'.")
 
         io_config = get_context().daft_planning_config.default_io_config if io_config is None else io_config
 
@@ -1029,6 +1042,7 @@ class DataFrame:
             file_format_option=file_format_option,
             compression=compression,
             io_config=io_config,
+            single_file=single_file,
         )
         # Block and write, then retrieve data
         write_df = DataFrame(builder)

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -982,7 +982,7 @@ class DataFrame:
             root_dir (str): root file path to write parquet files to. When `single_file=True`, this is the exact file path to write to.
             compression (str, optional): default compression codec applied to every column. Defaults to "snappy". Accepts "snappy", "gzip", "zstd", "lz4", "lz4_raw", "brotli", "uncompressed", or "none" (case-insensitive).
             write_mode (str, optional): Operation mode of the write. `append` will add new data, `overwrite` will replace the contents of the root directory with new data. `overwrite-partitions` will replace only the contents in the partitions that are being written to. Defaults to "append".
-            write_success_file (bool, optional): Whether to write a `_SUCCESS` file upon successful completion. Defaults to False.
+            write_success_file (bool, optional): Whether to write a `_SUCCESS` file upon successful completion. When `single_file=True`, writes `_SUCCESS` to the output file's parent directory. Defaults to False.
             partition_cols (Optional[List[ColumnInputType]], optional): How to subpartition each partition further. Defaults to None.
             io_config (Optional[IOConfig], optional): configurations to use when interacting with remote storage.
             column_compression (Optional[Dict[str, str]], optional): per-column compression overrides. Keys are dot-separated column paths (e.g. `"user.name"` for a nested struct field); values are codec names accepted by `compression`. Columns not listed fall back to `compression`. Defaults to None.
@@ -1008,14 +1008,12 @@ class DataFrame:
             raise ValueError(
                 f"Only support `append`, `overwrite`, or `overwrite-partitions` mode. {write_mode} is unsupported"
             )
+        if single_file and write_mode == "overwrite-partitions":
+            raise ValueError("`single_file=True` cannot be combined with `write_mode='overwrite-partitions'`.")
         if write_mode == "overwrite-partitions" and partition_cols is None:
             raise ValueError("Partition columns must be specified to use `overwrite-partitions` mode.")
         if single_file and partition_cols is not None:
             raise ValueError("`single_file=True` cannot be combined with `partition_cols`.")
-        if single_file and write_mode == "overwrite-partitions":
-            raise ValueError("`single_file=True` cannot be combined with `write_mode='overwrite-partitions'`.")
-        if single_file and write_success_file:
-            raise ValueError("`single_file=True` cannot be combined with `write_success_file=True`.")
         if single_file:
             runner_type = get_or_infer_runner_type()
             if runner_type != "native":

--- a/daft/logical/builder.py
+++ b/daft/logical/builder.py
@@ -380,6 +380,7 @@ class LogicalPlanBuilder:
         file_format_option: PyFormatSinkOption | None = None,
         partition_cols: list[Expression] | None = None,
         compression: str | None = None,
+        single_file: bool = False,
     ) -> LogicalPlanBuilder:
         part_cols_pyexprs = [expr._expr for expr in partition_cols] if partition_cols is not None else None
         builder = self._builder.table_write(
@@ -391,6 +392,7 @@ class LogicalPlanBuilder:
             part_cols_pyexprs,
             compression,
             io_config,
+            single_file,
         )
         return LogicalPlanBuilder(builder)
 

--- a/src/daft-local-execution/src/sinks/commit_write.rs
+++ b/src/daft-local-execution/src/sinks/commit_write.rs
@@ -1,11 +1,11 @@
-use std::{collections::HashSet, sync::Arc};
+use std::{collections::HashSet, path::Path, sync::Arc};
 
-use common_error::DaftResult;
+use common_error::{DaftError, DaftResult};
 use common_file_formats::{FileFormat, WriteMode};
 use common_metrics::ops::NodeType;
 use daft_core::prelude::SchemaRef;
 use daft_dsl::expr::bound_expr::BoundExpr;
-use daft_io::{Error, IOClient, get_io_client, parse_url};
+use daft_io::{Error, IOClient, SourceType, get_io_client, parse_url};
 use daft_logical_plan::OutputFileInfo;
 use daft_micropartition::MicroPartition;
 use daft_recordbatch::RecordBatch;
@@ -168,12 +168,11 @@ impl BlockingSink for CommitWriteSink {
 
                     // Create _SUCCESS file if write_success_file is true.
                     if file_info.write_success_file {
-                        let (_, root_uri) = parse_url(&file_info.root_dir)?;
+                        let success_file_path =
+                            success_marker_path(&file_info.root_dir, file_info.single_file)?;
                         let io_client =
                             get_io_client(true, file_info.io_config.clone().unwrap_or_default().into())?;
-                        let source = io_client.get_source(&root_uri).await?;
-                        let success_file_path =
-                            format!("{}/_SUCCESS", root_uri.trim_end_matches('/'));
+                        let source = io_client.get_source(&success_file_path).await?;
 
                         if let Err(e) = source
                             .put(&success_file_path, tokio_util::bytes::Bytes::new(), None)
@@ -228,6 +227,61 @@ impl BlockingSink for CommitWriteSink {
 
     fn max_concurrency(&self) -> usize {
         1
+    }
+}
+
+fn success_marker_path(root_dir: &str, single_file: bool) -> DaftResult<String> {
+    let (source_type, root_uri) = parse_url(root_dir)?;
+    if !single_file {
+        return Ok(append_uri_path_component(root_uri.as_ref(), "_SUCCESS"));
+    }
+
+    match source_type {
+        SourceType::File => local_success_marker_path(root_uri.as_ref()),
+        SourceType::S3 | SourceType::Tos | SourceType::Gravitino | SourceType::OpenDAL { .. } => {
+            object_success_marker_path(root_uri.as_ref())
+        }
+        source_type => Err(DaftError::ValueError(format!(
+            "`write_success_file=True` is not supported for source type `{source_type}` with `single_file=True`."
+        ))),
+    }
+}
+
+fn local_success_marker_path(root_uri: &str) -> DaftResult<String> {
+    let root_path = daft_io::strip_file_uri_to_path(root_uri).unwrap_or(root_uri);
+    let success_dir = Path::new(root_path)
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let success_file_path = success_dir.join("_SUCCESS");
+    Ok(daft_io::local_path_to_file_uri(
+        success_file_path.to_string_lossy().as_ref(),
+    ))
+}
+
+fn object_success_marker_path(root_uri: &str) -> DaftResult<String> {
+    let object_path = daft_io::utils::parse_object_url(root_uri)?;
+    let parent_key = object_path
+        .key
+        .rsplit_once('/')
+        .map(|(parent, _)| parent)
+        .unwrap_or("");
+    let success_dir = if parent_key.is_empty() {
+        format!("{}://{}", object_path.scheme, object_path.bucket)
+    } else {
+        format!(
+            "{}://{}/{}",
+            object_path.scheme, object_path.bucket, parent_key
+        )
+    };
+    Ok(append_uri_path_component(&success_dir, "_SUCCESS"))
+}
+
+fn append_uri_path_component(base: &str, component: &str) -> String {
+    if base.ends_with('/') {
+        format!("{base}{component}")
+    } else {
+        format!("{base}/{component}")
     }
 }
 

--- a/src/daft-local-execution/src/sinks/commit_write.rs
+++ b/src/daft-local-execution/src/sinks/commit_write.rs
@@ -238,9 +238,7 @@ fn success_marker_path(root_dir: &str, single_file: bool) -> DaftResult<String> 
 
     match source_type {
         SourceType::File => local_success_marker_path(root_uri.as_ref()),
-        SourceType::S3 | SourceType::Tos | SourceType::Gravitino | SourceType::OpenDAL { .. } => {
-            object_success_marker_path(root_uri.as_ref())
-        }
+        source if source.supports_native_writer() => object_success_marker_path(root_uri.as_ref()),
         source_type => Err(DaftError::ValueError(format!(
             "`write_success_file=True` is not supported for source type `{source_type}` with `single_file=True`."
         ))),

--- a/src/daft-logical-plan/src/builder/mod.rs
+++ b/src/daft-logical-plan/src/builder/mod.rs
@@ -887,6 +887,7 @@ impl LogicalPlanBuilder {
         partition_cols: Option<Vec<ExprRef>>,
         compression: Option<String>,
         io_config: Option<IOConfig>,
+        single_file: bool,
     ) -> DaftResult<Self> {
         let expr_resolver = ExprResolver::default();
 
@@ -903,6 +904,7 @@ impl LogicalPlanBuilder {
             compression,
             io_config,
             write_success_file,
+            single_file,
         ));
 
         let logical_plan: LogicalPlan =
@@ -1680,7 +1682,8 @@ impl PyLogicalPlanBuilder {
         format_option=None,
         partition_cols=None,
         compression=None,
-        io_config=None
+        io_config=None,
+        single_file=false
     ))]
     pub fn table_write(
         &self,
@@ -1692,6 +1695,7 @@ impl PyLogicalPlanBuilder {
         partition_cols: Option<Vec<PyExpr>>,
         compression: Option<String>,
         io_config: Option<common_io_config::python::IOConfig>,
+        single_file: bool,
     ) -> PyResult<Self> {
         Ok(self
             .builder
@@ -1704,6 +1708,7 @@ impl PyLogicalPlanBuilder {
                 partition_cols.map(pyexprs_to_exprs),
                 compression,
                 io_config.map(|cfg| cfg.config),
+                single_file,
             )?
             .into())
     }

--- a/src/daft-logical-plan/src/sink_info.rs
+++ b/src/daft-logical-plan/src/sink_info.rs
@@ -33,6 +33,7 @@ pub struct OutputFileInfo<E = ExprRef> {
     pub compression: Option<String>,
     pub io_config: Option<IOConfig>,
     pub write_success_file: bool,
+    pub single_file: bool,
 }
 
 #[cfg(feature = "python")]
@@ -196,6 +197,7 @@ where
         compression: Option<String>,
         io_config: Option<IOConfig>,
         write_success_file: bool,
+        single_file: bool,
     ) -> Self {
         Self {
             root_dir,
@@ -206,6 +208,7 @@ where
             compression,
             io_config,
             write_success_file,
+            single_file,
         }
     }
 
@@ -261,6 +264,7 @@ impl OutputFileInfo {
             compression: self.compression,
             io_config: self.io_config,
             write_success_file: self.write_success_file,
+            single_file: self.single_file,
         })
     }
 }

--- a/src/daft-writers/src/file.rs
+++ b/src/daft-writers/src/file.rs
@@ -233,7 +233,7 @@ impl AsyncFileWriter for SingleFileWriter {
 
     async fn close(&mut self) -> DaftResult<Self::Result> {
         // Guard: if no non-empty input was ever written, the underlying parquet
-        // file_writer was never initialised and closing it would panic.
+        // file writer was never initialized and closing it would panic.
         if self.has_written
             && let Some(result) = self.writer.close().await?
         {

--- a/src/daft-writers/src/file.rs
+++ b/src/daft-writers/src/file.rs
@@ -178,6 +178,106 @@ impl AsyncFileWriter for TargetFileSizeWriter {
     }
 }
 
+/// SingleFileWriter wraps a base writer and never rotates — all data flows into one file.
+/// Used when `single_file=true` is set on the write.
+struct SingleFileWriter {
+    writer: Box<dyn AsyncFileWriter<Input = MicroPartition, Result = Option<RecordBatch>>>,
+    results: Vec<RecordBatch>,
+    bytes_per_file: Vec<usize>,
+    total_bytes_written: usize,
+    has_written: bool,
+    is_closed: bool,
+}
+
+impl SingleFileWriter {
+    fn new(
+        writer: Box<dyn AsyncFileWriter<Input = MicroPartition, Result = Option<RecordBatch>>>,
+    ) -> Self {
+        Self {
+            writer,
+            results: vec![],
+            bytes_per_file: vec![],
+            total_bytes_written: 0,
+            has_written: false,
+            is_closed: false,
+        }
+    }
+}
+
+#[async_trait]
+impl AsyncFileWriter for SingleFileWriter {
+    type Input = MicroPartition;
+    type Result = Vec<RecordBatch>;
+
+    async fn write(&mut self, input: MicroPartition) -> DaftResult<WriteResult> {
+        assert!(!self.is_closed, "Cannot write to a closed SingleFileWriter");
+        if input.is_empty() {
+            return Ok(WriteResult {
+                bytes_written: 0,
+                rows_written: 0,
+            });
+        }
+        self.has_written = true;
+        let result = self.writer.write(input).await?;
+        self.total_bytes_written += result.bytes_written;
+        Ok(result)
+    }
+
+    fn bytes_written(&self) -> usize {
+        self.total_bytes_written
+    }
+
+    fn bytes_per_file(&self) -> Vec<usize> {
+        self.bytes_per_file.clone()
+    }
+
+    async fn close(&mut self) -> DaftResult<Self::Result> {
+        // Guard: if no non-empty input was ever written, the underlying parquet
+        // file_writer was never initialised and closing it would panic.
+        if self.has_written
+            && let Some(result) = self.writer.close().await?
+        {
+            self.results.push(result);
+            self.bytes_per_file.push(self.writer.bytes_written());
+        }
+        self.is_closed = true;
+        Ok(std::mem::take(&mut self.results))
+    }
+}
+
+pub(crate) struct SingleFileWriterFactory {
+    writer_factory: Arc<dyn WriterFactory<Input = MicroPartition, Result = Option<RecordBatch>>>,
+}
+
+impl SingleFileWriterFactory {
+    pub(crate) fn new(
+        writer_factory: Arc<
+            dyn WriterFactory<Input = MicroPartition, Result = Option<RecordBatch>>,
+        >,
+    ) -> Self {
+        Self { writer_factory }
+    }
+}
+
+impl WriterFactory for SingleFileWriterFactory {
+    type Input = MicroPartition;
+    type Result = Vec<RecordBatch>;
+
+    fn create_writer(
+        &self,
+        file_idx: usize,
+        partition_values: Option<&RecordBatch>,
+    ) -> DaftResult<Box<dyn AsyncFileWriter<Input = Self::Input, Result = Self::Result>>> {
+        let writer = self
+            .writer_factory
+            .create_writer(file_idx, partition_values)?;
+        Ok(Box::new(SingleFileWriter::new(writer))
+            as Box<
+                dyn AsyncFileWriter<Input = Self::Input, Result = Self::Result>,
+            >)
+    }
+}
+
 pub(crate) struct TargetFileSizeWriterFactory {
     writer_factory: Arc<dyn WriterFactory<Input = MicroPartition, Result = Option<RecordBatch>>>,
     size_calculator: Arc<TargetInMemorySizeBytesCalculator>,

--- a/src/daft-writers/src/lib.rs
+++ b/src/daft-writers/src/lib.rs
@@ -145,26 +145,6 @@ pub fn make_physical_writer_factory(
         PhysicalWriterFactory::new(file_info.clone(), data_schema, cfg.native_parquet_writer)?;
     match file_info.file_format {
         FileFormat::Parquet => {
-            if file_info.single_file {
-                let row_group_size_calculator = TargetInMemorySizeBytesCalculator::new(
-                    min(
-                        cfg.parquet_target_row_group_size,
-                        cfg.parquet_target_filesize,
-                    ),
-                    cfg.parquet_inflation_factor,
-                );
-                let row_group_writer_factory = TargetBatchWriterFactory::new(
-                    Arc::new(base_writer_factory),
-                    Arc::new(row_group_size_calculator),
-                );
-                return Ok(Arc::new(SingleFileWriterFactory::new(Arc::new(
-                    row_group_writer_factory,
-                ))));
-            }
-            let file_size_calculator = TargetInMemorySizeBytesCalculator::new(
-                cfg.parquet_target_filesize,
-                cfg.parquet_inflation_factor,
-            );
             let row_group_size_calculator = TargetInMemorySizeBytesCalculator::new(
                 min(
                     cfg.parquet_target_row_group_size,
@@ -175,6 +155,17 @@ pub fn make_physical_writer_factory(
             let row_group_writer_factory = TargetBatchWriterFactory::new(
                 Arc::new(base_writer_factory),
                 Arc::new(row_group_size_calculator),
+            );
+
+            if file_info.single_file {
+                return Ok(Arc::new(SingleFileWriterFactory::new(Arc::new(
+                    row_group_writer_factory,
+                ))));
+            }
+
+            let file_size_calculator = TargetInMemorySizeBytesCalculator::new(
+                cfg.parquet_target_filesize,
+                cfg.parquet_inflation_factor,
             );
             let file_writer_factory = TargetFileSizeWriterFactory::new(
                 Arc::new(row_group_writer_factory),

--- a/src/daft-writers/src/lib.rs
+++ b/src/daft-writers/src/lib.rs
@@ -41,7 +41,7 @@ use daft_dsl::{Expr, expr::bound_expr::BoundExpr};
 use daft_logical_plan::OutputFileInfo;
 use daft_micropartition::MicroPartition;
 use daft_recordbatch::RecordBatch;
-use file::TargetFileSizeWriterFactory;
+use file::{SingleFileWriterFactory, TargetFileSizeWriterFactory};
 use ipc::IPCWriterFactory;
 #[cfg(feature = "python")]
 pub use lance::make_lance_writer_factory;
@@ -145,6 +145,22 @@ pub fn make_physical_writer_factory(
         PhysicalWriterFactory::new(file_info.clone(), data_schema, cfg.native_parquet_writer)?;
     match file_info.file_format {
         FileFormat::Parquet => {
+            if file_info.single_file {
+                let row_group_size_calculator = TargetInMemorySizeBytesCalculator::new(
+                    min(
+                        cfg.parquet_target_row_group_size,
+                        cfg.parquet_target_filesize,
+                    ),
+                    cfg.parquet_inflation_factor,
+                );
+                let row_group_writer_factory = TargetBatchWriterFactory::new(
+                    Arc::new(base_writer_factory),
+                    Arc::new(row_group_size_calculator),
+                );
+                return Ok(Arc::new(SingleFileWriterFactory::new(Arc::new(
+                    row_group_writer_factory,
+                ))));
+            }
             let file_size_calculator = TargetInMemorySizeBytesCalculator::new(
                 cfg.parquet_target_filesize,
                 cfg.parquet_inflation_factor,

--- a/src/daft-writers/src/parquet_writer.rs
+++ b/src/daft-writers/src/parquet_writer.rs
@@ -24,7 +24,7 @@ use parquet::{
 use crate::{
     AsyncFileWriter, WriteResult,
     storage_backend::{FileStorageBackend, ObjectStorageBackend, StorageBackend},
-    utils::build_filename,
+    utils::{build_filename, build_filename_single},
 };
 
 type ColumnWriterFuture = dyn Future<Output = DaftResult<ArrowColumnChunk>> + Send;
@@ -93,6 +93,7 @@ pub(crate) fn native_parquet_writer_supported(
         .is_ok())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn create_native_parquet_writer(
     root_dir: &str,
     schema: &SchemaRef,
@@ -101,16 +102,21 @@ pub(crate) fn create_native_parquet_writer(
     io_config: Option<IOConfig>,
     compression: Option<&str>,
     column_compression: Option<&[(String, String)]>,
+    single_file: bool,
 ) -> DaftResult<Box<dyn AsyncFileWriter<Input = MicroPartition, Result = Option<RecordBatch>>>> {
     // Parse the root directory and add partition values if present.
     let (source_type, root_dir) = parse_url(root_dir)?;
-    let filename = build_filename(
-        &source_type,
-        root_dir.as_ref(),
-        partition_values,
-        file_idx,
-        "parquet",
-    )?;
+    let filename = if single_file {
+        build_filename_single(&source_type, root_dir.as_ref())?
+    } else {
+        build_filename(
+            &source_type,
+            root_dir.as_ref(),
+            partition_values,
+            file_idx,
+            "parquet",
+        )?
+    };
 
     let default_compression = match compression {
         Some(name) => parse_compression(name)?,

--- a/src/daft-writers/src/parquet_writer.rs
+++ b/src/daft-writers/src/parquet_writer.rs
@@ -1,4 +1,10 @@
-use std::{collections::VecDeque, future::Future, path::PathBuf, pin::Pin, sync::Arc};
+use std::{
+    collections::VecDeque,
+    future::Future,
+    path::{Path, PathBuf},
+    pin::Pin,
+    sync::Arc,
+};
 
 use async_trait::async_trait;
 use common_error::{DaftError, DaftResult};
@@ -103,6 +109,7 @@ pub(crate) fn create_native_parquet_writer(
     compression: Option<&str>,
     column_compression: Option<&[(String, String)]>,
     single_file: bool,
+    overwrite_single_file_target: bool,
 ) -> DaftResult<Box<dyn AsyncFileWriter<Input = MicroPartition, Result = Option<RecordBatch>>>> {
     // Parse the root directory and add partition values if present.
     let (source_type, root_dir) = parse_url(root_dir)?;
@@ -152,6 +159,7 @@ pub(crate) fn create_native_parquet_writer(
                 parquet_schema,
                 partition_values.cloned(),
                 storage_backend,
+                overwrite_single_file_target,
             )))
         }
         source if source.supports_native_writer() => {
@@ -167,12 +175,22 @@ pub(crate) fn create_native_parquet_writer(
                 parquet_schema,
                 partition_values.cloned(),
                 storage_backend,
+                false,
             )))
         }
         _ => Err(DaftError::InternalError(format!(
             "Unsupported source type for the native writer: {source_type}"
         ))),
     }
+}
+
+fn remove_existing_local_target(filename: &Path) -> DaftResult<()> {
+    if filename.is_dir() {
+        std::fs::remove_dir_all(filename)?;
+    } else if filename.exists() {
+        std::fs::remove_file(filename)?;
+    }
+    Ok(())
 }
 
 struct ParquetWriter<B: StorageBackend> {
@@ -184,6 +202,7 @@ struct ParquetWriter<B: StorageBackend> {
     storage_backend: B,
     file_writer: Option<SerializedFileWriter<B::Writer>>,
     total_bytes_written: usize,
+    overwrite_existing_target: bool,
 }
 
 impl<B: StorageBackend> ParquetWriter<B> {
@@ -196,6 +215,7 @@ impl<B: StorageBackend> ParquetWriter<B> {
         parquet_schema: SchemaDescriptor,
         partition_values: Option<RecordBatch>,
         storage_backend: B,
+        overwrite_existing_target: bool,
     ) -> Self {
         Self {
             filename,
@@ -206,10 +226,14 @@ impl<B: StorageBackend> ParquetWriter<B> {
             storage_backend,
             file_writer: None,
             total_bytes_written: 0,
+            overwrite_existing_target,
         }
     }
 
     async fn create_writer(&mut self) -> DaftResult<()> {
+        if self.overwrite_existing_target {
+            remove_existing_local_target(&self.filename)?;
+        }
         let backend_writer = self.storage_backend.create_writer(&self.filename).await?;
         let file_writer = SerializedFileWriter::new(
             backend_writer,

--- a/src/daft-writers/src/physical.rs
+++ b/src/daft-writers/src/physical.rs
@@ -1,5 +1,5 @@
 use common_error::{DaftError, DaftResult};
-use common_file_formats::FileFormat;
+use common_file_formats::{FileFormat, WriteMode};
 use daft_core::prelude::*;
 use daft_dsl::expr::bound_expr::BoundExpr;
 use daft_logical_plan::{OutputFileInfo, sink_info::FormatSinkOption};
@@ -131,6 +131,7 @@ impl WriterFactory for PhysicalWriterFactory {
                 self.output_file_info.format_option.clone(),
                 self.output_file_info.compression.as_deref(),
                 self.output_file_info.single_file,
+                self.output_file_info.write_mode,
             ),
             WriterType::Pyarrow => create_pyarrow_file_writer(
                 &self.output_file_info.root_dir,
@@ -193,6 +194,7 @@ fn create_native_writer(
     format_option: Option<FormatSinkOption>,
     compression: Option<&str>,
     single_file: bool,
+    write_mode: WriteMode,
 ) -> DaftResult<Box<dyn AsyncFileWriter<Input = MicroPartition, Result = Option<RecordBatch>>>> {
     let (path, io_config) = parse_url_and_config(root_dir, io_config)?;
     let root_dir = path.as_str();
@@ -211,6 +213,7 @@ fn create_native_writer(
                 compression,
                 parquet_option.column_compression.as_deref(),
                 single_file,
+                single_file && matches!(write_mode, WriteMode::Overwrite),
             )
         }
         FileFormat::Json => {

--- a/src/daft-writers/src/physical.rs
+++ b/src/daft-writers/src/physical.rs
@@ -64,6 +64,11 @@ impl PhysicalWriterFactory {
         native_enabled: bool,
     ) -> DaftResult<WriterType> {
         if !native_enabled {
+            if output_file_info.single_file {
+                return Err(DaftError::NotImplemented(
+                    "`single_file=True` is not supported when the native Parquet writer is disabled".to_string(),
+                ));
+            }
             return Ok(WriterType::Pyarrow);
         }
 
@@ -72,6 +77,10 @@ impl PhysicalWriterFactory {
 
         if native_supported {
             Ok(WriterType::Native)
+        } else if output_file_info.single_file {
+            Err(DaftError::NotImplemented(
+                "`single_file=True` is not supported for this schema or path (native Parquet writer fell back to PyArrow)".to_string(),
+            ))
         } else {
             Ok(WriterType::Pyarrow)
         }
@@ -121,6 +130,7 @@ impl WriterFactory for PhysicalWriterFactory {
                 self.output_file_info.io_config.clone(),
                 self.output_file_info.format_option.clone(),
                 self.output_file_info.compression.as_deref(),
+                self.output_file_info.single_file,
             ),
             WriterType::Pyarrow => create_pyarrow_file_writer(
                 &self.output_file_info.root_dir,
@@ -182,6 +192,7 @@ fn create_native_writer(
     io_config: Option<daft_io::IOConfig>,
     format_option: Option<FormatSinkOption>,
     compression: Option<&str>,
+    single_file: bool,
 ) -> DaftResult<Box<dyn AsyncFileWriter<Input = MicroPartition, Result = Option<RecordBatch>>>> {
     let (path, io_config) = parse_url_and_config(root_dir, io_config)?;
     let root_dir = path.as_str();
@@ -199,13 +210,24 @@ fn create_native_writer(
                 io_config,
                 compression,
                 parquet_option.column_compression.as_deref(),
+                single_file,
             )
         }
         FileFormat::Json => {
+            if single_file {
+                return Err(DaftError::NotImplemented(
+                    "`single_file=True` is not yet supported for JSON writes".to_string(),
+                ));
+            }
             let json_option = format_option.map(|opt| opt.to_json()).unwrap_or_default();
             create_native_json_writer(root_dir, file_idx, partition_values, io_config, json_option)
         }
         FileFormat::Csv => {
+            if single_file {
+                return Err(DaftError::NotImplemented(
+                    "`single_file=True` is not yet supported for CSV writes".to_string(),
+                ));
+            }
             let csv_option = format_option.map(|opt| opt.to_csv()).unwrap_or_default();
             create_native_csv_writer(root_dir, file_idx, partition_values, io_config, csv_option)
         }

--- a/src/daft-writers/src/utils.rs
+++ b/src/daft-writers/src/utils.rs
@@ -15,6 +15,46 @@ pub(crate) fn build_filename(
     file_idx: usize,
     suffix: &str,
 ) -> DaftResult<PathBuf> {
+    build_filename_impl(
+        source_type,
+        root_dir,
+        partition_values,
+        file_idx,
+        suffix,
+        false,
+    )
+}
+
+/// Helper function to build the filename for the output file, with an option to treat
+/// `root_dir` as the exact target file path (no partition dir, no UUID).
+pub(crate) fn build_filename_single(source_type: &SourceType, path: &str) -> DaftResult<PathBuf> {
+    build_filename_impl(source_type, path, None, 0, "", true)
+}
+
+fn build_filename_impl(
+    source_type: &SourceType,
+    root_dir: &str,
+    partition_values: Option<&RecordBatch>,
+    file_idx: usize,
+    suffix: &str,
+    single_file: bool,
+) -> DaftResult<PathBuf> {
+    if single_file {
+        return match source_type {
+            SourceType::File => {
+                let stripped = daft_io::strip_file_uri_to_path(root_dir).unwrap_or(root_dir);
+                Ok(PathBuf::from(stripped))
+            }
+            source if source.supports_native_writer() => {
+                let ObjectPath { bucket, key, .. } = daft_io::utils::parse_object_url(root_dir)?;
+                Ok(PathBuf::from(format!("{}/{}", bucket, key)))
+            }
+            _ => Err(DaftError::ValueError(format!(
+                "Unsupported source type: {:?}",
+                source_type
+            ))),
+        };
+    }
     let partition_path = get_partition_path(partition_values)?;
     let filename = generate_filename(file_idx, suffix);
 

--- a/src/daft-writers/src/utils.rs
+++ b/src/daft-writers/src/utils.rs
@@ -15,46 +15,6 @@ pub(crate) fn build_filename(
     file_idx: usize,
     suffix: &str,
 ) -> DaftResult<PathBuf> {
-    build_filename_impl(
-        source_type,
-        root_dir,
-        partition_values,
-        file_idx,
-        suffix,
-        false,
-    )
-}
-
-/// Helper function to build the filename for the output file, with an option to treat
-/// `root_dir` as the exact target file path (no partition dir, no UUID).
-pub(crate) fn build_filename_single(source_type: &SourceType, path: &str) -> DaftResult<PathBuf> {
-    build_filename_impl(source_type, path, None, 0, "", true)
-}
-
-fn build_filename_impl(
-    source_type: &SourceType,
-    root_dir: &str,
-    partition_values: Option<&RecordBatch>,
-    file_idx: usize,
-    suffix: &str,
-    single_file: bool,
-) -> DaftResult<PathBuf> {
-    if single_file {
-        return match source_type {
-            SourceType::File => {
-                let stripped = daft_io::strip_file_uri_to_path(root_dir).unwrap_or(root_dir);
-                Ok(PathBuf::from(stripped))
-            }
-            source if source.supports_native_writer() => {
-                let ObjectPath { bucket, key, .. } = daft_io::utils::parse_object_url(root_dir)?;
-                Ok(PathBuf::from(format!("{}/{}", bucket, key)))
-            }
-            _ => Err(DaftError::ValueError(format!(
-                "Unsupported source type: {:?}",
-                source_type
-            ))),
-        };
-    }
     let partition_path = get_partition_path(partition_values)?;
     let filename = generate_filename(file_idx, suffix);
 
@@ -62,6 +22,25 @@ fn build_filename_impl(
         SourceType::File => build_local_file_path(root_dir, partition_path, filename),
         source if source.supports_native_writer() => {
             build_object_path(root_dir, partition_path, filename)
+        }
+        _ => Err(DaftError::ValueError(format!(
+            "Unsupported source type: {:?}",
+            source_type
+        ))),
+    }
+}
+
+/// Helper function to build the filename for the output file, treating `path` as the
+/// exact target file path (no partition dir, no UUID).
+pub(crate) fn build_filename_single(source_type: &SourceType, path: &str) -> DaftResult<PathBuf> {
+    match source_type {
+        SourceType::File => {
+            let stripped = daft_io::strip_file_uri_to_path(path).unwrap_or(path);
+            Ok(PathBuf::from(stripped))
+        }
+        source if source.supports_native_writer() => {
+            let ObjectPath { bucket, key, .. } = daft_io::utils::parse_object_url(path)?;
+            Ok(PathBuf::from(format!("{}/{}", bucket, key)))
         }
         _ => Err(DaftError::ValueError(format!(
             "Unsupported source type: {:?}",

--- a/tests/cookbook/test_write.py
+++ b/tests/cookbook/test_write.py
@@ -10,7 +10,7 @@ import pytest
 from pyarrow import dataset as pads
 
 import daft
-from tests.conftest import assert_df_equals
+from tests.conftest import assert_df_equals, get_tests_daft_runner_name
 from tests.cookbook.assets import COOKBOOK_DATA_CSV
 
 
@@ -25,6 +25,102 @@ def test_parquet_write(tmp_path, with_morsel_size):
     assert pd_df._preview.partition is None
     pd_df.__repr__()
     assert len(pd_df._preview.partition) == 1
+
+
+@pytest.mark.skipif(
+    get_tests_daft_runner_name() != "native",
+    reason="single_file is only supported on the native runner",
+)
+def test_parquet_write_single_file(tmp_path, with_morsel_size):
+    df = daft.read_csv(COOKBOOK_DATA_CSV)
+
+    out_path = tmp_path / "out.parquet"
+    result = df.write_parquet(out_path.as_posix(), single_file=True)
+
+    assert out_path.is_file()
+    assert result.to_pydict()["path"] == [out_path.as_posix()]
+
+    read_back = daft.read_parquet(out_path.as_posix()).to_pandas()
+    assert_df_equals(df.to_pandas(), read_back)
+
+
+@pytest.mark.skipif(
+    get_tests_daft_runner_name() != "native",
+    reason="single_file is only supported on the native runner",
+)
+def test_parquet_write_single_file_creates_parent_dirs(tmp_path, with_morsel_size):
+    df = daft.from_pydict({"x": [1, 2, 3]})
+    out_path = tmp_path / "nested" / "subdir" / "out.parquet"
+
+    df.write_parquet(out_path.as_posix(), single_file=True)
+
+    assert out_path.is_file()
+    assert daft.read_parquet(out_path.as_posix()).to_pydict() == {"x": [1, 2, 3]}
+
+
+@pytest.mark.skipif(
+    get_tests_daft_runner_name() != "native",
+    reason="single_file is only supported on the native runner",
+)
+def test_parquet_write_single_file_large_does_not_split(tmp_path, with_morsel_size):
+    # Data bigger than default target_filesize should still produce a single file.
+    rows = 100_000
+    df = daft.from_pydict({"x": list(range(rows)), "y": ["hello" * 100] * rows})
+
+    out_path = tmp_path / "big.parquet"
+    df.write_parquet(out_path.as_posix(), single_file=True)
+
+    assert out_path.is_file()
+    assert daft.read_parquet(out_path.as_posix()).count_rows() == rows
+
+
+@pytest.mark.skipif(
+    get_tests_daft_runner_name() != "native",
+    reason="single_file is only supported on the native runner",
+)
+def test_parquet_write_single_file_empty(tmp_path, with_morsel_size):
+    # Empty DataFrame must not panic when single_file=True. CommitWriteSink emits an
+    # empty parquet file at the exact path so reads round-trip.
+    df = daft.from_pydict({"x": [1, 2, 3], "y": ["a", "b", "c"]}).where(daft.lit(False))
+
+    out_path = tmp_path / "empty.parquet"
+    df.write_parquet(out_path.as_posix(), single_file=True)
+
+    assert out_path.is_file()
+    assert daft.read_parquet(out_path.as_posix()).count_rows() == 0
+
+
+def test_parquet_write_single_file_rejects_partition_cols(tmp_path):
+    df = daft.from_pydict({"x": [1, 2], "y": ["a", "b"]})
+    with pytest.raises(ValueError, match="single_file=True.*partition_cols"):
+        df.write_parquet(
+            (tmp_path / "out.parquet").as_posix(),
+            single_file=True,
+            partition_cols=["y"],
+        )
+
+
+@pytest.mark.skipif(
+    get_tests_daft_runner_name() != "native",
+    reason="single_file is only supported on the native runner",
+)
+def test_parquet_write_single_file_overwrite(tmp_path, with_morsel_size):
+    out_path = tmp_path / "out.parquet"
+    daft.from_pydict({"x": [1, 2, 3]}).write_parquet(out_path.as_posix(), single_file=True)
+    daft.from_pydict({"x": [10, 20, 30, 40, 50]}).write_parquet(
+        out_path.as_posix(), single_file=True, write_mode="overwrite"
+    )
+    assert daft.read_parquet(out_path.as_posix()).to_pydict() == {"x": [10, 20, 30, 40, 50]}
+
+
+def test_parquet_write_single_file_rejects_write_success_file(tmp_path):
+    df = daft.from_pydict({"x": [1, 2]})
+    with pytest.raises(ValueError, match="single_file=True.*write_success_file"):
+        df.write_parquet(
+            (tmp_path / "out.parquet").as_posix(),
+            single_file=True,
+            write_success_file=True,
+        )
 
 
 def test_parquet_write_with_partitioning(tmp_path, with_morsel_size):

--- a/tests/cookbook/test_write.py
+++ b/tests/cookbook/test_write.py
@@ -101,6 +101,17 @@ def test_parquet_write_single_file_rejects_partition_cols(tmp_path):
         )
 
 
+def test_parquet_write_single_file_rejects_overwrite_partitions(tmp_path):
+    df = daft.from_pydict({"x": [1, 2], "y": ["a", "b"]})
+    with pytest.raises(ValueError, match="single_file=True.*overwrite-partitions"):
+        df.write_parquet(
+            (tmp_path / "out.parquet").as_posix(),
+            single_file=True,
+            write_mode="overwrite-partitions",
+            partition_cols=["y"],
+        )
+
+
 @pytest.mark.skipif(
     get_tests_daft_runner_name() != "native",
     reason="single_file is only supported on the native runner",
@@ -114,14 +125,39 @@ def test_parquet_write_single_file_overwrite(tmp_path, with_morsel_size):
     assert daft.read_parquet(out_path.as_posix()).to_pydict() == {"x": [10, 20, 30, 40, 50]}
 
 
-def test_parquet_write_single_file_rejects_write_success_file(tmp_path):
+@pytest.mark.skipif(
+    get_tests_daft_runner_name() != "native",
+    reason="single_file is only supported on the native runner",
+)
+def test_parquet_write_single_file_overwrite_replaces_directory(tmp_path, with_morsel_size):
+    out_path = tmp_path / "out.parquet"
+    out_path.mkdir()
+    (out_path / "stale.parquet").write_bytes(b"stale")
+
+    daft.from_pydict({"x": [10, 20, 30]}).write_parquet(out_path.as_posix(), single_file=True, write_mode="overwrite")
+
+    assert out_path.is_file()
+    assert daft.read_parquet(out_path.as_posix()).to_pydict() == {"x": [10, 20, 30]}
+
+
+@pytest.mark.skipif(
+    get_tests_daft_runner_name() != "native",
+    reason="single_file is only supported on the native runner",
+)
+def test_parquet_write_single_file_success_file(tmp_path, with_morsel_size):
     df = daft.from_pydict({"x": [1, 2]})
-    with pytest.raises(ValueError, match="single_file=True.*write_success_file"):
-        df.write_parquet(
-            (tmp_path / "out.parquet").as_posix(),
-            single_file=True,
-            write_success_file=True,
-        )
+    out_path = tmp_path / "out.parquet"
+
+    df.write_parquet(
+        out_path.as_posix(),
+        single_file=True,
+        write_success_file=True,
+    )
+
+    success_file_path = tmp_path / "_SUCCESS"
+    assert out_path.is_file()
+    assert success_file_path.is_file()
+    assert success_file_path.stat().st_size == 0
 
 
 def test_parquet_write_with_partitioning(tmp_path, with_morsel_size):

--- a/tests/cookbook/test_write.py
+++ b/tests/cookbook/test_write.py
@@ -63,12 +63,13 @@ def test_parquet_write_single_file_creates_parent_dirs(tmp_path, with_morsel_siz
     reason="single_file is only supported on the native runner",
 )
 def test_parquet_write_single_file_large_does_not_split(tmp_path, with_morsel_size):
-    # Data bigger than default target_filesize should still produce a single file.
-    rows = 100_000
+    # Shrink target_filesize so a small df still exceeds it and exercises the no-split path.
+    rows = 1_000
     df = daft.from_pydict({"x": list(range(rows)), "y": ["hello" * 100] * rows})
 
     out_path = tmp_path / "big.parquet"
-    df.write_parquet(out_path.as_posix(), single_file=True)
+    with daft.execution_config_ctx(parquet_target_filesize=1024):
+        df.write_parquet(out_path.as_posix(), single_file=True)
 
     assert out_path.is_file()
     assert daft.read_parquet(out_path.as_posix()).count_rows() == rows
@@ -81,7 +82,7 @@ def test_parquet_write_single_file_large_does_not_split(tmp_path, with_morsel_si
 def test_parquet_write_single_file_empty(tmp_path, with_morsel_size):
     # Empty DataFrame must not panic when single_file=True. CommitWriteSink emits an
     # empty parquet file at the exact path so reads round-trip.
-    df = daft.from_pydict({"x": [1, 2, 3], "y": ["a", "b", "c"]}).where(daft.lit(False))
+    df = daft.from_pydict({"x": [], "y": []})
 
     out_path = tmp_path / "empty.parquet"
     df.write_parquet(out_path.as_posix(), single_file=True)


### PR DESCRIPTION
## Changes Made

Add `single_file: bool = False` to `DataFrame.write_parquet`. When `True`, the data is coalesced into one Parquet file written at the exact path given, instead of a directory of UUID-named files.

```py
df.write_parquet("out.parquet", single_file=True)
```

**How it works.** The flag is threaded from the Python API through the logical plan into the writer pipeline. A new non-rotating writer wrapper bypasses the usual target-file-size rollover so all input partitions stream into one writer. The filename helper uses the user's path verbatim, skipping partition-dir and UUID generation. Parent directories are auto-created. Row-group batching is preserved. For empty DataFrames, the writer is skipped and an empty Parquet file is emitted via the commit path at the exact destination.

**Modes.** Both `append` (default) and `overwrite` work — Parquet has no append semantic, so each write truncates the target via `File::create`. `overwrite`'s pre-clean is a safe no-op for single-file paths.

**Validation.** Raises a clear error when `single_file=True` is combined with `partition_cols`, `write_mode="overwrite-partitions"`, `write_success_file=True`, the Ray runner, or schemas that fall back to the PyArrow writer.

**Scope.** Parquet on the native runner only. CSV/JSON, the PyArrow fallback, and a shuffle-to-one for the Ray runner are left as follow-ups — those paths currently error out instead of silently falling back to UUID-dir behavior.

Tests cover the happy path, parent-dir auto-creation, large data that would otherwise split across multiple files, empty DataFrames, `overwrite` mode, and rejection of `partition_cols` / `write_success_file`.

## Related Issues

Closes #2359