### PR TITLE
feat(shuffle): default flight shuffle compression to lz4

### DIFF
--- a/daft/context.py
+++ b/daft/context.py
@@ -293,7 +293,7 @@ def set_execution_config(
         enable_dynamic_batching: Whether to enable dynamic batching. Defaults to False.
         dynamic_batching_strategy: The strategy to use for dynamic batching. Defaults to 'auto'.
         flight_shuffle_dirs: Directories to use for flight shuffle. Defaults to ["/tmp"]. Must not be empty.
-        flight_shuffle_compression: Arrow IPC compression for flight shuffle spill files. One of "lz4", "zstd", or "none". Defaults to "lz4".
+        flight_shuffle_compression: Arrow IPC compression for flight shuffle spill files. One of "lz4", "zstd", or "none". Defaults to "lz4". Pass "none" to disable compression; passing Python None leaves the current config unchanged.
         enable_multi_glob_path_tasks: Whether to create multiple glob path tasks in Ray Runner to achieve parallel glob. Defaults to False.
     """
     # Replace values in the DaftExecutionConfig with user-specified overrides

--- a/daft/context.py
+++ b/daft/context.py
@@ -293,7 +293,7 @@ def set_execution_config(
         enable_dynamic_batching: Whether to enable dynamic batching. Defaults to False.
         dynamic_batching_strategy: The strategy to use for dynamic batching. Defaults to 'auto'.
         flight_shuffle_dirs: Directories to use for flight shuffle. Defaults to ["/tmp"]. Must not be empty.
-        flight_shuffle_compression: Arrow IPC compression for flight shuffle spill files. One of "lz4", "zstd", or "none". Defaults to None (uncompressed).
+        flight_shuffle_compression: Arrow IPC compression for flight shuffle spill files. One of "lz4", "zstd", or "none". Defaults to "lz4".
         enable_multi_glob_path_tasks: Whether to create multiple glob path tasks in Ray Runner to achieve parallel glob. Defaults to False.
     """
     # Replace values in the DaftExecutionConfig with user-specified overrides

--- a/docs/optimization/shuffle.md
+++ b/docs/optimization/shuffle.md
@@ -79,8 +79,8 @@ Arrow IPC compression for the spill files. One of `"lz4"` (the default), `"zstd"
 | Storage | Recommended | Why |
 |---|---|---|
 | Local NVMe | `"lz4"` (default) | Cheap enough on CPU that it wins even when disk isn't the ceiling — about 10% in our benchmarks. |
-| gp3 EBS or network-attached | `"zstd"` | When bandwidth is the limit, compression is the biggest knob available — over 2× faster than uncompressed — and zstd's tighter ratio consistently beats lz4. |
-| HDD or slow shared FS | `"zstd"` | Same reasoning, more pronounced. |
+| gp3 EBS or network-attached | `"zstd"` | When bandwidth is the limit, compression is the biggest knob available — worth ~2.3× over uncompressed — and zstd's tighter ratio consistently beats lz4. |
+| HDD or slow shared FS, or a network-constrained cluster | `"zstd"` | Same reasoning: bytes are the bottleneck. |
 
 Set `"none"` only if you're CPU-bound on very fast storage — for example, several local NVMe drives whose aggregate bandwidth outruns what the CPU can compress through.
 

--- a/docs/optimization/shuffle.md
+++ b/docs/optimization/shuffle.md
@@ -26,7 +26,7 @@ If you're picking a partition count for `repartition` or thinking about batch si
 
 Under `auto`, Daft picks between `map_reduce` and `pre_shuffle_merge` based on the geometric mean of input and output partition counts. If `sqrt(input_partitions × output_partitions) > pre_shuffle_merge_partition_threshold` (default `200`), Daft uses `pre_shuffle_merge`; otherwise `map_reduce`.
 
-`auto` does not switch to `flight_shuffle` automatically, because `flight_shuffle` requires the user to choose where spill files go (`flight_shuffle_dirs`). When Daft sees a shuffle likely to hit the object-store ceiling (input size ≥ 10 GiB or partition product ≥ 500,000), it prints a hint in the query plan with the configuration to enable.
+`auto` does not switch to `flight_shuffle` automatically, because spilling a large shuffle to the default `flight_shuffle_dirs` of `["/tmp"]` — often a small or slow root volume — could fill the disk or underperform. Instead, when Daft sees a shuffle likely to hit the object-store ceiling (input size ≥ 10 GiB or partition product ≥ 500,000), it prints a hint in the query plan with the configuration to enable.
 
 ### Why `map_reduce` falls over at scale
 

--- a/docs/optimization/shuffle.md
+++ b/docs/optimization/shuffle.md
@@ -1,6 +1,6 @@
 # Shuffle Algorithms
 
-A *shuffle* is the all-to-all data movement behind [`df.repartition(...)`][daft.DataFrame.repartition], hash joins, sorts, and groupbys. With `M` input partitions and `N` output partitions, a shuffle is `M × N` logical transfers: 4,096 at `64 × 64`, 16.8 million at `4096 × 4096`.
+A *shuffle* is the all-to-all data movement behind [`df.repartition(...)`][daft.DataFrame.repartition], hash joins, sorts, and groupbys.
 
 The `shuffle_algorithm` config option controls how Daft executes that movement, and the right choice depends on how big the shuffle is. Shuffles only happen on the distributed (Ray) runner — the native (single-machine) runner executes the entire query in one process and has no shuffle step.
 
@@ -30,7 +30,7 @@ Under `auto`, Daft picks between `map_reduce` and `pre_shuffle_merge` based on t
 
 ### Why `map_reduce` falls over at scale
 
-`map_reduce` writes one Ray object per `(input, output)` slot, and each tracked object costs about 3 KB of metadata on the Ray driver. Multiply by `M × N`:
+`map_reduce` writes one Ray object per `(input, output)` slot, and each tracked object costs about 3 KB of metadata on the Ray driver. Multiply by `M` mappers × `N` reducers:
 
 | Mappers × Reducers | Slots  | Head-node metadata |
 |---|---|---|

--- a/docs/optimization/shuffle.md
+++ b/docs/optimization/shuffle.md
@@ -8,7 +8,7 @@ If you're picking a partition count for `repartition` or thinking about batch si
 >
 > - Stay on the default `shuffle_algorithm="auto"` for most queries. Daft picks between `map_reduce` and `pre_shuffle_merge` based on partition count.
 > - If your shuffle is **>10 GB of data** or **>500K partition slots** (`input_partitions × output_partitions`), switch to `flight_shuffle`. Daft prints a hint in the query plan when it sees one.
-> - When you enable `flight_shuffle`, point `flight_shuffle_dirs` at a fast local disk. The default is `["/tmp"]`. Enable `flight_shuffle_compression="zstd"` on EBS or other networked volumes.
+> - When you enable `flight_shuffle`, point `flight_shuffle_dirs` at a fast local disk. The default is `["/tmp"]`. Spill files are `lz4`-compressed by default; set `flight_shuffle_compression="zstd"` on EBS or other networked volumes.
 
 ## Shuffle algorithms
 
@@ -53,7 +53,7 @@ import daft
 daft.context.set_execution_config(
     shuffle_algorithm="flight_shuffle",
     flight_shuffle_dirs=["/mnt/nvme0", "/mnt/nvme1"],  # round-robins across them
-    flight_shuffle_compression=None,                    # set to "lz4" or "zstd" on slower disk
+    flight_shuffle_compression="lz4",                   # the default; set "zstd" on slower disk
 )
 ```
 
@@ -65,20 +65,20 @@ Local directories where Daft writes shuffle spill files. Defaults to `["/tmp"]`.
 
 - **Point this at the fastest local disk you have.** On AWS that means the local NVMe on instances like `i8ge.*` or `i4i.*`. On Kubernetes it's whatever is mounted from node-local SSD.
 - **Give it more than one device when you can.** Daft round-robins writes across the list, so two NVMe volumes roughly double aggregate write bandwidth.
-- **Size it for the shuffle, not the dataset.** Plan for `dataset_size ÷ compression_ratio` of free space per node. A 10 TB shuffle uncompressed across 32 workers is about 310 GB of spill per worker; at `zstd` 3× it's closer to 100 GB.
+- **Size it for the shuffle, not the dataset.** Plan for `dataset_size ÷ compression_ratio` of free space per node. A 10 TB shuffle across 32 workers is about 310 GB of spill per worker uncompressed; at the default `lz4` (~2×) it's closer to 155 GB, and at `zstd` (~3×) closer to 100 GB.
 - Daft cleans the dirs up when the query exits.
 
 ### `flight_shuffle_compression`
 
-Arrow IPC compression for the spill files. Set to `"lz4"` or `"zstd"`; defaults to `None` (uncompressed).
+Arrow IPC compression for the spill files. One of `"lz4"` (the default), `"zstd"`, or `"none"`. A frame is compressed once on the map side and stays compressed across the disk write, the disk read, and the wire — decompression happens only at the reducer — so compression pays off whenever storage or network bandwidth, not CPU, is the bottleneck.
 
 | Storage | Recommended | Why |
 |---|---|---|
-| Local NVMe | `None` | The disk isn't the bottleneck. Compression spends CPU that the map task can use instead. |
-| gp3 EBS or network-attached | `"zstd"` | Compresses about 3× before the write, roughly tripling effective volume bandwidth. |
+| Local NVMe | `"lz4"` (default) | Cheap enough on CPU that it wins even when disk isn't the ceiling — about 10% in our benchmarks. |
+| gp3 EBS or network-attached | `"zstd"` | When bandwidth is the limit, compression is the biggest knob available — over 2× faster than uncompressed — and zstd's tighter ratio consistently beats lz4. |
 | HDD or slow shared FS | `"zstd"` | Same reasoning, more pronounced. |
 
-`"lz4"` is a lighter middle ground if `zstd` shows up as CPU-bound in your profile.
+Set `"none"` only if you're CPU-bound on very fast storage — for example, several local NVMe drives whose aggregate bandwidth outruns what the CPU can compress through.
 
 ## Choosing between algorithms
 

--- a/docs/optimization/shuffle.md
+++ b/docs/optimization/shuffle.md
@@ -26,7 +26,7 @@ If you're picking a partition count for `repartition` or thinking about batch si
 
 Under `auto`, Daft picks between `map_reduce` and `pre_shuffle_merge` based on the geometric mean of input and output partition counts. If `sqrt(input_partitions × output_partitions) > pre_shuffle_merge_partition_threshold` (default `200`), Daft uses `pre_shuffle_merge`; otherwise `map_reduce`.
 
-`auto` does not switch to `flight_shuffle` automatically, because spilling a large shuffle to the default `flight_shuffle_dirs` of `["/tmp"]` — often a small or slow root volume — could fill the disk or underperform. Instead, when Daft sees a shuffle likely to hit the object-store ceiling (input size ≥ 10 GiB or partition product ≥ 500,000), it prints a hint in the query plan with the configuration to enable.
+`auto` does not switch to `flight_shuffle` automatically. Instead, when Daft sees a shuffle likely to hit the object-store ceiling (input size ≥ 10 GiB or partition product ≥ 500,000), it prints a hint in the query plan with the configuration to enable.
 
 ### Why `map_reduce` falls over at scale
 

--- a/docs/optimization/shuffle.md
+++ b/docs/optimization/shuffle.md
@@ -76,8 +76,6 @@ Local directories where Daft writes shuffle spill files. Defaults to `["/tmp"]`.
 
 Arrow IPC compression for the spill files. One of `"lz4"` (the default), `"zstd"`, or `"none"`.
 
-A frame is compressed once on the map side and stays compressed across the disk write, the disk read, and the wire; decompression happens only at the reducer. Compression therefore pays off whenever storage or network bandwidth — not CPU — is the bottleneck.
-
 | Storage | Recommended | Why |
 |---|---|---|
 | Local NVMe | `"lz4"` (default) | Cheap enough on CPU that it wins even when disk isn't the ceiling — about 10% in our benchmarks. |

--- a/docs/optimization/shuffle.md
+++ b/docs/optimization/shuffle.md
@@ -1,6 +1,8 @@
 # Shuffle Algorithms
 
-A *shuffle* is the all-to-all data movement behind [`df.repartition(...)`][daft.DataFrame.repartition], hash joins, sorts, and groupbys. Shuffles only happen on the distributed (Ray) runner; the native (single-machine) runner executes the entire query in one process and has no shuffle step. With `M` input partitions and `N` output partitions, a shuffle is `M × N` logical transfers: 4,096 at `64 × 64`, 16.8 million at `4096 × 4096`. The `shuffle_algorithm` config option controls how Daft executes that movement, and the right choice depends on how big the shuffle is.
+A *shuffle* is the all-to-all data movement behind [`df.repartition(...)`][daft.DataFrame.repartition], hash joins, sorts, and groupbys. With `M` input partitions and `N` output partitions, a shuffle is `M × N` logical transfers: 4,096 at `64 × 64`, 16.8 million at `4096 × 4096`.
+
+The `shuffle_algorithm` config option controls how Daft executes that movement, and the right choice depends on how big the shuffle is. Shuffles only happen on the distributed (Ray) runner — the native (single-machine) runner executes the entire query in one process and has no shuffle step.
 
 If you're picking a partition count for `repartition` or thinking about batch size, start with [Partitioning and Batching](partitioning.md). Partition count is the input to shuffle cost, and `into_batches` controls the batch sizes shuffles produce.
 
@@ -37,7 +39,9 @@ Under `auto`, Daft picks between `map_reduce` and `pre_shuffle_merge` based on t
 | 4096 × 4096 | 16.8M | ~50 GB  |
 | 8192 × 8192 | 67M   | ~200 GB |
 
-At `4096 × 4096` the driver holds 50 GB of pointers before any data has moved, which usually shows up as a head-node OOM or as a scheduler stall. `pre_shuffle_merge` reduces this cost by coalescing small input partitions before the shuffle, lowering `M`, but it can't change the underlying `M × N` shape. `flight_shuffle` writes shuffle bytes to local disk and serves them between workers over Arrow Flight, reducing head-node cost from `M × N × 3 KB` to roughly `(M + N) × 200 B` of descriptors.
+At `4096 × 4096` the driver holds 50 GB of pointers before any data has moved, which usually shows up as a head-node OOM or as a scheduler stall.
+
+`pre_shuffle_merge` reduces this cost by coalescing small input partitions before the shuffle, lowering `M`, but it can't change the underlying `M × N` shape. `flight_shuffle` writes shuffle bytes to local disk and serves them between workers over Arrow Flight, reducing head-node cost from `M × N × 3 KB` to roughly `(M + N) × 200 B` of descriptors.
 
 Symptoms that point to `flight_shuffle`:
 
@@ -70,7 +74,9 @@ Local directories where Daft writes shuffle spill files. Defaults to `["/tmp"]`.
 
 ### `flight_shuffle_compression`
 
-Arrow IPC compression for the spill files. One of `"lz4"` (the default), `"zstd"`, or `"none"`. A frame is compressed once on the map side and stays compressed across the disk write, the disk read, and the wire — decompression happens only at the reducer — so compression pays off whenever storage or network bandwidth, not CPU, is the bottleneck.
+Arrow IPC compression for the spill files. One of `"lz4"` (the default), `"zstd"`, or `"none"`.
+
+A frame is compressed once on the map side and stays compressed across the disk write, the disk read, and the wire; decompression happens only at the reducer. Compression therefore pays off whenever storage or network bandwidth — not CPU — is the bottleneck.
 
 | Storage | Recommended | Why |
 |---|---|---|

--- a/src/common/daft-config/src/lib.rs
+++ b/src/common/daft-config/src/lib.rs
@@ -200,7 +200,7 @@ impl Default for DaftExecutionConfig {
             enable_dynamic_batching: false,
             dynamic_batching_strategy: "auto".to_string(),
             flight_shuffle_dirs: vec!["/tmp".to_string()],
-            flight_shuffle_compression: None,
+            flight_shuffle_compression: Some("lz4".to_string()),
             enable_multi_glob_path_tasks: false,
         }
     }


### PR DESCRIPTION
## Changes Made

Flight shuffle spill files are now lz4-compressed by default (previously uncompressed). Benchmarks on a 1 TB TPC-H repartition sweep show lz4 wins at every partition count: ~10% faster on local NVMe and ~2.3× faster on EBS gp3, since frames are compressed once on the map side and stay compressed across disk and the wire. Set `flight_shuffle_compression="none"` to restore the old behavior.

Also updates the shuffle docs with benchmark-backed recommendations per storage type.

## Related Issues

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)