### PR TITLE
perf(window): return Series from window ops to reduce intermediate RecordBatch copies

### DIFF
--- a/src/daft-local-execution/src/sinks/window_order_by_only.rs
+++ b/src/daft-local-execution/src/sinks/window_order_by_only.rs
@@ -8,6 +8,7 @@ use daft_dsl::{
     expr::bound_expr::{BoundExpr, BoundWindowExpr},
 };
 use daft_micropartition::MicroPartition;
+use daft_recordbatch::RecordBatch;
 use itertools::Itertools;
 use tracing::{Span, instrument};
 
@@ -136,35 +137,35 @@ impl BlockingSink for WindowOrderByOnlySink {
                             continue;
                         }
 
-                        let mut result_batch = batch;
-
-                        // Apply each window expression
-                        for (wexpr, name) in params.window_exprs.iter().zip(&params.aliases) {
-                            result_batch = match wexpr.as_ref() {
-                                WindowExpr::RowNumber => {
-                                    result_batch.window_row_number(name.clone())?
-                                }
-                                WindowExpr::Rank => result_batch.window_rank(
-                                    name.clone(),
-                                    &params.order_by,
-                                    false,
-                                )?,
-                                WindowExpr::DenseRank => result_batch.window_rank(
-                                    name.clone(),
-                                    &params.order_by,
-                                    true,
-                                )?,
-                                _ => {
-                                    return Err(DaftError::ValueError(
+                        let new_cols: Vec<Series> = params
+                            .window_exprs
+                            .iter()
+                            .zip(&params.aliases)
+                            .map(|(window_expr, name)| -> DaftResult<Series> {
+                                match window_expr.as_ref() {
+                                    WindowExpr::RowNumber => batch.window_row_number_col(name),
+                                    WindowExpr::Rank => {
+                                        batch.window_rank_col(name, &params.order_by, false)
+                                    }
+                                    WindowExpr::DenseRank => {
+                                        batch.window_rank_col(name, &params.order_by, true)
+                                    }
+                                    _ => Err(DaftError::ValueError(
                                         format!(
                                             "Unsupported window function for order by only: {:?}",
-                                            wexpr
+                                            window_expr
                                         )
                                         .into(),
-                                    ));
+                                    )),
                                 }
-                            };
-                        }
+                            })
+                            .collect::<DaftResult<_>>()?;
+
+                        let result_batch = if new_cols.is_empty() {
+                            batch
+                        } else {
+                            batch.union(&RecordBatch::from_nonempty_columns(new_cols)?)?
+                        };
                         out_batches.push(result_batch);
                     }
 

--- a/src/daft-local-execution/src/sinks/window_partition_and_dynamic_frame.rs
+++ b/src/daft-local-execution/src/sinks/window_partition_and_dynamic_frame.rs
@@ -169,7 +169,7 @@ impl BlockingSink for WindowPartitionAndDynamicFrameSink {
                                 input_data.eval_expression_list(&params.partition_by)?;
                             let (_, partitionvals_indices) = partitionby_table.make_groups()?;
 
-                            let mut partitions = partitionvals_indices
+                            let partitions = partitionvals_indices
                                 .iter()
                                 .map(|indices| {
                                     let indices_arr =
@@ -178,32 +178,46 @@ impl BlockingSink for WindowPartitionAndDynamicFrameSink {
                                 })
                                 .collect::<Vec<_>>();
 
-                            for partition in &mut partitions {
-                                // Sort the partition by the order_by columns
-                                *partition = partition.sort(
-                                    &params.order_by,
-                                    &params.descending,
-                                    &params.nulls_first,
-                                )?;
-
-                                for (agg_expr, name) in
-                                    params.aggregations.iter().zip(params.aliases.iter())
-                                {
-                                    let dtype =
-                                        agg_expr.as_ref().to_field(&params.original_schema)?.dtype;
-                                    *partition = partition.window_agg_dynamic_frame(
-                                        name.clone(),
-                                        agg_expr,
+                            let grouped_results: Vec<RecordBatch> = partitions
+                                .into_iter()
+                                .map(|partition| -> DaftResult<RecordBatch> {
+                                    let partition = partition.sort(
                                         &params.order_by,
                                         &params.descending,
-                                        params.min_periods,
-                                        &dtype,
-                                        &params.frame,
+                                        &params.nulls_first,
                                     )?;
-                                }
-                            }
 
-                            let final_result = RecordBatch::concat(&partitions)?;
+                                    let new_cols: Vec<Series> = params
+                                        .aggregations
+                                        .iter()
+                                        .zip(params.aliases.iter())
+                                        .map(|(agg_expr, name)| -> DaftResult<Series> {
+                                            let dtype = agg_expr
+                                                .as_ref()
+                                                .to_field(&params.original_schema)?
+                                                .dtype;
+                                            partition.window_agg_dynamic_frame_col(
+                                                name,
+                                                agg_expr,
+                                                &params.order_by,
+                                                &params.descending,
+                                                params.min_periods,
+                                                &dtype,
+                                                &params.frame,
+                                            )
+                                        })
+                                        .collect::<DaftResult<_>>()?;
+
+                                    if new_cols.is_empty() {
+                                        Ok(partition)
+                                    } else {
+                                        partition
+                                            .union(&RecordBatch::from_nonempty_columns(new_cols)?)
+                                    }
+                                })
+                                .collect::<DaftResult<_>>()?;
+
+                            let final_result = RecordBatch::concat(&grouped_results)?;
                             Ok(final_result)
                         });
                     }

--- a/src/daft-local-execution/src/sinks/window_partition_and_dynamic_frame.rs
+++ b/src/daft-local-execution/src/sinks/window_partition_and_dynamic_frame.rs
@@ -169,18 +169,12 @@ impl BlockingSink for WindowPartitionAndDynamicFrameSink {
                                 input_data.eval_expression_list(&params.partition_by)?;
                             let (_, partitionvals_indices) = partitionby_table.make_groups()?;
 
-                            let partitions = partitionvals_indices
+                            let grouped_results: Vec<RecordBatch> = partitionvals_indices
                                 .iter()
-                                .map(|indices| {
+                                .map(|indices| -> DaftResult<RecordBatch> {
                                     let indices_arr =
                                         UInt64Array::from_vec("indices", indices.to_vec());
-                                    input_data.take(&indices_arr).unwrap()
-                                })
-                                .collect::<Vec<_>>();
-
-                            let grouped_results: Vec<RecordBatch> = partitions
-                                .into_iter()
-                                .map(|partition| -> DaftResult<RecordBatch> {
+                                    let partition = input_data.take(&indices_arr)?;
                                     let partition = partition.sort(
                                         &params.order_by,
                                         &params.descending,

--- a/src/daft-local-execution/src/sinks/window_partition_and_order_by.rs
+++ b/src/daft-local-execution/src/sinks/window_partition_and_order_by.rs
@@ -160,7 +160,7 @@ impl BlockingSink for WindowPartitionAndOrderBySink {
                                 input_data.eval_expression_list(&params.partition_by)?;
                             let (_, groupvals_indices) = groupby_table.make_groups()?;
 
-                            let mut partitions = groupvals_indices
+                            let partitions = groupvals_indices
                                 .iter()
                                 .map(|indices| {
                                     let indices_arr =
@@ -169,58 +169,66 @@ impl BlockingSink for WindowPartitionAndOrderBySink {
                                 })
                                 .collect::<Vec<_>>();
 
-                            for partition in &mut partitions {
-                                // Sort the partition by the order_by columns
-                                *partition = partition.sort(
-                                    &params.order_by,
-                                    &params.descending,
-                                    &params.nulls_first,
-                                )?;
+                            let grouped_results: Vec<RecordBatch> = partitions
+                                .into_iter()
+                                .map(|partition| -> DaftResult<RecordBatch> {
+                                    let partition = partition.sort(
+                                        &params.order_by,
+                                        &params.descending,
+                                        &params.nulls_first,
+                                    )?;
 
-                                for (window_expr, name) in
-                                    params.window_exprs.iter().zip(params.aliases.iter())
-                                {
-                                    *partition = match window_expr.as_ref() {
-                                        WindowExpr::Agg(agg_expr) => {
-                                            let new_col = partition
-                                                .eval_expression(&BoundExpr::new_unchecked(
-                                                    Arc::new(Expr::Agg(agg_expr.clone())),
-                                                ))?
-                                                .broadcast(partition.len())?
-                                                .rename(name.clone());
-                                            let agg_batch =
-                                                RecordBatch::from_nonempty_columns(vec![new_col])?;
-                                            partition.union(&agg_batch)?
-                                        }
-                                        WindowExpr::RowNumber => {
-                                            partition.window_row_number(name.clone())?
-                                        }
-                                        WindowExpr::Rank => partition.window_rank(
-                                            name.clone(),
-                                            &params.order_by,
-                                            false,
-                                        )?,
-                                        WindowExpr::DenseRank => partition.window_rank(
-                                            name.clone(),
-                                            &params.order_by,
-                                            true,
-                                        )?,
-                                        WindowExpr::Offset {
-                                            input,
-                                            offset,
-                                            default,
-                                        } => partition.window_offset(
-                                            name.clone(),
-                                            BoundExpr::new_unchecked(input.clone()),
-                                            *offset,
-                                            default.clone().map(BoundExpr::new_unchecked),
-                                        )?,
+                                    let new_cols: Vec<Series> = params
+                                        .window_exprs
+                                        .iter()
+                                        .zip(params.aliases.iter())
+                                        .map(|(window_expr, name)| -> DaftResult<Series> {
+                                            match window_expr.as_ref() {
+                                                WindowExpr::Agg(agg_expr) => {
+                                                    let agg = partition.eval_expression(
+                                                        &BoundExpr::new_unchecked(Arc::new(
+                                                            Expr::Agg(agg_expr.clone()),
+                                                        )),
+                                                    )?;
+                                                    Ok(agg.broadcast(partition.len())?.rename(name))
+                                                }
+                                                WindowExpr::RowNumber => {
+                                                    partition.window_row_number_col(name)
+                                                }
+                                                WindowExpr::Rank => partition.window_rank_col(
+                                                    name,
+                                                    &params.order_by,
+                                                    false,
+                                                ),
+                                                WindowExpr::DenseRank => partition.window_rank_col(
+                                                    name,
+                                                    &params.order_by,
+                                                    true,
+                                                ),
+                                                WindowExpr::Offset {
+                                                    input,
+                                                    offset,
+                                                    default,
+                                                } => partition.window_offset_col(
+                                                    name,
+                                                    BoundExpr::new_unchecked(input.clone()),
+                                                    *offset,
+                                                    default.clone().map(BoundExpr::new_unchecked),
+                                                ),
+                                            }
+                                        })
+                                        .collect::<DaftResult<_>>()?;
+
+                                    if new_cols.is_empty() {
+                                        Ok(partition)
+                                    } else {
+                                        partition
+                                            .union(&RecordBatch::from_nonempty_columns(new_cols)?)
                                     }
-                                }
-                            }
+                                })
+                                .collect::<DaftResult<_>>()?;
 
-                            let final_result = RecordBatch::concat(&partitions)?;
-                            Ok(final_result)
+                            RecordBatch::concat(&grouped_results)
                         });
                     }
 

--- a/src/daft-local-execution/src/sinks/window_partition_and_order_by.rs
+++ b/src/daft-local-execution/src/sinks/window_partition_and_order_by.rs
@@ -160,18 +160,12 @@ impl BlockingSink for WindowPartitionAndOrderBySink {
                                 input_data.eval_expression_list(&params.partition_by)?;
                             let (_, groupvals_indices) = groupby_table.make_groups()?;
 
-                            let partitions = groupvals_indices
+                            let grouped_results: Vec<RecordBatch> = groupvals_indices
                                 .iter()
-                                .map(|indices| {
+                                .map(|indices| -> DaftResult<RecordBatch> {
                                     let indices_arr =
                                         UInt64Array::from_vec("indices", indices.to_vec());
-                                    input_data.take(&indices_arr).unwrap()
-                                })
-                                .collect::<Vec<_>>();
-
-                            let grouped_results: Vec<RecordBatch> = partitions
-                                .into_iter()
-                                .map(|partition| -> DaftResult<RecordBatch> {
+                                    let partition = input_data.take(&indices_arr)?;
                                     let partition = partition.sort(
                                         &params.order_by,
                                         &params.descending,

--- a/src/daft-recordbatch/src/ops/window.rs
+++ b/src/daft-recordbatch/src/ops/window.rs
@@ -81,26 +81,6 @@ impl RecordBatch {
         self.union(&window_result)
     }
 
-    pub fn window_agg(&self, to_agg: &BoundAggExpr, name: String) -> DaftResult<Self> {
-        if matches!(
-            to_agg.as_ref(),
-            AggExpr::MapGroups { .. } | AggExpr::AggFn { .. } | AggExpr::AggFnCombine { .. }
-        ) {
-            return Err(DaftError::ValueError(
-                "MapGroups and extension aggregations (AggFn) are not supported in window functions".into(),
-            ));
-        }
-
-        let agg_result = self.eval_agg_expression(to_agg, None)?;
-        let window_col = agg_result.rename(&name);
-
-        // Broadcast the aggregation result to match the length of the partition
-        let broadcast_result = window_col.broadcast(self.len())?;
-
-        let window_result = Self::from_nonempty_columns(vec![broadcast_result])?;
-        self.union(&window_result)
-    }
-
     fn is_range_frame(start_boundary: &WindowBoundary, end_boundary: &WindowBoundary) -> bool {
         matches!(start_boundary, WindowBoundary::RangeOffset(_))
             || matches!(end_boundary, WindowBoundary::RangeOffset(_))
@@ -296,16 +276,16 @@ impl RecordBatch {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn window_agg_dynamic_frame(
+    pub fn window_agg_dynamic_frame_col(
         &self,
-        name: String,
+        name: &str,
         agg_expr: &BoundAggExpr,
         order_by: &[BoundExpr],
         descending: &[bool],
         min_periods: usize,
         dtype: &DataType,
         frame: &WindowFrame,
-    ) -> DaftResult<Self> {
+    ) -> DaftResult<Series> {
         let total_rows = self.len();
 
         if matches!(frame.start, WindowBoundary::UnboundedFollowing) {
@@ -332,8 +312,8 @@ impl RecordBatch {
             Some(agg_state) => {
                 if Self::is_range_frame(&frame.start, &frame.end) {
                     Self::validate_range_frame_order_by(order_by)?;
-                    self.window_agg_range_incremental(
-                        &name,
+                    self.window_agg_range_incremental_col(
+                        name,
                         &frame.start,
                         &frame.end,
                         &order_by[0],
@@ -344,8 +324,8 @@ impl RecordBatch {
                     )
                 } else {
                     let (start, end) = Self::extract_row_offsets(&frame.start, &frame.end);
-                    self.window_agg_rows_incremental(
-                        &name,
+                    self.window_agg_rows_incremental_col(
+                        name,
                         start,
                         end,
                         min_periods,
@@ -357,9 +337,9 @@ impl RecordBatch {
             None => {
                 if Self::is_range_frame(&frame.start, &frame.end) {
                     Self::validate_range_frame_order_by(order_by)?;
-                    self.window_agg_range(
+                    self.window_agg_range_col(
                         agg_expr,
-                        &name,
+                        name,
                         dtype,
                         &frame.start,
                         &frame.end,
@@ -370,9 +350,9 @@ impl RecordBatch {
                     )
                 } else {
                     let (start, end) = Self::extract_row_offsets(&frame.start, &frame.end);
-                    self.window_agg_rows(
+                    self.window_agg_rows_col(
                         agg_expr,
-                        &name,
+                        name,
                         dtype,
                         start,
                         end,
@@ -385,7 +365,7 @@ impl RecordBatch {
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn window_agg_rows_incremental(
+    fn window_agg_rows_incremental_col(
         &self,
         name: &str,
         start_boundary: Option<i64>,
@@ -393,7 +373,7 @@ impl RecordBatch {
         min_periods: usize,
         total_rows: usize,
         mut agg_state: Box<dyn WindowAggStateOps>,
-    ) -> DaftResult<Self> {
+    ) -> DaftResult<Series> {
         // Track previous window boundaries
         let mut prev_frame_start = 0;
         let mut prev_frame_end = 0;
@@ -433,13 +413,11 @@ impl RecordBatch {
         let nulls = NullBuffer::union(nulls.as_ref(), agg_state.nulls());
 
         // Build the final result series
-        let renamed_result = agg_state.with_nulls(nulls)?;
-        let window_batch = Self::from_nonempty_columns(vec![renamed_result])?;
-        self.union(&window_batch)
+        agg_state.with_nulls(nulls)
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn window_agg_rows(
+    fn window_agg_rows_col(
         &self,
         agg_expr: &BoundAggExpr,
         name: &str,
@@ -448,7 +426,7 @@ impl RecordBatch {
         end_boundary: Option<i64>,
         min_periods: usize,
         total_rows: usize,
-    ) -> DaftResult<Self> {
+    ) -> DaftResult<Series> {
         let null_series = Series::full_null(name, dtype, 1);
 
         // Use the non-optimized implementation (recalculate for each row)
@@ -476,15 +454,12 @@ impl RecordBatch {
             }
         }
 
-        // Rename the result and create the final record batch
         let final_result_series = Series::concat(&result_series.iter().collect::<Vec<_>>())?;
-        let renamed_result = final_result_series.rename(name);
-        let window_batch = Self::from_nonempty_columns(vec![renamed_result])?;
-        self.union(&window_batch)
+        Ok(final_result_series.rename(name))
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn window_agg_range_incremental(
+    fn window_agg_range_incremental_col(
         &self,
         name: &str,
         start_boundary: &WindowBoundary,
@@ -494,7 +469,7 @@ impl RecordBatch {
         min_periods: usize,
         total_rows: usize,
         mut agg_state: Box<dyn WindowAggStateOps>,
-    ) -> DaftResult<Self> {
+    ) -> DaftResult<Series> {
         // Use the optimized implementation with incremental state updates
         // Initialize the state for incremental aggregation
         let order_by_col = self.eval_expression(order_by)?;
@@ -556,13 +531,11 @@ impl RecordBatch {
         let nulls = NullBuffer::union(nulls.as_ref(), agg_state.nulls());
 
         // Build the final result series
-        let renamed_result = agg_state.with_nulls(nulls)?;
-        let window_batch = Self::from_nonempty_columns(vec![renamed_result])?;
-        self.union(&window_batch)
+        agg_state.with_nulls(nulls)
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn window_agg_range(
+    fn window_agg_range_col(
         &self,
         agg_expr: &BoundAggExpr,
         name: &str,
@@ -573,7 +546,7 @@ impl RecordBatch {
         descending: bool,
         min_periods: usize,
         total_rows: usize,
-    ) -> DaftResult<Self> {
+    ) -> DaftResult<Series> {
         let order_by_col = self.eval_expression(order_by)?;
         let null_series = Series::full_null(name, dtype, 1);
 
@@ -626,32 +599,24 @@ impl RecordBatch {
             }
         }
 
-        // Rename the result and create the final record batch
         let final_result_series = Series::concat(&result_series.iter().collect::<Vec<_>>())?;
-        let renamed_result = final_result_series.rename(name);
-        let window_batch = Self::from_nonempty_columns(vec![renamed_result])?;
-        self.union(&window_batch)
+        Ok(final_result_series.rename(name))
     }
 
-    pub fn window_row_number(&self, name: String) -> DaftResult<Self> {
+    pub fn window_row_number_col(&self, name: &str) -> DaftResult<Series> {
         let row_numbers: Vec<u64> = (1..=self.len() as u64).collect();
-        let row_number_series = UInt64Array::from_vec(name.as_str(), row_numbers).into_series();
-        let row_number_batch = Self::from_nonempty_columns(vec![row_number_series])?;
-
-        self.union(&row_number_batch)
+        Ok(UInt64Array::from_vec(name, row_numbers).into_series())
     }
 
-    pub fn window_rank(
+    pub fn window_rank_col(
         &self,
-        name: String,
+        name: &str,
         order_by: &[BoundExpr],
         dense: bool,
-    ) -> DaftResult<Self> {
+    ) -> DaftResult<Series> {
         if self.is_empty() {
             // Empty partition case - no work needed
-            let rank_series = UInt64Array::from_vec(name.as_str(), Vec::<u64>::new()).into_series();
-            let rank_batch = Self::from_nonempty_columns(vec![rank_series])?;
-            return self.union(&rank_batch);
+            return Ok(UInt64Array::from_vec(name, Vec::<u64>::new()).into_series());
         }
 
         // Get the order_by columns
@@ -697,25 +662,20 @@ impl RecordBatch {
             }))
             .collect();
 
-        let rank_series = UInt64Array::from_vec(name.as_str(), rank_numbers).into_series();
-        let rank_batch = Self::from_nonempty_columns(vec![rank_series])?;
-
-        self.union(&rank_batch)
+        Ok(UInt64Array::from_vec(name, rank_numbers).into_series())
     }
 
-    pub fn window_offset(
+    pub fn window_offset_col(
         &self,
-        name: String,
+        name: &str,
         expr: BoundExpr,
         offset: isize,
         default: Option<BoundExpr>,
-    ) -> DaftResult<Self> {
+    ) -> DaftResult<Series> {
         // Short-circuit if offset is 0 - just return the value itself
         if offset == 0 {
             let expr_col = self.eval_expression(&expr)?;
-            let renamed_col = expr_col.rename(&name);
-            let result_batch = Self::from_nonempty_columns(vec![renamed_col])?;
-            return self.union(&result_batch);
+            return Ok(expr_col.rename(name));
         }
 
         let expr_col = self.eval_expression(&expr)?;
@@ -753,7 +713,7 @@ impl RecordBatch {
             }
         };
 
-        let mut result_col = if self.is_empty() || abs_offset >= self.len() {
+        let result_col = if self.is_empty() || abs_offset >= self.len() {
             // Special case: empty array or offset exceeds array length
             process_default(&default, expr_col.data_type(), 0, self.len(), self.len())?
         } else if offset > 0 {
@@ -782,9 +742,6 @@ impl RecordBatch {
             Series::concat(&cols)?
         };
 
-        result_col = result_col.rename(&name);
-        let offset_batch = Self::from_nonempty_columns(vec![result_col])?;
-
-        self.union(&offset_batch)
+        Ok(result_col.rename(name))
     }
 }


### PR DESCRIPTION
Refactored the finalize() path in four window function physical nodes to reduce peak memory usage.

Previously, window operation methods returned a new RecordBatch containing all original columns plus the new window column. Calling multiple window functions on a partition would create N intermediate RecordBatch copies, each growing by one column.

Now, window operation methods return just the new Series column. All new columns are collected first, then appended to the original partition in a single union.
```
| Operation             | Before    | Now       | Δ    |
|-----------------------|-----------|-----------|------|
| partition & order by  | 17,009 MB | 14,750 MB | −13% |
| partition_only        | 13,918 MB | 9,400 MB  | −32% |
| dynamic_frame         | 17,917 MB | 14,428 MB | −19% |
| order_by_only         | 15,170 MB | 10,370 MB | −32% |
```

One of a few optimizations that can help with: https://github.com/Eventual-Inc/Daft/issues/5316