### PR TITLE
docs(checkpoint): fill in user-facing API docstrings + examples (re-land #6999)

### DIFF
--- a/daft/checkpoint.py
+++ b/daft/checkpoint.py
@@ -32,10 +32,26 @@ class CheckpointStore:
         path: URI for the store root (e.g. ``s3://bucket/checkpoints``).
         io_config: Optional IO configuration for the object store backend.
 
-    Example:
+    Examples:
+        Source-side (anti-join on prior keys):
         >>> store = daft.CheckpointStore("s3://bucket/ckpt")
         >>> config = daft.CheckpointConfig(store=store, on="file_id")
-        >>> df = daft.read_parquet("s3://input/", checkpoint=config)
+        >>> df = daft.read_parquet("s3://input/", checkpoint=config)  # doctest: +SKIP
+
+        Sink-side (idempotent commit). Pair the same store into the source and
+        the sink so the pipeline's checkpointed keys are visible at commit time:
+        >>> store = daft.CheckpointStore("s3://bucket/ckpt")
+        >>> df = daft.read_parquet(  # doctest: +SKIP
+        ...     "s3://input/",
+        ...     checkpoint=daft.CheckpointConfig(store=store, on="file_id"),
+        ... )
+        >>> df.write_iceberg(  # doctest: +SKIP
+        ...     table,
+        ...     checkpoint=daft.IdempotentCommit(store=store, idempotence_key="job-2026-05-04"),
+        ... )
+
+    See Also:
+        [Checkpointing guide](../use-case/checkpointing.md) for the conceptual overview.
     """
 
     _path: str
@@ -64,12 +80,45 @@ class CheckpointStore:
         return self._store
 
     def list_checkpoints(self) -> list[Any]:
+        """List every checkpoint entry in the store, in arbitrary order.
+
+        Each entry carries its lifecycle status — ``Staged`` (in-flight,
+        awaiting ``checkpoint(id)``), ``Checkpointed`` (``checkpoint(id)``
+        returned, catalog commit pending), or ``Committed`` (catalog has
+        acknowledged the commit). Useful for diagnostics; sinks consume
+        this list internally during recovery.
+        """
         return self._get_store().list_checkpoints()
 
     def get_checkpointed_files(self) -> list[Any]:
+        """Return file-metadata blobs from ``Checkpointed`` entries not yet ``Committed``.
+
+        Used by sink helpers during recovery: after a crash between pipeline
+        completion and the catalog commit, these are the file references the
+        sink re-commits on rerun. Returns an empty list when every entry is
+        already ``Committed``.
+        """
         return self._get_store().get_checkpointed_files()
 
     def mark_committed(self, checkpoint_ids: list[str]) -> None:
+        """Transition a batch of checkpoint ids to ``Committed`` in the store.
+
+        Called by sinks after the catalog commit lands, to move ``Checkpointed``
+        entries to their terminal state. Idempotent — entries already in
+        ``Committed`` are left unchanged.
+
+        Args:
+            checkpoint_ids: ids to mark committed.
+
+        Raises:
+            Errors if any id is still ``Staged`` (not yet ``checkpoint()``'d)
+            or unknown to the store.
+
+        Note:
+            On error, ids processed before the failing one may already be
+            ``Committed``. Retrying the full batch is safe — the already-
+            committed ids no-op on retry.
+        """
         self._get_store().mark_committed(checkpoint_ids)
 
     def __repr__(self) -> str:
@@ -86,7 +135,7 @@ class CheckpointConfig:
     On re-run, rows whose key already exists in the store are skipped.
 
     Args:
-        store: The :class:`CheckpointStore` holding sealed keys.
+        store: The :class:`CheckpointStore` holding checkpointed keys.
         on: Name of the source column that uniquely identifies inputs (e.g.
             a file hash or document ID). Must exist in the source schema.
         settings: Optional tuning for the key-filtering anti-join. Defaults

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -1304,6 +1304,23 @@ class DataFrame:
             >>> df = daft.from_pydict({"user_id": [1, 2, 3], "name": ["Alice", "Bob", "Charlie"]})
             >>> df = df.write_iceberg(table, mode="overwrite")  # doctest: +SKIP
 
+            Idempotent commit with a checkpoint store. The same store is
+            paired into the source for the upstream anti-join and into the
+            sink for the commit marker:
+            >>> store = daft.CheckpointStore("s3://bucket/ckpt")  # doctest: +SKIP
+            >>> df = daft.read_parquet(  # doctest: +SKIP
+            ...     "s3://input/",
+            ...     checkpoint=daft.CheckpointConfig(store=store, on="file_id"),
+            ... )
+            >>> df.write_iceberg(  # doctest: +SKIP
+            ...     table,
+            ...     checkpoint=daft.IdempotentCommit(store=store, idempotence_key="job-2026-05-04"),
+            ... )
+
+        See Also:
+            [Checkpointing guide](../use-case/checkpointing.md) for the
+            conceptual overview of the ``checkpoint=`` parameter.
+
         """
         import pyarrow as pa
         import pyiceberg
@@ -1738,6 +1755,22 @@ class DataFrame:
             >>> import deltalake
             >>> df = daft.from_pydict({"x": [1, 2, 3], "y": ["a", "b", "c"]})
             >>> df.write_deltalake("s3://my-bucket/my-deltalake-table")  # doctest: +SKIP
+
+            Idempotent commit with a checkpoint store. Same store on both
+            sides of the pipeline:
+            >>> store = daft.CheckpointStore("s3://bucket/ckpt")  # doctest: +SKIP
+            >>> df = daft.read_parquet(  # doctest: +SKIP
+            ...     "s3://input/",
+            ...     checkpoint=daft.CheckpointConfig(store=store, on="file_id"),
+            ... )
+            >>> df.write_deltalake(  # doctest: +SKIP
+            ...     "s3://my-bucket/my-table/",
+            ...     checkpoint=daft.IdempotentCommit(store=store, idempotence_key="job-2026-05-04"),
+            ... )
+
+        See Also:
+            [Checkpointing guide](../use-case/checkpointing.md) for the
+            conceptual overview of the ``checkpoint=`` parameter.
         """
         import json
 

--- a/daft/io/_parquet.py
+++ b/daft/io/_parquet.py
@@ -66,6 +66,19 @@ def read_parquet(
         >>> io_config = IOConfig(s3=S3Config(region="us-west-2", anonymous=True))
         >>> df = daft.read_parquet("s3://path/to/files-*.parquet", io_config=io_config)
         >>> df.show()
+
+        Resume across runs with a checkpoint store. Pair the same store on the
+        source and a downstream idempotent sink so prior runs' keys are
+        anti-joined out of the input:
+        >>> store = daft.CheckpointStore("s3://bucket/ckpt")  # doctest: +SKIP
+        >>> df = daft.read_parquet(  # doctest: +SKIP
+        ...     "s3://input/",
+        ...     checkpoint=daft.CheckpointConfig(store=store, on="file_id"),
+        ... )
+
+    See Also:
+        [Checkpointing guide](../use-case/checkpointing.md) for the conceptual
+        overview of the ``checkpoint=`` parameter.
     """
     io_config = context.get_context().daft_planning_config.default_io_config if io_config is None else io_config
 


### PR DESCRIPTION
## Re-land of #6999

#6999 was stacked on the observability branch (#6998) and merged into it — but #6998 was then closed in favor of #7026, which came from a different branch. Net effect: the docstrings never reached `main` despite the merged badge. This PR cherry-picks the reviewed commit onto `main` directly.

Original PR: #6999 (already approved + merged into the now-abandoned base branch)

## Changes

- `daft.CheckpointStore`: sink-side example (`write_iceberg(checkpoint=)`) alongside the source-side one; docstrings for `list_checkpoints`, `get_checkpointed_files`, `mark_committed`
- `daft.read_parquet`: document `checkpoint=` / `on=`, Ray-only runner constraint, example
- `DataFrame.write_iceberg` / `write_deltalake`: document `checkpoint=` with examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)