### PR TITLE
fix: fix inverted return semantics of needs_hash_repartition 

### DIFF
--- a/src/daft-distributed/src/pipeline_node/aggregate.rs
+++ b/src/daft-distributed/src/pipeline_node/aggregate.rs
@@ -374,7 +374,7 @@ impl LogicalPlanToPipelineNodeTranslator {
         partition_by: Vec<BoundExpr>,
         input_size_bytes: usize,
     ) -> DaftResult<DistributedPipelineNode> {
-        if Self::needs_hash_repartition(&input_node, &group_by)? {
+        if !Self::needs_hash_repartition(&input_node, &group_by)? {
             let node_id = self.get_next_pipeline_node_id();
             return Ok(DistributedPipelineNode::new(
                 Arc::new(AggregateNode::new(

--- a/src/daft-distributed/src/pipeline_node/translate.rs
+++ b/src/daft-distributed/src/pipeline_node/translate.rs
@@ -114,7 +114,7 @@ impl LogicalPlanToPipelineNodeTranslator {
             false
         };
 
-        Ok(is_compatible)
+        Ok(!is_compatible)
     }
 }
 
@@ -434,7 +434,7 @@ impl TreeNodeVisitor for LogicalPlanToPipelineNodeTranslator {
                 let input_node = self.curr_node.pop().unwrap();
 
                 // Check if we can elide the repartition
-                if Self::needs_hash_repartition(&input_node, &columns)? {
+                if !Self::needs_hash_repartition(&input_node, &columns)? {
                     DistributedPipelineNode::new(
                         Arc::new(DistinctNode::new(
                             self.get_next_pipeline_node_id(),
@@ -498,7 +498,7 @@ impl TreeNodeVisitor for LogicalPlanToPipelineNodeTranslator {
                 let input_size_bytes = window.input.materialized_stats().approx_stats.size_bytes;
                 let repartition = if partition_by.is_empty() {
                     self.gen_gather_node(input_node, input_size_bytes)
-                } else if Self::needs_hash_repartition(&input_node, &partition_by)? {
+                } else if !Self::needs_hash_repartition(&input_node, &partition_by)? {
                     input_node
                 } else {
                     self.gen_repartition_node(

--- a/src/daft-distributed/src/pipeline_node/translate.rs
+++ b/src/daft-distributed/src/pipeline_node/translate.rs
@@ -100,7 +100,7 @@ impl LogicalPlanToPipelineNodeTranslator {
         let input_clustering_spec = &input_node.config().clustering_spec;
         // If there is only one partition, we can skip the shuffle
         if input_clustering_spec.num_partitions() == 1 {
-            return Ok(true);
+            return Ok(false);
         }
 
         // The clustering keys are already bound (to the input node's schema). We can skip the


### PR DESCRIPTION
`needs_hash_repartition` was returning `true` when it meant "already partitioned — skip the shuffle",                                                                                                                                                                                                                                                                 
this is the opposite of what the name implies. 

This fixes the return value to mean `true` = "repartition                                                                                                                                                                                                                                                              IS needed" and updates all three call sites accordingly.    