### PR TITLE
refactor(dashboard): unify query runner metadata into RunnerInfo

### DIFF
--- a/daft/daft/__init__.pyi
+++ b/daft/daft/__init__.pyi
@@ -2612,22 +2612,26 @@ class PyQueryMetadata:
     output_schema: PySchema
     unoptimized_plan: str
     runner: str
-    ray_dashboard_url: str | None
+    dashboard_url: str | None
     entrypoint: str | None
     python_version: str | None
     daft_version: str | None
-    ray_version: str | None
+    runner_version: str | None
+    distributed: bool
+    task_events_enabled: bool | None
 
     def __init__(
         self,
         output_schema: PySchema,
         unoptimized_plan: str,
         runner: str,
-        ray_dashboard_url: str | None = None,
+        dashboard_url: str | None = None,
         entrypoint: str | None = None,
         python_version: str | None = None,
         daft_version: str | None = None,
-        ray_version: str | None = None,
+        runner_version: str | None = None,
+        distributed: bool = False,
+        task_events_enabled: bool | None = None,
     ) -> None: ...
 
 class PyQueryResult:

--- a/daft/runners/native_runner.py
+++ b/daft/runners/native_runner.py
@@ -109,7 +109,6 @@ class NativeRunner(Runner[MicroPartition]):
                     output_schema._schema,
                     builder.repr_json(),
                     "Native (Swordfish)",
-                    ray_dashboard_url=None,
                     entrypoint=entrypoint,
                     python_version=python_version,
                     daft_version=daft_version,

--- a/daft/runners/ray_runner.py
+++ b/daft/runners/ray_runner.py
@@ -602,6 +602,8 @@ class RayRunner(Runner[ray.ObjectRef]):
 
         entrypoint = "python " + " ".join(sys.argv)
         dashboard_url = os.environ.get("DAFT_DASHBOARD_URL")
+        task_events_raw = os.environ.get("DAFT_TASK_EVENTS_ENABLED")
+        task_events_enabled = task_events_raw.strip().lower() in ("1", "true") if task_events_raw is not None else False
 
         # Log Dashboard URL if configured
         if dashboard_url:
@@ -637,11 +639,13 @@ class RayRunner(Runner[ray.ObjectRef]):
                         output_schema._schema,
                         unoptimized_plan_json,
                         "Ray (Flotilla)",
-                        ray_dashboard_url,
-                        entrypoint,
+                        dashboard_url=ray_dashboard_url,
+                        entrypoint=entrypoint,
                         python_version=platform.python_version(),
                         daft_version=daft.get_version(),
-                        ray_version=ray.__version__,
+                        runner_version=ray.__version__,
+                        distributed=True,
+                        task_events_enabled=task_events_enabled,
                     ),
                 )
                 ctx._notify_optimization_start(query_id)

--- a/daft/subscribers/event_log.py
+++ b/daft/subscribers/event_log.py
@@ -195,8 +195,8 @@ class EventLogSubscriber(Subscriber):
             "daft_version": event.metadata.daft_version,
             "python_version": event.metadata.python_version,
         }
-        if event.metadata.ray_version is not None:
-            payload["runner_version"] = event.metadata.ray_version
+        if event.metadata.runner_version is not None:
+            payload["runner_version"] = event.metadata.runner_version
 
         self._write_event(
             event.query_id,

--- a/src/daft-context/src/python.rs
+++ b/src/daft-context/src/python.rs
@@ -7,7 +7,7 @@ use pyo3::prelude::*;
 
 use crate::{
     DaftContext, subscribers,
-    subscribers::{QueryMetadata, QueryResult},
+    subscribers::{QueryMetadata, QueryResult, RunnerInfo},
 };
 
 #[pyclass(frozen, from_py_object)]
@@ -17,27 +17,33 @@ pub struct PyQueryMetadata(pub(crate) Arc<QueryMetadata>);
 #[pymethods]
 impl PyQueryMetadata {
     #[new]
-    #[pyo3(signature = (output_schema, unoptimized_plan, runner, ray_dashboard_url=None, entrypoint=None, python_version=None, daft_version=None, ray_version=None))]
+    #[pyo3(signature = (output_schema, unoptimized_plan, runner, dashboard_url=None, entrypoint=None, python_version=None, daft_version=None, runner_version=None, distributed=false, task_events_enabled=None))]
     #[allow(clippy::too_many_arguments)]
     fn __new__(
         output_schema: PySchema,
         unoptimized_plan: &str,
         runner: &str,
-        ray_dashboard_url: Option<String>,
+        dashboard_url: Option<String>,
         entrypoint: Option<String>,
         python_version: Option<String>,
         daft_version: Option<String>,
-        ray_version: Option<String>,
+        runner_version: Option<String>,
+        distributed: bool,
+        task_events_enabled: Option<bool>,
     ) -> Self {
         Self(Arc::new(QueryMetadata {
             output_schema: output_schema.into(),
             unoptimized_plan: unoptimized_plan.into(),
-            runner: runner.into(),
-            ray_dashboard_url,
+            runner: RunnerInfo {
+                name: runner.to_string(),
+                version: runner_version,
+                distributed,
+                dashboard_url,
+                task_events_enabled,
+            },
             entrypoint,
             python_version,
             daft_version,
-            ray_version,
         }))
     }
     #[getter]
@@ -50,11 +56,11 @@ impl PyQueryMetadata {
     }
     #[getter]
     pub fn runner(&self) -> String {
-        self.0.runner.clone()
+        self.0.runner.name.clone()
     }
     #[getter]
-    pub fn ray_dashboard_url(&self) -> Option<String> {
-        self.0.ray_dashboard_url.clone()
+    pub fn dashboard_url(&self) -> Option<String> {
+        self.0.runner.dashboard_url.clone()
     }
     #[getter]
     pub fn entrypoint(&self) -> Option<String> {
@@ -69,8 +75,16 @@ impl PyQueryMetadata {
         self.0.daft_version.clone()
     }
     #[getter]
-    pub fn ray_version(&self) -> Option<String> {
-        self.0.ray_version.clone()
+    pub fn runner_version(&self) -> Option<String> {
+        self.0.runner.version.clone()
+    }
+    #[getter]
+    pub fn distributed(&self) -> bool {
+        self.0.runner.distributed
+    }
+    #[getter]
+    pub fn task_events_enabled(&self) -> Option<bool> {
+        self.0.runner.task_events_enabled
     }
 }
 

--- a/src/daft-context/src/subscribers/dashboard.rs
+++ b/src/daft-context/src/subscribers/dashboard.rs
@@ -253,19 +253,22 @@ impl DashboardSubscriber {
         if self.is_worker() {
             return Ok(());
         }
-
         self.enqueue_json(
             format!("engine/query/{}/start", query_id),
             "query_start",
             &daft_dashboard::engine::StartQueryArgs {
                 start_sec: secs_from_epoch(),
                 unoptimized_plan: metadata.unoptimized_plan.clone(),
-                runner: Some(metadata.runner.clone()),
-                ray_dashboard_url: metadata.ray_dashboard_url.clone(),
+                runner: daft_dashboard::engine::RunnerInfo {
+                    name: metadata.runner.name.clone(),
+                    version: metadata.runner.version.clone(),
+                    distributed: metadata.runner.distributed,
+                    dashboard_url: metadata.runner.dashboard_url.clone(),
+                    task_events_enabled: metadata.runner.task_events_enabled,
+                },
                 entrypoint: metadata.entrypoint.clone(),
                 python_version: metadata.python_version.clone(),
                 daft_version: metadata.daft_version.clone(),
-                ray_version: metadata.ray_version.clone(),
             },
         );
         Ok(())

--- a/src/daft-context/src/subscribers/debug.rs
+++ b/src/daft-context/src/subscribers/debug.rs
@@ -23,7 +23,7 @@ impl DebugSubscriber {
         eprintln!(
             "query_start query_id={} runner={} unoptimized_plan=\n{}",
             event.header.query_id,
-            event.metadata.runner,
+            event.metadata.runner.name,
             event.metadata.unoptimized_plan.as_ref()
         );
         Ok(())

--- a/src/daft-context/src/subscribers/events.rs
+++ b/src/daft-context/src/subscribers/events.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashMap, sync::Arc};
 
+use common_daft_config::DaftExecutionConfig;
 use common_metrics::{
     NodeID, QueryID, QueryPlan, StatSnapshot, Stats,
     ops::{NodeCategory, NodeInfo, NodeType},
@@ -74,6 +75,67 @@ impl From<&NodeInfo> for OperatorMeta {
             origin_node_id: info.node_origin_id,
             node_phase: info.node_phase.clone(),
             context: info.context.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ExecutionConfig {
+    pub default_morsel_size: usize,
+    pub scantask_max_parallel: usize,
+    pub min_cpu_per_task: f64,
+
+    pub enable_scan_task_split_and_merge: bool,
+    pub scan_tasks_min_size_bytes: usize,
+    pub scan_tasks_max_size_bytes: usize,
+    pub max_sources_per_scan_task: usize,
+    pub parquet_split_row_groups_max_files: usize,
+
+    pub broadcast_join_size_bytes_threshold: usize,
+    pub hash_join_partition_size_leniency: f64,
+
+    pub shuffle_algorithm: String,
+    pub shuffle_aggregation_default_partitions: usize,
+    pub pre_shuffle_merge_threshold: usize,
+    pub pre_shuffle_merge_partition_threshold: usize,
+
+    pub partial_aggregation_threshold: usize,
+    pub high_cardinality_aggregation_threshold: f64,
+
+    pub maintain_order: bool,
+
+    pub enable_dynamic_batching: bool,
+    pub dynamic_batching_strategy: String,
+}
+
+impl From<&DaftExecutionConfig> for ExecutionConfig {
+    fn from(config: &DaftExecutionConfig) -> Self {
+        Self {
+            default_morsel_size: config.default_morsel_size.get(),
+            scantask_max_parallel: config.scantask_max_parallel,
+            min_cpu_per_task: config.min_cpu_per_task,
+
+            enable_scan_task_split_and_merge: config.enable_scan_task_split_and_merge,
+            scan_tasks_min_size_bytes: config.scan_tasks_min_size_bytes,
+            scan_tasks_max_size_bytes: config.scan_tasks_max_size_bytes,
+            max_sources_per_scan_task: config.max_sources_per_scan_task,
+            parquet_split_row_groups_max_files: config.parquet_split_row_groups_max_files,
+
+            broadcast_join_size_bytes_threshold: config.broadcast_join_size_bytes_threshold,
+            hash_join_partition_size_leniency: config.hash_join_partition_size_leniency,
+
+            shuffle_algorithm: config.shuffle_algorithm.clone(),
+            shuffle_aggregation_default_partitions: config.shuffle_aggregation_default_partitions,
+            pre_shuffle_merge_threshold: config.pre_shuffle_merge_threshold,
+            pre_shuffle_merge_partition_threshold: config.pre_shuffle_merge_partition_threshold,
+
+            partial_aggregation_threshold: config.partial_aggregation_threshold,
+            high_cardinality_aggregation_threshold: config.high_cardinality_aggregation_threshold,
+
+            maintain_order: config.maintain_order,
+
+            enable_dynamic_batching: config.enable_dynamic_batching,
+            dynamic_batching_strategy: config.dynamic_batching_strategy.clone(),
         }
     }
 }
@@ -169,6 +231,7 @@ pub struct OptimizationCompleteEvent {
 pub struct ExecStartEvent {
     pub header: EventHeader,
     pub physical_plan: QueryPlan,
+    // pub execution_config: Option<ExecutionConfig>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/daft-context/src/subscribers/events.rs
+++ b/src/daft-context/src/subscribers/events.rs
@@ -1,6 +1,5 @@
 use std::{collections::HashMap, sync::Arc};
 
-use common_daft_config::DaftExecutionConfig;
 use common_metrics::{
     NodeID, QueryID, QueryPlan, StatSnapshot, Stats,
     ops::{NodeCategory, NodeInfo, NodeType},
@@ -75,67 +74,6 @@ impl From<&NodeInfo> for OperatorMeta {
             origin_node_id: info.node_origin_id,
             node_phase: info.node_phase.clone(),
             context: info.context.clone(),
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct ExecutionConfig {
-    pub default_morsel_size: usize,
-    pub scantask_max_parallel: usize,
-    pub min_cpu_per_task: f64,
-
-    pub enable_scan_task_split_and_merge: bool,
-    pub scan_tasks_min_size_bytes: usize,
-    pub scan_tasks_max_size_bytes: usize,
-    pub max_sources_per_scan_task: usize,
-    pub parquet_split_row_groups_max_files: usize,
-
-    pub broadcast_join_size_bytes_threshold: usize,
-    pub hash_join_partition_size_leniency: f64,
-
-    pub shuffle_algorithm: String,
-    pub shuffle_aggregation_default_partitions: usize,
-    pub pre_shuffle_merge_threshold: usize,
-    pub pre_shuffle_merge_partition_threshold: usize,
-
-    pub partial_aggregation_threshold: usize,
-    pub high_cardinality_aggregation_threshold: f64,
-
-    pub maintain_order: bool,
-
-    pub enable_dynamic_batching: bool,
-    pub dynamic_batching_strategy: String,
-}
-
-impl From<&DaftExecutionConfig> for ExecutionConfig {
-    fn from(config: &DaftExecutionConfig) -> Self {
-        Self {
-            default_morsel_size: config.default_morsel_size.get(),
-            scantask_max_parallel: config.scantask_max_parallel,
-            min_cpu_per_task: config.min_cpu_per_task,
-
-            enable_scan_task_split_and_merge: config.enable_scan_task_split_and_merge,
-            scan_tasks_min_size_bytes: config.scan_tasks_min_size_bytes,
-            scan_tasks_max_size_bytes: config.scan_tasks_max_size_bytes,
-            max_sources_per_scan_task: config.max_sources_per_scan_task,
-            parquet_split_row_groups_max_files: config.parquet_split_row_groups_max_files,
-
-            broadcast_join_size_bytes_threshold: config.broadcast_join_size_bytes_threshold,
-            hash_join_partition_size_leniency: config.hash_join_partition_size_leniency,
-
-            shuffle_algorithm: config.shuffle_algorithm.clone(),
-            shuffle_aggregation_default_partitions: config.shuffle_aggregation_default_partitions,
-            pre_shuffle_merge_threshold: config.pre_shuffle_merge_threshold,
-            pre_shuffle_merge_partition_threshold: config.pre_shuffle_merge_partition_threshold,
-
-            partial_aggregation_threshold: config.partial_aggregation_threshold,
-            high_cardinality_aggregation_threshold: config.high_cardinality_aggregation_threshold,
-
-            maintain_order: config.maintain_order,
-
-            enable_dynamic_batching: config.enable_dynamic_batching,
-            dynamic_batching_strategy: config.dynamic_batching_strategy.clone(),
         }
     }
 }
@@ -231,7 +169,6 @@ pub struct OptimizationCompleteEvent {
 pub struct ExecStartEvent {
     pub header: EventHeader,
     pub physical_plan: QueryPlan,
-    // pub execution_config: Option<ExecutionConfig>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/daft-context/src/subscribers/mod.rs
+++ b/src/daft-context/src/subscribers/mod.rs
@@ -1,5 +1,6 @@
 pub mod dashboard;
 mod debug;
+// pub mod eventlog;
 pub mod events;
 #[cfg(feature = "python")]
 pub mod python;
@@ -17,16 +18,23 @@ pub use events::Event;
 
 use crate::subscribers::events::EventHeader;
 
+#[derive(Debug, Clone)]
+pub struct RunnerInfo {
+    pub name: String,
+    pub version: Option<String>,
+    pub distributed: bool,
+    pub dashboard_url: Option<String>,
+    pub task_events_enabled: Option<bool>,
+}
+
 #[derive(Debug)]
 pub struct QueryMetadata {
     pub output_schema: SchemaRef,
     pub unoptimized_plan: QueryPlan,
-    pub runner: String,
-    pub ray_dashboard_url: Option<String>,
+    pub runner: RunnerInfo,
     pub entrypoint: Option<String>,
     pub python_version: Option<String>,
     pub daft_version: Option<String>,
-    pub ray_version: Option<String>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/daft-context/src/subscribers/mod.rs
+++ b/src/daft-context/src/subscribers/mod.rs
@@ -1,6 +1,5 @@
 pub mod dashboard;
 mod debug;
-// pub mod eventlog;
 pub mod events;
 #[cfg(feature = "python")]
 pub mod python;

--- a/src/daft-dashboard/frontend/src/app/queries/page.tsx
+++ b/src/daft-dashboard/frontend/src/app/queries/page.tsx
@@ -116,33 +116,30 @@ const columns = [
     cell: info => toHumanReadableDate(info.getValue()),
     sortingFn: "basic",
   }),
-  columnHelper.accessor("runner", {
+  columnHelper.accessor(row => row.runner.name, {
+    id: "runner",
     header: "Engine",
     cell: info => getEngineName(info.getValue()),
     sortingFn: "alphanumeric",
   }),
-  // @ts-ignore
-  columnHelper.accessor("ray_dashboard_url", {
-    header: "Ray UI",
+  columnHelper.display({
+    id: "dashboard_url",
+    header: "Dashboard",
     cell: info => {
-      let url = info.getValue();
-      if (url) {
-        if (!url.startsWith("http://") && !url.startsWith("https://")) {
-          url = "http://" + url;
-        }
-        return (
-          <a
-            href={url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center gap-1 text-blue-500 hover:underline"
-            onClick={(e) => e.stopPropagation()}
-          >
-            Open Ray UI <ExternalLinkIcon className="h-4 w-4" />
-          </a>
-        );
-      }
-      return null;
+      const url = info.row.original.runner.dashboard_url;
+      if (!url) return null;
+      const href = url.startsWith("http://") || url.startsWith("https://") ? url : `http://${url}`;
+      return (
+        <a
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center gap-1 text-blue-500 hover:underline"
+          onClick={(e) => e.stopPropagation()}
+        >
+          Open Dashboard <ExternalLinkIcon className="h-4 w-4" />
+        </a>
+      );
     },
     enableSorting: false,
   })

--- a/src/daft-dashboard/frontend/src/app/query/page.tsx
+++ b/src/daft-dashboard/frontend/src/app/query/page.tsx
@@ -29,6 +29,7 @@ const MetaField = ({
   mono,
   title,
   align = "left",
+  wrap = false,
 }: {
   label: string;
   value: string;
@@ -36,6 +37,7 @@ const MetaField = ({
   mono?: boolean;
   title?: string;
   align?: "left" | "right";
+  wrap?: boolean;
 }) => (
   <div className={`min-w-0 ${align === "right" ? "text-right" : ""}`}>
     <p className={`${main.className} text-[10px] uppercase tracking-wider text-zinc-500 leading-none mb-1`}>
@@ -52,7 +54,7 @@ const MetaField = ({
       </a>
     ) : (
       <p
-        className={`${main.className} text-base ${mono ? "font-mono" : ""} text-zinc-100 truncate`}
+        className={`${main.className} text-base ${mono ? "font-mono" : ""} text-zinc-100 ${wrap ? "break-all" : "truncate"}`}
         title={title ?? value}
       >
         {value}
@@ -69,8 +71,7 @@ function QueryPageInner() {
   const debug = useMemo(() => searchParams.has("debug"), [searchParams]);
   const [query, setQuery] = useState<QueryInfo | null>(null);
 
-  const engine = query ? getEngineName(query.runner) : null;
-  const isFlotilla = engine === "Flotilla";
+  const canShowTasksPanel = query?.runner.distributed === true;
 
   // Tab + tasks-sidebar state is URL-driven so deep links survive reload.
   // - `tab`: active tab id
@@ -244,26 +245,26 @@ function QueryPageInner() {
           <div className="flex-1 px-6 py-3 grid grid-cols-4 gap-x-8 gap-y-3 content-center overflow-hidden">
             {/* Row 1 */}
             <MetaField label="Query ID" value={query.id} mono />
-            <MetaField label="Engine" value={getEngineName(query.runner)} mono />
+            <MetaField label="Engine" value={getEngineName(query.runner.name)} mono />
             <MetaField label="Start Time" value={toHumanReadableDate(query.start_sec)} mono />
             <MetaField label="End Time" value={end_sec ? toHumanReadableDate(end_sec) : "—"} mono align="right" />
 
             {/* Row 2 */}
-            <MetaField label="Entrypoint" value={query.entrypoint || "—"} mono title={query.entrypoint} />
+            <MetaField label="Entrypoint" value={query.entrypoint || "—"} mono title={query.entrypoint} wrap />
             <MetaField label="Daft Version" value={query.daft_version || "—"} mono />
-            {query.ray_dashboard_url ? (
+            {query.runner.dashboard_url ? (
               <MetaField
-                label="Ray Dashboard"
-                href={query.ray_dashboard_url.startsWith("http") ? query.ray_dashboard_url : `http://${query.ray_dashboard_url}`}
-                value="Open in Ray"
+                label="Dashboard"
+                href={query.runner.dashboard_url.startsWith("http") ? query.runner.dashboard_url : `http://${query.runner.dashboard_url}`}
+                value="Open Dashboard"
               />
             ) : (
               <div />
             )}
-            {(query.python_version || query.ray_version) ? (
+            {(query.python_version || query.runner.version) ? (
               <MetaField
                 label="Versions"
-                value={[query.python_version && `Python ${query.python_version}`, query.ray_version && `Ray ${query.ray_version}`].filter(Boolean).join(" | ")}
+                value={[query.python_version && `Python ${query.python_version}`, query.runner.version && `${query.runner.name} ${query.runner.version}`].filter(Boolean).join(" | ")}
                 mono
                 align="right"
               />
@@ -320,16 +321,17 @@ function QueryPageInner() {
                       exec_state={query.state as ExecutingState}
                       highlightedNodeId={nodeFilter}
                       hoveredNodeIds={hoveredNodeIds}
-                      onViewTasks={isFlotilla ? handleViewTasksForNode : undefined}
-                      tasksOpen={isFlotilla && tasksOpen}
-                      onOpenTasks={isFlotilla ? handleOpenTasks : undefined}
+                      onViewTasks={canShowTasksPanel ? handleViewTasksForNode : undefined}
+                      tasksOpen={canShowTasksPanel && tasksOpen}
+                      onOpenTasks={canShowTasksPanel ? handleOpenTasks : undefined}
                       queryStatus={query.state.status}
                     />
                   </div>
-                  {isFlotilla && tasksOpen && queryId && (
+                  {canShowTasksPanel && tasksOpen && queryId && (
                     <div className="w-1/2 min-w-[940px] max-w-[1200px] flex-shrink-0 border-l border-zinc-800 h-full">
                       <TasksSidebar
                         exec_state={query.state as ExecutingState}
+                        runner={query.runner}
                         nodeFilter={nodeFilter}
                         onClearFilter={handleClearNodeFilter}
                         onSelectNode={handleSelectNode}

--- a/src/daft-dashboard/frontend/src/app/query/page.tsx
+++ b/src/daft-dashboard/frontend/src/app/query/page.tsx
@@ -25,6 +25,7 @@ const TAB_TRIGGER_CLS = "rounded-none bg-transparent px-4 py-2.5 text-sm font-me
 const MetaField = ({
   label,
   value,
+  rows,
   href,
   mono,
   title,
@@ -32,7 +33,9 @@ const MetaField = ({
   wrap = false,
 }: {
   label: string;
-  value: string;
+  value?: string;
+  /** Stacked label→value lines; takes precedence over `value`. */
+  rows?: { label: string; value: string }[];
   href?: string;
   mono?: boolean;
   title?: string;
@@ -43,7 +46,20 @@ const MetaField = ({
     <p className={`${main.className} text-[10px] uppercase tracking-wider text-zinc-500 leading-none mb-1`}>
       {label}
     </p>
-    {href ? (
+    {rows ? (
+      <div className="space-y-0.5">
+        {rows.map((r) => (
+          <p
+            key={r.label}
+            className={`${main.className} text-sm ${mono ? "font-mono" : ""} text-zinc-100 truncate`}
+            title={`${r.label} ${r.value}`}
+          >
+            <span className="text-zinc-500">{r.label} </span>
+            {r.value}
+          </p>
+        ))}
+      </div>
+    ) : href ? (
       <a
         href={href}
         target="_blank"
@@ -264,9 +280,16 @@ function QueryPageInner() {
             {(query.python_version || query.runner.version) ? (
               <MetaField
                 label="Versions"
-                value={[query.python_version && `Python ${query.python_version}`, query.runner.version && `${query.runner.name} ${query.runner.version}`].filter(Boolean).join(" | ")}
-                mono
                 align="right"
+                mono
+                rows={[
+                  query.python_version && { label: "Python", value: query.python_version },
+                  query.runner.version && {
+                    // "Ray (Flotilla)" -> "Ray"; the Engine cell already shows "Flotilla".
+                    label: query.runner.name.split(" (")[0],
+                    value: query.runner.version,
+                  },
+                ].filter(Boolean) as { label: string; value: string }[]}
               />
             ) : (
               <div />

--- a/src/daft-dashboard/frontend/src/app/query/tasks-sidebar.tsx
+++ b/src/daft-dashboard/frontend/src/app/query/tasks-sidebar.tsx
@@ -3,7 +3,7 @@
 import { useMemo, useState } from "react";
 import { ChevronDown, ChevronRight, PanelRightClose, X } from "lucide-react";
 import { main } from "@/lib/utils";
-import { ExecutingState, OperatorStatus, TaskInfo, TaskSource } from "./types";
+import { RunnerInfo, ExecutingState, OperatorStatus, TaskInfo, TaskSource } from "./types";
 import {
   formatBytes,
   formatCount,
@@ -40,6 +40,7 @@ import {
  */
 export default function TasksSidebar({
   exec_state,
+  runner,
   nodeFilter,
   onClearFilter,
   onSelectNode,
@@ -47,6 +48,7 @@ export default function TasksSidebar({
   onClose,
 }: {
   exec_state: ExecutingState;
+  runner?: RunnerInfo;
   /** If set, only show rows whose `node_ids` contains this id. */
   nodeFilter: number | null;
   /** Called when the user clears the node filter. */
@@ -154,14 +156,25 @@ export default function TasksSidebar({
 
       <div className="flex-1 overflow-auto">
         {rows.length === 0 && activeTasks.length === 0 ? (
-          <div className="p-8 text-center">
-            <p className={`${main.className} text-zinc-400`}>
-              {nodeFilter != null
-                ? "No tasks for this filter."
-                : allRows.length === 0
-                  ? "No tasks reported yet."
-                  : "No tasks match."}
-            </p>
+          <div className="p-8 text-center space-y-2">
+            {nodeFilter != null ? (
+              <p className={`${main.className} text-zinc-400`}>No tasks for this filter.</p>
+            ) : allRows.length > 0 ? (
+              <p className={`${main.className} text-zinc-400`}>No tasks match.</p>
+            ) : runner?.task_events_enabled === false ? (
+              <>
+                <p className={`${main.className} text-zinc-400`}>No task events reported for this query.</p>
+                <p className={`${main.className} text-zinc-500 text-xs`}>
+                  Task reporting may be disabled. Set{" "}
+                  <code className="bg-zinc-800 px-1 rounded">DAFT_TASK_EVENTS_ENABLED=1</code>{" "}
+                  and rerun the query to see task-level details.
+                </p>
+              </>
+            ) : queryActive ? (
+              <p className={`${main.className} text-zinc-400`}>No tasks reported yet.</p>
+            ) : (
+              <p className={`${main.className} text-zinc-400`}>No task events were received for this query.</p>
+            )}
           </div>
         ) : (
           <>

--- a/src/daft-dashboard/frontend/src/app/query/types.ts
+++ b/src/daft-dashboard/frontend/src/app/query/types.ts
@@ -206,16 +206,22 @@ export type QueryState =
       marked_dead_sec: number;
     };
 
+export type RunnerInfo = {
+  name: string;
+  version?: string | null;
+  distributed: boolean;
+  dashboard_url?: string | null;
+  task_events_enabled?: boolean | null;
+};
+
 export type QueryInfo = {
   id: string;
   start_sec: number;
   last_heartbeat_sec: number;
   unoptimized_plan: string;
-  runner: string;
-  ray_dashboard_url?: string;
+  runner: RunnerInfo;
   entrypoint?: string;
   python_version?: string;
   daft_version?: string;
-  ray_version?: string;
   state: QueryState;
 };

--- a/src/daft-dashboard/frontend/src/hooks/use-queries.ts
+++ b/src/daft-dashboard/frontend/src/hooks/use-queries.ts
@@ -65,16 +65,22 @@ export type QueryStatusName =
   | "Canceled"
   | "Dead";
 
+export type RunnerInfo = {
+  name: string;
+  version?: string | null;
+  distributed: boolean;
+  dashboard_url?: string | null;
+  task_events_enabled?: boolean | null;
+};
+
 export type QuerySummary = {
   id: string;
   start_sec: number;
   status: QueryStatus;
-  runner: string;
-  ray_dashboard_url?: string;
+  runner: RunnerInfo;
   entrypoint?: string;
   python_version?: string;
   daft_version?: string;
-  ray_version?: string;
 };
 
 export type QuerySummaryMap = { [_: string]: QuerySummary };

--- a/src/daft-dashboard/frontend/src/hooks/use-queries.ts
+++ b/src/daft-dashboard/frontend/src/hooks/use-queries.ts
@@ -1,5 +1,7 @@
 import { createContext, useContext } from "react";
 
+import type { RunnerInfo } from "@/app/query/types";
+
 export type PendingStatus = {
   status: "Pending";
   start_sec: number;
@@ -64,14 +66,6 @@ export type QueryStatusName =
   | "Failed"
   | "Canceled"
   | "Dead";
-
-export type RunnerInfo = {
-  name: string;
-  version?: string | null;
-  distributed: boolean;
-  dashboard_url?: string | null;
-  task_events_enabled?: boolean | null;
-};
 
 export type QuerySummary = {
   id: string;

--- a/src/daft-dashboard/src/engine.rs
+++ b/src/daft-dashboard/src/engine.rs
@@ -33,17 +33,25 @@ use crate::state::{
     QueryInfo, QueryState, TaskStatus, TaskStore,
 };
 
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct RunnerInfo {
+    pub name: String,
+    pub version: Option<String>,
+    #[serde(default)]
+    pub distributed: bool,
+    pub dashboard_url: Option<String>,
+    pub task_events_enabled: Option<bool>,
+}
+
 #[derive(Clone, Deserialize, Serialize)]
 #[cfg_attr(debug_assertions, derive(Debug))]
 pub struct StartQueryArgs {
     pub start_sec: f64,
     pub unoptimized_plan: QueryPlan,
-    pub runner: Option<String>,
-    pub ray_dashboard_url: Option<String>,
+    pub runner: RunnerInfo,
     pub entrypoint: Option<String>,
     pub python_version: Option<String>,
     pub daft_version: Option<String>,
-    pub ray_version: Option<String>,
 }
 
 async fn query_start(
@@ -68,14 +76,10 @@ pub(crate) fn apply_query_start(
         start_sec: args.start_sec,
         last_heartbeat_sec: secs_from_epoch(),
         unoptimized_plan: args.unoptimized_plan,
-        runner: args
-            .runner
-            .unwrap_or_else(|| "Native (Swordfish)".to_string()),
-        ray_dashboard_url: args.ray_dashboard_url,
+        runner: args.runner,
         entrypoint: args.entrypoint,
         python_version: args.python_version,
         daft_version: args.daft_version,
-        ray_version: args.ray_version,
         state: QueryState::Pending,
     };
 
@@ -1139,7 +1143,9 @@ pub(crate) fn routes() -> Router<Arc<DashboardState>> {
 mod eviction_tests {
     use std::sync::Arc;
 
-    use super::{DashboardState, MAX_QUERIES_RETAINED, QueryInfo, QueryState, evict_old_queries};
+    use super::{
+        DashboardState, MAX_QUERIES_RETAINED, QueryInfo, QueryState, RunnerInfo, evict_old_queries,
+    };
 
     fn insert_query(state: &DashboardState, id: &str, start_sec: f64, active: bool) {
         let qid: common_metrics::QueryID = Arc::from(id);
@@ -1161,12 +1167,16 @@ mod eviction_tests {
                 start_sec,
                 last_heartbeat_sec: start_sec,
                 unoptimized_plan: Arc::from(""),
-                runner: "test".to_string(),
-                ray_dashboard_url: None,
+                runner: RunnerInfo {
+                    name: "test".to_string(),
+                    version: None,
+                    distributed: false,
+                    dashboard_url: None,
+                    task_events_enabled: None,
+                },
                 entrypoint: None,
                 python_version: None,
                 daft_version: None,
-                ray_version: None,
                 state: query_state,
             },
         );
@@ -1235,12 +1245,16 @@ mod eviction_tests {
                 start_sec: 0.0,
                 last_heartbeat_sec: 0.0,
                 unoptimized_plan: Arc::from(""),
-                runner: "test".to_string(),
-                ray_dashboard_url: None,
+                runner: RunnerInfo {
+                    name: "test".to_string(),
+                    version: None,
+                    distributed: false,
+                    dashboard_url: None,
+                    task_events_enabled: None,
+                },
                 entrypoint: None,
                 python_version: None,
                 daft_version: None,
-                ray_version: None,
                 state: QueryState::Finalizing {
                     plan_info: PlanInfo {
                         plan_start_sec: 0.0,

--- a/src/daft-dashboard/src/import.rs
+++ b/src/daft-dashboard/src/import.rs
@@ -15,9 +15,9 @@ use common_metrics::Stat;
 use crate::{
     engine::{
         ExecEmitStatsArgsRecv, ExecEndArgs, ExecStartArgs, FinalizeArgs, PlanEndArgs,
-        PlanStartArgs, StartQueryArgs, apply_emit_stats, apply_exec_end, apply_exec_start,
-        apply_operator_end, apply_operator_start, apply_plan_end, apply_plan_start,
-        apply_query_end, apply_query_start,
+        PlanStartArgs, RunnerInfo, StartQueryArgs, apply_emit_stats, apply_exec_end,
+        apply_exec_start, apply_operator_end, apply_operator_start, apply_plan_end,
+        apply_plan_start, apply_query_end, apply_query_start,
     },
     events::{Event, MetricValue},
     state::DashboardState,
@@ -133,11 +133,18 @@ fn import_event(event: &Event, state: &DashboardState) -> Result<(), EventLogErr
             StartQueryArgs {
                 start_sec: e.timestamp,
                 unoptimized_plan: e.plan.clone().into(),
-                runner: e.runner.clone(),
-                ray_dashboard_url: e.dashboard_url.clone(),
+                runner: RunnerInfo {
+                    name: e
+                        .runner
+                        .clone()
+                        .unwrap_or_else(|| "Native (Swordfish)".to_string()),
+                    version: e.runner_version.clone(),
+                    distributed: false,
+                    dashboard_url: e.dashboard_url.clone(),
+                    task_events_enabled: None,
+                },
                 entrypoint: e.entrypoint.clone(),
                 daft_version: e.daft_version.clone(),
-                ray_version: e.runner_version.clone(),
                 python_version: e.python_version.clone(),
             },
         ),

--- a/src/daft-dashboard/src/state.rs
+++ b/src/daft-dashboard/src/state.rs
@@ -13,7 +13,7 @@ use serde::Serialize;
 use tokio::sync::{broadcast, watch};
 use uuid::Uuid;
 
-use crate::engine::TaskStatsEntry;
+use crate::engine::{RunnerInfo, TaskStatsEntry};
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub(crate) enum OperatorStatus {
@@ -696,17 +696,13 @@ pub(crate) struct QuerySummary {
     pub id: QueryID,
     pub start_sec: f64,
     pub status: QueryStatus,
-    pub runner: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub ray_dashboard_url: Option<String>,
+    pub runner: RunnerInfo,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub entrypoint: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub python_version: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub daft_version: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub ray_version: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -778,12 +774,10 @@ pub(crate) struct QueryInfo {
     pub start_sec: f64,
     pub last_heartbeat_sec: f64,
     pub unoptimized_plan: QueryPlan,
-    pub runner: String,
-    pub ray_dashboard_url: Option<String>,
+    pub runner: RunnerInfo,
     pub entrypoint: Option<String>,
     pub python_version: Option<String>,
     pub daft_version: Option<String>,
-    pub ray_version: Option<String>,
     pub state: QueryState,
 }
 
@@ -836,11 +830,9 @@ impl QueryInfo {
             start_sec: self.start_sec,
             status: self.status(),
             runner: self.runner.clone(),
-            ray_dashboard_url: self.ray_dashboard_url.clone(),
             entrypoint: self.entrypoint.clone(),
             python_version: self.python_version.clone(),
             daft_version: self.daft_version.clone(),
-            ray_version: self.ray_version.clone(),
         }
     }
 }

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -43,7 +43,7 @@ def _make_query_metadata() -> PyQueryMetadata:
         df.schema()._schema,
         df._builder.repr_json(),
         "Native (Swordfish)",
-        ray_dashboard_url=None,
+        dashboard_url=None,
         entrypoint="pytest",
     )
 


### PR DESCRIPTION
## Changes Made
Replaces the Ray-specific `ray_dashboard_url` and `ray_version` fields on query metadata with a single, always-present RunnerInfo struct.

This makes `distributed` an honest field (false for native) and generalizes the dashboard beyond Ray — the "Open Dashboard" link, version display, and tasks panel now key off `runner.distributed` instead of sniffing the runner string for "Flotilla".
