### PR TITLE
feat(delta-lake): support column mapping for reads

### DIFF
--- a/daft/io/delta_lake/delta_lake_scan.py
+++ b/daft/io/delta_lake/delta_lake_scan.py
@@ -9,6 +9,8 @@ from urllib.request import Request, urlopen
 
 import deltalake
 from deltalake.exceptions import TableNotFoundError
+from deltalake.schema import ArrayType, MapType, StructType
+from deltalake.schema import Schema as DeltaSchema
 from deltalake.table import DeltaTable
 from packaging.version import parse
 
@@ -25,6 +27,7 @@ from daft.daft import (
     ScanTask,
     StorageConfig,
 )
+from daft.io.delta_lake._deltalake import delta_schema_to_pyarrow
 from daft.io.delta_lake.utils import construct_delta_file_path
 from daft.io.object_store_options import io_config_to_storage_options
 from daft.io.scan import ScanOperator
@@ -42,11 +45,7 @@ _CM_PHYSICAL_NAME_KEY = "delta.columnMapping.physicalName"
 
 def _delta_field_to_pyfield(field: deltalake.schema.Field) -> PyField:
     """Convert a Delta `Field` to a Daft `PyField` carrying its logical name and real dtype."""
-    from deltalake.schema import Schema
-
-    from daft.io.delta_lake._deltalake import delta_schema_to_pyarrow
-
-    pa_field = delta_schema_to_pyarrow(Schema([field])).field(0)
+    pa_field = delta_schema_to_pyarrow(DeltaSchema([field])).field(0)
     return PyField.create(field.name, DataType.from_arrow_type(pa_field.type)._dtype)
 
 
@@ -58,7 +57,6 @@ def _iter_mapped_fields(schema: deltalake.Schema) -> Iterator[deltalake.schema.F
     fields (e.g. `array<struct<...>>`). We recurse through container types but only
     yield fields that actually carry the mapping metadata.
     """
-    from deltalake.schema import ArrayType, MapType, StructType
 
     def walk_type(t: object) -> Iterator[deltalake.schema.Field]:
         if isinstance(t, StructType):
@@ -207,8 +205,6 @@ class DeltaLakeScanOperator(ScanOperator):
                 self._table.load_as_version(version)
 
         self._storage_config = storage_config
-
-        from ._deltalake import delta_schema_to_pyarrow
 
         delta_schema = self._table.schema()
         self._schema = Schema.from_pyarrow_schema(delta_schema_to_pyarrow(delta_schema))

--- a/daft/io/delta_lake/delta_lake_scan.py
+++ b/daft/io/delta_lake/delta_lake_scan.py
@@ -14,9 +14,11 @@ from packaging.version import parse
 
 import daft
 import daft.exceptions
+from daft import DataType
 from daft.daft import (
     FileFormatConfig,
     ParquetSourceConfig,
+    PyField,
     PyPartitionField,
     PyPushdowns,
     S3Config,
@@ -33,6 +35,69 @@ if TYPE_CHECKING:
     from datetime import datetime
 
 logger = logging.getLogger(__name__)
+
+_CM_ID_KEY = "delta.columnMapping.id"
+_CM_PHYSICAL_NAME_KEY = "delta.columnMapping.physicalName"
+
+
+def _delta_field_to_pyfield(field: deltalake.schema.Field) -> PyField:
+    """Convert a Delta `Field` to a Daft `PyField` carrying its logical name and real dtype."""
+    from deltalake.schema import Schema
+
+    from daft.io.delta_lake._deltalake import delta_schema_to_pyarrow
+
+    pa_field = delta_schema_to_pyarrow(Schema([field])).field(0)
+    return PyField.create(field.name, DataType.from_arrow_type(pa_field.type)._dtype)
+
+
+def _iter_mapped_fields(schema: deltalake.Schema) -> Iterator[deltalake.schema.Field]:
+    """Yield every Delta `Field` in the schema that carries column-mapping metadata.
+
+    Per Delta protocol, list elements / map keys / map values are anonymous (no
+    `columnMapping.id`), but their *element type* may still contain mapped struct
+    fields (e.g. `array<struct<...>>`). We recurse through container types but only
+    yield fields that actually carry the mapping metadata.
+    """
+    from deltalake.schema import ArrayType, MapType, StructType
+
+    def walk_type(t: object) -> Iterator[deltalake.schema.Field]:
+        if isinstance(t, StructType):
+            for sub in t.fields:
+                if (sub.metadata or {}).get(_CM_ID_KEY) is not None:
+                    yield sub
+                yield from walk_type(sub.type)
+        elif isinstance(t, ArrayType):
+            yield from walk_type(t.element_type)
+        elif isinstance(t, MapType):
+            yield from walk_type(t.key_type)
+            yield from walk_type(t.value_type)
+
+    for field in schema.fields:
+        if (field.metadata or {}).get(_CM_ID_KEY) is not None:
+            yield field
+        yield from walk_type(field.type)
+
+
+def _column_mapping_maps(
+    schema: deltalake.Schema,
+) -> tuple[dict[int, PyField], dict[str, str]]:
+    """Build column-mapping lookups for a column-mapped Delta schema.
+
+    Returns:
+    - `field_id -> PyField(logical_name, dtype)` covering every mapped field including
+      nested, for the Parquet field-id rename path.
+    - `physical_name -> logical_name` for top-level fields only, used to rename min/max
+      stats columns (delta-rs exposes those keyed by physical name).
+    """
+    field_ids = {
+        int(field.metadata[_CM_ID_KEY]): _delta_field_to_pyfield(field) for field in _iter_mapped_fields(schema)
+    }
+    phys_to_logical = {
+        meta[_CM_PHYSICAL_NAME_KEY]: field.name
+        for field in schema.fields
+        if (meta := field.metadata or {}).get(_CM_PHYSICAL_NAME_KEY) is not None
+    }
+    return field_ids, phys_to_logical
 
 
 def get_s3_bucket_region(bucket_name: str) -> str | None:
@@ -119,10 +184,7 @@ class DeltaLakeScanOperator(ScanOperator):
                                 region_name=s3_config_from_env.region_name,
                             )
                         )
-        elif scheme == "gcs" or scheme == "gs":
-            # TO-DO: Handle any key-value replacements in `io_config` if there are missing elements
-            pass
-        elif scheme == "az" or scheme == "abfs" or scheme == "abfss":
+        elif scheme == "gcs" or scheme == "gs" or scheme == "az" or scheme == "abfs" or scheme == "abfss":
             # TO-DO: Handle any key-value replacements in `io_config` if there are missing elements
             pass
 
@@ -148,7 +210,22 @@ class DeltaLakeScanOperator(ScanOperator):
 
         from ._deltalake import delta_schema_to_pyarrow
 
-        self._schema = Schema.from_pyarrow_schema(delta_schema_to_pyarrow(self._table.schema()))
+        delta_schema = self._table.schema()
+        self._schema = Schema.from_pyarrow_schema(delta_schema_to_pyarrow(delta_schema))
+
+        cm_mode = self._table.metadata().configuration.get("delta.columnMapping.mode", "none").lower()
+        if cm_mode not in ("none", "id", "name"):
+            raise NotImplementedError(f"Unsupported Delta Lake column mapping mode: {cm_mode!r}")
+        # delta-rs validates that every mapped field carries `delta.columnMapping.id` at
+        # `DeltaTable()` construction (raises "Kernel error: Invalid column mapping mode: …
+        # lacks the delta.columnMapping.id annotation"), so we can build the mapping
+        # without re-checking that here.
+        if cm_mode == "none":
+            self._field_id_mapping: dict[int, PyField] | None = None
+            self._stats_physical_to_logical: dict[str, str] = {}
+        else:
+            self._field_id_mapping, self._stats_physical_to_logical = _column_mapping_maps(delta_schema)
+
         partition_columns = set(self._table.metadata().partition_columns)
         self._partition_keys = [
             PyPartitionField(field._field) for field in self._schema if field.name in partition_columns
@@ -211,9 +288,6 @@ class DeltaLakeScanOperator(ScanOperator):
                 "Alternatively, you can set ignore_deletion_vectors=True to skip checking for deletion vectors."
             )
 
-        # TODO(Clark): Add support for column mappings.
-        # Issue: https://github.com/Eventual-Inc/Daft/issues/1955
-
         limit_files = pushdowns.limit is not None and pushdowns.filters is None and pushdowns.partition_filters is None
         rows_left = pushdowns.limit if pushdowns.limit is not None else 0
         scan_tasks = []
@@ -253,7 +327,9 @@ class DeltaLakeScanOperator(ScanOperator):
                 size_bytes = add_actions["size_bytes"][task_idx].as_py()
             except KeyError:
                 size_bytes = None
-            file_format_config = FileFormatConfig.from_parquet_config(ParquetSourceConfig())
+            file_format_config = FileFormatConfig.from_parquet_config(
+                ParquetSourceConfig(field_id_mapping=self._field_id_mapping)
+            )
 
             if is_partitioned:
                 dtype = add_actions.schema.field(partition_field_name).type
@@ -289,6 +365,8 @@ class DeltaLakeScanOperator(ScanOperator):
                 arrays = {}
                 for field_idx in range(dtype.num_fields):
                     field_name = dtype.field(field_idx).name
+                    # delta-rs exposes stats under physical names when column mapping is on.
+                    logical_name = self._stats_physical_to_logical.get(field_name, field_name)
                     try:
                         arrow_arr = pa.array(
                             [min_values[field_name], max_values[field_name]],
@@ -307,7 +385,7 @@ class DeltaLakeScanOperator(ScanOperator):
                             ],
                             type=dtype.field(field_idx).type,
                         )
-                    arrays[field_name] = daft.Series.from_arrow(arrow_arr, field_name)
+                    arrays[logical_name] = daft.Series.from_arrow(arrow_arr, logical_name)
                 stats = daft.recordbatch.RecordBatch.from_pydict(arrays)
             else:
                 stats = None

--- a/src/daft-parquet/src/metadata.rs
+++ b/src/daft-parquet/src/metadata.rs
@@ -10,6 +10,10 @@ use crate::{Error, ParquetMetadataSnafu, task_err};
 
 const FOOTER_SIZE: usize = 8;
 
+/// Parquet key-value metadata key for the embedded Arrow schema hint written by
+/// pyarrow/arrow-cpp. See `parquet-format-thrift` KeyValue.
+const ARROW_SCHEMA_KEY: &str = "ARROW:schema";
+
 // ---------------------------------------------------------------------------
 // Arrow-rs field ID mapping
 // ---------------------------------------------------------------------------
@@ -221,23 +225,38 @@ pub(crate) fn apply_field_ids_to_arrowrs_parquet_metadata(
         })
         .collect();
 
-    // 4. Rebuild FileMetaData and ParquetMetaData
+    // 4. Rebuild FileMetaData and ParquetMetaData. Strip the embedded ARROW:schema
+    // hint: it still carries the original (physical) field names and disagrees with
+    // the renamed parquet type tree, causing arrow-rs to fail with
+    // `incompatible arrow schema, expected field named <physical> got <logical>`.
+    // Dropping it forces arrow-rs to infer from the renamed parquet types.
     Ok(Arc::new(ParquetMetaData::new(
-        rebuild_file_metadata(metadata.file_metadata(), new_schema_descr),
+        rebuild_file_metadata(metadata.file_metadata(), new_schema_descr, true),
         new_row_groups?,
     )))
 }
 
 /// Rebuild a `FileMetaData` with a new schema descriptor (preserving everything else).
+///
+/// When `strip_arrow_schema` is true the embedded `ARROW:schema` key-value entry is
+/// removed; this is required after a field-id rename where the embedded arrow schema
+/// would otherwise disagree with the renamed parquet types.
 fn rebuild_file_metadata(
     fm: &parquet::file::metadata::FileMetaData,
     new_schema_descr: Arc<parquet::schema::types::SchemaDescriptor>,
+    strip_arrow_schema: bool,
 ) -> parquet::file::metadata::FileMetaData {
+    let key_value_metadata = fm.key_value_metadata().map(|kv| {
+        kv.iter()
+            .filter(|entry| !strip_arrow_schema || entry.key != ARROW_SCHEMA_KEY)
+            .cloned()
+            .collect::<Vec<_>>()
+    });
     parquet::file::metadata::FileMetaData::new(
         fm.version(),
         fm.num_rows(),
         fm.created_by().map(str::to_string),
-        fm.key_value_metadata().cloned(),
+        key_value_metadata,
         new_schema_descr,
         fm.column_orders().cloned(),
     )
@@ -291,7 +310,7 @@ pub(crate) fn strip_string_types_from_parquet_metadata(
         .collect();
 
     Ok(Arc::new(ParquetMetaData::new(
-        rebuild_file_metadata(metadata.file_metadata(), new_schema_descr),
+        rebuild_file_metadata(metadata.file_metadata(), new_schema_descr, false),
         new_row_groups?,
     )))
 }

--- a/tests/integration/delta_lake/test_column_mapping.py
+++ b/tests/integration/delta_lake/test_column_mapping.py
@@ -7,6 +7,7 @@ import uuid
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
+from deltalake import DeltaTable
 
 import daft
 from daft.logical.schema import Schema
@@ -169,8 +170,6 @@ def test_deltalake_read_column_mapping_flat(tmp_path, mode):
     )
 
     df = daft.read_deltalake(str(path))
-    from deltalake import DeltaTable
-
     expected_schema = Schema.from_pyarrow_schema(pa.schema(DeltaTable(path).schema().to_arrow()))
     assert df.schema() == expected_schema
     assert_pyarrow_tables_equal(df.to_arrow().sort_by("a"), data.sort_by("a"))

--- a/tests/integration/delta_lake/test_column_mapping.py
+++ b/tests/integration/delta_lake/test_column_mapping.py
@@ -46,16 +46,26 @@ def _physical_schema(
     )
 
 
-def _add_action(path: str, size: int, partition_values: dict[str, str]) -> dict:
-    return {
-        "add": {
-            "path": path,
-            "partitionValues": partition_values,
-            "size": size,
-            "modificationTime": 0,
-            "dataChange": True,
-        }
+def _add_action(
+    path: str,
+    size: int,
+    partition_values: dict[str, str] | None = None,
+    stats: dict | None = None,
+) -> dict:
+    """Build a Delta `add` action. `stats` keys must use PHYSICAL names per Delta spec."""
+    action: dict = {
+        "path": path,
+        "size": size,
+        "modificationTime": 0,
+        "dataChange": True,
     }
+
+    if partition_values is not None:
+        action["partitionValues"] = partition_values
+    if stats is not None:
+        action["stats"] = json.dumps(stats)
+
+    return {"add": action}
 
 
 def _write_cm_table(
@@ -117,13 +127,13 @@ def _write_cm_table(
                 _add_action(
                     file_rel,
                     (path / file_rel).stat().st_size,
-                    {p: str(v) for p, v in zip(phys_part_keys, key)},
+                    partition_values={p: str(v) for p, v in zip(phys_part_keys, key)},
                 )
             )
     else:
         file_rel = f"part-{uuid.uuid4().hex}.parquet"
         pq.write_table(physical_table, path / file_rel)
-        add_entries.append(_add_action(file_rel, (path / file_rel).stat().st_size, {}))
+        add_entries.append(_add_action(file_rel, (path / file_rel).stat().st_size))
 
     protocol: dict = {
         "protocol": {
@@ -274,7 +284,7 @@ def _write_nested_struct_cm_table(path: pathlib.Path) -> pa.Table:
 
     file_rel = f"part-{uuid.uuid4().hex}.parquet"
     pq.write_table(physical_table, path / file_rel)
-    add = _add_action(file_rel, (path / file_rel).stat().st_size, {})
+    add = _add_action(file_rel, (path / file_rel).stat().st_size)
 
     actions = [
         {
@@ -365,17 +375,11 @@ def test_deltalake_read_column_mapping_stats_pruning(tmp_path):
     )
 
     def _add(name: str, lo: int, hi: int) -> dict:
-        return {
-            "add": {
-                "path": name,
-                "partitionValues": {},
-                "size": (path / name).stat().st_size,
-                "modificationTime": 0,
-                "dataChange": True,
-                # Stats keys use PHYSICAL names per Delta spec.
-                "stats": json.dumps({"numRecords": 3, "minValues": {"col-aaa": lo}, "maxValues": {"col-aaa": hi}}),
-            }
-        }
+        return _add_action(
+            name,
+            (path / name).stat().st_size,
+            stats={"numRecords": 3, "minValues": {"col-aaa": lo}, "maxValues": {"col-aaa": hi}},
+        )
 
     actions = [
         {"protocol": {"minReaderVersion": 2, "minWriterVersion": 5}},

--- a/tests/integration/delta_lake/test_column_mapping.py
+++ b/tests/integration/delta_lake/test_column_mapping.py
@@ -332,6 +332,76 @@ def test_deltalake_read_column_mapping_malformed_no_field_ids(tmp_path):
         daft.read_deltalake(str(path))
 
 
+def test_deltalake_read_column_mapping_stats_pruning(tmp_path):
+    """Stats keyed by physical names get translated to logical names for predicate pushdown.
+
+    Two files with disjoint ranges; a predicate matching one file's range should return only
+    that file's rows. Exercises the min/max rename in `to_scan_tasks`.
+    """
+    pytest.importorskip("deltalake")
+    path = tmp_path / "cm_stats"
+    path.mkdir()
+    (path / "_delta_log").mkdir()
+
+    phys_schema = pa.schema([pa.field("col-aaa", pa.int64(), metadata={b"PARQUET:field_id": b"1"})])
+    pq.write_table(pa.table({"col-aaa": [1, 2, 3]}, schema=phys_schema), path / "f1.parquet")
+    pq.write_table(pa.table({"col-aaa": [10, 11, 12]}, schema=phys_schema), path / "f2.parquet")
+
+    schema_str = json.dumps(
+        {
+            "type": "struct",
+            "fields": [
+                {
+                    "name": "a",
+                    "type": "long",
+                    "nullable": True,
+                    "metadata": {
+                        "delta.columnMapping.id": 1,
+                        "delta.columnMapping.physicalName": "col-aaa",
+                    },
+                }
+            ],
+        }
+    )
+
+    def _add(name: str, lo: int, hi: int) -> dict:
+        return {
+            "add": {
+                "path": name,
+                "partitionValues": {},
+                "size": (path / name).stat().st_size,
+                "modificationTime": 0,
+                "dataChange": True,
+                # Stats keys use PHYSICAL names per Delta spec.
+                "stats": json.dumps({"numRecords": 3, "minValues": {"col-aaa": lo}, "maxValues": {"col-aaa": hi}}),
+            }
+        }
+
+    actions = [
+        {"protocol": {"minReaderVersion": 2, "minWriterVersion": 5}},
+        {
+            "metaData": {
+                "id": str(uuid.uuid4()),
+                "format": {"provider": "parquet", "options": {}},
+                "schemaString": schema_str,
+                "partitionColumns": [],
+                "configuration": {
+                    "delta.columnMapping.mode": "name",
+                    "delta.columnMapping.maxColumnId": "1",
+                },
+                "createdTime": 0,
+            }
+        },
+        _add("f1.parquet", 1, 3),
+        _add("f2.parquet", 10, 12),
+    ]
+    (path / "_delta_log" / "00000000000000000000.json").write_text("\n".join(json.dumps(a) for a in actions))
+
+    result = daft.read_deltalake(str(path)).where(daft.col("a") == 2).to_arrow()
+    expected = pa.table({"a": pa.array([2], type=pa.int64())})
+    assert_pyarrow_tables_equal(result, expected)
+
+
 def test_deltalake_read_column_mapping_nested_struct(tmp_path):
     """Read a column-mapped table with a top-level struct column.
 

--- a/tests/integration/delta_lake/test_column_mapping.py
+++ b/tests/integration/delta_lake/test_column_mapping.py
@@ -1,0 +1,370 @@
+from __future__ import annotations
+
+import json
+import pathlib
+import uuid
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+import daft
+from daft.logical.schema import Schema
+from tests.utils import assert_pyarrow_tables_equal
+
+_DELTA_TYPE_BY_PA: dict[pa.DataType, str] = {
+    pa.int32(): "integer",
+    pa.int64(): "long",
+    pa.string(): "string",
+    pa.large_string(): "string",
+    pa.float32(): "float",
+    pa.float64(): "double",
+    pa.bool_(): "boolean",
+}
+
+
+def _delta_type(pa_type: pa.DataType) -> str:
+    try:
+        return _DELTA_TYPE_BY_PA[pa_type]
+    except KeyError:
+        raise NotImplementedError(f"Unsupported pyarrow type for fixture: {pa_type}") from None
+
+
+def _physical_schema(
+    arrow_schema: pa.Schema,
+    logical_to_physical: dict[str, str],
+    field_ids: dict[str, int],
+) -> pa.Schema:
+    return pa.schema(
+        [
+            arrow_schema.field(name)
+            .with_name(logical_to_physical[name])
+            .with_metadata({b"PARQUET:field_id": str(field_ids[name]).encode()})
+            for name in arrow_schema.names
+        ]
+    )
+
+
+def _add_action(path: str, size: int, partition_values: dict[str, str]) -> dict:
+    return {
+        "add": {
+            "path": path,
+            "partitionValues": partition_values,
+            "size": size,
+            "modificationTime": 0,
+            "dataChange": True,
+        }
+    }
+
+
+def _write_cm_table(
+    path: pathlib.Path,
+    data: pa.Table,
+    mode: str,
+    logical_to_physical: dict[str, str],
+    field_ids: dict[str, int],
+    partition_columns: list[str] | None = None,
+) -> None:
+    """Hand-craft a Delta table with columnMapping enabled.
+
+    Pre-assigns physical names and field ids for each logical column. Writing the
+    _delta_log manually is required because delta-rs (1.5.x) cannot enable columnMapping
+    through the Python writer; this lets us exercise Daft's read path regardless.
+    """
+    partition_columns = partition_columns or []
+    path.mkdir(parents=True, exist_ok=True)
+    log_dir = path / "_delta_log"
+    log_dir.mkdir(exist_ok=True)
+
+    # Schema JSON: logical names at the top, physical names + ids in field metadata.
+    fields_json = [
+        {
+            "name": name,
+            "type": _delta_type(data.schema.field(name).type),
+            "nullable": data.schema.field(name).nullable,
+            "metadata": {
+                "delta.columnMapping.id": field_ids[name],
+                "delta.columnMapping.physicalName": logical_to_physical[name],
+            },
+        }
+        for name in data.schema.names
+    ]
+    schema_str = json.dumps({"type": "struct", "fields": fields_json})
+
+    # Rewrite the parquet table with physical column names + PARQUET:field_id metadata.
+    physical_table = pa.Table.from_arrays(
+        data.columns,
+        schema=_physical_schema(data.schema, logical_to_physical, field_ids),
+    )
+
+    # Delta-rs quirk: metaData.partitionColumns uses LOGICAL names, but add.partitionValues
+    # keys use PHYSICAL names. Empirically this is what delta-rs 1.5 accepts.
+    add_entries: list[dict] = []
+    if partition_columns:
+        phys_part_keys = [logical_to_physical[c] for c in partition_columns]
+        groups: dict[tuple, list[int]] = {}
+        for row_idx in range(physical_table.num_rows):
+            key = tuple(physical_table.column(p)[row_idx].as_py() for p in phys_part_keys)
+            groups.setdefault(key, []).append(row_idx)
+        for key, indices in groups.items():
+            sub = physical_table.take(pa.array(indices)).drop(phys_part_keys)
+            rel_dir = "/".join(f"{p}={v}" for p, v in zip(phys_part_keys, key))
+            file_rel = f"{rel_dir}/part-{uuid.uuid4().hex}.parquet"
+            (path / rel_dir).mkdir(parents=True, exist_ok=True)
+            pq.write_table(sub, path / file_rel)
+            add_entries.append(
+                _add_action(
+                    file_rel,
+                    (path / file_rel).stat().st_size,
+                    {p: str(v) for p, v in zip(phys_part_keys, key)},
+                )
+            )
+    else:
+        file_rel = f"part-{uuid.uuid4().hex}.parquet"
+        pq.write_table(physical_table, path / file_rel)
+        add_entries.append(_add_action(file_rel, (path / file_rel).stat().st_size, {}))
+
+    protocol: dict = {
+        "protocol": {
+            "minReaderVersion": 2 if mode == "name" else 3,
+            "minWriterVersion": 5 if mode == "name" else 7,
+        }
+    }
+    if mode == "id":
+        protocol["protocol"]["readerFeatures"] = ["columnMapping"]
+        protocol["protocol"]["writerFeatures"] = ["columnMapping"]
+
+    metadata = {
+        "metaData": {
+            "id": str(uuid.uuid4()),
+            "format": {"provider": "parquet", "options": {}},
+            "schemaString": schema_str,
+            "partitionColumns": partition_columns,
+            "configuration": {
+                "delta.columnMapping.mode": mode,
+                "delta.columnMapping.maxColumnId": str(max(field_ids.values())),
+            },
+            "createdTime": 0,
+        }
+    }
+
+    log_file = log_dir / "00000000000000000000.json"
+    with log_file.open("w") as f:
+        for action in [protocol, metadata, *add_entries]:
+            f.write(json.dumps(action) + "\n")
+
+
+@pytest.mark.parametrize("mode", ["name", "id"])
+def test_deltalake_read_column_mapping_flat(tmp_path, mode):
+    pytest.importorskip("deltalake")
+    path = tmp_path / f"cm_{mode}_flat"
+
+    data = pa.table({"a": pa.array([1, 2, 3], type=pa.int64()), "b": ["x", "y", "z"]})
+    _write_cm_table(
+        path,
+        data,
+        mode=mode,
+        logical_to_physical={"a": "col-aaa", "b": "col-bbb"},
+        field_ids={"a": 1, "b": 2},
+    )
+
+    df = daft.read_deltalake(str(path))
+    from deltalake import DeltaTable
+
+    expected_schema = Schema.from_pyarrow_schema(pa.schema(DeltaTable(path).schema().to_arrow()))
+    assert df.schema() == expected_schema
+    assert_pyarrow_tables_equal(df.to_arrow().sort_by("a"), data.sort_by("a"))
+
+
+@pytest.mark.parametrize("mode", ["name", "id"])
+def test_deltalake_read_column_mapping_select_projection(tmp_path, mode):
+    pytest.importorskip("deltalake")
+    path = tmp_path / f"cm_{mode}_select"
+
+    data = pa.table(
+        {
+            "a": pa.array([1, 2, 3], type=pa.int64()),
+            "b": ["x", "y", "z"],
+            "c": pa.array([1.1, 2.2, 3.3], type=pa.float64()),
+        }
+    )
+    _write_cm_table(
+        path,
+        data,
+        mode=mode,
+        logical_to_physical={"a": "col-aaa", "b": "col-bbb", "c": "col-ccc"},
+        field_ids={"a": 1, "b": 2, "c": 3},
+    )
+
+    result = daft.read_deltalake(str(path)).select("a", "c").to_arrow().sort_by("a")
+    expected = data.select(["a", "c"]).sort_by("a")
+    assert_pyarrow_tables_equal(result, expected)
+
+
+def _write_nested_struct_cm_table(path: pathlib.Path) -> pa.Table:
+    """Hand-craft a column-mapped Delta table with a top-level struct column.
+
+    Logical schema: `outer struct<a: long, b: string>`.
+    Physical names: `outer`→`col-outer`, `a`→`col-a`, `b`→`col-b`. Field ids 1/2/3.
+    Returns the logical pyarrow Table for comparison.
+    """
+    path.mkdir(parents=True, exist_ok=True)
+    log_dir = path / "_delta_log"
+    log_dir.mkdir(exist_ok=True)
+
+    schema_str = json.dumps(
+        {
+            "type": "struct",
+            "fields": [
+                {
+                    "name": "outer",
+                    "type": {
+                        "type": "struct",
+                        "fields": [
+                            {
+                                "name": "a",
+                                "type": "long",
+                                "nullable": True,
+                                "metadata": {
+                                    "delta.columnMapping.id": 2,
+                                    "delta.columnMapping.physicalName": "col-a",
+                                },
+                            },
+                            {
+                                "name": "b",
+                                "type": "string",
+                                "nullable": True,
+                                "metadata": {
+                                    "delta.columnMapping.id": 3,
+                                    "delta.columnMapping.physicalName": "col-b",
+                                },
+                            },
+                        ],
+                    },
+                    "nullable": True,
+                    "metadata": {
+                        "delta.columnMapping.id": 1,
+                        "delta.columnMapping.physicalName": "col-outer",
+                    },
+                }
+            ],
+        }
+    )
+
+    # Logical table for return; physical table is the same shape under physical names + field_ids.
+    logical_table = pa.table(
+        {
+            "outer": pa.array(
+                [{"a": 1, "b": "x"}, {"a": 2, "b": "y"}],
+                type=pa.struct([("a", pa.int64()), ("b", pa.string())]),
+            )
+        }
+    )
+    # Rebuild the struct array under physical child names (pa.array.cast across mismatched
+    # field names produces nulls — must reconstruct from the children directly).
+    src_struct = logical_table.column("outer").chunk(0)
+    physical_struct = pa.StructArray.from_arrays(
+        [src_struct.field("a"), src_struct.field("b")],
+        fields=[
+            pa.field("col-a", pa.int64(), metadata={b"PARQUET:field_id": b"2"}),
+            pa.field("col-b", pa.string(), metadata={b"PARQUET:field_id": b"3"}),
+        ],
+    )
+    physical_outer = pa.field("col-outer", physical_struct.type, metadata={b"PARQUET:field_id": b"1"})
+    physical_table = pa.Table.from_arrays([physical_struct], schema=pa.schema([physical_outer]))
+
+    file_rel = f"part-{uuid.uuid4().hex}.parquet"
+    pq.write_table(physical_table, path / file_rel)
+    add = _add_action(file_rel, (path / file_rel).stat().st_size, {})
+
+    actions = [
+        {
+            "protocol": {
+                "minReaderVersion": 2,
+                "minWriterVersion": 5,
+            }
+        },
+        {
+            "metaData": {
+                "id": str(uuid.uuid4()),
+                "format": {"provider": "parquet", "options": {}},
+                "schemaString": schema_str,
+                "partitionColumns": [],
+                "configuration": {
+                    "delta.columnMapping.mode": "name",
+                    "delta.columnMapping.maxColumnId": "3",
+                },
+                "createdTime": 0,
+            }
+        },
+        add,
+    ]
+    (log_dir / "00000000000000000000.json").write_text("\n".join(json.dumps(a) for a in actions))
+    return logical_table
+
+
+def test_deltalake_read_column_mapping_malformed_no_field_ids(tmp_path):
+    """Mode set but schema fields lack `delta.columnMapping.id` — delta-rs rejects at load."""
+    pytest.importorskip("deltalake")
+    path = tmp_path / "cm_malformed"
+    path.mkdir()
+    (path / "_delta_log").mkdir()
+    schema_str = json.dumps(
+        {
+            "type": "struct",
+            "fields": [{"name": "a", "type": "long", "nullable": True, "metadata": {}}],
+        }
+    )
+    actions = [
+        {"protocol": {"minReaderVersion": 2, "minWriterVersion": 5}},
+        {
+            "metaData": {
+                "id": str(uuid.uuid4()),
+                "format": {"provider": "parquet", "options": {}},
+                "schemaString": schema_str,
+                "partitionColumns": [],
+                "configuration": {"delta.columnMapping.mode": "name"},
+                "createdTime": 0,
+            }
+        },
+    ]
+    (path / "_delta_log" / "00000000000000000000.json").write_text("\n".join(json.dumps(a) for a in actions))
+    with pytest.raises(Exception, match="delta.columnMapping.id"):
+        daft.read_deltalake(str(path))
+
+
+def test_deltalake_read_column_mapping_nested_struct(tmp_path):
+    """Read a column-mapped table with a top-level struct column.
+
+    Exercises `_iter_mapped_fields` recursion through nested structs plus the
+    nested rename in `apply_field_ids_to_arrowrs_parquet_metadata`.
+    """
+    pytest.importorskip("deltalake")
+    expected = _write_nested_struct_cm_table(tmp_path / "cm_nested")
+    result = daft.read_deltalake(str(tmp_path / "cm_nested")).to_arrow()
+    assert_pyarrow_tables_equal(result, expected)
+
+
+@pytest.mark.parametrize("mode", ["name", "id"])
+def test_deltalake_read_column_mapping_partitioned(tmp_path, mode):
+    pytest.importorskip("deltalake")
+    path = tmp_path / f"cm_{mode}_partitioned"
+
+    data = pa.table(
+        {
+            "a": pa.array([1, 2, 3, 4], type=pa.int64()),
+            "part": ["p1", "p1", "p2", "p2"],
+        }
+    )
+    _write_cm_table(
+        path,
+        data,
+        mode=mode,
+        logical_to_physical={"a": "col-aaa", "part": "col-ppp"},
+        field_ids={"a": 1, "part": 2},
+        partition_columns=["part"],
+    )
+
+    sort_keys = [("part", "ascending"), ("a", "ascending")]
+    result = daft.read_deltalake(str(path)).to_arrow().sort_by(sort_keys)
+    assert_pyarrow_tables_equal(result, data.sort_by(sort_keys))


### PR DESCRIPTION
## Changes Made

Read Delta Lake tables with `delta.columnMapping.mode = id` or `name`. Previously raised at scan-op construction.

**How it works.**
Builds a `field_id → PyField(logical_name, dtype)` map from delta-rs's column metadata and threads it through `ParquetSourceConfig.field_id_mapping`, reusing the Parquet field-id rename path originally added for Iceberg.
Stats columns from `add_actions` (keyed by physical names) are translated to logical names via a top-level `physical → logical` lookup.

**ARROW:schema fix.**
After a field-id rename the embedded `ARROW:schema` hint still carries physical names and disagrees with the renamed parquet type tree, so arrow-rs errors with `incompatible arrow schema, expected field named <physical> got <logical>`.
Strip the hint so arrow-rs re-infers from the renamed parquet types. `rebuild_file_metadata` gains a `strip_arrow_schema: bool` flag; the raw-string strip path passes `false` (no rename, hint stays valid).

**Test fixture.**
Hand-crafts `_delta_log` JSON + parquet because deltalake 1.5.x cannot enable column mapping through the Python writer (`CommitFailedError: Unsupported table features required: [ColumnMapping]`).

**Coverage.**
Both `id` and `name` modes across flat reads, projection, partitioning, top-level nested struct (exercises walk recursion + nested rename), and a malformed-table error path.

## Related Issues

Closes #1955
