### PR TITLE
feat(checkpoint): distributed observability counters

### DIFF
--- a/src/common/metrics/src/lib.rs
+++ b/src/common/metrics/src/lib.rs
@@ -125,6 +125,11 @@ pub const ROWS_IN_KEY: &str = "rows.in";
 pub const ROWS_OUT_KEY: &str = "rows.out";
 pub const ROWS_WRITTEN_KEY: &str = "rows.written";
 
+// Checkpoint metrics
+pub const CHECKPOINT_FILES_STAGED_KEY: &str = "checkpoint.files_staged";
+pub const CHECKPOINTS_SEALED_KEY: &str = "checkpoint.sealed";
+pub const CHECKPOINT_KEYS_STAGED_KEY: &str = "checkpoint.keys_staged";
+
 // Join metrics
 pub const JOIN_BUILD_ROWS_INSERTED_KEY: &str = "rows.join.build_inserted";
 pub const JOIN_BUILD_BYTES_INSERTED_KEY: &str = "bytes.join.build_inserted";
@@ -164,6 +169,9 @@ pub const UNIT_BYTES: &str = "By";
 pub const UNIT_MICROSECONDS: &str = "us";
 pub const UNIT_TASKS: &str = "{task}";
 pub const UNIT_PERCENT: &str = "%";
+pub const UNIT_FILES: &str = "{file}";
+pub const UNIT_CHECKPOINTS: &str = "{checkpoint}";
+pub const UNIT_KEYS: &str = "{key}";
 
 #[cfg(feature = "python")]
 pub fn register_modules(parent: &Bound<PyModule>) -> PyResult<()> {

--- a/src/common/metrics/src/snapshot.rs
+++ b/src/common/metrics/src/snapshot.rs
@@ -8,7 +8,8 @@ use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 
 use crate::{
-    BYTES_IN_KEY, BYTES_OUT_KEY, BYTES_READ_KEY, BYTES_WRITTEN_KEY, DURATION_KEY,
+    BYTES_IN_KEY, BYTES_OUT_KEY, BYTES_READ_KEY, BYTES_WRITTEN_KEY, CHECKPOINT_FILES_STAGED_KEY,
+    CHECKPOINT_KEYS_STAGED_KEY, CHECKPOINTS_SEALED_KEY, DURATION_KEY,
     JOIN_BUILD_BYTES_INSERTED_KEY, JOIN_PROBE_BYTES_IN_KEY, JOIN_PROBE_BYTES_OUT_KEY,
     NUM_TASKS_KEY, ROWS_IN_KEY, ROWS_OUT_KEY, ROWS_WRITTEN_KEY, Stat, Stats,
 };
@@ -397,6 +398,10 @@ pub struct WriteSnapshot {
     pub bytes_in: u64,
     #[serde(default)]
     pub num_tasks: u64,
+    #[serde(default)]
+    pub checkpoint_files_staged: u64,
+    #[serde(default)]
+    pub checkpoints_sealed: u64,
 }
 
 impl StatSnapshotImpl for WriteSnapshot {
@@ -412,6 +417,8 @@ impl StatSnapshotImpl for WriteSnapshot {
             BYTES_WRITTEN_KEY; Stat::Bytes(self.bytes_written),
             BYTES_IN_KEY; Stat::Bytes(self.bytes_in),
             NUM_TASKS_KEY; Stat::Count(self.num_tasks),
+            CHECKPOINT_FILES_STAGED_KEY; Stat::Count(self.checkpoint_files_staged),
+            CHECKPOINTS_SEALED_KEY; Stat::Count(self.checkpoints_sealed),
         ]
     }
 
@@ -434,6 +441,62 @@ impl WriteSnapshot {
             bytes_written: self.bytes_written + other.bytes_written,
             bytes_in: self.bytes_in + other.bytes_in,
             num_tasks: self.num_tasks + other.num_tasks,
+            checkpoint_files_staged: self.checkpoint_files_staged + other.checkpoint_files_staged,
+            checkpoints_sealed: self.checkpoints_sealed + other.checkpoints_sealed,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Encode, Decode, Serialize, Deserialize)]
+pub struct StageCheckpointKeysSnapshot {
+    pub cpu_us: u64,
+    pub rows_in: u64,
+    pub rows_out: u64,
+    pub keys_staged: u64,
+    #[serde(default)]
+    pub bytes_in: u64,
+    #[serde(default)]
+    pub bytes_out: u64,
+    #[serde(default)]
+    pub num_tasks: u64,
+}
+
+impl StatSnapshotImpl for StageCheckpointKeysSnapshot {
+    fn duration_us(&self) -> u64 {
+        self.cpu_us
+    }
+
+    fn to_stats(&self) -> Stats {
+        stats![
+            DURATION_KEY; Stat::Duration(Duration::from_micros(self.cpu_us)),
+            ROWS_IN_KEY; Stat::Count(self.rows_in),
+            ROWS_OUT_KEY; Stat::Count(self.rows_out),
+            CHECKPOINT_KEYS_STAGED_KEY; Stat::Count(self.keys_staged),
+            BYTES_IN_KEY; Stat::Bytes(self.bytes_in),
+            BYTES_OUT_KEY; Stat::Bytes(self.bytes_out),
+            NUM_TASKS_KEY; Stat::Count(self.num_tasks),
+        ]
+    }
+
+    fn to_message(&self) -> String {
+        format!(
+            "{} rows in, {} keys staged",
+            HumanCount(self.rows_in),
+            HumanCount(self.keys_staged),
+        )
+    }
+}
+
+impl StageCheckpointKeysSnapshot {
+    pub fn merge(self, other: &Self) -> Self {
+        Self {
+            cpu_us: self.cpu_us + other.cpu_us,
+            rows_in: self.rows_in + other.rows_in,
+            rows_out: self.rows_out + other.rows_out,
+            keys_staged: self.keys_staged + other.keys_staged,
+            bytes_in: self.bytes_in + other.bytes_in,
+            bytes_out: self.bytes_out + other.bytes_out,
+            num_tasks: self.num_tasks + other.num_tasks,
         }
     }
 }
@@ -448,6 +511,7 @@ pub enum StatSnapshot {
     Udf(UdfSnapshot),
     Join(JoinSnapshot),
     Write(WriteSnapshot),
+    StageCheckpointKeys(StageCheckpointKeysSnapshot),
 }
 
 impl StatSnapshot {
@@ -461,6 +525,9 @@ impl StatSnapshot {
             (Self::Udf(a), Self::Udf(b)) => Self::Udf(a.merge(b)),
             (Self::Join(a), Self::Join(b)) => Self::Join(a.merge(b)),
             (Self::Write(a), Self::Write(b)) => Self::Write(a.merge(b)),
+            (Self::StageCheckpointKeys(a), Self::StageCheckpointKeys(b)) => {
+                Self::StageCheckpointKeys(a.merge(b))
+            }
             (s, _) => s,
         }
     }
@@ -618,6 +685,8 @@ mod tests {
                     rows_written: 0,
                     bytes_written: 0,
                     bytes_in: 0,
+                    checkpoint_files_staged: 0,
+                    checkpoints_sealed: 0,
                 }),
                 StatSnapshot::Write(WriteSnapshot {
                     num_tasks: 2,
@@ -626,6 +695,8 @@ mod tests {
                     rows_written: 0,
                     bytes_written: 0,
                     bytes_in: 0,
+                    checkpoint_files_staged: 0,
+                    checkpoints_sealed: 0,
                 }),
                 3,
             ),

--- a/src/daft-distributed/src/pipeline_node/sink.rs
+++ b/src/daft-distributed/src/pipeline_node/sink.rs
@@ -3,7 +3,8 @@ use std::sync::{Arc, atomic::Ordering};
 use common_error::DaftResult;
 use common_file_formats::FileFormat;
 use common_metrics::{
-    BYTES_WRITTEN_KEY, Counter, Meter, ROWS_WRITTEN_KEY, StatSnapshot, UNIT_BYTES, UNIT_ROWS,
+    BYTES_WRITTEN_KEY, CHECKPOINT_FILES_STAGED_KEY, CHECKPOINTS_SEALED_KEY, Counter, Meter,
+    ROWS_WRITTEN_KEY, StatSnapshot, UNIT_BYTES, UNIT_CHECKPOINTS, UNIT_FILES, UNIT_ROWS,
     ops::{NodeCategory, NodeInfo, NodeType},
     snapshot::WriteSnapshot,
 };
@@ -38,6 +39,8 @@ pub struct WriteStats {
     rows_written: Counter,
     bytes_written: Counter,
     num_tasks: Counter,
+    checkpoint_files_staged: Counter,
+    checkpoints_sealed: Counter,
     node_kv: Vec<KeyValue>,
 }
 
@@ -59,6 +62,16 @@ impl WriteStats {
                 Some(UNIT_BYTES.into()),
             ),
             num_tasks: meter.num_tasks_metric(),
+            checkpoint_files_staged: meter.u64_counter_with_desc_and_unit(
+                CHECKPOINT_FILES_STAGED_KEY,
+                None,
+                Some(UNIT_FILES.into()),
+            ),
+            checkpoints_sealed: meter.u64_counter_with_desc_and_unit(
+                CHECKPOINTS_SEALED_KEY,
+                None,
+                Some(UNIT_CHECKPOINTS.into()),
+            ),
             node_kv,
         }
     }
@@ -78,6 +91,10 @@ impl RuntimeStats for WriteStats {
             .add(snapshot.rows_written, self.node_kv.as_slice());
         self.bytes_written
             .add(snapshot.bytes_written, self.node_kv.as_slice());
+        self.checkpoint_files_staged
+            .add(snapshot.checkpoint_files_staged, self.node_kv.as_slice());
+        self.checkpoints_sealed
+            .add(snapshot.checkpoints_sealed, self.node_kv.as_slice());
     }
 
     fn export_snapshot(&self) -> StatSnapshot {
@@ -88,6 +105,8 @@ impl RuntimeStats for WriteStats {
             bytes_written: self.bytes_written.load(Ordering::Relaxed),
             bytes_in: self.bytes_in.load(Ordering::Relaxed),
             num_tasks: self.num_tasks.load(Ordering::Relaxed),
+            checkpoint_files_staged: self.checkpoint_files_staged.load(Ordering::Relaxed),
+            checkpoints_sealed: self.checkpoints_sealed.load(Ordering::Relaxed),
         })
     }
 

--- a/src/daft-distributed/src/pipeline_node/stage_checkpoint_keys.rs
+++ b/src/daft-distributed/src/pipeline_node/stage_checkpoint_keys.rs
@@ -1,22 +1,24 @@
-use std::sync::Arc;
+use std::sync::{Arc, atomic::Ordering};
 
 use common_checkpoint_config::CheckpointConfig;
 use common_metrics::{
-    Meter,
-    ops::{NodeCategory, NodeType},
+    CHECKPOINT_KEYS_STAGED_KEY, Counter, Meter, StatSnapshot, UNIT_KEYS,
+    ops::{NodeCategory, NodeInfo, NodeType},
+    snapshot::StageCheckpointKeysSnapshot,
 };
 use daft_local_plan::{LocalNodeContext, LocalPhysicalPlan};
 use daft_logical_plan::stats::StatsState;
 use daft_schema::schema::SchemaRef;
+use opentelemetry::KeyValue;
 
 use super::{DistributedPipelineNode, PipelineNodeImpl, TaskBuilderStream};
 use crate::{
-    pipeline_node::{ClusteringStrategy, NodeID, PipelineNodeConfig, PipelineNodeContext},
-    plan::{PlanConfig, PlanExecutionContext},
-    statistics::{
-        RuntimeStats,
-        stats::{BaseCounters, RuntimeStatsRef},
+    pipeline_node::{
+        ClusteringStrategy, NodeID, PipelineNodeConfig, PipelineNodeContext,
+        metrics::key_values_from_context,
     },
+    plan::{PlanConfig, PlanExecutionContext},
+    statistics::{RuntimeStats, stats::RuntimeStatsRef},
 };
 
 pub(crate) struct StageCheckpointKeysNode {
@@ -59,33 +61,68 @@ impl StageCheckpointKeysNode {
 }
 
 struct StageCheckpointKeysStats {
-    base: BaseCounters,
+    duration_us: Counter,
+    rows_in: Counter,
+    rows_out: Counter,
+    bytes_in: Counter,
+    bytes_out: Counter,
+    keys_staged: Counter,
+    num_tasks: Counter,
+    node_kv: Vec<KeyValue>,
 }
 
 impl StageCheckpointKeysStats {
     fn new(meter: &Meter, context: &PipelineNodeContext) -> Self {
+        let node_kv = key_values_from_context(context);
         Self {
-            base: BaseCounters::new(meter, context),
+            duration_us: meter.duration_us_metric(),
+            rows_in: meter.rows_in_metric(),
+            rows_out: meter.rows_out_metric(),
+            bytes_in: meter.bytes_in_metric(),
+            bytes_out: meter.bytes_out_metric(),
+            keys_staged: meter.u64_counter_with_desc_and_unit(
+                CHECKPOINT_KEYS_STAGED_KEY,
+                None,
+                Some(UNIT_KEYS.into()),
+            ),
+            num_tasks: meter.num_tasks_metric(),
+            node_kv,
         }
     }
 }
 
 impl RuntimeStats for StageCheckpointKeysStats {
-    fn handle_worker_node_stats(
-        &self,
-        _node_info: &common_metrics::ops::NodeInfo,
-        snapshot: &common_metrics::StatSnapshot,
-    ) {
-        use common_metrics::snapshot::StatSnapshotImpl as _;
-        self.base.add_duration_us(snapshot.duration_us());
+    fn handle_worker_node_stats(&self, _node_info: &NodeInfo, snapshot: &StatSnapshot) {
+        let StatSnapshot::StageCheckpointKeys(snapshot) = snapshot else {
+            return;
+        };
+        self.duration_us
+            .add(snapshot.cpu_us, self.node_kv.as_slice());
+        self.rows_in.add(snapshot.rows_in, self.node_kv.as_slice());
+        self.rows_out
+            .add(snapshot.rows_out, self.node_kv.as_slice());
+        self.bytes_in
+            .add(snapshot.bytes_in, self.node_kv.as_slice());
+        self.bytes_out
+            .add(snapshot.bytes_out, self.node_kv.as_slice());
+        self.keys_staged
+            .add(snapshot.keys_staged, self.node_kv.as_slice());
     }
 
-    fn export_snapshot(&self) -> common_metrics::StatSnapshot {
-        self.base.export_default_snapshot()
+    fn export_snapshot(&self) -> StatSnapshot {
+        StatSnapshot::StageCheckpointKeys(StageCheckpointKeysSnapshot {
+            cpu_us: self.duration_us.load(Ordering::Relaxed),
+            rows_in: self.rows_in.load(Ordering::Relaxed),
+            rows_out: self.rows_out.load(Ordering::Relaxed),
+            keys_staged: self.keys_staged.load(Ordering::Relaxed),
+            bytes_in: self.bytes_in.load(Ordering::Relaxed),
+            bytes_out: self.bytes_out.load(Ordering::Relaxed),
+            num_tasks: self.num_tasks.load(Ordering::Relaxed),
+        })
     }
 
     fn increment_num_tasks(&self) {
-        self.base.increment_num_tasks();
+        self.num_tasks.add(1, self.node_kv.as_slice());
     }
 }
 

--- a/src/daft-local-execution/src/intermediate_ops/stage_checkpoint_keys.rs
+++ b/src/daft-local-execution/src/intermediate_ops/stage_checkpoint_keys.rs
@@ -1,11 +1,16 @@
-use std::sync::Arc;
+use std::sync::{Arc, atomic::Ordering};
 
 use common_checkpoint_config::CheckpointIdMap;
 use common_error::DaftResult;
-use common_metrics::ops::NodeType;
+use common_metrics::{
+    CHECKPOINT_KEYS_STAGED_KEY, Counter, Meter, StatSnapshot, UNIT_KEYS,
+    ops::{NodeInfo, NodeType},
+    snapshot::StageCheckpointKeysSnapshot,
+};
 use daft_checkpoint::CheckpointStoreRef;
 use daft_dsl::{Expr, expr::bound_expr::BoundExpr};
 use daft_micropartition::MicroPartition;
+use opentelemetry::KeyValue;
 use tracing::{Span, instrument};
 
 use super::intermediate_op::{IntermediateOpExecuteResult, IntermediateOperator};
@@ -13,7 +18,81 @@ use crate::{
     ExecutionTaskSpawner,
     dynamic_batching::StaticBatchingStrategy,
     pipeline::{InputId, MorselSizeRequirement, NodeName},
+    runtime_stats::RuntimeStats,
 };
+
+pub struct StageCheckpointKeysStats {
+    duration_us: Counter,
+    rows_in: Counter,
+    rows_out: Counter,
+    bytes_in: Counter,
+    bytes_out: Counter,
+    num_tasks: Counter,
+    keys_staged: Counter,
+    node_kv: Vec<KeyValue>,
+}
+
+impl StageCheckpointKeysStats {
+    fn add_keys_staged(&self, keys: u64) {
+        self.keys_staged.add(keys, self.node_kv.as_slice());
+    }
+}
+
+impl RuntimeStats for StageCheckpointKeysStats {
+    fn new(meter: &Meter, node_info: &NodeInfo) -> Self {
+        let node_kv = node_info.to_key_values();
+        Self {
+            duration_us: meter.duration_us_metric(),
+            rows_in: meter.rows_in_metric(),
+            rows_out: meter.rows_out_metric(),
+            bytes_in: meter.bytes_in_metric(),
+            bytes_out: meter.bytes_out_metric(),
+            num_tasks: meter.num_tasks_metric(),
+            keys_staged: meter.u64_counter_with_desc_and_unit(
+                CHECKPOINT_KEYS_STAGED_KEY,
+                None,
+                Some(UNIT_KEYS.into()),
+            ),
+            node_kv,
+        }
+    }
+
+    fn build_snapshot(&self, ordering: Ordering) -> StatSnapshot {
+        StatSnapshot::StageCheckpointKeys(StageCheckpointKeysSnapshot {
+            cpu_us: self.duration_us.load(ordering),
+            rows_in: self.rows_in.load(ordering),
+            rows_out: self.rows_out.load(ordering),
+            keys_staged: self.keys_staged.load(ordering),
+            bytes_in: self.bytes_in.load(ordering),
+            bytes_out: self.bytes_out.load(ordering),
+            num_tasks: self.num_tasks.load(ordering),
+        })
+    }
+
+    fn add_rows_in(&self, rows: u64) {
+        self.rows_in.add(rows, self.node_kv.as_slice());
+    }
+
+    fn add_rows_out(&self, rows: u64) {
+        self.rows_out.add(rows, self.node_kv.as_slice());
+    }
+
+    fn add_duration_us(&self, cpu_us: u64) {
+        self.duration_us.add(cpu_us, self.node_kv.as_slice());
+    }
+
+    fn add_bytes_in(&self, bytes: u64) {
+        self.bytes_in.add(bytes, self.node_kv.as_slice());
+    }
+
+    fn add_bytes_out(&self, bytes: u64) {
+        self.bytes_out.add(bytes, self.node_kv.as_slice());
+    }
+
+    fn increment_num_tasks(&self) {
+        self.num_tasks.add(1, self.node_kv.as_slice());
+    }
+}
 
 /// Checkpoint operator that records which source keys are being processed.
 ///
@@ -44,6 +123,7 @@ impl StageCheckpointKeysOperator {
 
 impl IntermediateOperator for StageCheckpointKeysOperator {
     type State = ();
+    type Stats = StageCheckpointKeysStats;
     type BatchingStrategy = StaticBatchingStrategy;
 
     #[instrument(skip_all, name = "StageCheckpointKeysOperator::execute")]
@@ -51,7 +131,7 @@ impl IntermediateOperator for StageCheckpointKeysOperator {
         &self,
         input: MicroPartition,
         state: Self::State,
-        _runtime_stats: Arc<Self::Stats>,
+        runtime_stats: Arc<Self::Stats>,
         task_spawner: &ExecutionTaskSpawner,
         input_id: InputId,
     ) -> IntermediateOpExecuteResult<Self> {
@@ -62,9 +142,13 @@ impl IntermediateOperator for StageCheckpointKeysOperator {
         task_spawner
             .spawn(
                 async move {
+                    // rows.in/out are recorded by the intermediate-op runner; this
+                    // op only owns the checkpoint-specific keys_staged counter.
                     for rb in input.record_batches() {
                         let key_series = rb.eval_expression(&key_expr)?;
+                        let key_count = key_series.len() as u64;
                         store.stage_keys(&checkpoint_id, key_series).await?;
+                        runtime_stats.add_keys_staged(key_count);
                     }
                     Ok((state, input))
                 },

--- a/src/daft-local-execution/src/runtime_stats/values.rs
+++ b/src/daft-local-execution/src/runtime_stats/values.rs
@@ -35,6 +35,12 @@ pub trait RuntimeStats: Send + Sync + std::any::Any {
     /// not directly comparable across operator kinds — interpret relative
     /// to the operator's own scale.
     fn increment_num_tasks(&self);
+
+    /// Record file-metadata blobs staged to a checkpoint store. No-op unless
+    /// the node is a checkpoint-enabled write sink.
+    fn add_checkpoint_files_staged(&self, _files: u64) {}
+    /// Record a sealed checkpoint. No-op unless the node is a checkpoint-enabled sink.
+    fn add_checkpoints_sealed(&self, _n: u64) {}
 }
 
 pub struct DefaultRuntimeStats {

--- a/src/daft-local-execution/src/sinks/blocking_sink.rs
+++ b/src/daft-local-execution/src/sinks/blocking_sink.rs
@@ -253,9 +253,13 @@ impl<Op: BlockingSink + 'static> BlockingSinkNode<Op> {
                     if let Some((ref store, _, file_format)) = checkpoint {
                         let file_metadata = Self::encode_file_metadata(&partitions, file_format)?;
                         if !file_metadata.is_empty() {
+                            let num_files = file_metadata.len() as u64;
                             store
                                 .stage_files(checkpoint_id.as_ref().unwrap(), file_metadata)
                                 .await?;
+                            per_input
+                                .runtime_stats
+                                .add_checkpoint_files_staged(num_files);
                         }
                     }
 
@@ -285,6 +289,7 @@ impl<Op: BlockingSink + 'static> BlockingSinkNode<Op> {
             }
             if let Some((store, _, _)) = &checkpoint {
                 store.checkpoint(checkpoint_id.as_ref().unwrap()).await?;
+                per_input.runtime_stats.add_checkpoints_sealed(1);
             }
             let _ = output_tx.send(PipelineMessage::Flush(input_id)).await;
             Ok(TaskResult::Finalized)

--- a/src/daft-local-execution/src/sinks/write.rs
+++ b/src/daft-local-execution/src/sinks/write.rs
@@ -2,7 +2,8 @@ use std::sync::{Arc, atomic::Ordering};
 
 use common_error::DaftResult;
 use common_metrics::{
-    BYTES_WRITTEN_KEY, Counter, Meter, ROWS_WRITTEN_KEY, StatSnapshot, UNIT_BYTES, UNIT_ROWS,
+    BYTES_WRITTEN_KEY, CHECKPOINT_FILES_STAGED_KEY, CHECKPOINTS_SEALED_KEY, Counter, Meter,
+    ROWS_WRITTEN_KEY, StatSnapshot, UNIT_BYTES, UNIT_CHECKPOINTS, UNIT_FILES, UNIT_ROWS,
     ops::{NodeInfo, NodeType},
     snapshot::WriteSnapshot,
 };
@@ -30,6 +31,8 @@ pub(crate) struct WriteStats {
     rows_written: Counter,
     bytes_written: Counter,
     num_tasks: Counter,
+    checkpoint_files_staged: Counter,
+    checkpoints_sealed: Counter,
 
     node_kv: Vec<KeyValue>,
 }
@@ -62,6 +65,16 @@ impl RuntimeStats for WriteStats {
                 Some(UNIT_BYTES.into()),
             ),
             num_tasks: meter.num_tasks_metric(),
+            checkpoint_files_staged: meter.u64_counter_with_desc_and_unit(
+                CHECKPOINT_FILES_STAGED_KEY,
+                None,
+                Some(UNIT_FILES.into()),
+            ),
+            checkpoints_sealed: meter.u64_counter_with_desc_and_unit(
+                CHECKPOINTS_SEALED_KEY,
+                None,
+                Some(UNIT_CHECKPOINTS.into()),
+            ),
 
             node_kv,
         }
@@ -79,6 +92,8 @@ impl RuntimeStats for WriteStats {
             bytes_written,
             bytes_in: self.bytes_in.load(ordering),
             num_tasks: self.num_tasks.load(ordering),
+            checkpoint_files_staged: self.checkpoint_files_staged.load(ordering),
+            checkpoints_sealed: self.checkpoints_sealed.load(ordering),
         })
     }
 
@@ -103,6 +118,15 @@ impl RuntimeStats for WriteStats {
 
     fn increment_num_tasks(&self) {
         self.num_tasks.add(1, self.node_kv.as_slice());
+    }
+
+    fn add_checkpoint_files_staged(&self, files: u64) {
+        self.checkpoint_files_staged
+            .add(files, self.node_kv.as_slice());
+    }
+
+    fn add_checkpoints_sealed(&self, n: u64) {
+        self.checkpoints_sealed.add(n, self.node_kv.as_slice());
     }
 }
 


### PR DESCRIPTION
## What

Surfaces checkpoint progress on the dashboard for distributed (Flotilla) checkpoint writes, via three run-total counters:

- **`keys_staged`** — on the `StageCheckpointKeys` source operator (source keys recorded for dedup)
- **`files_staged`** — on the write sink (staged file-metadata blobs)
- **`checkpoints_sealed`** — on the write sink (successful seals)

## Why

A checkpointed write previously gave no observability — there was no way to see from the dashboard whether/how much a run staged or sealed. These counters make checkpoint activity visible alongside the existing `rows.written` / throughput stats.

## How

The counters ride the existing `StatSnapshot` aggregation path rather than introducing a new mechanism:

- Each worker's `RuntimeStats` records the counter and includes it in its `StatSnapshot` (`StageCheckpointKeysSnapshot`, and two new fields on `WriteSnapshot`).
- The distributed pipeline node's `handle_worker_node_stats` sums the snapshot fields into driver-side meter counters and re-emits them via `export_snapshot`.
- Non-checkpoint operators report zero via default no-op `RuntimeStats` trait methods, so nothing changes for ordinary writes.

The source op also now records `rows.in/out` (previously it ignored its stats handle, so the node showed empty throughput); row tallies are owned by the intermediate-op runner to avoid double-counting.

## Testing

Verified end-to-end on a local Flotilla run (Ray runner, mock S3): a paired `read_parquet(checkpoint=...)` → `write_deltalake(checkpoint=...)` job shows `keys_staged=200`, `files_staged=1`, `checkpoints_sealed=1` on the dashboard, cross-checked against the staged objects in the store. A recovery rerun (same key) correctly stages zero.

## Scope

Counters only. Driver-side lifecycle *events* (commit / recovery) and the dashboard-server UI for them are intentionally left as follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)