### PR TITLE
fix(flight-shuffle): reduce coordinator memory to O(map_tasks + partitions)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3109,7 +3109,6 @@ dependencies = [
  "daft-functions-list",
  "daft-logical-plan",
  "daft-micropartition",
- "daft-partition-refs",
  "daft-recordbatch",
  "daft-scan",
  "indexmap",

--- a/src/daft-distributed/src/pipeline_node/shuffles/backends/flight.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/backends/flight.rs
@@ -36,6 +36,16 @@ pub(crate) fn register_cleanup(
     plan_context.register_shuffle_dirs(shuffle_dirs_to_register);
 }
 
+/// `partition_ref_id` layout: `(input_id << 32) | partition_idx`.
+fn input_id_from_ref(flight_ref: &FlightPartitionRef) -> u32 {
+    (flight_ref.partition_ref_id >> 32) as u32
+}
+
+/// `partition_ref_id` layout: `(input_id << 32) | partition_idx`.
+fn partition_idx_from_ref(flight_ref: &FlightPartitionRef) -> u32 {
+    (flight_ref.partition_ref_id & 0xFFFF_FFFF) as u32
+}
+
 /// Fold a stream of flight-shuffle map outputs into one read input per partition.
 ///
 /// Each map task emits one `FlightPartitionRef` per output partition, so collecting them
@@ -68,8 +78,7 @@ pub(crate) async fn fold_outputs_from_stream(
         inputs_by_server
             .entry(flight_ref.server_address.clone())
             .or_default()
-            // High 32 bits of partition_ref_id = map input id.
-            .push((flight_ref.partition_ref_id >> 32) as u32);
+            .push(input_id_from_ref(flight_ref));
     }
 
     let inputs_by_server = Arc::new(inputs_by_server);
@@ -93,16 +102,12 @@ pub(crate) fn read_inputs_from_refs(
             .as_any()
             .downcast_ref::<FlightPartitionRef>()
             .expect("expected flight partition ref");
-        // partition_ref_id = (input_id << 32) | partition_idx.
         groups
-            .entry((
-                flight_ref.shuffle_id,
-                (flight_ref.partition_ref_id & 0xFFFF_FFFF) as u32,
-            ))
+            .entry((flight_ref.shuffle_id, partition_idx_from_ref(flight_ref)))
             .or_default()
             .entry(flight_ref.server_address.clone())
             .or_default()
-            .push((flight_ref.partition_ref_id >> 32) as u32);
+            .push(input_id_from_ref(flight_ref));
     }
 
     groups

--- a/src/daft-distributed/src/pipeline_node/shuffles/backends/flight.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/backends/flight.rs
@@ -1,10 +1,14 @@
+use std::{collections::BTreeMap, sync::Arc};
+
 use common_error::DaftResult;
+use common_partitioning::PartitionRef;
 use daft_local_plan::{
     FlightShuffleReadInput, LocalNodeContext, LocalPhysicalPlan, ShuffleReadBackend,
 };
 use daft_logical_plan::stats::StatsState;
 use daft_partition_refs::FlightPartitionRef;
 use daft_schema::schema::SchemaRef;
+use futures::{Stream, StreamExt};
 
 use crate::{
     pipeline_node::{MaterializedOutput, NodeID, PipelineNodeImpl},
@@ -32,26 +36,97 @@ pub(crate) fn register_cleanup(
     plan_context.register_shuffle_dirs(shuffle_dirs_to_register);
 }
 
+/// Fold a stream of flight-shuffle map outputs into one read input per partition.
+///
+/// Each map task emits one `FlightPartitionRef` per output partition, so collecting them
+/// all (as the generic transpose does) holds O(map_tasks x num_partitions) refs on the
+/// coordinator — e.g. 10k map tasks x 8k partitions is ~82M refs, tens of GB of heap.
+/// But the refs are structured (`partition_ref_id = (input_id << 32) | partition_idx`,
+/// one per partition per map input), so the matrix is recoverable from just the set of
+/// input ids per server — O(map_tasks) total, shared across all partitions via `Arc`.
+/// The reduce side reconstructs the exact refs, issuing the same requests as if the
+/// full matrix had been kept, so retried map tasks' stale registrations are never
+/// addressed.
+pub(crate) async fn fold_outputs_from_stream(
+    mut materialized_stream: impl Stream<Item = DaftResult<MaterializedOutput>> + Send + Unpin,
+    num_partitions: usize,
+    shuffle_id: u64,
+) -> DaftResult<Vec<FlightShuffleReadInput>> {
+    let mut inputs_by_server: BTreeMap<String, Vec<u32>> = BTreeMap::new();
+
+    while let Some(output) = materialized_stream.next().await {
+        // A map output is one input's writes on one server: its refs all share
+        // (server_address, input_id), one ref per partition. So the first ref
+        // identifies the whole output.
+        let Some(partition) = output?.into_inner().0.into_iter().next() else {
+            continue;
+        };
+        let flight_ref = partition
+            .as_any()
+            .downcast_ref::<FlightPartitionRef>()
+            .expect("expected flight partition ref");
+        inputs_by_server
+            .entry(flight_ref.server_address.clone())
+            .or_default()
+            // High 32 bits of partition_ref_id = map input id.
+            .push((flight_ref.partition_ref_id >> 32) as u32);
+    }
+
+    let inputs_by_server = Arc::new(inputs_by_server);
+    Ok((0..num_partitions)
+        .map(|partition_idx| FlightShuffleReadInput {
+            shuffle_id,
+            partition_idx: partition_idx as u32,
+            inputs_by_server: inputs_by_server.clone(),
+        })
+        .collect())
+}
+
+/// Express an arbitrary set of flight partition refs as read inputs, grouped by
+/// (shuffle, partition idx).
+pub(crate) fn read_inputs_from_refs(
+    partition_refs: Vec<PartitionRef>,
+) -> Vec<FlightShuffleReadInput> {
+    let mut groups: BTreeMap<(u64, u32), BTreeMap<String, Vec<u32>>> = BTreeMap::new();
+    for partition in partition_refs {
+        let flight_ref = partition
+            .as_any()
+            .downcast_ref::<FlightPartitionRef>()
+            .expect("expected flight partition ref");
+        // partition_ref_id = (input_id << 32) | partition_idx.
+        groups
+            .entry((
+                flight_ref.shuffle_id,
+                (flight_ref.partition_ref_id & 0xFFFF_FFFF) as u32,
+            ))
+            .or_default()
+            .entry(flight_ref.server_address.clone())
+            .or_default()
+            .push((flight_ref.partition_ref_id >> 32) as u32);
+    }
+
+    groups
+        .into_iter()
+        .map(
+            |((shuffle_id, partition_idx), inputs_by_server)| FlightShuffleReadInput {
+                shuffle_id,
+                partition_idx,
+                inputs_by_server: Arc::new(inputs_by_server),
+            },
+        )
+        .collect()
+}
+
 pub(crate) async fn emit_read_tasks(
     node_id: NodeID,
     schema: SchemaRef,
-    partition_groups: Vec<Vec<MaterializedOutput>>,
+    read_inputs: Vec<FlightShuffleReadInput>,
     node: &dyn PipelineNodeImpl,
     result_tx: Sender<SwordfishTaskBuilder>,
 ) -> DaftResult<()> {
-    for partition_group in partition_groups {
-        let psets = partition_group
-            .into_iter()
-            .flat_map(|output| output.into_inner().0)
-            .map(|partition| {
-                partition
-                    .as_any()
-                    .downcast_ref::<FlightPartitionRef>()
-                    .expect("expected flight partition ref")
-                    .clone()
-            })
-            .collect::<Vec<_>>();
-
+    for read_input in read_inputs {
+        // Fresh plan per task: `SwordfishTaskBuilder::build` mutates the plan in
+        // place and requires sole ownership of its Arc.
         let shuffle_read_plan = LocalPhysicalPlan::shuffle_read(
             node_id,
             schema.clone(),
@@ -59,9 +134,8 @@ pub(crate) async fn emit_read_tasks(
             StatsState::NotMaterialized,
             LocalNodeContext::new(Some(node_id as usize)),
         );
-
         let task = SwordfishTaskBuilder::new(shuffle_read_plan, node, node_id)
-            .with_flight_shuffle_reads(node_id, vec![FlightShuffleReadInput { refs: psets }]);
+            .with_flight_shuffle_reads(node_id, vec![read_input]);
 
         let _ = result_tx.send(task).await;
     }

--- a/src/daft-distributed/src/pipeline_node/shuffles/backends/mod.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/backends/mod.rs
@@ -1,11 +1,10 @@
 use common_error::DaftResult;
 use common_partitioning::PartitionRef;
 use daft_local_plan::{
-    FlightShuffleReadInput, LocalNodeContext, LocalPhysicalPlan, LocalPhysicalPlanRef,
+    LocalNodeContext, LocalPhysicalPlan, LocalPhysicalPlanRef,
     ShuffleBackend as LocalShuffleBackend, ShuffleReadBackend,
 };
 use daft_logical_plan::stats::StatsState;
-use daft_partition_refs::FlightPartitionRef;
 use daft_schema::schema::SchemaRef;
 
 use crate::{
@@ -123,15 +122,7 @@ impl ShuffleBackend {
                 SwordfishTaskBuilder::new(plan, node, node_id).with_psets(node_id, partition_refs)
             }
             DistributedShuffleBackend::Flight(_) => {
-                let flight_refs = partition_refs
-                    .into_iter()
-                    .map(|p| {
-                        p.as_any()
-                            .downcast_ref::<FlightPartitionRef>()
-                            .expect("expected flight partition ref")
-                            .clone()
-                    })
-                    .collect::<Vec<_>>();
+                let read_inputs = flight::read_inputs_from_refs(partition_refs);
                 let shuffle_read = LocalPhysicalPlan::shuffle_read(
                     node_id,
                     self.schema.clone(),
@@ -140,22 +131,33 @@ impl ShuffleBackend {
                     LocalNodeContext::new(Some(node_id as usize)),
                 );
                 let plan = wrap_plan(shuffle_read);
-                SwordfishTaskBuilder::new(plan, node, node_id).with_flight_shuffle_reads(
-                    node_id,
-                    vec![FlightShuffleReadInput { refs: flight_refs }],
-                )
+                SwordfishTaskBuilder::new(plan, node, node_id)
+                    .with_flight_shuffle_reads(node_id, read_inputs)
             }
         }
     }
 
-    pub(crate) async fn emit_read_tasks(
+    /// Group a stream of map-task outputs into per-partition read tasks.
+    ///
+    /// The Ray backend transposes the full (tasks x partitions) matrix of object refs.
+    /// The flight backend folds the stream into per-server map-input lists shared by
+    /// all reduce tasks, keeping coordinator memory O(map_tasks + partitions) instead
+    /// of O(map_tasks x partitions).
+    pub(crate) async fn emit_read_tasks_from_stream(
         &self,
-        partition_groups: Vec<Vec<MaterializedOutput>>,
+        materialized_stream: impl futures::Stream<Item = DaftResult<MaterializedOutput>> + Send + Unpin,
+        num_partitions: usize,
         node: &dyn PipelineNodeImpl,
         result_tx: Sender<SwordfishTaskBuilder>,
     ) -> DaftResult<()> {
         match &self.backend {
             DistributedShuffleBackend::Ray => {
+                let partition_groups =
+                    crate::utils::transpose::transpose_materialized_outputs_from_stream(
+                        materialized_stream,
+                        num_partitions,
+                    )
+                    .await?;
                 ray::emit_read_tasks(
                     self.node_id,
                     self.schema.clone(),
@@ -165,11 +167,17 @@ impl ShuffleBackend {
                 )
                 .await
             }
-            DistributedShuffleBackend::Flight(_) => {
+            DistributedShuffleBackend::Flight(cfg) => {
+                let read_inputs = flight::fold_outputs_from_stream(
+                    materialized_stream,
+                    num_partitions,
+                    cfg.shuffle_id,
+                )
+                .await?;
                 flight::emit_read_tasks(
                     self.node_id,
                     self.schema.clone(),
-                    partition_groups,
+                    read_inputs,
                     node,
                     result_tx,
                 )

--- a/src/daft-distributed/src/pipeline_node/shuffles/gather.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/gather.rs
@@ -79,9 +79,15 @@ impl GatherNode {
             .await?;
 
         // Gather = single read task that consumes every ref from every worker.
-        self.shuffle_backend
-            .emit_read_tasks(vec![materialized], self.as_ref(), result_tx)
-            .await
+        let refs = materialized
+            .into_iter()
+            .flat_map(|output| output.into_inner().0)
+            .collect();
+        let task = self
+            .shuffle_backend
+            .build_refs_task_builder(refs, self.as_ref(), |plan| plan);
+        let _ = result_tx.send(task).await;
+        Ok(())
     }
 }
 

--- a/src/daft-distributed/src/pipeline_node/shuffles/repartition.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/repartition.rs
@@ -18,10 +18,7 @@ use crate::{
         scheduler::SchedulerHandle,
         task::{SwordfishTask, SwordfishTaskBuilder},
     },
-    utils::{
-        channel::{Sender, create_channel},
-        transpose::transpose_materialized_outputs_from_stream,
-    },
+    utils::channel::{Sender, create_channel},
 };
 
 pub(crate) struct RepartitionNode {
@@ -90,11 +87,8 @@ impl RepartitionNode {
             task_id_counter,
         );
 
-        let transposed_outputs =
-            transpose_materialized_outputs_from_stream(outputs, self.num_partitions).await?;
-
         self.shuffle_backend
-            .emit_read_tasks(transposed_outputs, self.as_ref(), result_tx)
+            .emit_read_tasks_from_stream(outputs, self.num_partitions, self.as_ref(), result_tx)
             .await
     }
 }

--- a/src/daft-local-execution/src/sources/shuffle_read.rs
+++ b/src/daft-local-execution/src/sources/shuffle_read.rs
@@ -11,9 +11,11 @@ use common_runtime::{JoinSet, combine_stream, get_compute_pool_num_threads, get_
 use daft_core::prelude::SchemaRef;
 use daft_local_plan::{FlightShuffleReadInput, InputId};
 use daft_micropartition::MicroPartition;
-use daft_partition_refs::FlightPartitionRef;
 use daft_recordbatch::RecordBatch;
-use daft_shuffles::{client::FlightClientManager, server::flight_server::ShuffleFlightServer};
+use daft_shuffles::{
+    client::FlightClientManager, server::flight_server::ShuffleFlightServer,
+    shuffle_cache::partition_ref_id,
+};
 use futures::{FutureExt, StreamExt, stream::BoxStream};
 use tracing::instrument;
 
@@ -55,76 +57,63 @@ impl ShuffleReadSource {
         }
     }
 
+    /// Resolve read inputs to the exact `(shuffle_id, server_address, partition_ref_ids)`
+    /// requests to issue, merged so each server is contacted once.
+    fn to_server_requests(inputs: Vec<FlightShuffleReadInput>) -> Vec<(u64, String, Vec<u64>)> {
+        let mut refs_by_server: HashMap<(u64, String), Vec<u64>> = HashMap::new();
+        for input in inputs {
+            for (address, input_ids) in input.inputs_by_server.iter() {
+                refs_by_server
+                    .entry((input.shuffle_id, address.clone()))
+                    .or_default()
+                    .extend(
+                        input_ids
+                            .iter()
+                            .map(|id| partition_ref_id(*id, input.partition_idx as usize)),
+                    );
+            }
+        }
+        refs_by_server
+            .into_iter()
+            .map(|((shuffle_id, address), ref_ids)| (shuffle_id, address, ref_ids))
+            .collect()
+    }
+
     async fn get_partition_stream(
         client_manager: FlightClientManager,
         local_server: Arc<ShuffleFlightServer>,
         local_address: &str,
-        refs: Vec<FlightPartitionRef>,
+        inputs: Vec<FlightShuffleReadInput>,
         schema: SchemaRef,
     ) -> DaftResult<BoxStream<'static, DaftResult<RecordBatch>>> {
-        let (local_refs, remote_refs): (Vec<_>, Vec<_>) = refs
+        let (local_requests, remote_requests): (Vec<_>, Vec<_>) = Self::to_server_requests(inputs)
             .into_iter()
-            .partition(|r| r.server_address == local_address);
+            .partition(|(_, address, _)| address == local_address);
 
-        let local_stream = if !local_refs.is_empty() {
-            Some(
+        let mut local_streams = Vec::new();
+        for (shuffle_id, _, partition_ref_ids) in local_requests {
+            local_streams.push(
                 local_server
-                    .get_partition_local(
-                        local_refs[0].shuffle_id,
-                        &local_refs
-                            .iter()
-                            .map(|r| r.partition_ref_id)
-                            .collect::<Vec<_>>(),
-                    )
+                    .get_partition_local(shuffle_id, &partition_ref_ids)
                     .await?,
-            )
-        } else {
-            None
-        };
-
-        let remote_stream = if remote_refs.is_empty() {
-            None
-        } else {
-            let mut refs_by_server: HashMap<(u64, String), Vec<u64>> = HashMap::new();
-            for partition_ref in remote_refs {
-                refs_by_server
-                    .entry((
-                        partition_ref.shuffle_id,
-                        partition_ref.server_address.clone(),
-                    ))
-                    .or_default()
-                    .push(partition_ref.partition_ref_id);
-            }
-            let fetches = refs_by_server
-                .into_iter()
-                .map(|((shuffle_id, server_address), partition_ref_ids)| {
-                    let client_manager = client_manager.clone();
-                    let schema = schema.clone();
-                    async move {
-                        client_manager
-                            .fetch_partition(
-                                shuffle_id,
-                                &server_address,
-                                &partition_ref_ids,
-                                schema,
-                            )
-                            .await
-                    }
-                })
-                .collect::<Vec<_>>();
-            // Some(futures::future::try_join_all(fetches).await?)
-            let streams = futures::future::try_join_all(fetches).await?;
-            Some(futures::stream::select_all(streams).boxed())
-        };
-
-        match (local_stream, remote_stream) {
-            (None, None) => Ok(futures::stream::empty().boxed()),
-            (Some(local_stream), None) => Ok(local_stream.boxed()),
-            (None, Some(remote_stream)) => Ok(remote_stream.boxed()),
-            (Some(local_stream), Some(remote_stream)) => {
-                Ok(futures::stream::select(local_stream, remote_stream).boxed())
-            }
+            );
         }
+
+        let fetches = remote_requests
+            .into_iter()
+            .map(|(shuffle_id, server_address, partition_ref_ids)| {
+                let client_manager = client_manager.clone();
+                let schema = schema.clone();
+                async move {
+                    client_manager
+                        .fetch_partition(shuffle_id, &server_address, &partition_ref_ids, schema)
+                        .await
+                }
+            })
+            .collect::<Vec<_>>();
+        let remote_streams = futures::future::try_join_all(fetches).await?;
+
+        Ok(futures::stream::select_all(local_streams.into_iter().chain(remote_streams)).boxed())
     }
 
     fn spawn_flight_shuffle_processor(
@@ -141,39 +130,24 @@ impl ShuffleReadSource {
         io_runtime.spawn(async move {
             let client_manager = FlightClientManager::new();
             let mut task_set = JoinSet::new();
-            let mut pending_tasks: VecDeque<(InputId, FlightShuffleReadInput)> = VecDeque::new();
+            let mut pending_tasks: VecDeque<(InputId, Vec<FlightShuffleReadInput>)> = VecDeque::new();
             let mut input_id_pending_counts: HashMap<InputId, usize> = HashMap::new();
             let mut receiver_exhausted = false;
 
             while !receiver_exhausted || !pending_tasks.is_empty() || !task_set.is_empty() {
                 while task_set.len() < num_parallel_tasks
-                    && let Some((input_id, input)) = pending_tasks.pop_front()
+                    && let Some((input_id, inputs)) = pending_tasks.pop_front()
                 {
-                    let stream = Self::get_partition_stream(client_manager.clone(), local_server.clone(), &local_address, input.refs, schema.clone()).await?;
+                    let stream = Self::get_partition_stream(client_manager.clone(), local_server.clone(), &local_address, inputs, schema.clone()).await?;
                     task_set.spawn(forward_partition_stream(stream, schema.clone(), output_sender.clone(), input_id));
                 }
 
                 tokio::select! {
                     recv_result = receiver.recv(), if !receiver_exhausted => {
                         match recv_result {
-                            Some((input_id, inputs)) if inputs.is_empty() => {
-                                let empty = MicroPartition::empty(Some(schema.clone()));
-                                if output_sender.send(PipelineMessage::Morsel {
-                                    input_id,
-                                    partition: empty,
-                                }).await.is_err() {
-                                    return Ok(());
-                                }
-                                if output_sender.send(PipelineMessage::Flush(input_id)).await.is_err() {
-                                    return Ok(());
-                                }
-                            }
                             Some((input_id, inputs)) => {
-                                let num_inputs = inputs.len();
-                                *input_id_pending_counts.entry(input_id).or_insert(0) += num_inputs;
-                                for input in inputs {
-                                    pending_tasks.push_back((input_id, input));
-                                }
+                                *input_id_pending_counts.entry(input_id).or_insert(0) += 1;
+                                pending_tasks.push_back((input_id, inputs));
                             }
                             None => {
                                 receiver_exhausted = true;
@@ -225,10 +199,9 @@ async fn forward_partition_stream(
             return Ok(input_id);
         }
     }
-    // If the stream produced no batches (all refs were zero-row / file-less),
-    // still emit a single empty `MicroPartition` so the downstream pipeline
-    // sees one output per input. Matches the `inputs.is_empty()` branch in
-    // `spawn_flight_shuffle_processor`.
+    // If the stream produced no batches (no read inputs, or all refs were
+    // zero-row / file-less), still emit a single empty `MicroPartition` so the
+    // downstream pipeline sees one output per input.
     if !emitted_any {
         let empty = MicroPartition::empty(Some(schema.clone()));
         let _ = sender

--- a/src/daft-local-plan/Cargo.toml
+++ b/src/daft-local-plan/Cargo.toml
@@ -10,7 +10,6 @@ daft-core = {path = "../daft-core", default-features = false}
 daft-dsl = {path = "../daft-dsl", default-features = false}
 daft-logical-plan = {path = "../daft-logical-plan", default-features = false}
 daft-micropartition = {path = "../daft-micropartition", default-features = false}
-daft-partition-refs = {path = "../daft-partition-refs", default-features = false}
 daft-scan = {path = "../daft-scan", default-features = false}
 daft-recordbatch = {path = "../daft-recordbatch", default-features = false}
 bincode = {workspace = true}
@@ -35,7 +34,6 @@ python = [
   "daft-dsl/python",
   "daft-logical-plan/python",
   "daft-micropartition/python",
-  "daft-partition-refs/python",
   "daft-scan/python"
 ]
 

--- a/src/daft-local-plan/src/plan.rs
+++ b/src/daft-local-plan/src/plan.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     sync::{Arc, LockResult},
 };
 
@@ -23,7 +23,6 @@ use daft_logical_plan::{
     partitioning::RepartitionSpec,
     stats::{PlanStats, StatsState},
 };
-use daft_partition_refs::FlightPartitionRef;
 use daft_scan::{Pushdowns, SourceConfig};
 use serde::{Deserialize, Serialize};
 
@@ -2475,9 +2474,17 @@ pub struct ShuffleRead {
     pub context: LocalNodeContext,
 }
 
+/// Fetch one output partition of a shuffle.
+///
+/// The exact refs to fetch (`(input_id << 32) | partition_idx`) are reconstructed
+/// from the map input ids that wrote data on each server. The map is shared (`Arc`)
+/// by all of a shuffle's reduce tasks, so the coordinator holds it once instead of
+/// one ref per (map input, partition).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FlightShuffleReadInput {
-    pub refs: Vec<FlightPartitionRef>,
+    pub shuffle_id: u64,
+    pub partition_idx: u32,
+    pub inputs_by_server: Arc<BTreeMap<String, Vec<u32>>>,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Problem

The flight-shuffle coordinator retains one `FlightPartitionRef` per (map task × output partition) and transposes the full matrix before emitting any reduce task. At 10k map tasks × 8192 partitions that is ~82M refs (~26 GB of heap) — Ray's memory monitor kills the head-node actor right at map completion:

```
ray.exceptions.OutOfMemoryError: ... task name=flotilla-plan-runner ... actual memory used=26.08GB
```

## Fix

The ref matrix is fully structured — `partition_ref_id = (input_id << 32) | partition_idx`, one ref per partition per map input — so it is recoverable from just the map input ids per server. The coordinator now folds the map-output stream into that single map, shared via `Arc` by all reduce tasks (each carrying only its `partition_idx`), and readers reconstruct their exact ref ids at fetch time.

Coordinator memory: **O(map_tasks × partitions) → O(map_tasks + partitions)**.

The reconstructed requests are byte-identical to what the full matrix would have produced, so the flight server is untouched and fault tolerance is unchanged: retried map tasks' stale registrations are never addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
