### PR TITLE
fix(asof-join): use unknown clustering spec instead of hash          

### DIFF
--- a/src/daft-distributed/src/pipeline_node/join/asof_join.rs
+++ b/src/daft-distributed/src/pipeline_node/join/asof_join.rs
@@ -76,10 +76,7 @@ impl AsofJoinNode {
         let config = PipelineNodeConfig::new(
             output_schema,
             plan_config.config.clone(),
-            ClusteringStrategy::Explicit(BoundClusteringSpec::hash(
-                num_partitions,
-                left_by.clone(),
-            )),
+            ClusteringStrategy::Explicit(BoundClusteringSpec::unknown(num_partitions)),
         );
         Self {
             config,


### PR DESCRIPTION
The AsofJoinNode was advertising hash partitioning in its PipelineNodeConfig, but the node internally performs range repartitioning. 