### PR TITLE
refactor(checkpoint): drop "seal" vocabulary from Rust API surface

### DIFF
--- a/src/daft-checkpoint/src/error.rs
+++ b/src/daft-checkpoint/src/error.rs
@@ -12,8 +12,8 @@ pub enum CheckpointError {
     #[snafu(display("Checkpoint {id} not found"))]
     CheckpointNotFound { id: CheckpointId },
 
-    #[snafu(display("Checkpoint {id} is already sealed"))]
-    AlreadySealed { id: CheckpointId },
+    #[snafu(display("Checkpoint {id} is already checkpointed"))]
+    AlreadyCheckpointed { id: CheckpointId },
 
     #[snafu(display("Checkpoint {id} is not yet checkpointed"))]
     NotCheckpointed { id: CheckpointId },

--- a/src/daft-checkpoint/src/impls/s3.rs
+++ b/src/daft-checkpoint/src/impls/s3.rs
@@ -45,14 +45,14 @@ enum ManifestStatus {
 
 /// Written to `{prefix}/{id}/manifest.json` by `checkpoint()`.
 ///
-/// Presence of this file marks the checkpoint as sealed. `mark_committed()` overwrites
+/// Presence of this file transitions the checkpoint to `Checkpointed`. `mark_committed()` overwrites
 /// it with `committed_at` set, transitioning the checkpoint to the `Committed` state.
 #[derive(Clone, Serialize, Deserialize)]
 struct Manifest {
     checkpoint_id: String,
     status: ManifestStatus,
     created_at: String,
-    sealed_at: String,
+    checkpointed_at: String,
     committed_at: Option<String>,
     num_key_files: usize,
     num_file_files: usize,
@@ -104,7 +104,7 @@ impl StagedEntry {
 ///     files/
 ///       0000.bin          ← FileMetadata blob; one file per stage_files() call
 ///       ...
-///     manifest.json       ← written by checkpoint(); presence = sealed;
+///     manifest.json       ← written by checkpoint(); presence = Checkpointed;
 ///                           overwritten by mark_committed() with committed_at set
 /// ```
 pub struct S3CheckpointStore {
@@ -263,10 +263,10 @@ impl S3CheckpointStore {
         Self::put_bytes(&self.client, &path, raw).await
     }
 
-    /// Ensures the checkpoint is not yet sealed, then atomically reserves index
+    /// Ensures the checkpoint is not yet `Checkpointed`, then atomically reserves index
     /// slots by calling `update` inside the staged lock.
     ///
-    /// Returns `AlreadySealed` if `manifest.json` already exists for this ID
+    /// Returns `AlreadyCheckpointed` if `manifest.json` already exists for this ID
     /// and the ID is not tracked in the in-memory staged map (i.e., this
     /// process didn't stage it).
     async fn reserve_slots(
@@ -285,7 +285,7 @@ impl S3CheckpointStore {
 
         // First call for this ID — check S3 to catch post-restart misuse.
         match self.read_manifest(id).await {
-            Ok(_) => return Err(CheckpointError::AlreadySealed { id: id.clone() }),
+            Ok(_) => return Err(CheckpointError::AlreadyCheckpointed { id: id.clone() }),
             Err(CheckpointError::CheckpointNotFound { .. }) => {}
             Err(e) => return Err(e),
         }
@@ -297,12 +297,12 @@ impl S3CheckpointStore {
         Ok(update(entry))
     }
 
-    /// Returns all sealed manifests (checkpointed + committed) as `(id, manifest)`
+    /// Returns all visible manifests (`Checkpointed` + `Committed`) as `(id, manifest)`
     /// pairs. Re-globs and re-reads on every call — there is intentionally no
     /// cache. The store is observed across processes (workers write, drivers
     /// read), so a cached snapshot in one process would silently miss writes
     /// committed by another.
-    async fn sealed_manifests(&self) -> CheckpointResult<Vec<(CheckpointId, Manifest)>> {
+    async fn checkpointed_manifests(&self) -> CheckpointResult<Vec<(CheckpointId, Manifest)>> {
         let manifest_paths = self.glob_paths(&self.manifests_glob()).await?;
         let ids: Vec<CheckpointId> = manifest_paths
             .iter()
@@ -426,11 +426,11 @@ impl S3CheckpointStore {
         Ok(())
     }
 
-    /// Enumerate paths of sealed (checkpointed or committed) key parquet files.
-    pub async fn sealed_file_paths(&self) -> CheckpointResult<Vec<String>> {
-        let sealed = self.sealed_manifests().await?;
+    /// Enumerate paths of visible (`Checkpointed` or `Committed`) key parquet files.
+    pub async fn checkpointed_file_paths(&self) -> CheckpointResult<Vec<String>> {
+        let manifests = self.checkpointed_manifests().await?;
         let mut paths: Vec<String> = Vec::new();
-        for (id, manifest) in &sealed {
+        for (id, manifest) in &manifests {
             for i in 0..manifest.num_key_files {
                 paths.push(self.key_path(id, i));
             }
@@ -503,7 +503,7 @@ impl CheckpointStore for S3CheckpointStore {
             None => {
                 // No in-memory staged entry for this id. Two sub-cases, both
                 // handled as a no-op success:
-                //   (a) Already sealed in a prior call — idempotent retry.
+                //   (a) Already `Checkpointed` in a prior call — idempotent retry.
                 //       read_manifest succeeds; nothing more to do.
                 //   (b) Never staged at all (e.g. 0-row source after the
                 //       anti-join — the sink generated an id but no SCKO or
@@ -527,12 +527,12 @@ impl CheckpointStore for S3CheckpointStore {
             r?;
         }
 
-        // manifest.json is written last — its presence is the atomic seal.
+        // manifest.json is written last — its presence atomically transitions the entry to Checkpointed.
         let manifest = Manifest {
             checkpoint_id: id.to_string(),
             status: ManifestStatus::Checkpointed,
             created_at: rfc3339_from(created_at),
-            sealed_at: rfc3339_from(SystemTime::now()),
+            checkpointed_at: rfc3339_from(SystemTime::now()),
             committed_at: None,
             num_key_files,
             num_file_files,
@@ -556,7 +556,7 @@ impl CheckpointStore for S3CheckpointStore {
         // Include both checkpointed and committed keys — all are needed for the
         // skip-on-rerun filter.
         let mut key_paths: Vec<String> = Vec::new();
-        for (id, manifest) in &self.sealed_manifests().await? {
+        for (id, manifest) in &self.checkpointed_manifests().await? {
             for i in 0..manifest.num_key_files {
                 key_paths.push(self.key_path(id, i));
             }
@@ -573,7 +573,7 @@ impl CheckpointStore for S3CheckpointStore {
         &self,
     ) -> CheckpointResult<BoxStream<'_, CheckpointResult<FileMetadata>>> {
         let mut file_paths: Vec<String> = Vec::new();
-        for (id, manifest) in &self.sealed_manifests().await? {
+        for (id, manifest) in &self.checkpointed_manifests().await? {
             if manifest.status == ManifestStatus::Committed {
                 continue; // Already committed to the catalog — files no longer needed.
             }
@@ -622,7 +622,7 @@ impl CheckpointStore for S3CheckpointStore {
             id.clone(),
             status,
             system_time_from_rfc3339(&manifest.created_at)?,
-            Some(system_time_from_rfc3339(&manifest.sealed_at)?),
+            Some(system_time_from_rfc3339(&manifest.checkpointed_at)?),
             manifest
                 .committed_at
                 .as_deref()
@@ -634,20 +634,20 @@ impl CheckpointStore for S3CheckpointStore {
     async fn list_checkpoints(
         &self,
     ) -> CheckpointResult<BoxStream<'_, CheckpointResult<Checkpoint>>> {
-        let sealed = self.sealed_manifests().await?;
-        let sealed_ids: std::collections::HashSet<&CheckpointId> =
-            sealed.iter().map(|(id, _)| id).collect();
+        let manifests = self.checkpointed_manifests().await?;
+        let manifest_ids: std::collections::HashSet<&CheckpointId> =
+            manifests.iter().map(|(id, _)| id).collect();
 
         let mut checkpoints: Vec<Checkpoint> = Vec::new();
 
         // Staged entries — skip any id that already has a manifest on S3, as the
-        // sealed state is authoritative and takes precedence over the in-memory entry.
+        // `Checkpointed` state is authoritative and takes precedence over the in-memory entry.
         {
             let staged = self.staged.lock().map_err(|e| CheckpointError::Internal {
                 message: format!("staged lock poisoned: {e}"),
             })?;
             for (id, entry) in staged.iter() {
-                if sealed_ids.contains(id) {
+                if manifest_ids.contains(id) {
                     continue;
                 }
                 checkpoints.push(Checkpoint::new(
@@ -660,7 +660,7 @@ impl CheckpointStore for S3CheckpointStore {
             }
         }
 
-        for (id, manifest) in &sealed {
+        for (id, manifest) in &manifests {
             let status = if manifest.status == ManifestStatus::Committed {
                 CheckpointStatus::Committed
             } else {
@@ -670,7 +670,7 @@ impl CheckpointStore for S3CheckpointStore {
                 id.clone(),
                 status,
                 system_time_from_rfc3339(&manifest.created_at)?,
-                Some(system_time_from_rfc3339(&manifest.sealed_at)?),
+                Some(system_time_from_rfc3339(&manifest.checkpointed_at)?),
                 manifest
                     .committed_at
                     .as_deref()
@@ -689,7 +689,7 @@ impl CheckpointStore for S3CheckpointStore {
             return Ok(());
         }
 
-        // Read all manifests concurrently — also validates each checkpoint is sealed.
+        // Read all manifests concurrently — also validates each checkpoint has reached `Checkpointed`.
         // Use join_all (not try_join_all) so we can map errors to specific types.
         let results = join_all(ids.iter().map(|id| self.read_manifest(id))).await;
 
@@ -867,7 +867,7 @@ mod tests {
             checkpoint_id: "task-0-checkpoint-abc".to_string(),
             status: ManifestStatus::Checkpointed,
             created_at: now.clone(),
-            sealed_at: now.clone(),
+            checkpointed_at: now.clone(),
             committed_at: None,
             num_key_files: 3,
             num_file_files: 1,
@@ -877,7 +877,7 @@ mod tests {
         assert_eq!(decoded.checkpoint_id, manifest.checkpoint_id);
         assert_eq!(decoded.status, ManifestStatus::Checkpointed);
         assert_eq!(decoded.created_at, now);
-        assert_eq!(decoded.sealed_at, now);
+        assert_eq!(decoded.checkpointed_at, now);
         assert_eq!(decoded.committed_at, None);
         assert_eq!(decoded.num_key_files, 3);
         assert_eq!(decoded.num_file_files, 1);
@@ -890,7 +890,7 @@ mod tests {
             checkpoint_id: "task-0-checkpoint-abc".to_string(),
             status: ManifestStatus::Committed,
             created_at: now.clone(),
-            sealed_at: now.clone(),
+            checkpointed_at: now.clone(),
             committed_at: Some(now.clone()),
             num_key_files: 1,
             num_file_files: 0,

--- a/src/daft-checkpoint/src/scan.rs
+++ b/src/daft-checkpoint/src/scan.rs
@@ -1,4 +1,4 @@
-//! [`ScanOperator`] for reading sealed checkpoint keys from file-backed stores.
+//! [`ScanOperator`] for reading checkpointed keys from file-backed stores.
 
 use std::sync::Arc;
 
@@ -90,11 +90,11 @@ impl ScanOperator for BlobStoreCheckpointedKeysScanOperator {
                             message: format!("failed to build S3CheckpointStore: {e}"),
                         }
                     })?;
-                store.sealed_file_paths().await
+                store.checkpointed_file_paths().await
             })
             .map_err(|e| {
                 DaftError::External(
-                    format!("failed to enumerate sealed checkpoint key files: {e}").into(),
+                    format!("failed to enumerate checkpointed key files: {e}").into(),
                 )
             })?;
 
@@ -177,7 +177,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn sealed_checkpoints_produce_one_task_per_key_file() {
+    async fn checkpointed_entries_produce_one_task_per_key_file() {
         let dir = tempfile::tempdir().unwrap();
         let (config, store) = make_store(dir.path());
 
@@ -194,7 +194,7 @@ mod tests {
         let id3 = CheckpointId::generate(2);
         store.stage_keys(&id3, keys(&["ignored"])).await.unwrap();
 
-        let mut expected_paths = store.sealed_file_paths().await.unwrap();
+        let mut expected_paths = store.checkpointed_file_paths().await.unwrap();
         expected_paths.sort();
 
         let op = BlobStoreCheckpointedKeysScanOperator::new(config, key_schema());
@@ -216,7 +216,7 @@ mod tests {
     async fn advertised_schema_is_passed_through_verbatim() {
         // The scan operator advertises whatever schema is handed to it, so
         // callers (the optimizer rule) are responsible for passing the
-        // canonical sealed-keys column name. Pin that the operator does
+        // canonical SEALED_KEYS_COLUMN name. Pin that the operator does
         // expose the schema given at construction — a regression that
         // rewrote the schema internally would silently break the anti-join's
         // right-side resolution.

--- a/src/daft-checkpoint/src/store.rs
+++ b/src/daft-checkpoint/src/store.rs
@@ -25,20 +25,20 @@ pub type CheckpointStoreRef = Arc<dyn CheckpointStore>;
 /// `staged → checkpointed → committed`
 ///
 /// - **Staged:** Keys and files written but not yet visible to readers.
-/// - **Checkpointed:** Sealed — keys and files are coupled and visible.
+/// - **Checkpointed:** Keys and files are coupled and visible.
 /// - **Committed:** Catalog commit succeeded — files no longer returned by
 ///   [`get_checkpointed_files`], but keys remain visible for skip-on-rerun.
 ///
 /// 1. [`stage_keys`] and [`stage_files`] accumulate data under a
 ///    [`CheckpointId`]. Staged data is invisible to readers.
-/// 2. [`checkpoint`] seals the checkpoint — its keys and files become visible
-///    to readers as an atomic unit.
+/// 2. [`checkpoint`] couples the staged keys and files into a single
+///    `Checkpointed` entry, making them visible to readers atomically.
 /// 3. [`mark_committed`] records that the checkpoint's files have been durably
 ///    committed to an external catalog.
 ///
 /// # Consistency
 ///
-/// Checkpoint data is append-only and immutable once sealed. Readers of
+/// Checkpoint data is append-only and immutable once `Checkpointed`. Readers of
 /// [`get_checkpointed_keys`] and [`get_checkpointed_files`] see a
 /// monotonically growing set — new checkpoints may appear between calls,
 /// but existing data never changes or disappears. No isolation between
@@ -63,13 +63,13 @@ pub trait CheckpointStore: Send + Sync {
     /// composite keys, etc.). Callers must stage consistent Series types
     /// (same schema) across calls for the same checkpoint.
     ///
-    /// Returns [`AlreadySealed`] if the checkpoint has already been sealed.
+    /// Returns [`AlreadyCheckpointed`] if `checkpoint()` has already been called for this id.
     ///
     /// **Not idempotent** — uses append semantics. Duplicate keys are not
     /// deduplicated because keys arrive incrementally in batches; dedup would
     /// add cost for no benefit at this layer.
     ///
-    /// [`AlreadySealed`]: crate::error::CheckpointError::AlreadySealed
+    /// [`AlreadyCheckpointed`]: crate::error::CheckpointError::AlreadyCheckpointed
     async fn stage_keys(&self, id: &CheckpointId, keys: Series) -> CheckpointResult<()>;
 
     /// Stage output file metadata into a checkpoint. May be called multiple
@@ -79,25 +79,26 @@ pub trait CheckpointStore: Send + Sync {
     /// Implicitly creates a `Staged` checkpoint entry on first call for a
     /// new ID, same as [`stage_keys`](Self::stage_keys).
     ///
-    /// Returns [`AlreadySealed`] if the checkpoint has already been sealed.
+    /// Returns [`AlreadyCheckpointed`] if `checkpoint()` has already been called for this id.
     ///
     /// **Not idempotent** — uses append semantics, same as [`stage_keys`](Self::stage_keys).
     ///
-    /// [`AlreadySealed`]: crate::error::CheckpointError::AlreadySealed
+    /// [`AlreadyCheckpointed`]: crate::error::CheckpointError::AlreadyCheckpointed
     async fn stage_files(
         &self,
         id: &CheckpointId,
         files: Vec<FileMetadata>,
     ) -> CheckpointResult<()>;
 
-    /// Checkpoint (seal) a staged entry — couples the staged keys and files, making them
-    /// visible to readers. No further staging is allowed after this call.
+    /// Transition a staged entry to `Checkpointed` — couples the staged keys
+    /// and files, making them visible to readers. No further staging is
+    /// allowed after this call.
     ///
-    /// **Idempotent and tolerant of unstaged ids.** No-op if the checkpoint
-    /// has already been sealed (post-restart retry), and also a no-op if the
+    /// **Idempotent and tolerant of unstaged ids.** No-op if the entry is
+    /// already `Checkpointed` (post-restart retry), and also a no-op if the
     /// id was never staged (an empty pipeline run that auto-generated an id
-    /// but never produced any keys or files — sealing nothing is sealing
-    /// nothing). Callers that need to detect unstaged ids must do so via
+    /// but never produced any keys or files — checkpointing nothing is
+    /// checkpointing nothing). Callers that need to detect unstaged ids must do so via
     /// [`get_checkpoint`](Self::get_checkpoint) or
     /// [`list_checkpoints`](Self::list_checkpoints) instead.
     ///
@@ -142,7 +143,7 @@ pub trait CheckpointStore: Send + Sync {
     /// [`get_checkpointed_files`](Self::get_checkpointed_files).
     ///
     /// **Idempotent** for already-committed checkpoints (no-op). Errors if a
-    /// checkpoint is still in `Staged` state (not yet sealed). This supports
+    /// checkpoint is still in `Staged` state. This supports
     /// crash recovery: if the caller crashes after committing some IDs but
     /// before finishing, a retry succeeds without error.
     ///

--- a/src/daft-checkpoint/src/test_utils.rs
+++ b/src/daft-checkpoint/src/test_utils.rs
@@ -88,7 +88,7 @@ pub async fn test_lifecycle(store: &dyn CheckpointStore) {
     assert_eq!(collect_key_strings(store).await, Vec::<String>::new());
     assert_eq!(collect_files(store).await, Vec::<FileMetadata>::new());
 
-    // Seal makes data visible
+    // checkpoint() makes data visible
     store.checkpoint(&id).await.unwrap();
     assert_eq!(collect_key_strings(store).await, vec!["a", "b"]);
     assert_eq!(
@@ -138,7 +138,7 @@ pub async fn test_idempotency(store: &dyn CheckpointStore) {
     store.stage_keys(&id, keys(&["a"])).await.unwrap();
     store.stage_files(&id, vec![file(b"f1")]).await.unwrap();
 
-    // Double seal
+    // Double checkpoint() — idempotent
     store.checkpoint(&id).await.unwrap();
     store.checkpoint(&id).await.unwrap();
     assert_eq!(collect_key_strings(store).await, vec!["a"]);
@@ -156,12 +156,12 @@ pub async fn test_idempotency(store: &dyn CheckpointStore) {
     assert_eq!(collect_key_strings(store).await, vec!["a"]);
     assert_eq!(collect_files(store).await, Vec::<FileMetadata>::new());
 
-    // seal() on committed is also a no-op
+    // checkpoint() on `Committed` is also a no-op
     store.checkpoint(&id).await.unwrap();
 }
 
 pub async fn test_error_paths(store: &dyn CheckpointStore) {
-    // Sealing an unknown ID is a tolerated no-op (covers empty-pipeline-run
+    // Calling checkpoint() on an unknown ID is a tolerated no-op (covers empty-pipeline-run
     // flows where an id is auto-generated but never staged).
     store.checkpoint(&CheckpointId::generate(0)).await.unwrap();
 
@@ -172,26 +172,26 @@ pub async fn test_error_paths(store: &dyn CheckpointStore) {
         .unwrap_err();
     assert!(matches!(err, CheckpointError::CheckpointNotFound { .. }));
 
-    // Stage after seal
+    // Stage after checkpoint() — should error
     let id = CheckpointId::generate(0);
     store.stage_keys(&id, keys(&["a"])).await.unwrap();
     store.checkpoint(&id).await.unwrap();
 
     let err = store.stage_keys(&id, keys(&["b"])).await.unwrap_err();
-    assert!(matches!(err, CheckpointError::AlreadySealed { .. }));
+    assert!(matches!(err, CheckpointError::AlreadyCheckpointed { .. }));
 
     let err = store.stage_files(&id, vec![file(b"f")]).await.unwrap_err();
-    assert!(matches!(err, CheckpointError::AlreadySealed { .. }));
+    assert!(matches!(err, CheckpointError::AlreadyCheckpointed { .. }));
 
-    // Stage after commit (also AlreadySealed)
+    // Stage after commit (also AlreadyCheckpointed)
     store
         .mark_committed(std::slice::from_ref(&id))
         .await
         .unwrap();
     let err = store.stage_keys(&id, keys(&["c"])).await.unwrap_err();
-    assert!(matches!(err, CheckpointError::AlreadySealed { .. }));
+    assert!(matches!(err, CheckpointError::AlreadyCheckpointed { .. }));
 
-    // mark_committed on staged (not sealed)
+    // mark_committed on `Staged` (not yet `Checkpointed`)
     let id2 = CheckpointId::generate(0);
     store.stage_keys(&id2, keys(&["x"])).await.unwrap();
     let err = store.mark_committed(&[id2]).await.unwrap_err();
@@ -199,7 +199,7 @@ pub async fn test_error_paths(store: &dyn CheckpointStore) {
 }
 
 pub async fn test_orphaned_staged_entries(store: &dyn CheckpointStore) {
-    // Orphan: staged but never sealed (simulates crash)
+    // Orphan: `Staged` but never reached `Checkpointed` (simulates crash)
     let orphan_id = CheckpointId::generate(0);
     store
         .stage_keys(&orphan_id, keys(&["orphan"]))
@@ -244,17 +244,17 @@ pub async fn test_crud(store: &dyn CheckpointStore) {
         .unwrap_err();
     assert!(matches!(err, CheckpointError::CheckpointNotFound { .. }));
 
-    // Stage → Sealed → Committed lifecycle via get_checkpoint
+    // Staged → Checkpointed → Committed lifecycle via get_checkpoint
     store.stage_keys(&id1, keys(&["a"])).await.unwrap();
     let ckpt = store.get_checkpoint(&id1).await.unwrap();
     assert_eq!(ckpt.status, CheckpointStatus::Staged);
-    assert!(ckpt.sealed_at.is_none());
+    assert!(ckpt.checkpointed_at.is_none());
     assert!(ckpt.committed_at.is_none());
 
     store.checkpoint(&id1).await.unwrap();
     let ckpt = store.get_checkpoint(&id1).await.unwrap();
     assert_eq!(ckpt.status, CheckpointStatus::Checkpointed);
-    assert!(ckpt.sealed_at.is_some());
+    assert!(ckpt.checkpointed_at.is_some());
     assert!(ckpt.committed_at.is_none());
 
     store
@@ -263,10 +263,10 @@ pub async fn test_crud(store: &dyn CheckpointStore) {
         .unwrap();
     let ckpt = store.get_checkpoint(&id1).await.unwrap();
     assert_eq!(ckpt.status, CheckpointStatus::Committed);
-    assert!(ckpt.sealed_at.is_some());
+    assert!(ckpt.checkpointed_at.is_some());
     assert!(ckpt.committed_at.is_some());
-    assert!(ckpt.sealed_at.unwrap() >= ckpt.created_at);
-    assert!(ckpt.committed_at.unwrap() >= ckpt.sealed_at.unwrap());
+    assert!(ckpt.checkpointed_at.unwrap() >= ckpt.created_at);
+    assert!(ckpt.committed_at.unwrap() >= ckpt.checkpointed_at.unwrap());
 
     // list_checkpoints with mixed states
     store.stage_keys(&id2, keys(&["b"])).await.unwrap();
@@ -304,11 +304,11 @@ pub async fn test_retry_after_partial_failure(store: &dyn CheckpointStore) {
     let good_id = CheckpointId::generate(0);
     let staged_id = CheckpointId::generate(0);
 
-    // good_id: fully sealed
+    // good_id: fully `Checkpointed`
     store.stage_keys(&good_id, keys(&["a"])).await.unwrap();
     store.checkpoint(&good_id).await.unwrap();
 
-    // staged_id: only staged (not sealed)
+    // staged_id: only `Staged` (no checkpoint() yet)
     store.stage_keys(&staged_id, keys(&["b"])).await.unwrap();
 
     // First attempt: partial failure — good_id commits, staged_id errors

--- a/src/daft-checkpoint/src/types.rs
+++ b/src/daft-checkpoint/src/types.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 pub enum CheckpointStatus {
     /// Keys and files are being accumulated. Not visible to readers.
     Staged,
-    /// Sealed — keys and files are coupled and visible to readers.
+    /// Keys and files are coupled and visible to readers.
     Checkpointed,
     /// Catalog commit succeeded. Files no longer returned by
     /// `get_checkpointed_files`, but keys remain visible.
@@ -36,8 +36,8 @@ pub struct Checkpoint {
     pub status: CheckpointStatus,
     /// When the checkpoint entry was first created (first `stage_keys`/`stage_files` call).
     pub created_at: SystemTime,
-    /// When the checkpoint was sealed via `checkpoint()`.
-    pub sealed_at: Option<SystemTime>,
+    /// When the checkpoint transitioned to `Checkpointed` via `checkpoint()`.
+    pub checkpointed_at: Option<SystemTime>,
     /// When the checkpoint was marked committed via `mark_committed()`.
     pub committed_at: Option<SystemTime>,
 }
@@ -49,14 +49,14 @@ impl Checkpoint {
         id: CheckpointId,
         status: CheckpointStatus,
         created_at: SystemTime,
-        sealed_at: Option<SystemTime>,
+        checkpointed_at: Option<SystemTime>,
         committed_at: Option<SystemTime>,
     ) -> Self {
         Self {
             id,
             status,
             created_at,
-            sealed_at,
+            checkpointed_at,
             committed_at,
         }
     }

--- a/src/daft-checkpoint/tests/s3_store.rs
+++ b/src/daft-checkpoint/tests/s3_store.rs
@@ -114,7 +114,7 @@ async fn test_lifecycle() {
     assert_eq!(collect_key_strings(&store).await, Vec::<String>::new());
     assert_eq!(collect_files(&store).await, Vec::<FileMetadata>::new());
 
-    // Seal makes data visible.
+    // checkpoint() makes data visible.
     store.checkpoint(&id).await.unwrap();
     assert_eq!(collect_key_strings(&store).await, vec!["a", "b"]);
     assert_eq!(
@@ -216,16 +216,16 @@ async fn test_error_paths() {
         CheckpointError::CheckpointNotFound { .. } | CheckpointError::NotCheckpointed { .. }
     ));
 
-    // stage_keys after checkpoint() → AlreadySealed
+    // stage_keys after checkpoint() → AlreadyCheckpointed
     let id = CheckpointId::generate(0);
     store.stage_keys(&id, keys(&["a"])).await.unwrap();
     store.checkpoint(&id).await.unwrap();
 
     let err = store.stage_keys(&id, keys(&["b"])).await.unwrap_err();
-    assert!(matches!(err, CheckpointError::AlreadySealed { .. }));
+    assert!(matches!(err, CheckpointError::AlreadyCheckpointed { .. }));
 
     let err = store.stage_files(&id, vec![file(b"f")]).await.unwrap_err();
-    assert!(matches!(err, CheckpointError::AlreadySealed { .. }));
+    assert!(matches!(err, CheckpointError::AlreadyCheckpointed { .. }));
 
     // mark_committed on staged (not yet checkpointed)
     let id2 = CheckpointId::generate(1);
@@ -326,15 +326,15 @@ async fn test_get_checkpoint_and_list() {
     store.stage_keys(&id1, keys(&["a"])).await.unwrap();
     let ckpt = store.get_checkpoint(&id1).await.unwrap();
     assert_eq!(ckpt.status, CheckpointStatus::Staged);
-    assert!(ckpt.sealed_at.is_none());
+    assert!(ckpt.checkpointed_at.is_none());
     assert!(ckpt.committed_at.is_none());
 
     store.checkpoint(&id1).await.unwrap();
     let ckpt = store.get_checkpoint(&id1).await.unwrap();
     assert_eq!(ckpt.status, CheckpointStatus::Checkpointed);
-    assert!(ckpt.sealed_at.is_some());
+    assert!(ckpt.checkpointed_at.is_some());
     assert!(ckpt.committed_at.is_none());
-    assert!(ckpt.sealed_at.unwrap() >= ckpt.created_at);
+    assert!(ckpt.checkpointed_at.unwrap() >= ckpt.created_at);
 
     store
         .mark_committed(std::slice::from_ref(&id1))
@@ -393,7 +393,7 @@ async fn test_stage_keys_renames_to_canonical_column() {
     let id = CheckpointId::generate(0);
 
     // Pass in a series whose field name is the source's column ("file_id"),
-    // not the canonical sealed-keys column ("key"). The store must rename it
+    // not the canonical SEALED_KEYS_COLUMN ("key"). The store must rename it
     // on the way in so the on-disk parquet uses the canonical name.
     let source_named = Utf8Array::from_slice("file_id", &["a", "b", "c"]).into_series();
     assert_eq!(source_named.name(), "file_id");
@@ -584,25 +584,25 @@ async fn test_parquet_file_metadata_roundtrip() {
 }
 
 // ---------------------------------------------------------------------------
-// 14. sealed_file_paths visibility lifecycle
+// 14. checkpointed_file_paths visibility lifecycle
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
-async fn test_sealed_file_paths_lifecycle() {
+async fn test_checkpointed_file_paths_lifecycle() {
     let (_dir, store) = make_store();
 
     // Empty store → no paths.
-    assert!(store.sealed_file_paths().await.unwrap().is_empty());
+    assert!(store.checkpointed_file_paths().await.unwrap().is_empty());
 
     // Staged only → still no paths (staged-only keys must be invisible so the
     // current run doesn't wrongly skip work that was never durably recorded).
     let id = CheckpointId::generate(0);
     store.stage_keys(&id, keys(&["a", "b"])).await.unwrap();
-    assert!(store.sealed_file_paths().await.unwrap().is_empty());
+    assert!(store.checkpointed_file_paths().await.unwrap().is_empty());
 
-    // Sealed → at least one path.
+    // After checkpoint() → at least one path.
     store.checkpoint(&id).await.unwrap();
-    assert!(!store.sealed_file_paths().await.unwrap().is_empty());
+    assert!(!store.checkpointed_file_paths().await.unwrap().is_empty());
 
     // After mark_committed, paths remain available — keys remain visible for
     // skip-on-rerun even after the associated files are committed.
@@ -610,7 +610,7 @@ async fn test_sealed_file_paths_lifecycle() {
         .mark_committed(std::slice::from_ref(&id))
         .await
         .unwrap();
-    assert!(!store.sealed_file_paths().await.unwrap().is_empty());
+    assert!(!store.checkpointed_file_paths().await.unwrap().is_empty());
 }
 
 // ---------------------------------------------------------------------------
@@ -624,8 +624,8 @@ async fn test_checkpoint_on_never_staged_id_is_a_noop() {
 
     // Empty-source case: pipeline produced 0 rows after the anti-join, sink
     // generated an id but no SCKO/sink call ever staged keys or files. We
-    // succeed quietly rather than sealing a content-less manifest — consumers
-    // can already tell "this id sealed nothing" from the absence of a manifest.
+    // succeed quietly rather than writing a content-less manifest — consumers
+    // can already tell "this id checkpointed nothing" from the absence of a manifest.
     store.checkpoint(&id).await.unwrap();
 
     let ckpt = store.get_checkpoint(&id).await;
@@ -633,7 +633,7 @@ async fn test_checkpoint_on_never_staged_id_is_a_noop() {
         ckpt,
         Err(CheckpointError::CheckpointNotFound { .. })
     ));
-    assert!(store.sealed_file_paths().await.unwrap().is_empty());
+    assert!(store.checkpointed_file_paths().await.unwrap().is_empty());
 
     // Idempotent retry — still a no-op.
     store.checkpoint(&id).await.unwrap();


### PR DESCRIPTION
## Why

The user-facing checkpoint lifecycle is `Staged → Checkpointed → Committed`, and the method is `checkpoint(id)`. The Rust trait docs and one error variant used a parallel vocabulary — "seal" / "sealed" — that appears nowhere in the Python API or user guide. A user reading the Python docs and a user reading `cargo doc` (or hitting an `AlreadySealed` traceback) saw two different words for the same transition.

## Changes

- `store.rs` — trait + method docs rewritten using the `Checkpointed` state name and `checkpoint(id)` method name
- `error.rs` — `AlreadySealed` → `AlreadyCheckpointed` (variant + `Display` string + all call sites)
- `scan.rs` — module docs + comments
- `impls/s3.rs`, `test_utils.rs`, `types.rs`, `tests/s3_store.rs` — internal helpers/comments follow suit (`sealed_manifests` → `checkpointed_manifests`, etc.)

Not touched: `SEALED_KEYS_COLUMN` — that's the canonical on-disk column name for sealed-keys parquet files; the value already shipped and renaming it would change the on-disk format.

Rust API break is fine: checkpointing isn't publicly announced yet and there are no external consumers of the trait.

Note: `S3CheckpointStore` keeps its name deliberately — team consensus is "S3" reads as "S3-compatible" (it works against any IOClient-backed store incl. `file://`).

## Verification

- `grep -rn -i "seal" src/daft-checkpoint/` → only `SEALED_KEYS_COLUMN`
- `cargo doc -p daft-checkpoint --no-deps --features s3` renders only `Staged`/`Checkpointed`/`Committed` vocabulary
- `cargo test -p daft-checkpoint --features s3,test-utils` → 39 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)