### PR TITLE
refactor(distributed): rename needs_hash_repartition to can_skip_hash_repartition     

### DIFF
--- a/src/daft-distributed/src/pipeline_node/aggregate.rs
+++ b/src/daft-distributed/src/pipeline_node/aggregate.rs
@@ -374,7 +374,7 @@ impl LogicalPlanToPipelineNodeTranslator {
         partition_by: Vec<BoundExpr>,
         input_size_bytes: usize,
     ) -> DaftResult<DistributedPipelineNode> {
-        if Self::needs_hash_repartition(&input_node, &group_by)? {
+        if Self::can_skip_hash_repartition(&input_node, &group_by)? {
             let node_id = self.get_next_pipeline_node_id();
             return Ok(DistributedPipelineNode::new(
                 Arc::new(AggregateNode::new(

--- a/src/daft-distributed/src/pipeline_node/clustering.rs
+++ b/src/daft-distributed/src/pipeline_node/clustering.rs
@@ -3,7 +3,7 @@
 //! [`BoundClusteringSpec`] is the bound (`T = BoundExpr`) instantiation of the generic
 //! [`daft_logical_plan::partitioning::ClusteringSpec`]. The logical plan only ever deals with the
 //! resolved-by-name form (`ClusteringSpec`); binding happens here, at the logical -> pipeline
-//! boundary, so every downstream check (`needs_hash_repartition`, join co-partitioning) can compare
+//! boundary, so every downstream check (`can_skip_hash_repartition`, join co-partitioning) can compare
 //! bound expressions directly instead of re-binding on the fly.
 //!
 //! Pipeline nodes never call these helpers directly. Every node establishes its output clustering

--- a/src/daft-distributed/src/pipeline_node/translate.rs
+++ b/src/daft-distributed/src/pipeline_node/translate.rs
@@ -93,7 +93,7 @@ impl LogicalPlanToPipelineNodeTranslator {
         self.hints.push(msg);
     }
 
-    pub(crate) fn needs_hash_repartition(
+    pub(crate) fn can_skip_hash_repartition(
         input_node: &DistributedPipelineNode,
         partition_columns: &[BoundExpr],
     ) -> DaftResult<bool> {
@@ -434,7 +434,7 @@ impl TreeNodeVisitor for LogicalPlanToPipelineNodeTranslator {
                 let input_node = self.curr_node.pop().unwrap();
 
                 // Check if we can elide the repartition
-                if Self::needs_hash_repartition(&input_node, &columns)? {
+                if Self::can_skip_hash_repartition(&input_node, &columns)? {
                     DistributedPipelineNode::new(
                         Arc::new(DistinctNode::new(
                             self.get_next_pipeline_node_id(),
@@ -498,7 +498,7 @@ impl TreeNodeVisitor for LogicalPlanToPipelineNodeTranslator {
                 let input_size_bytes = window.input.materialized_stats().approx_stats.size_bytes;
                 let repartition = if partition_by.is_empty() {
                     self.gen_gather_node(input_node, input_size_bytes)
-                } else if Self::needs_hash_repartition(&input_node, &partition_by)? {
+                } else if Self::can_skip_hash_repartition(&input_node, &partition_by)? {
                     input_node
                 } else {
                     self.gen_repartition_node(


### PR DESCRIPTION
 Renames `needs_hash_repartition` to `can_skip_hash_repartition` to fix misleading semantics —                                                                                                                                                                                                                                                                   the function returns `true` when the shuffle can be skipped, not when it's needed.         