### PR TITLE
fix: pass options in Gravitino PostgreSQL read method

### DIFF
--- a/daft/catalog/__gravitino/_catalog.py
+++ b/daft/catalog/__gravitino/_catalog.py
@@ -252,7 +252,6 @@ class GravitinoPostgresTable(GravitinoTable):
     """GravitinoPostgresTable is for Gravitino Postgres tables with provider contains 'postgres'."""
 
     _postgres_table: PostgresTable
-    _read_options: set[str] = set()
     _write_options: set[str] = {"enable_rls"}
 
     @classmethod
@@ -265,8 +264,10 @@ class GravitinoPostgresTable(GravitinoTable):
         return t
 
     def read(self, **options: Any) -> DataFrame:
-        Table._validate_options("Gravitino read", options, self._read_options)
-        return self._postgres_table.read()
+        from daft.catalog.__postgres import PostgresTable
+
+        Table._validate_options("Gravitino read", options, PostgresTable._read_options)
+        return self._postgres_table.read(**options)
 
     def append(self, df: DataFrame, **options: Any) -> None:
         self._validate_options("Gravitino write", options, self._write_options)
@@ -330,7 +331,6 @@ def _open_postgres_table(table_info: GravitinoTableInfo) -> PostgresTable:
     table_name = f"{table_info.schema}.{table_info.name}"
 
     catalog = Catalog.from_postgres(connection, extensions=filtered_extensions)
-
     table = catalog.get_table(table_name)
     if not isinstance(table, PostgresTable):
         raise GravitinoTableTypeError(f"Expected PostgresTable, got {type(table).__name__}.")

--- a/tests/catalog/test_gravitino.py
+++ b/tests/catalog/test_gravitino.py
@@ -556,6 +556,16 @@ class TestGravitinoTable:
         with pytest.raises(ValueError, match="Unsupported option"):
             gravitino_table.read(invalid_option="value")
 
+    def test_read_postgres_with_invalid_option(self, postgres_gravitino_table):
+        """Test reading a Postgres table with invalid option raises error."""
+        with pytest.raises(ValueError, match="Unsupported option"):
+            postgres_gravitino_table.read(invalid_option="value")
+
+    def test_read_postgres_table_with_infer_schema(self, postgres_gravitino_table):
+        """Test reading a Postgres table with infer_schema option."""
+        result = postgres_gravitino_table.read(infer_schema=True)
+        assert result is not None
+
     def test_schema_calls_read(self, gravitino_table):
         """Test schema() method calls read().schema()."""
         mock_df = Mock()


### PR DESCRIPTION
Adds missing handling of the options parameter in the read method when using Gravitino to read from PostgreSQL.

## Changes Made

Validate the options dictionary
Pass options to the underlying PostgreSQL read call via Gravitino connector

## Related Issues

Closes #7046
