### PR TITLE
test(parquet): cover embedding and image roundtrips

### DIFF
--- a/tests/io/test_parquet_roundtrip.py
+++ b/tests/io/test_parquet_roundtrip.py
@@ -163,6 +163,46 @@ def test_roundtrip_sparse_tensor_types(tmp_path, fixed_shape):
     assert before.to_arrow() == after.to_arrow()
 
 
+@pytest.mark.parametrize("native_parquet_writer", [True, False])
+def test_roundtrip_embedding_type(tmp_path, native_parquet_writer):
+    expected_dtype = DataType.embedding(DataType.float32(), 3)
+    data = [
+        np.array([1.0, 2.0, 3.0], dtype=np.float32),
+        np.array([4.0, 5.0, 6.0], dtype=np.float32),
+        None,
+    ]
+    before = daft.from_pydict({"foo": Series.from_pylist(data)})
+    before = before.with_column("foo", before["foo"].cast(expected_dtype))
+
+    with execution_config_ctx(native_parquet_writer=native_parquet_writer):
+        before.write_parquet(str(tmp_path))
+        after = daft.read_parquet(str(tmp_path))
+
+    assert before.schema()["foo"].dtype == expected_dtype
+    assert after.schema()["foo"].dtype == expected_dtype
+    assert before.to_arrow().equals(after.to_arrow(), check_metadata=False)
+
+
+@pytest.mark.parametrize("native_parquet_writer", [True, False])
+def test_roundtrip_image_type(tmp_path, native_parquet_writer):
+    expected_dtype = DataType.image("RGB", 2, 2)
+    data = [
+        np.zeros((2, 2, 3), dtype=np.uint8),
+        np.full((2, 2, 3), 255, dtype=np.uint8),
+        None,
+    ]
+    before = daft.from_pydict({"foo": Series.from_pylist(data, dtype=DataType.python())})
+    before = before.with_column("foo", before["foo"].cast(expected_dtype))
+
+    with execution_config_ctx(native_parquet_writer=native_parquet_writer):
+        before.write_parquet(str(tmp_path))
+        after = daft.read_parquet(str(tmp_path))
+
+    assert before.schema()["foo"].dtype == expected_dtype
+    assert after.schema()["foo"].dtype == expected_dtype
+    assert before.to_arrow().equals(after.to_arrow(), check_metadata=False)
+
+
 @pytest.mark.parametrize("has_none", [True, False])
 def test_roundtrip_boolean_rle(tmp_path, has_none):
     file_path = f"{tmp_path}/test.parquet"
@@ -241,8 +281,3 @@ def test_parquet_file_writer_empty_micropartition(tmp_path):
     # Empty micropartition should result in an empty record batch.
     assert len(result) == 0
     assert "path" in result.schema().column_names()
-
-
-# TODO: reading/writing:
-# 1. Embedding type
-# 2. Image type


### PR DESCRIPTION
## Changes Made

Add Parquet roundtrip coverage for Daft embedding and image logical types.

## Related Issues

None.