### PR TITLE
fix(filesystem): fix pyarrow fs memory by caching by value, not identity

### DIFF
--- a/daft/filesystem.py
+++ b/daft/filesystem.py
@@ -22,7 +22,15 @@ class PyArrowFSWithExpiry:
     expiry: datetime | None
 
 
-_CACHED_FSES: dict[tuple[str, IOConfig | None], PyArrowFSWithExpiry] = {}
+_CACHED_FSES: dict[tuple[str, str], PyArrowFSWithExpiry] = {}
+
+
+def _io_config_cache_key(io_config: IOConfig | None) -> str:
+    # IOConfig.__eq__ is identity-based on the PyO3 wrapper, so two semantically-equal
+    # configs constructed at different times miss the dict. Key on the content-repr
+    # instead; the cached entry's `expiry` field still drives refresh-credentials
+    # invalidation.
+    return "None" if io_config is None else repr(io_config)
 
 
 def _get_fs_from_cache(protocol: str, io_config: IOConfig | None) -> pafs.FileSystem | None:
@@ -32,8 +40,9 @@ def _get_fs_from_cache(protocol: str, io_config: IOConfig | None) -> pafs.FileSy
     """
     global _CACHED_FSES
 
-    if (protocol, io_config) in _CACHED_FSES:
-        fs = _CACHED_FSES[(protocol, io_config)]
+    key = (protocol, _io_config_cache_key(io_config))
+    if key in _CACHED_FSES:
+        fs = _CACHED_FSES[key]
 
         if fs.expiry is None or fs.expiry > datetime.now(timezone.utc):
             return fs.fs
@@ -45,7 +54,7 @@ def _put_fs_in_cache(protocol: str, fs: pafs.FileSystem, io_config: IOConfig | N
     """Put pyarrow filesystem in cache under provided protocol."""
     global _CACHED_FSES
 
-    _CACHED_FSES[(protocol, io_config)] = PyArrowFSWithExpiry(fs, expiry)
+    _CACHED_FSES[(protocol, _io_config_cache_key(io_config))] = PyArrowFSWithExpiry(fs, expiry)
 
 
 def get_filesystem(protocol: str, **kwargs: Any) -> fsspec.AbstractFileSystem:

--- a/tests/io/test_filesystem_cache.py
+++ b/tests/io/test_filesystem_cache.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pyarrow.fs as pafs
+import pytest
+
+import daft.filesystem as fs_mod
+from daft.io import IOConfig, S3Config
+
+
+@pytest.fixture(autouse=True)
+def clear_fs_cache():
+    fs_mod._CACHED_FSES.clear()
+    yield
+    fs_mod._CACHED_FSES.clear()
+
+
+def test_cache_hits_for_semantically_equal_io_configs():
+    """Two separately constructed but semantically-equal IOConfigs must reuse one cached filesystem.
+
+    Regression test: IOConfig.__eq__ is identity-based on the PyO3 wrapper, so the original
+    cache key (protocol, IOConfig) missed on every call when the Rust side handed a fresh
+    Python wrapper to each writer. That caused per-writer S3FileSystem rebuilds and the
+    file-descriptor / thread-pool leak in long-running write_iceberg jobs.
+    """
+    cfg_a = IOConfig(s3=S3Config(region_name="us-east-1", endpoint_url="http://example"))
+    cfg_b = IOConfig(s3=S3Config(region_name="us-east-1", endpoint_url="http://example"))
+
+    assert cfg_a is not cfg_b
+    # IOConfig.__eq__ is identity-based; this is the bug we're working around.
+    assert cfg_a != cfg_b
+
+    with patch.object(fs_mod, "_build_filesystem", wraps=fs_mod._build_filesystem) as build:
+        _, fs1 = fs_mod._resolve_paths_and_filesystem("/tmp", io_config=cfg_a)
+        _, fs2 = fs_mod._resolve_paths_and_filesystem("/tmp", io_config=cfg_b)
+
+    assert fs1 is fs2, "cache must return the same filesystem instance for equal IOConfigs"
+    assert build.call_count == 1, f"expected one _build_filesystem call, got {build.call_count}"
+
+
+def test_cache_misses_for_distinct_io_configs():
+    """Sanity check: configs with different content do not collide on the cache key."""
+    cfg_us = IOConfig(s3=S3Config(region_name="us-east-1"))
+    cfg_eu = IOConfig(s3=S3Config(region_name="eu-west-1"))
+
+    with patch.object(fs_mod, "_build_filesystem", wraps=fs_mod._build_filesystem) as build:
+        _, fs_us = fs_mod._resolve_paths_and_filesystem("/tmp", io_config=cfg_us)
+        _, fs_eu = fs_mod._resolve_paths_and_filesystem("/tmp", io_config=cfg_eu)
+
+    assert fs_us is not fs_eu
+    assert build.call_count == 2
+
+
+def test_cache_hits_for_none_io_config():
+    """Repeated calls with io_config=None must hit the cache."""
+    with patch.object(fs_mod, "_build_filesystem", wraps=fs_mod._build_filesystem) as build:
+        _, fs1 = fs_mod._resolve_paths_and_filesystem("/tmp", io_config=None)
+        _, fs2 = fs_mod._resolve_paths_and_filesystem("/tmp", io_config=None)
+
+    assert fs1 is fs2
+    assert build.call_count == 1
+    assert isinstance(fs1, pafs.LocalFileSystem)


### PR DESCRIPTION
## Changes Made

Fixes a memory leak in pyarrow fs. In long-running `write_iceberg` jobs this drained file descriptors and threads until the process OOM'd. This was triggered with a refresh-credentials S3 setup, but the cache is broken for every IOConfig. This PR keys the cache on `repr(io_config)`

The audit found that `IOConfig.__hash__` returns equal values for semantically-equal configs, but `__eq__` is identity-based on the PyO3 wrapper. The dict-keyed cache at `daft/filesystem.py:35` therefore missed on **every** call when the Rust side handed a fresh Python wrapper to each writer, rebuilding a new PyArrow `S3FileSystem` (with its own thread pool and connection pool) per output file.

| | FD slope / iter | RSS slope MiB / iter |
|---|---|---|
| Before fix | +63.9 | +2.15 |
| After fix | **−0.05** | +0.39 |

## Related Issues

- N/A