### PR TITLE
perf: update jemalloc 5.3.0 → 5.3.1 to fix muzzy decay performance bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7968,9 +7968,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-ctl"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "661f1f6a57b3a36dc9174a2c10f19513b4866816e13425d3e418b11cc37bc24c"
+checksum = "3a184c43b8ab2f41df2733b55556e3f5f632f4aeaa205b1bb018f574b7f5f142"
 dependencies = [
  "libc",
  "paste",
@@ -7979,9 +7979,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-sys"
-version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+version = "0.7.1+5.3.1-0-g81034ce1f1373e37dc865038e1bc8eeecf559ce8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+checksum = "1a2825c78386b4ae0314074867860ba9577875de945f05992c38815cbec327f0"
 dependencies = [
  "cc",
  "libc",
@@ -7989,9 +7989,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemallocator"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+checksum = "249f09e49ab1609436f34c776e84231bead18d6a955f119f939bdc1d847561bd"
 dependencies = [
  "libc",
  "tikv-jemalloc-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,8 +174,8 @@ debug = true
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 libc = {workspace = true}
-tikv-jemalloc-ctl = {version = "0.6.0", features = ["stats"]}
-tikv-jemallocator = {version = "0.6.0", features = [
+tikv-jemalloc-ctl = {version = "0.7.0", features = ["stats"]}
+tikv-jemallocator = {version = "0.7.0", features = [
   "disable_initial_exec_tls"
 ]}
 

--- a/src/daft-local-execution/Cargo.toml
+++ b/src/daft-local-execution/Cargo.toml
@@ -62,7 +62,7 @@ dashmap = {workspace = true}
 sysinfo = {workspace = true}
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-tikv-jemalloc-ctl = {version = "0.6.0", features = ["stats"]}
+tikv-jemalloc-ctl = {version = "0.7.0", features = ["stats"]}
 
 [features]
 python = [


### PR DESCRIPTION
## Summary

- Bumps `tikv-jemallocator` from 0.6.x to 0.7.0 and `tikv-jemalloc-ctl` from 0.6.x to 0.7.0 (underlying jemalloc 5.3.0 → 5.3.1)
- jemalloc 5.3.0 has a bug where `muzzy_decay_ms` values other than `-1` cause severe performance degradation (up to 7x slower in Polars benchmarks)
- Daft sets `muzzy_decay_ms:1000` on Linux and `muzzy_decay_ms:0` on macOS — both hit this bug

## Context

Polars discovered and fixed this in [pola-rs/polars#27797](https://github.com/pola-rs/polars/pull/27797). The jemalloc 5.3.1 release fixes the muzzy decay codepath so non-`-1` values no longer tank performance.

## Test plan

- [ ] CI passes on Linux (where `muzzy_decay_ms:1000` was actively hitting the bug)
- [ ] Local macOS build succeeds (where `muzzy_decay_ms:0` was hitting the bug)