### PR TITLE
feat(dataframe): Add profile to dataframe public api

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -350,7 +350,12 @@ class DataFrame:
         return None
 
     @DataframePublicAPI
-    def profile(self, top_n: int = 5, file: io.IOBase | None = None) -> None:
+    def profile(
+        self,
+        top_n: int = 5,
+        file: io.IOBase | None = None,
+        show_details: bool = False,
+    ) -> None:
         """Prints a concise profile summary for a materialized DataFrame.
 
         The profile is based on the execution metrics collected when the DataFrame was materialized. This method does
@@ -363,7 +368,12 @@ class DataFrame:
         Examples:
             >>> import daft
             >>> df = daft.from_pydict({"x": [1, 2, 3]}).collect()
-            >>> df.profile()  # doctest: +SKIP
+            >>> # show details like Total Time, Rows read and other metric
+            >>> df.profile(top_n=3, show_details=True)  # doctest: +SKIP
+            >>>
+            >>> df = daft.from_pydict({"x": [1, 2, 3]}).collect()
+            >>> # show basic information
+            >>> df.profile()
         """
         if top_n < 1:
             raise ValueError("top_n must be at least 1")
@@ -372,7 +382,7 @@ class DataFrame:
         if self._metadata is None:
             raise ValueError("Profile is not available because execution metadata was not recorded")
 
-        print(self._metadata.format_profile(top_n=top_n), file=file)
+        print(self._metadata.format_profile(top_n=top_n, show_details=show_details), file=file)
 
     def num_partitions(self) -> int | None:
         """Returns the number of partitions that will be used to execute this DataFrame.

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -349,6 +349,31 @@ class DataFrame:
             )
         return None
 
+    @DataframePublicAPI
+    def profile(self, top_n: int = 5, file: io.IOBase | None = None) -> None:
+        """Prints a concise profile summary for a materialized DataFrame.
+
+        The profile is based on the execution metrics collected when the DataFrame was materialized. This method does
+        not execute the DataFrame; call :meth:`collect`, :meth:`show`, or another materializing method first.
+
+        Args:
+            top_n: Number of slowest operators to show. Defaults to 5.
+            file: Location to print the output to, or defaults to None which uses Python's default print location.
+
+        Examples:
+            >>> import daft
+            >>> df = daft.from_pydict({"x": [1, 2, 3]}).collect()
+            >>> df.profile()  # doctest: +SKIP
+        """
+        if top_n < 1:
+            raise ValueError("top_n must be at least 1")
+        if self._result_cache is None:
+            raise ValueError("Profile is not available until the DataFrame has been materialized")
+        if self._metadata is None:
+            raise ValueError("Profile is not available because execution metadata was not recorded")
+
+        print(self._metadata.format_profile(top_n=top_n), file=file)
+
     def num_partitions(self) -> int | None:
         """Returns the number of partitions that will be used to execute this DataFrame.
 
@@ -4176,7 +4201,11 @@ class DataFrame:
             Example with Null values and empty lists:
 
             >>> df2 = daft.from_pydict(
-            ...     {"id": [1, 2, 3, 4], "values": [[1, 2], [], None, [3]], "labels": [["a", "b"], [], None, ["c"]]}
+            ...     {
+            ...         "id": [1, 2, 3, 4],
+            ...         "values": [[1, 2], [], None, [3]],
+            ...         "labels": [["a", "b"], [], None, ["c"]],
+            ...     }
             ... )
             >>> df2.collect()
             ╭───────┬─────────────┬──────────────╮
@@ -4931,7 +4960,11 @@ class DataFrame:
             >>> import daft
             >>> from daft import col
             >>> df = daft.from_pydict(
-            ...     {"student_id": [1, 2, 3, 4], "test1": [0.5, 0.4, 0.6, 0.7], "test2": [0.9, 0.8, 0.7, 1.0]}
+            ...     {
+            ...         "student_id": [1, 2, 3, 4],
+            ...         "test1": [0.5, 0.4, 0.6, 0.7],
+            ...         "test2": [0.9, 0.8, 0.7, 1.0],
+            ...     }
             ... )
             >>> agg_df = df.agg(
             ...     df["test1"].mean(),

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -364,6 +364,7 @@ class DataFrame:
         Args:
             top_n: Number of slowest operators to show. Defaults to 5.
             file: Location to print the output to, or defaults to None which uses Python's default print location.
+            show_details: If True, include per-operator row and byte counts alongside durations. Defaults to False.
 
         Examples:
             >>> import daft
@@ -373,7 +374,7 @@ class DataFrame:
             >>>
             >>> df = daft.from_pydict({"x": [1, 2, 3]}).collect()
             >>> # show basic information
-            >>> df.profile()
+            >>> df.profile()  # doctest: +SKIP
         """
         if top_n < 1:
             raise ValueError("top_n must be at least 1")

--- a/daft/execution/metadata.py
+++ b/daft/execution/metadata.py
@@ -4,6 +4,7 @@ import json
 import os
 import time
 import warnings
+from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any, TypeAlias, TypedDict
 
@@ -18,6 +19,77 @@ class Metric(TypedDict):
 
 Metrics: TypeAlias = list[tuple[str, Metric]]
 PlanNode: TypeAlias = dict[str, Any]
+
+
+@dataclass(frozen=True)
+class _ProfileNode:
+    name: str
+    node_type: str
+    category: str
+    duration_us: float
+    rows_in: float | None
+    rows_out: float | None
+    bytes_read: float | None
+    bytes_in: float | None
+    bytes_out: float | None
+
+
+def _format_duration(duration_us: float) -> str:
+    if duration_us < 1_000:
+        return f"{duration_us:.0f} us"
+    if duration_us < 1_000_000:
+        return f"{duration_us / 1_000:.2f} ms"
+    return f"{duration_us / 1_000_000:.2f} s"
+
+
+def _format_count(value: float | None) -> str:
+    if value is None:
+        return "N/A"
+    return f"{int(value):,}"
+
+
+def _format_bytes(value: float | None) -> str:
+    if value is None:
+        return "N/A"
+
+    units = ["B", "KiB", "MiB", "GiB", "TiB", "PiB"]
+    current = float(value)
+    unit = units[0]
+    for unit in units:
+        if abs(current) < 1024 or unit == units[-1]:
+            break
+        current /= 1024
+
+    if unit == "B":
+        return f"{int(current)} {unit}"
+    return f"{current:.2f} {unit}"
+
+
+def _stats_to_dict(stats: Metrics) -> dict[str, Metric]:
+    return {name: metric for name, metric in stats}
+
+
+def _metric_value(stats: dict[str, Metric], name: str) -> float | None:
+    metric = stats.get(name)
+    if metric is None:
+        return None
+    return float(metric["value"])
+
+
+def _metric_duration_us(stats: dict[str, Metric]) -> float:
+    metric = stats.get("duration")
+    if metric is None:
+        return 0
+
+    value = float(metric["value"])
+    unit = metric["unit"]
+    if unit in ("us", "µs"):
+        return value
+    if unit == "ms":
+        return value * 1_000
+    if unit == "s":
+        return value * 1_000_000
+    return value
 
 
 def _traverse_plan(plan: PlanNode, metrics: dict[int, Metrics]) -> tuple[list[str], dict[int, int]]:
@@ -101,6 +173,76 @@ class ExecutionMetadata:
 
     def to_recordbatch(self) -> RecordBatch:
         return RecordBatch._from_pyrecordbatch(self._py.to_recordbatch())
+
+    def _profile_nodes(self) -> list[_ProfileNode]:
+        profile_nodes = []
+        for row in self.to_recordbatch().to_pylist():
+            stats = _stats_to_dict(row["stats"])
+            profile_nodes.append(
+                _ProfileNode(
+                    name=str(row["name"]),
+                    node_type=str(row["type"]),
+                    category=str(row["category"]),
+                    duration_us=_metric_duration_us(stats),
+                    rows_in=_metric_value(stats, "rows.in"),
+                    rows_out=_metric_value(stats, "rows.out"),
+                    bytes_read=_metric_value(stats, "bytes.read"),
+                    bytes_in=_metric_value(stats, "bytes.in"),
+                    bytes_out=_metric_value(stats, "bytes.out"),
+                )
+            )
+        return profile_nodes
+
+    def format_profile(self, top_n: int = 5) -> str:
+        """Return a concise query profile summary from execution metrics."""
+        nodes = self._profile_nodes()
+        # total_operator_us is the sum of duration_us across all nodes, which may be less than total query duration
+        # due to missing metrics or unaccounted time (e.g. scheduling, network).
+        total_operator_us = sum(node.duration_us for node in nodes)
+        source_nodes = [node for node in nodes if node.category.lower() == "source" or node.bytes_read is not None]
+        rows_read = sum(node.rows_out or 0 for node in source_nodes)
+        bytes_scanned = sum(node.bytes_read or 0 for node in nodes)
+        slowest_nodes = sorted(nodes, key=lambda node: node.duration_us, reverse=True)[:top_n]
+
+        lines = [
+            "== Query Profile ==",
+            "",
+            f"Query ID: {self.query_id}",
+            f"Total operator time: {_format_duration(total_operator_us)}",
+            f"Rows read: {_format_count(rows_read)}",
+            f"Bytes scanned: {_format_bytes(bytes_scanned)}",
+            "",
+            "Slowest operators:",
+        ]
+
+        if slowest_nodes:
+            for index, node in enumerate(slowest_nodes, start=1):
+                details = [
+                    _format_duration(node.duration_us),
+                    f"rows in: {_format_count(node.rows_in)}",
+                    f"rows out: {_format_count(node.rows_out)}",
+                ]
+                if node.bytes_read is not None:
+                    details.append(f"bytes read: {_format_bytes(node.bytes_read)}")
+                elif node.bytes_in is not None or node.bytes_out is not None:
+                    details.append(f"bytes in/out: {_format_bytes(node.bytes_in)} / {_format_bytes(node.bytes_out)}")
+                lines.append(f"{index}. {node.name} ({node.node_type}) - {', '.join(details)}")
+        else:
+            lines.append("No operator metrics were recorded.")
+
+        warnings_out = []
+        if not nodes:
+            warnings_out.append("No execution metrics were recorded.")
+        elif total_operator_us <= 0:
+            warnings_out.append("No operator duration metrics were recorded.")
+        elif len(nodes) > 1 and slowest_nodes and slowest_nodes[0].duration_us / total_operator_us >= 0.8:
+            warnings_out.append(f"Most operator time was spent in {slowest_nodes[0].name}.")
+
+        if warnings_out:
+            lines.extend(["", "Warnings:"])
+            lines.extend(f"- {warning}" for warning in warnings_out)
+
+        return "\n".join(lines)
 
     def _plan_to_mermaid_string(self) -> str:
         """Convert query_plan dict to mermaid diagram string (bottom-up)."""

--- a/daft/execution/metadata.py
+++ b/daft/execution/metadata.py
@@ -193,7 +193,7 @@ class ExecutionMetadata:
             )
         return profile_nodes
 
-    def format_profile(self, top_n: int = 5) -> str:
+    def format_profile(self, top_n: int = 5, show_details: bool = False) -> str:
         """Return a concise query profile summary from execution metrics."""
         nodes = self._profile_nodes()
         # total_operator_us is the sum of duration_us across all nodes, which may be less than total query duration
@@ -217,16 +217,25 @@ class ExecutionMetadata:
 
         if slowest_nodes:
             for index, node in enumerate(slowest_nodes, start=1):
-                details = [
-                    _format_duration(node.duration_us),
-                    f"rows in: {_format_count(node.rows_in)}",
-                    f"rows out: {_format_count(node.rows_out)}",
-                ]
-                if node.bytes_read is not None:
-                    details.append(f"bytes read: {_format_bytes(node.bytes_read)}")
-                elif node.bytes_in is not None or node.bytes_out is not None:
-                    details.append(f"bytes in/out: {_format_bytes(node.bytes_in)} / {_format_bytes(node.bytes_out)}")
-                lines.append(f"{index}. {node.name} ({node.node_type}) - {', '.join(details)}")
+                title = f"{index}. {node.name} ({node.node_type})"
+                duration = _format_duration(node.duration_us)
+                if show_details:
+                    details = [
+                        duration,
+                        f"rows in: {_format_count(node.rows_in)}",
+                        f"rows out: {_format_count(node.rows_out)}",
+                    ]
+
+                    if node.bytes_read is not None:
+                        details.append(f"bytes read: {_format_bytes(node.bytes_read)}")
+                    elif node.bytes_in is not None or node.bytes_out is not None:
+                        details.append(
+                            f"bytes in/out: {_format_bytes(node.bytes_in)} / {_format_bytes(node.bytes_out)}"
+                        )
+
+                    lines.append(f"{title} - {', '.join(details)}")
+                else:
+                    lines.append(f"{title} - {duration}")
         else:
             lines.append("No operator metrics were recorded.")
 

--- a/daft/execution/metadata.py
+++ b/daft/execution/metadata.py
@@ -83,6 +83,9 @@ def _metric_duration_us(stats: dict[str, Metric]) -> float:
 
     value = float(metric["value"])
     unit = metric["unit"]
+    if unit is None:
+        raise ValueError("Duration metric unit is missing")
+
     if unit in ("us", "µs"):
         return value
     if unit == "ms":
@@ -236,8 +239,6 @@ class ExecutionMetadata:
                     lines.append(f"{title} - {', '.join(details)}")
                 else:
                     lines.append(f"{title} - {duration}")
-        else:
-            lines.append("No operator metrics were recorded.")
 
         warnings_out = []
         if not nodes:

--- a/src/daft-distributed/src/pipeline_node/random_shuffle.rs
+++ b/src/daft-distributed/src/pipeline_node/random_shuffle.rs
@@ -5,8 +5,8 @@ use std::{
 
 use common_error::DaftResult;
 use common_metrics::ops::{NodeCategory, NodeType};
-use daft_dsl::expr::bound_expr::BoundExpr;
-use daft_functions::random::random_int_expr;
+use daft_dsl::{ExprRef, expr::bound_expr::BoundExpr, lit, resolved_col};
+use daft_functions::{hash::hash as hash_expr, random::random_int_expr};
 use daft_local_plan::{LocalNodeContext, LocalPhysicalPlan};
 use daft_logical_plan::{partitioning::RandomShuffleConfig, stats::StatsState};
 use daft_schema::schema::SchemaRef;
@@ -72,6 +72,21 @@ impl RandomShuffleNode {
         }
     }
 
+    fn sort_by_exprs(&self, seed: Option<u64>) -> Vec<ExprRef> {
+        if let Some(seed) = seed {
+            let mut columns = self.config.schema.field_names().map(resolved_col);
+            if let Some(first) = columns.next() {
+                let mut row_hash = hash_expr(first, Some(lit(seed)), None);
+                for column in columns {
+                    row_hash = hash_expr(column, Some(row_hash), None);
+                }
+                return vec![row_hash];
+            }
+        }
+
+        vec![random_int_expr(i64::MIN, i64::MAX, seed)]
+    }
+
     fn local_sort_with_random_key(
         &self,
         partition_group: Vec<MaterializedOutput>,
@@ -89,10 +104,8 @@ impl RandomShuffleNode {
             hasher.finish()
         });
 
-        let sort_by = BoundExpr::bind_all(
-            &[random_int_expr(i64::MIN, i64::MAX, partition_seed)],
-            &self.config.schema,
-        )?;
+        let sort_by =
+            BoundExpr::bind_all(&self.sort_by_exprs(partition_seed), &self.config.schema)?;
         let node_id = self.node_id();
         Ok(self
             .shuffle_backend

--- a/src/daft-functions/src/hash.rs
+++ b/src/daft-functions/src/hash.rs
@@ -1,6 +1,10 @@
+use std::sync::Arc;
+
 use common_error::{DaftError, DaftResult};
 use daft_core::prelude::*;
-use daft_dsl::functions::{prelude::*, scalar::ScalarFn};
+use daft_dsl::functions::{
+    BuiltinScalarFn, BuiltinScalarFnVariant, FunctionArg, prelude::*, scalar::ScalarFn,
+};
 use daft_hash::HashFunctionKind;
 use serde::{Deserialize, Serialize};
 
@@ -105,15 +109,19 @@ impl ScalarUDF for HashFunction {
 
 #[must_use]
 pub fn hash(input: ExprRef, seed: Option<ExprRef>, hash_function: Option<ExprRef>) -> ExprRef {
-    let mut inputs = vec![input];
+    let mut inputs = vec![FunctionArg::unnamed(input)];
     if let Some(seed) = seed {
-        inputs.push(seed);
+        inputs.push(FunctionArg::named("seed", seed));
     }
     if let Some(hash_function) = hash_function {
-        inputs.push(hash_function);
+        inputs.push(FunctionArg::named("hash_function", hash_function));
     }
 
-    ScalarFn::builtin(HashFunction, inputs).into()
+    ScalarFn::Builtin(BuiltinScalarFn {
+        func: BuiltinScalarFnVariant::Sync(Arc::new(HashFunction)),
+        inputs: FunctionArgs::new_unchecked(inputs),
+    })
+    .into()
 }
 
 fn hash_with_seed(

--- a/src/daft-local-plan/src/translate.rs
+++ b/src/daft-local-plan/src/translate.rs
@@ -1,16 +1,17 @@
 use std::collections::HashMap;
 
 use common_error::{DaftError, DaftResult};
-use daft_core::join::JoinStrategy;
+use daft_core::{join::JoinStrategy, prelude::SchemaRef};
 use daft_dsl::{
+    ExprRef,
     expr::{
         agg::extract_agg_expr,
         bound_expr::{BoundAggExpr, BoundExpr, BoundVLLMExpr, BoundWindowExpr},
     },
     join::normalize_join_keys,
-    resolved_col, window_to_agg_exprs,
+    lit, resolved_col, window_to_agg_exprs,
 };
-use daft_functions::random::random_int_expr;
+use daft_functions::{hash::hash as hash_expr, random::random_int_expr};
 use daft_logical_plan::{JoinType, LogicalPlan, LogicalPlanRef, SourceInfo, stats::StatsState};
 use daft_micropartition::MicroPartitionRef;
 use daft_scan::{ScanState, ScanTaskRef};
@@ -24,6 +25,21 @@ pub fn translate(
 ) -> DaftResult<(LocalPhysicalPlanRef, HashMap<SourceId, Input>)> {
     let mut source_counter = SourceIdCounter::default();
     translate_helper(plan, &mut source_counter, psets)
+}
+
+fn shuffle_sort_by(schema: &SchemaRef, seed: Option<u64>) -> Vec<ExprRef> {
+    if let Some(seed) = seed {
+        let mut columns = schema.field_names().map(resolved_col);
+        if let Some(first) = columns.next() {
+            let mut row_hash = hash_expr(first, Some(lit(seed)), None);
+            for column in columns {
+                row_hash = hash_expr(column, Some(row_hash), None);
+            }
+            return vec![row_hash];
+        }
+    }
+
+    vec![random_int_expr(i64::MIN, i64::MAX, seed)]
 }
 
 fn translate_helper(
@@ -392,7 +408,7 @@ fn translate_helper(
         LogicalPlan::Shuffle(shuffle) => {
             let (input_plan, inputs) = translate_helper(&shuffle.input, source_counter, psets)?;
             let sort_by = BoundExpr::bind_all(
-                &[random_int_expr(i64::MIN, i64::MAX, shuffle.seed)],
+                &shuffle_sort_by(input_plan.schema(), shuffle.seed),
                 input_plan.schema(),
             )?;
             Ok((

--- a/src/daft-logical-plan/src/ops/shuffle.rs
+++ b/src/daft-logical-plan/src/ops/shuffle.rs
@@ -54,9 +54,7 @@ impl Shuffle {
     }
 
     pub fn multiline_display(&self) -> Vec<String> {
-        let mut res = vec![String::from(
-            "Shuffle: random row order (via random_int + sort)",
-        )];
+        let mut res = vec![String::from("Shuffle: random row order")];
         res.push(format!("Seed = {:?}", self.seed));
         if let StatsState::Materialized(stats) = &self.stats_state {
             res.push(format!("Stats = {}", stats));

--- a/tests/dataframe/test_metrics.py
+++ b/tests/dataframe/test_metrics.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import io
+
+import pytest
+
 import daft
 
 
@@ -11,3 +15,33 @@ def test_collect_populates_metrics() -> None:
     assert df.metrics is not None
     metrics_rows = df.metrics.to_pylist()
     assert metrics_rows
+
+
+def test_profile_requires_materialized_dataframe() -> None:
+    df = daft.from_pydict({"id": [1, 2, 3]}).select("id")
+
+    with pytest.raises(ValueError, match="Profile is not available until the DataFrame has been materialized"):
+        df.profile()
+
+
+def test_profile_prints_query_summary() -> None:
+    df = daft.from_pydict({"id": [1, 2, 3], "value": [10, 20, 30]}).select("id", "value").limit(2).collect()
+
+    output = io.StringIO()
+    df.profile(top_n=1, file=output)
+    text = output.getvalue()
+
+    assert "== Query Profile ==" in text
+    assert "Query ID:" in text
+    assert "Total operator time:" in text
+    assert "Rows read:" in text
+    assert "Bytes scanned:" in text
+    assert "Slowest operators:" in text
+    assert "1. " in text
+
+
+def test_profile_validates_top_n() -> None:
+    df = daft.from_pydict({"id": [1, 2, 3]})
+
+    with pytest.raises(ValueError, match="top_n must be at least 1"):
+        df.profile(top_n=0)


### PR DESCRIPTION
## Changes Made

Add `DataFrame.profile()` to print a concise execution profile summary for a materialized DataFrame.

This method exposes execution metrics collected during DataFrame materialization and helps users quickly inspect the slowest operators without manually digging into internal metadata.

`show_details=False`
<img width="325" height="198" alt="image" src="https://github.com/user-attachments/assets/f0beaa72-1cfe-4b52-9a3e-c6e5519977ed" />

`show_details=True`
<img width="629" height="201" alt="image" src="https://github.com/user-attachments/assets/f4393cf7-d5d1-426f-9457-82ccf5bf242d" />


## Related Issues

Closes: #7030 
