### PR TITLE
feat(iceberg): support branch and tag reads in SQL

### DIFF
--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -1304,7 +1304,7 @@ jobs:
     needs: skipcheck
     if: ${{ needs.skipcheck.outputs.skip == 'false' }}
     runs-on: blacksmith-8vcpu-ubuntu-2204
-    timeout-minutes: 45
+    timeout-minutes: 60
     env:
       package-name: daft
       RUSTFLAGS: -C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2

--- a/daft/io/iceberg/_iceberg.py
+++ b/daft/io/iceberg/_iceberg.py
@@ -90,7 +90,8 @@ def _resolve_ref_snapshot_id(table: "PyIcebergTable", ref_name: str, ref_kind: s
     return ref.snapshot_id
 
 
-def _resolve_snapshot_id(
+# Internal helper used by read_iceberg and the Rust SQL scan path; not a public API.
+def resolve_snapshot_id(
     table: "PyIcebergTable",
     snapshot_id: int | None,
     branch: str | None,
@@ -163,7 +164,7 @@ def read_iceberg(
     if isinstance(table, (str, os.PathLike)):
         table = StaticTable.from_metadata(metadata_location=os.fspath(table))
 
-    snapshot_id = _resolve_snapshot_id(table, snapshot_id, branch, tag)
+    snapshot_id = resolve_snapshot_id(table, snapshot_id, branch, tag)
 
     io_config = (
         _convert_iceberg_file_io_properties_to_io_config(table.io.properties, table.location())

--- a/src/daft-logical-plan/src/scan_builder.rs
+++ b/src/daft-logical-plan/src/scan_builder.rs
@@ -399,6 +399,8 @@ pub fn delta_scan<T: IntoGlobPath>(
 pub fn iceberg_scan<T: AsRef<str>>(
     metadata_location: T,
     snapshot_id: Option<usize>,
+    branch: Option<String>,
+    tag: Option<String>,
     io_config: Option<IOConfig>,
 ) -> DaftResult<LogicalPlanBuilder> {
     use pyo3::IntoPyObjectExt;
@@ -408,6 +410,10 @@ pub fn iceberg_scan<T: AsRef<str>>(
         let iceberg_static_table = iceberg_table_module.getattr("StaticTable")?;
         let iceberg_table =
             iceberg_static_table.call_method1("from_metadata", (metadata_location.as_ref(),))?;
+        let iceberg_helper_module = PyModule::import(py, "daft.io.iceberg._iceberg")?;
+        let snapshot_id = iceberg_helper_module
+            .getattr("_resolve_snapshot_id")?
+            .call1((&iceberg_table, snapshot_id, branch, tag))?;
         let iceberg_scan_module = PyModule::import(py, "daft.io.iceberg.iceberg_scan")?;
         let iceberg_scan_class = iceberg_scan_module.getattr("IcebergScanOperator")?;
         let iceberg_scan = iceberg_scan_class
@@ -423,9 +429,11 @@ pub fn iceberg_scan<T: AsRef<str>>(
 
 #[cfg(not(feature = "python"))]
 pub fn iceberg_scan<T: AsRef<str>>(
-    uri: T,
-    snapshot_id: Option<usize>,
-    io_config: Option<IOConfig>,
+    _uri: T,
+    _snapshot_id: Option<usize>,
+    _branch: Option<String>,
+    _tag: Option<String>,
+    _io_config: Option<IOConfig>,
 ) -> DaftResult<LogicalPlanBuilder> {
     panic!("Iceberg scan requires the 'python' feature to be enabled.")
 }

--- a/src/daft-logical-plan/src/scan_builder.rs
+++ b/src/daft-logical-plan/src/scan_builder.rs
@@ -412,7 +412,7 @@ pub fn iceberg_scan<T: AsRef<str>>(
             iceberg_static_table.call_method1("from_metadata", (metadata_location.as_ref(),))?;
         let iceberg_helper_module = PyModule::import(py, "daft.io.iceberg._iceberg")?;
         let snapshot_id = iceberg_helper_module
-            .getattr("_resolve_snapshot_id")?
+            .getattr("resolve_snapshot_id")?
             .call1((&iceberg_table, snapshot_id, branch, tag))?;
         let iceberg_scan_module = PyModule::import(py, "daft.io.iceberg.iceberg_scan")?;
         let iceberg_scan_class = iceberg_scan_module.getattr("IcebergScanOperator")?;

--- a/src/daft-sql/src/table_provider/read_iceberg.rs
+++ b/src/daft-sql/src/table_provider/read_iceberg.rs
@@ -16,13 +16,19 @@ pub(super) struct SqlReadIceberg;
 struct SqlReadIcebergArgs {
     metadata_location: String,
     snapshot_id: Option<usize>,
+    branch: Option<String>,
+    tag: Option<String>,
     io_config: Option<IOConfig>,
 }
 
 impl SqlReadIcebergArgs {
     /// Like a TryFrom<SQLFunctionArguments> but from TalbeFunctionArgs directly and passing the planner.
     fn try_from(planner: &SQLPlanner, args: &TableFunctionArgs) -> SQLPlannerResult<Self> {
-        planner.plan_function_args(&args.args, &["snapshot_id", "io_config"], 1)
+        planner.plan_function_args(
+            &args.args,
+            &["snapshot_id", "branch", "tag", "io_config"],
+            1,
+        )
     }
 }
 
@@ -35,10 +41,14 @@ impl TryFrom<SQLFunctionArguments> for SqlReadIcebergArgs {
             .try_get_positional(0)?
             .expect("read_iceberg requires a path");
         let snapshot_id: Option<usize> = args.try_get_named("snapshot_id")?;
+        let branch: Option<String> = args.try_get_named("branch")?;
+        let tag: Option<String> = args.try_get_named("tag")?;
         let io_config: Option<IOConfig> = functions::args::parse_io_config(&args)?.into();
         Ok(Self {
             metadata_location,
             snapshot_id,
+            branch,
+            tag,
             io_config,
         })
     }
@@ -56,6 +66,8 @@ impl SQLTableFunction for SqlReadIceberg {
         Ok(daft_logical_plan::scan_builder::iceberg_scan(
             args.metadata_location,
             args.snapshot_id,
+            args.branch,
+            args.tag,
             args.io_config,
         )?)
     }

--- a/tests/sql/test_sql_read_iceberg.py
+++ b/tests/sql/test_sql_read_iceberg.py
@@ -1,8 +1,81 @@
 from __future__ import annotations
 
+from urllib.parse import unquote, urlparse
+
+import pyarrow as pa
 import pytest
 
 import daft
+
+pyiceberg = pytest.importorskip("pyiceberg")
+
+from pyiceberg.catalog.sql import SqlCatalog
+from pyiceberg.schema import Schema
+from pyiceberg.types import LongType, NestedField, StringType
+
+
+def _metadata_path(metadata_location: str) -> str:
+    parsed = urlparse(metadata_location)
+    return unquote(parsed.path) if parsed.scheme == "file" else metadata_location
+
+
+def test_sql_read_iceberg_branch_and_tag_with_schema_evolution(tmp_path):
+    catalog = SqlCatalog(
+        "default",
+        uri=f"sqlite:///{tmp_path}/pyiceberg_catalog.db",
+        warehouse=f"file://{tmp_path}",
+    )
+    try:
+        catalog.create_namespace("default")
+        table = catalog.create_table("default.t", Schema(NestedField(1, "x", LongType())))
+
+        daft.from_pydict({"x": [1, 2]}).write_iceberg(table)
+        first_snapshot_id = table.current_snapshot().snapshot_id
+        table.manage_snapshots().create_branch(first_snapshot_id, "first_branch").create_tag(
+            first_snapshot_id, "first_tag"
+        ).commit()
+        table.refresh()
+
+        daft.from_pydict({"x": [3, 4]}).write_iceberg(table)
+        main_snapshot_id = table.current_snapshot().snapshot_id
+        table.manage_snapshots().create_branch(main_snapshot_id, "schema_branch").commit()
+        table.refresh()
+
+        with table.update_schema() as update:
+            update.add_column("y", StringType())
+        table.refresh()
+        table.append(pa.table({"x": [5, 6], "y": ["a", "b"]}), branch="schema_branch")
+        table.refresh()
+
+        schema_branch_snapshot_id = table.refs()["schema_branch"].snapshot_id
+        table.manage_snapshots().create_tag(schema_branch_snapshot_id, "schema_tag").commit()
+        table.refresh()
+
+        metadata_location = _metadata_path(table.metadata_location)
+
+        main_df = daft.sql(f"SELECT * FROM read_iceberg('{metadata_location}')")
+        first_snapshot_df = daft.sql(
+            f"SELECT * FROM read_iceberg('{metadata_location}', snapshot_id => {first_snapshot_id})"
+        )
+        first_branch_df = daft.sql(f"SELECT * FROM read_iceberg('{metadata_location}', branch => 'first_branch')")
+        first_tag_df = daft.sql(f"SELECT * FROM read_iceberg('{metadata_location}', tag => 'first_tag')")
+        schema_branch_df = daft.sql(f"SELECT * FROM read_iceberg('{metadata_location}', branch => 'schema_branch')")
+        schema_tag_df = daft.sql(f"SELECT * FROM read_iceberg('{metadata_location}', tag => 'schema_tag')")
+
+        assert main_df.sort("x").to_pydict() == {"x": [1, 2, 3, 4], "y": [None, None, None, None]}
+        assert first_snapshot_df.sort("x").to_pydict() == {"x": [1, 2]}
+        assert first_branch_df.sort("x").to_pydict() == {"x": [1, 2]}
+        assert first_tag_df.sort("x").to_pydict() == {"x": [1, 2]}
+        assert schema_branch_df.sort("x").to_pydict() == {
+            "x": [1, 2, 3, 4, 5, 6],
+            "y": [None, None, None, None, "a", "b"],
+        }
+        assert schema_tag_df.sort("x").to_pydict() == {
+            "x": [1, 2, 3, 4, 5, 6],
+            "y": [None, None, None, None, "a", "b"],
+        }
+    finally:
+        catalog.engine.dispose()
 
 
 @pytest.mark.skip(

--- a/tests/sql/test_sql_read_iceberg.py
+++ b/tests/sql/test_sql_read_iceberg.py
@@ -74,6 +74,16 @@ def test_sql_read_iceberg_branch_and_tag_with_schema_evolution(tmp_path):
             "x": [1, 2, 3, 4, 5, 6],
             "y": [None, None, None, None, "a", "b"],
         }
+        with pytest.raises(Exception, match="Only one of snapshot_id, branch, or tag may be provided") as exc_info:
+            daft.sql(
+                f"SELECT * FROM read_iceberg('{metadata_location}', "
+                f"snapshot_id => {first_snapshot_id}, branch => 'first_branch', tag => 'first_tag')"
+            )
+        assert exc_info.type.__name__ == "InvalidSQLException"
+        for ref_kind in ("branch", "tag"):
+            with pytest.raises(Exception, match=f"Iceberg {ref_kind} 'does_not_exist' does not exist") as exc_info:
+                daft.sql(f"SELECT * FROM read_iceberg('{metadata_location}', {ref_kind} => 'does_not_exist')")
+            assert exc_info.type.__name__ == "InvalidSQLException"
     finally:
         catalog.engine.dispose()
 


### PR DESCRIPTION
## Changes Made
Adds branch and tag read selectors for SQL read_iceberg by resolving refs to snapshot IDs before the existing scan path. Includes SQL coverage across Iceberg branch/tag reads and schema evolution.

## Related Issues
Closes #7091
