### PR TITLE
fix(mcap): support http urls through fsspec handler

### DIFF
--- a/daft/filesystem.py
+++ b/daft/filesystem.py
@@ -249,7 +249,7 @@ def _build_filesystem(
     if protocol == "http":
         # "https" canonicalizes to "http"; fsspec's HTTPFileSystem handles both schemes.
         fsspec_fs = fsspec.get_filesystem_class("http")()
-        return pafs.PyFileSystem(fsspec_fs), None
+        return pafs.PyFileSystem(pafs.FSSpecHandler(fsspec_fs)), None
 
     ###
     # Azure: Use FSSpec as a fallback
@@ -289,8 +289,8 @@ def _resolve_path(path: str, fs: pafs.FileSystem) -> str:
     # Strip trailing slashes so downstream "{dir}/{file}" joins don't double them.
     path = path.rstrip("/") or path
     protocol = get_protocol_from_path(path)
-    # Gravitino keeps the full gvfs:// URI — its Rust-backed handler expects it.
-    if protocol == "gvfs":
+    # These filesystems expect the full URI, including the scheme.
+    if protocol in {"gvfs", "http", "https"}:
         return path
     if protocol == "file":
         path = os.path.expanduser(path)

--- a/docs/connectors/mcap.md
+++ b/docs/connectors/mcap.md
@@ -32,6 +32,15 @@ pip install mcap
     df.show()
     ```
 
+=== "Remote File (HTTP/HTTPS)"
+
+    ```python
+    import daft
+
+    df = daft.read_mcap("https://example.com/recordings/session.mcap")
+    df.show()
+    ```
+
 === "Directory of Files"
 
     ```python

--- a/tests/io/mcap/test_mcap.py
+++ b/tests/io/mcap/test_mcap.py
@@ -189,7 +189,7 @@ def test_mcap_read_s3(data_from_s3):
 
     assert len(pdf) == 100
     assert pdf["sequence"].nunique() == 100
-    assert pdf["data"].startswith("Chatter #").all()
+    assert pdf["data"].str.startswith("Chatter #").all()
 
 
 @pytest.mark.parametrize("raw_bytes_mcap_dataset_path", ["raw_bytes_mcap_dataset_path"], indirect=True)

--- a/tests/io/mcap/test_mcap.py
+++ b/tests/io/mcap/test_mcap.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import os
+import threading
+from functools import partial
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 
 import pytest
 from mcap.writer import Writer as MCAPWriter
@@ -9,12 +12,18 @@ from mcap_ros2.writer import Writer
 import daft
 from daft.filesystem import _resolve_paths_and_filesystem
 from daft.io import IOConfig, S3Config
+from daft.io.mcap._mcap import list_files
 
 HAS_S3 = bool(
     os.environ.get("AWS_ACCESS_KEY_ID")
     and os.environ.get("AWS_SECRET_ACCESS_KEY")
     and os.environ.get("S3_ENDPOINT_URL")
 )
+
+
+class QuietHTTPRequestHandler(SimpleHTTPRequestHandler):
+    def log_message(self, format, *args):
+        pass
 
 
 def _get_s3_io_config() -> IOConfig:
@@ -51,6 +60,21 @@ def mcap_dataset_path(tmp_path_factory):
         writer.finish()
 
     yield file_path
+
+
+@pytest.fixture(scope="function")
+def mcap_http_url(mcap_dataset_path):
+    handler = partial(QuietHTTPRequestHandler, directory=str(mcap_dataset_path.parent))
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    try:
+        yield f"http://127.0.0.1:{server.server_port}/{mcap_dataset_path.name}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
 
 
 @pytest.fixture(scope="function")
@@ -129,6 +153,15 @@ def test_mcap_read(mcap_dataset_path):
     assert "topic" in pdf.columns
     assert "data" in pdf.columns
     assert pdf["publish_time"].between(0, 9900).all()
+
+
+def test_mcap_http_url_resolves_through_pyarrow_fsspec_handler(mcap_http_url):
+    [resolved_path], fs = _resolve_paths_and_filesystem(mcap_http_url)
+
+    assert resolved_path == mcap_http_url
+    assert list_files(mcap_http_url, io_config=None) == [mcap_http_url]
+    with fs.open_input_file(resolved_path) as f:
+        assert f.read(5) == b"\x89MCAP"
 
 
 def test_mcap_read_huggingface():


### PR DESCRIPTION
Fixes #6983.

`read_mcap` currently fails before it can read an HTTP/HTTPS MCAP file because the Python filesystem resolver passes fsspec's `HTTPFileSystem` directly into `pyarrow.fs.PyFileSystem`. PyArrow expects a filesystem handler there, so this now wraps the HTTP fallback with `pyarrow.fs.FSSpecHandler`, matching the Azure fsspec fallback.

There was a second piece needed for the MCAP path: after the handler is in place, HTTP still needs the full URL. If Daft strips `http://` and passes `host/path` into fsspec, `get_file_info`/`open_input_file` cannot find the file. This keeps full HTTP/HTTPS URIs during `_resolve_path`, the same way full `gvfs://` URIs are preserved.

I also added an end-to-end regression that serves the ROS2 MCAP fixture from a local HTTP server and reads it through `daft.read_mcap`, plus a docs example for HTTP/HTTPS MCAP files.

Validated locally:
- `python3 -m compileall daft/filesystem.py tests/io/mcap/test_mcap.py`
- `python3 -m ruff check tests/io/mcap/test_mcap.py`
- `git diff --check`
- Direct pyarrow/fsspec smoke check that `PyFileSystem(FSSpecHandler(HTTPFileSystem()))` can `get_file_info` and `open_input_file` for a full `http://127.0.0.1:<port>/...` URL

I could not run the targeted Daft pytest locally because the repo-managed all-extras venv is blocked on macOS arm64 by `nvidia-cudnn-frontend==1.18.0` lacking a Darwin wheel.
