### PR TITLE
test(lance): import test helpers from daft-lance

### DIFF
--- a/tests/io/lancedb/test_expression_point_lookup.py
+++ b/tests/io/lancedb/test_expression_point_lookup.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from daft_lance.point_lookup import detect_point_lookup_columns
+
 from daft import col
-from daft.io.lance.point_lookup import detect_point_lookup_columns
 from daft.logical.schema import DataType
 
 

--- a/tests/io/lancedb/test_lance_batching.py
+++ b/tests/io/lancedb/test_lance_batching.py
@@ -5,8 +5,8 @@ from unittest.mock import patch
 
 import pyarrow as pa
 import pytest
+from daft_lance.lance_data_sink import LanceDataSink
 
-from daft.io.lance.lance_data_sink import LanceDataSink
 from daft.recordbatch import MicroPartition
 from daft.schema import Schema
 

--- a/tests/io/lancedb/test_lancedb_count_pushdown_coverage.py
+++ b/tests/io/lancedb/test_lancedb_count_pushdown_coverage.py
@@ -6,11 +6,11 @@ import lance
 import pyarrow as pa
 import pyarrow.compute as pc
 import pytest
+from daft_lance.lance_scan import LanceDBScanOperator, _lancedb_count_result_function
 
 import daft
 from daft import col
 from daft.daft import CountMode
-from daft.io.lance.lance_scan import LanceDBScanOperator, _lancedb_count_result_function
 from daft.recordbatch import RecordBatch
 
 

--- a/tests/io/lancedb/test_lancedb_factory_function.py
+++ b/tests/io/lancedb/test_lancedb_factory_function.py
@@ -5,8 +5,8 @@ from typing import Any
 import pyarrow as pa
 import pyarrow.compute as pc
 import pytest
+from daft_lance.lance_scan import _lancedb_table_factory_function
 
-from daft.io.lance.lance_scan import _lancedb_table_factory_function
 from daft.recordbatch import RecordBatch
 
 # Import-or-skip lance once at module level so individual tests don't need to do this

--- a/tests/io/lancedb/test_lancedb_point_lookup.py
+++ b/tests/io/lancedb/test_lancedb_point_lookup.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import pyarrow as pa
 import pytest
+from daft_lance.lance_scan import LanceDBScanOperator, _lancedb_table_factory_function
 
 from daft import col
-from daft.io.lance import lance_scan
 
 # Import-or-skip lance once at module level so individual tests don't need to do this
 lance = pytest.importorskip("lance")
@@ -20,7 +20,7 @@ def lance_dataset(tmp_path_factory):
 
 
 def _scan(ds):
-    return lance_scan.LanceDBScanOperator(ds)
+    return LanceDBScanOperator(ds)
 
 
 @pytest.mark.parametrize("idx_type", ["BTREE", "BITMAP", "BLOOMFILTER"])
@@ -88,7 +88,7 @@ def test_scanner_without_fragments(lance_dataset, idx_type):
 
     arrow_filter = Expression._from_pyexpr((col("id") == 2)._expr).to_arrow_expr()
     # Invoke factory with fragment_ids=None to exercise index-driven fragment selection
-    gen = lance_scan._lancedb_table_factory_function(
+    gen = _lancedb_table_factory_function(
         ds.uri,
         getattr(ds, "_lance_open_kwargs", None),
         None,


### PR DESCRIPTION
## Changes Made

Import Lance test helpers directly from `daft_lance` instead of using `daft.io.lance` compatibility re-exports.

## Related Issues

None.
