### PR TITLE
fix(parquet): cast map values to explicit schema

### DIFF
--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -1304,7 +1304,7 @@ jobs:
     needs: skipcheck
     if: ${{ needs.skipcheck.outputs.skip == 'false' }}
     runs-on: blacksmith-8vcpu-ubuntu-2204
-    timeout-minutes: 45
+    timeout-minutes: 60
     env:
       package-name: daft
       RUSTFLAGS: -C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2

--- a/src/daft-core/src/array/ops/cast.rs
+++ b/src/daft-core/src/array/ops/cast.rs
@@ -1658,11 +1658,18 @@ impl ListArray {
                     }
                 }
             }
-            DataType::Map { .. } => Ok(MapArray::new(
-                Field::new(self.name(), dtype.clone()),
-                self.clone(),
-            )
-            .into_series()),
+            DataType::Map { key, value } => {
+                let physical_dtype = DataType::List(Box::new(DataType::Struct(vec![
+                    Field::new("key", *key.clone()),
+                    Field::new("value", *value.clone()),
+                ])));
+                let result = self.cast(&physical_dtype)?;
+                let map_array = MapArray::new(
+                    Field::new(self.name(), dtype.clone()),
+                    result.list()?.clone(),
+                );
+                Ok(map_array.into_series())
+            }
             DataType::Embedding(..) => {
                 let result = self.cast(&dtype.to_physical())?;
                 let embedding_array = EmbeddingArray::new(

--- a/tests/io/test_parquet.py
+++ b/tests/io/test_parquet.py
@@ -183,6 +183,114 @@ def test_read_parquet_row_group_edges(tmp_path):
         daft.read_parquet([str(path)], row_groups=[[2]]).to_pydict()
 
 
+def test_read_parquet_casts_map_values_to_explicit_schema(tmp_path):
+    int32_path = tmp_path / "map_i32.parquet"
+    int64_path = tmp_path / "map_i64.parquet"
+
+    papq.write_table(pa.table({"m": pa.array([[("a", 1)]], type=pa.map_(pa.string(), pa.int32()))}), int32_path)
+    papq.write_table(pa.table({"m": pa.array([[("b", 2)]], type=pa.map_(pa.string(), pa.int64()))}), int64_path)
+
+    df = daft.read_parquet(
+        [str(int32_path), str(int64_path)],
+        schema={"m": DataType.map(DataType.string(), DataType.int64())},
+    )
+
+    assert df.to_pydict() == {"m": [[("a", 1)], [("b", 2)]]}
+
+
+def test_read_parquet_casts_map_logical_values_to_explicit_schema(tmp_path):
+    path = tmp_path / "map_timestamp.parquet"
+    ts = datetime.datetime.fromisoformat("2024-01-01T12:00:00")
+
+    papq.write_table(pa.table({"m": pa.array([[("a", ts)]], type=pa.map_(pa.string(), pa.timestamp("ns")))}), path)
+
+    df = daft.read_parquet(
+        [str(path)],
+        schema={"m": DataType.map(DataType.string(), DataType.timestamp(TimeUnit.us()))},
+    )
+
+    assert df.to_pydict() == {"m": [[("a", ts)]]}
+
+
+def test_read_parquet_casts_map_keys_to_explicit_schema(tmp_path):
+    int32_path = tmp_path / "map_key_i32.parquet"
+    int64_path = tmp_path / "map_key_i64.parquet"
+
+    papq.write_table(pa.table({"m": pa.array([[(1, "a")]], type=pa.map_(pa.int32(), pa.string()))}), int32_path)
+    papq.write_table(pa.table({"m": pa.array([[(2, "b")]], type=pa.map_(pa.int64(), pa.string()))}), int64_path)
+
+    df = daft.read_parquet(
+        [str(int32_path), str(int64_path)],
+        schema={"m": DataType.map(DataType.int64(), DataType.string())},
+    )
+
+    assert df.to_pydict() == {"m": [[(1, "a")], [(2, "b")]]}
+
+
+def test_read_parquet_casts_nested_map_values_to_explicit_schema(tmp_path):
+    int32_path = tmp_path / "map_list_i32.parquet"
+    int64_path = tmp_path / "map_list_i64.parquet"
+
+    papq.write_table(
+        pa.table({"m": pa.array([[("a", [1, 2])]], type=pa.map_(pa.string(), pa.list_(pa.int32())))}),
+        int32_path,
+    )
+    papq.write_table(
+        pa.table({"m": pa.array([[("b", [3, 4])]], type=pa.map_(pa.string(), pa.list_(pa.int64())))}),
+        int64_path,
+    )
+
+    df = daft.read_parquet(
+        [str(int32_path), str(int64_path)],
+        schema={"m": DataType.map(DataType.string(), DataType.list(DataType.int64()))},
+    )
+
+    assert df.to_pydict() == {"m": [[("a", [1, 2])], [("b", [3, 4])]]}
+
+
+def test_read_parquet_fills_map_struct_values_to_explicit_schema(tmp_path):
+    struct_x_path = tmp_path / "map_struct_x.parquet"
+    struct_xy_path = tmp_path / "map_struct_xy.parquet"
+
+    papq.write_table(
+        pa.table(
+            {
+                "m": pa.array(
+                    [[("a", {"x": 1})]],
+                    type=pa.map_(pa.string(), pa.struct([pa.field("x", pa.int64())])),
+                )
+            }
+        ),
+        struct_x_path,
+    )
+    papq.write_table(
+        pa.table(
+            {
+                "m": pa.array(
+                    [[("b", {"x": 2, "y": "present"})]],
+                    type=pa.map_(
+                        pa.string(),
+                        pa.struct([pa.field("x", pa.int64()), pa.field("y", pa.large_string())]),
+                    ),
+                )
+            }
+        ),
+        struct_xy_path,
+    )
+
+    df = daft.read_parquet(
+        [str(struct_x_path), str(struct_xy_path)],
+        schema={
+            "m": DataType.map(
+                DataType.string(),
+                DataType.struct({"x": DataType.int64(), "y": DataType.string()}),
+            )
+        },
+    )
+
+    assert df.to_pydict() == {"m": [[("a", {"x": 1, "y": None})], [("b", {"x": 2, "y": "present"})]]}
+
+
 # Test fix for issue #2537.
 # This issue arose when the last row of a top-level column has a leaf field with values that span
 # more than one data page.


### PR DESCRIPTION
## Changes Made

Cast a map column's physical list/struct storage to the requested map schema before wrapping it as a logical `Map`.

Added Parquet regression coverage for explicit-schema reads that cast primitive map values and fill newly added fields in map struct values.

## Related Issues

Closes #7092
