### PR TITLE
docs: reorder UDF API docs to prioritize new API and deprecate legacy

### DIFF
--- a/docs/api/udf.md
+++ b/docs/api/udf.md
@@ -2,27 +2,13 @@
 
 User-Defined Functions (UDFs) are a mechanism to run Python code on the data that lives in a DataFrame. A UDF can be used just like [Expressions](expressions.md), allowing users to express computation that should be executed by Daft lazily.
 
-To write a UDF, you should use the `@udf` decorator, which can decorate either a Python function or a Python class, producing a UDF.
+To write a UDF, you should use `@daft.func` or `@daft.cls`, which provide a streamlined way to turn Python functions into Daft operations that work seamlessly with DataFrame expressions.
 
-Learn more about [UDFs](../custom-code/udfs.md) in Daft User Guide.
+Learn more about UDFs in the [User Guide](../custom-code/func.md).
 
-## Creating UDFs
+## Function UDFs
 
-::: daft.udf.udf
-    options:
-        heading_level: 3
-
-<!-- this function needs serious reformatting with the example and resource request section should not be a heading -->
-
-## Using UDFs
-
-::: daft.udf.UDF
-    options:
-        filters: ["!^_", "__call__"]
-
-## New UDFs
-
-`@daft.func` and `@daft.cls` are the new interface for creating user-defined functions in Daft. They provide a streamlined way to turn Python functions into Daft operations that work seamlessly with DataFrame expressions.
+`@daft.func` and `@daft.cls` are the recommended interface for creating user-defined functions in Daft.
 
 Learn more in the [User Guide](../custom-code/func.md).
 
@@ -45,3 +31,33 @@ Learn more in the [User Guide](../custom-code/func.md).
 Learn more in the [User Guide](../custom-code/udaf.md).
 
 ::: daft.udaf
+
+## Legacy UDFs
+
+!!! danger "To Be Removed in 0.8.0"
+
+    The `@daft.udf` decorator has been **deprecated** since Daft 0.7.0 and **will be removed in 0.8.0**.
+    Please use `@daft.func` and `@daft.cls` instead.
+
+    Using `@daft.udf` emits the following warning:
+
+    ```
+    DeprecationWarning: The `@daft.udf` decorator is deprecated since Daft version >= 0.7.0
+    and will be removed in >= 0.8.0. Please use `@daft.func` and `@daft.cls` instead.
+    See the migration guide for more details:
+    https://docs.daft.ai/en/stable/custom-code/migration/
+    ```
+
+    See the [migration guide](../custom-code/migration.md) for how to update your code.
+
+### Creating Legacy UDFs
+
+::: daft.udf.udf
+    options:
+        heading_level: 4
+
+### Using Legacy UDFs
+
+::: daft.udf.UDF
+    options:
+        filters: ["!^_", "__call__"]

--- a/docs/api/udf.md
+++ b/docs/api/udf.md
@@ -2,15 +2,11 @@
 
 User-Defined Functions (UDFs) are a mechanism to run Python code on the data that lives in a DataFrame. A UDF can be used just like [Expressions](expressions.md), allowing users to express computation that should be executed by Daft lazily.
 
-To write a UDF, use the `@daft.func` or `@daft.cls` decorators to turn Python functions into Daft operations that work seamlessly with DataFrame expressions.
+To write a UDF, use the `@daft.func` or `@daft.cls` decorators to turn Python functions into Daft operations that work seamlessly with DataFrame expressions. Daft also supports custom aggregation functions, or UDAFs with `@daft.udaf` with a three-stage pipeline (aggregate, combine, finalize) that plugs into Daft's distributed aggregation engine.
 
-Learn more about UDFs in the [User Guide](../custom-code/func.md).
+Learn more about user-defined functions in the user guide: [`daft.func`](../custom-code/func.md), [`daft.cls`](../custom-code/cls.md), [`daft.udaf`](../custom-code/udaf.md).
 
 ## Stateless Function UDFs
-
-`@daft.func` and `@daft.cls` are the recommended interface for creating user-defined functions in Daft.
-
-Learn more in the [User Guide](../custom-code/func.md).
 
 ::: daft.func
 
@@ -27,10 +23,6 @@ Learn more in the [User Guide](../custom-code/func.md).
 ::: daft.udf.udf_v2.Func
 
 ## Aggregate UDFs
-
-`@daft.udaf` lets you define custom aggregation functions with a three-stage pipeline (aggregate, combine, finalize) that plugs into Daft's distributed aggregation engine.
-
-Learn more in the [User Guide](../custom-code/udaf.md).
 
 ::: daft.udaf
 

--- a/docs/api/udf.md
+++ b/docs/api/udf.md
@@ -2,11 +2,11 @@
 
 User-Defined Functions (UDFs) are a mechanism to run Python code on the data that lives in a DataFrame. A UDF can be used just like [Expressions](expressions.md), allowing users to express computation that should be executed by Daft lazily.
 
-To write a UDF, you should use `@daft.func` or `@daft.cls`, which provide a streamlined way to turn Python functions into Daft operations that work seamlessly with DataFrame expressions.
+To write a UDF, use the `@daft.func` or `@daft.cls` decorators to turn Python functions into Daft operations that work seamlessly with DataFrame expressions.
 
 Learn more about UDFs in the [User Guide](../custom-code/func.md).
 
-## Function UDFs
+## Stateless Function UDFs
 
 `@daft.func` and `@daft.cls` are the recommended interface for creating user-defined functions in Daft.
 
@@ -15,6 +15,8 @@ Learn more in the [User Guide](../custom-code/func.md).
 ::: daft.func
 
 ::: daft.udf._FuncDecorator
+
+## Stateful Class UDFs
 
 ::: daft.cls
 


### PR DESCRIPTION
## Summary
- Reorders the UDF API reference page so `@daft.func` / `@daft.cls` appear first as the recommended interface
- Moves legacy `@daft.udf` docs to the bottom under a "Legacy UDFs" section
- Adds a prominent deprecation warning (`danger` admonition) noting removal in 0.8.0 with the exact `DeprecationWarning` text and a link to the migration guide

## Test plan
- [ ] Verify docs build cleanly (`mkdocs build`)
- [ ] Check the rendered UDF API page shows the new ordering and deprecation banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)