### PR TITLE
feat(parquet): accept PathLike paths in read_parquet

### DIFF
--- a/daft/io/_parquet.py
+++ b/daft/io/_parquet.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 
 @PublicAPI
 def read_parquet(
-    path: str | os.PathLike[str] | list[str | os.PathLike[str]],
+    path: str | os.PathLike[str] | list[str] | list[os.PathLike[str]],
     row_groups: list[list[int]] | None = None,
     infer_schema: bool = True,
     schema: dict[str, DataType] | None = None,
@@ -38,7 +38,7 @@ def read_parquet(
     """Creates a DataFrame from Parquet file(s).
 
     Args:
-        path (str | os.PathLike | list[str | os.PathLike]): Path to Parquet file (allows for wildcards; supports remote URLs to object stores such as ``s3://`` or ``gs://``)
+        path (str | os.PathLike | list[str] | list[os.PathLike]): Path to Parquet file (allows for wildcards; supports remote URLs to object stores such as ``s3://`` or ``gs://``)
         row_groups (List[int] or List[List[int]]): List of row groups to read corresponding to each file.
         infer_schema (bool): Whether to infer the schema of the Parquet, defaults to True.
         schema (dict[str, DataType]): A schema that is used as the definitive schema for the Parquet file if infer_schema is False, otherwise it is used as a schema hint that is applied after the schema is inferred (overriding the types of inferred columns, and appending any new columns not found during inference).
@@ -73,10 +73,11 @@ def read_parquet(
     if isinstance(path, list) and len(path) == 0:
         raise ValueError("Cannot read DataFrame from empty list of Parquet filepaths")
 
+    normalized_path: str | list[str]
     if isinstance(path, list):
-        path = [os.fspath(p) for p in path]
+        normalized_path = [os.fspath(p) for p in path]
     else:
-        path = os.fspath(path)
+        normalized_path = os.fspath(path)
 
     # If running on Ray, we want to limit the amount of concurrency and requests being made.
     # This is because each Ray worker process receives its own pool of thread workers and connections
@@ -89,9 +90,9 @@ def read_parquet(
 
     pytimeunit = coerce_int96_timestamp_unit._timeunit if coerce_int96_timestamp_unit is not None else None
 
-    if isinstance(path, list) and row_groups is not None and len(path) != len(row_groups):
+    if isinstance(normalized_path, list) and row_groups is not None and len(normalized_path) != len(row_groups):
         raise ValueError("row_groups must be the same length as the list of paths provided.")
-    if isinstance(row_groups, list) and not isinstance(path, list):
+    if isinstance(row_groups, list) and not isinstance(normalized_path, list):
         raise ValueError("row_groups are only supported when reading multiple non-globbed/wildcarded files")
 
     file_format_config = FileFormatConfig.from_parquet_config(
@@ -100,7 +101,7 @@ def read_parquet(
     storage_config = StorageConfig(multithreaded_io, io_config)
 
     builder = get_tabular_files_scan(
-        path=path,
+        path=normalized_path,
         infer_schema=infer_schema,
         schema=schema,
         file_format_config=file_format_config,

--- a/daft/io/_parquet.py
+++ b/daft/io/_parquet.py
@@ -1,6 +1,7 @@
 # ruff: noqa: I002
 # isort: dont-add-import: from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING
 
 from daft import context, runners
@@ -22,7 +23,7 @@ if TYPE_CHECKING:
 
 @PublicAPI
 def read_parquet(
-    path: str | list[str],
+    path: str | os.PathLike[str] | list[str | os.PathLike[str]],
     row_groups: list[list[int]] | None = None,
     infer_schema: bool = True,
     schema: dict[str, DataType] | None = None,
@@ -37,7 +38,7 @@ def read_parquet(
     """Creates a DataFrame from Parquet file(s).
 
     Args:
-        path (str): Path to Parquet file (allows for wildcards; supports remote URLs to object stores such as ``s3://`` or ``gs://``)
+        path (str | os.PathLike | list[str | os.PathLike]): Path to Parquet file (allows for wildcards; supports remote URLs to object stores such as ``s3://`` or ``gs://``)
         row_groups (List[int] or List[List[int]]): List of row groups to read corresponding to each file.
         infer_schema (bool): Whether to infer the schema of the Parquet, defaults to True.
         schema (dict[str, DataType]): A schema that is used as the definitive schema for the Parquet file if infer_schema is False, otherwise it is used as a schema hint that is applied after the schema is inferred (overriding the types of inferred columns, and appending any new columns not found during inference).
@@ -71,6 +72,11 @@ def read_parquet(
 
     if isinstance(path, list) and len(path) == 0:
         raise ValueError("Cannot read DataFrame from empty list of Parquet filepaths")
+
+    if isinstance(path, list):
+        path = [os.fspath(p) for p in path]
+    else:
+        path = os.fspath(path)
 
     # If running on Ray, we want to limit the amount of concurrency and requests being made.
     # This is because each Ray worker process receives its own pool of thread workers and connections

--- a/tests/io/test_parquet.py
+++ b/tests/io/test_parquet.py
@@ -4,6 +4,7 @@ import contextlib
 import datetime
 import io
 import os
+import pathlib
 import tempfile
 import uuid
 
@@ -32,6 +33,23 @@ def _parquet_write_helper(data: pa.Table, row_group_size: int | None = None, pap
         file = os.path.join(directory_name, "tempfile")
         papq.write_table(data, file, row_group_size=row_group_size, **papq_write_table_kwargs)
         yield file
+
+
+def test_read_parquet_accepts_pathlike(tmp_path: pathlib.Path):
+    path = tmp_path / "data.parquet"
+    papq.write_table(pa.Table.from_pydict({"foo": [1, 2, 3]}), path)
+
+    assert daft.read_parquet(path).to_pydict() == {"foo": [1, 2, 3]}
+
+
+def test_read_parquet_accepts_pathlike_list(tmp_path: pathlib.Path):
+    paths = []
+    for i in range(3):
+        path = tmp_path / f"data-{i}.parquet"
+        papq.write_table(pa.Table.from_pydict({"foo": [i]}), path)
+        paths.append(path)
+
+    assert daft.read_parquet(paths).sort("foo").to_pydict() == {"foo": [0, 1, 2]}
 
 
 @pytest.mark.parametrize("use_deprecated_int96_timestamps", [True, False])


### PR DESCRIPTION
## Changes Made

Allows `daft.read_parquet` to accept single and list `os.PathLike` inputs by normalizing them before scan construction. Adds tests for both forms.

## Related Issues

None