### PR TITLE
docs(lance): fix daft-lance repository links

### DIFF
--- a/daft/io/lance/_lance.py
+++ b/daft/io/lance/_lance.py
@@ -135,7 +135,7 @@ def read_lance(
 def merge_columns(*args: Any, **kwargs: Any) -> Any:
     """This method is deprecated and will be removed in a future release.
 
-    Please use ``daft_lance.merge_columns`` from the [`daft-lance`](https://github.com/Eventual-Inc/daft-lance) package instead: `pip install daft-lance`.
+    Please use ``daft_lance.merge_columns`` from the [`daft-lance`](https://github.com/daft-engine/daft-lance) package instead: `pip install daft-lance`.
     """
     warnings.warn(
         "daft.io.lance.merge_columns is deprecated and will be removed in a future release. "
@@ -149,7 +149,7 @@ def merge_columns(*args: Any, **kwargs: Any) -> Any:
 def merge_columns_df(*args: Any, **kwargs: Any) -> Any:
     """This method is deprecated and will be removed in a future release.
 
-    Please use ``daft_lance.merge_columns_df`` from the [`daft-lance`](https://github.com/Eventual-Inc/daft-lance) package instead: `pip install daft-lance`.
+    Please use ``daft_lance.merge_columns_df`` from the [`daft-lance`](https://github.com/daft-engine/daft-lance) package instead: `pip install daft-lance`.
     """
     warnings.warn(
         "daft.io.lance.merge_columns_df is deprecated and will be removed in a future release. "
@@ -163,7 +163,7 @@ def merge_columns_df(*args: Any, **kwargs: Any) -> Any:
 def create_scalar_index(*args: Any, **kwargs: Any) -> Any:
     """This method is deprecated and will be removed in a future release.
 
-    Please use ``daft_lance.create_scalar_index`` from the [`daft-lance`](https://github.com/Eventual-Inc/daft-lance) package instead: `pip install daft-lance`.
+    Please use ``daft_lance.create_scalar_index`` from the [`daft-lance`](https://github.com/daft-engine/daft-lance) package instead: `pip install daft-lance`.
     """
     warnings.warn(
         "daft.io.lance.create_scalar_index is deprecated and will be removed in a future release. "
@@ -177,7 +177,7 @@ def create_scalar_index(*args: Any, **kwargs: Any) -> Any:
 def compact_files(*args: Any, **kwargs: Any) -> Any:
     """This method is deprecated and will be removed in a future release.
 
-    Please use ``daft_lance.compact_files`` from the [`daft-lance`](https://github.com/Eventual-Inc/daft-lance) package instead: `pip install daft-lance`.
+    Please use ``daft_lance.compact_files`` from the [`daft-lance`](https://github.com/daft-engine/daft-lance) package instead: `pip install daft-lance`.
     """
     warnings.warn(
         "daft.io.lance.compact_files is deprecated and will be removed in a future release. "


### PR DESCRIPTION
## Changes Made

  Update deprecated Lance wrapper docstrings to point to the public `daft-engine/daft-lance` repository.

  ## Related Issues

  None.