### PR TITLE
perf(window): reduce unnecessary copies of data in finalize() step of window functions to reduce memory usage

### DIFF
--- a/src/daft-local-execution/src/sinks/window_base.rs
+++ b/src/daft-local-execution/src/sinks/window_base.rs
@@ -1,6 +1,7 @@
 use common_error::DaftResult;
-use daft_core::prelude::SchemaRef;
+use daft_core::{array::ops::build_multi_array_compare, datatypes::UInt64Array, prelude::*};
 use daft_dsl::expr::bound_expr::BoundExpr;
+use daft_groupby::IntoGroups;
 use daft_micropartition::MicroPartition;
 use daft_recordbatch::RecordBatch;
 
@@ -65,4 +66,48 @@ pub trait WindowSinkParams: Send + Sync {
     fn original_schema(&self) -> &SchemaRef;
     fn partition_by(&self) -> &[BoundExpr];
     fn name(&self) -> &'static str;
+}
+
+/// Groups rows by the partition_by columns, returning one Vec<u64> of row indices per group.
+pub(super) fn partition_into_groups(
+    all_partitions: &[RecordBatch],
+    partition_by: &[BoundExpr],
+) -> DaftResult<Vec<Vec<u64>>> {
+    let partition_key_batches: Vec<RecordBatch> = all_partitions
+        .iter()
+        .map(|p| p.eval_expression_list(partition_by))
+        .collect::<DaftResult<_>>()?;
+    let partition_keys = RecordBatch::concat(&partition_key_batches)?;
+    let (_, groups) = partition_keys.make_groups()?;
+    Ok(groups
+        .into_iter()
+        .map(|g| g.into_iter().collect())
+        .collect())
+}
+
+/// Sorts each group by the order_by columns and materializes them as RecordBatches,
+/// skipping empty groups.
+pub(super) fn sort_and_materialize_groups(
+    groups: Vec<Vec<u64>>,
+    full_data: RecordBatch,
+    order_by: &[BoundExpr],
+    descending: &[bool],
+    nulls_first: &[bool],
+) -> DaftResult<Vec<RecordBatch>> {
+    let order_keys = full_data.eval_expression_list(order_by)?;
+    let order_key_series: Vec<Series> = order_keys
+        .columns()
+        .iter()
+        .map(|c| c.as_materialized_series().clone())
+        .collect();
+    let cmp = build_multi_array_compare(&order_key_series, descending, nulls_first)?;
+
+    groups
+        .into_iter()
+        .filter(|g| !g.is_empty())
+        .map(|mut group_idxs| {
+            group_idxs.sort_by(|&a, &b| cmp(a as usize, b as usize));
+            full_data.take(&UInt64Array::from_vec("idx", group_idxs))
+        })
+        .collect()
 }

--- a/src/daft-local-execution/src/sinks/window_order_by_only.rs
+++ b/src/daft-local-execution/src/sinks/window_order_by_only.rs
@@ -105,82 +105,65 @@ impl BlockingSink for WindowOrderByOnlySink {
         spawner
             .spawn(
                 async move {
-                    // Gather all partitions from all states
-                    let all_partitions = states
+                    let all_batches: Vec<RecordBatch> = states
                         .into_iter()
-                        .flat_map(|mut state| std::mem::take(&mut state.partitions))
-                        .collect::<Vec<_>>();
+                        .flat_map(|state| {
+                            state
+                                .partitions
+                                .into_iter()
+                                .flat_map(|mp| mp.record_batches().to_vec())
+                        })
+                        .collect();
 
-                    // Concatenate all partitions
-                    let concatenated = MicroPartition::concat(all_partitions)?;
+                    if all_batches.is_empty() {
+                        return Ok(BlockingSinkOutput::Partitions(vec![MicroPartition::empty(
+                            Some(params.original_schema.clone()),
+                        )]));
+                    }
 
-                    // Sort the concatenated partition by order_by
-                    let sorted = concatenated.sort(
+                    let sorted = RecordBatch::concat(&all_batches)?.sort(
                         &params.order_by,
                         &params.descending,
                         &params.nulls_first,
                     )?;
 
-                    if sorted.is_empty() {
-                        let empty_result =
-                            MicroPartition::empty(Some(params.original_schema.clone()));
-                        return Ok(BlockingSinkOutput::Partitions(vec![empty_result]));
-                    }
-
-                    // Convert to RecordBatch for window operations
-                    let tables = sorted.record_batches();
-                    let mut out_batches = Vec::with_capacity(tables.len());
-
-                    // Process each batch with window functions
-                    for batch in tables.iter().cloned() {
-                        if batch.is_empty() {
-                            continue;
-                        }
-
-                        let new_cols: Vec<Series> = params
-                            .window_exprs
-                            .iter()
-                            .zip(&params.aliases)
-                            .map(|(window_expr, name)| -> DaftResult<Series> {
-                                match window_expr.as_ref() {
-                                    WindowExpr::RowNumber => batch.window_row_number_col(name),
-                                    WindowExpr::Rank => {
-                                        batch.window_rank_col(name, &params.order_by, false)
-                                    }
-                                    WindowExpr::DenseRank => {
-                                        batch.window_rank_col(name, &params.order_by, true)
-                                    }
-                                    _ => Err(DaftError::ValueError(
-                                        format!(
-                                            "Unsupported window function for order by only: {:?}",
-                                            window_expr
-                                        )
-                                        .into(),
-                                    )),
+                    let new_cols: Vec<Series> = params
+                        .window_exprs
+                        .iter()
+                        .zip(&params.aliases)
+                        .map(|(window_expr, name)| -> DaftResult<Series> {
+                            match window_expr.as_ref() {
+                                WindowExpr::RowNumber => sorted.window_row_number_col(name),
+                                WindowExpr::Rank => {
+                                    sorted.window_rank_col(name, &params.order_by, false)
                                 }
-                            })
-                            .collect::<DaftResult<_>>()?;
+                                WindowExpr::DenseRank => {
+                                    sorted.window_rank_col(name, &params.order_by, true)
+                                }
+                                _ => Err(DaftError::ValueError(
+                                    format!(
+                                        "Unsupported window function for order by only: {:?}",
+                                        window_expr
+                                    )
+                                    .into(),
+                                )),
+                            }
+                        })
+                        .collect::<DaftResult<_>>()?;
 
-                        let result_batch = if new_cols.is_empty() {
-                            batch
-                        } else {
-                            batch.union(&RecordBatch::from_nonempty_columns(new_cols)?)?
-                        };
-                        out_batches.push(result_batch);
-                    }
-
-                    // Create final output partition
-                    let output = if out_batches.is_empty() {
-                        MicroPartition::empty(Some(params.original_schema.clone()))
+                    let result = if new_cols.is_empty() {
+                        sorted
                     } else {
-                        MicroPartition::new_loaded(
-                            params.original_schema.clone(),
-                            out_batches.into(),
-                            None,
-                        )
+                        sorted.union(&RecordBatch::from_nonempty_columns(new_cols)?)?
                     };
 
-                    Ok(BlockingSinkOutput::Partitions(vec![output]))
+                    Ok(BlockingSinkOutput::Partitions(vec![
+                        MicroPartition::new_loaded(
+                            params.original_schema.clone(),
+                            vec![result].into(),
+                            None,
+                        ),
+                    ]))
                 },
                 Span::current(),
             )

--- a/src/daft-local-execution/src/sinks/window_partition_and_dynamic_frame.rs
+++ b/src/daft-local-execution/src/sinks/window_partition_and_dynamic_frame.rs
@@ -2,12 +2,11 @@ use std::sync::Arc;
 
 use common_error::{DaftError, DaftResult};
 use common_metrics::ops::NodeType;
-use daft_core::{datatypes::UInt64Array, prelude::*};
+use daft_core::prelude::*;
 use daft_dsl::{
     WindowFrame,
     expr::bound_expr::{BoundAggExpr, BoundExpr},
 };
-use daft_groupby::IntoGroups;
 use daft_micropartition::MicroPartition;
 use daft_recordbatch::RecordBatch;
 use itertools::Itertools;
@@ -17,7 +16,9 @@ use super::{
     blocking_sink::{
         BlockingSink, BlockingSinkFinalizeResult, BlockingSinkOutput, BlockingSinkSinkResult,
     },
-    window_base::{WindowBaseState, WindowSinkParams},
+    window_base::{
+        WindowBaseState, WindowSinkParams, partition_into_groups, sort_and_materialize_groups,
+    },
 };
 use crate::{
     ExecutionTaskSpawner,
@@ -157,30 +158,29 @@ impl BlockingSink for WindowPartitionAndDynamicFrameSink {
                         }
 
                         per_partition_tasks.spawn(async move {
-                            let input_data = RecordBatch::concat(&all_partitions)?;
+                            let groups =
+                                partition_into_groups(&all_partitions, &params.partition_by)?;
+                            let full_data = {
+                                let batches = all_partitions;
+                                RecordBatch::concat(&batches)?
+                            };
+                            let partitions = sort_and_materialize_groups(
+                                groups,
+                                full_data,
+                                &params.order_by,
+                                &params.descending,
+                                &params.nulls_first,
+                            )?;
 
-                            if input_data.is_empty() {
+                            if partitions.is_empty() {
                                 return Ok(RecordBatch::empty(Some(
                                     params.original_schema.clone(),
                                 )));
                             }
 
-                            let partitionby_table =
-                                input_data.eval_expression_list(&params.partition_by)?;
-                            let (_, partitionvals_indices) = partitionby_table.make_groups()?;
-
-                            let grouped_results: Vec<RecordBatch> = partitionvals_indices
-                                .iter()
-                                .map(|indices| -> DaftResult<RecordBatch> {
-                                    let indices_arr =
-                                        UInt64Array::from_vec("indices", indices.to_vec());
-                                    let partition = input_data.take(&indices_arr)?;
-                                    let partition = partition.sort(
-                                        &params.order_by,
-                                        &params.descending,
-                                        &params.nulls_first,
-                                    )?;
-
+                            let grouped_results: Vec<RecordBatch> = partitions
+                                .into_iter()
+                                .map(|partition| -> DaftResult<RecordBatch> {
                                     let new_cols: Vec<Series> = params
                                         .aggregations
                                         .iter()

--- a/src/daft-local-execution/src/sinks/window_partition_and_order_by.rs
+++ b/src/daft-local-execution/src/sinks/window_partition_and_order_by.rs
@@ -2,12 +2,11 @@ use std::sync::Arc;
 
 use common_error::{DaftError, DaftResult};
 use common_metrics::ops::NodeType;
-use daft_core::{datatypes::UInt64Array, prelude::*};
+use daft_core::prelude::*;
 use daft_dsl::{
     Expr, WindowExpr,
     expr::bound_expr::{BoundExpr, BoundWindowExpr},
 };
-use daft_groupby::IntoGroups;
 use daft_micropartition::MicroPartition;
 use daft_recordbatch::RecordBatch;
 use itertools::Itertools;
@@ -17,7 +16,9 @@ use super::{
     blocking_sink::{
         BlockingSink, BlockingSinkFinalizeResult, BlockingSinkOutput, BlockingSinkSinkResult,
     },
-    window_base::{WindowBaseState, WindowSinkParams},
+    window_base::{
+        WindowBaseState, WindowSinkParams, partition_into_groups, sort_and_materialize_groups,
+    },
 };
 use crate::{
     ExecutionTaskSpawner,
@@ -148,30 +149,29 @@ impl BlockingSink for WindowPartitionAndOrderBySink {
                         }
 
                         per_partition_tasks.spawn(async move {
-                            let input_data = RecordBatch::concat(&all_partitions)?;
+                            let groups =
+                                partition_into_groups(&all_partitions, &params.partition_by)?;
+                            let full_data = {
+                                let batches = all_partitions;
+                                RecordBatch::concat(&batches)?
+                            };
+                            let partitions = sort_and_materialize_groups(
+                                groups,
+                                full_data,
+                                &params.order_by,
+                                &params.descending,
+                                &params.nulls_first,
+                            )?;
 
-                            if input_data.is_empty() {
+                            if partitions.is_empty() {
                                 return Ok(RecordBatch::empty(Some(
                                     params.original_schema.clone(),
                                 )));
                             }
 
-                            let groupby_table =
-                                input_data.eval_expression_list(&params.partition_by)?;
-                            let (_, groupvals_indices) = groupby_table.make_groups()?;
-
-                            let grouped_results: Vec<RecordBatch> = groupvals_indices
-                                .iter()
-                                .map(|indices| -> DaftResult<RecordBatch> {
-                                    let indices_arr =
-                                        UInt64Array::from_vec("indices", indices.to_vec());
-                                    let partition = input_data.take(&indices_arr)?;
-                                    let partition = partition.sort(
-                                        &params.order_by,
-                                        &params.descending,
-                                        &params.nulls_first,
-                                    )?;
-
+                            let grouped_results: Vec<RecordBatch> = partitions
+                                .into_iter()
+                                .map(|partition| -> DaftResult<RecordBatch> {
                                     let new_cols: Vec<Series> = params
                                         .window_exprs
                                         .iter()

--- a/src/daft-local-execution/src/sinks/window_partition_only.rs
+++ b/src/daft-local-execution/src/sinks/window_partition_only.rs
@@ -129,15 +129,15 @@ impl BlockingSink for WindowPartitionOnlySink {
                         let params = params.clone();
 
                         per_partition_tasks.spawn(async move {
-                            let input_data = RecordBatch::concat(&all_partitions)?;
-
-                            let result = input_data.window_grouped_agg(
+                            let input_data = {
+                                let batches = all_partitions;
+                                RecordBatch::concat(&batches)?
+                            };
+                            input_data.window_grouped_agg(
                                 &params.agg_exprs,
                                 &params.aliases,
                                 &params.partition_by,
-                            )?;
-
-                            Ok(result)
+                            )
                         });
                     }
 


### PR DESCRIPTION
The window function physical nodes that involve sorting (partition+order-by and partition+dynamic-frame) were performing two full-width materializations per group: first to extract the group rows, then again to produce a sorted copy. The sort operated on a full-width batch even though only the order-key columns are needed to determine sort order.                
  
This PR changes the per-group sort path to work at the index level: only the order-key columns are extracted per group, sorted via argsort to produce a final index ordering, and then the group is materialized exactly once in its final sorted form. This halves the number of full-width take calls per group.                                                          
                                                                                                                                                                                                                                                                                                                                                                            Additionally, the concatenated source data is now explicitly released before the window function application loop begins
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
  
```
| Operation            | #7011       | Ours      | Δ    |
|----------------------|-------------|-----------|------|
| partition & order by | 14,750 MB   | 8,931 MB  | −39% |
| partition_only       | 9,400 MB    | 8,651 MB  | −8%  |
| dynamic_frame        | 14,428 MB   | 8,924 MB  | −38% |
| order_by_only        | 10,370 MB   | 10,370 MB | 0%   |
```