### PR TITLE
feat(functions): add UUIDv7 timestamp-extraction partition transforms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2737,6 +2737,7 @@ version = "0.3.0-dev0"
 dependencies = [
  "arrow-array 57.3.0",
  "arrow-buffer 57.3.0",
+ "chrono",
  "common-error",
  "daft-core",
  "daft-dsl",

--- a/daft/functions/__init__.py
+++ b/daft/functions/__init__.py
@@ -220,6 +220,10 @@ from .partition import (
     partition_years,
     partition_iceberg_bucket,
     partition_iceberg_truncate,
+    extract_minute_uuid7,
+    extract_hour_uuid7,
+    extract_day_uuid7,
+    extract_month_uuid7,
 )
 from .spatial import great_circle_distance
 from .str import (
@@ -381,6 +385,10 @@ __all__ = [
     "exp",
     "explode",
     "expm1",
+    "extract_day_uuid7",
+    "extract_hour_uuid7",
+    "extract_minute_uuid7",
+    "extract_month_uuid7",
     "factorial",
     "file",
     "file_path",

--- a/daft/functions/partition.py
+++ b/daft/functions/partition.py
@@ -71,3 +71,64 @@ def partition_iceberg_truncate(expr: Expression, w: int) -> Expression:
         Expression: Expression of the Same Type of the input
     """
     return Expression._from_pyexpr(expr._expr.partitioning_iceberg_truncate(w))
+
+
+def extract_minute_uuid7(expr: Expression) -> Expression:
+    """Partitioning Transform that extracts the number of minutes since epoch (1970-01-01) from a UUIDv7.
+
+    A UUIDv7 embeds a 48-bit Unix-millisecond timestamp in its first 6 bytes. The input must be a
+    Uuid or a FixedSizeBinary of 16 bytes (128 bits).
+
+    Args:
+        expr: a Uuid or FixedSizeBinary(16) expression of UUIDv7 values
+
+    Returns:
+        Expression: Int64 Expression with the number of minutes since epoch
+    """
+    return Expression._call_builtin_scalar_fn("extract_minute_uuid7", expr)
+
+
+def extract_hour_uuid7(expr: Expression) -> Expression:
+    """Partitioning Transform that extracts the number of hours since epoch (1970-01-01) from a UUIDv7.
+
+    A UUIDv7 embeds a 48-bit Unix-millisecond timestamp in its first 6 bytes. The input must be a
+    Uuid or a FixedSizeBinary of 16 bytes (128 bits).
+
+    Args:
+        expr: a Uuid or FixedSizeBinary(16) expression of UUIDv7 values
+
+    Returns:
+        Expression: Int64 Expression with the number of hours since epoch
+    """
+    return Expression._call_builtin_scalar_fn("extract_hour_uuid7", expr)
+
+
+def extract_day_uuid7(expr: Expression) -> Expression:
+    """Partitioning Transform that extracts the number of days since epoch (1970-01-01) from a UUIDv7.
+
+    A UUIDv7 embeds a 48-bit Unix-millisecond timestamp in its first 6 bytes. The input must be a
+    Uuid or a FixedSizeBinary of 16 bytes (128 bits).
+
+    Args:
+        expr: a Uuid or FixedSizeBinary(16) expression of UUIDv7 values
+
+    Returns:
+        Expression: Int64 Expression with the number of days since epoch
+    """
+    return Expression._call_builtin_scalar_fn("extract_day_uuid7", expr)
+
+
+def extract_month_uuid7(expr: Expression) -> Expression:
+    """Partitioning Transform that extracts the number of calendar months since 1970-01 from a UUIDv7.
+
+    The result is `(year - 1970) * 12 + (month - 1)`, matching `partition_months`. A UUIDv7 embeds a
+    48-bit Unix-millisecond timestamp in its first 6 bytes. The input must be a Uuid or a
+    FixedSizeBinary of 16 bytes (128 bits).
+
+    Args:
+        expr: a Uuid or FixedSizeBinary(16) expression of UUIDv7 values
+
+    Returns:
+        Expression: Int64 Expression with the number of months since 1970-01
+    """
+    return Expression._call_builtin_scalar_fn("extract_month_uuid7", expr)

--- a/src/daft-functions/Cargo.toml
+++ b/src/daft-functions/Cargo.toml
@@ -6,6 +6,7 @@ daft-hash = {workspace = true}
 xxhash-rust = {workspace = true}
 arrow-array = {workspace = true}
 arrow-buffer = {workspace = true}
+chrono = {workspace = true}
 num-traits = {workspace = true}
 pyo3 = {workspace = true, optional = true}
 typetag = {workspace = true}

--- a/src/daft-functions/src/lib.rs
+++ b/src/daft-functions/src/lib.rs
@@ -31,7 +31,9 @@ pub use python::register as register_modules;
 use simhash::SimHashFunction;
 use snafu::Snafu;
 use to_struct::ToStructFunction;
-use uuid::{Uuid, UuidV7};
+use uuid::{
+    ExtractDayUuid7, ExtractHourUuid7, ExtractMinuteUuid7, ExtractMonthUuid7, Uuid, UuidV7,
+};
 
 use crate::{concat_ws::ConcatWs, slice::Slice};
 
@@ -75,5 +77,9 @@ impl FunctionModule for MiscFunctions {
         parent.add_fn(Slice);
         parent.add_fn(Uuid);
         parent.add_fn(UuidV7);
+        parent.add_fn(ExtractMinuteUuid7);
+        parent.add_fn(ExtractHourUuid7);
+        parent.add_fn(ExtractDayUuid7);
+        parent.add_fn(ExtractMonthUuid7);
     }
 }

--- a/src/daft-functions/src/uuid.rs
+++ b/src/daft-functions/src/uuid.rs
@@ -1,15 +1,16 @@
 use std::sync::Arc;
 
 use arrow_array::builder::FixedSizeBinaryBuilder;
+use chrono::{DateTime, Datelike};
 use common_error::{DaftError, DaftResult};
 use daft_core::{
-    prelude::{DataType, Field, FromArrow, Schema, UuidArray},
+    prelude::{DataType, Field, FixedSizeBinaryArray, FromArrow, Int64Array, Schema, UuidArray},
     series::{IntoSeries, Series},
 };
 use daft_dsl::{
     ExprRef,
     functions::{
-        FunctionArgs, ScalarUDF,
+        FunctionArgs, ScalarUDF, UnaryArg,
         scalar::{EvalContext, ScalarFn},
     },
 };
@@ -17,6 +18,9 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid as RustUuid;
 
 const UUID_LEN: i32 = 16;
+
+/// Number of bytes in a UUID (128 bits).
+const UUID_BYTES: usize = 16;
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Uuid;
@@ -111,6 +115,169 @@ pub fn uuidv7() -> ExprRef {
     ScalarFn::builtin(UuidV7, vec![]).into()
 }
 
+// ---------------------------------------------------------------------------
+// UUIDv7 timestamp-extraction partition transforms.
+//
+// A UUIDv7 packs a 48-bit big-endian Unix-millisecond timestamp in its first 6
+// bytes (RFC 9562 §5.7). These functions decode that timestamp and bucket it,
+// mirroring the Iceberg-style partition transforms (`partition_hours`, etc.):
+//   - minute / hour / day: count of units since the Unix epoch (floor division)
+//   - month: calendar months since 1970-01 (== (year-1970)*12 + (month-1)),
+//            matching `partition_months`.
+// The input is a UUID (`DataType::Uuid`) or a `FixedSizeBinary(16)`; the output
+// is `Int64`. The UUID *version*/*variant* bits do not affect the result — only
+// the leading 48 timestamp bits are read — but inputs are expected to be v7.
+// ---------------------------------------------------------------------------
+
+/// Which UUIDv7 timestamp bucket to extract.
+#[derive(Clone, Copy)]
+enum Uuid7Unit {
+    Minute,
+    Hour,
+    Day,
+    Month,
+}
+
+/// Reads the 48-bit big-endian Unix-millisecond timestamp from the first 6 bytes
+/// of a UUIDv7.
+#[inline]
+fn ms_from_uuid7(bytes: &[u8]) -> i64 {
+    debug_assert!(bytes.len() >= 6);
+    (i64::from(bytes[0]) << 40)
+        | (i64::from(bytes[1]) << 32)
+        | (i64::from(bytes[2]) << 24)
+        | (i64::from(bytes[3]) << 16)
+        | (i64::from(bytes[4]) << 8)
+        | i64::from(bytes[5])
+}
+
+/// Buckets a UUIDv7 millisecond timestamp into the requested unit. Returns `None`
+/// only if the (always non-negative, 48-bit) timestamp is somehow out of chrono's
+/// representable range, which cannot happen for real UUIDv7 values.
+#[inline]
+fn bucket_uuid7(bytes: &[u8], unit: Uuid7Unit) -> Option<i64> {
+    let ms = ms_from_uuid7(bytes);
+    match unit {
+        Uuid7Unit::Minute => Some(ms.div_euclid(60_000)),
+        Uuid7Unit::Hour => Some(ms.div_euclid(3_600_000)),
+        Uuid7Unit::Day => Some(ms.div_euclid(86_400_000)),
+        Uuid7Unit::Month => DateTime::from_timestamp_millis(ms)
+            .map(|dt| (i64::from(dt.year()) - 1970) * 12 + (i64::from(dt.month()) - 1)),
+    }
+}
+
+/// Returns the input's bytes as a `FixedSizeBinaryArray`, accepting either a
+/// `DataType::Uuid` (read through its physical array) or a `FixedSizeBinary(16)`.
+fn uuid7_fixed_size_binary<'a>(
+    input: &'a Series,
+    fn_name: &str,
+) -> DaftResult<&'a FixedSizeBinaryArray> {
+    match input.data_type() {
+        DataType::Uuid => Ok(&input.downcast::<UuidArray>()?.physical),
+        DataType::FixedSizeBinary(UUID_BYTES) => input.downcast::<FixedSizeBinaryArray>(),
+        other => Err(DaftError::TypeError(format!(
+            "Expected input to '{fn_name}' to be a Uuid or FixedSizeBinary(16), got {other}"
+        ))),
+    }
+}
+
+fn extract_uuid7(input: &Series, unit: Uuid7Unit, fn_name: &str) -> DaftResult<Series> {
+    let bytes = uuid7_fixed_size_binary(input, fn_name)?;
+    let field = Field::new(input.name(), DataType::Int64);
+    let result = Int64Array::from_iter(
+        field,
+        bytes
+            .into_iter()
+            .map(|b| b.and_then(|b| bucket_uuid7(b, unit))),
+    );
+    Ok(result.into_series())
+}
+
+/// Validates the input dtype and returns the `Int64` output field. Shared by all
+/// four extraction functions' `get_return_field`.
+fn uuid7_return_field(
+    inputs: FunctionArgs<ExprRef>,
+    schema: &Schema,
+    fn_name: &str,
+) -> DaftResult<Field> {
+    let UnaryArg { input } = inputs.try_into()?;
+    let field = input.to_field(schema)?;
+    match field.dtype {
+        DataType::Uuid | DataType::FixedSizeBinary(UUID_BYTES) => {
+            Ok(Field::new(field.name, DataType::Int64))
+        }
+        other => Err(DaftError::TypeError(format!(
+            "Expected input to '{fn_name}' to be a Uuid or FixedSizeBinary(16), got {other}"
+        ))),
+    }
+}
+
+/// Generates a ScalarUDF struct + builder fn for a UUIDv7 extraction transform.
+macro_rules! impl_uuid7_extract {
+    ($struct:ident, $builder:ident, $name:literal, $unit:expr, $doc:literal) => {
+        #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+        pub struct $struct;
+
+        #[typetag::serde]
+        impl ScalarUDF for $struct {
+            fn name(&self) -> &'static str {
+                $name
+            }
+
+            fn call(&self, inputs: FunctionArgs<Series>, _ctx: &EvalContext) -> DaftResult<Series> {
+                let UnaryArg { input } = inputs.try_into()?;
+                extract_uuid7(&input, $unit, $name)
+            }
+
+            fn get_return_field(
+                &self,
+                inputs: FunctionArgs<ExprRef>,
+                schema: &Schema,
+            ) -> DaftResult<Field> {
+                uuid7_return_field(inputs, schema, $name)
+            }
+
+            fn docstring(&self) -> &'static str {
+                $doc
+            }
+        }
+
+        #[must_use]
+        pub fn $builder(input: ExprRef) -> ExprRef {
+            ScalarFn::builtin($struct, vec![input]).into()
+        }
+    };
+}
+
+impl_uuid7_extract!(
+    ExtractMinuteUuid7,
+    extract_minute_uuid7,
+    "extract_minute_uuid7",
+    Uuid7Unit::Minute,
+    "Extracts the number of minutes since the Unix epoch from the timestamp embedded in a UUIDv7."
+);
+impl_uuid7_extract!(
+    ExtractHourUuid7,
+    extract_hour_uuid7,
+    "extract_hour_uuid7",
+    Uuid7Unit::Hour,
+    "Extracts the number of hours since the Unix epoch from the timestamp embedded in a UUIDv7."
+);
+impl_uuid7_extract!(
+    ExtractDayUuid7,
+    extract_day_uuid7,
+    "extract_day_uuid7",
+    Uuid7Unit::Day,
+    "Extracts the number of days since the Unix epoch from the timestamp embedded in a UUIDv7."
+);
+impl_uuid7_extract!(
+    ExtractMonthUuid7,
+    extract_month_uuid7,
+    "extract_month_uuid7",
+    Uuid7Unit::Month,
+    "Extracts the number of calendar months since 1970-01 from the timestamp embedded in a UUIDv7."
+);
+
 fn uuid_series_from_builder(mut builder: FixedSizeBinaryBuilder) -> DaftResult<Series> {
     Ok(
         UuidArray::from_arrow(Field::new("", DataType::Uuid), Arc::new(builder.finish()))?
@@ -153,5 +320,130 @@ mod tests {
         for idx in 1..array.len() {
             assert!(array.value(idx - 1) < array.value(idx));
         }
+    }
+
+    /// Builds a 16-byte UUIDv7-shaped value with the given ms timestamp in the
+    /// leading 48 bits. The remaining bytes (including version/variant) are set
+    /// to a non-zero pattern to prove they don't affect extraction.
+    fn uuid7_bytes(ms: u64) -> [u8; 16] {
+        let mut b = [0xABu8; 16];
+        b[0] = ((ms >> 40) & 0xFF) as u8;
+        b[1] = ((ms >> 32) & 0xFF) as u8;
+        b[2] = ((ms >> 24) & 0xFF) as u8;
+        b[3] = ((ms >> 16) & 0xFF) as u8;
+        b[4] = ((ms >> 8) & 0xFF) as u8;
+        b[5] = (ms & 0xFF) as u8;
+        // version 7 nibble and variant bits, as a real UUIDv7 would have
+        b[6] = 0x70 | (b[6] & 0x0F);
+        b[8] = 0x80 | (b[8] & 0x3F);
+        b
+    }
+
+    #[test]
+    fn ms_from_uuid7_reads_leading_48_bits() {
+        assert_eq!(ms_from_uuid7(&uuid7_bytes(0)), 0);
+        assert_eq!(ms_from_uuid7(&uuid7_bytes(1)), 1);
+        // 2024-01-01T00:00:00Z
+        let ms = 1_704_067_200_000;
+        assert_eq!(ms_from_uuid7(&uuid7_bytes(ms)), ms as i64);
+        // Maximum 48-bit value.
+        let max48 = (1u64 << 48) - 1;
+        assert_eq!(ms_from_uuid7(&uuid7_bytes(max48)), max48 as i64);
+    }
+
+    #[test]
+    fn ms_extraction_ignores_version_and_variant_bytes() {
+        // Bytes 6 and 8 carry version/variant; they must not leak into the result.
+        let a = uuid7_bytes(1_704_067_200_000);
+        let mut b = a;
+        b[6] = 0x7F;
+        b[8] = 0xBF;
+        b[15] = 0x00;
+        assert_eq!(ms_from_uuid7(&a), ms_from_uuid7(&b));
+    }
+
+    #[test]
+    fn bucket_minute_hour_day_floor_divide() {
+        // 2024-01-01T00:00:00Z = 1704067200000 ms.
+        let ms = 1_704_067_200_000u64;
+        let b = uuid7_bytes(ms);
+        assert_eq!(
+            bucket_uuid7(&b, Uuid7Unit::Minute),
+            Some(ms as i64 / 60_000)
+        );
+        assert_eq!(
+            bucket_uuid7(&b, Uuid7Unit::Hour),
+            Some(ms as i64 / 3_600_000)
+        );
+        assert_eq!(
+            bucket_uuid7(&b, Uuid7Unit::Day),
+            Some(ms as i64 / 86_400_000)
+        );
+        // Epoch maps everything to 0.
+        let z = uuid7_bytes(0);
+        assert_eq!(bucket_uuid7(&z, Uuid7Unit::Minute), Some(0));
+        assert_eq!(bucket_uuid7(&z, Uuid7Unit::Hour), Some(0));
+        assert_eq!(bucket_uuid7(&z, Uuid7Unit::Day), Some(0));
+        assert_eq!(bucket_uuid7(&z, Uuid7Unit::Month), Some(0));
+    }
+
+    #[test]
+    fn bucket_minute_hour_day_known_values() {
+        // 90 minutes after epoch.
+        let ms = 90 * 60_000;
+        let b = uuid7_bytes(ms);
+        assert_eq!(bucket_uuid7(&b, Uuid7Unit::Minute), Some(90));
+        assert_eq!(bucket_uuid7(&b, Uuid7Unit::Hour), Some(1)); // floor(90/60)
+        assert_eq!(bucket_uuid7(&b, Uuid7Unit::Day), Some(0));
+    }
+
+    #[test]
+    fn bucket_month_is_calendar_months_since_epoch() {
+        // 1970-01 => 0
+        assert_eq!(bucket_uuid7(&uuid7_bytes(0), Uuid7Unit::Month), Some(0));
+        // 1970-02-01T00:00:00Z = 2678400000 ms => month index 1
+        assert_eq!(
+            bucket_uuid7(&uuid7_bytes(2_678_400_000), Uuid7Unit::Month),
+            Some(1)
+        );
+        // 2024-03-15T12:00:00Z => (2024-1970)*12 + (3-1) = 648 + 2 = 650
+        // 2024-03-15T12:00:00Z = 1710504000000 ms
+        assert_eq!(
+            bucket_uuid7(&uuid7_bytes(1_710_504_000_000), Uuid7Unit::Month),
+            Some(650)
+        );
+    }
+
+    #[test]
+    fn extract_uuid7_over_series_with_nulls() {
+        use daft_core::prelude::FixedSizeBinaryArray;
+
+        let ms_a = 1_704_067_200_000u64; // 2024-01-01
+        let ms_b = 1_710_504_000_000u64; // 2024-03-15
+        let a = uuid7_bytes(ms_a);
+        let b = uuid7_bytes(ms_b);
+        let values: Vec<Option<&[u8]>> = vec![Some(a.as_slice()), None, Some(b.as_slice())];
+        let arr =
+            FixedSizeBinaryArray::from_iter("id", values.into_iter(), UUID_BYTES).into_series();
+
+        let hours = extract_uuid7(&arr, Uuid7Unit::Hour, "extract_hour_uuid7").unwrap();
+        assert_eq!(hours.data_type(), &DataType::Int64);
+        let got: Vec<Option<i64>> = hours.i64().unwrap().into_iter().collect();
+        assert_eq!(
+            got,
+            vec![
+                Some(ms_a as i64 / 3_600_000),
+                None,
+                Some(ms_b as i64 / 3_600_000)
+            ]
+        );
+    }
+
+    #[test]
+    fn extract_uuid7_rejects_non_uuid_input() {
+        let s = Int64Array::from_iter(Field::new("x", DataType::Int64), [Some(1i64)].into_iter())
+            .into_series();
+        let err = extract_uuid7(&s, Uuid7Unit::Hour, "extract_hour_uuid7");
+        assert!(err.is_err());
     }
 }

--- a/src/daft-functions/src/uuid.rs
+++ b/src/daft-functions/src/uuid.rs
@@ -17,10 +17,8 @@ use daft_dsl::{
 use serde::{Deserialize, Serialize};
 use uuid::Uuid as RustUuid;
 
-const UUID_LEN: i32 = 16;
-
 /// Number of bytes in a UUID (128 bits).
-const UUID_BYTES: usize = 16;
+const UUID_LEN: usize = 16;
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Uuid;
@@ -34,7 +32,7 @@ impl ScalarUDF for Uuid {
     fn call(&self, _inputs: FunctionArgs<Series>, ctx: &EvalContext) -> DaftResult<Series> {
         let len = ctx.row_count;
 
-        let mut builder = FixedSizeBinaryBuilder::with_capacity(len, UUID_LEN);
+        let mut builder = FixedSizeBinaryBuilder::with_capacity(len, UUID_LEN as i32);
         for _ in 0..len {
             builder.append_value(RustUuid::new_v4())?;
         }
@@ -141,8 +139,7 @@ enum Uuid7Unit {
 /// Reads the 48-bit big-endian Unix-millisecond timestamp from the first 6 bytes
 /// of a UUIDv7.
 #[inline]
-fn ms_from_uuid7(bytes: &[u8]) -> i64 {
-    debug_assert!(bytes.len() >= 6);
+fn ms_from_uuid7(bytes: &[u8; UUID_LEN]) -> i64 {
     (i64::from(bytes[0]) << 40)
         | (i64::from(bytes[1]) << 32)
         | (i64::from(bytes[2]) << 24)
@@ -155,7 +152,7 @@ fn ms_from_uuid7(bytes: &[u8]) -> i64 {
 /// only if the (always non-negative, 48-bit) timestamp is somehow out of chrono's
 /// representable range, which cannot happen for real UUIDv7 values.
 #[inline]
-fn bucket_uuid7(bytes: &[u8], unit: Uuid7Unit) -> Option<i64> {
+fn bucket_uuid7(bytes: &[u8; UUID_LEN], unit: Uuid7Unit) -> Option<i64> {
     let ms = ms_from_uuid7(bytes);
     match unit {
         Uuid7Unit::Minute => Some(ms.div_euclid(60_000)),
@@ -174,7 +171,7 @@ fn uuid7_fixed_size_binary<'a>(
 ) -> DaftResult<&'a FixedSizeBinaryArray> {
     match input.data_type() {
         DataType::Uuid => Ok(&input.downcast::<UuidArray>()?.physical),
-        DataType::FixedSizeBinary(UUID_BYTES) => input.downcast::<FixedSizeBinaryArray>(),
+        DataType::FixedSizeBinary(UUID_LEN) => input.downcast::<FixedSizeBinaryArray>(),
         other => Err(DaftError::TypeError(format!(
             "Expected input to '{fn_name}' to be a Uuid or FixedSizeBinary(16), got {other}"
         ))),
@@ -186,9 +183,11 @@ fn extract_uuid7(input: &Series, unit: Uuid7Unit, fn_name: &str) -> DaftResult<S
     let field = Field::new(input.name(), DataType::Int64);
     let result = Int64Array::from_iter(
         field,
-        bytes
-            .into_iter()
-            .map(|b| b.and_then(|b| bucket_uuid7(b, unit))),
+        bytes.into_iter().map(|b| {
+            // `uuid7_fixed_size_binary` guarantees each value is exactly 16 bytes wide.
+            b.and_then(|b| <&[u8; UUID_LEN]>::try_from(b).ok())
+                .and_then(|b| bucket_uuid7(b, unit))
+        }),
     );
     Ok(result.into_series())
 }
@@ -203,7 +202,7 @@ fn uuid7_return_field(
     let UnaryArg { input } = inputs.try_into()?;
     let field = input.to_field(schema)?;
     match field.dtype {
-        DataType::Uuid | DataType::FixedSizeBinary(UUID_BYTES) => {
+        DataType::Uuid | DataType::FixedSizeBinary(UUID_LEN) => {
             Ok(Field::new(field.name, DataType::Int64))
         }
         other => Err(DaftError::TypeError(format!(
@@ -212,71 +211,133 @@ fn uuid7_return_field(
     }
 }
 
-/// Generates a ScalarUDF struct + builder fn for a UUIDv7 extraction transform.
-macro_rules! impl_uuid7_extract {
-    ($struct:ident, $builder:ident, $name:literal, $unit:expr, $doc:literal) => {
-        #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
-        pub struct $struct;
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct ExtractMinuteUuid7;
 
-        #[typetag::serde]
-        impl ScalarUDF for $struct {
-            fn name(&self) -> &'static str {
-                $name
-            }
+#[typetag::serde]
+impl ScalarUDF for ExtractMinuteUuid7 {
+    fn name(&self) -> &'static str {
+        "extract_minute_uuid7"
+    }
 
-            fn call(&self, inputs: FunctionArgs<Series>, _ctx: &EvalContext) -> DaftResult<Series> {
-                let UnaryArg { input } = inputs.try_into()?;
-                extract_uuid7(&input, $unit, $name)
-            }
+    fn call(&self, inputs: FunctionArgs<Series>, _ctx: &EvalContext) -> DaftResult<Series> {
+        let UnaryArg { input } = inputs.try_into()?;
+        extract_uuid7(&input, Uuid7Unit::Minute, self.name())
+    }
 
-            fn get_return_field(
-                &self,
-                inputs: FunctionArgs<ExprRef>,
-                schema: &Schema,
-            ) -> DaftResult<Field> {
-                uuid7_return_field(inputs, schema, $name)
-            }
+    fn get_return_field(
+        &self,
+        inputs: FunctionArgs<ExprRef>,
+        schema: &Schema,
+    ) -> DaftResult<Field> {
+        uuid7_return_field(inputs, schema, self.name())
+    }
 
-            fn docstring(&self) -> &'static str {
-                $doc
-            }
-        }
-
-        #[must_use]
-        pub fn $builder(input: ExprRef) -> ExprRef {
-            ScalarFn::builtin($struct, vec![input]).into()
-        }
-    };
+    fn docstring(&self) -> &'static str {
+        "Extracts the number of minutes since the Unix epoch from the timestamp embedded in a UUIDv7."
+    }
 }
 
-impl_uuid7_extract!(
-    ExtractMinuteUuid7,
-    extract_minute_uuid7,
-    "extract_minute_uuid7",
-    Uuid7Unit::Minute,
-    "Extracts the number of minutes since the Unix epoch from the timestamp embedded in a UUIDv7."
-);
-impl_uuid7_extract!(
-    ExtractHourUuid7,
-    extract_hour_uuid7,
-    "extract_hour_uuid7",
-    Uuid7Unit::Hour,
-    "Extracts the number of hours since the Unix epoch from the timestamp embedded in a UUIDv7."
-);
-impl_uuid7_extract!(
-    ExtractDayUuid7,
-    extract_day_uuid7,
-    "extract_day_uuid7",
-    Uuid7Unit::Day,
-    "Extracts the number of days since the Unix epoch from the timestamp embedded in a UUIDv7."
-);
-impl_uuid7_extract!(
-    ExtractMonthUuid7,
-    extract_month_uuid7,
-    "extract_month_uuid7",
-    Uuid7Unit::Month,
-    "Extracts the number of calendar months since 1970-01 from the timestamp embedded in a UUIDv7."
-);
+#[must_use]
+pub fn extract_minute_uuid7(input: ExprRef) -> ExprRef {
+    ScalarFn::builtin(ExtractMinuteUuid7, vec![input]).into()
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct ExtractHourUuid7;
+
+#[typetag::serde]
+impl ScalarUDF for ExtractHourUuid7 {
+    fn name(&self) -> &'static str {
+        "extract_hour_uuid7"
+    }
+
+    fn call(&self, inputs: FunctionArgs<Series>, _ctx: &EvalContext) -> DaftResult<Series> {
+        let UnaryArg { input } = inputs.try_into()?;
+        extract_uuid7(&input, Uuid7Unit::Hour, self.name())
+    }
+
+    fn get_return_field(
+        &self,
+        inputs: FunctionArgs<ExprRef>,
+        schema: &Schema,
+    ) -> DaftResult<Field> {
+        uuid7_return_field(inputs, schema, self.name())
+    }
+
+    fn docstring(&self) -> &'static str {
+        "Extracts the number of hours since the Unix epoch from the timestamp embedded in a UUIDv7."
+    }
+}
+
+#[must_use]
+pub fn extract_hour_uuid7(input: ExprRef) -> ExprRef {
+    ScalarFn::builtin(ExtractHourUuid7, vec![input]).into()
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct ExtractDayUuid7;
+
+#[typetag::serde]
+impl ScalarUDF for ExtractDayUuid7 {
+    fn name(&self) -> &'static str {
+        "extract_day_uuid7"
+    }
+
+    fn call(&self, inputs: FunctionArgs<Series>, _ctx: &EvalContext) -> DaftResult<Series> {
+        let UnaryArg { input } = inputs.try_into()?;
+        extract_uuid7(&input, Uuid7Unit::Day, self.name())
+    }
+
+    fn get_return_field(
+        &self,
+        inputs: FunctionArgs<ExprRef>,
+        schema: &Schema,
+    ) -> DaftResult<Field> {
+        uuid7_return_field(inputs, schema, self.name())
+    }
+
+    fn docstring(&self) -> &'static str {
+        "Extracts the number of days since the Unix epoch from the timestamp embedded in a UUIDv7."
+    }
+}
+
+#[must_use]
+pub fn extract_day_uuid7(input: ExprRef) -> ExprRef {
+    ScalarFn::builtin(ExtractDayUuid7, vec![input]).into()
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct ExtractMonthUuid7;
+
+#[typetag::serde]
+impl ScalarUDF for ExtractMonthUuid7 {
+    fn name(&self) -> &'static str {
+        "extract_month_uuid7"
+    }
+
+    fn call(&self, inputs: FunctionArgs<Series>, _ctx: &EvalContext) -> DaftResult<Series> {
+        let UnaryArg { input } = inputs.try_into()?;
+        extract_uuid7(&input, Uuid7Unit::Month, self.name())
+    }
+
+    fn get_return_field(
+        &self,
+        inputs: FunctionArgs<ExprRef>,
+        schema: &Schema,
+    ) -> DaftResult<Field> {
+        uuid7_return_field(inputs, schema, self.name())
+    }
+
+    fn docstring(&self) -> &'static str {
+        "Extracts the number of calendar months since 1970-01 from the timestamp embedded in a UUIDv7."
+    }
+}
+
+#[must_use]
+pub fn extract_month_uuid7(input: ExprRef) -> ExprRef {
+    ScalarFn::builtin(ExtractMonthUuid7, vec![input]).into()
+}
 
 fn uuid_series_from_builder(mut builder: FixedSizeBinaryBuilder) -> DaftResult<Series> {
     Ok(
@@ -286,7 +347,7 @@ fn uuid_series_from_builder(mut builder: FixedSizeBinaryBuilder) -> DaftResult<S
 }
 
 fn uuid_v7_kernel(len: usize) -> DaftResult<FixedSizeBinaryBuilder> {
-    let mut builder = FixedSizeBinaryBuilder::with_capacity(len, UUID_LEN);
+    let mut builder = FixedSizeBinaryBuilder::with_capacity(len, UUID_LEN as i32);
 
     for _ in 0..len {
         builder.append_value(RustUuid::now_v7())?;
@@ -416,15 +477,12 @@ mod tests {
 
     #[test]
     fn extract_uuid7_over_series_with_nulls() {
-        use daft_core::prelude::FixedSizeBinaryArray;
-
         let ms_a = 1_704_067_200_000u64; // 2024-01-01
         let ms_b = 1_710_504_000_000u64; // 2024-03-15
         let a = uuid7_bytes(ms_a);
         let b = uuid7_bytes(ms_b);
         let values: Vec<Option<&[u8]>> = vec![Some(a.as_slice()), None, Some(b.as_slice())];
-        let arr =
-            FixedSizeBinaryArray::from_iter("id", values.into_iter(), UUID_BYTES).into_series();
+        let arr = FixedSizeBinaryArray::from_iter("id", values.into_iter(), UUID_LEN).into_series();
 
         let hours = extract_uuid7(&arr, Uuid7Unit::Hour, "extract_hour_uuid7").unwrap();
         assert_eq!(hours.data_type(), &DataType::Int64);

--- a/src/daft-functions/src/uuid.rs
+++ b/src/daft-functions/src/uuid.rs
@@ -148,18 +148,21 @@ fn ms_from_uuid7(bytes: &[u8; UUID_LEN]) -> i64 {
         | i64::from(bytes[5])
 }
 
-/// Buckets a UUIDv7 millisecond timestamp into the requested unit. Returns `None`
-/// only if the (always non-negative, 48-bit) timestamp is somehow out of chrono's
-/// representable range, which cannot happen for real UUIDv7 values.
+/// Buckets a UUIDv7 millisecond timestamp into the requested unit.
 #[inline]
-fn bucket_uuid7(bytes: &[u8; UUID_LEN], unit: Uuid7Unit) -> Option<i64> {
+fn bucket_uuid7(bytes: &[u8; UUID_LEN], unit: Uuid7Unit) -> i64 {
     let ms = ms_from_uuid7(bytes);
     match unit {
-        Uuid7Unit::Minute => Some(ms.div_euclid(60_000)),
-        Uuid7Unit::Hour => Some(ms.div_euclid(3_600_000)),
-        Uuid7Unit::Day => Some(ms.div_euclid(86_400_000)),
-        Uuid7Unit::Month => DateTime::from_timestamp_millis(ms)
-            .map(|dt| (i64::from(dt.year()) - 1970) * 12 + (i64::from(dt.month()) - 1)),
+        Uuid7Unit::Minute => ms.div_euclid(60_000),
+        Uuid7Unit::Hour => ms.div_euclid(3_600_000),
+        Uuid7Unit::Day => ms.div_euclid(86_400_000),
+        // A 48-bit (always non-negative) millisecond timestamp is always within
+        // chrono's representable range, so this never fails for a real UUIDv7.
+        Uuid7Unit::Month => {
+            let dt = DateTime::from_timestamp_millis(ms)
+                .expect("48-bit millisecond timestamp is always representable");
+            (i64::from(dt.year()) - 1970) * 12 + (i64::from(dt.month()) - 1)
+        }
     }
 }
 
@@ -184,9 +187,13 @@ fn extract_uuid7(input: &Series, unit: Uuid7Unit, fn_name: &str) -> DaftResult<S
     let result = Int64Array::from_iter(
         field,
         bytes.into_iter().map(|b| {
-            // `uuid7_fixed_size_binary` guarantees each value is exactly 16 bytes wide.
-            b.and_then(|b| <&[u8; UUID_LEN]>::try_from(b).ok())
-                .and_then(|b| bucket_uuid7(b, unit))
+            b.map(|b| {
+                // `uuid7_fixed_size_binary` guarantees each value is exactly 16 bytes wide.
+                let bytes: &[u8; UUID_LEN] = b
+                    .try_into()
+                    .expect("FixedSizeBinary(16) values are always 16 bytes");
+                bucket_uuid7(bytes, unit)
+            })
         }),
     );
     Ok(result.into_series())
@@ -428,24 +435,15 @@ mod tests {
         // 2024-01-01T00:00:00Z = 1704067200000 ms.
         let ms = 1_704_067_200_000u64;
         let b = uuid7_bytes(ms);
-        assert_eq!(
-            bucket_uuid7(&b, Uuid7Unit::Minute),
-            Some(ms as i64 / 60_000)
-        );
-        assert_eq!(
-            bucket_uuid7(&b, Uuid7Unit::Hour),
-            Some(ms as i64 / 3_600_000)
-        );
-        assert_eq!(
-            bucket_uuid7(&b, Uuid7Unit::Day),
-            Some(ms as i64 / 86_400_000)
-        );
+        assert_eq!(bucket_uuid7(&b, Uuid7Unit::Minute), ms as i64 / 60_000);
+        assert_eq!(bucket_uuid7(&b, Uuid7Unit::Hour), ms as i64 / 3_600_000);
+        assert_eq!(bucket_uuid7(&b, Uuid7Unit::Day), ms as i64 / 86_400_000);
         // Epoch maps everything to 0.
         let z = uuid7_bytes(0);
-        assert_eq!(bucket_uuid7(&z, Uuid7Unit::Minute), Some(0));
-        assert_eq!(bucket_uuid7(&z, Uuid7Unit::Hour), Some(0));
-        assert_eq!(bucket_uuid7(&z, Uuid7Unit::Day), Some(0));
-        assert_eq!(bucket_uuid7(&z, Uuid7Unit::Month), Some(0));
+        assert_eq!(bucket_uuid7(&z, Uuid7Unit::Minute), 0);
+        assert_eq!(bucket_uuid7(&z, Uuid7Unit::Hour), 0);
+        assert_eq!(bucket_uuid7(&z, Uuid7Unit::Day), 0);
+        assert_eq!(bucket_uuid7(&z, Uuid7Unit::Month), 0);
     }
 
     #[test]
@@ -453,25 +451,25 @@ mod tests {
         // 90 minutes after epoch.
         let ms = 90 * 60_000;
         let b = uuid7_bytes(ms);
-        assert_eq!(bucket_uuid7(&b, Uuid7Unit::Minute), Some(90));
-        assert_eq!(bucket_uuid7(&b, Uuid7Unit::Hour), Some(1)); // floor(90/60)
-        assert_eq!(bucket_uuid7(&b, Uuid7Unit::Day), Some(0));
+        assert_eq!(bucket_uuid7(&b, Uuid7Unit::Minute), 90);
+        assert_eq!(bucket_uuid7(&b, Uuid7Unit::Hour), 1); // floor(90/60)
+        assert_eq!(bucket_uuid7(&b, Uuid7Unit::Day), 0);
     }
 
     #[test]
     fn bucket_month_is_calendar_months_since_epoch() {
         // 1970-01 => 0
-        assert_eq!(bucket_uuid7(&uuid7_bytes(0), Uuid7Unit::Month), Some(0));
+        assert_eq!(bucket_uuid7(&uuid7_bytes(0), Uuid7Unit::Month), 0);
         // 1970-02-01T00:00:00Z = 2678400000 ms => month index 1
         assert_eq!(
             bucket_uuid7(&uuid7_bytes(2_678_400_000), Uuid7Unit::Month),
-            Some(1)
+            1
         );
         // 2024-03-15T12:00:00Z => (2024-1970)*12 + (3-1) = 648 + 2 = 650
         // 2024-03-15T12:00:00Z = 1710504000000 ms
         assert_eq!(
             bucket_uuid7(&uuid7_bytes(1_710_504_000_000), Uuid7Unit::Month),
-            Some(650)
+            650
         );
     }
 

--- a/tests/functions/test_uuid7_partition.py
+++ b/tests/functions/test_uuid7_partition.py
@@ -1,0 +1,235 @@
+"""Tests for the UUIDv7 timestamp-extraction partition transforms.
+
+`extract_minute_uuid7` / `extract_hour_uuid7` / `extract_day_uuid7` /
+`extract_month_uuid7` decode the 48-bit Unix-millisecond timestamp embedded in
+the first 6 bytes of a UUIDv7 and bucket it, mirroring the Iceberg-style
+`partition_hours` / `partition_days` / `partition_months` transforms. The input
+is a `Uuid` or a `FixedSizeBinary(16)` (128 bits); the output is `Int64`.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+import daft
+from daft import DataType, col
+from daft.functions import (
+    extract_day_uuid7,
+    extract_hour_uuid7,
+    extract_minute_uuid7,
+    extract_month_uuid7,
+)
+from daft.functions import uuid as uuid_fn
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _uuid7_bytes(ms: int, *, filler: int = 0xAB) -> bytes:
+    """Builds a 16-byte UUIDv7-shaped value with `ms` in the leading 48 bits.
+
+    The version (0x7) and variant (0b10) bits are set as a real UUIDv7 would
+    have them; the remaining bytes are `filler` to prove they don't leak into
+    the extracted timestamp.
+    """
+    b = bytearray([filler] * 16)
+    b[0:6] = ms.to_bytes(6, "big")
+    b[6] = 0x70 | (b[6] & 0x0F)
+    b[8] = 0x80 | (b[8] & 0x3F)
+    return bytes(b)
+
+
+def _ms(dt: datetime) -> int:
+    return int(dt.replace(tzinfo=timezone.utc).timestamp() * 1000)
+
+
+def _fsb16_df(values: list[bytes | None]) -> daft.DataFrame:
+    """A single-column DataFrame `id` of dtype FixedSizeBinary(16)."""
+    return daft.from_pydict({"id": values}).select(col("id").cast(DataType.fixed_size_binary(16)))
+
+
+def _df_schema_dtypes(df: daft.DataFrame) -> list[DataType]:
+    return [df.schema()[name].dtype for name in df.column_names]
+
+
+# Known instants and their expected buckets, computed independently in Python.
+_INSTANTS = [
+    datetime(1970, 1, 1),
+    datetime(1970, 1, 1, 0, 1),  # one minute after epoch
+    datetime(1999, 12, 31, 23, 59, 59),
+    datetime(2024, 1, 1),
+    datetime(2024, 3, 15, 12, 30, 45),
+    datetime(2026, 5, 30, 8, 0, 0),
+]
+
+
+def _expected(dt: datetime) -> dict[str, int]:
+    ms = _ms(dt)
+    return {
+        "minute": ms // 60_000,
+        "hour": ms // 3_600_000,
+        "day": ms // 86_400_000,
+        "month": (dt.year - 1970) * 12 + (dt.month - 1),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Core correctness over FixedSizeBinary(16)
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("dt", _INSTANTS)
+def test_extract_all_units_known_instants(dt: datetime):
+    df = _fsb16_df([_uuid7_bytes(_ms(dt))])
+    out = df.select(
+        extract_minute_uuid7(col("id")).alias("minute"),
+        extract_hour_uuid7(col("id")).alias("hour"),
+        extract_day_uuid7(col("id")).alias("day"),
+        extract_month_uuid7(col("id")).alias("month"),
+    )
+    # All four transforms return Int64.
+    for dtype in _df_schema_dtypes(out):
+        assert dtype == DataType.int64()
+    result = out.to_pydict()
+    exp = _expected(dt)
+    assert result["minute"] == [exp["minute"]]
+    assert result["hour"] == [exp["hour"]]
+    assert result["day"] == [exp["day"]]
+    assert result["month"] == [exp["month"]]
+
+
+def test_epoch_buckets_to_zero():
+    df = _fsb16_df([_uuid7_bytes(0)])
+    out = df.select(
+        extract_minute_uuid7(col("id")).alias("minute"),
+        extract_hour_uuid7(col("id")).alias("hour"),
+        extract_day_uuid7(col("id")).alias("day"),
+        extract_month_uuid7(col("id")).alias("month"),
+    ).to_pydict()
+    assert out == {"minute": [0], "hour": [0], "day": [0], "month": [0]}
+
+
+@pytest.mark.parametrize(
+    "dt,expected_month",
+    [
+        (datetime(1970, 1, 1), 0),
+        (datetime(1970, 2, 1), 1),
+        (datetime(1970, 12, 31), 11),
+        (datetime(1971, 1, 1), 12),
+        (datetime(2000, 12, 31, 23, 59, 59), (2000 - 1970) * 12 + 11),
+        (datetime(2024, 3, 15), (2024 - 1970) * 12 + 2),
+    ],
+)
+def test_month_is_calendar_months_since_epoch(dt: datetime, expected_month: int):
+    df = _fsb16_df([_uuid7_bytes(_ms(dt))])
+    out = df.select(extract_month_uuid7(col("id")).alias("month")).to_pydict()
+    assert out["month"] == [expected_month]
+
+
+def test_multiple_rows_and_nulls():
+    rows = [_uuid7_bytes(_ms(datetime(2024, 1, 1))), None, _uuid7_bytes(_ms(datetime(2024, 3, 15)))]
+    df = _fsb16_df(rows)
+    out = df.select(extract_hour_uuid7(col("id")).alias("hour")).to_pydict()
+    assert out["hour"] == [
+        _ms(datetime(2024, 1, 1)) // 3_600_000,
+        None,
+        _ms(datetime(2024, 3, 15)) // 3_600_000,
+    ]
+
+
+def test_version_and_variant_bits_do_not_affect_extraction():
+    ms = _ms(datetime(2024, 3, 15, 12, 30, 45))
+    # Two values with the same timestamp but different filler / version-variant nibbles.
+    a = _uuid7_bytes(ms, filler=0x00)
+    b = _uuid7_bytes(ms, filler=0xFF)
+    df = _fsb16_df([a, b])
+    out = df.select(
+        extract_minute_uuid7(col("id")).alias("minute"),
+        extract_hour_uuid7(col("id")).alias("hour"),
+        extract_day_uuid7(col("id")).alias("day"),
+        extract_month_uuid7(col("id")).alias("month"),
+    ).to_pydict()
+    assert out["minute"][0] == out["minute"][1]
+    assert out["hour"][0] == out["hour"][1]
+    assert out["day"][0] == out["day"][1]
+    assert out["month"][0] == out["month"][1]
+
+
+# ---------------------------------------------------------------------------
+# Uuid logical-type input
+# ---------------------------------------------------------------------------
+def test_uuid_logical_type_matches_fixed_size_binary_path():
+    """Extraction on a Uuid column equals extraction on its FixedSizeBinary(16) bytes."""
+    gen = daft.from_pydict({"x": list(range(16))}).select(uuid_fn("v7").alias("id"))
+    out = gen.select(
+        extract_hour_uuid7(col("id")).alias("uuid_hour"),
+        extract_minute_uuid7(col("id")).alias("uuid_minute"),
+        extract_day_uuid7(col("id")).alias("uuid_day"),
+        extract_month_uuid7(col("id")).alias("uuid_month"),
+        # Cast the same Uuid to FixedSizeBinary(16) and extract from that.
+        extract_hour_uuid7(col("id").cast(DataType.fixed_size_binary(16))).alias("fsb_hour"),
+        extract_minute_uuid7(col("id").cast(DataType.fixed_size_binary(16))).alias("fsb_minute"),
+        extract_day_uuid7(col("id").cast(DataType.fixed_size_binary(16))).alias("fsb_day"),
+        extract_month_uuid7(col("id").cast(DataType.fixed_size_binary(16))).alias("fsb_month"),
+    ).to_pydict()
+    assert out["uuid_hour"] == out["fsb_hour"]
+    assert out["uuid_minute"] == out["fsb_minute"]
+    assert out["uuid_day"] == out["fsb_day"]
+    assert out["uuid_month"] == out["fsb_month"]
+
+
+def test_extracted_units_are_internally_consistent():
+    gen = daft.from_pydict({"x": list(range(8))}).select(uuid_fn("v7").alias("id"))
+    out = gen.select(
+        extract_minute_uuid7(col("id")).alias("minute"),
+        extract_hour_uuid7(col("id")).alias("hour"),
+        extract_day_uuid7(col("id")).alias("day"),
+    ).to_pydict()
+    for minute, hour, day in zip(out["minute"], out["hour"], out["day"]):
+        assert minute // 60 == hour
+        assert hour // 24 == day
+        # uuidv7() uses the current time; sanity-check it is well past 2020.
+        assert day > _ms(datetime(2020, 1, 1)) // 86_400_000
+
+
+# ---------------------------------------------------------------------------
+# Type validation
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "df",
+    [
+        daft.from_pydict({"id": [1, 2, 3]}),  # Int64
+        daft.from_pydict({"id": ["a", "b"]}),  # Utf8
+        daft.from_pydict({"id": [b"abcdefgh"]}).select(
+            col("id").cast(DataType.fixed_size_binary(8))
+        ),  # wrong fixed size
+    ],
+)
+def test_rejects_invalid_input_types(df: daft.DataFrame):
+    with pytest.raises(Exception):
+        df.select(extract_hour_uuid7(col("id"))).collect()
+
+
+# ---------------------------------------------------------------------------
+# SQL accessibility
+# ---------------------------------------------------------------------------
+def test_sql_matches_expression_api():
+    df = _fsb16_df([_uuid7_bytes(_ms(dt)) for dt in _INSTANTS])
+    expected = df.select(
+        extract_minute_uuid7(col("id")).alias("minute"),
+        extract_hour_uuid7(col("id")).alias("hour"),
+        extract_day_uuid7(col("id")).alias("day"),
+        extract_month_uuid7(col("id")).alias("month"),
+    ).to_pydict()
+    actual = daft.sql(
+        """
+        SELECT
+            extract_minute_uuid7(id) AS minute,
+            extract_hour_uuid7(id) AS hour,
+            extract_day_uuid7(id) AS day,
+            extract_month_uuid7(id) AS month
+        FROM df
+        """,
+        df=df,
+    ).to_pydict()
+    assert actual == expected


### PR DESCRIPTION
Adds extract_minute_uuid7 / extract_hour_uuid7 / extract_day_uuid7 / extract_month_uuid7 — partition transforms that decode the 48-bit Unix-ms timestamp embedded in a UUIDv7's first 6 bytes and bucket it, mirroring the Iceberg-style partition_hours / partition_days / partition_months transforms.

- Input: Uuid or FixedSizeBinary(16) (128 bits); output: Int64.
- minute/hour/day are counts since the Unix epoch (floor division); month is calendar months since 1970-01 ((year-1970)*12 + month-1), matching partition_months. Version/variant bits are ignored — only the leading 48 timestamp bits are read.
- Implemented as ScalarUDFs in daft-functions (auto-registered, SQL-callable), exposed via daft.functions.extract_*_uuid7.

Tests: per-unit correctness against known instants (FixedSizeBinary and Uuid inputs), epoch, calendar-month boundaries, nulls, version/variant independence, type validation, and SQL parity.

> Note: this PR is now independent of the clustering-spec work — it was rebased off the clustering stack onto `main`. The end-to-end "shuffle-free over a custom DataSource clustered by extract_hour_uuid7" test lives with the clustering PR, since it depends on `DataSource.get_clustering_spec()` / `ClusteringSpec`.