### PR TITLE
feat(io): add native Kafka write support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3513,6 +3513,7 @@ dependencies = [
  "common-daft-config",
  "common-error",
  "common-file-formats",
+ "common-hashable-float-wrapper",
  "common-runtime",
  "daft-core",
  "daft-dsl",
@@ -3520,10 +3521,12 @@ dependencies = [
  "daft-logical-plan",
  "daft-micropartition",
  "daft-recordbatch",
+ "futures",
  "hashbrown 0.16.1",
  "parking_lot 0.12.5",
  "parquet",
  "pyo3",
+ "rdkafka",
  "tokio",
  "url",
  "urlencoding",
@@ -5659,6 +5662,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "numpy"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6742,6 +6767,35 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "rdkafka"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7956f9ac12b5712e50372d9749a3102f4810a8d42481c5eae3748d36d585bcf"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "libc",
+ "log",
+ "rdkafka-sys",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "slab",
+ "tokio",
+]
+
+[[package]]
+name = "rdkafka-sys"
+version = "4.10.0+2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e234cf318915c1059d4921ef7f75616b5219b10b46e9f3a511a15eb4b56a3f77"
+dependencies = [
+ "libc",
+ "num_enum",
+ "pkg-config",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1391,6 +1391,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.11.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.1",
+ "shlex",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1599,6 +1617,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1670,6 +1697,17 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -5303,6 +5341,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libz-sys"
+version = "1.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15d118bbf3771060e7311cc7bb0545b01d08a8b4a7de949198dec1fa0ca1c0f7"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5473,6 +5523,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5539,6 +5595,16 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "rawpointer",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -5807,6 +5873,28 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-src"
+version = "300.5.4+3.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507b3792995dae9b0df8a1c1e3771e8418b7c2d9f0baeba32e6fe8b06c7cb72"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.112"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+dependencies = [
+ "cc",
+ "libc",
+ "openssl-src",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "opentelemetry"
@@ -6793,8 +6881,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e234cf318915c1059d4921ef7f75616b5219b10b46e9f3a511a15eb4b56a3f77"
 dependencies = [
  "libc",
+ "libz-sys",
  "num_enum",
+ "openssl-sys",
  "pkg-config",
+ "zstd-sys",
 ]
 
 [[package]]
@@ -8643,6 +8734,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "ve-tos-generic"
 version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9600,6 +9697,7 @@ version = "2.0.16+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
+ "bindgen",
  "cc",
  "pkg-config",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3521,7 +3521,6 @@ dependencies = [
  "daft-logical-plan",
  "daft-micropartition",
  "daft-recordbatch",
- "futures",
  "hashbrown 0.16.1",
  "parking_lot 0.12.5",
  "parquet",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5875,28 +5875,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
-name = "openssl-src"
-version = "300.5.4+3.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507b3792995dae9b0df8a1c1e3771e8418b7c2d9f0baeba32e6fe8b06c7cb72"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.112"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
-dependencies = [
- "cc",
- "libc",
- "openssl-src",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "opentelemetry"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6883,7 +6861,6 @@ dependencies = [
  "libc",
  "libz-sys",
  "num_enum",
- "openssl-sys",
  "pkg-config",
  "zstd-sys",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -343,7 +343,7 @@ prost = "0.13.5"
 prost-types = "0.13.5"
 rand = "^0.9"
 rayon = "1.11.0"
-rdkafka = {version = "0.39.0", default-features = false, features = ["tokio"]}
+rdkafka = {version = "0.39.0", default-features = false, features = ["tokio", "libz", "ssl-vendored", "zstd"]}
 regex = "1.12.2"
 rstest = "0.26.1"
 reqwest = {version = "0.12.19", default-features = false, features = ["json"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -343,7 +343,7 @@ prost = "0.13.5"
 prost-types = "0.13.5"
 rand = "^0.9"
 rayon = "1.11.0"
-rdkafka = {version = "0.39.0", default-features = false, features = ["tokio", "libz", "ssl-vendored", "zstd"]}
+rdkafka = {version = "0.39.0", default-features = false, features = ["tokio", "libz", "zstd"]}
 regex = "1.12.2"
 rstest = "0.26.1"
 reqwest = {version = "0.12.19", default-features = false, features = ["json"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -342,6 +342,7 @@ prost = "0.13.5"
 prost-types = "0.13.5"
 rand = "^0.9"
 rayon = "1.11.0"
+rdkafka = {version = "0.39.0", default-features = false, features = ["tokio"]}
 regex = "1.12.2"
 rstest = "0.26.1"
 reqwest = {version = "0.12.19", default-features = false, features = ["json"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ python = [
   "daft-image/python",
   "daft-io/python",
   "daft-json/python",
+  "daft-local-execution/kafka",
   "daft-local-execution/python",
   "daft-local-plan/python",
   "daft-logical-plan/python",

--- a/daft/daft/__init__.pyi
+++ b/daft/daft/__init__.pyi
@@ -2315,8 +2315,8 @@ class LogicalPlanBuilder:
         timestamp_ms_col: str | None,
         value_format: str,
         key_format: str,
-        kafka_client_config: dict[str, Any] | None,
-        timeout_ms: int,
+        kafka_client_config: dict[str, Any] | None = None,
+        timeout_ms: int = 10000,
     ) -> LogicalPlanBuilder: ...
     def iceberg_write(
         self,

--- a/daft/daft/__init__.pyi
+++ b/daft/daft/__init__.pyi
@@ -2302,6 +2302,22 @@ class LogicalPlanBuilder:
         compression: str | None = None,
         io_config: IOConfig | None = None,
     ) -> LogicalPlanBuilder: ...
+    def kafka_write(
+        self,
+        bootstrap_servers: str,
+        topic: str | None,
+        topic_col: str | None,
+        value_col: str,
+        key_col: str | None,
+        headers_col: str | None,
+        partition: int | None,
+        partition_col: str | None,
+        timestamp_ms_col: str | None,
+        value_format: str,
+        key_format: str,
+        kafka_client_config: dict[str, Any] | None,
+        timeout_ms: int,
+    ) -> LogicalPlanBuilder: ...
     def iceberg_write(
         self,
         table_name: str,

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -160,7 +160,7 @@ def _resolve_kafka_timestamp_ms_col(timestamp_ms_col: object, column_names: Sequ
         if _KAFKA_DEFAULT_TIMESTAMP_MS_COL_NAME in column_names:
             return _KAFKA_DEFAULT_TIMESTAMP_MS_COL_NAME
         return None
-    return typing.cast(str | None, timestamp_ms_col)
+    return typing.cast("str | None", timestamp_ms_col)
 
 
 def to_logical_plan_builder(*parts: MicroPartition) -> LogicalPlanBuilder:
@@ -1345,7 +1345,7 @@ class DataFrame:
         headers_col: str | None = None,
         partition: int | None = None,
         partition_col: str | None = None,
-        timestamp_ms_col: str | None = typing.cast(str | None, _DEFAULT_KAFKA_TIMESTAMP_MS_COL),
+        timestamp_ms_col: str | None = typing.cast("str | None", _DEFAULT_KAFKA_TIMESTAMP_MS_COL),
         value_format: str = "raw",
         key_format: str = "raw",
         kafka_client_config: Mapping[str, object] | None = None,
@@ -1387,7 +1387,9 @@ class DataFrame:
                 options passed to librdkafka. ``bootstrap.servers`` is managed by
                 ``bootstrap_servers`` and cannot be overridden. ``transactional.id`` is not
                 supported yet.
-            timeout_ms (int): Timeout in milliseconds for Kafka delivery and flush operations.
+            timeout_ms (int): Timeout in milliseconds for Kafka delivery, queue, and flush
+                operations. If ``kafka_client_config`` does not set ``delivery.timeout.ms`` or
+                ``message.timeout.ms``, this value is passed to librdkafka as the delivery timeout.
                 Defaults to 10_000.
 
         Returns:

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -90,6 +90,38 @@ T = TypeVar("T")
 R = TypeVar("R")
 P = ParamSpec("P")
 
+_KAFKA_VALUE_FORMATS = {"raw", "utf8", "json"}
+_KAFKA_KEY_FORMATS = {"raw", "utf8"}
+_KAFKA_MANAGED_CONFIG_KEYS = {"bootstrap.servers"}
+_KAFKA_UNSUPPORTED_CONFIG_KEYS = {"transactional.id"}
+
+
+def _normalize_kafka_bootstrap_servers(bootstrap_servers: str | typing.Sequence[str]) -> str:
+    if isinstance(bootstrap_servers, str):
+        return bootstrap_servers
+    return ",".join(str(server) for server in bootstrap_servers)
+
+
+def _validate_kafka_client_config(kafka_client_config: Mapping[str, object] | None) -> dict[str, object] | None:
+    if kafka_client_config is None:
+        return None
+
+    normalized: dict[str, object] = {}
+    for raw_key, value in kafka_client_config.items():
+        key = str(raw_key)
+        if key in _KAFKA_MANAGED_CONFIG_KEYS:
+            raise ValueError(f"[write_kafka] kafka_client_config must not override managed key: {key!r}")
+        if key in _KAFKA_UNSUPPORTED_CONFIG_KEYS:
+            raise NotImplementedError(f"[write_kafka] {key} is not supported yet")
+        if isinstance(value, (str, int, bool, float)) or value is None:
+            normalized[key] = value
+            continue
+        raise TypeError(
+            f"[write_kafka] kafka_client_config value for key {key!r} must be a scalar "
+            f"(str, int, bool, float, or None), got {type(value).__name__}"
+        )
+    return normalized
+
 
 def to_logical_plan_builder(*parts: MicroPartition) -> LogicalPlanBuilder:
     """Creates a Daft DataFrame from a single RecordBatch.
@@ -1255,6 +1287,72 @@ class DataFrame:
         # Keep the original logical plan so explain() can still show upstream operators
         # (e.g. filters/projections before the write), instead of collapsing to an
         # in-memory source after collect() caches the result.
+        result_df = DataFrame(write_df._get_current_builder())
+        result_df._result_cache = write_df._result_cache
+        result_df._preview = write_df._preview
+        result_df._metadata = write_df._metadata
+        return result_df
+
+    @DataframePublicAPI
+    def write_kafka(
+        self,
+        bootstrap_servers: str | typing.Sequence[str],
+        topic: str | None = None,
+        *,
+        topic_col: str | None = None,
+        value_col: str = "value",
+        key_col: str | None = "key",
+        headers_col: str | None = None,
+        partition: int | None = None,
+        partition_col: str | None = None,
+        timestamp_ms_col: str | None = "timestamp_ms",
+        value_format: Literal["raw", "utf8", "json"] = "raw",
+        key_format: Literal["raw", "utf8"] = "raw",
+        kafka_client_config: Mapping[str, object] | None = None,
+        timeout_ms: int = 10_000,
+    ) -> "DataFrame":
+        """Writes the DataFrame to Kafka, returning task-level write summaries.
+
+        This call is blocking and executes the DataFrame.
+        """
+        if (topic is None) == (topic_col is None):
+            raise ValueError("[write_kafka] exactly one of topic or topic_col must be provided")
+        if topic is not None and topic == "":
+            raise ValueError("[write_kafka] topic must be non-empty")
+        if partition is not None and partition < 0:
+            raise ValueError("[write_kafka] partition must be >= 0")
+        if partition is not None and partition_col is not None:
+            raise ValueError("[write_kafka] partition and partition_col are mutually exclusive")
+        if timeout_ms <= 0:
+            raise ValueError("[write_kafka] timeout_ms must be > 0")
+        if value_format not in _KAFKA_VALUE_FORMATS:
+            raise ValueError("[write_kafka] value_format must be one of: raw, utf8, json")
+        if key_format not in _KAFKA_KEY_FORMATS:
+            raise ValueError("[write_kafka] key_format must be one of: raw, utf8")
+
+        bootstrap_servers_str = _normalize_kafka_bootstrap_servers(bootstrap_servers)
+        normalized_client_config = _validate_kafka_client_config(kafka_client_config)
+
+        builder = self._builder.write_kafka(
+            bootstrap_servers=bootstrap_servers_str,
+            topic=topic,
+            topic_col=topic_col,
+            value_col=value_col,
+            key_col=key_col,
+            headers_col=headers_col,
+            partition=partition,
+            partition_col=partition_col,
+            timestamp_ms_col=timestamp_ms_col,
+            value_format=value_format,
+            key_format=key_format,
+            kafka_client_config=normalized_client_config,
+            timeout_ms=timeout_ms,
+        )
+
+        write_df = DataFrame(builder)
+        write_df.collect()
+        assert write_df._result is not None
+
         result_df = DataFrame(write_df._get_current_builder())
         result_df._result_cache = write_df._result_cache
         result_df._preview = write_df._preview

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -1346,8 +1346,8 @@ class DataFrame:
         partition: int | None = None,
         partition_col: str | None = None,
         timestamp_ms_col: str | None = typing.cast(str | None, _DEFAULT_KAFKA_TIMESTAMP_MS_COL),
-        value_format: Literal["raw", "utf8", "json"] = "raw",
-        key_format: Literal["raw", "utf8"] = "raw",
+        value_format: str = "raw",
+        key_format: str = "raw",
         kafka_client_config: Mapping[str, object] | None = None,
         timeout_ms: int = 10_000,
     ) -> "DataFrame":
@@ -1377,12 +1377,12 @@ class DataFrame:
             timestamp_ms_col (str | None): Optional column containing Kafka message timestamps
                 as epoch milliseconds. If omitted, Daft uses ``"timestamp_ms"`` when that column
                 exists; pass ``None`` to always let Kafka assign timestamps.
-            value_format (Literal["raw", "utf8", "json"]): Encoding used for ``value_col``.
+            value_format (str): Encoding used for ``value_col``.
                 ``"raw"`` expects binary values, ``"utf8"`` expects strings, and ``"json"``
                 serializes JSON-compatible Daft values. A top-level null value sends a Kafka
                 null value; nested JSON nulls remain JSON ``null``.
-            key_format (Literal["raw", "utf8"]): Encoding used for ``key_col``. Defaults to
-                ``"raw"``.
+            key_format (str): Encoding used for ``key_col``. Must be ``"raw"`` or ``"utf8"``.
+                Defaults to ``"raw"``.
             kafka_client_config (Mapping[str, object] | None): Optional scalar Kafka producer
                 options passed to librdkafka. ``bootstrap.servers`` is managed by
                 ``bootstrap_servers`` and cannot be overridden. ``transactional.id`` is not

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -12,7 +12,7 @@ import os
 import pathlib
 import typing
 import warnings
-from collections.abc import Callable, Iterable, Iterator, Mapping
+from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from functools import partial, reduce
@@ -98,8 +98,28 @@ _KAFKA_UNSUPPORTED_CONFIG_KEYS = {"transactional.id"}
 
 def _normalize_kafka_bootstrap_servers(bootstrap_servers: str | typing.Sequence[str]) -> str:
     if isinstance(bootstrap_servers, str):
+        if bootstrap_servers == "":
+            raise ValueError("[write_kafka] bootstrap_servers must be non-empty")
         return bootstrap_servers
-    return ",".join(str(server) for server in bootstrap_servers)
+    if isinstance(bootstrap_servers, (bytes, bytearray)):
+        raise TypeError(
+            "[write_kafka] bootstrap_servers must be a non-empty string or sequence of non-empty strings"
+        )
+    if not isinstance(bootstrap_servers, Sequence):
+        raise TypeError(
+            "[write_kafka] bootstrap_servers must be a non-empty string or sequence of non-empty strings"
+        )
+    if len(bootstrap_servers) == 0:
+        raise ValueError("[write_kafka] bootstrap_servers sequence must be non-empty")
+
+    normalized_servers: list[str] = []
+    for server in bootstrap_servers:
+        if not isinstance(server, str):
+            raise TypeError("[write_kafka] bootstrap_servers sequence values must be strings")
+        if server == "":
+            raise ValueError("[write_kafka] bootstrap_servers sequence values must be non-empty")
+        normalized_servers.append(server)
+    return ",".join(normalized_servers)
 
 
 def _validate_kafka_client_config(kafka_client_config: Mapping[str, object] | None) -> dict[str, object] | None:
@@ -107,8 +127,11 @@ def _validate_kafka_client_config(kafka_client_config: Mapping[str, object] | No
         return None
 
     normalized: dict[str, object] = {}
-    for raw_key, value in kafka_client_config.items():
-        key = str(raw_key)
+    for key, value in kafka_client_config.items():
+        if not isinstance(key, str):
+            raise TypeError("[write_kafka] kafka_client_config keys must be strings")
+        if key == "":
+            raise ValueError("[write_kafka] kafka_client_config keys must be non-empty")
         if key in _KAFKA_MANAGED_CONFIG_KEYS:
             raise ValueError(f"[write_kafka] kafka_client_config must not override managed key: {key!r}")
         if key in _KAFKA_UNSUPPORTED_CONFIG_KEYS:
@@ -1313,7 +1336,16 @@ class DataFrame:
     ) -> "DataFrame":
         """Writes the DataFrame to Kafka, returning task-level write summaries.
 
-        This call is blocking and executes the DataFrame.
+        Exactly one of ``topic`` or ``topic_col`` must be provided. ``kafka_client_config``
+        may contain scalar Kafka client options, but Daft-managed options such as
+        ``bootstrap.servers`` cannot be overridden and transactional writes are not yet
+        supported.
+
+        Returns:
+            DataFrame: Task-level write summaries, including row and byte counts.
+
+        Note:
+            This call is **blocking** and will execute the DataFrame when called.
         """
         if (topic is None) == (topic_col is None):
             raise ValueError("[write_kafka] exactly one of topic or topic_col must be provided")

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -94,6 +94,15 @@ _KAFKA_VALUE_FORMATS = {"raw", "utf8", "json"}
 _KAFKA_KEY_FORMATS = {"raw", "utf8"}
 _KAFKA_MANAGED_CONFIG_KEYS = {"bootstrap.servers"}
 _KAFKA_UNSUPPORTED_CONFIG_KEYS = {"transactional.id"}
+_KAFKA_DEFAULT_TIMESTAMP_MS_COL_NAME = "timestamp_ms"
+
+
+class _DefaultKafkaTimestampMsCol:
+    def __repr__(self) -> str:
+        return repr(_KAFKA_DEFAULT_TIMESTAMP_MS_COL_NAME)
+
+
+_DEFAULT_KAFKA_TIMESTAMP_MS_COL = _DefaultKafkaTimestampMsCol()
 
 
 def _normalize_kafka_bootstrap_servers(bootstrap_servers: str | typing.Sequence[str]) -> str:
@@ -144,6 +153,14 @@ def _validate_kafka_client_config(kafka_client_config: Mapping[str, object] | No
             f"(str, int, bool, float, or None), got {type(value).__name__}"
         )
     return normalized
+
+
+def _resolve_kafka_timestamp_ms_col(timestamp_ms_col: object, column_names: Sequence[str]) -> str | None:
+    if timestamp_ms_col is _DEFAULT_KAFKA_TIMESTAMP_MS_COL:
+        if _KAFKA_DEFAULT_TIMESTAMP_MS_COL_NAME in column_names:
+            return _KAFKA_DEFAULT_TIMESTAMP_MS_COL_NAME
+        return None
+    return typing.cast(str | None, timestamp_ms_col)
 
 
 def to_logical_plan_builder(*parts: MicroPartition) -> LogicalPlanBuilder:
@@ -1328,7 +1345,7 @@ class DataFrame:
         headers_col: str | None = None,
         partition: int | None = None,
         partition_col: str | None = None,
-        timestamp_ms_col: str | None = "timestamp_ms",
+        timestamp_ms_col: str | None = typing.cast(str | None, _DEFAULT_KAFKA_TIMESTAMP_MS_COL),
         value_format: Literal["raw", "utf8", "json"] = "raw",
         key_format: Literal["raw", "utf8"] = "raw",
         kafka_client_config: Mapping[str, object] | None = None,
@@ -1336,16 +1353,70 @@ class DataFrame:
     ) -> "DataFrame":
         """Writes the DataFrame to Kafka, returning task-level write summaries.
 
-        Exactly one of ``topic`` or ``topic_col`` must be provided. ``kafka_client_config``
-        may contain scalar Kafka client options, but Daft-managed options such as
-        ``bootstrap.servers`` cannot be overridden and transactional writes are not yet
-        supported.
+        This method is a native Kafka producer sink. Exactly one of ``topic`` or
+        ``topic_col`` must be provided. Writes are at-least-once: if a later message
+        or flush fails, messages already acknowledged by Kafka are not rolled back.
+
+        Args:
+            bootstrap_servers (str | Sequence[str]): Kafka bootstrap server(s) to connect to.
+                Can be a single server string or a sequence of server strings.
+            topic (str | None): Static Kafka topic for all rows. Mutually exclusive with
+                ``topic_col``.
+            topic_col (str | None): Column containing the Kafka topic for each row. Mutually
+                exclusive with ``topic``. Topic values must be non-null strings.
+            value_col (str): Column containing Kafka message values. Defaults to ``"value"``.
+            key_col (str | None): Optional column containing Kafka message keys. Defaults to
+                ``"key"``. Set to ``None`` to write without keys.
+            headers_col (str | None): Optional column containing Kafka headers as a list of
+                structs with ``key`` and ``value`` fields. This preserves duplicate header
+                keys and header order.
+            partition (int | None): Optional static non-negative Kafka partition for all rows.
+                Mutually exclusive with ``partition_col``.
+            partition_col (str | None): Optional column containing per-row Kafka partitions.
+                Null partition values let Kafka choose the partition.
+            timestamp_ms_col (str | None): Optional column containing Kafka message timestamps
+                as epoch milliseconds. If omitted, Daft uses ``"timestamp_ms"`` when that column
+                exists; pass ``None`` to always let Kafka assign timestamps.
+            value_format (Literal["raw", "utf8", "json"]): Encoding used for ``value_col``.
+                ``"raw"`` expects binary values, ``"utf8"`` expects strings, and ``"json"``
+                serializes JSON-compatible Daft values. A top-level null value sends a Kafka
+                null value; nested JSON nulls remain JSON ``null``.
+            key_format (Literal["raw", "utf8"]): Encoding used for ``key_col``. Defaults to
+                ``"raw"``.
+            kafka_client_config (Mapping[str, object] | None): Optional scalar Kafka producer
+                options passed to librdkafka. ``bootstrap.servers`` is managed by
+                ``bootstrap_servers`` and cannot be overridden. ``transactional.id`` is not
+                supported yet.
+            timeout_ms (int): Timeout in milliseconds for Kafka delivery and flush operations.
+                Defaults to 10_000.
 
         Returns:
-            DataFrame: Task-level write summaries, including row and byte counts.
+            DataFrame: Task-level write summaries with columns ``task_id``,
+                ``messages_attempted``, ``messages_delivered``, ``messages_failed``,
+                ``bytes_delivered``, and ``first_error``.
 
         Note:
             This call is **blocking** and will execute the DataFrame when called.
+
+        Examples:
+            Write binary key/value rows to a static topic:
+
+            >>> import daft
+            >>> df = daft.from_pydict({"key": [b"k1"], "value": [b"v1"]})
+            >>> summary = df.write_kafka(  # doctest: +SKIP
+            ...     bootstrap_servers="localhost:9092",
+            ...     topic="events",
+            ... )
+
+            Write JSON values with UTF-8 keys:
+
+            >>> df = daft.from_pylist([{"key": "k1", "value": {"event": "created"}}])
+            >>> summary = df.write_kafka(  # doctest: +SKIP
+            ...     bootstrap_servers="localhost:9092",
+            ...     topic="events",
+            ...     key_format="utf8",
+            ...     value_format="json",
+            ... )
         """
         if (topic is None) == (topic_col is None):
             raise ValueError("[write_kafka] exactly one of topic or topic_col must be provided")
@@ -1364,6 +1435,7 @@ class DataFrame:
 
         bootstrap_servers_str = _normalize_kafka_bootstrap_servers(bootstrap_servers)
         normalized_client_config = _validate_kafka_client_config(kafka_client_config)
+        resolved_timestamp_ms_col = _resolve_kafka_timestamp_ms_col(timestamp_ms_col, self.column_names)
 
         builder = self._builder.write_kafka(
             bootstrap_servers=bootstrap_servers_str,
@@ -1374,7 +1446,7 @@ class DataFrame:
             headers_col=headers_col,
             partition=partition,
             partition_col=partition_col,
-            timestamp_ms_col=timestamp_ms_col,
+            timestamp_ms_col=resolved_timestamp_ms_col,
             value_format=value_format,
             key_format=key_format,
             kafka_client_config=normalized_client_config,

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -111,13 +111,9 @@ def _normalize_kafka_bootstrap_servers(bootstrap_servers: str | typing.Sequence[
             raise ValueError("[write_kafka] bootstrap_servers must be non-empty")
         return bootstrap_servers
     if isinstance(bootstrap_servers, (bytes, bytearray)):
-        raise TypeError(
-            "[write_kafka] bootstrap_servers must be a non-empty string or sequence of non-empty strings"
-        )
+        raise TypeError("[write_kafka] bootstrap_servers must be a non-empty string or sequence of non-empty strings")
     if not isinstance(bootstrap_servers, Sequence):
-        raise TypeError(
-            "[write_kafka] bootstrap_servers must be a non-empty string or sequence of non-empty strings"
-        )
+        raise TypeError("[write_kafka] bootstrap_servers must be a non-empty string or sequence of non-empty strings")
     if len(bootstrap_servers) == 0:
         raise ValueError("[write_kafka] bootstrap_servers sequence must be non-empty")
 

--- a/daft/logical/builder.py
+++ b/daft/logical/builder.py
@@ -394,6 +394,40 @@ class LogicalPlanBuilder:
         )
         return LogicalPlanBuilder(builder)
 
+    def write_kafka(
+        self,
+        *,
+        bootstrap_servers: str,
+        topic: str | None,
+        topic_col: str | None,
+        value_col: str,
+        key_col: str | None,
+        headers_col: str | None,
+        partition: int | None,
+        partition_col: str | None,
+        timestamp_ms_col: str | None,
+        value_format: str,
+        key_format: str,
+        kafka_client_config: dict[str, object] | None,
+        timeout_ms: int,
+    ) -> LogicalPlanBuilder:
+        builder = self._builder.kafka_write(
+            bootstrap_servers,
+            topic,
+            topic_col,
+            value_col,
+            key_col,
+            headers_col,
+            partition,
+            partition_col,
+            timestamp_ms_col,
+            value_format,
+            key_format,
+            kafka_client_config,
+            timeout_ms,
+        )
+        return LogicalPlanBuilder(builder)
+
     def write_iceberg(self, table: IcebergTable, io_config: IOConfig) -> LogicalPlanBuilder:
         from daft.io.iceberg.iceberg_write import get_missing_columns, partition_field_to_expr
 

--- a/docs/api/io.md
+++ b/docs/api/io.md
@@ -100,6 +100,10 @@ Daft offers a variety of approaches to creating a DataFrame from reading various
     options:
         heading_level: 3
 
+::: daft.dataframe.DataFrame.write_kafka
+    options:
+        heading_level: 3
+
 ::: daft.dataframe.DataFrame.write_parquet
     options:
         heading_level: 3

--- a/docs/connectors/index.md
+++ b/docs/connectors/index.md
@@ -89,11 +89,12 @@ See also [Apache Paimon](paimon.md) for detailed integration.
 
 !!! warning "Experimental"
 
-    This connector is experimental. Currently only bounded batch reads are supported — there is no streaming/unbounded mode and no offset commit management.
+    This connector is experimental. Reads are bounded batch reads without streaming/unbounded mode or offset commit management. Writes are at-least-once and do not support transactions.
 
-| Function                           | Description                                          |
-|------------------------------------|------------------------------------------------------|
-| [`read_kafka`][daft.io.read_kafka] | Read messages from Kafka topic(s) into a DataFrame   |
+| Function                                                 | Description                                          |
+|----------------------------------------------------------|------------------------------------------------------|
+| [`read_kafka`][daft.io.read_kafka]                       | Read messages from Kafka topic(s) into a DataFrame   |
+| [`write_kafka`][daft.dataframe.DataFrame.write_kafka]    | Write DataFrame rows to Kafka topic(s)               |
 
 See also [Kafka](kafka.md) for detailed integration.
 

--- a/docs/connectors/kafka.md
+++ b/docs/connectors/kafka.md
@@ -1,14 +1,15 @@
-# Reading from Kafka
+# Kafka
 
 !!! warning "Experimental"
 
     This connector is experimental and the API may change in future releases. Current limitations:
 
-    - **Bounded batch reads only** — no streaming or unbounded mode
+    - **Bounded batch reads only** — no streaming or unbounded read mode
     - **No offset commit management** — consumer group offsets are not committed
-    - **No write support** — Daft cannot produce messages to Kafka
+    - **At-least-once writes only** — already delivered messages are not rolled back after a later failure
+    - **No transactional writes** — `transactional.id` is rejected
 
-[Apache Kafka](https://kafka.apache.org/) is a distributed event streaming platform. Daft can read bounded ranges of messages from Kafka topics into DataFrames using [`daft.read_kafka()`][daft.io.read_kafka].
+[Apache Kafka](https://kafka.apache.org/) is a distributed event streaming platform. Daft can read bounded ranges of messages from Kafka topics into DataFrames using [`daft.read_kafka()`][daft.io.read_kafka] and can write DataFrames to Kafka topics using [`df.write_kafka()`][daft.dataframe.DataFrame.write_kafka].
 
 Daft currently supports:
 
@@ -17,10 +18,11 @@ Daft currently supports:
 3. **Partition filtering**: Read from specific partitions within a topic
 4. **Flexible bounds**: Specify start/end using `"earliest"`/`"latest"`, timestamps (datetime, ISO-8601, or epoch ms), or explicit per-partition offset maps
 5. **Limit pushdown**: Use `.limit(N)` to stop reading early once enough rows are collected
+6. **Native batch writes**: Produce DataFrame rows to a static or per-row topic with optional keys, partitions, timestamps, and headers
 
 ## Installing Daft with Kafka Support
 
-Daft integrates with Kafka through the [confluent-kafka](https://github.com/confluentinc/confluent-kafka-python) package:
+Daft reads from Kafka through the [confluent-kafka](https://github.com/confluentinc/confluent-kafka-python) package:
 
 ```bash
 pip install -U "daft[kafka]"
@@ -32,7 +34,9 @@ Or install the dependency manually:
 pip install confluent-kafka
 ```
 
-## Output Schema
+Kafka writes use Daft's native producer path and do not require the Python `confluent-kafka` package.
+
+## Read Output Schema
 
 Every `read_kafka` call returns a DataFrame with the following fixed schema:
 
@@ -184,3 +188,160 @@ Pass additional [librdkafka configuration](https://github.com/confluentinc/librd
     The following keys are managed internally and cannot be overridden via `kafka_client_config`:
     `bootstrap.servers`, `group.id`, `enable.auto.commit`, `enable.auto.offset.store`.
     These are configured through the dedicated `bootstrap_servers` and `group_id` parameters of `read_kafka()` instead.
+
+## Writing Messages
+
+Use `DataFrame.write_kafka()` to produce each input row as a Kafka message. The call is blocking and returns a DataFrame with task-level write summaries.
+
+### Basic Usage
+
+Write binary keys and values to a single topic:
+
+=== "🐍 Python"
+
+    ```python
+    import daft
+
+    df = daft.from_pydict(
+        {
+            "key": [b"user-1", b"user-2"],
+            "value": [b"created", b"updated"],
+        }
+    )
+
+    summary = df.write_kafka(
+        bootstrap_servers="localhost:9092",
+        topic="events",
+        key_col="key",
+        value_col="value",
+    )
+    summary.show()
+    ```
+
+### JSON Values
+
+Set `value_format="json"` to serialize JSON-compatible Daft values. A top-level null value is written as a Kafka null value, which is commonly used as a tombstone in compacted topics. Nested nulls inside structs or lists remain JSON `null`.
+
+=== "🐍 Python"
+
+    ```python
+    df = daft.from_pylist(
+        [
+            {"key": "user-1", "value": {"op": "upsert", "tags": ["new", None]}},
+            {"key": "user-2", "value": None},
+        ]
+    )
+
+    df.write_kafka(
+        bootstrap_servers="localhost:9092",
+        topic="user-events",
+        key_col="key",
+        value_col="value",
+        key_format="utf8",
+        value_format="json",
+    )
+    ```
+
+### Dynamic Topics and Partitions
+
+Use `topic_col` to choose the topic per row. Use either `partition` for a fixed partition or `partition_col` for a per-row partition. Null partition values let Kafka choose the partition.
+
+=== "🐍 Python"
+
+    ```python
+    df = daft.from_pydict(
+        {
+            "topic": ["events-a", "events-b"],
+            "value": [b"a", b"b"],
+            "partition": [0, None],
+        }
+    )
+
+    df.write_kafka(
+        bootstrap_servers=["broker-1:9092", "broker-2:9092"],
+        topic_col="topic",
+        value_col="value",
+        key_col=None,
+        partition_col="partition",
+    )
+    ```
+
+### Timestamps and Headers
+
+`timestamp_ms_col` defaults to `"timestamp_ms"` when that column is present. Header values should be a list of structs with `key` and `value` fields. This representation preserves duplicate header keys and ordering.
+
+=== "🐍 Python"
+
+    ```python
+    df = daft.from_pylist(
+        [
+            {
+                "key": b"k",
+                "value": b"v",
+                "timestamp_ms": 1710000000000,
+                "headers": [
+                    {"key": "trace", "value": b"a"},
+                    {"key": "trace", "value": b"b"},
+                ],
+            }
+        ]
+    )
+
+    df.write_kafka(
+        bootstrap_servers="localhost:9092",
+        topic="events",
+        key_col="key",
+        value_col="value",
+        headers_col="headers",
+        timestamp_ms_col="timestamp_ms",
+    )
+    ```
+
+## Write Summary Schema
+
+`write_kafka` returns one row per write task:
+
+| Column               | Type     | Description                                             |
+|----------------------|----------|---------------------------------------------------------|
+| `task_id`            | `int64`  | Daft write task identifier                              |
+| `messages_attempted` | `uint64` | Number of messages attempted by the task                |
+| `messages_delivered` | `uint64` | Number of messages acknowledged by Kafka                |
+| `messages_failed`    | `uint64` | Number of messages that failed delivery                 |
+| `bytes_delivered`    | `uint64` | Delivered key, value, and header bytes counted by Daft  |
+| `first_error`        | `string` | First delivery or flush error for the task, if any      |
+
+Delivery counts come from Kafka delivery results. `write_kafka` is at-least-once: if a task errors after some messages are delivered, those messages remain in Kafka.
+
+## Write Formats
+
+| Field       | Parameter          | Formats                         | Null behavior                                  |
+|-------------|--------------------|---------------------------------|------------------------------------------------|
+| topic       | `topic`/`topic_col` | UTF-8 string                    | Dynamic topics must not be null                |
+| key         | `key_col`          | `raw` binary or `utf8` string   | Null key is allowed                            |
+| value       | `value_col`        | `raw`, `utf8`, or `json`        | Null value sends a Kafka null value            |
+| partition   | `partition`/`partition_col` | non-negative `int32`/`int64` | Null dynamic partition lets Kafka choose       |
+| timestamp   | `timestamp_ms_col` | `int64` epoch milliseconds      | Null timestamp lets Kafka assign the timestamp |
+| headers     | `headers_col`      | list of `{key, value}` structs  | Null headers are treated as no headers         |
+
+## Kafka Producer Configuration
+
+Pass additional [librdkafka configuration](https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md) options via `kafka_client_config`:
+
+=== "🐍 Python"
+
+    ```python
+    df.write_kafka(
+        bootstrap_servers="localhost:9092",
+        topic="events",
+        kafka_client_config={
+            "acks": "all",
+            "enable.idempotence": True,
+            "compression.type": "zstd",
+            "client.id": "daft-writer",
+        },
+    )
+    ```
+
+!!! note
+
+    `bootstrap.servers` is managed by the `bootstrap_servers` parameter and cannot be overridden through `kafka_client_config`. `transactional.id` is not supported yet and will raise an error.

--- a/docs/connectors/kafka.md
+++ b/docs/connectors/kafka.md
@@ -304,10 +304,10 @@ Use `topic_col` to choose the topic per row. Use either `partition` for a fixed 
 | Column               | Type     | Description                                             |
 |----------------------|----------|---------------------------------------------------------|
 | `task_id`            | `int64`  | Daft write task identifier                              |
-| `messages_attempted` | `uint64` | Number of messages attempted by the task                |
-| `messages_delivered` | `uint64` | Number of messages acknowledged by Kafka                |
-| `messages_failed`    | `uint64` | Number of messages that failed delivery                 |
-| `bytes_delivered`    | `uint64` | Delivered key, value, and header bytes counted by Daft  |
+| `messages_attempted` | `int64`  | Number of messages attempted by the task                |
+| `messages_delivered` | `int64`  | Number of messages acknowledged by Kafka                |
+| `messages_failed`    | `int64`  | Number of messages that failed delivery                 |
+| `bytes_delivered`    | `int64`  | Delivered key, value, and header bytes counted by Daft  |
 | `first_error`        | `string` | First delivery or flush error for the task, if any      |
 
 Delivery counts come from Kafka delivery results. `write_kafka` is at-least-once: if a task errors after some messages are delivered, those messages remain in Kafka.
@@ -342,6 +342,10 @@ Pass additional [librdkafka configuration](https://github.com/confluentinc/librd
     )
     ```
 
+`timeout_ms` is used for Kafka enqueue, delivery, and flush timeouts. If `kafka_client_config` does not include `delivery.timeout.ms` or `message.timeout.ms`, Daft passes `timeout_ms` through as librdkafka's `delivery.timeout.ms`.
+
 !!! note
 
     `bootstrap.servers` is managed by the `bootstrap_servers` parameter and cannot be overridden through `kafka_client_config`. `transactional.id` is not supported yet and will raise an error.
+
+Native Kafka writes are built with librdkafka support for TLS and common compression codecs including zlib and zstd. Kerberos/GSSAPI builds are not enabled by default.

--- a/docs/superpowers/plans/2026-06-10-native-kafka-write-implementation-plan.md
+++ b/docs/superpowers/plans/2026-06-10-native-kafka-write-implementation-plan.md
@@ -1,0 +1,2365 @@
+# Native Kafka Write Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build `DataFrame.write_kafka(...)` as a Daft-native, Rust-backed Kafka producer sink with task-level summaries and broad `librdkafka` config passthrough.
+
+**Architecture:** Add a native `KafkaInfo` sink to Daft logical planning, translate it to a `KafkaWrite` local physical plan, and execute it through the existing `WriteSink`/`WriterFactory` path. Keep Kafka client code localized in `daft-writers/src/kafka`, using `rdkafka::producer::FutureProducer` behind a testable producer trait.
+
+**Tech Stack:** Python public DataFrame API, PyO3 logical builder bindings, Daft logical/local/distributed plan crates, Daft local execution, `daft-writers`, `rdkafka`, Redpanda integration tests, pytest, cargo.
+
+---
+
+## File Structure
+
+- Modify `daft/dataframe/dataframe.py`
+  - Public `DataFrame.write_kafka(...)` API.
+  - Python-side argument normalization for easy failures.
+  - Blocking write execution pattern matching `write_parquet`, `write_csv`, and `write_json`.
+
+- Modify `daft/logical/builder.py`
+  - Python wrapper method `LogicalPlanBuilder.write_kafka(...)`.
+  - Convert optional column names into Python expressions before calling the Rust builder.
+
+- Modify `daft/daft/__init__.pyi`
+  - Type stub for the PyO3 `LogicalPlanBuilder.kafka_write(...)` method.
+
+- Leave `src/daft-logical-plan/Cargo.toml` unchanged for float hashing
+  - `common-hashable-float-wrapper` is already present in this crate.
+
+- Modify `src/daft-logical-plan/src/sink_info.rs`
+  - Add `KafkaInfo(KafkaWriteInfo<E>)`.
+  - Add Kafka plan config types.
+  - Add bind/display helpers.
+
+- Modify `src/daft-logical-plan/src/ops/sink.rs`
+  - Add Kafka task summary output schema.
+  - Add display branch for Kafka sinks.
+
+- Modify `src/daft-logical-plan/src/builder/mod.rs`
+  - Add Rust `LogicalPlanBuilder::kafka_write(...)`.
+  - Add PyO3 `PyLogicalPlanBuilder.kafka_write(...)`.
+
+- Modify `src/daft-local-plan/src/plan.rs`
+  - Add `LocalPhysicalPlan::KafkaWrite(KafkaWrite)`.
+  - Add constructor, schema access, context access, child traversal, and replacement handling.
+
+- Modify `src/daft-local-plan/src/translate.rs`
+  - Translate `SinkInfo::KafkaInfo` into `LocalPhysicalPlan::KafkaWrite`.
+
+- Modify `src/daft-distributed/src/pipeline_node/sink.rs`
+  - Translate distributed `SinkInfo::KafkaInfo` into local Kafka write plans.
+
+- Modify `src/daft-local-execution/src/sinks/write.rs`
+  - Add `WriteFormat::Kafka`.
+  - Return `"Kafka Write"` from `name()`.
+
+- Modify `src/daft-local-execution/src/pipeline.rs`
+  - Build `daft_writers::make_kafka_writer_factory(...)`.
+  - Create `WriteSink::new(WriteFormat::Kafka, ...)`.
+
+- Modify `src/daft-writers/Cargo.toml`
+  - Add optional `rdkafka`.
+  - Add a `kafka` feature.
+  - Add `futures` for bounded in-flight delivery handling.
+
+- Modify `src/daft-writers/src/lib.rs`
+  - Gate and export the Kafka writer factory.
+
+- Create `src/daft-writers/src/kafka/mod.rs`
+  - Module exports.
+
+- Create `src/daft-writers/src/kafka/config.rs`
+  - Config normalization and protected key validation.
+
+- Create `src/daft-writers/src/kafka/record.rs`
+  - Row projection to `KafkaOutgoingRecord`.
+
+- Create `src/daft-writers/src/kafka/headers.rs`
+  - Header extraction and duplicate key preservation.
+
+- Create `src/daft-writers/src/kafka/producer.rs`
+  - `KafkaProducer` trait, `RdkafkaProducer`, and `FakeProducer` for tests.
+
+- Create `src/daft-writers/src/kafka/accounting.rs`
+  - Counters, first error capture, byte accounting, summary `RecordBatch`.
+
+- Create `src/daft-writers/src/kafka/metrics.rs`
+  - Optional statistics snapshot data shape.
+
+- Create `src/daft-writers/src/kafka/writer.rs`
+  - `KafkaWriterFactory` and `KafkaWriter`.
+
+- Create `tests/io/test_kafka_write_mock.py`
+  - Broker-free Python validation tests.
+
+- Modify `tests/integration/io/test_kafka_integration.py`
+  - Redpanda write/read round trips.
+
+- Modify `docs/connectors/kafka.md`
+  - Document write support.
+
+- Modify `docs/api/io.md`
+  - Add API docs entry only after confirming this page lists DataFrame write APIs.
+
+---
+
+### Task 1: Python API Validation Tests
+
+**Files:**
+- Create: `tests/io/test_kafka_write_mock.py`
+- Modify in Task 2: `daft/dataframe/dataframe.py`
+- Modify in Task 2: `daft/logical/builder.py`
+
+- [ ] **Step 1: Write failing export and validation tests**
+
+Create `tests/io/test_kafka_write_mock.py` with:
+
+```python
+from __future__ import annotations
+
+import pytest
+
+import daft
+
+
+def test_write_kafka_is_exported_on_dataframe() -> None:
+    df = daft.from_pydict({"value": [b"a"]})
+    assert hasattr(df, "write_kafka")
+
+
+@pytest.mark.parametrize(
+    "kwargs,exc,match",
+    [
+        (
+            {"bootstrap_servers": "localhost:9092"},
+            ValueError,
+            "exactly one of topic or topic_col",
+        ),
+        (
+            {"bootstrap_servers": "localhost:9092", "topic": "topic-a", "topic_col": "topic"},
+            ValueError,
+            "exactly one of topic or topic_col",
+        ),
+        (
+            {"bootstrap_servers": "localhost:9092", "topic": ""},
+            ValueError,
+            "topic must be non-empty",
+        ),
+        (
+            {"bootstrap_servers": "localhost:9092", "topic": "topic-a", "partition": -1},
+            ValueError,
+            "partition must be >= 0",
+        ),
+        (
+            {
+                "bootstrap_servers": "localhost:9092",
+                "topic": "topic-a",
+                "partition": 0,
+                "partition_col": "partition",
+            },
+            ValueError,
+            "partition and partition_col are mutually exclusive",
+        ),
+        (
+            {"bootstrap_servers": "localhost:9092", "topic": "topic-a", "timeout_ms": 0},
+            ValueError,
+            "timeout_ms must be > 0",
+        ),
+        (
+            {"bootstrap_servers": "localhost:9092", "topic": "topic-a", "value_format": "avro"},
+            ValueError,
+            "value_format must be one of",
+        ),
+        (
+            {"bootstrap_servers": "localhost:9092", "topic": "topic-a", "key_format": "json"},
+            ValueError,
+            "key_format must be one of",
+        ),
+        (
+            {
+                "bootstrap_servers": "localhost:9092",
+                "topic": "topic-a",
+                "kafka_client_config": {"bootstrap.servers": "other:9092"},
+            },
+            ValueError,
+            "must not override managed key",
+        ),
+        (
+            {
+                "bootstrap_servers": "localhost:9092",
+                "topic": "topic-a",
+                "kafka_client_config": {"transactional.id": "tx-1"},
+            },
+            NotImplementedError,
+            "transactional.id is not supported",
+        ),
+        (
+            {
+                "bootstrap_servers": "localhost:9092",
+                "topic": "topic-a",
+                "kafka_client_config": {"acks": {"nested": "invalid"}},
+            },
+            TypeError,
+            "must be a scalar",
+        ),
+    ],
+)
+def test_write_kafka_rejects_invalid_inputs(
+    kwargs: dict[str, object],
+    exc: type[Exception],
+    match: str,
+) -> None:
+    df = daft.from_pydict({"value": [b"a"]})
+    with pytest.raises(exc, match=match):
+        df.write_kafka(**kwargs)
+
+
+def test_write_kafka_normalization_helpers_accept_valid_values() -> None:
+    from daft.dataframe.dataframe import _normalize_kafka_bootstrap_servers, _validate_kafka_client_config
+
+    assert _normalize_kafka_bootstrap_servers("localhost:9092") == "localhost:9092"
+    assert _normalize_kafka_bootstrap_servers(["a:9092", "b:9092"]) == "a:9092,b:9092"
+    assert _validate_kafka_client_config(
+        {
+            "acks": "all",
+            "enable.idempotence": True,
+            "linger.ms": 10,
+            "queue.buffering.max.kbytes": 1024.5,
+            "client.id": None,
+        }
+    ) == {
+        "acks": "all",
+        "enable.idempotence": True,
+        "linger.ms": 10,
+        "queue.buffering.max.kbytes": 1024.5,
+        "client.id": None,
+    }
+```
+
+- [ ] **Step 2: Run the new tests to verify they fail**
+
+Run:
+
+```bash
+pytest tests/io/test_kafka_write_mock.py -q
+```
+
+Expected: tests fail because `DataFrame.write_kafka` is not implemented.
+
+- [ ] **Step 3: Commit failing tests**
+
+```bash
+git add tests/io/test_kafka_write_mock.py
+git commit -m "test: define kafka write api validation contract" \
+  -m "Constraint: Kafka write is a public API and should fail fast before planning invalid producer work." \
+  -m "Confidence: high" \
+  -m "Scope-risk: narrow" \
+  -m "Tested: pytest tests/io/test_kafka_write_mock.py -q (expected failure before implementation)"
+```
+
+---
+
+### Task 2: Python API and Builder Wrapper
+
+**Files:**
+- Modify: `daft/dataframe/dataframe.py`
+- Modify: `daft/logical/builder.py`
+- Modify: `daft/daft/__init__.pyi`
+- Test: `tests/io/test_kafka_write_mock.py`
+
+- [ ] **Step 1: Add Python helper constants and validation in `daft/dataframe/dataframe.py`**
+
+Add near the other module-level helpers:
+
+```python
+_KAFKA_VALUE_FORMATS = {"raw", "utf8", "json"}
+_KAFKA_KEY_FORMATS = {"raw", "utf8"}
+_KAFKA_MANAGED_CONFIG_KEYS = {"bootstrap.servers"}
+_KAFKA_UNSUPPORTED_CONFIG_KEYS = {"transactional.id"}
+
+
+def _normalize_kafka_bootstrap_servers(bootstrap_servers: str | typing.Sequence[str]) -> str:
+    if isinstance(bootstrap_servers, str):
+        return bootstrap_servers
+    return ",".join(str(server) for server in bootstrap_servers)
+
+
+def _validate_kafka_client_config(kafka_client_config: Mapping[str, object] | None) -> dict[str, object] | None:
+    if kafka_client_config is None:
+        return None
+
+    normalized: dict[str, object] = {}
+    for raw_key, value in kafka_client_config.items():
+        key = str(raw_key)
+        if key in _KAFKA_MANAGED_CONFIG_KEYS:
+            raise ValueError(f"[write_kafka] kafka_client_config must not override managed key: {key!r}")
+        if key in _KAFKA_UNSUPPORTED_CONFIG_KEYS:
+            raise NotImplementedError(f"[write_kafka] {key} is not supported yet")
+        if isinstance(value, (str, int, bool, float)) or value is None:
+            normalized[key] = value
+            continue
+        raise TypeError(
+            f"[write_kafka] kafka_client_config value for key {key!r} must be a scalar "
+            f"(str, int, bool, float, or None), got {type(value).__name__}"
+        )
+    return normalized
+```
+
+- [ ] **Step 2: Add `DataFrame.write_kafka`**
+
+Add after `write_json(...)` and before catalog-specific writes:
+
+```python
+    @DataframePublicAPI
+    def write_kafka(
+        self,
+        bootstrap_servers: str | typing.Sequence[str],
+        topic: str | None = None,
+        *,
+        topic_col: str | None = None,
+        value_col: str = "value",
+        key_col: str | None = "key",
+        headers_col: str | None = None,
+        partition: int | None = None,
+        partition_col: str | None = None,
+        timestamp_ms_col: str | None = "timestamp_ms",
+        value_format: Literal["raw", "utf8", "json"] = "raw",
+        key_format: Literal["raw", "utf8"] = "raw",
+        kafka_client_config: Mapping[str, object] | None = None,
+        timeout_ms: int = 10_000,
+    ) -> "DataFrame":
+        """Writes the DataFrame to Kafka, returning task-level write summaries.
+
+        This call is blocking and executes the DataFrame.
+        """
+        if (topic is None) == (topic_col is None):
+            raise ValueError("[write_kafka] exactly one of topic or topic_col must be provided")
+        if topic is not None and topic == "":
+            raise ValueError("[write_kafka] topic must be non-empty")
+        if partition is not None and partition < 0:
+            raise ValueError("[write_kafka] partition must be >= 0")
+        if partition is not None and partition_col is not None:
+            raise ValueError("[write_kafka] partition and partition_col are mutually exclusive")
+        if timeout_ms <= 0:
+            raise ValueError("[write_kafka] timeout_ms must be > 0")
+        if value_format not in _KAFKA_VALUE_FORMATS:
+            raise ValueError("[write_kafka] value_format must be one of: raw, utf8, json")
+        if key_format not in _KAFKA_KEY_FORMATS:
+            raise ValueError("[write_kafka] key_format must be one of: raw, utf8")
+
+        bootstrap_servers_str = _normalize_kafka_bootstrap_servers(bootstrap_servers)
+        normalized_client_config = _validate_kafka_client_config(kafka_client_config)
+
+        builder = self._builder.write_kafka(
+            bootstrap_servers=bootstrap_servers_str,
+            topic=topic,
+            topic_col=topic_col,
+            value_col=value_col,
+            key_col=key_col,
+            headers_col=headers_col,
+            partition=partition,
+            partition_col=partition_col,
+            timestamp_ms_col=timestamp_ms_col,
+            value_format=value_format,
+            key_format=key_format,
+            kafka_client_config=normalized_client_config,
+            timeout_ms=timeout_ms,
+        )
+
+        write_df = DataFrame(builder)
+        write_df.collect()
+        assert write_df._result is not None
+
+        result_df = DataFrame(write_df._get_current_builder())
+        result_df._result_cache = write_df._result_cache
+        result_df._preview = write_df._preview
+        result_df._metadata = write_df._metadata
+        return result_df
+```
+
+- [ ] **Step 3: Add wrapper method in `daft/logical/builder.py`**
+
+Add near `write_tabular`:
+
+```python
+    def write_kafka(
+        self,
+        *,
+        bootstrap_servers: str,
+        topic: str | None,
+        topic_col: str | None,
+        value_col: str,
+        key_col: str | None,
+        headers_col: str | None,
+        partition: int | None,
+        partition_col: str | None,
+        timestamp_ms_col: str | None,
+        value_format: str,
+        key_format: str,
+        kafka_client_config: dict[str, object] | None,
+        timeout_ms: int,
+    ) -> LogicalPlanBuilder:
+        builder = self._builder.kafka_write(
+            bootstrap_servers,
+            topic,
+            topic_col,
+            value_col,
+            key_col,
+            headers_col,
+            partition,
+            partition_col,
+            timestamp_ms_col,
+            value_format,
+            key_format,
+            kafka_client_config,
+            timeout_ms,
+        )
+        return LogicalPlanBuilder(builder)
+```
+
+- [ ] **Step 4: Add PyO3 stub in `daft/daft/__init__.pyi`**
+
+Add to `class LogicalPlanBuilder` near other write methods:
+
+```python
+    def kafka_write(
+        self,
+        bootstrap_servers: str,
+        topic: str | None,
+        topic_col: str | None,
+        value_col: str,
+        key_col: str | None,
+        headers_col: str | None,
+        partition: int | None,
+        partition_col: str | None,
+        timestamp_ms_col: str | None,
+        value_format: str,
+        key_format: str,
+        kafka_client_config: dict[str, Any] | None,
+        timeout_ms: int,
+    ) -> LogicalPlanBuilder: ...
+```
+
+- [ ] **Step 5: Run validation tests to verify remaining failure moves into Rust binding**
+
+Run:
+
+```bash
+pytest tests/io/test_kafka_write_mock.py -q
+```
+
+Expected: failures now mention missing `LogicalPlanBuilder.kafka_write` on the PyO3 object, or Rust builder missing the method.
+
+- [ ] **Step 6: Commit Python API shell**
+
+```bash
+git add daft/dataframe/dataframe.py daft/logical/builder.py daft/daft/__init__.pyi
+git commit -m "feat: add kafka write dataframe api shell" \
+  -m "Constraint: Keep public argument failures in Python before entering native planning." \
+  -m "Confidence: medium" \
+  -m "Scope-risk: narrow" \
+  -m "Tested: pytest tests/io/test_kafka_write_mock.py -q (expected Rust binding failure)"
+```
+
+---
+
+### Task 3: Logical Plan Kafka Sink Types
+
+**Files:**
+- Modify: `src/daft-logical-plan/src/sink_info.rs`
+- Modify: `src/daft-logical-plan/src/ops/sink.rs`
+- Modify: `src/daft-logical-plan/src/builder/mod.rs`
+- Test: `cargo check -p daft-logical-plan --no-default-features`
+
+- [ ] **Step 1: Add Kafka plan types in `sink_info.rs`**
+
+Add imports:
+
+```rust
+use std::collections::BTreeMap;
+
+use common_hashable_float_wrapper::FloatWrapper;
+```
+
+Add types after `OutputFileInfo`:
+
+```rust
+#[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(debug_assertions, derive(Debug))]
+pub struct KafkaWriteInfo<E = ExprRef> {
+    pub bootstrap_servers: String,
+    pub topic: KafkaTopic<E>,
+    pub value_col: E,
+    pub key_col: Option<E>,
+    pub headers_col: Option<E>,
+    pub partition: Option<KafkaPartition<E>>,
+    pub timestamp_ms_col: Option<E>,
+    pub value_format: KafkaValueFormat,
+    pub key_format: KafkaKeyFormat,
+    pub kafka_client_config: BTreeMap<String, KafkaConfigValue>,
+    pub timeout_ms: u64,
+}
+
+#[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(debug_assertions, derive(Debug))]
+pub enum KafkaTopic<E = ExprRef> {
+    Static(String),
+    Dynamic(E),
+}
+
+#[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(debug_assertions, derive(Debug))]
+pub enum KafkaPartition<E = ExprRef> {
+    Static(i32),
+    Dynamic(E),
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(debug_assertions, derive(Debug))]
+pub enum KafkaValueFormat {
+    Raw,
+    Utf8,
+    Json,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(debug_assertions, derive(Debug))]
+pub enum KafkaKeyFormat {
+    Raw,
+    Utf8,
+}
+
+#[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(debug_assertions, derive(Debug))]
+pub enum KafkaConfigValue {
+    String(String),
+    Int(i64),
+    Float(FloatWrapper<f64>),
+    Bool(bool),
+    Null,
+}
+```
+
+- [ ] **Step 2: Add `SinkInfo::KafkaInfo`**
+
+Update the enum:
+
+```rust
+pub enum SinkInfo<E = ExprRef> {
+    OutputFileInfo(OutputFileInfo<E>),
+    KafkaInfo(KafkaWriteInfo<E>),
+    #[cfg(feature = "python")]
+    CatalogInfo(CatalogInfo<E>),
+    #[cfg(feature = "python")]
+    DataSinkInfo(DataSinkInfo),
+}
+```
+
+- [ ] **Step 3: Add bind helpers in `sink_info.rs`**
+
+Add implementations:
+
+```rust
+impl KafkaWriteInfo {
+    pub fn bind(&self, schema: &Schema) -> DaftResult<KafkaWriteInfo<BoundExpr>> {
+        Ok(KafkaWriteInfo {
+            bootstrap_servers: self.bootstrap_servers.clone(),
+            topic: self.topic.clone().bind(schema)?,
+            value_col: BoundExpr::try_new(self.value_col.clone(), schema)?,
+            key_col: self
+                .key_col
+                .clone()
+                .map(|expr| BoundExpr::try_new(expr, schema))
+                .transpose()?,
+            headers_col: self
+                .headers_col
+                .clone()
+                .map(|expr| BoundExpr::try_new(expr, schema))
+                .transpose()?,
+            partition: self
+                .partition
+                .clone()
+                .map(|partition| partition.bind(schema))
+                .transpose()?,
+            timestamp_ms_col: self
+                .timestamp_ms_col
+                .clone()
+                .map(|expr| BoundExpr::try_new(expr, schema))
+                .transpose()?,
+            value_format: self.value_format,
+            key_format: self.key_format,
+            kafka_client_config: self.kafka_client_config.clone(),
+            timeout_ms: self.timeout_ms,
+        })
+    }
+
+    pub fn multiline_display(&self) -> Vec<String> {
+        vec![
+            format!("Bootstrap servers = {}", self.bootstrap_servers),
+            format!("Topic = {}", self.topic),
+            format!("Value format = {:?}", self.value_format),
+            format!("Key format = {:?}", self.key_format),
+        ]
+    }
+}
+
+impl KafkaTopic {
+    fn bind(&self, schema: &Schema) -> DaftResult<KafkaTopic<BoundExpr>> {
+        match self {
+            Self::Static(topic) => Ok(KafkaTopic::Static(topic.clone())),
+            Self::Dynamic(expr) => Ok(KafkaTopic::Dynamic(BoundExpr::try_new(expr.clone(), schema)?)),
+        }
+    }
+}
+
+impl KafkaPartition {
+    fn bind(&self, schema: &Schema) -> DaftResult<KafkaPartition<BoundExpr>> {
+        match self {
+            Self::Static(partition) => Ok(KafkaPartition::Static(*partition)),
+            Self::Dynamic(expr) => Ok(KafkaPartition::Dynamic(BoundExpr::try_new(expr.clone(), schema)?)),
+        }
+    }
+}
+```
+
+Add `Display` implementations:
+
+```rust
+impl<E> std::fmt::Display for KafkaTopic<E>
+where
+    E: ToString,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(topic) => write!(f, "{}", topic),
+            Self::Dynamic(expr) => write!(f, "{}", expr.to_string()),
+        }
+    }
+}
+```
+
+Update `SinkInfo::bind`:
+
+```rust
+Self::KafkaInfo(kafka_info) => Ok(SinkInfo::KafkaInfo(kafka_info.clone().bind(schema)?)),
+```
+
+- [ ] **Step 4: Add Kafka return schema in `ops/sink.rs`**
+
+Add branch:
+
+```rust
+SinkInfo::KafkaInfo(_) => vec![
+    Field::new("task_id", DataType::Int64),
+    Field::new("messages_attempted", DataType::Int64),
+    Field::new("messages_delivered", DataType::Int64),
+    Field::new("messages_failed", DataType::Int64),
+    Field::new("bytes_delivered", DataType::Int64),
+    Field::new("first_error", DataType::Utf8),
+],
+```
+
+Add display branch:
+
+```rust
+SinkInfo::KafkaInfo(kafka_info) => {
+    res.push("Sink: Kafka".to_string());
+    res.extend(kafka_info.multiline_display());
+}
+```
+
+- [ ] **Step 5: Add Rust builder method in `builder/mod.rs`**
+
+Add imports for Kafka types:
+
+```rust
+use crate::sink_info::{
+    KafkaConfigValue, KafkaKeyFormat, KafkaPartition, KafkaTopic, KafkaValueFormat, KafkaWriteInfo,
+};
+```
+
+Add helper parsers:
+
+```rust
+fn parse_kafka_value_format(value_format: &str) -> DaftResult<KafkaValueFormat> {
+    match value_format {
+        "raw" => Ok(KafkaValueFormat::Raw),
+        "utf8" => Ok(KafkaValueFormat::Utf8),
+        "json" => Ok(KafkaValueFormat::Json),
+        other => Err(DaftError::ValueError(format!(
+            "[write_kafka] value_format must be one of raw, utf8, json; got {other}"
+        ))),
+    }
+}
+
+fn parse_kafka_key_format(key_format: &str) -> DaftResult<KafkaKeyFormat> {
+    match key_format {
+        "raw" => Ok(KafkaKeyFormat::Raw),
+        "utf8" => Ok(KafkaKeyFormat::Utf8),
+        other => Err(DaftError::ValueError(format!(
+            "[write_kafka] key_format must be one of raw, utf8; got {other}"
+        ))),
+    }
+}
+```
+
+Add method:
+
+```rust
+#[allow(clippy::too_many_arguments)]
+pub fn kafka_write(
+    &self,
+    bootstrap_servers: String,
+    topic: Option<String>,
+    topic_col: Option<ExprRef>,
+    value_col: ExprRef,
+    key_col: Option<ExprRef>,
+    headers_col: Option<ExprRef>,
+    partition: Option<i32>,
+    partition_col: Option<ExprRef>,
+    timestamp_ms_col: Option<ExprRef>,
+    value_format: String,
+    key_format: String,
+    kafka_client_config: BTreeMap<String, KafkaConfigValue>,
+    timeout_ms: u64,
+) -> DaftResult<Self> {
+    let topic = match (topic, topic_col) {
+        (Some(topic), None) => KafkaTopic::Static(topic),
+        (None, Some(topic_col)) => KafkaTopic::Dynamic(topic_col),
+        _ => {
+            return Err(DaftError::ValueError(
+                "[write_kafka] exactly one of topic or topic_col must be provided".to_string(),
+            ));
+        }
+    };
+    let partition = match (partition, partition_col) {
+        (Some(partition), None) => Some(KafkaPartition::Static(partition)),
+        (None, Some(partition_col)) => Some(KafkaPartition::Dynamic(partition_col)),
+        (None, None) => None,
+        (Some(_), Some(_)) => {
+            return Err(DaftError::ValueError(
+                "[write_kafka] partition and partition_col are mutually exclusive".to_string(),
+            ));
+        }
+    };
+
+    let sink_info = SinkInfo::KafkaInfo(KafkaWriteInfo {
+        bootstrap_servers,
+        topic,
+        value_col,
+        key_col,
+        headers_col,
+        partition,
+        timestamp_ms_col,
+        value_format: parse_kafka_value_format(&value_format)?,
+        key_format: parse_kafka_key_format(&key_format)?,
+        kafka_client_config,
+        timeout_ms,
+    });
+    let logical_plan: LogicalPlan = ops::Sink::try_new(self.plan.clone(), sink_info.into())?.into();
+    Ok(self.with_new_plan(logical_plan))
+}
+```
+
+- [ ] **Step 6: Run logical-plan check**
+
+Run:
+
+```bash
+cargo check -p daft-logical-plan --no-default-features
+```
+
+Expected: pass for native Rust logical plan code.
+
+- [ ] **Step 7: Commit logical plan changes**
+
+```bash
+git add src/daft-logical-plan/src/sink_info.rs src/daft-logical-plan/src/ops/sink.rs src/daft-logical-plan/src/builder/mod.rs
+git commit -m "feat: add kafka sink logical plan types" \
+  -m "Constraint: Kafka write planning must remain serializable and independent of rdkafka." \
+  -m "Confidence: medium" \
+  -m "Scope-risk: moderate" \
+  -m "Tested: cargo check -p daft-logical-plan --no-default-features"
+```
+
+---
+
+### Task 4: PyO3 Kafka Builder Binding
+
+**Files:**
+- Modify: `src/daft-logical-plan/src/builder/mod.rs`
+- Test: `tests/io/test_kafka_write_mock.py`
+
+- [ ] **Step 1: Add Python config converter in `builder/mod.rs`**
+
+Inside the `#[cfg(feature = "python")]` section, add:
+
+```rust
+#[cfg(feature = "python")]
+fn py_kafka_config_to_rust(
+    _py: Python,
+    config: Option<pyo3::Bound<'_, pyo3::types::PyDict>>,
+) -> PyResult<BTreeMap<String, KafkaConfigValue>> {
+    let mut out = BTreeMap::new();
+    let Some(config) = config else {
+        return Ok(out);
+    };
+
+    for (key, value) in config.iter() {
+        let key = key.extract::<String>()?;
+        let value = if value.is_none() {
+            KafkaConfigValue::Null
+        } else if let Ok(v) = value.extract::<bool>() {
+            KafkaConfigValue::Bool(v)
+        } else if let Ok(v) = value.extract::<i64>() {
+            KafkaConfigValue::Int(v)
+        } else if let Ok(v) = value.extract::<f64>() {
+            KafkaConfigValue::Float(FloatWrapper(v))
+        } else if let Ok(v) = value.extract::<String>() {
+            KafkaConfigValue::String(v)
+        } else {
+            return Err(pyo3::exceptions::PyTypeError::new_err(format!(
+                "[write_kafka] kafka_client_config value for key {key:?} must be a scalar"
+            )));
+        };
+        out.insert(key, value);
+    }
+    Ok(out)
+}
+```
+
+Add imports for `FloatWrapper`, `Python`, and `PyDict` in the same import block that already contains the PyO3 builder methods.
+
+- [ ] **Step 2: Add PyO3 method**
+
+Add near other write PyO3 methods:
+
+```rust
+#[allow(clippy::too_many_arguments)]
+#[pyo3(signature = (
+    bootstrap_servers,
+    topic,
+    topic_col,
+    value_col,
+    key_col,
+    headers_col,
+    partition,
+    partition_col,
+    timestamp_ms_col,
+    value_format,
+    key_format,
+    kafka_client_config=None,
+    timeout_ms=10000
+))]
+pub fn kafka_write(
+    &self,
+    py: Python,
+    bootstrap_servers: String,
+    topic: Option<String>,
+    topic_col: Option<String>,
+    value_col: String,
+    key_col: Option<String>,
+    headers_col: Option<String>,
+    partition: Option<i32>,
+    partition_col: Option<String>,
+    timestamp_ms_col: Option<String>,
+    value_format: String,
+    key_format: String,
+    kafka_client_config: Option<pyo3::Bound<'_, pyo3::types::PyDict>>,
+    timeout_ms: u64,
+) -> PyResult<Self> {
+    let topic_col = topic_col.map(|name| unresolved_col(name.as_str()));
+    let value_col = unresolved_col(value_col.as_str());
+    let key_col = key_col.map(|name| unresolved_col(name.as_str()));
+    let headers_col = headers_col.map(|name| unresolved_col(name.as_str()));
+    let partition_col = partition_col.map(|name| unresolved_col(name.as_str()));
+    let timestamp_ms_col = timestamp_ms_col.map(|name| unresolved_col(name.as_str()));
+    let kafka_client_config = py_kafka_config_to_rust(py, kafka_client_config)?;
+
+    Ok(self
+        .builder
+        .kafka_write(
+            bootstrap_servers,
+            topic,
+            topic_col,
+            value_col,
+            key_col,
+            headers_col,
+            partition,
+            partition_col,
+            timestamp_ms_col,
+            value_format,
+            key_format,
+            kafka_client_config,
+            timeout_ms,
+        )?
+        .into())
+}
+```
+
+Add `unresolved_col` to the `daft_dsl` import list before compiling this method.
+
+- [ ] **Step 3: Run Python validation tests**
+
+Run:
+
+```bash
+pytest tests/io/test_kafka_write_mock.py -q
+```
+
+Expected: invalid input tests pass and valid helper tests pass. The public `write_kafka` path can still fail during execution until Task 10 wires local execution.
+
+- [ ] **Step 4: Commit PyO3 binding**
+
+```bash
+git add src/daft-logical-plan/src/builder/mod.rs daft/daft/__init__.pyi
+git commit -m "feat: expose kafka write in logical builder bindings" \
+  -m "Constraint: Python write_kafka must lower to native logical planning rather than DataSink." \
+  -m "Confidence: medium" \
+  -m "Scope-risk: moderate" \
+  -m "Tested: pytest tests/io/test_kafka_write_mock.py -q"
+```
+
+---
+
+### Task 5: Local and Distributed Plan Plumbing
+
+**Files:**
+- Modify: `src/daft-local-plan/src/plan.rs`
+- Modify: `src/daft-local-plan/src/translate.rs`
+- Modify: `src/daft-distributed/src/pipeline_node/sink.rs`
+- Test: `cargo check -p daft-local-plan --no-default-features`
+- Test: `cargo check -p daft-distributed --features python`
+
+- [ ] **Step 1: Add local physical enum variant and struct**
+
+In `src/daft-local-plan/src/plan.rs`, add enum variant:
+
+```rust
+KafkaWrite(KafkaWrite),
+```
+
+Add struct near other write structs:
+
+```rust
+#[derive(Serialize, Deserialize)]
+#[cfg_attr(debug_assertions, derive(Debug))]
+pub struct KafkaWrite {
+    pub input: LocalPhysicalPlanRef,
+    pub kafka_info: daft_logical_plan::KafkaWriteInfo<BoundExpr>,
+    pub file_schema: SchemaRef,
+    pub stats_state: StatsState,
+    pub context: LocalNodeContext,
+}
+```
+
+- [ ] **Step 2: Add constructor**
+
+Add to `impl LocalPhysicalPlan` near other write constructors:
+
+```rust
+pub fn kafka_write(
+    input: LocalPhysicalPlanRef,
+    kafka_info: daft_logical_plan::KafkaWriteInfo<BoundExpr>,
+    file_schema: SchemaRef,
+    stats_state: StatsState,
+    context: LocalNodeContext,
+) -> LocalPhysicalPlanRef {
+    Self::KafkaWrite(KafkaWrite {
+        input,
+        kafka_info,
+        file_schema,
+        stats_state,
+        context,
+    })
+    .arced()
+}
+```
+
+- [ ] **Step 3: Add match arms throughout `plan.rs`**
+
+Add `KafkaWrite` to each match that handles write-like unary nodes:
+
+```rust
+Self::KafkaWrite(KafkaWrite { stats_state, .. }) => stats_state,
+Self::KafkaWrite(KafkaWrite { context, .. }) => context,
+Self::KafkaWrite(KafkaWrite { context, .. }) => context,
+Self::KafkaWrite(KafkaWrite { file_schema, .. }) => file_schema,
+Self::KafkaWrite(KafkaWrite { input, .. }) => vec![input.clone()],
+```
+
+In `with_new_children`, add:
+
+```rust
+Self::KafkaWrite(KafkaWrite {
+    kafka_info,
+    file_schema,
+    stats_state,
+    context,
+    ..
+}) => Self::kafka_write(
+    new_children[0].clone(),
+    kafka_info.clone(),
+    file_schema.clone(),
+    stats_state.clone(),
+    context.clone(),
+),
+```
+
+- [ ] **Step 4: Translate logical sink to local Kafka write**
+
+In `src/daft-local-plan/src/translate.rs`, add:
+
+```rust
+SinkInfo::KafkaInfo(info) => LocalPhysicalPlan::kafka_write(
+    input_plan,
+    info.clone().bind(&data_schema)?,
+    sink.schema.clone(),
+    sink.stats_state.clone(),
+    LocalNodeContext::default(),
+),
+```
+
+- [ ] **Step 5: Translate distributed sink to local Kafka write**
+
+In `src/daft-distributed/src/pipeline_node/sink.rs`, add this branch. `SinkNode` stores a bound `SinkInfo`, so `info.clone()` has the `BoundExpr` shape expected by `LocalPhysicalPlan::kafka_write`.
+
+```rust
+SinkInfo::KafkaInfo(info) => LocalPhysicalPlan::kafka_write(
+    input,
+    info.clone(),
+    file_schema,
+    StatsState::NotMaterialized,
+    LocalNodeContext::new(Some(node_id as usize)),
+),
+```
+
+- [ ] **Step 6: Run cargo checks**
+
+Run:
+
+```bash
+cargo check -p daft-local-plan --no-default-features
+cargo check -p daft-distributed --features python
+```
+
+Expected: both pass.
+
+- [ ] **Step 7: Commit plan plumbing**
+
+```bash
+git add src/daft-local-plan/src/plan.rs src/daft-local-plan/src/translate.rs src/daft-distributed/src/pipeline_node/sink.rs
+git commit -m "feat: add kafka write physical plan plumbing" \
+  -m "Constraint: Kafka writes are direct external sinks and do not use CommitWrite." \
+  -m "Confidence: medium" \
+  -m "Scope-risk: moderate" \
+  -m "Tested: cargo check -p daft-local-plan --no-default-features; cargo check -p daft-distributed --features python"
+```
+
+---
+
+### Task 6: Kafka Writer Config and Accounting Units
+
+**Files:**
+- Modify: `src/daft-writers/Cargo.toml`
+- Modify: `Cargo.toml`
+- Modify: `src/daft-writers/src/lib.rs`
+- Create: `src/daft-writers/src/kafka/mod.rs`
+- Create: `src/daft-writers/src/kafka/config.rs`
+- Create: `src/daft-writers/src/kafka/accounting.rs`
+- Create: `src/daft-writers/src/kafka/metrics.rs`
+- Test: `cargo test -p daft-writers --no-default-features kafka::config kafka::accounting`
+
+- [ ] **Step 1: Add dependencies and features**
+
+In root `Cargo.toml` workspace dependencies, add:
+
+```toml
+rdkafka = { version = "0.38.0", default-features = false, features = ["tokio"] }
+```
+
+In `src/daft-writers/Cargo.toml`, add dependencies:
+
+```toml
+futures = {workspace = true}
+rdkafka = {workspace = true, optional = true}
+common-hashable-float-wrapper = {path = "../common/hashable-float-wrapper", default-features = false}
+```
+
+Add feature:
+
+```toml
+kafka = ["dep:rdkafka"]
+python = ["dep:pyo3", "kafka", "common-file-formats/python", "common-error/python", "daft-dsl/python", "daft-io/python", "daft-logical-plan/python", "daft-micropartition/python"]
+```
+
+- [ ] **Step 2: Wire module exports**
+
+In `src/daft-writers/src/lib.rs`, add:
+
+```rust
+#[cfg(feature = "kafka")]
+mod kafka;
+#[cfg(feature = "kafka")]
+pub use kafka::writer::make_kafka_writer_factory;
+```
+
+- [ ] **Step 3: Create `kafka/mod.rs`**
+
+```rust
+pub mod accounting;
+pub mod config;
+pub mod metrics;
+pub mod writer;
+pub mod headers;
+pub mod producer;
+pub mod record;
+```
+
+- [ ] **Step 4: Create config conversion**
+
+Create `src/daft-writers/src/kafka/config.rs`:
+
+```rust
+use common_error::{DaftError, DaftResult};
+use daft_logical_plan::KafkaConfigValue;
+
+const MANAGED_KEYS: &[&str] = &["bootstrap.servers"];
+const UNSUPPORTED_KEYS: &[&str] = &["transactional.id"];
+const SENSITIVE_MARKERS: &[&str] = &["password", "sasl.oauthbearer.config"];
+
+pub fn config_value_to_string(value: &KafkaConfigValue) -> String {
+    match value {
+        KafkaConfigValue::String(v) => v.clone(),
+        KafkaConfigValue::Int(v) => v.to_string(),
+        KafkaConfigValue::Float(v) => v.0.to_string(),
+        KafkaConfigValue::Bool(v) => v.to_string(),
+        KafkaConfigValue::Null => String::new(),
+    }
+}
+
+pub fn validate_config_key(key: &str) -> DaftResult<()> {
+    if MANAGED_KEYS.contains(&key) {
+        return Err(DaftError::ValueError(format!(
+            "[write_kafka] kafka_client_config must not override managed key: {key:?}"
+        )));
+    }
+    if UNSUPPORTED_KEYS.contains(&key) {
+        return Err(DaftError::NotImplemented(format!(
+            "[write_kafka] {key} is not supported yet"
+        )));
+    }
+    Ok(())
+}
+
+pub fn redact_config_value(key: &str, value: &str) -> String {
+    let lowered = key.to_ascii_lowercase();
+    if SENSITIVE_MARKERS.iter().any(|marker| lowered.contains(marker)) {
+        "<redacted>".to_string()
+    } else {
+        value.to_string()
+    }
+}
+
+#[cfg(feature = "kafka")]
+pub fn build_client_config(
+    bootstrap_servers: &str,
+    kafka_client_config: &std::collections::BTreeMap<String, KafkaConfigValue>,
+) -> DaftResult<rdkafka::ClientConfig> {
+    let mut config = rdkafka::ClientConfig::new();
+    config.set("bootstrap.servers", bootstrap_servers);
+    config.set("client.id", "daft-write-kafka");
+    for (key, value) in kafka_client_config {
+        validate_config_key(key)?;
+        let value = config_value_to_string(value);
+        config.set(key, value);
+    }
+    Ok(config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use common_hashable_float_wrapper::FloatWrapper;
+
+    #[test]
+    fn converts_scalar_values_to_strings() {
+        assert_eq!(config_value_to_string(&KafkaConfigValue::String("all".to_string())), "all");
+        assert_eq!(config_value_to_string(&KafkaConfigValue::Int(10)), "10");
+        assert_eq!(config_value_to_string(&KafkaConfigValue::Float(FloatWrapper(1.5))), "1.5");
+        assert_eq!(config_value_to_string(&KafkaConfigValue::Bool(true)), "true");
+        assert_eq!(config_value_to_string(&KafkaConfigValue::Null), "");
+    }
+
+    #[test]
+    fn rejects_managed_and_transactional_keys() {
+        assert!(validate_config_key("bootstrap.servers").is_err());
+        assert!(validate_config_key("transactional.id").is_err());
+        assert!(validate_config_key("acks").is_ok());
+    }
+
+    #[test]
+    fn redacts_sensitive_values() {
+        assert_eq!(redact_config_value("sasl.password", "secret"), "<redacted>");
+        assert_eq!(redact_config_value("acks", "all"), "all");
+    }
+}
+```
+
+- [ ] **Step 5: Create accounting**
+
+Create `src/daft-writers/src/kafka/accounting.rs`:
+
+```rust
+use common_error::DaftResult;
+use daft_core::prelude::{DataType, Field, Schema};
+use daft_recordbatch::RecordBatch;
+use std::sync::Arc;
+
+#[derive(Debug, Default, Clone)]
+pub struct KafkaWriteAccounting {
+    pub task_id: i64,
+    pub messages_attempted: i64,
+    pub messages_delivered: i64,
+    pub messages_failed: i64,
+    pub bytes_delivered: i64,
+    pub first_error: Option<String>,
+}
+
+impl KafkaWriteAccounting {
+    pub fn new(task_id: i64) -> Self {
+        Self {
+            task_id,
+            ..Self::default()
+        }
+    }
+
+    pub fn record_attempt(&mut self) {
+        self.messages_attempted += 1;
+    }
+
+    pub fn record_delivery(&mut self, bytes: usize) {
+        self.messages_delivered += 1;
+        self.bytes_delivered += bytes as i64;
+    }
+
+    pub fn record_failure(&mut self, err: impl Into<String>) {
+        self.messages_failed += 1;
+        if self.first_error.is_none() {
+            self.first_error = Some(err.into());
+        }
+    }
+
+    pub fn schema() -> Arc<Schema> {
+        Arc::new(Schema::new(vec![
+            Field::new("task_id", DataType::Int64),
+            Field::new("messages_attempted", DataType::Int64),
+            Field::new("messages_delivered", DataType::Int64),
+            Field::new("messages_failed", DataType::Int64),
+            Field::new("bytes_delivered", DataType::Int64),
+            Field::new("first_error", DataType::Utf8),
+        ]))
+    }
+
+    pub fn to_record_batch(&self) -> DaftResult<RecordBatch> {
+        RecordBatch::from_pydict(Arc::new(vec![
+            ("task_id".into(), vec![self.task_id.into()]),
+            ("messages_attempted".into(), vec![self.messages_attempted.into()]),
+            ("messages_delivered".into(), vec![self.messages_delivered.into()]),
+            ("messages_failed".into(), vec![self.messages_failed.into()]),
+            ("bytes_delivered".into(), vec![self.bytes_delivered.into()]),
+            ("first_error".into(), vec![self.first_error.clone().into()]),
+        ]))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keeps_first_error_and_counts_delivery() {
+        let mut accounting = KafkaWriteAccounting::new(7);
+        accounting.record_attempt();
+        accounting.record_delivery(11);
+        accounting.record_attempt();
+        accounting.record_failure("first");
+        accounting.record_failure("second");
+
+        assert_eq!(accounting.task_id, 7);
+        assert_eq!(accounting.messages_attempted, 2);
+        assert_eq!(accounting.messages_delivered, 1);
+        assert_eq!(accounting.messages_failed, 2);
+        assert_eq!(accounting.bytes_delivered, 11);
+        assert_eq!(accounting.first_error.as_deref(), Some("first"));
+    }
+}
+```
+
+Use the exact `RecordBatch` constructor that already exists in this repository. Before coding `to_record_batch`, run `rg -n "RecordBatch::from_|Int64Array|Utf8Array" src/daft-writers src/daft-recordbatch src/daft-core` and mirror the simplest existing Rust-side summary batch construction pattern.
+
+- [ ] **Step 6: Create metrics shape**
+
+Create `src/daft-writers/src/kafka/metrics.rs`:
+
+```rust
+#[derive(Debug, Clone, Default)]
+pub struct KafkaProducerMetrics {
+    pub txmsgs: i64,
+    pub txmsg_bytes: i64,
+    pub outbuf_msg_cnt: i64,
+    pub msg_cnt: i64,
+    pub msg_max: i64,
+}
+```
+
+- [ ] **Step 7: Run writer unit tests**
+
+Run:
+
+```bash
+cargo test -p daft-writers --features kafka kafka::config kafka::accounting
+cargo test -p daft-writers --no-default-features
+```
+
+Expected: Kafka feature tests pass with `--features kafka`; no-default-features build still passes.
+
+- [ ] **Step 8: Commit writer units**
+
+```bash
+git add Cargo.toml src/daft-writers/Cargo.toml src/daft-writers/src/lib.rs src/daft-writers/src/kafka
+git commit -m "feat: add kafka writer config and accounting units" \
+  -m "Constraint: Keep rdkafka optional and keep correctness accounting independent of producer statistics." \
+  -m "Confidence: medium" \
+  -m "Scope-risk: moderate" \
+  -m "Tested: cargo test -p daft-writers --features kafka kafka::config kafka::accounting; cargo test -p daft-writers --no-default-features"
+```
+
+---
+
+### Task 7: Record Projection, Headers, and Fake Producer
+
+**Files:**
+- Create: `src/daft-writers/src/kafka/headers.rs`
+- Create: `src/daft-writers/src/kafka/record.rs`
+- Create: `src/daft-writers/src/kafka/producer.rs`
+- Test: `cargo test -p daft-writers --features kafka kafka::record kafka::headers kafka::producer`
+
+- [ ] **Step 1: Define producer data types and fake producer**
+
+Create `src/daft-writers/src/kafka/producer.rs`:
+
+```rust
+use std::{collections::VecDeque, sync::Mutex, time::Duration};
+
+use async_trait::async_trait;
+use common_error::{DaftError, DaftResult};
+
+use super::metrics::KafkaProducerMetrics;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KafkaHeader {
+    pub key: String,
+    pub value: Option<Vec<u8>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KafkaOutgoingRecord {
+    pub topic: String,
+    pub key: Option<Vec<u8>>,
+    pub value: Option<Vec<u8>>,
+    pub headers: Vec<KafkaHeader>,
+    pub partition: Option<i32>,
+    pub timestamp_ms: Option<i64>,
+}
+
+impl KafkaOutgoingRecord {
+    pub fn delivered_bytes(&self) -> usize {
+        let key_bytes = self.key.as_ref().map_or(0, Vec::len);
+        let value_bytes = self.value.as_ref().map_or(0, Vec::len);
+        let header_bytes = self
+            .headers
+            .iter()
+            .map(|header| header.key.len() + header.value.as_ref().map_or(0, Vec::len))
+            .sum::<usize>();
+        key_bytes + value_bytes + header_bytes
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KafkaDelivery {
+    pub topic: String,
+    pub partition: i32,
+    pub offset: i64,
+    pub timestamp_ms: Option<i64>,
+}
+
+#[async_trait]
+pub trait KafkaProducer: Send + Sync {
+    async fn send(&self, record: KafkaOutgoingRecord) -> DaftResult<KafkaDelivery>;
+    async fn flush(&self, timeout: Duration) -> DaftResult<()>;
+
+    fn metrics_snapshot(&self) -> Option<KafkaProducerMetrics> {
+        None
+    }
+}
+
+pub struct FakeProducer {
+    deliveries: Mutex<VecDeque<DaftResult<KafkaDelivery>>>,
+    sent: Mutex<Vec<KafkaOutgoingRecord>>,
+    flush_result: Mutex<Option<DaftResult<()>>>,
+}
+
+impl FakeProducer {
+    pub fn succeeding() -> Self {
+        Self {
+            deliveries: Mutex::new(VecDeque::new()),
+            sent: Mutex::new(Vec::new()),
+            flush_result: Mutex::new(Some(Ok(()))),
+        }
+    }
+
+    pub fn with_delivery_result(result: DaftResult<KafkaDelivery>) -> Self {
+        let mut deliveries = VecDeque::new();
+        deliveries.push_back(result);
+        Self {
+            deliveries: Mutex::new(deliveries),
+            sent: Mutex::new(Vec::new()),
+            flush_result: Mutex::new(Some(Ok(()))),
+        }
+    }
+
+    pub fn sent_records(&self) -> Vec<KafkaOutgoingRecord> {
+        self.sent.lock().expect("fake producer mutex poisoned").clone()
+    }
+}
+
+#[async_trait]
+impl KafkaProducer for FakeProducer {
+    async fn send(&self, record: KafkaOutgoingRecord) -> DaftResult<KafkaDelivery> {
+        self.sent.lock().expect("fake producer mutex poisoned").push(record.clone());
+        if let Some(result) = self.deliveries.lock().expect("fake producer mutex poisoned").pop_front() {
+            return result;
+        }
+        Ok(KafkaDelivery {
+            topic: record.topic,
+            partition: record.partition.unwrap_or(0),
+            offset: 0,
+            timestamp_ms: record.timestamp_ms,
+        })
+    }
+
+    async fn flush(&self, _timeout: Duration) -> DaftResult<()> {
+        self.flush_result
+            .lock()
+            .expect("fake producer mutex poisoned")
+            .take()
+            .unwrap_or_else(|| Ok(()))
+    }
+}
+
+pub fn delivery_error(message: &str) -> DaftResult<KafkaDelivery> {
+    Err(DaftError::External(format!("[write_kafka] {message}")))
+}
+```
+
+- [ ] **Step 2: Implement headers extraction tests first**
+
+Create `src/daft-writers/src/kafka/headers.rs`:
+
+```rust
+use common_error::DaftResult;
+
+use super::producer::KafkaHeader;
+
+pub fn validate_header_key(key: &str) -> DaftResult<()> {
+    if key.is_empty() {
+        return Err(common_error::DaftError::ValueError(
+            "[write_kafka] Kafka header key must be non-empty".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+pub fn make_header(key: &str, value: Option<&[u8]>) -> DaftResult<KafkaHeader> {
+    validate_header_key(key)?;
+    Ok(KafkaHeader {
+        key: key.to_string(),
+        value: value.map(|bytes| bytes.to_vec()),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preserves_duplicate_header_keys() {
+        let headers = vec![
+            make_header("trace", Some(b"a")).unwrap(),
+            make_header("trace", Some(b"b")).unwrap(),
+            make_header("empty", None).unwrap(),
+        ];
+        assert_eq!(headers[0].key, "trace");
+        assert_eq!(headers[0].value.as_deref(), Some(&b"a"[..]));
+        assert_eq!(headers[1].key, "trace");
+        assert_eq!(headers[1].value.as_deref(), Some(&b"b"[..]));
+        assert_eq!(headers[2].value, None);
+    }
+
+    #[test]
+    fn rejects_empty_header_key() {
+        assert!(make_header("", Some(b"value")).is_err());
+    }
+}
+```
+
+- [ ] **Step 3: Implement record projection scaffold**
+
+Create `src/daft-writers/src/kafka/record.rs`:
+
+```rust
+use common_error::{DaftError, DaftResult};
+
+use super::producer::KafkaOutgoingRecord;
+
+pub fn validate_topic(topic: &str) -> DaftResult<()> {
+    if topic.is_empty() {
+        return Err(DaftError::ComputeError(
+            "[write_kafka] Kafka topic must be non-empty".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+pub fn validate_partition(partition: i32) -> DaftResult<()> {
+    if partition < 0 {
+        return Err(DaftError::ComputeError(
+            "[write_kafka] Kafka partition must be >= 0".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+pub fn make_test_record(
+    topic: &str,
+    key: Option<&[u8]>,
+    value: Option<&[u8]>,
+    partition: Option<i32>,
+    timestamp_ms: Option<i64>,
+) -> DaftResult<KafkaOutgoingRecord> {
+    validate_topic(topic)?;
+    if let Some(partition) = partition {
+        validate_partition(partition)?;
+    }
+    Ok(KafkaOutgoingRecord {
+        topic: topic.to_string(),
+        key: key.map(|bytes| bytes.to_vec()),
+        value: value.map(|bytes| bytes.to_vec()),
+        headers: vec![],
+        partition,
+        timestamp_ms,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builds_raw_record_and_counts_bytes() {
+        let record = make_test_record("events", Some(b"k"), Some(b"value"), Some(1), Some(123)).unwrap();
+        assert_eq!(record.topic, "events");
+        assert_eq!(record.key.as_deref(), Some(&b"k"[..]));
+        assert_eq!(record.value.as_deref(), Some(&b"value"[..]));
+        assert_eq!(record.partition, Some(1));
+        assert_eq!(record.timestamp_ms, Some(123));
+        assert_eq!(record.delivered_bytes(), 6);
+    }
+
+    #[test]
+    fn supports_tombstone_value() {
+        let record = make_test_record("events", Some(b"k"), None, None, None).unwrap();
+        assert_eq!(record.value, None);
+    }
+
+    #[test]
+    fn rejects_empty_topic_and_negative_partition() {
+        assert!(make_test_record("", None, Some(b"value"), None, None).is_err());
+        assert!(make_test_record("events", None, Some(b"value"), Some(-1), None).is_err());
+    }
+}
+```
+
+In later implementation, replace `make_test_record` with full row projection from `MicroPartition` while keeping these validation helpers.
+
+- [ ] **Step 4: Run unit tests**
+
+Run:
+
+```bash
+cargo test -p daft-writers --features kafka kafka::record kafka::headers kafka::producer
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit record and producer units**
+
+```bash
+git add src/daft-writers/src/kafka/headers.rs src/daft-writers/src/kafka/record.rs src/daft-writers/src/kafka/producer.rs
+git commit -m "feat: add kafka record and producer test seams" \
+  -m "Constraint: Keep delivery accounting testable without a Kafka broker." \
+  -m "Confidence: medium" \
+  -m "Scope-risk: moderate" \
+  -m "Tested: cargo test -p daft-writers --features kafka kafka::record kafka::headers kafka::producer"
+```
+
+---
+
+### Task 8: rdkafka Adapter and Kafka Writer
+
+**Files:**
+- Modify: `src/daft-writers/src/kafka/producer.rs`
+- Create: `src/daft-writers/src/kafka/writer.rs`
+- Modify: `src/daft-writers/src/lib.rs`
+- Test: `cargo test -p daft-writers --features kafka kafka::writer`
+
+- [ ] **Step 1: Add `RdkafkaProducer` adapter**
+
+In `producer.rs`, add under `#[cfg(feature = "kafka")]`:
+
+```rust
+#[cfg(feature = "kafka")]
+pub struct RdkafkaProducer {
+    inner: rdkafka::producer::FutureProducer,
+}
+
+#[cfg(feature = "kafka")]
+impl RdkafkaProducer {
+    pub fn new(inner: rdkafka::producer::FutureProducer) -> Self {
+        Self { inner }
+    }
+}
+
+#[cfg(feature = "kafka")]
+#[async_trait]
+impl KafkaProducer for RdkafkaProducer {
+    async fn send(&self, record: KafkaOutgoingRecord) -> DaftResult<KafkaDelivery> {
+        use rdkafka::producer::FutureRecord;
+        use std::time::Duration;
+
+        let mut future_record = FutureRecord::to(&record.topic);
+        if let Some(key) = &record.key {
+            future_record = future_record.key(key);
+        }
+        if let Some(value) = &record.value {
+            future_record = future_record.payload(value);
+        }
+        if let Some(partition) = record.partition {
+            future_record = future_record.partition(partition);
+        }
+        if let Some(timestamp_ms) = record.timestamp_ms {
+            future_record = future_record.timestamp(timestamp_ms);
+        }
+
+        let delivery = self
+            .inner
+            .send(future_record, Duration::from_secs(0))
+            .await
+            .map_err(|(err, _)| common_error::DaftError::External(format!("[write_kafka] delivery failed: {err}")))?;
+
+        Ok(KafkaDelivery {
+            topic: record.topic,
+            partition: delivery.partition,
+            offset: delivery.offset,
+            timestamp_ms: record.timestamp_ms,
+        })
+    }
+
+    async fn flush(&self, timeout: Duration) -> DaftResult<()> {
+        use rdkafka::producer::Producer;
+        self.inner
+            .flush(timeout)
+            .map_err(|err| common_error::DaftError::External(format!("[write_kafka] flush failed: {err}")))
+    }
+}
+```
+
+Add headers support by converting `KafkaHeader` into `rdkafka::message::OwnedHeaders` if compiler confirms the API shape. Use:
+
+```rust
+use rdkafka::message::{Header, OwnedHeaders};
+```
+
+and attach headers before send.
+
+- [ ] **Step 2: Implement writer factory and writer**
+
+Create `src/daft-writers/src/kafka/writer.rs`:
+
+```rust
+use std::{sync::Arc, time::Duration};
+
+use async_trait::async_trait;
+use common_error::{DaftError, DaftResult};
+use daft_logical_plan::KafkaWriteInfo;
+use daft_micropartition::MicroPartition;
+use daft_recordbatch::RecordBatch;
+
+use crate::{AsyncFileWriter, WriteResult, WriterFactory};
+
+use super::{
+    accounting::KafkaWriteAccounting,
+    config::build_client_config,
+    producer::{KafkaProducer, RdkafkaProducer},
+};
+
+pub fn make_kafka_writer_factory(
+    kafka_info: KafkaWriteInfo<daft_dsl::expr::bound_expr::BoundExpr>,
+) -> Arc<dyn WriterFactory<Input = MicroPartition, Result = Vec<RecordBatch>>> {
+    Arc::new(KafkaWriterFactory { kafka_info })
+}
+
+pub struct KafkaWriterFactory {
+    kafka_info: KafkaWriteInfo<daft_dsl::expr::bound_expr::BoundExpr>,
+}
+
+impl WriterFactory for KafkaWriterFactory {
+    type Input = MicroPartition;
+    type Result = Vec<RecordBatch>;
+
+    fn create_writer(
+        &self,
+        file_idx: usize,
+        _partition_values: Option<&RecordBatch>,
+    ) -> DaftResult<Box<dyn AsyncFileWriter<Input = Self::Input, Result = Self::Result>>> {
+        let client_config = build_client_config(
+            &self.kafka_info.bootstrap_servers,
+            &self.kafka_info.kafka_client_config,
+        )?;
+        let producer = client_config
+            .create()
+            .map_err(|err| DaftError::External(format!("[write_kafka] failed to create producer: {err}")))?;
+
+        Ok(Box::new(KafkaWriter::new(
+            self.kafka_info.clone(),
+            RdkafkaProducer::new(producer),
+            file_idx as i64,
+        )))
+    }
+}
+
+pub struct KafkaWriter<P: KafkaProducer> {
+    kafka_info: KafkaWriteInfo<daft_dsl::expr::bound_expr::BoundExpr>,
+    producer: P,
+    accounting: KafkaWriteAccounting,
+}
+
+impl<P: KafkaProducer> KafkaWriter<P> {
+    pub fn new(
+        kafka_info: KafkaWriteInfo<daft_dsl::expr::bound_expr::BoundExpr>,
+        producer: P,
+        task_id: i64,
+    ) -> Self {
+        Self {
+            kafka_info,
+            producer,
+            accounting: KafkaWriteAccounting::new(task_id),
+        }
+    }
+}
+
+#[async_trait]
+impl<P: KafkaProducer + 'static> AsyncFileWriter for KafkaWriter<P> {
+    type Input = MicroPartition;
+    type Result = Vec<RecordBatch>;
+
+    async fn write(&mut self, data: Self::Input) -> DaftResult<WriteResult> {
+        let _ = &self.kafka_info;
+        let rows = data.len();
+        for _ in 0..rows {
+            self.accounting.record_attempt();
+        }
+        Err(DaftError::NotImplemented(
+            "[write_kafka] row projection is not wired into KafkaWriter yet".to_string(),
+        ))
+    }
+
+    async fn close(&mut self) -> DaftResult<Self::Result> {
+        self.producer
+            .flush(Duration::from_millis(self.kafka_info.timeout_ms))
+            .await?;
+        Ok(vec![self.accounting.to_record_batch()?])
+    }
+
+    fn bytes_written(&self) -> usize {
+        self.accounting.bytes_delivered as usize
+    }
+
+    fn bytes_per_file(&self) -> Vec<usize> {
+        vec![self.accounting.bytes_delivered as usize]
+    }
+}
+```
+
+This intermediate writer compiles the factory path and deliberately returns `NotImplemented` until Task 9 wires full row projection. The public API should not be considered complete until Task 9 and integration tests pass.
+
+- [ ] **Step 3: Run writer check**
+
+Run:
+
+```bash
+cargo check -p daft-writers --features kafka
+```
+
+Expected: pass after adapting API details for `RecordBatch` construction and `rdkafka` headers.
+
+- [ ] **Step 4: Commit adapter and writer shell**
+
+```bash
+git add src/daft-writers/src/kafka/producer.rs src/daft-writers/src/kafka/writer.rs src/daft-writers/src/lib.rs
+git commit -m "feat: add rdkafka writer factory shell" \
+  -m "Constraint: Isolate rdkafka behind daft-writers and a testable producer trait." \
+  -m "Confidence: medium" \
+  -m "Scope-risk: moderate" \
+  -m "Tested: cargo check -p daft-writers --features kafka"
+```
+
+---
+
+### Task 9: Full Row Projection and Delivery Accounting
+
+**Files:**
+- Modify: `src/daft-writers/src/kafka/record.rs`
+- Modify: `src/daft-writers/src/kafka/headers.rs`
+- Modify: `src/daft-writers/src/kafka/writer.rs`
+- Test: `cargo test -p daft-writers --features kafka kafka::writer kafka::record kafka::headers`
+
+- [ ] **Step 1: Add record projection tests with `FakeProducer`**
+
+In `writer.rs` tests, add a test that constructs a simple `MicroPartition` with binary `key` and `value`, uses `KafkaWriter<FakeProducer>`, and asserts:
+
+```rust
+assert_eq!(accounting.messages_attempted, 1);
+assert_eq!(accounting.messages_delivered, 1);
+assert_eq!(accounting.messages_failed, 0);
+```
+
+Create a local helper using `RecordBatch` and `MicroPartition::new_loaded` so the test owns its binary `key` and `value` columns.
+
+- [ ] **Step 2: Implement projection from `MicroPartition` rows**
+
+In `record.rs`, add:
+
+```rust
+pub fn records_from_micropartition(
+    input: &MicroPartition,
+    info: &daft_logical_plan::KafkaWriteInfo<daft_dsl::expr::bound_expr::BoundExpr>,
+) -> DaftResult<Vec<KafkaOutgoingRecord>> {
+    let tables = input.get_tables()?;
+    let mut records = Vec::with_capacity(input.len());
+    for table in tables {
+        for row_idx in 0..table.len() {
+            records.push(record_from_row(&table, row_idx, info)?);
+        }
+    }
+    Ok(records)
+}
+```
+
+Implement `record_from_row` using Daft series accessors for each bound expression. The concrete accessors must match Daft's current `RecordBatch` APIs. Preserve these semantics:
+
+- Static topic uses the plan topic string.
+- Dynamic topic reads utf8 and rejects null.
+- Raw value reads binary and sends `None` for null.
+- UTF-8 value reads utf8 and encodes to bytes.
+- JSON value serializes a non-null Daft value to JSON bytes and sends tombstone for Daft null.
+- Raw key reads binary and sends `None` for null.
+- UTF-8 key reads utf8 and sends `None` for null.
+- Partition validates non-negative int32/int64.
+- Timestamp reads nullable int64.
+- Headers preserves list order and duplicate keys.
+
+- [ ] **Step 3: Replace writer `NotImplemented` with send loop**
+
+In `writer.rs`, replace `write` body:
+
+```rust
+async fn write(&mut self, data: Self::Input) -> DaftResult<WriteResult> {
+    let records = super::record::records_from_micropartition(&data, &self.kafka_info)?;
+    let mut rows_written = 0usize;
+    let mut bytes_written = 0usize;
+
+    for record in records {
+        self.accounting.record_attempt();
+        let delivered_bytes = record.delivered_bytes();
+        match self.producer.send(record).await {
+            Ok(_) => {
+                self.accounting.record_delivery(delivered_bytes);
+                rows_written += 1;
+                bytes_written += delivered_bytes;
+            }
+            Err(err) => {
+                self.accounting.record_failure(err.to_string());
+                return Err(err);
+            }
+        }
+    }
+
+    Ok(WriteResult {
+        rows_written,
+        bytes_written,
+    })
+}
+```
+
+After this passes, replace serial sends with bounded in-flight futures:
+
+```rust
+const MAX_IN_FLIGHT_PER_TASK: usize = 1024;
+```
+
+Use `futures::stream::FuturesUnordered` and drain when the set reaches the bound.
+
+- [ ] **Step 4: Run writer tests**
+
+Run:
+
+```bash
+cargo test -p daft-writers --features kafka kafka::writer kafka::record kafka::headers
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit full writer projection**
+
+```bash
+git add src/daft-writers/src/kafka/record.rs src/daft-writers/src/kafka/headers.rs src/daft-writers/src/kafka/writer.rs
+git commit -m "feat: implement kafka record projection and delivery accounting" \
+  -m "Constraint: write_kafka correctness summary must come from delivery results." \
+  -m "Confidence: medium" \
+  -m "Scope-risk: broad" \
+  -m "Tested: cargo test -p daft-writers --features kafka kafka::writer kafka::record kafka::headers"
+```
+
+---
+
+### Task 10: Local Execution Pipeline Integration
+
+**Files:**
+- Modify: `src/daft-local-execution/src/sinks/write.rs`
+- Modify: `src/daft-local-execution/src/pipeline.rs`
+- Test: `cargo check -p daft-local-execution --features python`
+- Test: `pytest tests/io/test_kafka_write_mock.py -q`
+
+- [ ] **Step 1: Add `WriteFormat::Kafka`**
+
+In `write.rs`:
+
+```rust
+#[derive(Debug)]
+pub enum WriteFormat {
+    Parquet,
+    PartitionedParquet,
+    Csv,
+    PartitionedCsv,
+    Json,
+    PartitionedJson,
+    Iceberg,
+    PartitionedIceberg,
+    Deltalake,
+    PartitionedDeltalake,
+    Lance,
+    Kafka,
+    DataSink(String),
+}
+```
+
+Add to `name()`:
+
+```rust
+WriteFormat::Kafka => "Kafka Write".into(),
+```
+
+- [ ] **Step 2: Add pipeline branch**
+
+In `pipeline.rs`, add branch near other write branches:
+
+```rust
+LocalPhysicalPlan::KafkaWrite(daft_local_plan::KafkaWrite {
+    input,
+    kafka_info,
+    file_schema,
+    stats_state,
+    context,
+}) => {
+    let child_node = physical_plan_to_pipeline(input, cfg, ctx, input_senders)?;
+    let writer_factory = daft_writers::make_kafka_writer_factory(kafka_info.clone());
+    let write_sink = WriteSink::new(
+        WriteFormat::Kafka,
+        writer_factory,
+        None,
+        file_schema.clone(),
+    );
+    BlockingSinkNode::new(
+        Arc::new(write_sink),
+        child_node,
+        stats_state.clone(),
+        ctx,
+        context,
+    )
+    .boxed()
+}
+```
+
+- [ ] **Step 3: Run checks and Python validation**
+
+Run:
+
+```bash
+cargo check -p daft-local-execution --features python
+pytest tests/io/test_kafka_write_mock.py -q
+```
+
+Expected: broker-free invalid-input tests and normalization helper tests pass. Broker-free tests do not assert successful delivery because public `write_kafka` is blocking and requires a broker.
+
+- [ ] **Step 4: Commit pipeline integration**
+
+```bash
+git add src/daft-local-execution/src/sinks/write.rs src/daft-local-execution/src/pipeline.rs
+git commit -m "feat: route kafka writes through local execution" \
+  -m "Constraint: Kafka write should reuse Daft WriteSink and WriterFactory execution semantics." \
+  -m "Confidence: medium" \
+  -m "Scope-risk: moderate" \
+  -m "Tested: cargo check -p daft-local-execution --features python; pytest tests/io/test_kafka_write_mock.py -q"
+```
+
+---
+
+### Task 11: Redpanda Integration Tests
+
+**Files:**
+- Modify: `tests/integration/io/test_kafka_integration.py`
+- Test: `DAFT_RUNNER=native pytest tests/integration/io/test_kafka_integration.py -m integration -q`
+
+- [ ] **Step 1: Add write round-trip test**
+
+Append:
+
+```python
+@pytest.mark.integration()
+def test_write_kafka_raw_roundtrip(kafka_context: dict[str, object]) -> None:
+    bootstrap = str(kafka_context["bootstrap"])
+    topic = f"daft-kafka-write-{uuid.uuid4().hex[:8]}"
+    _ensure_topic(bootstrap=bootstrap, topic=topic, num_partitions=2)
+
+    input_df = daft.from_pydict(
+        {
+            "key": [b"k1", b"k2", b"k3"],
+            "value": [b"v1", b"v2", b"v3"],
+            "partition": [0, 1, 0],
+        }
+    )
+    summary = input_df.write_kafka(
+        bootstrap_servers=bootstrap,
+        topic=topic,
+        key_col="key",
+        value_col="value",
+        partition_col="partition",
+        kafka_client_config={"acks": "all", "enable.idempotence": True},
+        timeout_ms=20_000,
+    ).collect()
+
+    rows = summary.to_pylist()
+    assert sum(row["messages_delivered"] for row in rows) == 3
+    assert sum(row["messages_failed"] for row in rows) == 0
+
+    out = daft.read_kafka(
+        bootstrap_servers=bootstrap,
+        topics=topic,
+        start="earliest",
+        end="latest",
+        timeout_ms=20_000,
+    ).collect()
+    decoded = _decode_rows(out.to_pylist())
+    assert {row["key"] for row in decoded} == {"k1", "k2", "k3"}
+    assert {row["value"] for row in decoded} == {"v1", "v2", "v3"}
+    assert {row["partition"] for row in decoded} == {0, 1}
+```
+
+Update `_decode_rows` so non-JSON values decode as UTF-8 when JSON parsing fails:
+
+```python
+try:
+    value = json.loads(bytes(value).decode("utf-8"))
+except json.JSONDecodeError:
+    value = bytes(value).decode("utf-8")
+```
+
+- [ ] **Step 2: Add JSON and dynamic topic test**
+
+Append:
+
+```python
+@pytest.mark.integration()
+def test_write_kafka_json_dynamic_topic(kafka_context: dict[str, object]) -> None:
+    bootstrap = str(kafka_context["bootstrap"])
+    topic_a = f"daft-kafka-json-a-{uuid.uuid4().hex[:8]}"
+    topic_b = f"daft-kafka-json-b-{uuid.uuid4().hex[:8]}"
+    _ensure_topic(bootstrap=bootstrap, topic=topic_a, num_partitions=1)
+    _ensure_topic(bootstrap=bootstrap, topic=topic_b, num_partitions=1)
+
+    daft.from_pydict(
+        {
+            "topic": [topic_a, topic_b],
+            "key": ["a", "b"],
+            "payload": [{"id": 1, "kind": "a"}, {"id": 2, "kind": "b"}],
+        }
+    ).write_kafka(
+        bootstrap_servers=bootstrap,
+        topic_col="topic",
+        key_col="key",
+        key_format="utf8",
+        value_col="payload",
+        value_format="json",
+        timeout_ms=20_000,
+    )
+
+    out_a = daft.read_kafka(bootstrap, topic_a, timeout_ms=20_000).collect()
+    out_b = daft.read_kafka(bootstrap, topic_b, timeout_ms=20_000).collect()
+    decoded_a = _decode_rows(out_a.to_pylist())
+    decoded_b = _decode_rows(out_b.to_pylist())
+    assert decoded_a[0]["value"] == {"id": 1, "kind": "a"}
+    assert decoded_b[0]["value"] == {"id": 2, "kind": "b"}
+```
+
+- [ ] **Step 3: Add headers test with direct consumer**
+
+Append:
+
+```python
+@pytest.mark.integration()
+def test_write_kafka_headers(kafka_context: dict[str, object]) -> None:
+    confluent_kafka = pytest.importorskip("confluent_kafka")
+    bootstrap = str(kafka_context["bootstrap"])
+    topic = f"daft-kafka-headers-{uuid.uuid4().hex[:8]}"
+    _ensure_topic(bootstrap=bootstrap, topic=topic, num_partitions=1)
+
+    daft.from_pydict(
+        {
+            "value": [b"payload"],
+            "headers": [[{"key": "trace", "value": b"a"}, {"key": "trace", "value": b"b"}]],
+        }
+    ).write_kafka(
+        bootstrap_servers=bootstrap,
+        topic=topic,
+        value_col="value",
+        headers_col="headers",
+        timeout_ms=20_000,
+    )
+
+    consumer = confluent_kafka.Consumer(
+        {
+            "bootstrap.servers": bootstrap,
+            "group.id": f"daft-kafka-headers-{uuid.uuid4().hex[:8]}",
+            "auto.offset.reset": "earliest",
+            "enable.auto.commit": False,
+        }
+    )
+    consumer.subscribe([topic])
+    msg = consumer.poll(20)
+    consumer.close()
+    assert msg is not None
+    assert msg.error() is None
+    assert msg.headers() == [("trace", b"a"), ("trace", b"b")]
+```
+
+- [ ] **Step 4: Run integration tests**
+
+Start the Redpanda service:
+
+```bash
+docker compose -f tests/integration/io/docker-compose/docker-compose.yml up -d redpanda
+```
+
+Run:
+
+```bash
+DAFT_RUNNER=native pytest tests/integration/io/test_kafka_integration.py -m integration -q
+```
+
+Expected: Kafka read and write integration tests pass against Redpanda.
+
+- [ ] **Step 5: Commit integration tests**
+
+```bash
+git add tests/integration/io/test_kafka_integration.py
+git commit -m "test: cover kafka write redpanda round trips" \
+  -m "Constraint: Kafka write needs broker-backed coverage for delivery and read-back behavior." \
+  -m "Confidence: medium" \
+  -m "Scope-risk: moderate" \
+  -m "Tested: DAFT_RUNNER=native pytest tests/integration/io/test_kafka_integration.py -m integration -q"
+```
+
+---
+
+### Task 12: Documentation and Final Verification
+
+**Files:**
+- Modify: `docs/connectors/kafka.md`
+- Modify: `docs/api/io.md`
+- Test: `make docs` if docs dependencies are available
+- Test: `cargo test --no-default-features --workspace`
+- Test: `make build`
+- Test: `DAFT_RUNNER=native make test EXTRA_ARGS="tests/io/test_kafka_write_mock.py tests/integration/io/test_kafka_integration.py -m 'integration or not integration'"`
+
+- [ ] **Step 1: Update Kafka connector docs**
+
+In `docs/connectors/kafka.md`, change the title:
+
+```markdown
+# Kafka
+```
+
+Update limitations:
+
+```markdown
+!!! warning "Experimental"
+
+    This connector is experimental and the API may change in future releases.
+
+    - Reads are bounded batch reads only.
+    - Consumer group offsets are not committed by `read_kafka`.
+    - Writes are at-least-once and do not support transactions or exactly-once semantics.
+```
+
+Add write section:
+
+```markdown
+## Writing Messages
+
+Use `DataFrame.write_kafka()` to produce one Kafka message per input row.
+
+=== "Python"
+
+    ```python
+    import daft
+
+    df = daft.from_pydict(
+        {
+            "key": [b"user-1", b"user-2"],
+            "value": [b"login", b"logout"],
+        }
+    )
+
+    summary = df.write_kafka(
+        bootstrap_servers="localhost:9092",
+        topic="events",
+        key_col="key",
+        value_col="value",
+        kafka_client_config={
+            "acks": "all",
+            "enable.idempotence": True,
+            "compression.type": "zstd",
+        },
+    )
+    summary.show()
+    ```
+
+`write_kafka` returns task-level summary rows with:
+
+| Column | Type | Description |
+| --- | --- | --- |
+| `task_id` | `int64` | Writer task identifier |
+| `messages_attempted` | `int64` | Records constructed for Kafka |
+| `messages_delivered` | `int64` | Records confirmed by Kafka delivery reports |
+| `messages_failed` | `int64` | Records that failed enqueue or delivery |
+| `bytes_delivered` | `int64` | Delivered key/value/header payload bytes |
+| `first_error` | `string` | First sanitized error, or null on success |
+```
+
+Add null semantics:
+
+```markdown
+!!! note "Null values and tombstones"
+
+    A null `value_col` writes a Kafka null payload, also known as a tombstone for compacted topics.
+    With `value_format="json"`, non-null values are serialized to JSON bytes.
+```
+
+Add config note:
+
+```markdown
+`kafka_client_config` is passed to librdkafka producer configuration. Daft manages
+`bootstrap.servers` through the `bootstrap_servers` argument and rejects `transactional.id`
+until transactional writes are explicitly supported.
+```
+
+- [ ] **Step 2: Check API docs index**
+
+Run:
+
+```bash
+rg -n "DataFrame.write_|write_parquet|write_csv|write_json|read_kafka" docs/api docs/connectors
+```
+
+When `docs/api/io.md` lists DataFrame write APIs, add:
+
+```markdown
+:::: daft.DataFrame.write_kafka
+```
+
+When it lists only module-level IO functions, leave `docs/api/io.md` unchanged and rely on generated DataFrame API docs.
+
+Check the generated docs locally before deciding.
+
+- [ ] **Step 3: Run format and targeted tests**
+
+Run:
+
+```bash
+make format
+cargo test -p daft-writers --features kafka kafka
+cargo test --no-default-features --workspace
+make build
+DAFT_RUNNER=native make test EXTRA_ARGS="tests/io/test_kafka_write_mock.py tests/integration/io/test_kafka_integration.py -m 'integration or not integration'"
+```
+
+Expected: all pass before opening a PR.
+
+- [ ] **Step 4: Run Ray smoke test**
+
+Run:
+
+```bash
+DAFT_RUNNER=ray pytest tests/integration/io/test_kafka_integration.py::test_write_kafka_raw_roundtrip -m integration -q
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit docs and verification fixes**
+
+```bash
+git add docs/connectors/kafka.md docs/api/io.md
+git commit -m "docs: document native kafka write support" \
+  -m "Constraint: Kafka write semantics must be explicit about at-least-once delivery and unsupported transactions." \
+  -m "Confidence: high" \
+  -m "Scope-risk: narrow" \
+  -m "Tested: make format; cargo test -p daft-writers --features kafka kafka; cargo test --no-default-features --workspace; make build; DAFT_RUNNER=native make test EXTRA_ARGS=\"tests/io/test_kafka_write_mock.py tests/integration/io/test_kafka_integration.py -m 'integration or not integration'\"; DAFT_RUNNER=ray pytest tests/integration/io/test_kafka_integration.py::test_write_kafka_raw_roundtrip -m integration -q"
+```
+
+---
+
+## Final PR Checklist
+
+- [ ] The issue link `Fixes #7101` or `Refs #7101` is in the PR body.
+- [ ] PR title follows Conventional Commits.
+- [ ] PR body includes `Changes Made` and `Related Issues`.
+- [ ] PR body discloses AI assistance and verification performed.
+- [ ] `cargo test --no-default-features --workspace` passes.
+- [ ] `make build` passes after Rust changes.
+- [ ] Python broker-free tests pass.
+- [ ] Redpanda native integration tests pass.
+- [ ] At least one Ray Kafka write/read round trip passes.
+- [ ] Docs mention at-least-once semantics, tombstones, config passthrough, and unsupported transactions.

--- a/docs/superpowers/plans/2026-06-11-kafka-write-local-e2e-implementation-plan.md
+++ b/docs/superpowers/plans/2026-06-11-kafka-write-local-e2e-implementation-plan.md
@@ -1,0 +1,757 @@
+# Kafka Write Local E2E Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an opt-in local Docker E2E test that validates Daft native `write_kafka` against a real Redpanda broker.
+
+**Architecture:** Create one local-only pytest module under `tests/local_e2e` with module-level environment gating so it is never run by default. Reuse the existing Redpanda Docker Compose service and local helper functions for broker readiness, topic creation, seed production, exact consumption, Daft readback, summary assertions, and message normalization.
+
+**Tech Stack:** pytest, Daft Python API, `confluent_kafka`, existing Redpanda Docker Compose service, native Daft runner.
+
+---
+
+## File Structure
+
+- Create `tests/local_e2e/test_kafka_write_e2e.py`
+  - Owns the full opt-in local Kafka write E2E.
+  - Contains local helpers only; do not import private helpers from existing integration tests.
+  - Skips at module import unless `DAFT_RUN_KAFKA_LOCAL_E2E=1`.
+
+- Modify `tests/conftest.py`
+  - Register the `local_e2e` marker next to the existing `integration` marker.
+  - Do not change default `addopts`; the environment gate plus explicit opt-in marker selection are the safety mechanisms.
+
+## Task 1: Opt-In Test Module Skeleton
+
+**Files:**
+- Create: `tests/local_e2e/test_kafka_write_e2e.py`
+
+- [ ] **Step 1: Create the local E2E test directory**
+
+Run:
+
+```bash
+mkdir -p tests/local_e2e
+```
+
+Expected: directory exists and no source files are modified.
+
+- [ ] **Step 2: Add a gated module skeleton**
+
+Create `tests/local_e2e/test_kafka_write_e2e.py` with:
+
+```python
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+if os.environ.get("DAFT_RUN_KAFKA_LOCAL_E2E") != "1":
+    pytest.skip("local Kafka E2E is opt-in", allow_module_level=True)
+
+
+pytestmark = [pytest.mark.integration, pytest.mark.local_e2e]
+
+
+def test_kafka_write_local_e2e_placeholder() -> None:
+    assert True
+```
+
+- [ ] **Step 3: Verify the module is skipped by default**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest tests/local_e2e/test_kafka_write_e2e.py -q -rs
+```
+
+Expected: one skipped module and exit code `0`.
+
+- [ ] **Step 4: Verify the module runs when opted in**
+
+Run:
+
+```bash
+DAFT_RUN_KAFKA_LOCAL_E2E=1 .venv/bin/python -m pytest tests/local_e2e/test_kafka_write_e2e.py -m "integration and local_e2e" -q
+```
+
+Expected: one placeholder test passes. The explicit `-m` expression overrides the repository default that excludes integration tests.
+
+## Task 2: Marker Registration
+
+**Files:**
+- Modify: `tests/conftest.py`
+
+- [ ] **Step 1: Register `local_e2e` marker**
+
+Modify `pytest_configure` in `tests/conftest.py` to keep the existing `integration` marker and add:
+
+```python
+config.addinivalue_line(
+    "markers",
+    "local_e2e: mark opt-in local end-to-end tests",
+)
+```
+
+Keep the existing default in `pyproject.toml` unchanged:
+
+```toml
+addopts = "-m 'not (integration or benchmark or hypothesis)'"
+```
+
+- [ ] **Step 2: Re-run the default skip check**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest tests/local_e2e/test_kafka_write_e2e.py -q -rs
+```
+
+Expected: module skipped and no unknown marker warning.
+
+## Task 3: Kafka Helper Layer
+
+**Files:**
+- Modify: `tests/local_e2e/test_kafka_write_e2e.py`
+
+- [ ] **Step 1: Replace the placeholder module with helper imports and constants**
+
+Replace the entire placeholder module with:
+
+```python
+from __future__ import annotations
+
+import json
+import os
+import time
+import uuid
+from collections.abc import Iterable, Iterator
+from contextlib import suppress
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+import daft
+
+
+if os.environ.get("DAFT_RUN_KAFKA_LOCAL_E2E") != "1":
+    pytest.skip("local Kafka E2E is opt-in", allow_module_level=True)
+
+
+pytestmark = [pytest.mark.integration, pytest.mark.local_e2e]
+
+BOOTSTRAP = "127.0.0.1:9092"
+WRITE_TIMEOUT_MS = 20_000
+
+
+@dataclass(frozen=True)
+class SeedRecord:
+    event_id: int
+    key: bytes
+    value: bytes
+    partition: int
+    timestamp_ms: int
+```
+
+- [ ] **Step 2: Add broker readiness and topic helpers**
+
+Append:
+
+```python
+def wait_for_kafka_ready(bootstrap: str, timeout_s: int = 60) -> None:
+    confluent_kafka = pytest.importorskip("confluent_kafka")
+
+    readiness_errors = (confluent_kafka.KafkaException, OSError, RuntimeError, TimeoutError)
+    deadline = time.time() + timeout_s
+    last: Exception | None = None
+    while time.time() < deadline:
+        consumer = None
+        try:
+            consumer = confluent_kafka.Consumer(
+                {
+                    "bootstrap.servers": bootstrap,
+                    "group.id": "daft-kafka-local-e2e-healthcheck",
+                    "enable.auto.commit": "false",
+                }
+            )
+            consumer.list_topics(timeout=5)
+            return
+        except readiness_errors as exc:
+            last = exc
+            time.sleep(1)
+        finally:
+            if consumer is not None:
+                with suppress(*readiness_errors):
+                    consumer.close()
+    raise RuntimeError(f"Kafka was not ready after {timeout_s}s: {last}")
+
+
+def create_topic(*, bootstrap: str, topic: str, partitions: int, config: dict[str, str] | None = None) -> None:
+    confluent_kafka = pytest.importorskip("confluent_kafka")
+    admin = pytest.importorskip("confluent_kafka.admin")
+
+    client = admin.AdminClient({"bootstrap.servers": bootstrap})
+    futures = client.create_topics(
+        [admin.NewTopic(topic, num_partitions=partitions, replication_factor=1, config=config)]
+    )
+    try:
+        futures[topic].result(timeout=30)
+    except confluent_kafka.KafkaException as exc:
+        if (
+            exc.args
+            and hasattr(exc.args[0], "code")
+            and callable(exc.args[0].code)
+            and exc.args[0].code() == confluent_kafka.KafkaError.TOPIC_ALREADY_EXISTS
+        ):
+            return
+        raise
+```
+
+- [ ] **Step 3: Add producer and consumer helpers**
+
+Append:
+
+```python
+def produce_seed_records(*, bootstrap: str, topic: str, records: Iterable[SeedRecord]) -> None:
+    confluent_kafka = pytest.importorskip("confluent_kafka")
+
+    producer = confluent_kafka.Producer({"bootstrap.servers": bootstrap})
+    for record in records:
+        producer.produce(
+            topic,
+            key=record.key,
+            value=record.value,
+            partition=record.partition,
+            timestamp=record.timestamp_ms,
+        )
+    remaining = producer.flush(30)
+    assert remaining == 0
+
+
+def consume_exactly(*, bootstrap: str, topic: str, count: int, timeout_s: int = 20) -> list[Any]:
+    confluent_kafka = pytest.importorskip("confluent_kafka")
+
+    consumer = confluent_kafka.Consumer(
+        {
+            "bootstrap.servers": bootstrap,
+            "group.id": f"daft-kafka-local-e2e-{uuid.uuid4().hex}",
+            "auto.offset.reset": "earliest",
+            "enable.auto.commit": "false",
+        }
+    )
+    consumer.subscribe([topic])
+    deadline = time.time() + timeout_s
+    messages: list[Any] = []
+    try:
+        while time.time() < deadline and len(messages) < count:
+            msg = consumer.poll(1)
+            if msg is None:
+                continue
+            if msg.error():
+                raise confluent_kafka.KafkaException(msg.error())
+            messages.append(msg)
+    finally:
+        consumer.close()
+
+    if len(messages) != count:
+        pytest.fail(f"timed out waiting for {count} message(s) from topic {topic!r}; got {len(messages)}")
+    return messages
+```
+
+- [ ] **Step 4: Add Daft read and assertion helpers**
+
+Append:
+
+```python
+def read_all_with_daft(*, bootstrap: str, topic: str) -> list[dict[str, Any]]:
+    return (
+        daft.read_kafka(
+            bootstrap_servers=bootstrap,
+            topics=topic,
+            group_id=f"daft-kafka-local-e2e-{uuid.uuid4().hex}",
+            timeout_ms=WRITE_TIMEOUT_MS,
+            start="earliest",
+            end="latest",
+        )
+        .collect()
+        .to_pylist()
+    )
+
+
+def assert_summary(summary: daft.DataFrame, *, attempted: int, delivered: int, failed: int = 0) -> None:
+    rows = summary.to_pylist()
+    assert rows
+    assert sum(int(row["messages_attempted"]) for row in rows) == attempted
+    assert sum(int(row["messages_delivered"]) for row in rows) == delivered
+    assert sum(int(row["messages_failed"]) for row in rows) == failed
+    assert sum(int(row["bytes_delivered"]) for row in rows) > 0
+    assert all(isinstance(row["task_id"], int) for row in rows)
+
+
+def normalize_message(msg: Any) -> dict[str, Any]:
+    return {
+        "key": msg.key(),
+        "value": msg.value(),
+        "partition": msg.partition(),
+        "timestamp_ms": msg.timestamp()[1],
+        "headers": msg.headers(),
+    }
+```
+
+- [ ] **Step 5: Add run context fixture**
+
+Append:
+
+```python
+@dataclass(frozen=True)
+class KafkaE2EContext:
+    bootstrap: str
+    run_id: str
+    base_ts_ms: int
+    source_topic: str
+    raw_topic: str
+    user_topic: str
+    order_topic: str
+    headers_topic: str
+    compact_topic: str
+
+
+@pytest.fixture(scope="module")
+def kafka_e2e_context() -> Iterator[KafkaE2EContext]:
+    pytest.importorskip("confluent_kafka")
+    wait_for_kafka_ready(BOOTSTRAP)
+
+    run_id = uuid.uuid4().hex[:8]
+    ctx = KafkaE2EContext(
+        bootstrap=BOOTSTRAP,
+        run_id=run_id,
+        base_ts_ms=int(time.time() * 1000),
+        source_topic=f"daft-e2e-src-{run_id}",
+        raw_topic=f"daft-e2e-raw-out-{run_id}",
+        user_topic=f"daft-e2e-json-user-{run_id}",
+        order_topic=f"daft-e2e-json-order-{run_id}",
+        headers_topic=f"daft-e2e-headers-{run_id}",
+        compact_topic=f"daft-e2e-compact-{run_id}",
+    )
+
+    create_topic(bootstrap=ctx.bootstrap, topic=ctx.source_topic, partitions=3)
+    create_topic(bootstrap=ctx.bootstrap, topic=ctx.raw_topic, partitions=3)
+    create_topic(bootstrap=ctx.bootstrap, topic=ctx.user_topic, partitions=2)
+    create_topic(bootstrap=ctx.bootstrap, topic=ctx.order_topic, partitions=2)
+    create_topic(bootstrap=ctx.bootstrap, topic=ctx.headers_topic, partitions=1)
+    create_topic(
+        bootstrap=ctx.bootstrap,
+        topic=ctx.compact_topic,
+        partitions=1,
+        config={"cleanup.policy": "compact"},
+    )
+
+    yield ctx
+```
+
+- [ ] **Step 6: Verify helper-only module still imports and runs no tests**
+
+Run:
+
+```bash
+DAFT_RUN_KAFKA_LOCAL_E2E=1 .venv/bin/python -m pytest tests/local_e2e/test_kafka_write_e2e.py -m "integration and local_e2e" -q
+```
+
+Expected: pytest collects zero tests or only fixture import passes. If pytest exits with "no tests ran" as code `5`, continue to Task 4 without treating this as a functional failure.
+
+## Task 4: Raw Mirror E2E Scenario
+
+**Files:**
+- Modify: `tests/local_e2e/test_kafka_write_e2e.py`
+
+- [ ] **Step 1: Add source record builder**
+
+Append before tests:
+
+```python
+def build_source_records(base_ts_ms: int) -> list[SeedRecord]:
+    rows = [
+        (1, b"user-001", {"event_id": 1, "kind": "signup", "amount": 0, "note": "hello"}, 0),
+        (2, b"order-001", {"event_id": 2, "kind": "purchase", "amount": 19.99, "note": "zstd-path"}, 1),
+        (3, b"user-001", {"event_id": 3, "kind": "update", "amount": 0, "note": "duplicate-key"}, 0),
+        (4, "user-004".encode("utf-8"), {"event_id": 4, "kind": "unicode", "note": "hello unicode"}, 2),
+        (5, b"user-005", {"event_id": 5, "kind": "logout", "amount": 0, "note": "small"}, 0),
+        (6, b"order-006", {"event_id": 6, "kind": "purchase", "amount": 42.5, "note": "medium"}, 1),
+        (7, b"user-007", {"event_id": 7, "kind": "profile", "amount": 0, "note": "large-" + "x" * 128}, 2),
+        (8, b"user-008", {"event_id": 8, "kind": "signup", "amount": 0, "note": "p0"}, 0),
+        (9, b"order-009", {"event_id": 9, "kind": "refund", "amount": -3.5, "note": "p1"}, 1),
+        (10, b"user-010", {"event_id": 10, "kind": "update", "amount": 0, "note": "p2"}, 2),
+        (11, b"user-011", {"event_id": 11, "kind": "signup", "amount": 0, "note": "p0-second"}, 0),
+        (12, b"order-012", {"event_id": 12, "kind": "purchase", "amount": 7.25, "note": "p1-second"}, 1),
+    ]
+    return [
+        SeedRecord(
+            event_id=event_id,
+            key=key,
+            value=json.dumps(value, sort_keys=True).encode("utf-8"),
+            partition=partition,
+            timestamp_ms=base_ts_ms + event_id,
+        )
+        for event_id, key, value, partition in rows
+    ]
+```
+
+- [ ] **Step 2: Add raw mirror test**
+
+Append:
+
+```python
+def test_raw_read_transform_write_roundtrip(kafka_e2e_context: KafkaE2EContext) -> None:
+    ctx = kafka_e2e_context
+    source_records = build_source_records(ctx.base_ts_ms)
+    produce_seed_records(bootstrap=ctx.bootstrap, topic=ctx.source_topic, records=source_records)
+
+    source_df = daft.read_kafka(
+        bootstrap_servers=ctx.bootstrap,
+        topics=ctx.source_topic,
+        group_id=f"daft-kafka-local-e2e-{uuid.uuid4().hex}",
+        timeout_ms=WRITE_TIMEOUT_MS,
+        start="earliest",
+        end="latest",
+    ).collect()
+    mirror_df = source_df.select("key", "value", "partition", "timestamp_ms")
+
+    summary = mirror_df.write_kafka(
+        bootstrap_servers=ctx.bootstrap,
+        topic=ctx.raw_topic,
+        key_col="key",
+        value_col="value",
+        partition_col="partition",
+        timestamp_ms_col="timestamp_ms",
+        kafka_client_config={
+            "acks": "all",
+            "enable.idempotence": True,
+            "compression.type": "zstd",
+            "client.id": f"daft-e2e-raw-{ctx.run_id}",
+        },
+        timeout_ms=WRITE_TIMEOUT_MS,
+    )
+
+    assert_summary(summary, attempted=len(source_records), delivered=len(source_records))
+
+    consumed = [normalize_message(msg) for msg in consume_exactly(
+        bootstrap=ctx.bootstrap,
+        topic=ctx.raw_topic,
+        count=len(source_records),
+    )]
+    expected = [
+        {
+            "key": record.key,
+            "value": record.value,
+            "partition": record.partition,
+            "timestamp_ms": record.timestamp_ms,
+        }
+        for record in source_records
+    ]
+    consumed_tuples = sorted(
+        (row["partition"], row["timestamp_ms"], row["key"], row["value"]) for row in consumed
+    )
+    expected_tuples = sorted(
+        (row["partition"], row["timestamp_ms"], row["key"], row["value"]) for row in expected
+    )
+    assert consumed_tuples == expected_tuples
+
+    daft_rows = read_all_with_daft(bootstrap=ctx.bootstrap, topic=ctx.raw_topic)
+    assert len(daft_rows) == len(source_records)
+```
+
+- [ ] **Step 3: Run the raw mirror test against Redpanda**
+
+Run:
+
+```bash
+docker compose -f tests/integration/io/docker-compose/docker-compose.yml up -d redpanda
+DAFT_RUN_KAFKA_LOCAL_E2E=1 DAFT_RUNNER=native \
+  .venv/bin/python -m pytest tests/local_e2e/test_kafka_write_e2e.py::test_raw_read_transform_write_roundtrip \
+  -m "integration and local_e2e" -q -s
+```
+
+Expected: test passes and summary counters match the 12 seeded records.
+
+## Task 5: JSON Dynamic Topic And Tombstone Scenario
+
+**Files:**
+- Modify: `tests/local_e2e/test_kafka_write_e2e.py`
+
+- [ ] **Step 1: Add JSON dynamic topic test**
+
+Append:
+
+```python
+def test_json_dynamic_topic_and_tombstone(kafka_e2e_context: KafkaE2EContext) -> None:
+    ctx = kafka_e2e_context
+    json_rows = [
+        {
+            "topic": ctx.user_topic,
+            "key": "user-001",
+            "value": {"op": "upsert", "name": "alice", "tags": ["new", None]},
+            "partition": 0,
+            "timestamp_ms": ctx.base_ts_ms + 100,
+        },
+        {
+            "topic": ctx.order_topic,
+            "key": "order-001",
+            "value": {"op": "created", "amount": 19.99, "ok": True},
+            "partition": 1,
+            "timestamp_ms": ctx.base_ts_ms + 101,
+        },
+        {
+            "topic": ctx.user_topic,
+            "key": "user-002",
+            "value": None,
+            "partition": 1,
+            "timestamp_ms": ctx.base_ts_ms + 102,
+        },
+    ]
+
+    summary = daft.from_pylist(json_rows).write_kafka(
+        bootstrap_servers=ctx.bootstrap,
+        topic_col="topic",
+        key_col="key",
+        value_col="value",
+        partition_col="partition",
+        timestamp_ms_col="timestamp_ms",
+        key_format="utf8",
+        value_format="json",
+        kafka_client_config={"acks": "all", "compression.type": "zstd"},
+        timeout_ms=WRITE_TIMEOUT_MS,
+    )
+
+    assert_summary(summary, attempted=3, delivered=3)
+
+    user_messages = {
+        msg.key().decode("utf-8"): normalize_message(msg)
+        for msg in consume_exactly(bootstrap=ctx.bootstrap, topic=ctx.user_topic, count=2)
+    }
+    order_messages = {
+        msg.key().decode("utf-8"): normalize_message(msg)
+        for msg in consume_exactly(bootstrap=ctx.bootstrap, topic=ctx.order_topic, count=1)
+    }
+
+    assert json.loads(user_messages["user-001"]["value"].decode("utf-8")) == json_rows[0]["value"]
+    assert user_messages["user-002"]["value"] is None
+    assert json.loads(order_messages["order-001"]["value"].decode("utf-8")) == json_rows[1]["value"]
+    assert user_messages["user-001"]["partition"] == 0
+    assert user_messages["user-002"]["partition"] == 1
+    assert order_messages["order-001"]["partition"] == 1
+```
+
+- [ ] **Step 2: Run the JSON dynamic topic test**
+
+Run:
+
+```bash
+DAFT_RUN_KAFKA_LOCAL_E2E=1 DAFT_RUNNER=native \
+  .venv/bin/python -m pytest tests/local_e2e/test_kafka_write_e2e.py::test_json_dynamic_topic_and_tombstone \
+  -m "integration and local_e2e" -q -s
+```
+
+Expected: test passes; top-level `None` is consumed as Kafka null value.
+
+## Task 6: Headers And Compact Tombstone Scenarios
+
+**Files:**
+- Modify: `tests/local_e2e/test_kafka_write_e2e.py`
+
+- [ ] **Step 1: Add headers test**
+
+Append:
+
+```python
+def test_headers_preserve_duplicate_order_and_null(kafka_e2e_context: KafkaE2EContext) -> None:
+    ctx = kafka_e2e_context
+    summary = daft.from_pylist(
+        [
+            {
+                "key": b"k1",
+                "value": b"v1",
+                "headers": [
+                    {"key": "trace", "value": b"a"},
+                    {"key": "trace", "value": b"b"},
+                    {"key": "nullable", "value": None},
+                ],
+            }
+        ]
+    ).write_kafka(
+        bootstrap_servers=ctx.bootstrap,
+        topic=ctx.headers_topic,
+        key_col="key",
+        value_col="value",
+        headers_col="headers",
+        kafka_client_config={"acks": "all"},
+        timeout_ms=WRITE_TIMEOUT_MS,
+    )
+
+    assert_summary(summary, attempted=1, delivered=1)
+    [message] = consume_exactly(bootstrap=ctx.bootstrap, topic=ctx.headers_topic, count=1)
+    assert message.headers() == [("trace", b"a"), ("trace", b"b"), ("nullable", None)]
+```
+
+- [ ] **Step 2: Add compact tombstone test**
+
+Append:
+
+```python
+def test_compacted_topic_receives_tombstone(kafka_e2e_context: KafkaE2EContext) -> None:
+    ctx = kafka_e2e_context
+    summary = daft.from_pylist(
+        [
+            {"key": "user-compact-001", "value": {"status": "active"}},
+            {"key": "user-compact-001", "value": None},
+        ]
+    ).write_kafka(
+        bootstrap_servers=ctx.bootstrap,
+        topic=ctx.compact_topic,
+        key_col="key",
+        value_col="value",
+        key_format="utf8",
+        value_format="json",
+        kafka_client_config={"acks": "all"},
+        timeout_ms=WRITE_TIMEOUT_MS,
+    )
+
+    assert_summary(summary, attempted=2, delivered=2)
+    messages = consume_exactly(bootstrap=ctx.bootstrap, topic=ctx.compact_topic, count=2)
+    assert [msg.key().decode("utf-8") for msg in messages] == ["user-compact-001", "user-compact-001"]
+    assert json.loads(messages[0].value().decode("utf-8")) == {"status": "active"}
+    assert messages[1].value() is None
+```
+
+- [ ] **Step 3: Run headers and compact tests**
+
+Run:
+
+```bash
+DAFT_RUN_KAFKA_LOCAL_E2E=1 DAFT_RUNNER=native \
+  .venv/bin/python -m pytest \
+  tests/local_e2e/test_kafka_write_e2e.py::test_headers_preserve_duplicate_order_and_null \
+  tests/local_e2e/test_kafka_write_e2e.py::test_compacted_topic_receives_tombstone \
+  -m "integration and local_e2e" -q -s
+```
+
+Expected: both tests pass.
+
+## Task 7: Validation Guardrails
+
+**Files:**
+- Modify: `tests/local_e2e/test_kafka_write_e2e.py`
+
+- [ ] **Step 1: Add validation tests**
+
+Append:
+
+```python
+def test_validation_guardrails(kafka_e2e_context: KafkaE2EContext) -> None:
+    ctx = kafka_e2e_context
+    df = daft.from_pydict({"value": [b"x"]})
+
+    with pytest.raises(NotImplementedError, match="transactional.id"):
+        df.write_kafka(
+            bootstrap_servers=ctx.bootstrap,
+            topic=ctx.raw_topic,
+            kafka_client_config={"transactional.id": "tx-1"},
+        )
+
+    with pytest.raises(Exception, match="topic"):
+        daft.from_pylist([{"topic": None, "value": b"x"}]).write_kafka(
+            bootstrap_servers=ctx.bootstrap,
+            topic_col="topic",
+            value_col="value",
+            timeout_ms=WRITE_TIMEOUT_MS,
+        )
+
+    with pytest.raises(Exception, match="topic"):
+        daft.from_pylist([{"topic": "", "value": b"x"}]).write_kafka(
+            bootstrap_servers=ctx.bootstrap,
+            topic_col="topic",
+            value_col="value",
+            timeout_ms=WRITE_TIMEOUT_MS,
+        )
+```
+
+- [ ] **Step 2: Run validation guardrails**
+
+Run:
+
+```bash
+DAFT_RUN_KAFKA_LOCAL_E2E=1 DAFT_RUNNER=native \
+  .venv/bin/python -m pytest tests/local_e2e/test_kafka_write_e2e.py::test_validation_guardrails \
+  -m "integration and local_e2e" -q -s
+```
+
+Expected: test passes without producing misleading success summaries.
+
+## Task 8: Full Verification
+
+**Files:**
+- Verify: `tests/local_e2e/test_kafka_write_e2e.py`
+- Verify: `tests/conftest.py`
+
+- [ ] **Step 1: Run Python syntax check**
+
+Run:
+
+```bash
+.venv/bin/python -m py_compile tests/local_e2e/test_kafka_write_e2e.py
+```
+
+Expected: exit code `0`.
+
+- [ ] **Step 2: Run targeted ruff check**
+
+Run:
+
+```bash
+.venv/bin/python -m ruff check tests/local_e2e/test_kafka_write_e2e.py
+```
+
+Expected: `All checks passed!`
+
+- [ ] **Step 3: Verify default skip behavior**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest tests/local_e2e/test_kafka_write_e2e.py -q -rs
+```
+
+Expected: module skipped because `DAFT_RUN_KAFKA_LOCAL_E2E` is not set.
+
+- [ ] **Step 4: Run full local E2E**
+
+Run:
+
+```bash
+docker compose -f tests/integration/io/docker-compose/docker-compose.yml up -d redpanda
+DAFT_RUN_KAFKA_LOCAL_E2E=1 DAFT_RUNNER=native \
+  .venv/bin/python -m pytest tests/local_e2e/test_kafka_write_e2e.py \
+  -m "integration and local_e2e" -q -s
+```
+
+Expected: all local E2E tests pass against Redpanda.
+
+- [ ] **Step 5: Confirm repository diff hygiene**
+
+Run:
+
+```bash
+git diff --check
+git status --short
+```
+
+Expected: no whitespace errors; only expected files are modified.
+
+## Self-Review Checklist
+
+- Spec coverage: Tasks cover opt-in invocation, Redpanda readiness, unique topics, source seed data, raw mirror, Daft readback, JSON dynamic topics, tombstones, headers, compact topic tombstone, null and empty dynamic topic guardrails, and verification commands.
+- Placeholder handling: The placeholder is limited to Task 1 bootstrap and is explicitly replaced before any E2E scenario is added; no task uses `TBD`, `TODO`, `fill in`, or unspecified test commands.
+- Type consistency: Helper names in tests match helper definitions: `wait_for_kafka_ready`, `create_topic`, `produce_seed_records`, `consume_exactly`, `read_all_with_daft`, `assert_summary`, and `normalize_message`.
+- Scope: TLS/SASL and broker-dependent delivery failure remain future extensions, matching the approved v1 design.

--- a/docs/superpowers/specs/2026-06-10-native-kafka-write-design.md
+++ b/docs/superpowers/specs/2026-06-10-native-kafka-write-design.md
@@ -1,0 +1,725 @@
+# Native Kafka Write Design
+
+## Summary
+
+Daft currently supports bounded Kafka reads through `daft.read_kafka(...)`, but does not provide a native Kafka write path. This design adds `DataFrame.write_kafka(...)` as a Daft-native Kafka producer sink backed by Rust and `rdkafka`/`librdkafka`.
+
+The target is a full Kafka producer sink for batch DataFrames:
+
+- Static and dynamic topic routing.
+- Raw, UTF-8, and JSON value encoding.
+- Raw and UTF-8 key encoding.
+- Static and dynamic partition selection.
+- Kafka message timestamps.
+- Kafka headers with duplicate key preservation.
+- Task-level write summary rows for logging and diagnosis.
+- `librdkafka` producer configuration passthrough.
+- Delivery-result based accounting.
+- Optional producer metrics/statistics hooks.
+
+The first version is explicitly at-least-once. It does not support transactions or exactly-once semantics.
+
+Related issue: https://github.com/Eventual-Inc/Daft/issues/7101
+
+## Context
+
+Current Kafka support lives in `daft/io/_kafka.py` and exposes:
+
+```python
+daft.read_kafka(
+    bootstrap_servers: str | Sequence[str],
+    topics: str | Sequence[str],
+    *,
+    start: object = "earliest",
+    end: object = "latest",
+    group_id: str = "daft-bounded-kafka-reader",
+    partitions: Sequence[int] | None = None,
+    chunk_size: int = 1024,
+    kafka_client_config: Mapping[str, object] | None = None,
+    timeout_ms: int = 10_000,
+)
+```
+
+`read_kafka` returns the fixed schema:
+
+```text
+topic: string
+partition: int32
+offset: int64
+timestamp_ms: int64
+key: binary
+value: binary
+```
+
+The write implementation should preserve useful naming alignment with `read_kafka`, especially `bootstrap_servers`, `kafka_client_config`, `timeout_ms`, and default `key`/`value`/`timestamp_ms` column names.
+
+Daft native writes currently flow through:
+
+```text
+DataFrame.write_*
+  -> LogicalPlanBuilder
+  -> SinkInfo
+  -> LocalPhysicalPlan
+  -> daft-local-execution WriteSink
+  -> daft-writers WriterFactory
+```
+
+Kafka write should join this native path rather than use Python `DataSink`.
+
+## Goals
+
+- Provide a first-class `DataFrame.write_kafka(...)` API.
+- Keep Kafka write native to Daft planner/execution/writer crates.
+- Use `rdkafka` as the Rust Kafka client.
+- Preserve broad `librdkafka` producer configuration access.
+- Return task-level summary rows by default.
+- Count delivered messages from Kafka delivery results, not from producer statistics.
+- Support native and Ray/distributed execution.
+- Keep no-default-feature Rust builds working.
+
+## Non-Goals
+
+- No transaction or exactly-once support in the first version.
+- No Schema Registry integration.
+- No Avro or Protobuf encoding.
+- No per-message delivery-report DataFrame by default.
+- No streaming or unbounded DataFrame sink.
+- No rewrite of `read_kafka` from Python to Rust as part of this feature.
+
+## Contribution Constraints
+
+This is a non-trivial Daft contribution. PRs should:
+
+- Link to issue `#7101`.
+- Include tests or explain gaps.
+- Keep changes reviewable.
+- Use Conventional Commit titles.
+- Disclose material AI assistance and verification.
+- Expect core owner review for logical plan, local plan, local execution, distributed execution, writers, and Cargo changes.
+
+## User API
+
+Proposed API:
+
+```python
+df.write_kafka(
+    bootstrap_servers: str | Sequence[str],
+    topic: str | None = None,
+    *,
+    topic_col: str | None = None,
+    value_col: str = "value",
+    key_col: str | None = "key",
+    headers_col: str | None = None,
+    partition: int | None = None,
+    partition_col: str | None = None,
+    timestamp_ms_col: str | None = "timestamp_ms",
+    value_format: Literal["raw", "utf8", "json"] = "raw",
+    key_format: Literal["raw", "utf8"] = "raw",
+    kafka_client_config: Mapping[str, object] | None = None,
+    timeout_ms: int = 10_000,
+) -> DataFrame
+```
+
+Rules:
+
+- `topic` and `topic_col` are mutually exclusive. Exactly one must be set.
+- `partition` and `partition_col` are mutually exclusive.
+- `bootstrap_servers`, `kafka_client_config`, and `timeout_ms` mirror `read_kafka`.
+- `value_col` is required semantically and defaults to `value`.
+- `key_col` defaults to opportunistic `key`: use it if present, otherwise write unkeyed messages.
+- `timestamp_ms_col` defaults to opportunistic `timestamp_ms`: use it if present, otherwise let Kafka assign timestamps.
+- Explicitly provided `key_col` or `timestamp_ms_col` must exist.
+- `key_col=None` disables keys.
+- `timestamp_ms_col=None` disables explicit timestamps.
+- `headers_col` uses Kafka-native ordered headers and should preserve duplicate keys.
+
+## Return Schema
+
+`write_kafka` returns task-level summary rows by default. This is more useful for logs and distributed diagnosis than a single global summary.
+
+Suggested schema:
+
+```text
+task_id: int64
+messages_attempted: int64
+messages_delivered: int64
+messages_failed: int64
+bytes_delivered: int64
+first_error: utf8
+```
+
+If Daft cannot reliably expose a numeric task id at the writer boundary, use `writer_id: int64` first and keep the same semantics.
+
+Do not return per-message offsets by default. For large writes, per-message delivery metadata would produce an output DataFrame as large as the input. A future `delivery_report_mode` can be designed separately if users need that level of detail.
+
+## Field Semantics
+
+| Kafka field | API source | Supported types | Null behavior |
+| --- | --- | --- | --- |
+| topic | `topic` or `topic_col` | static `str` or `Utf8` column | null dynamic topic is an error |
+| value | `value_col` | binary, utf8, or JSON-serializable value | null value sends Kafka tombstone |
+| key | `key_col` | binary or utf8 | null key writes unkeyed message |
+| partition | `partition` or `partition_col` | non-negative int32/int64 | null lets Kafka choose partition |
+| timestamp | `timestamp_ms_col` | int64 epoch milliseconds | null lets Kafka assign timestamp |
+| headers | `headers_col` | list of key/value structs | null means no headers |
+
+### Value Format
+
+`value_format="raw"`:
+
+- Requires `value_col` to be binary.
+- Sends bytes unchanged.
+- This is the default and best matches `read_kafka` round trips.
+
+`value_format="utf8"`:
+
+- Requires `value_col` to be string/utf8.
+- Encodes strings as UTF-8 bytes.
+
+`value_format="json"`:
+
+- Serializes the selected Daft value to UTF-8 JSON bytes.
+- Supports JSON-representable scalar, struct, list, and map values.
+- A Daft null value sends a Kafka tombstone.
+- A non-null JSON value that serializes to JSON `null` sends bytes `b"null"`.
+- Binary values should not be implicitly base64 encoded in the first version.
+
+### Key Format
+
+`key_format="raw"`:
+
+- Requires binary key values.
+
+`key_format="utf8"`:
+
+- Requires string/utf8 key values.
+
+Do not add `key_format="json"` in the first version. Kafka keys are commonly used for partitioning and compaction, and raw/utf8 keeps behavior predictable.
+
+### Headers
+
+Canonical type:
+
+```text
+list[struct<key: utf8, value: binary | utf8 | null>>
+```
+
+Kafka headers allow duplicate keys and preserve ordering. A map type should not be the canonical representation because it cannot preserve duplicate keys. A future convenience path may accept maps and convert them to ordered headers, but the native representation should remain list-of-struct.
+
+## Logical and Physical Plan Design
+
+Add a native Kafka sink variant:
+
+```rust
+pub enum SinkInfo<E = ExprRef> {
+    OutputFileInfo(OutputFileInfo<E>),
+    KafkaInfo(KafkaWriteInfo<E>),
+    #[cfg(feature = "python")]
+    CatalogInfo(CatalogInfo<E>),
+    #[cfg(feature = "python")]
+    DataSinkInfo(DataSinkInfo),
+}
+```
+
+Core plan object:
+
+```rust
+pub struct KafkaWriteInfo<E = ExprRef> {
+    pub bootstrap_servers: String,
+    pub topic: KafkaTopic<E>,
+    pub value: KafkaValue<E>,
+    pub key: Option<KafkaColumn<E>>,
+    pub headers: Option<KafkaHeaders<E>>,
+    pub partition: Option<KafkaPartition<E>>,
+    pub timestamp_ms: Option<E>,
+    pub value_format: KafkaValueFormat,
+    pub key_format: KafkaKeyFormat,
+    pub kafka_client_config: BTreeMap<String, KafkaConfigValue>,
+    pub timeout_ms: u64,
+}
+```
+
+Supporting enums:
+
+```rust
+pub enum KafkaTopic<E> {
+    Static(String),
+    Dynamic(E),
+}
+
+pub enum KafkaPartition<E> {
+    Static(i32),
+    Dynamic(E),
+}
+
+pub enum KafkaValueFormat {
+    Raw,
+    Utf8,
+    Json,
+}
+
+pub enum KafkaKeyFormat {
+    Raw,
+    Utf8,
+}
+
+pub enum KafkaConfigValue {
+    String(String),
+    Int(i64),
+    Float(HashableFloatWrapper),
+    Bool(bool),
+    Null,
+}
+```
+
+`KafkaWriteInfo` must:
+
+- Derive or implement `Clone`, `Serialize`, `Deserialize`, `PartialEq`, `Eq`, and `Hash`.
+- Avoid raw `f64` in hashable plan types. Use Daft's hashable float wrapper, or normalize Kafka config values to strings before storing them in the plan.
+- Use generic `E = ExprRef | BoundExpr`, like existing sink info types.
+- Bind expressions once against the input schema.
+- Avoid any direct dependency on `rdkafka` types.
+
+Physical flow:
+
+```text
+DataFrame.write_kafka(...)
+  -> LogicalPlanBuilder::kafka_write(...)
+  -> SinkInfo::KafkaInfo(KafkaWriteInfo<ExprRef>)
+  -> SinkInfo::bind(schema)
+  -> KafkaWriteInfo<BoundExpr>
+  -> LocalPhysicalPlan::KafkaWrite
+  -> WriteSink with WriteFormat::Kafka
+  -> daft_writers::kafka::KafkaWriterFactory
+```
+
+Kafka write should not use `CommitWrite`. File writes need a commit phase for files/manifests. Kafka is an external side-effect sink where delivery success is the task completion condition.
+
+## Rust Writer Design
+
+Add:
+
+```text
+src/daft-writers/src/kafka/
+  mod.rs
+  config.rs
+  record.rs
+  headers.rs
+  producer.rs
+  accounting.rs
+  metrics.rs
+  writer.rs
+```
+
+Responsibilities:
+
+- `config.rs`: normalize Daft config into `rdkafka::ClientConfig`.
+- `record.rs`: project Daft rows into Kafka outgoing records.
+- `headers.rs`: parse list-of-struct Kafka headers.
+- `producer.rs`: define a small producer trait and the `rdkafka` adapter.
+- `accounting.rs`: delivery counters and summary RecordBatch creation.
+- `metrics.rs`: optional `rdkafka` statistics snapshot handling.
+- `writer.rs`: `KafkaWriterFactory` and `KafkaWriter`.
+
+Core internal types:
+
+```rust
+pub struct KafkaOutgoingRecord {
+    pub topic: String,
+    pub key: Option<Vec<u8>>,
+    pub value: Option<Vec<u8>>,
+    pub headers: Vec<KafkaHeader>,
+    pub partition: Option<i32>,
+    pub timestamp_ms: Option<i64>,
+}
+
+pub struct KafkaHeader {
+    pub key: String,
+    pub value: Option<Vec<u8>>,
+}
+
+pub struct KafkaDelivery {
+    pub topic: String,
+    pub partition: i32,
+    pub offset: i64,
+    pub timestamp_ms: Option<i64>,
+}
+```
+
+Use a producer trait for testability:
+
+```rust
+#[async_trait]
+trait KafkaProducer: Send + Sync {
+    async fn send(&self, record: KafkaOutgoingRecord) -> DaftResult<KafkaDelivery>;
+    async fn flush(&self, timeout: Duration) -> DaftResult<()>;
+
+    fn metrics_snapshot(&self) -> Option<KafkaProducerMetrics> {
+        None
+    }
+}
+```
+
+`RdkafkaProducer` should wrap `rdkafka::producer::FutureProducer`.
+
+`FutureProducer` is preferred because Daft writer execution is async and delivery futures compose naturally with delivery-result accounting. `ThreadedProducer` is callback-oriented and would make error propagation and testing less direct.
+
+## Write and Close Behavior
+
+`KafkaWriter.write(input)`:
+
+```text
+1. Iterate rows from the input MicroPartition.
+2. Build KafkaOutgoingRecord from topic/key/value/headers/partition/timestamp.
+3. Increment messages_attempted only after record construction succeeds.
+4. Send with FutureProducer.
+5. Await bounded in-flight delivery futures.
+6. On delivery success, increment messages_delivered and bytes_delivered.
+7. On enqueue or delivery failure, increment messages_failed, store first_error, and return DaftError.
+8. Return WriteResult with delivered row and byte counts.
+```
+
+`KafkaWriter.close()`:
+
+```text
+1. Drain all remaining in-flight delivery futures.
+2. Flush producer with timeout_ms.
+3. Return task-level summary RecordBatch.
+```
+
+Use bounded in-flight futures internally so producer throughput is not fully serial. Do not expose a Daft-level `max_in_flight_messages` parameter in the first API unless needed. Let users tune librdkafka batching and queue behavior through `kafka_client_config`.
+
+## Delivery Semantics
+
+First version semantics:
+
+```text
+at-least-once
+delivery-result confirmed
+fail on delivery error
+no transaction
+no exactly-once
+```
+
+Important behavior:
+
+- Delivery success is based on Kafka delivery result.
+- Any task delivery error fails the Daft job.
+- Already delivered Kafka messages are not rolled back.
+- User retries or Daft task retries can duplicate messages.
+- Kafka producer idempotence can reduce retry duplicates but is not Daft-level exactly-once.
+
+## Config Passthrough
+
+`kafka_client_config` should preserve `librdkafka` flexibility:
+
+- Accept scalar values: `str`, `int`, `bool`, `float`, and `None`.
+- Convert keys to strings.
+- Convert values into `rdkafka::ClientConfig` values.
+- Reject non-scalar values.
+- Do not log config values.
+
+Managed or restricted keys:
+
+```text
+bootstrap.servers  # managed by Daft
+transactional.id   # rejected in first version
+```
+
+`client.id` should remain user-overridable. Daft may provide a default such as `daft-write-kafka`, but should not prevent user override.
+
+Supported through passthrough:
+
+```text
+acks
+enable.idempotence
+compression.type
+linger.ms
+batch.size
+message.timeout.ms
+request.timeout.ms
+queue.buffering.max.messages
+queue.buffering.max.kbytes
+security.protocol
+sasl.*
+ssl.*
+statistics.interval.ms
+delivery.timeout.ms
+retries
+```
+
+Do not whitelist only these keys. They are examples. Unknown librdkafka keys should generally pass through to `rdkafka::ClientConfig` so librdkafka can validate them.
+
+## Idempotence and Transactions
+
+Users may enable producer idempotence:
+
+```python
+df.write_kafka(
+    ...,
+    kafka_client_config={
+        "acks": "all",
+        "enable.idempotence": True,
+    },
+)
+```
+
+Document clearly that this is not exactly-once semantics for the Daft operation. It does not protect against user reruns, job retries, or task retries outside the producer session.
+
+Reject:
+
+```python
+kafka_client_config={"transactional.id": "..."}
+```
+
+with:
+
+```text
+NotImplemented("[write_kafka] transactional.id is not supported yet")
+```
+
+Future transactional support should use explicit Daft-owned API, for example:
+
+```python
+df.write_kafka(
+    ...,
+    delivery_semantics="at_least_once" | "transactional",
+    transactional_id_prefix="daft-job-...",
+)
+```
+
+Distributed transaction boundaries must be controlled by Daft, not by arbitrary user-provided shared `transactional.id` values.
+
+## Metrics
+
+Default correctness summary comes from delivery results:
+
+```text
+messages_attempted
+messages_delivered
+messages_failed
+bytes_delivered
+first_error
+```
+
+`rdkafka`/`librdkafka` statistics are observability data, not the source of correctness summary:
+
+- They are only emitted when `statistics.interval.ms` is set.
+- They are producer/client lifecycle snapshots.
+- They are asynchronous and periodic.
+- They should not replace delivery-result accounting.
+
+Internal optional snapshot:
+
+```rust
+pub struct KafkaProducerMetrics {
+    pub txmsgs: i64,
+    pub txmsg_bytes: i64,
+    pub outbuf_msg_cnt: i64,
+    pub msg_cnt: i64,
+    pub msg_max: i64,
+}
+```
+
+Do not add these fields to the public return schema in the first version. Prefer Daft runtime metrics or a future explicit metrics mode.
+
+## Error Model
+
+Use existing Daft errors with clear prefixes:
+
+| Scenario | Error |
+| --- | --- |
+| invalid public argument | `DaftError::ValueError` |
+| invalid config value type | `DaftError::TypeError` |
+| record projection/type error | `DaftError::ComputeError` |
+| Kafka enqueue/delivery/flush failure | `DaftError::External` |
+| `transactional.id` | `DaftError::NotImplemented` |
+
+All messages should start with `[write_kafka]`.
+
+Never include secret config values in logs or errors. Sensitive keys include:
+
+```text
+sasl.password
+ssl.key.password
+sasl.oauthbearer.config
+```
+
+## Feature Gating
+
+`rdkafka` should be optional and localized to `daft-writers`.
+
+Suggested shape:
+
+```toml
+[dependencies]
+rdkafka = { workspace = true, optional = true, default-features = false, features = ["tokio"] }
+
+[features]
+kafka = ["dep:rdkafka"]
+```
+
+Plan and execution crates can compile Kafka plan/config types without depending directly on `rdkafka`. Only the writer implementation should need the external client.
+
+No-default-feature CI must continue to pass:
+
+```bash
+cargo test --no-default-features --workspace
+```
+
+Open decision: whether the root `python` feature should include Kafka write by default for wheels, or whether Kafka write should be behind a separate build feature to avoid `librdkafka` build/link complexity.
+
+## Testing
+
+### Python Broker-Free Tests
+
+Add tests in `tests/io/test_kafka_write_mock.py` or extend `tests/io/test_kafka_mock.py`:
+
+- `DataFrame.write_kafka` exists.
+- `bootstrap_servers` accepts string and sequence.
+- `topic`/`topic_col` mutual exclusion.
+- `partition`/`partition_col` mutual exclusion.
+- `timeout_ms <= 0` fails.
+- `kafka_client_config` rejects non-scalar values.
+- `bootstrap.servers` cannot be overridden.
+- `transactional.id` is rejected.
+- `key_col=None` and `timestamp_ms_col=None` are accepted.
+- invalid `value_format` and `key_format` fail.
+
+### Rust Unit Tests
+
+Use `FakeProducer` to test without a broker:
+
+- Config normalization.
+- Sensitive config redaction.
+- Raw, UTF-8, and JSON record projection.
+- Null value tombstone behavior.
+- Null JSON distinction from bytes `b"null"`.
+- Static and dynamic topic routing.
+- Static and dynamic partition selection.
+- Timestamp handling.
+- Ordered headers and duplicate key preservation.
+- Delivery accounting.
+- First-error capture.
+- Delivery failure and flush failure propagation.
+- Bounded in-flight future draining.
+
+### Redpanda Integration Tests
+
+Reuse `tests/integration/io/docker-compose/docker-compose.yml`.
+
+Add integration tests for:
+
+- Raw binary key/value round trip using `read_kafka`.
+- UTF-8 value writes.
+- JSON value writes.
+- Static partition and timestamp.
+- Dynamic topic routing.
+- Headers, verified through a Kafka consumer because `read_kafka` does not currently return headers.
+
+Avoid flaky integration failure tests that depend on broker shutdown. Use fake producer tests for failure behavior.
+
+### Native and Ray
+
+Run at least one native and one Ray write/read round trip:
+
+```bash
+DAFT_RUNNER=native pytest tests/integration/io/test_kafka_integration.py -m integration
+DAFT_RUNNER=ray pytest tests/integration/io/test_kafka_integration.py -m integration
+```
+
+If Ray coverage is expensive, keep one minimal Ray round trip and run richer type/header cases with the native runner.
+
+## Documentation
+
+Update:
+
+```text
+docs/connectors/kafka.md
+docs/api/io.md or generated API docs entry
+```
+
+Document:
+
+- Kafka connector supports read and write.
+- `write_kafka` is experimental.
+- At-least-once semantics.
+- Null value sends tombstone.
+- Idempotence recommended config.
+- `transactional.id` and EOS unsupported.
+- `kafka_client_config` passes through librdkafka producer options.
+- Headers use ordered list-of-struct.
+- Return value is task-level summary.
+
+Example:
+
+```python
+df.write_kafka(
+    bootstrap_servers="localhost:9092",
+    topic="events",
+    key_col="key",
+    value_col="value",
+    kafka_client_config={
+        "acks": "all",
+        "enable.idempotence": True,
+        "compression.type": "zstd",
+    },
+)
+```
+
+JSON example:
+
+```python
+df.write_kafka(
+    bootstrap_servers="localhost:9092",
+    topic="events-json",
+    value_col="payload",
+    value_format="json",
+)
+```
+
+## Suggested Implementation Boundary
+
+First implementation includes:
+
+- Static topic.
+- Dynamic topic.
+- Raw key/value.
+- UTF-8 key/value.
+- JSON value.
+- Static/dynamic partition.
+- Timestamp.
+- Headers.
+- Task-level summary.
+- Delivery-result accounting.
+- Bounded in-flight sends.
+- `librdkafka` config passthrough.
+- Optional statistics capture hook.
+- Idempotence through config.
+
+First implementation excludes:
+
+- Transactional writes.
+- Exactly-once semantics.
+- Schema Registry.
+- Avro and Protobuf.
+- Per-message delivery report output.
+- Rust rewrite of `read_kafka`.
+- Streaming/unbounded sink.
+
+## Review Strategy
+
+Even though the feature is a single Kafka write capability, it touches multiple Daft layers. If maintainers prefer smaller review units, split PRs as:
+
+1. API, logical plan, local plan, return schema, validation, and docs skeleton.
+2. `rdkafka` writer, full record construction, task summary, and tests.
+3. Integration hardening, Ray coverage, docs polish, and metrics hooks.
+
+If maintainers accept one PR, keep commits modular by layer so review remains tractable.
+
+## Open Decisions
+
+- Whether `python` should enable Kafka write by default in published wheels.
+- Whether the public return field should be `task_id` or `writer_id`.
+- Whether Daft should expose a public `max_in_flight_messages` tuning parameter in the first release.
+- Whether optional `rdkafka` statistics should be integrated into Daft runtime metrics immediately or deferred.

--- a/docs/superpowers/specs/2026-06-11-kafka-write-local-e2e-design.md
+++ b/docs/superpowers/specs/2026-06-11-kafka-write-local-e2e-design.md
@@ -1,0 +1,387 @@
+# Kafka Write Local E2E Design
+
+## Purpose
+
+This design adds an opt-in local end-to-end test flow for Daft's native
+`DataFrame.write_kafka(...)` path. The test is intended for Daft Kafka write
+development confidence, not for default community CI. It uses a real Redpanda
+broker through Docker, writes real Kafka records through Daft's native Rust
+producer, and verifies results with both Kafka's Python client and
+`daft.read_kafka(...)`.
+
+The E2E should prove that Daft can:
+
+- Read records from a real Kafka-compatible broker.
+- Transform and write those records back through native `write_kafka`.
+- Preserve Kafka record fields: topic, partition, key, value, timestamp, and
+  headers.
+- Encode JSON values correctly, including top-level tombstones and nested JSON
+  nulls.
+- Pass through common librdkafka producer configuration such as `acks`,
+  idempotence, compression, and `client.id`.
+- Return task-level write summaries with useful counters.
+- Surface expected validation failures without reporting success.
+
+## Non-Goals
+
+- This test should not become a default required upstream CI check.
+- This test should not require TLS, SASL, Kerberos, or a production-like Kafka
+  security setup in v1.
+- This test should not wait for Kafka log compaction to occur. It only verifies
+  that Daft writes tombstone records correctly.
+- This test should not replace the existing mock/unit/integration tests.
+
+## Location And Invocation
+
+Add the local-only test at:
+
+```text
+tests/local_e2e/test_kafka_write_e2e.py
+```
+
+Use the existing Redpanda service in:
+
+```text
+tests/integration/io/docker-compose/docker-compose.yml
+```
+
+Recommended manual invocation:
+
+```bash
+docker compose -f tests/integration/io/docker-compose/docker-compose.yml up -d redpanda
+DAFT_RUN_KAFKA_LOCAL_E2E=1 DAFT_RUNNER=native \
+  .venv/bin/python -m pytest tests/local_e2e/test_kafka_write_e2e.py -q -s
+```
+
+The test module should skip unless `DAFT_RUN_KAFKA_LOCAL_E2E=1` is present:
+
+```python
+if os.environ.get("DAFT_RUN_KAFKA_LOCAL_E2E") != "1":
+    pytest.skip("local Kafka E2E is opt-in", allow_module_level=True)
+```
+
+Use module-level markers:
+
+```python
+pytestmark = [pytest.mark.local_e2e, pytest.mark.integration]
+```
+
+## Broker And Topic Setup
+
+Use `127.0.0.1:9092` as the bootstrap address, matching the existing Redpanda
+Docker Compose service. The test should wait for broker readiness with
+`confluent_kafka.Consumer.list_topics(timeout=...)`.
+
+Each run creates a unique `run_id` and all topic names include that id:
+
+```text
+daft-e2e-src-{run_id}
+daft-e2e-raw-out-{run_id}
+daft-e2e-json-user-{run_id}
+daft-e2e-json-order-{run_id}
+daft-e2e-headers-{run_id}
+daft-e2e-compact-{run_id}
+daft-e2e-bad-{run_id}
+```
+
+Topic configuration:
+
+| Topic role | Partitions | Notes |
+| --- | ---: | --- |
+| `src` | 3 | Seeded by Kafka producer, read by Daft |
+| `raw-out` | 3 | Written by Daft raw mirror flow |
+| `json-user` | 2 | Dynamic topic write target |
+| `json-order` | 2 | Dynamic topic write target |
+| `headers` | 1 | Header ordering assertions are easier on one partition |
+| `compact` | 1 | Set `cleanup.policy=compact`; do not wait for compaction |
+| `bad` | 0 | Do not create by default; reserved for failure testing |
+
+## Test Data
+
+### Source Records
+
+Seed at least 12 records into the source topic with Kafka's Python producer.
+Records should cover:
+
+- All 3 source partitions.
+- Duplicate keys.
+- Unicode keys and values.
+- Different payload sizes.
+- Explicit `timestamp_ms`.
+- Raw bytes that contain JSON text.
+
+Representative rows:
+
+```python
+source_records = [
+    {
+        "event_id": 1,
+        "key": b"user-001",
+        "value": b'{"event_id":1,"kind":"signup","amount":0,"note":"hello"}',
+        "partition": 0,
+        "timestamp_ms": base_ts_ms + 1,
+    },
+    {
+        "event_id": 2,
+        "key": b"order-001",
+        "value": b'{"event_id":2,"kind":"purchase","amount":19.99,"note":"zstd-path"}',
+        "partition": 1,
+        "timestamp_ms": base_ts_ms + 2,
+    },
+    {
+        "event_id": 3,
+        "key": b"user-001",
+        "value": b'{"event_id":3,"kind":"update","amount":0,"note":"duplicate-key"}',
+        "partition": 0,
+        "timestamp_ms": base_ts_ms + 3,
+    },
+    {
+        "event_id": 4,
+        "key": "user-004".encode("utf-8"),
+        "value": json.dumps(
+            {"event_id": 4, "kind": "unicode", "note": "hello unicode"},
+            ensure_ascii=False,
+        ).encode("utf-8"),
+        "partition": 2,
+        "timestamp_ms": base_ts_ms + 4,
+    },
+]
+```
+
+Avoid non-ASCII literals in the file unless the repo style already permits them;
+use escaped or ASCII-only examples when possible.
+
+### JSON Dynamic Topic Rows
+
+Use Daft `from_pylist` rows:
+
+```python
+json_rows = [
+    {
+        "topic": user_topic,
+        "key": "user-001",
+        "value": {"op": "upsert", "name": "alice", "tags": ["new", None]},
+        "partition": 0,
+        "timestamp_ms": base_ts_ms + 100,
+    },
+    {
+        "topic": order_topic,
+        "key": "order-001",
+        "value": {"op": "created", "amount": 19.99, "ok": True},
+        "partition": 1,
+        "timestamp_ms": base_ts_ms + 101,
+    },
+    {
+        "topic": user_topic,
+        "key": "user-002",
+        "value": None,
+        "partition": 1,
+        "timestamp_ms": base_ts_ms + 102,
+    },
+]
+```
+
+This verifies dynamic topic routing, UTF-8 key encoding, JSON serialization,
+nested JSON nulls, top-level tombstones, explicit partition, and explicit
+timestamp.
+
+### Header Rows
+
+Use one single-partition topic for deterministic header assertions:
+
+```python
+header_rows = [
+    {
+        "key": b"k1",
+        "value": b"v1",
+        "headers": [
+            {"key": "trace", "value": b"a"},
+            {"key": "trace", "value": b"b"},
+            {"key": "nullable", "value": None},
+        ],
+    }
+]
+```
+
+This verifies duplicate header keys, ordering, and null header values.
+
+### Compacted Topic Rows
+
+Use a compacted topic to verify tombstone compatibility:
+
+```python
+compact_rows = [
+    {"key": "user-compact-001", "value": {"status": "active"}},
+    {"key": "user-compact-001", "value": None},
+]
+```
+
+Do not wait for compaction. Assert that Kafka contains both records and that the
+second record has `msg.value() is None`.
+
+## E2E Scenarios
+
+### Scenario 1: Kafka Source To Daft To Kafka Raw Mirror
+
+Flow:
+
+1. Create source and raw output topics.
+2. Seed source records using `confluent_kafka.Producer`.
+3. Read source topic with `daft.read_kafka(start="earliest", end="latest")`.
+4. Select `key`, `value`, `partition`, and `timestamp_ms`.
+5. Write the selected DataFrame with `write_kafka(...)`.
+
+Producer config:
+
+```python
+kafka_client_config={
+    "acks": "all",
+    "enable.idempotence": True,
+    "compression.type": "zstd",
+    "client.id": f"daft-e2e-raw-{run_id}",
+}
+```
+
+Assertions:
+
+- `messages_attempted` sum equals source row count.
+- `messages_delivered` sum equals source row count.
+- `messages_failed` sum is `0`.
+- `bytes_delivered` sum is greater than `0`.
+- `task_id` values are integers; do not require them to start at zero.
+- Kafka consumer reads the exact expected keys, values, partitions, and
+  timestamps from `raw-out`.
+- `daft.read_kafka(...)` can read all raw output rows back.
+
+Order should only be asserted within a single partition. For multi-partition
+topics, compare normalized sets or group by partition.
+
+### Scenario 2: JSON Dynamic Topic And Tombstone
+
+Flow:
+
+1. Create `json-user` and `json-order` topics.
+2. Build `json_rows` with Daft `from_pylist`.
+3. Write with:
+
+```python
+write_kafka(
+    bootstrap_servers=bootstrap,
+    topic_col="topic",
+    key_col="key",
+    value_col="value",
+    partition_col="partition",
+    timestamp_ms_col="timestamp_ms",
+    key_format="utf8",
+    value_format="json",
+    kafka_client_config={"acks": "all", "compression.type": "zstd"},
+    timeout_ms=20_000,
+)
+```
+
+Assertions:
+
+- User topic receives the user upsert and user tombstone.
+- Order topic receives the order event.
+- Nested Python `None` serializes as JSON `null`.
+- Top-level Python `None` writes Kafka null value.
+- UTF-8 keys decode to the expected strings.
+- Explicit partitions and timestamps are visible on consumed records.
+
+### Scenario 3: Headers
+
+Flow:
+
+1. Create headers topic with one partition.
+2. Write `header_rows` with `headers_col="headers"`.
+3. Consume with Kafka's Python consumer.
+
+Assertions:
+
+- Headers equal `[("trace", b"a"), ("trace", b"b"), ("nullable", None)]`.
+- Duplicate keys and order are preserved.
+- Summary reports one attempted and one delivered message.
+
+### Scenario 4: Compacted Topic Tombstone
+
+Flow:
+
+1. Create compact topic with `cleanup.policy=compact`.
+2. Write `compact_rows` using `key_format="utf8"` and `value_format="json"`.
+3. Consume the two records with Kafka's Python consumer.
+
+Assertions:
+
+- First record value decodes to `{"status": "active"}`.
+- Second record has the same key and `msg.value() is None`.
+- Summary reports two attempted and two delivered messages.
+
+### Scenario 5: Validation Guardrails
+
+Include stable validation failures:
+
+- `kafka_client_config={"transactional.id": "tx-1"}` raises
+  `NotImplementedError`.
+- Dynamic topic `None` or empty string raises an error containing
+  `[write_kafka]` and topic context.
+
+Do not include broker-dependent delivery failure in v1 unless it is proven
+stable with Redpanda. A future P1 test can try writing to a non-existent topic
+with `allow.auto.create.topics=False` and short `message.timeout.ms`.
+
+## Helper Functions
+
+The test module should keep helper functions local and explicit:
+
+```python
+wait_for_kafka_ready(bootstrap)
+create_topic(bootstrap, topic, partitions, config=None)
+produce_seed_records(bootstrap, topic, records)
+consume_exactly(bootstrap, topic, count, timeout_s=20)
+read_all_with_daft(bootstrap, topic)
+assert_summary(summary, attempted, delivered, failed=0)
+normalize_kafka_message(msg)
+```
+
+Implementation notes:
+
+- Use a fresh consumer group id for each consume/read helper.
+- Use bounded deadlines and clear failure messages.
+- Prefer exact count consumption when the expected count is known.
+- Close consumers in `finally`.
+- Do not rely on cross-partition ordering.
+- Print topic names and consumed counts in failures.
+- Keep topic cleanup best-effort; unique topic names already avoid collisions.
+
+## Acceptance Criteria
+
+The local E2E passes when:
+
+- Redpanda is reachable through Docker on `127.0.0.1:9092`.
+- The raw mirror flow writes all source records and preserves key, value,
+  partition, and timestamp.
+- Daft can read back the raw mirror topic.
+- Dynamic topic routing writes user and order records to distinct topics.
+- JSON serialization preserves nested nulls and writes top-level nulls as Kafka
+  tombstones.
+- Headers preserve duplicate keys, order, and null values.
+- The compacted topic receives an upsert followed by a tombstone.
+- Summary rows report expected attempted, delivered, failed, and bytes counters.
+- Validation failures are raised without creating misleading success summaries.
+
+## Future Extensions
+
+P1:
+
+- Broker delivery failure with topic auto-creation disabled and short delivery
+  timeout.
+- Larger batch, for example 5,000 rows, to exercise multiple Daft partitions and
+  task summaries.
+- Optional Ray runner run if the local environment has Ray available.
+
+P2:
+
+- Separate TLS-enabled Redpanda profile with generated CA and client
+  certificate material.
+- SASL/PLAIN profile if the broker image supports a lightweight local setup.
+- More producer config coverage for retries, linger, batching, and queue limits.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ homepage = "https://www.daft.ai"
 repository = "https://github.com/Eventual-Inc/Daft"
 
 [project.optional-dependencies]
-all = ["daft[aws, azure, clickhouse, deltalake, gcp, google, gravitino, hudi, huggingface, iceberg, lance, numpy, openai, pandas, postgres, ray, sentence-transformers, sql, transformers, turbopuffer, unity, video]"]
+all = ["daft[aws, azure, clickhouse, deltalake, gcp, google, gravitino, hudi, huggingface, iceberg, kafka, lance, numpy, openai, pandas, postgres, ray, sentence-transformers, sql, transformers, turbopuffer, unity, video]"]
 aws = ["boto3<1.44.0", "mypy-boto3-glue"]
 azure = []
 clickhouse = ["clickhouse_connect<1.1.0"]
@@ -41,6 +41,7 @@ gravitino = ["requests>=2.28.0,<3.0.0"]
 hudi = ["pyarrow >= 16.0.0,<25.0.0"]
 huggingface = ["huggingface-hub<1.17.0", "datasets<4.9.0"]
 iceberg = ["pyiceberg >= 0.7.0, != 0.9.1, != 0.10.0, <= 0.11.1"]
+kafka = ["confluent-kafka"]
 lance = ["daft-lance"]
 numpy = ["numpy<2.4.0"]
 openai = ["openai<2.39.0", "numpy<2.4.0", "pillow==12.2.0"]

--- a/src/common/error/src/error.rs
+++ b/src/common/error/src/error.rs
@@ -53,7 +53,7 @@ pub enum DaftError {
     #[error("MiscTransient {0}")]
     MiscTransient(GenericError),
     #[error("DaftError::External {0}")]
-    External(GenericError),
+    External(#[source] GenericError),
     #[error("DaftError::SerdeJsonError {0}")]
     SerdeJsonError(#[from] serde_json::Error),
     #[error("DaftError::FmtError {0}")]
@@ -78,6 +78,21 @@ impl DaftError {
     }
     pub fn type_error<T: std::fmt::Display>(msg: T) -> Self {
         Self::TypeError(msg.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{error::Error, io};
+
+    use super::DaftError;
+
+    #[test]
+    fn external_error_exposes_wrapped_error_as_source() {
+        let err = DaftError::External(Box::new(io::Error::other("external source")));
+
+        assert_eq!(err.to_string(), "DaftError::External external source");
+        assert_eq!(err.source().unwrap().to_string(), "external source");
     }
 }
 

--- a/src/common/error/src/error.rs
+++ b/src/common/error/src/error.rs
@@ -81,21 +81,6 @@ impl DaftError {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use std::{error::Error, io};
-
-    use super::DaftError;
-
-    #[test]
-    fn external_error_exposes_wrapped_error_as_source() {
-        let err = DaftError::External(Box::new(io::Error::other("external source")));
-
-        assert_eq!(err.to_string(), "DaftError::External external source");
-        assert_eq!(err.source().unwrap().to_string(), "external source");
-    }
-}
-
 #[macro_export]
 macro_rules! ensure {
     ($cond:expr, $msg:expr) => {
@@ -121,5 +106,20 @@ macro_rules! value_err {
 impl<'py> From<pyo3::pyclass::PyClassGuardError<'_, 'py>> for DaftError {
     fn from(error: pyo3::pyclass::PyClassGuardError<'_, 'py>) -> Self {
         Self::PyO3Error(error.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{error::Error, io};
+
+    use super::DaftError;
+
+    #[test]
+    fn external_error_exposes_wrapped_error_as_source() {
+        let err = DaftError::External(Box::new(io::Error::other("external source")));
+
+        assert_eq!(err.to_string(), "DaftError::External external source");
+        assert_eq!(err.source().unwrap().to_string(), "external source");
     }
 }

--- a/src/daft-distributed/src/pipeline_node/sink.rs
+++ b/src/daft-distributed/src/pipeline_node/sink.rs
@@ -133,6 +133,7 @@ fn sink_display_name(sink_info: &SinkInfo<BoundExpr>) -> String {
                 (_, _) => "Write".to_string(),
             }
         }
+        SinkInfo::KafkaInfo(_) => "Kafka Write".to_string(),
         #[cfg(feature = "python")]
         SinkInfo::CatalogInfo(catalog_info) => match &catalog_info.catalog {
             CatalogType::Iceberg(ic) => {
@@ -209,6 +210,13 @@ impl SinkNode {
                 data_schema,
                 file_schema,
                 info.clone(),
+                StatsState::NotMaterialized,
+                LocalNodeContext::new(Some(node_id as usize)),
+            ),
+            SinkInfo::KafkaInfo(info) => LocalPhysicalPlan::kafka_write(
+                input,
+                info.clone(),
+                file_schema,
                 StatsState::NotMaterialized,
                 LocalNodeContext::new(Some(node_id as usize)),
             ),
@@ -296,6 +304,10 @@ impl PipelineNodeImpl for SinkNode {
             SinkInfo::OutputFileInfo(output_file_info) => {
                 res.push(format!("Sink: {:?}", output_file_info.file_format));
                 res.extend(output_file_info.multiline_display());
+            }
+            SinkInfo::KafkaInfo(info) => {
+                res.push("Sink: Kafka".to_string());
+                res.extend(info.multiline_display());
             }
             #[cfg(feature = "python")]
             SinkInfo::CatalogInfo(catalog_info) => match &catalog_info.catalog {

--- a/src/daft-local-execution/Cargo.toml
+++ b/src/daft-local-execution/Cargo.toml
@@ -40,7 +40,7 @@ daft-recordbatch = {path = "../daft-recordbatch", default-features = false}
 daft-scan = {path = "../daft-scan", default-features = false}
 daft-shuffles = {path = "../daft-shuffles", default-features = false}
 daft-warc = {path = "../daft-warc", default-features = false}
-daft-writers = {path = "../daft-writers", default-features = false, features = ["kafka"]}
+daft-writers = {path = "../daft-writers", default-features = false}
 futures = {workspace = true}
 indexmap = {workspace = true}
 indicatif = {workspace = true}
@@ -65,6 +65,7 @@ sysinfo = {workspace = true}
 tikv-jemalloc-ctl = {version = "0.7.0", features = ["stats"]}
 
 [features]
+kafka = ["daft-writers/kafka"]
 python = [
   "dep:pyo3",
   "dep:pyo3-async-runtimes",

--- a/src/daft-local-execution/Cargo.toml
+++ b/src/daft-local-execution/Cargo.toml
@@ -40,7 +40,7 @@ daft-recordbatch = {path = "../daft-recordbatch", default-features = false}
 daft-scan = {path = "../daft-scan", default-features = false}
 daft-shuffles = {path = "../daft-shuffles", default-features = false}
 daft-warc = {path = "../daft-warc", default-features = false}
-daft-writers = {path = "../daft-writers", default-features = false}
+daft-writers = {path = "../daft-writers", default-features = false, features = ["kafka"]}
 futures = {workspace = true}
 indexmap = {workspace = true}
 indicatif = {workspace = true}

--- a/src/daft-local-execution/src/pipeline.rs
+++ b/src/daft-local-execution/src/pipeline.rs
@@ -1462,6 +1462,14 @@ fn physical_plan_to_pipeline(
             )
             .boxed()
         }
+        LocalPhysicalPlan::KafkaWrite(_) => {
+            return Err(crate::Error::PipelineCreationError {
+                source: DaftError::not_implemented(
+                    "[write_kafka] Kafka write execution is not implemented in the native runner yet",
+                ),
+                plan_name: physical_plan.name().to_string(),
+            });
+        }
         #[cfg(feature = "python")]
         LocalPhysicalPlan::CatalogWrite(daft_local_plan::CatalogWrite {
             input,

--- a/src/daft-local-execution/src/pipeline.rs
+++ b/src/daft-local-execution/src/pipeline.rs
@@ -1462,13 +1462,29 @@ fn physical_plan_to_pipeline(
             )
             .boxed()
         }
-        LocalPhysicalPlan::KafkaWrite(_) => {
-            return Err(crate::Error::PipelineCreationError {
-                source: DaftError::not_implemented(
-                    "[write_kafka] Kafka write execution is not implemented in the native runner yet",
-                ),
-                plan_name: physical_plan.name().to_string(),
-            });
+        LocalPhysicalPlan::KafkaWrite(daft_local_plan::KafkaWrite {
+            input,
+            kafka_info,
+            file_schema,
+            stats_state,
+            context,
+        }) => {
+            let child_node = physical_plan_to_pipeline(input, cfg, ctx, input_senders)?;
+            let writer_factory = daft_writers::make_kafka_writer_factory(kafka_info.clone());
+            let write_sink = WriteSink::new(
+                WriteFormat::Kafka,
+                writer_factory,
+                None,
+                file_schema.clone(),
+            );
+            BlockingSinkNode::new(
+                Arc::new(write_sink),
+                child_node,
+                stats_state.clone(),
+                ctx,
+                context,
+            )
+            .boxed()
         }
         #[cfg(feature = "python")]
         LocalPhysicalPlan::CatalogWrite(daft_local_plan::CatalogWrite {

--- a/src/daft-local-execution/src/pipeline.rs
+++ b/src/daft-local-execution/src/pipeline.rs
@@ -407,6 +407,8 @@ pub fn translate_physical_plan_to_pipeline(
     // effects), wrap the pipeline in a CheckpointTerminusNode that stages keys
     // and calls `store.checkpoint(id)` per input. Write-sink plans already
     // handle this via SCKO + BlockingSinkNode::with_checkpoint.
+    // Kafka writes have external side effects and are not checkpointed as
+    // file-write sinks unless that behavior is deliberately implemented.
     let root_is_write_sink = matches!(
         physical_plan,
         LocalPhysicalPlan::PhysicalWrite(_) | LocalPhysicalPlan::CommitWrite(_)
@@ -1469,22 +1471,35 @@ fn physical_plan_to_pipeline(
             stats_state,
             context,
         }) => {
-            let child_node = physical_plan_to_pipeline(input, cfg, ctx, input_senders)?;
-            let writer_factory = daft_writers::make_kafka_writer_factory(kafka_info.clone());
-            let write_sink = WriteSink::new(
-                WriteFormat::Kafka,
-                writer_factory,
-                None,
-                file_schema.clone(),
-            );
-            BlockingSinkNode::new(
-                Arc::new(write_sink),
-                child_node,
-                stats_state.clone(),
-                ctx,
-                context,
-            )
-            .boxed()
+            #[cfg(feature = "kafka")]
+            {
+                let child_node = physical_plan_to_pipeline(input, cfg, ctx, input_senders)?;
+                let writer_factory = daft_writers::make_kafka_writer_factory(kafka_info.clone());
+                let write_sink = WriteSink::new(
+                    WriteFormat::Kafka,
+                    writer_factory,
+                    None,
+                    file_schema.clone(),
+                );
+                BlockingSinkNode::new(
+                    Arc::new(write_sink),
+                    child_node,
+                    stats_state.clone(),
+                    ctx,
+                    context,
+                )
+                .boxed()
+            }
+            #[cfg(not(feature = "kafka"))]
+            {
+                let _ = (input, kafka_info, file_schema, stats_state, context);
+                return Err(DaftError::not_implemented(
+                    "Kafka write support requires the `kafka` feature",
+                ))
+                .with_context(|_| PipelineCreationSnafu {
+                    plan_name: physical_plan.name(),
+                });
+            }
         }
         #[cfg(feature = "python")]
         LocalPhysicalPlan::CatalogWrite(daft_local_plan::CatalogWrite {
@@ -1824,4 +1839,65 @@ fn physical_plan_to_pipeline(
     };
 
     Ok(pipeline_node)
+}
+
+#[cfg(all(test, feature = "kafka"))]
+mod tests {
+    use std::{collections::BTreeMap, sync::Arc};
+
+    use common_daft_config::DaftExecutionConfig;
+    use daft_core::prelude::{DataType, Field, Schema};
+    use daft_dsl::unresolved_col;
+    use daft_local_plan::{LocalNodeContext, LocalPhysicalPlan};
+    use daft_logical_plan::{
+        sink_info::{KafkaKeyFormat, KafkaTopic, KafkaValueFormat, KafkaWriteInfo},
+        stats::StatsState,
+    };
+
+    use super::{BuilderContext, translate_physical_plan_to_pipeline, viz_pipeline_ascii};
+
+    #[test]
+    fn kafka_write_translates_to_named_pipeline_without_broker() {
+        let data_schema = Arc::new(Schema::new(vec![Field::new("value", DataType::Utf8)]));
+        let file_schema = Arc::new(Schema::new(vec![Field::new("summary", DataType::UInt64)]));
+        let kafka_info = KafkaWriteInfo {
+            bootstrap_servers: "localhost:9092".to_string(),
+            topic: KafkaTopic::Static("topic-a".to_string()),
+            value_col: unresolved_col("value"),
+            key_col: None,
+            headers_col: None,
+            partition: None,
+            timestamp_ms_col: None,
+            value_format: KafkaValueFormat::Utf8,
+            key_format: KafkaKeyFormat::Utf8,
+            kafka_client_config: BTreeMap::new(),
+            timeout_ms: 1000,
+        }
+        .bind(&data_schema)
+        .unwrap();
+        let plan = LocalPhysicalPlan::kafka_write(
+            LocalPhysicalPlan::in_memory_scan(
+                0,
+                data_schema,
+                0,
+                StatsState::NotMaterialized,
+                LocalNodeContext::default(),
+            ),
+            kafka_info,
+            file_schema,
+            StatsState::NotMaterialized,
+            LocalNodeContext::default(),
+        );
+        let cfg = Arc::new(DaftExecutionConfig::default());
+        let ctx = BuilderContext::new();
+
+        let (pipeline_node, _) =
+            translate_physical_plan_to_pipeline(&plan, &cfg, &ctx).expect("translation succeeds");
+
+        let ascii = viz_pipeline_ascii(pipeline_node.as_ref(), true);
+        assert!(
+            ascii.contains("Kafka Write"),
+            "pipeline ASCII should include Kafka Write, got:\n{ascii}"
+        );
+    }
 }

--- a/src/daft-local-execution/src/sinks/write.rs
+++ b/src/daft-local-execution/src/sinks/write.rs
@@ -278,8 +278,8 @@ impl BlockingSink for WriteSink {
         NodeType::Write
     }
 
-    fn make_state(&self, _input_id: InputId) -> DaftResult<Self::State> {
-        let writer = self.writer_factory.create_writer(0, None)?;
+    fn make_state(&self, input_id: InputId) -> DaftResult<Self::State> {
+        let writer = self.writer_factory.create_writer(input_id as usize, None)?;
         Ok(WriteState::new(writer))
     }
 
@@ -294,5 +294,78 @@ impl BlockingSink for WriteSink {
 
     fn max_concurrency(&self) -> usize {
         1
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use async_trait::async_trait;
+    use daft_core::prelude::Schema;
+
+    use super::*;
+
+    struct RecordingWriterFactory {
+        file_indices: Arc<Mutex<Vec<usize>>>,
+    }
+
+    impl WriterFactory for RecordingWriterFactory {
+        type Input = MicroPartition;
+        type Result = Vec<RecordBatch>;
+
+        fn create_writer(
+            &self,
+            file_idx: usize,
+            _partition_values: Option<&RecordBatch>,
+        ) -> DaftResult<Box<dyn AsyncFileWriter<Input = Self::Input, Result = Self::Result>>>
+        {
+            self.file_indices.lock().unwrap().push(file_idx);
+            Ok(Box::new(NoopWriter))
+        }
+    }
+
+    struct NoopWriter;
+
+    #[async_trait]
+    impl AsyncFileWriter for NoopWriter {
+        type Input = MicroPartition;
+        type Result = Vec<RecordBatch>;
+
+        async fn write(&mut self, data: Self::Input) -> DaftResult<WriteResult> {
+            Ok(WriteResult {
+                bytes_written: 0,
+                rows_written: data.len(),
+            })
+        }
+
+        async fn close(&mut self) -> DaftResult<Self::Result> {
+            Ok(vec![])
+        }
+
+        fn bytes_written(&self) -> usize {
+            0
+        }
+
+        fn bytes_per_file(&self) -> Vec<usize> {
+            vec![0]
+        }
+    }
+
+    #[test]
+    fn make_state_uses_input_id_as_writer_index() {
+        let file_indices = Arc::new(Mutex::new(Vec::new()));
+        let sink = WriteSink::new(
+            WriteFormat::Kafka,
+            Arc::new(RecordingWriterFactory {
+                file_indices: file_indices.clone(),
+            }),
+            None,
+            Arc::new(Schema::empty()),
+        );
+
+        <WriteSink as BlockingSink>::make_state(&sink, 42).unwrap();
+
+        assert_eq!(*file_indices.lock().unwrap(), vec![42]);
     }
 }

--- a/src/daft-local-execution/src/sinks/write.rs
+++ b/src/daft-local-execution/src/sinks/write.rs
@@ -143,6 +143,7 @@ pub enum WriteFormat {
     Deltalake,
     PartitionedDeltalake,
     Lance,
+    Kafka,
     DataSink(String),
 }
 
@@ -268,6 +269,7 @@ impl BlockingSink for WriteSink {
             WriteFormat::Deltalake => "DeltaLake Write".into(),
             WriteFormat::PartitionedDeltalake => "Partitioned DeltaLake Write".into(),
             WriteFormat::Lance => "Lance Write".into(),
+            WriteFormat::Kafka => "Kafka Write".into(),
             WriteFormat::DataSink(name) => name.clone().into(),
         }
     }

--- a/src/daft-local-plan/src/lib.rs
+++ b/src/daft-local-plan/src/lib.rs
@@ -10,11 +10,11 @@ use daft_scan::ScanTaskRef;
 pub use plan::{
     AsofJoin, CommitWrite, Concat, CrossJoin, Dedup, Explode, Filter, FlightShuffleReadInput,
     GatherWrite, GlobScan, HashAggregate, HashJoin, InMemoryScan, IntoBatches, IntoPartitions,
-    Limit, LocalNodeContext, LocalPhysicalPlan, LocalPhysicalPlanRef, MonotonicallyIncreasingId,
-    PhysicalScan, PhysicalWrite, Pivot, PlaceholderScan, Project, RepartitionWrite, Sample,
-    SamplingMethod, ShuffleBackend, ShuffleRead, ShuffleReadBackend, Sort, SortMergeJoin,
-    StageCheckpointKeys, TopN, UDFProject, UnGroupedAggregate, Unpivot, VLLMProject,
-    WindowOrderByOnly, WindowPartitionAndDynamicFrame, WindowPartitionAndOrderBy,
+    KafkaWrite, Limit, LocalNodeContext, LocalPhysicalPlan, LocalPhysicalPlanRef,
+    MonotonicallyIncreasingId, PhysicalScan, PhysicalWrite, Pivot, PlaceholderScan, Project,
+    RepartitionWrite, Sample, SamplingMethod, ShuffleBackend, ShuffleRead, ShuffleReadBackend,
+    Sort, SortMergeJoin, StageCheckpointKeys, TopN, UDFProject, UnGroupedAggregate, Unpivot,
+    VLLMProject, WindowOrderByOnly, WindowPartitionAndDynamicFrame, WindowPartitionAndOrderBy,
     WindowPartitionOnly,
 };
 #[cfg(feature = "python")]

--- a/src/daft-local-plan/src/plan.rs
+++ b/src/daft-local-plan/src/plan.rs
@@ -2534,6 +2534,9 @@ pub struct FlightShuffleReadInput {
 
 #[cfg(test)]
 mod task_topology_tests {
+    use daft_core::datatypes::{DataType, Field};
+    use daft_logical_plan::sink_info::{KafkaKeyFormat, KafkaTopic, KafkaValueFormat};
+
     use super::*;
 
     fn scan() -> LocalPhysicalPlanRef {
@@ -2628,5 +2631,70 @@ mod task_topology_tests {
         let plan = scan();
         let _retained = plan.clone();
         let _ = plan.mark_task_root();
+    }
+
+    #[test]
+    fn kafka_write_preserves_schema_child_and_info_with_new_children() {
+        let data_schema = Arc::new(Schema::new(vec![Field::new("value", DataType::Utf8)]));
+        let file_schema = Arc::new(Schema::new(vec![Field::new("summary", DataType::UInt64)]));
+        let replacement_file_schema = Arc::new(Schema::new(vec![Field::new(
+            "replacement",
+            DataType::UInt64,
+        )]));
+        let kafka_info = daft_logical_plan::sink_info::KafkaWriteInfo {
+            bootstrap_servers: "localhost:9092".to_string(),
+            topic: KafkaTopic::Static("topic-a".to_string()),
+            value_col: daft_dsl::unresolved_col("value"),
+            key_col: None,
+            headers_col: None,
+            partition: None,
+            timestamp_ms_col: None,
+            value_format: KafkaValueFormat::Utf8,
+            key_format: KafkaKeyFormat::Utf8,
+            kafka_client_config: BTreeMap::new(),
+            timeout_ms: 1000,
+        }
+        .bind(&data_schema)
+        .unwrap();
+        let plan = LocalPhysicalPlan::kafka_write(
+            LocalPhysicalPlan::in_memory_scan(
+                0,
+                data_schema.clone(),
+                0,
+                StatsState::NotMaterialized,
+                LocalNodeContext::default(),
+            ),
+            kafka_info.clone(),
+            file_schema.clone(),
+            StatsState::NotMaterialized,
+            LocalNodeContext::default(),
+        );
+
+        assert_eq!(plan.schema(), &file_schema);
+        let children = plan.children();
+        assert_eq!(children.len(), 1);
+        assert_eq!(children[0].schema(), &data_schema);
+
+        let replacement = LocalPhysicalPlan::in_memory_scan(
+            1,
+            replacement_file_schema.clone(),
+            0,
+            StatsState::NotMaterialized,
+            LocalNodeContext::default(),
+        );
+        let rewritten = plan.with_new_children(&[replacement]);
+
+        let LocalPhysicalPlan::KafkaWrite(KafkaWrite {
+            kafka_info: rewritten_info,
+            file_schema: rewritten_file_schema,
+            input,
+            ..
+        }) = rewritten.as_ref()
+        else {
+            panic!("expected KafkaWrite");
+        };
+        assert_eq!(rewritten_info, &kafka_info);
+        assert_eq!(rewritten_file_schema, &file_schema);
+        assert_eq!(input.schema(), &replacement_file_schema);
     }
 }

--- a/src/daft-local-plan/src/plan.rs
+++ b/src/daft-local-plan/src/plan.rs
@@ -21,6 +21,7 @@ use daft_dsl::{
 use daft_logical_plan::{
     InMemoryInfo, OutputFileInfo,
     partitioning::RepartitionSpec,
+    sink_info::KafkaWriteInfo,
     stats::{PlanStats, StatsState},
 };
 use daft_scan::{Pushdowns, SourceConfig};
@@ -105,6 +106,7 @@ pub enum LocalPhysicalPlan {
     // BroadcastJoin(BroadcastJoin),
     PhysicalWrite(PhysicalWrite),
     CommitWrite(CommitWrite),
+    KafkaWrite(KafkaWrite),
     // TabularWriteJson(TabularWriteJson),
     // TabularWriteCsv(TabularWriteCsv),
     #[cfg(feature = "python")]
@@ -184,6 +186,7 @@ impl LocalPhysicalPlan {
             | Self::AsofJoin(AsofJoin { stats_state, .. })
             | Self::PhysicalWrite(PhysicalWrite { stats_state, .. })
             | Self::CommitWrite(CommitWrite { stats_state, .. })
+            | Self::KafkaWrite(KafkaWrite { stats_state, .. })
             | Self::IntoPartitions(IntoPartitions { stats_state, .. })
             | Self::RepartitionWrite(RepartitionWrite { stats_state, .. })
             | Self::GatherWrite(GatherWrite { stats_state, .. })
@@ -237,6 +240,7 @@ impl LocalPhysicalPlan {
             | Self::AsofJoin(AsofJoin { context, .. })
             | Self::PhysicalWrite(PhysicalWrite { context, .. })
             | Self::CommitWrite(CommitWrite { context, .. })
+            | Self::KafkaWrite(KafkaWrite { context, .. })
             | Self::IntoPartitions(IntoPartitions { context, .. })
             | Self::RepartitionWrite(RepartitionWrite { context, .. })
             | Self::GatherWrite(GatherWrite { context, .. })
@@ -287,6 +291,7 @@ impl LocalPhysicalPlan {
             | Self::AsofJoin(AsofJoin { context, .. })
             | Self::PhysicalWrite(PhysicalWrite { context, .. })
             | Self::CommitWrite(CommitWrite { context, .. })
+            | Self::KafkaWrite(KafkaWrite { context, .. })
             | Self::IntoPartitions(IntoPartitions { context, .. })
             | Self::RepartitionWrite(RepartitionWrite { context, .. })
             | Self::GatherWrite(GatherWrite { context, .. })
@@ -1021,6 +1026,23 @@ impl LocalPhysicalPlan {
         .arced()
     }
 
+    pub fn kafka_write(
+        input: LocalPhysicalPlanRef,
+        kafka_info: KafkaWriteInfo<BoundExpr>,
+        file_schema: SchemaRef,
+        stats_state: StatsState,
+        context: LocalNodeContext,
+    ) -> LocalPhysicalPlanRef {
+        Self::KafkaWrite(KafkaWrite {
+            input,
+            kafka_info,
+            file_schema,
+            stats_state,
+            context,
+        })
+        .arced()
+    }
+
     #[cfg(feature = "python")]
     pub fn catalog_write(
         input: LocalPhysicalPlanRef,
@@ -1209,6 +1231,7 @@ impl LocalPhysicalPlan {
             | Self::WindowOrderByOnly(WindowOrderByOnly { schema, .. }) => schema,
             Self::PhysicalWrite(PhysicalWrite { file_schema, .. }) => file_schema,
             Self::CommitWrite(CommitWrite { file_schema, .. }) => file_schema,
+            Self::KafkaWrite(KafkaWrite { file_schema, .. }) => file_schema,
             Self::InMemoryScan(InMemoryScan { schema, .. }) => schema,
             #[cfg(feature = "python")]
             Self::CatalogWrite(CatalogWrite { file_schema, .. }) => file_schema,
@@ -1287,7 +1310,8 @@ impl LocalPhysicalPlan {
                 input, ..
             })
             | Self::PhysicalWrite(PhysicalWrite { input, .. })
-            | Self::CommitWrite(CommitWrite { input, .. }) => vec![input.clone()],
+            | Self::CommitWrite(CommitWrite { input, .. })
+            | Self::KafkaWrite(KafkaWrite { input, .. }) => vec![input.clone()],
 
             Self::HashJoin(HashJoin { left, right, .. }) => vec![left.clone(), right.clone()],
             Self::CrossJoin(CrossJoin { left, right, .. }) => vec![left.clone(), right.clone()],
@@ -1665,7 +1689,6 @@ impl LocalPhysicalPlan {
                     context.clone(),
                 ),
                 Self::CommitWrite(CommitWrite {
-                    input,
                     data_schema,
                     stats_state,
                     file_schema,
@@ -1680,9 +1703,21 @@ impl LocalPhysicalPlan {
                     stats_state.clone(),
                     context.clone(),
                 ),
+                Self::KafkaWrite(KafkaWrite {
+                    kafka_info,
+                    file_schema,
+                    stats_state,
+                    context,
+                    ..
+                }) => Self::kafka_write(
+                    new_child.clone(),
+                    kafka_info.clone(),
+                    file_schema.clone(),
+                    stats_state.clone(),
+                    context.clone(),
+                ),
                 #[cfg(feature = "python")]
                 Self::DataSink(DataSink {
-                    input,
                     data_sink_info,
                     file_schema,
                     stats_state,
@@ -2309,6 +2344,16 @@ pub struct CommitWrite {
     pub data_schema: SchemaRef,
     pub file_schema: SchemaRef,
     pub file_info: OutputFileInfo<BoundExpr>,
+    pub stats_state: StatsState,
+    pub context: LocalNodeContext,
+}
+
+#[derive(Serialize, Deserialize)]
+#[cfg_attr(debug_assertions, derive(Debug))]
+pub struct KafkaWrite {
+    pub input: LocalPhysicalPlanRef,
+    pub kafka_info: KafkaWriteInfo<BoundExpr>,
+    pub file_schema: SchemaRef,
     pub stats_state: StatsState,
     pub context: LocalNodeContext,
 }

--- a/src/daft-local-plan/src/translate.rs
+++ b/src/daft-local-plan/src/translate.rs
@@ -632,6 +632,13 @@ fn translate_helper(
                         LocalNodeContext::default(),
                     )
                 }
+                SinkInfo::KafkaInfo(info) => LocalPhysicalPlan::kafka_write(
+                    input_plan,
+                    info.clone().bind(&data_schema)?,
+                    sink.schema.clone(),
+                    sink.stats_state.clone(),
+                    LocalNodeContext::default(),
+                ),
                 #[cfg(feature = "python")]
                 SinkInfo::CatalogInfo(info) => match &info.catalog {
                     daft_logical_plan::CatalogType::DeltaLake(..)

--- a/src/daft-logical-plan/src/builder/mod.rs
+++ b/src/daft-logical-plan/src/builder/mod.rs
@@ -12,6 +12,8 @@ use common_daft_config::{DaftExecutionConfig, DaftPlanningConfig};
 use common_display::mermaid::MermaidDisplayOptions;
 use common_error::{DaftError, DaftResult};
 use common_file_formats::{FileFormat, WriteMode};
+#[cfg(feature = "python")]
+use common_hashable_float_wrapper::FloatWrapper;
 use common_io_config::IOConfig;
 use common_treenode::TreeNode;
 use daft_algebra::boolean::combine_conjunction;
@@ -33,8 +35,10 @@ use {
     daft_dsl::python::PyExpr,
     // daft_scan::python::pylib::ScanOperatorHandle,
     daft_schema::python::schema::PySchema,
+    pyo3::PyTypeCheck,
     pyo3::intern,
     pyo3::prelude::*,
+    pyo3::types::{PyBool, PyDict, PyFloat, PyInt, PyString},
 };
 
 use crate::{
@@ -1356,6 +1360,45 @@ fn pyexprs_to_exprs(vec: Vec<PyExpr>) -> Vec<ExprRef> {
 }
 
 #[cfg(feature = "python")]
+fn py_kafka_client_config_to_config(
+    kafka_client_config: Option<&Bound<'_, PyDict>>,
+) -> PyResult<BTreeMap<String, KafkaConfigValue>> {
+    let Some(kafka_client_config) = kafka_client_config else {
+        return Ok(BTreeMap::new());
+    };
+
+    kafka_client_config
+        .iter()
+        .map(|(key, value)| {
+            let key: String = key.extract()?;
+            let value = if value.is_none() {
+                KafkaConfigValue::Null
+            } else if PyBool::type_check(&value) {
+                KafkaConfigValue::Bool(value.extract()?)
+            } else if PyInt::type_check(&value) {
+                KafkaConfigValue::Int(value.extract()?)
+            } else if PyFloat::type_check(&value) {
+                let value: f64 = value.extract()?;
+                if !value.is_finite() {
+                    return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                        "[write_kafka] kafka_client_config value for {key:?} must be finite"
+                    )));
+                }
+                KafkaConfigValue::Float(FloatWrapper(value))
+            } else if PyString::type_check(&value) {
+                KafkaConfigValue::String(value.extract()?)
+            } else {
+                return Err(pyo3::exceptions::PyTypeError::new_err(format!(
+                    "[write_kafka] kafka_client_config value for {key:?} must be None, bool, int, float, or str"
+                )));
+            };
+
+            Ok((key, value))
+        })
+        .collect()
+}
+
+#[cfg(feature = "python")]
 #[pymethods]
 impl PyLogicalPlanBuilder {
     #[staticmethod]
@@ -1802,6 +1845,60 @@ impl PyLogicalPlanBuilder {
                 partition_cols.map(pyexprs_to_exprs),
                 compression,
                 io_config.map(|cfg| cfg.config),
+            )?
+            .into())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    #[pyo3(signature = (
+        bootstrap_servers,
+        topic,
+        topic_col,
+        value_col,
+        key_col,
+        headers_col,
+        partition,
+        partition_col,
+        timestamp_ms_col,
+        value_format,
+        key_format,
+        kafka_client_config=None,
+        timeout_ms=10000
+    ))]
+    pub fn kafka_write(
+        &self,
+        bootstrap_servers: String,
+        topic: Option<String>,
+        topic_col: Option<String>,
+        value_col: String,
+        key_col: Option<String>,
+        headers_col: Option<String>,
+        partition: Option<i32>,
+        partition_col: Option<String>,
+        timestamp_ms_col: Option<String>,
+        value_format: String,
+        key_format: String,
+        kafka_client_config: Option<&Bound<'_, PyDict>>,
+        timeout_ms: u64,
+    ) -> PyResult<Self> {
+        let kafka_client_config = py_kafka_client_config_to_config(kafka_client_config)?;
+
+        Ok(self
+            .builder
+            .kafka_write(
+                bootstrap_servers,
+                topic,
+                topic_col.map(|name| unresolved_col(name.as_str())),
+                unresolved_col(value_col.as_str()),
+                key_col.map(|name| unresolved_col(name.as_str())),
+                headers_col.map(|name| unresolved_col(name.as_str())),
+                partition,
+                partition_col.map(|name| unresolved_col(name.as_str())),
+                timestamp_ms_col.map(|name| unresolved_col(name.as_str())),
+                value_format,
+                key_format,
+                kafka_client_config,
+                timeout_ms,
             )?
             .into())
     }

--- a/src/daft-logical-plan/src/builder/mod.rs
+++ b/src/daft-logical-plan/src/builder/mod.rs
@@ -1,7 +1,7 @@
 mod resolve_expr;
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     future::Future,
     sync::Arc,
 };
@@ -47,7 +47,10 @@ use crate::{
     },
     optimization::{OptimizerBuilder, OptimizerConfig},
     partitioning::{HashRepartitionConfig, RandomShuffleConfig, RepartitionSpec},
-    sink_info::{FormatSinkOption, OutputFileInfo, SinkInfo},
+    sink_info::{
+        FormatSinkOption, KafkaConfigValue, KafkaKeyFormat, KafkaPartition, KafkaTopic,
+        KafkaValueFormat, KafkaWriteInfo, OutputFileInfo, SinkInfo,
+    },
     source_info::{GlobScanInfo, InMemoryInfo, SourceInfo},
 };
 
@@ -120,6 +123,28 @@ impl IntoGlobPath for Vec<&str> {
         self.iter().map(|s| (*s).to_string()).collect()
     }
 }
+
+pub fn parse_kafka_value_format(format: &str) -> DaftResult<KafkaValueFormat> {
+    match format.to_ascii_lowercase().as_str() {
+        "raw" => Ok(KafkaValueFormat::Raw),
+        "utf8" => Ok(KafkaValueFormat::Utf8),
+        "json" => Ok(KafkaValueFormat::Json),
+        other => Err(DaftError::ValueError(format!(
+            "Unsupported Kafka value format: {other}. Expected one of: raw, utf8, json"
+        ))),
+    }
+}
+
+pub fn parse_kafka_key_format(format: &str) -> DaftResult<KafkaKeyFormat> {
+    match format.to_ascii_lowercase().as_str() {
+        "raw" => Ok(KafkaKeyFormat::Raw),
+        "utf8" => Ok(KafkaKeyFormat::Utf8),
+        other => Err(DaftError::ValueError(format!(
+            "Unsupported Kafka key format: {other}. Expected one of: raw, utf8"
+        ))),
+    }
+}
+
 impl LogicalPlanBuilder {
     /// Replace the LogicalPlanBuilder's plan with the provided plan
     pub fn with_new_plan<LP: Into<Arc<LogicalPlan>>>(&self, plan: LP) -> Self {
@@ -904,6 +929,79 @@ impl LogicalPlanBuilder {
             io_config,
             write_success_file,
         ));
+
+        let logical_plan: LogicalPlan =
+            ops::Sink::try_new(self.plan.clone(), sink_info.into())?.into();
+        Ok(self.with_new_plan(logical_plan))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn kafka_write(
+        &self,
+        bootstrap_servers: String,
+        topic: Option<String>,
+        topic_col: Option<ExprRef>,
+        value_col: ExprRef,
+        key_col: Option<ExprRef>,
+        headers_col: Option<ExprRef>,
+        partition: Option<i32>,
+        partition_col: Option<ExprRef>,
+        timestamp_ms_col: Option<ExprRef>,
+        value_format: String,
+        key_format: String,
+        kafka_client_config: BTreeMap<String, KafkaConfigValue>,
+        timeout_ms: u64,
+    ) -> DaftResult<Self> {
+        let value_format = parse_kafka_value_format(&value_format)?;
+        let key_format = parse_kafka_key_format(&key_format)?;
+
+        let expr_resolver = ExprResolver::default();
+        let resolve_expr = |expr: ExprRef| -> DaftResult<ExprRef> {
+            expr_resolver.resolve_single(expr, self.plan.clone())
+        };
+
+        let topic = match (topic, topic_col) {
+            (Some(topic), None) => KafkaTopic::Static(topic),
+            (None, Some(topic_col)) => KafkaTopic::Dynamic(resolve_expr(topic_col)?),
+            (Some(_), Some(_)) => {
+                return Err(DaftError::ValueError(
+                    "Must provide exactly one of topic or topic_col for Kafka write".to_string(),
+                ));
+            }
+            (None, None) => {
+                return Err(DaftError::ValueError(
+                    "Must provide exactly one of topic or topic_col for Kafka write".to_string(),
+                ));
+            }
+        };
+
+        let partition = match (partition, partition_col) {
+            (Some(partition), None) => Some(KafkaPartition::Static(partition)),
+            (None, Some(partition_col)) => {
+                Some(KafkaPartition::Dynamic(resolve_expr(partition_col)?))
+            }
+            (Some(_), Some(_)) => {
+                return Err(DaftError::ValueError(
+                    "Must provide at most one of partition or partition_col for Kafka write"
+                        .to_string(),
+                ));
+            }
+            (None, None) => None,
+        };
+
+        let sink_info = SinkInfo::KafkaInfo(KafkaWriteInfo {
+            bootstrap_servers,
+            topic,
+            value_col: resolve_expr(value_col)?,
+            key_col: key_col.map(&resolve_expr).transpose()?,
+            headers_col: headers_col.map(&resolve_expr).transpose()?,
+            partition,
+            timestamp_ms_col: timestamp_ms_col.map(&resolve_expr).transpose()?,
+            value_format,
+            key_format,
+            kafka_client_config,
+            timeout_ms,
+        });
 
         let logical_plan: LogicalPlan =
             ops::Sink::try_new(self.plan.clone(), sink_info.into())?.into();

--- a/src/daft-logical-plan/src/ops/sink.rs
+++ b/src/daft-logical-plan/src/ops/sink.rs
@@ -42,6 +42,14 @@ impl Sink {
                 }
                 fields
             }
+            SinkInfo::KafkaInfo(_) => vec![
+                Field::new("task_id", DataType::Int64),
+                Field::new("messages_attempted", DataType::Int64),
+                Field::new("messages_delivered", DataType::Int64),
+                Field::new("messages_failed", DataType::Int64),
+                Field::new("bytes_delivered", DataType::Int64),
+                Field::new("first_error", DataType::Utf8),
+            ],
             #[cfg(feature = "python")]
             SinkInfo::CatalogInfo(catalog_info) => {
                 match catalog_info.catalog {
@@ -95,6 +103,10 @@ impl Sink {
             SinkInfo::OutputFileInfo(output_file_info) => {
                 res.push(format!("Sink: {:?}", output_file_info.file_format));
                 res.extend(output_file_info.multiline_display());
+            }
+            SinkInfo::KafkaInfo(kafka_write_info) => {
+                res.push("Sink: Kafka".to_string());
+                res.extend(kafka_write_info.multiline_display());
             }
             #[cfg(feature = "python")]
             SinkInfo::CatalogInfo(catalog_info) => match &catalog_info.catalog {

--- a/src/daft-logical-plan/src/sink_info.rs
+++ b/src/daft-logical-plan/src/sink_info.rs
@@ -1,7 +1,8 @@
-use std::{hash::Hash, sync::Arc};
+use std::{collections::BTreeMap, fmt, hash::Hash, sync::Arc};
 
 use common_error::DaftResult;
 use common_file_formats::{FileFormat, WriteMode};
+use common_hashable_float_wrapper::FloatWrapper;
 use common_io_config::IOConfig;
 #[cfg(feature = "python")]
 use common_py_serde::{deserialize_py_object, serialize_py_object};
@@ -16,6 +17,7 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(debug_assertions, derive(Debug))]
 pub enum SinkInfo<E = ExprRef> {
     OutputFileInfo(OutputFileInfo<E>),
+    KafkaInfo(KafkaWriteInfo<E>),
     #[cfg(feature = "python")]
     CatalogInfo(CatalogInfo<E>),
     #[cfg(feature = "python")]
@@ -33,6 +35,61 @@ pub struct OutputFileInfo<E = ExprRef> {
     pub compression: Option<String>,
     pub io_config: Option<IOConfig>,
     pub write_success_file: bool,
+}
+
+#[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(debug_assertions, derive(Debug))]
+pub struct KafkaWriteInfo<E = ExprRef> {
+    pub bootstrap_servers: String,
+    pub topic: KafkaTopic<E>,
+    pub value_col: E,
+    pub key_col: Option<E>,
+    pub headers_col: Option<E>,
+    pub partition: Option<KafkaPartition<E>>,
+    pub timestamp_ms_col: Option<E>,
+    pub value_format: KafkaValueFormat,
+    pub key_format: KafkaKeyFormat,
+    pub kafka_client_config: BTreeMap<String, KafkaConfigValue>,
+    pub timeout_ms: u64,
+}
+
+#[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(debug_assertions, derive(Debug))]
+pub enum KafkaTopic<E = ExprRef> {
+    Static(String),
+    Dynamic(E),
+}
+
+#[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(debug_assertions, derive(Debug))]
+pub enum KafkaPartition<E = ExprRef> {
+    Static(i32),
+    Dynamic(E),
+}
+
+#[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(debug_assertions, derive(Debug))]
+pub enum KafkaValueFormat {
+    Raw,
+    Utf8,
+    Json,
+}
+
+#[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(debug_assertions, derive(Debug))]
+pub enum KafkaKeyFormat {
+    Raw,
+    Utf8,
+}
+
+#[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(debug_assertions, derive(Debug))]
+pub enum KafkaConfigValue {
+    String(String),
+    Int(i64),
+    Float(FloatWrapper<f64>),
+    Bool(bool),
+    Null,
 }
 
 #[cfg(feature = "python")]
@@ -229,12 +286,96 @@ where
     }
 }
 
+impl<E> KafkaWriteInfo<E>
+where
+    E: ToString,
+{
+    pub fn multiline_display(&self) -> Vec<String> {
+        let mut res = vec![
+            format!("Bootstrap servers = {}", self.bootstrap_servers),
+            format!("Topic = {}", self.topic),
+            format!("Value column = {}", self.value_col.to_string()),
+        ];
+        if let Some(key_col) = &self.key_col {
+            res.push(format!("Key column = {}", key_col.to_string()));
+        }
+        if let Some(headers_col) = &self.headers_col {
+            res.push(format!("Headers column = {}", headers_col.to_string()));
+        }
+        if let Some(partition) = &self.partition {
+            res.push(format!("Partition = {}", partition));
+        }
+        if let Some(timestamp_ms_col) = &self.timestamp_ms_col {
+            res.push(format!(
+                "Timestamp ms column = {}",
+                timestamp_ms_col.to_string()
+            ));
+        }
+        res.push(format!("Value format = {}", self.value_format));
+        res.push(format!("Key format = {}", self.key_format));
+        res.push(format!(
+            "Kafka client config entries = {}",
+            self.kafka_client_config.len()
+        ));
+        res.push(format!("Timeout ms = {}", self.timeout_ms));
+        res
+    }
+}
+
+impl<E> fmt::Display for KafkaTopic<E>
+where
+    E: ToString,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Static(topic) => write!(f, "Static({topic})"),
+            Self::Dynamic(expr) => write!(f, "Dynamic({})", expr.to_string()),
+        }
+    }
+}
+
+impl<E> fmt::Display for KafkaPartition<E>
+where
+    E: ToString,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Static(partition) => write!(f, "Static({partition})"),
+            Self::Dynamic(expr) => write!(f, "Dynamic({})", expr.to_string()),
+        }
+    }
+}
+
+impl fmt::Display for KafkaValueFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let format = match self {
+            Self::Raw => "raw",
+            Self::Utf8 => "utf8",
+            Self::Json => "json",
+        };
+        write!(f, "{format}")
+    }
+}
+
+impl fmt::Display for KafkaKeyFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let format = match self {
+            Self::Raw => "raw",
+            Self::Utf8 => "utf8",
+        };
+        write!(f, "{format}")
+    }
+}
+
 impl SinkInfo {
     pub fn bind(&self, schema: &Schema) -> DaftResult<SinkInfo<BoundExpr>> {
         match self {
             Self::OutputFileInfo(output_file_info) => Ok(SinkInfo::OutputFileInfo(
                 output_file_info.clone().bind(schema)?,
             )),
+            Self::KafkaInfo(kafka_write_info) => {
+                Ok(SinkInfo::KafkaInfo(kafka_write_info.clone().bind(schema)?))
+            }
             #[cfg(feature = "python")]
             Self::CatalogInfo(catalog_info) => {
                 Ok(SinkInfo::CatalogInfo(catalog_info.clone().bind(schema)?))
@@ -261,6 +402,54 @@ impl OutputFileInfo {
             compression: self.compression,
             io_config: self.io_config,
             write_success_file: self.write_success_file,
+        })
+    }
+}
+
+impl KafkaWriteInfo {
+    pub fn bind(self, schema: &Schema) -> DaftResult<KafkaWriteInfo<BoundExpr>> {
+        Ok(KafkaWriteInfo {
+            bootstrap_servers: self.bootstrap_servers,
+            topic: self.topic.bind(schema)?,
+            value_col: BoundExpr::try_new(self.value_col, schema)?,
+            key_col: self
+                .key_col
+                .map(|expr| BoundExpr::try_new(expr, schema))
+                .transpose()?,
+            headers_col: self
+                .headers_col
+                .map(|expr| BoundExpr::try_new(expr, schema))
+                .transpose()?,
+            partition: self
+                .partition
+                .map(|partition| partition.bind(schema))
+                .transpose()?,
+            timestamp_ms_col: self
+                .timestamp_ms_col
+                .map(|expr| BoundExpr::try_new(expr, schema))
+                .transpose()?,
+            value_format: self.value_format,
+            key_format: self.key_format,
+            kafka_client_config: self.kafka_client_config,
+            timeout_ms: self.timeout_ms,
+        })
+    }
+}
+
+impl KafkaTopic {
+    fn bind(self, schema: &Schema) -> DaftResult<KafkaTopic<BoundExpr>> {
+        Ok(match self {
+            Self::Static(topic) => KafkaTopic::Static(topic),
+            Self::Dynamic(expr) => KafkaTopic::Dynamic(BoundExpr::try_new(expr, schema)?),
+        })
+    }
+}
+
+impl KafkaPartition {
+    fn bind(self, schema: &Schema) -> DaftResult<KafkaPartition<BoundExpr>> {
+        Ok(match self {
+            Self::Static(partition) => KafkaPartition::Static(partition),
+            Self::Dynamic(expr) => KafkaPartition::Dynamic(BoundExpr::try_new(expr, schema)?),
         })
     }
 }

--- a/src/daft-writers/Cargo.toml
+++ b/src/daft-writers/Cargo.toml
@@ -10,6 +10,7 @@ chrono-tz = {workspace = true}
 common-daft-config = {path = "../common/daft-config", default-features = false}
 common-error = {path = "../common/error", default-features = false}
 common-file-formats = {path = "../common/file-formats", default-features = false}
+common-hashable-float-wrapper = {path = "../common/hashable-float-wrapper", default-features = false}
 common-runtime = {path = "../common/runtime", default-features = false}
 daft-core = {path = "../daft-core", default-features = false}
 daft-dsl = {path = "../daft-dsl", default-features = false}
@@ -17,17 +18,20 @@ daft-io = {path = "../daft-io", default-features = false}
 daft-logical-plan = {path = "../daft-logical-plan", default-features = false}
 daft-micropartition = {path = "../daft-micropartition", default-features = false}
 daft-recordbatch = {path = "../daft-recordbatch", default-features = false}
+futures = {workspace = true}
 hashbrown = {workspace = true}
 parking_lot = {workspace = true}
 parquet = {workspace = true}
 pyo3 = {workspace = true, optional = true}
+rdkafka = {workspace = true, optional = true}
 tokio = {workspace = true}
 url = {workspace = true}
 urlencoding = "2.1.3"
 uuid = {workspace = true, features = ["v4"]}
 
 [features]
-python = ["dep:pyo3", "common-file-formats/python", "common-error/python", "daft-dsl/python", "daft-io/python", "daft-logical-plan/python", "daft-micropartition/python"]
+kafka = ["dep:rdkafka"]
+python = ["dep:pyo3", "common-file-formats/python", "common-error/python", "daft-dsl/python", "daft-io/python", "daft-logical-plan/python", "daft-micropartition/python", "kafka"]
 
 [dev-dependencies]
 arrow-array = {workspace = true}

--- a/src/daft-writers/Cargo.toml
+++ b/src/daft-writers/Cargo.toml
@@ -10,7 +10,6 @@ chrono-tz = {workspace = true}
 common-daft-config = {path = "../common/daft-config", default-features = false}
 common-error = {path = "../common/error", default-features = false}
 common-file-formats = {path = "../common/file-formats", default-features = false}
-common-hashable-float-wrapper = {path = "../common/hashable-float-wrapper", default-features = false}
 common-runtime = {path = "../common/runtime", default-features = false}
 daft-core = {path = "../daft-core", default-features = false}
 daft-dsl = {path = "../daft-dsl", default-features = false}
@@ -18,7 +17,6 @@ daft-io = {path = "../daft-io", default-features = false}
 daft-logical-plan = {path = "../daft-logical-plan", default-features = false}
 daft-micropartition = {path = "../daft-micropartition", default-features = false}
 daft-recordbatch = {path = "../daft-recordbatch", default-features = false}
-futures = {workspace = true}
 hashbrown = {workspace = true}
 parking_lot = {workspace = true}
 parquet = {workspace = true}
@@ -31,11 +29,12 @@ uuid = {workspace = true, features = ["v4"]}
 
 [features]
 kafka = ["dep:rdkafka"]
-python = ["dep:pyo3", "common-file-formats/python", "common-error/python", "daft-dsl/python", "daft-io/python", "daft-logical-plan/python", "daft-micropartition/python", "kafka"]
+python = ["dep:pyo3", "common-file-formats/python", "common-error/python", "daft-dsl/python", "daft-io/python", "daft-logical-plan/python", "daft-micropartition/python"]
 
 [dev-dependencies]
 arrow-array = {workspace = true}
 bytes = {workspace = true}
+common-hashable-float-wrapper = {path = "../common/hashable-float-wrapper", default-features = false}
 
 [lints]
 workspace = true

--- a/src/daft-writers/src/kafka/accounting.rs
+++ b/src/daft-writers/src/kafka/accounting.rs
@@ -39,6 +39,9 @@ impl KafkaWriteAccounting {
         }
     }
 
+    // TODO: Wire this into the native Kafka write result contract once that
+    // path consumes the logical accounting schema outside tests.
+    #[allow(dead_code)]
     pub fn schema() -> Arc<Schema> {
         Arc::new(Schema::new(vec![
             Field::new("task_id", DataType::Int64),

--- a/src/daft-writers/src/kafka/accounting.rs
+++ b/src/daft-writers/src/kafka/accounting.rs
@@ -68,6 +68,16 @@ mod tests {
 
     use super::*;
 
+    fn assert_i64_column(batch: &RecordBatch, index: usize, name: &str, value: i64) {
+        let column = &batch.columns()[index];
+        assert_eq!(column.name(), name);
+        assert_eq!(column.data_type(), &DataType::Int64);
+        assert_eq!(
+            column.as_materialized_series().i64().unwrap().get(0),
+            Some(value)
+        );
+    }
+
     #[test]
     fn counts_deliveries_and_failures_and_preserves_first_error() {
         let mut accounting = KafkaWriteAccounting::new(7);
@@ -117,6 +127,11 @@ mod tests {
             batch.schema.as_ref(),
             KafkaWriteAccounting::schema().as_ref()
         );
+        assert_i64_column(&batch, 0, "task_id", 9);
+        assert_i64_column(&batch, 1, "messages_attempted", 0);
+        assert_i64_column(&batch, 2, "messages_delivered", 0);
+        assert_i64_column(&batch, 3, "messages_failed", 0);
+        assert_i64_column(&batch, 4, "bytes_delivered", 0);
         let first_error = &batch.columns()[5];
         assert_eq!(first_error.name(), "first_error");
         assert_eq!(first_error.data_type(), &DataType::Utf8);
@@ -126,10 +141,18 @@ mod tests {
     #[test]
     fn builds_summary_record_batch_with_error_value() {
         let mut accounting = KafkaWriteAccounting::new(10);
+        accounting.record_attempt();
+        accounting.record_attempt();
+        accounting.record_delivery(128);
         accounting.record_failure("failed");
         let batch = accounting.to_record_batch().unwrap();
 
         assert_eq!(batch.len(), 1);
+        assert_i64_column(&batch, 0, "task_id", 10);
+        assert_i64_column(&batch, 1, "messages_attempted", 2);
+        assert_i64_column(&batch, 2, "messages_delivered", 1);
+        assert_i64_column(&batch, 3, "messages_failed", 1);
+        assert_i64_column(&batch, 4, "bytes_delivered", 128);
         assert_eq!(batch.columns()[5].str_value(0).unwrap(), "failed");
     }
 }

--- a/src/daft-writers/src/kafka/accounting.rs
+++ b/src/daft-writers/src/kafka/accounting.rs
@@ -1,0 +1,135 @@
+use std::sync::Arc;
+
+use common_error::DaftResult;
+use daft_core::prelude::{DataType, Field, Int64Array, IntoSeries, Schema, Utf8Array};
+use daft_recordbatch::RecordBatch;
+
+#[derive(Debug, Default, Clone)]
+pub struct KafkaWriteAccounting {
+    pub task_id: i64,
+    pub messages_attempted: i64,
+    pub messages_delivered: i64,
+    pub messages_failed: i64,
+    pub bytes_delivered: i64,
+    pub first_error: Option<String>,
+}
+
+impl KafkaWriteAccounting {
+    pub fn new(task_id: i64) -> Self {
+        Self {
+            task_id,
+            ..Default::default()
+        }
+    }
+
+    pub fn record_attempt(&mut self) {
+        self.messages_attempted = self.messages_attempted.saturating_add(1);
+    }
+
+    pub fn record_delivery(&mut self, bytes: usize) {
+        self.messages_delivered = self.messages_delivered.saturating_add(1);
+        let bytes = i64::try_from(bytes).unwrap_or(i64::MAX);
+        self.bytes_delivered = self.bytes_delivered.saturating_add(bytes);
+    }
+
+    pub fn record_failure(&mut self, err: impl Into<String>) {
+        self.messages_failed = self.messages_failed.saturating_add(1);
+        if self.first_error.is_none() {
+            self.first_error = Some(err.into());
+        }
+    }
+
+    pub fn schema() -> Arc<Schema> {
+        Arc::new(Schema::new(vec![
+            Field::new("task_id", DataType::Int64),
+            Field::new("messages_attempted", DataType::Int64),
+            Field::new("messages_delivered", DataType::Int64),
+            Field::new("messages_failed", DataType::Int64),
+            Field::new("bytes_delivered", DataType::Int64),
+            Field::new("first_error", DataType::Utf8),
+        ]))
+    }
+
+    pub fn to_record_batch(&self) -> DaftResult<RecordBatch> {
+        RecordBatch::from_nonempty_columns(vec![
+            Int64Array::from_vec("task_id", vec![self.task_id]).into_series(),
+            Int64Array::from_vec("messages_attempted", vec![self.messages_attempted]).into_series(),
+            Int64Array::from_vec("messages_delivered", vec![self.messages_delivered]).into_series(),
+            Int64Array::from_vec("messages_failed", vec![self.messages_failed]).into_series(),
+            Int64Array::from_vec("bytes_delivered", vec![self.bytes_delivered]).into_series(),
+            Utf8Array::from_iter("first_error", [self.first_error.as_deref()]).into_series(),
+        ])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use daft_core::prelude::DataType;
+
+    use super::*;
+
+    #[test]
+    fn counts_deliveries_and_failures_and_preserves_first_error() {
+        let mut accounting = KafkaWriteAccounting::new(7);
+
+        accounting.record_attempt();
+        accounting.record_attempt();
+        accounting.record_delivery(12);
+        accounting.record_failure("first");
+        accounting.record_failure("second");
+
+        assert_eq!(accounting.task_id, 7);
+        assert_eq!(accounting.messages_attempted, 2);
+        assert_eq!(accounting.messages_delivered, 1);
+        assert_eq!(accounting.messages_failed, 2);
+        assert_eq!(accounting.bytes_delivered, 12);
+        assert_eq!(accounting.first_error.as_deref(), Some("first"));
+    }
+
+    #[test]
+    fn saturates_accounting_counters() {
+        let mut accounting = KafkaWriteAccounting {
+            messages_attempted: i64::MAX,
+            messages_delivered: i64::MAX,
+            messages_failed: i64::MAX,
+            bytes_delivered: i64::MAX - 1,
+            ..KafkaWriteAccounting::new(11)
+        };
+
+        accounting.record_attempt();
+        accounting.record_delivery(usize::MAX);
+        accounting.record_failure("overflow");
+
+        assert_eq!(accounting.messages_attempted, i64::MAX);
+        assert_eq!(accounting.messages_delivered, i64::MAX);
+        assert_eq!(accounting.messages_failed, i64::MAX);
+        assert_eq!(accounting.bytes_delivered, i64::MAX);
+        assert_eq!(accounting.first_error.as_deref(), Some("overflow"));
+    }
+
+    #[test]
+    fn builds_summary_record_batch_with_expected_schema_and_null_error() {
+        let accounting = KafkaWriteAccounting::new(9);
+        let batch = accounting.to_record_batch().unwrap();
+
+        assert_eq!(batch.len(), 1);
+        assert_eq!(
+            batch.schema.as_ref(),
+            KafkaWriteAccounting::schema().as_ref()
+        );
+        let first_error = &batch.columns()[5];
+        assert_eq!(first_error.name(), "first_error");
+        assert_eq!(first_error.data_type(), &DataType::Utf8);
+        assert!(!first_error.is_valid(0));
+    }
+
+    #[test]
+    fn builds_summary_record_batch_with_error_value() {
+        let mut accounting = KafkaWriteAccounting::new(10);
+        accounting.record_failure("failed");
+        let batch = accounting.to_record_batch().unwrap();
+
+        assert_eq!(batch.len(), 1);
+        assert_eq!(batch.columns()[5].str_value(0).unwrap(), "failed");
+    }
+}

--- a/src/daft-writers/src/kafka/config.rs
+++ b/src/daft-writers/src/kafka/config.rs
@@ -4,6 +4,8 @@ use common_error::{DaftError, DaftResult};
 use daft_logical_plan::sink_info::KafkaConfigValue;
 
 const DEFAULT_CLIENT_ID: &str = "daft-write-kafka";
+const DELIVERY_TIMEOUT_MS: &str = "delivery.timeout.ms";
+const MESSAGE_TIMEOUT_MS: &str = "message.timeout.ms";
 // TODO: Use this in user-facing Kafka diagnostics when config logging lands.
 #[allow(dead_code)]
 const REDACTED: &str = "<redacted>";
@@ -56,11 +58,15 @@ pub fn redact_config_value(key: &str, value: &str) -> String {
 pub fn build_client_config(
     bootstrap_servers: &str,
     kafka_client_config: &BTreeMap<String, KafkaConfigValue>,
+    timeout_ms: u64,
 ) -> DaftResult<rdkafka::ClientConfig> {
     let mut client_config = rdkafka::ClientConfig::new();
     client_config
         .set("bootstrap.servers", bootstrap_servers)
         .set("client.id", DEFAULT_CLIENT_ID);
+    if !has_user_delivery_timeout(kafka_client_config) {
+        client_config.set(DELIVERY_TIMEOUT_MS, timeout_ms.to_string());
+    }
 
     for (key, value) in kafka_client_config {
         validate_config_key(key)?;
@@ -69,6 +75,14 @@ pub fn build_client_config(
     }
 
     Ok(client_config)
+}
+
+#[cfg(feature = "kafka")]
+fn has_user_delivery_timeout(kafka_client_config: &BTreeMap<String, KafkaConfigValue>) -> bool {
+    kafka_client_config.keys().any(|key| {
+        let key = key.to_ascii_lowercase();
+        key == DELIVERY_TIMEOUT_MS || key == MESSAGE_TIMEOUT_MS
+    })
 }
 
 #[cfg(test)]
@@ -156,7 +170,8 @@ mod tests {
     #[cfg(feature = "kafka")]
     #[test]
     fn builds_client_config_with_managed_bootstrap_and_default_client_id() {
-        let client_config = build_client_config("localhost:9092", &BTreeMap::new()).unwrap();
+        let client_config =
+            build_client_config("localhost:9092", &BTreeMap::new(), 10_000).unwrap();
 
         assert_eq!(
             client_config.get("bootstrap.servers"),
@@ -178,9 +193,47 @@ mod tests {
             KafkaConfigValue::String("all".to_string()),
         );
 
-        let client_config = build_client_config("localhost:9092", &user_config).unwrap();
+        let client_config = build_client_config("localhost:9092", &user_config, 10_000).unwrap();
 
         assert_eq!(client_config.get("client.id"), Some("custom-client"));
         assert_eq!(client_config.get("acks"), Some("all"));
+    }
+
+    #[cfg(feature = "kafka")]
+    #[test]
+    fn build_client_config_sets_default_delivery_timeout_from_write_timeout() {
+        let client_config =
+            build_client_config("localhost:9092", &BTreeMap::new(), 12_345).unwrap();
+
+        assert_eq!(client_config.get("delivery.timeout.ms"), Some("12345"));
+    }
+
+    #[cfg(feature = "kafka")]
+    #[test]
+    fn build_client_config_preserves_delivery_timeout_override() {
+        let mut user_config = BTreeMap::new();
+        user_config.insert(
+            "delivery.timeout.ms".to_string(),
+            KafkaConfigValue::Int(60_000),
+        );
+
+        let client_config = build_client_config("localhost:9092", &user_config, 12_345).unwrap();
+
+        assert_eq!(client_config.get("delivery.timeout.ms"), Some("60000"));
+    }
+
+    #[cfg(feature = "kafka")]
+    #[test]
+    fn build_client_config_preserves_legacy_message_timeout_override() {
+        let mut user_config = BTreeMap::new();
+        user_config.insert(
+            "Message.Timeout.Ms".to_string(),
+            KafkaConfigValue::Int(60_000),
+        );
+
+        let client_config = build_client_config("localhost:9092", &user_config, 12_345).unwrap();
+
+        assert_eq!(client_config.get("Message.Timeout.Ms"), Some("60000"));
+        assert_eq!(client_config.get("delivery.timeout.ms"), None);
     }
 }

--- a/src/daft-writers/src/kafka/config.rs
+++ b/src/daft-writers/src/kafka/config.rs
@@ -12,6 +12,8 @@ pub fn config_value_to_string(value: &KafkaConfigValue) -> String {
         KafkaConfigValue::Int(value) => value.to_string(),
         KafkaConfigValue::Float(value) => value.0.to_string(),
         KafkaConfigValue::Bool(value) => value.to_string(),
+        // librdkafka represents configuration values as strings; Daft nulls intentionally
+        // map to an empty value so users can pass through configs that use empty strings.
         KafkaConfigValue::Null => String::new(),
     }
 }
@@ -32,8 +34,11 @@ pub fn validate_config_key(key: &str) -> DaftResult<()> {
 
 pub fn redact_config_value(key: &str, value: &str) -> String {
     let key = key.to_ascii_lowercase();
-    if key.contains("password")
+    if key == "sasl.jaas.config"
+        || key == "basic.auth.user.info"
         || key == "sasl.oauthbearer.config"
+        || key.contains("password")
+        || key.contains("credential")
         || key.contains("secret")
         || key.contains("token")
     {
@@ -100,9 +105,17 @@ mod tests {
 
         let managed = validate_config_key("bootstrap.servers").unwrap_err();
         assert!(managed.to_string().contains("bootstrap.servers"));
+        let managed_mixed_case = validate_config_key("BOOTSTRAP.SERVERS").unwrap_err();
+        assert!(managed_mixed_case.to_string().contains("bootstrap.servers"));
 
         let unsupported = validate_config_key("transactional.id").unwrap_err();
         assert!(unsupported.to_string().contains("transactional.id"));
+        let unsupported_mixed_case = validate_config_key("Transactional.ID").unwrap_err();
+        assert!(
+            unsupported_mixed_case
+                .to_string()
+                .contains("transactional.id")
+        );
     }
 
     #[test]
@@ -115,8 +128,24 @@ mod tests {
             redact_config_value("sasl.oauthbearer.config", "token=abc"),
             "<redacted>"
         );
+        assert_eq!(
+            redact_config_value("SASL.JAAS.CONFIG", "username=alice password=abc"),
+            "<redacted>"
+        );
+        assert_eq!(
+            redact_config_value("Basic.Auth.User.Info", "alice:abc"),
+            "<redacted>"
+        );
+        assert_eq!(
+            redact_config_value("Sasl.OAuthBearer.Config", "token=abc"),
+            "<redacted>"
+        );
         assert_eq!(redact_config_value("api.token", "abc"), "<redacted>");
         assert_eq!(redact_config_value("client.secret", "abc"), "<redacted>");
+        assert_eq!(
+            redact_config_value("schema.registry.credential.source", "user-info"),
+            "<redacted>"
+        );
         assert_eq!(redact_config_value("acks", "all"), "all");
     }
 

--- a/src/daft-writers/src/kafka/config.rs
+++ b/src/daft-writers/src/kafka/config.rs
@@ -4,6 +4,8 @@ use common_error::{DaftError, DaftResult};
 use daft_logical_plan::sink_info::KafkaConfigValue;
 
 const DEFAULT_CLIENT_ID: &str = "daft-write-kafka";
+// TODO: Use this in user-facing Kafka diagnostics when config logging lands.
+#[allow(dead_code)]
 const REDACTED: &str = "<redacted>";
 
 pub fn config_value_to_string(value: &KafkaConfigValue) -> String {
@@ -32,6 +34,8 @@ pub fn validate_config_key(key: &str) -> DaftResult<()> {
     }
 }
 
+// TODO: Use this in user-facing Kafka diagnostics when config logging lands.
+#[allow(dead_code)]
 pub fn redact_config_value(key: &str, value: &str) -> String {
     let key = key.to_ascii_lowercase();
     if key == "sasl.jaas.config"

--- a/src/daft-writers/src/kafka/config.rs
+++ b/src/daft-writers/src/kafka/config.rs
@@ -1,0 +1,153 @@
+use std::collections::BTreeMap;
+
+use common_error::{DaftError, DaftResult};
+use daft_logical_plan::sink_info::KafkaConfigValue;
+
+const DEFAULT_CLIENT_ID: &str = "daft-write-kafka";
+const REDACTED: &str = "<redacted>";
+
+pub fn config_value_to_string(value: &KafkaConfigValue) -> String {
+    match value {
+        KafkaConfigValue::String(value) => value.clone(),
+        KafkaConfigValue::Int(value) => value.to_string(),
+        KafkaConfigValue::Float(value) => value.0.to_string(),
+        KafkaConfigValue::Bool(value) => value.to_string(),
+        KafkaConfigValue::Null => String::new(),
+    }
+}
+
+pub fn validate_config_key(key: &str) -> DaftResult<()> {
+    match key.to_ascii_lowercase().as_str() {
+        "bootstrap.servers" => Err(DaftError::ValueError(
+            "[write_kafka] kafka_client_config must not override managed key: \
+             \"bootstrap.servers\""
+                .to_string(),
+        )),
+        "transactional.id" => Err(DaftError::not_implemented(
+            "[write_kafka] transactional.id is not supported yet",
+        )),
+        _ => Ok(()),
+    }
+}
+
+pub fn redact_config_value(key: &str, value: &str) -> String {
+    let key = key.to_ascii_lowercase();
+    if key.contains("password")
+        || key == "sasl.oauthbearer.config"
+        || key.contains("secret")
+        || key.contains("token")
+    {
+        REDACTED.to_string()
+    } else {
+        value.to_string()
+    }
+}
+
+#[cfg(feature = "kafka")]
+pub fn build_client_config(
+    bootstrap_servers: &str,
+    kafka_client_config: &BTreeMap<String, KafkaConfigValue>,
+) -> DaftResult<rdkafka::ClientConfig> {
+    let mut client_config = rdkafka::ClientConfig::new();
+    client_config
+        .set("bootstrap.servers", bootstrap_servers)
+        .set("client.id", DEFAULT_CLIENT_ID);
+
+    for (key, value) in kafka_client_config {
+        validate_config_key(key)?;
+        let value = config_value_to_string(value);
+        client_config.set(key, value);
+    }
+
+    Ok(client_config)
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(feature = "kafka")]
+    use std::collections::BTreeMap;
+
+    use common_hashable_float_wrapper::FloatWrapper;
+
+    use super::*;
+
+    #[test]
+    fn converts_scalar_config_values_to_strings() {
+        assert_eq!(
+            config_value_to_string(&KafkaConfigValue::String("all".to_string())),
+            "all"
+        );
+        assert_eq!(config_value_to_string(&KafkaConfigValue::Int(42)), "42");
+        assert_eq!(
+            config_value_to_string(&KafkaConfigValue::Float(FloatWrapper(1.25))),
+            "1.25"
+        );
+        assert_eq!(
+            config_value_to_string(&KafkaConfigValue::Bool(true)),
+            "true"
+        );
+        assert_eq!(
+            config_value_to_string(&KafkaConfigValue::Bool(false)),
+            "false"
+        );
+        assert_eq!(config_value_to_string(&KafkaConfigValue::Null), "");
+    }
+
+    #[test]
+    fn validates_managed_and_unsupported_config_keys() {
+        assert!(validate_config_key("acks").is_ok());
+        assert!(validate_config_key("client.id").is_ok());
+
+        let managed = validate_config_key("bootstrap.servers").unwrap_err();
+        assert!(managed.to_string().contains("bootstrap.servers"));
+
+        let unsupported = validate_config_key("transactional.id").unwrap_err();
+        assert!(unsupported.to_string().contains("transactional.id"));
+    }
+
+    #[test]
+    fn redacts_sensitive_config_values() {
+        assert_eq!(
+            redact_config_value("sasl.password", "super-secret"),
+            "<redacted>"
+        );
+        assert_eq!(
+            redact_config_value("sasl.oauthbearer.config", "token=abc"),
+            "<redacted>"
+        );
+        assert_eq!(redact_config_value("api.token", "abc"), "<redacted>");
+        assert_eq!(redact_config_value("client.secret", "abc"), "<redacted>");
+        assert_eq!(redact_config_value("acks", "all"), "all");
+    }
+
+    #[cfg(feature = "kafka")]
+    #[test]
+    fn builds_client_config_with_managed_bootstrap_and_default_client_id() {
+        let client_config = build_client_config("localhost:9092", &BTreeMap::new()).unwrap();
+
+        assert_eq!(
+            client_config.get("bootstrap.servers"),
+            Some("localhost:9092")
+        );
+        assert_eq!(client_config.get("client.id"), Some(DEFAULT_CLIENT_ID));
+    }
+
+    #[cfg(feature = "kafka")]
+    #[test]
+    fn build_client_config_allows_client_id_override() {
+        let mut user_config = BTreeMap::new();
+        user_config.insert(
+            "client.id".to_string(),
+            KafkaConfigValue::String("custom-client".to_string()),
+        );
+        user_config.insert(
+            "acks".to_string(),
+            KafkaConfigValue::String("all".to_string()),
+        );
+
+        let client_config = build_client_config("localhost:9092", &user_config).unwrap();
+
+        assert_eq!(client_config.get("client.id"), Some("custom-client"));
+        assert_eq!(client_config.get("acks"), Some("all"));
+    }
+}

--- a/src/daft-writers/src/kafka/headers.rs
+++ b/src/daft-writers/src/kafka/headers.rs
@@ -2,6 +2,8 @@ use common_error::{DaftError, DaftResult};
 
 use super::producer::KafkaHeader;
 
+// TODO(native-kafka-write): remove once Task 8/9 validates headers from writer integration.
+#[allow(dead_code)]
 pub(crate) fn validate_header_key(key: &str) -> DaftResult<()> {
     if key.is_empty() {
         return Err(DaftError::ValueError(
@@ -12,6 +14,8 @@ pub(crate) fn validate_header_key(key: &str) -> DaftResult<()> {
     Ok(())
 }
 
+// TODO(native-kafka-write): remove once Task 8/9 builds headers from writer integration.
+#[allow(dead_code)]
 pub(crate) fn make_header(key: &str, value: Option<&[u8]>) -> DaftResult<KafkaHeader> {
     validate_header_key(key)?;
 

--- a/src/daft-writers/src/kafka/headers.rs
+++ b/src/daft-writers/src/kafka/headers.rs
@@ -40,8 +40,16 @@ pub(crate) fn headers_for_row(headers: &Series, row_idx: usize) -> DaftResult<Ve
             "[write_kafka] kafka headers must contain struct entries: {err}"
         ))
     })?;
-    let keys = entries.get("key")?;
-    let values = entries.get("value")?;
+    let keys = entries.get("key").map_err(|err| {
+        DaftError::ValueError(format!(
+            "[write_kafka] kafka headers must contain a key field: {err}"
+        ))
+    })?;
+    let values = entries.get("value").map_err(|err| {
+        DaftError::ValueError(format!(
+            "[write_kafka] kafka headers must contain a value field: {err}"
+        ))
+    })?;
     let keys = keys.utf8().map_err(|err| {
         DaftError::ValueError(format!(
             "[write_kafka] kafka header key must be Utf8: {err}"
@@ -76,7 +84,9 @@ pub(crate) fn headers_for_row(headers: &Series, row_idx: usize) -> DaftResult<Ve
 mod tests {
     use std::sync::Arc;
 
-    use arrow_array::builder::{BinaryBuilder, LargeListBuilder, StringBuilder, StructBuilder};
+    use arrow_array::builder::{
+        BinaryBuilder, LargeListBuilder, NullBuilder, StringBuilder, StructBuilder,
+    };
     use arrow_schema::{DataType as ArrowDataType, Field as ArrowField, Fields};
     use daft_core::prelude::Field;
 
@@ -152,6 +162,150 @@ mod tests {
         );
         assert!(null_row.is_empty());
         assert_eq!(third_row, vec![make_header("nullable", None).unwrap()]);
+    }
+
+    #[test]
+    fn parses_utf8_header_value_column() {
+        let mut builder = LargeListBuilder::new(StructBuilder::from_fields(
+            Fields::from(vec![
+                ArrowField::new("key", ArrowDataType::Utf8, true),
+                ArrowField::new("value", ArrowDataType::Utf8, true),
+            ]),
+            1,
+        ));
+        {
+            let values = builder.values();
+            values
+                .field_builder::<StringBuilder>(0)
+                .unwrap()
+                .append_value("text");
+            values
+                .field_builder::<StringBuilder>(1)
+                .unwrap()
+                .append_value("hello");
+            values.append(true);
+        }
+        builder.append(true);
+        let headers = Series::from_arrow(
+            Arc::new(Field::new(
+                "headers",
+                DataType::List(Box::new(DataType::Struct(vec![
+                    Field::new("key", DataType::Utf8),
+                    Field::new("value", DataType::Utf8),
+                ]))),
+            )),
+            Arc::new(builder.finish()),
+        )
+        .unwrap();
+
+        let parsed = headers_for_row(&headers, 0).unwrap();
+
+        assert_eq!(parsed, vec![make_header("text", Some(b"hello")).unwrap()]);
+    }
+
+    #[test]
+    fn parses_null_header_value_column() {
+        let mut builder = LargeListBuilder::new(StructBuilder::from_fields(
+            Fields::from(vec![
+                ArrowField::new("key", ArrowDataType::Utf8, true),
+                ArrowField::new("value", ArrowDataType::Null, true),
+            ]),
+            1,
+        ));
+        {
+            let values = builder.values();
+            values
+                .field_builder::<StringBuilder>(0)
+                .unwrap()
+                .append_value("nullish");
+            values
+                .field_builder::<NullBuilder>(1)
+                .unwrap()
+                .append_null();
+            values.append(true);
+        }
+        builder.append(true);
+        let headers = Series::from_arrow(
+            Arc::new(Field::new(
+                "headers",
+                DataType::List(Box::new(DataType::Struct(vec![
+                    Field::new("key", DataType::Utf8),
+                    Field::new("value", DataType::Null),
+                ]))),
+            )),
+            Arc::new(builder.finish()),
+        )
+        .unwrap();
+
+        let parsed = headers_for_row(&headers, 0).unwrap();
+
+        assert_eq!(parsed, vec![make_header("nullish", None).unwrap()]);
+    }
+
+    #[test]
+    fn rejects_header_struct_missing_key_field() {
+        let mut builder = LargeListBuilder::new(StructBuilder::from_fields(
+            Fields::from(vec![ArrowField::new("value", ArrowDataType::Binary, true)]),
+            1,
+        ));
+        {
+            let values = builder.values();
+            values
+                .field_builder::<BinaryBuilder>(0)
+                .unwrap()
+                .append_value(b"value");
+            values.append(true);
+        }
+        builder.append(true);
+        let headers = Series::from_arrow(
+            Arc::new(Field::new(
+                "headers",
+                DataType::List(Box::new(DataType::Struct(vec![Field::new(
+                    "value",
+                    DataType::Binary,
+                )]))),
+            )),
+            Arc::new(builder.finish()),
+        )
+        .unwrap();
+
+        let err = headers_for_row(&headers, 0).unwrap_err();
+
+        assert!(err.to_string().contains("[write_kafka]"));
+        assert!(err.to_string().contains("key field"));
+    }
+
+    #[test]
+    fn rejects_header_struct_missing_value_field() {
+        let mut builder = LargeListBuilder::new(StructBuilder::from_fields(
+            Fields::from(vec![ArrowField::new("key", ArrowDataType::Utf8, true)]),
+            1,
+        ));
+        {
+            let values = builder.values();
+            values
+                .field_builder::<StringBuilder>(0)
+                .unwrap()
+                .append_value("key");
+            values.append(true);
+        }
+        builder.append(true);
+        let headers = Series::from_arrow(
+            Arc::new(Field::new(
+                "headers",
+                DataType::List(Box::new(DataType::Struct(vec![Field::new(
+                    "key",
+                    DataType::Utf8,
+                )]))),
+            )),
+            Arc::new(builder.finish()),
+        )
+        .unwrap();
+
+        let err = headers_for_row(&headers, 0).unwrap_err();
+
+        assert!(err.to_string().contains("[write_kafka]"));
+        assert!(err.to_string().contains("value field"));
     }
 
     #[test]

--- a/src/daft-writers/src/kafka/headers.rs
+++ b/src/daft-writers/src/kafka/headers.rs
@@ -94,7 +94,7 @@ mod tests {
 
     #[test]
     fn preserves_duplicate_keys_and_order() {
-        let headers = vec![
+        let headers = [
             make_header("same", Some(b"first")).unwrap(),
             make_header("other", Some(b"middle")).unwrap(),
             make_header("same", Some(b"second")).unwrap(),

--- a/src/daft-writers/src/kafka/headers.rs
+++ b/src/daft-writers/src/kafka/headers.rs
@@ -1,9 +1,8 @@
 use common_error::{DaftError, DaftResult};
+use daft_core::prelude::{DataType, Series};
 
 use super::producer::KafkaHeader;
 
-// TODO(native-kafka-write): remove once Task 9 validates headers from writer projection.
-#[allow(dead_code)]
 pub(crate) fn validate_header_key(key: &str) -> DaftResult<()> {
     if key.is_empty() {
         return Err(DaftError::ValueError(
@@ -14,8 +13,6 @@ pub(crate) fn validate_header_key(key: &str) -> DaftResult<()> {
     Ok(())
 }
 
-// TODO(native-kafka-write): remove once Task 9 builds headers from writer projection.
-#[allow(dead_code)]
 pub(crate) fn make_header(key: &str, value: Option<&[u8]>) -> DaftResult<KafkaHeader> {
     validate_header_key(key)?;
 
@@ -25,8 +22,64 @@ pub(crate) fn make_header(key: &str, value: Option<&[u8]>) -> DaftResult<KafkaHe
     })
 }
 
+pub(crate) fn headers_for_row(headers: &Series, row_idx: usize) -> DaftResult<Vec<KafkaHeader>> {
+    let Some(entries) = headers
+        .list()
+        .map_err(|err| {
+            DaftError::ValueError(format!(
+                "[write_kafka] kafka headers must be List(Struct([key, value])): {err}"
+            ))
+        })?
+        .get(row_idx)
+    else {
+        return Ok(vec![]);
+    };
+
+    let entries = entries.struct_().map_err(|err| {
+        DaftError::ValueError(format!(
+            "[write_kafka] kafka headers must contain struct entries: {err}"
+        ))
+    })?;
+    let keys = entries.get("key")?;
+    let values = entries.get("value")?;
+    let keys = keys.utf8().map_err(|err| {
+        DaftError::ValueError(format!(
+            "[write_kafka] kafka header key must be Utf8: {err}"
+        ))
+    })?;
+
+    let mut parsed = Vec::with_capacity(keys.len());
+    for header_idx in 0..keys.len() {
+        let key = keys.get(header_idx).ok_or_else(|| {
+            DaftError::ValueError("[write_kafka] kafka header key must not be null".to_string())
+        })?;
+        let value = match values.data_type() {
+            DataType::Binary => values.binary()?.get(header_idx).map(<[u8]>::to_vec),
+            DataType::Utf8 => values
+                .utf8()?
+                .get(header_idx)
+                .map(|value| value.as_bytes().to_vec()),
+            DataType::Null => None,
+            other => {
+                return Err(DaftError::ValueError(format!(
+                    "[write_kafka] kafka header value must be Binary, Utf8, or Null, got {other}"
+                )));
+            }
+        };
+        parsed.push(make_header(key, value.as_deref())?);
+    }
+
+    Ok(parsed)
+}
+
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use arrow_array::builder::{BinaryBuilder, LargeListBuilder, StringBuilder, StructBuilder};
+    use arrow_schema::{DataType as ArrowDataType, Field as ArrowField, Fields};
+    use daft_core::prelude::Field;
+
     use super::*;
 
     #[test]
@@ -59,5 +112,111 @@ mod tests {
 
         assert!(err.to_string().contains("[write_kafka]"));
         assert!(err.to_string().contains("header key"));
+    }
+
+    fn header_series() -> Series {
+        let mut builder = arrow_header_builder(4);
+        append_header(&mut builder, "same", Some(b"first"));
+        append_header(&mut builder, "other", Some(b"middle"));
+        append_header(&mut builder, "same", Some(b"second"));
+        builder.append(true);
+        builder.append(false);
+        append_header(&mut builder, "nullable", None);
+        builder.append(true);
+
+        Series::from_arrow(
+            Arc::new(Field::new(
+                "headers",
+                DataType::List(Box::new(header_struct_dtype())),
+            )),
+            Arc::new(builder.finish()),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn parses_list_of_struct_headers_for_row() {
+        let headers = header_series();
+
+        let first_row = headers_for_row(&headers, 0).unwrap();
+        let null_row = headers_for_row(&headers, 1).unwrap();
+        let third_row = headers_for_row(&headers, 2).unwrap();
+
+        assert_eq!(
+            first_row,
+            vec![
+                make_header("same", Some(b"first")).unwrap(),
+                make_header("other", Some(b"middle")).unwrap(),
+                make_header("same", Some(b"second")).unwrap(),
+            ]
+        );
+        assert!(null_row.is_empty());
+        assert_eq!(third_row, vec![make_header("nullable", None).unwrap()]);
+    }
+
+    #[test]
+    fn rejects_null_header_key_from_projection() {
+        let mut builder = arrow_header_builder(1);
+        {
+            let values = builder.values();
+            values
+                .field_builder::<StringBuilder>(0)
+                .unwrap()
+                .append_null();
+            values
+                .field_builder::<BinaryBuilder>(1)
+                .unwrap()
+                .append_value(b"value");
+            values.append(true);
+        }
+        builder.append(true);
+        let headers = Series::from_arrow(
+            Arc::new(Field::new(
+                "headers",
+                DataType::List(Box::new(header_struct_dtype())),
+            )),
+            Arc::new(builder.finish()),
+        )
+        .unwrap();
+
+        let err = headers_for_row(&headers, 0).unwrap_err();
+
+        assert!(err.to_string().contains("[write_kafka]"));
+        assert!(err.to_string().contains("header key"));
+    }
+
+    fn header_struct_dtype() -> DataType {
+        DataType::Struct(vec![
+            Field::new("key", DataType::Utf8),
+            Field::new("value", DataType::Binary),
+        ])
+    }
+
+    fn arrow_header_builder(capacity: usize) -> LargeListBuilder<StructBuilder> {
+        LargeListBuilder::new(StructBuilder::from_fields(
+            Fields::from(vec![
+                ArrowField::new("key", ArrowDataType::Utf8, true),
+                ArrowField::new("value", ArrowDataType::Binary, true),
+            ]),
+            capacity,
+        ))
+    }
+
+    fn append_header(
+        builder: &mut LargeListBuilder<StructBuilder>,
+        key: &str,
+        value: Option<&[u8]>,
+    ) {
+        let values = builder.values();
+        values
+            .field_builder::<StringBuilder>(0)
+            .unwrap()
+            .append_value(key);
+        let value_builder = values.field_builder::<BinaryBuilder>(1).unwrap();
+        match value {
+            Some(value) => value_builder.append_value(value),
+            None => value_builder.append_null(),
+        }
+        values.append(true);
     }
 }

--- a/src/daft-writers/src/kafka/headers.rs
+++ b/src/daft-writers/src/kafka/headers.rs
@@ -2,7 +2,7 @@ use common_error::{DaftError, DaftResult};
 
 use super::producer::KafkaHeader;
 
-// TODO(native-kafka-write): remove once Task 8/9 validates headers from writer integration.
+// TODO(native-kafka-write): remove once Task 9 validates headers from writer projection.
 #[allow(dead_code)]
 pub(crate) fn validate_header_key(key: &str) -> DaftResult<()> {
     if key.is_empty() {
@@ -14,7 +14,7 @@ pub(crate) fn validate_header_key(key: &str) -> DaftResult<()> {
     Ok(())
 }
 
-// TODO(native-kafka-write): remove once Task 8/9 builds headers from writer integration.
+// TODO(native-kafka-write): remove once Task 9 builds headers from writer projection.
 #[allow(dead_code)]
 pub(crate) fn make_header(key: &str, value: Option<&[u8]>) -> DaftResult<KafkaHeader> {
     validate_header_key(key)?;

--- a/src/daft-writers/src/kafka/headers.rs
+++ b/src/daft-writers/src/kafka/headers.rs
@@ -1,0 +1,59 @@
+use common_error::{DaftError, DaftResult};
+
+use super::producer::KafkaHeader;
+
+pub(crate) fn validate_header_key(key: &str) -> DaftResult<()> {
+    if key.is_empty() {
+        return Err(DaftError::ValueError(
+            "[write_kafka] kafka header key must not be empty".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+pub(crate) fn make_header(key: &str, value: Option<&[u8]>) -> DaftResult<KafkaHeader> {
+    validate_header_key(key)?;
+
+    Ok(KafkaHeader {
+        key: key.to_string(),
+        value: value.map(<[u8]>::to_vec),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preserves_duplicate_keys_and_order() {
+        let headers = vec![
+            make_header("same", Some(b"first")).unwrap(),
+            make_header("other", Some(b"middle")).unwrap(),
+            make_header("same", Some(b"second")).unwrap(),
+        ];
+
+        assert_eq!(headers[0].key, "same");
+        assert_eq!(headers[0].value.as_deref(), Some(&b"first"[..]));
+        assert_eq!(headers[1].key, "other");
+        assert_eq!(headers[1].value.as_deref(), Some(&b"middle"[..]));
+        assert_eq!(headers[2].key, "same");
+        assert_eq!(headers[2].value.as_deref(), Some(&b"second"[..]));
+    }
+
+    #[test]
+    fn preserves_null_header_values() {
+        let header = make_header("nullable", None).unwrap();
+
+        assert_eq!(header.key, "nullable");
+        assert_eq!(header.value, None);
+    }
+
+    #[test]
+    fn rejects_empty_header_key() {
+        let err = validate_header_key("").unwrap_err();
+
+        assert!(err.to_string().contains("[write_kafka]"));
+        assert!(err.to_string().contains("header key"));
+    }
+}

--- a/src/daft-writers/src/kafka/metrics.rs
+++ b/src/daft-writers/src/kafka/metrics.rs
@@ -1,4 +1,6 @@
 #[derive(Debug, Clone, Default)]
+// TODO: wire producer metrics into the native Kafka producer implementation.
+#[allow(dead_code)]
 pub struct KafkaProducerMetrics {
     pub txmsgs: i64,
     pub txmsg_bytes: i64,

--- a/src/daft-writers/src/kafka/metrics.rs
+++ b/src/daft-writers/src/kafka/metrics.rs
@@ -1,0 +1,8 @@
+#[derive(Debug, Clone, Default)]
+pub struct KafkaProducerMetrics {
+    pub txmsgs: i64,
+    pub txmsg_bytes: i64,
+    pub outbuf_msg_cnt: i64,
+    pub msg_cnt: i64,
+    pub msg_max: i64,
+}

--- a/src/daft-writers/src/kafka/mod.rs
+++ b/src/daft-writers/src/kafka/mod.rs
@@ -1,0 +1,3 @@
+pub mod accounting;
+pub mod config;
+pub mod metrics;

--- a/src/daft-writers/src/kafka/mod.rs
+++ b/src/daft-writers/src/kafka/mod.rs
@@ -1,10 +1,11 @@
-// TODO(native-kafka-write): remove once Task 8/9 wires accounting into the writer integration.
+// TODO(native-kafka-write): remove once Task 9 records attempts, deliveries, and failures.
 #[allow(dead_code)]
 pub mod accounting;
-// TODO(native-kafka-write): remove once Task 8/9 wires config into the writer integration.
+// TODO(native-kafka-write): remove once Task 9/10 surfaces redacted Kafka config diagnostics.
 #[allow(dead_code)]
 pub mod config;
 pub(crate) mod headers;
 pub mod metrics;
 pub(crate) mod producer;
 pub(crate) mod record;
+pub mod writer;

--- a/src/daft-writers/src/kafka/mod.rs
+++ b/src/daft-writers/src/kafka/mod.rs
@@ -1,4 +1,8 @@
+// TODO(native-kafka-write): remove once Task 8/9 wires accounting into the writer integration.
+#[allow(dead_code)]
 pub mod accounting;
+// TODO(native-kafka-write): remove once Task 8/9 wires config into the writer integration.
+#[allow(dead_code)]
 pub mod config;
 pub(crate) mod headers;
 pub mod metrics;

--- a/src/daft-writers/src/kafka/mod.rs
+++ b/src/daft-writers/src/kafka/mod.rs
@@ -1,3 +1,6 @@
 pub mod accounting;
 pub mod config;
+pub(crate) mod headers;
 pub mod metrics;
+pub(crate) mod producer;
+pub(crate) mod record;

--- a/src/daft-writers/src/kafka/mod.rs
+++ b/src/daft-writers/src/kafka/mod.rs
@@ -1,8 +1,4 @@
-// TODO(native-kafka-write): remove once Task 9 records attempts, deliveries, and failures.
-#[allow(dead_code)]
 pub mod accounting;
-// TODO(native-kafka-write): remove once Task 9/10 surfaces redacted Kafka config diagnostics.
-#[allow(dead_code)]
 pub mod config;
 pub(crate) mod headers;
 pub mod metrics;

--- a/src/daft-writers/src/kafka/producer.rs
+++ b/src/daft-writers/src/kafka/producer.rs
@@ -1,0 +1,222 @@
+use std::{collections::VecDeque, time::Duration};
+
+use async_trait::async_trait;
+use common_error::{DaftError, DaftResult};
+use parking_lot::Mutex;
+
+use super::metrics::KafkaProducerMetrics;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct KafkaHeader {
+    pub key: String,
+    pub value: Option<Vec<u8>>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct KafkaOutgoingRecord {
+    pub topic: String,
+    pub key: Option<Vec<u8>>,
+    pub value: Option<Vec<u8>>,
+    pub headers: Vec<KafkaHeader>,
+    pub partition: Option<i32>,
+    pub timestamp_ms: Option<i64>,
+}
+
+impl KafkaOutgoingRecord {
+    pub(crate) fn delivered_bytes(&self) -> usize {
+        let record_bytes =
+            self.key.as_ref().map_or(0, Vec::len) + self.value.as_ref().map_or(0, Vec::len);
+
+        self.headers.iter().fold(record_bytes, |bytes, header| {
+            bytes + header.key.len() + header.value.as_ref().map_or(0, Vec::len)
+        })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct KafkaDelivery {
+    pub topic: String,
+    pub partition: i32,
+    pub offset: i64,
+    pub timestamp_ms: Option<i64>,
+}
+
+#[async_trait]
+pub(crate) trait KafkaProducer: Send + Sync {
+    async fn send(&self, record: KafkaOutgoingRecord) -> DaftResult<KafkaDelivery>;
+
+    async fn flush(&self, timeout: Duration) -> DaftResult<()>;
+
+    fn metrics_snapshot(&self) -> Option<KafkaProducerMetrics> {
+        None
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct FakeProducer {
+    sent_records: Mutex<Vec<KafkaOutgoingRecord>>,
+    delivery_results: Mutex<VecDeque<DaftResult<KafkaDelivery>>>,
+    flush_result: Mutex<Option<DaftResult<()>>>,
+    next_offset: Mutex<i64>,
+}
+
+impl FakeProducer {
+    pub(crate) fn succeeding() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn with_delivery_results(results: Vec<DaftResult<KafkaDelivery>>) -> Self {
+        Self {
+            delivery_results: Mutex::new(results.into()),
+            ..Self::default()
+        }
+    }
+
+    pub(crate) fn with_flush_result(result: DaftResult<()>) -> Self {
+        Self {
+            flush_result: Mutex::new(Some(result)),
+            ..Self::default()
+        }
+    }
+
+    pub(crate) fn sent_records(&self) -> Vec<KafkaOutgoingRecord> {
+        self.sent_records.lock().clone()
+    }
+}
+
+pub(crate) fn delivery_error(message: impl Into<String>) -> DaftError {
+    DaftError::ValueError(format!("[write_kafka] {}", message.into()))
+}
+
+#[async_trait]
+impl KafkaProducer for FakeProducer {
+    async fn send(&self, record: KafkaOutgoingRecord) -> DaftResult<KafkaDelivery> {
+        self.sent_records.lock().push(record.clone());
+
+        if let Some(result) = self.delivery_results.lock().pop_front() {
+            return result;
+        }
+
+        let mut next_offset = self.next_offset.lock();
+        let delivery = KafkaDelivery {
+            topic: record.topic,
+            partition: record.partition.unwrap_or(0),
+            offset: *next_offset,
+            timestamp_ms: record.timestamp_ms,
+        };
+        *next_offset = next_offset.saturating_add(1);
+
+        Ok(delivery)
+    }
+
+    async fn flush(&self, _timeout: Duration) -> DaftResult<()> {
+        self.flush_result.lock().take().unwrap_or(Ok(()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    fn record(
+        topic: &str,
+        partition: Option<i32>,
+        timestamp_ms: Option<i64>,
+    ) -> KafkaOutgoingRecord {
+        KafkaOutgoingRecord {
+            topic: topic.to_string(),
+            key: Some(b"key".to_vec()),
+            value: Some(b"value".to_vec()),
+            headers: vec![KafkaHeader {
+                key: "header".to_string(),
+                value: Some(b"bytes".to_vec()),
+            }],
+            partition,
+            timestamp_ms,
+        }
+    }
+
+    #[test]
+    fn delivered_bytes_counts_key_value_and_headers() {
+        let record = KafkaOutgoingRecord {
+            topic: "topic".to_string(),
+            key: Some(b"key".to_vec()),
+            value: Some(b"value".to_vec()),
+            headers: vec![
+                KafkaHeader {
+                    key: "a".to_string(),
+                    value: Some(b"bc".to_vec()),
+                },
+                KafkaHeader {
+                    key: "null".to_string(),
+                    value: None,
+                },
+            ],
+            partition: None,
+            timestamp_ms: None,
+        };
+
+        assert_eq!(record.delivered_bytes(), 3 + 5 + 1 + 2 + 4);
+    }
+
+    #[tokio::test]
+    async fn succeeding_fake_records_sent_records_and_deliveries() {
+        let producer = FakeProducer::succeeding();
+        let first = record("topic", Some(2), Some(123));
+        let second = record("topic", None, None);
+
+        let first_delivery = producer.send(first.clone()).await.unwrap();
+        let second_delivery = producer.send(second.clone()).await.unwrap();
+
+        assert_eq!(producer.sent_records(), vec![first, second]);
+        assert_eq!(
+            first_delivery,
+            KafkaDelivery {
+                topic: "topic".to_string(),
+                partition: 2,
+                offset: 0,
+                timestamp_ms: Some(123),
+            }
+        );
+        assert_eq!(second_delivery.offset, 1);
+        assert_eq!(second_delivery.partition, 0);
+        assert!(producer.metrics_snapshot().is_none());
+    }
+
+    #[tokio::test]
+    async fn fake_uses_queued_delivery_results_fifo() {
+        let queued = KafkaDelivery {
+            topic: "queued".to_string(),
+            partition: 4,
+            offset: 99,
+            timestamp_ms: Some(7),
+        };
+        let producer = FakeProducer::with_delivery_results(vec![
+            Ok(queued.clone()),
+            Err(delivery_error("delivery failed")),
+        ]);
+
+        assert_eq!(
+            producer.send(record("ignored", None, None)).await.unwrap(),
+            queued
+        );
+
+        let err = producer
+            .send(record("still-recorded", None, None))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("[write_kafka] delivery failed"));
+        assert_eq!(producer.sent_records().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn fake_flush_can_return_configured_result_once() {
+        let producer = FakeProducer::with_flush_result(Err(delivery_error("flush failed")));
+
+        let err = producer.flush(Duration::from_millis(1)).await.unwrap_err();
+        assert!(err.to_string().contains("[write_kafka] flush failed"));
+        producer.flush(Duration::from_millis(1)).await.unwrap();
+    }
+}

--- a/src/daft-writers/src/kafka/producer.rs
+++ b/src/daft-writers/src/kafka/producer.rs
@@ -7,12 +7,16 @@ use parking_lot::Mutex;
 use super::metrics::KafkaProducerMetrics;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+// TODO(native-kafka-write): remove once Task 8/9 wires outgoing records into the writer integration.
+#[allow(dead_code)]
 pub(crate) struct KafkaHeader {
     pub key: String,
     pub value: Option<Vec<u8>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+// TODO(native-kafka-write): remove once Task 8/9 wires outgoing records into the writer integration.
+#[allow(dead_code)]
 pub(crate) struct KafkaOutgoingRecord {
     pub topic: String,
     pub key: Option<Vec<u8>>,
@@ -23,6 +27,8 @@ pub(crate) struct KafkaOutgoingRecord {
 }
 
 impl KafkaOutgoingRecord {
+    // TODO(native-kafka-write): remove once Task 8/9 records delivery accounting from writer integration.
+    #[allow(dead_code)]
     pub(crate) fn delivered_bytes(&self) -> usize {
         let record_bytes =
             self.key.as_ref().map_or(0, Vec::len) + self.value.as_ref().map_or(0, Vec::len);
@@ -34,6 +40,8 @@ impl KafkaOutgoingRecord {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+// TODO(native-kafka-write): remove once Task 8/9 wires delivery results into the writer integration.
+#[allow(dead_code)]
 pub(crate) struct KafkaDelivery {
     pub topic: String,
     pub partition: i32,
@@ -41,6 +49,8 @@ pub(crate) struct KafkaDelivery {
     pub timestamp_ms: Option<i64>,
 }
 
+// TODO(native-kafka-write): remove once Task 8/9 adds the concrete producer adapter and writer integration.
+#[allow(dead_code)]
 #[async_trait]
 pub(crate) trait KafkaProducer: Send + Sync {
     async fn send(&self, record: KafkaOutgoingRecord) -> DaftResult<KafkaDelivery>;
@@ -53,6 +63,8 @@ pub(crate) trait KafkaProducer: Send + Sync {
 }
 
 #[derive(Debug, Default)]
+// TODO(native-kafka-write): remove once Task 8/9 writer integration consumes the fake in higher-level tests.
+#[allow(dead_code)]
 pub(crate) struct FakeProducer {
     sent_records: Mutex<Vec<KafkaOutgoingRecord>>,
     delivery_results: Mutex<VecDeque<DaftResult<KafkaDelivery>>>,
@@ -61,10 +73,14 @@ pub(crate) struct FakeProducer {
 }
 
 impl FakeProducer {
+    // TODO(native-kafka-write): remove once Task 8/9 writer integration consumes the fake in higher-level tests.
+    #[allow(dead_code)]
     pub(crate) fn succeeding() -> Self {
         Self::default()
     }
 
+    // TODO(native-kafka-write): remove once Task 8/9 writer integration consumes the fake in higher-level tests.
+    #[allow(dead_code)]
     pub(crate) fn with_delivery_results(results: Vec<DaftResult<KafkaDelivery>>) -> Self {
         Self {
             delivery_results: Mutex::new(results.into()),
@@ -72,6 +88,8 @@ impl FakeProducer {
         }
     }
 
+    // TODO(native-kafka-write): remove once Task 8/9 writer integration consumes the fake in higher-level tests.
+    #[allow(dead_code)]
     pub(crate) fn with_flush_result(result: DaftResult<()>) -> Self {
         Self {
             flush_result: Mutex::new(Some(result)),
@@ -79,13 +97,17 @@ impl FakeProducer {
         }
     }
 
+    // TODO(native-kafka-write): remove once Task 8/9 writer integration consumes the fake in higher-level tests.
+    #[allow(dead_code)]
     pub(crate) fn sent_records(&self) -> Vec<KafkaOutgoingRecord> {
         self.sent_records.lock().clone()
     }
 }
 
+// TODO(native-kafka-write): remove once Task 8/9 surfaces producer delivery errors through writer integration.
+#[allow(dead_code)]
 pub(crate) fn delivery_error(message: impl Into<String>) -> DaftError {
-    DaftError::ValueError(format!("[write_kafka] {}", message.into()))
+    DaftError::ComputeError(format!("[write_kafka] {}", message.into()))
 }
 
 #[async_trait]

--- a/src/daft-writers/src/kafka/producer.rs
+++ b/src/daft-writers/src/kafka/producer.rs
@@ -1,7 +1,10 @@
-use std::{collections::VecDeque, time::Duration};
+#[cfg(test)]
+use std::collections::VecDeque;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use common_error::{DaftError, DaftResult};
+#[cfg(test)]
 use parking_lot::Mutex;
 #[cfg(feature = "kafka")]
 use rdkafka::{
@@ -29,8 +32,6 @@ pub(crate) struct KafkaOutgoingRecord {
 }
 
 impl KafkaOutgoingRecord {
-    // TODO(native-kafka-write): remove once Task 9 records delivery accounting from writer projection.
-    #[allow(dead_code)]
     pub(crate) fn delivered_bytes(&self) -> usize {
         let record_bytes =
             self.key.as_ref().map_or(0, Vec::len) + self.value.as_ref().map_or(0, Vec::len);
@@ -51,8 +52,6 @@ pub(crate) struct KafkaDelivery {
 
 #[async_trait]
 pub(crate) trait KafkaProducer: Send + Sync {
-    // TODO(native-kafka-write): remove once Task 9 wires row projection to producer sends.
-    #[allow(dead_code)]
     async fn send(
         &self,
         record: KafkaOutgoingRecord,
@@ -61,7 +60,6 @@ pub(crate) trait KafkaProducer: Send + Sync {
 
     async fn flush(&self, timeout: Duration) -> DaftResult<()>;
 
-    // TODO(native-kafka-write): remove once Task 9 decides producer metrics integration.
     #[allow(dead_code)]
     fn metrics_snapshot(&self) -> Option<KafkaProducerMetrics> {
         None
@@ -81,9 +79,8 @@ impl RdkafkaProducer {
     }
 }
 
+#[cfg(test)]
 #[derive(Debug, Default)]
-// TODO(native-kafka-write): remove once Task 9 consumes the fake in row-projection tests.
-#[allow(dead_code)]
 pub(crate) struct FakeProducer {
     sent_records: Mutex<Vec<KafkaOutgoingRecord>>,
     delivery_results: Mutex<VecDeque<DaftResult<KafkaDelivery>>>,
@@ -91,15 +88,12 @@ pub(crate) struct FakeProducer {
     next_offset: Mutex<i64>,
 }
 
+#[cfg(test)]
 impl FakeProducer {
-    // TODO(native-kafka-write): remove once Task 9 consumes the fake in row-projection tests.
-    #[allow(dead_code)]
     pub(crate) fn succeeding() -> Self {
         Self::default()
     }
 
-    // TODO(native-kafka-write): remove once Task 9 consumes the fake in row-projection tests.
-    #[allow(dead_code)]
     pub(crate) fn with_delivery_results(results: Vec<DaftResult<KafkaDelivery>>) -> Self {
         Self {
             delivery_results: Mutex::new(results.into()),
@@ -107,8 +101,6 @@ impl FakeProducer {
         }
     }
 
-    // TODO(native-kafka-write): remove once Task 9 consumes the fake in row-projection tests.
-    #[allow(dead_code)]
     pub(crate) fn with_flush_result(result: DaftResult<()>) -> Self {
         Self {
             flush_result: Mutex::new(Some(result)),
@@ -116,15 +108,12 @@ impl FakeProducer {
         }
     }
 
-    // TODO(native-kafka-write): remove once Task 9 consumes the fake in row-projection tests.
-    #[allow(dead_code)]
     pub(crate) fn sent_records(&self) -> Vec<KafkaOutgoingRecord> {
         self.sent_records.lock().clone()
     }
 }
 
-// TODO(native-kafka-write): remove once Task 9 consumes fake producer failures from writer tests.
-#[allow(dead_code)]
+#[cfg(test)]
 pub(crate) fn delivery_error(message: impl Into<String>) -> DaftError {
     DaftError::External(format!("[write_kafka] {}", message.into()).into())
 }
@@ -181,8 +170,6 @@ where
 }
 
 #[cfg(feature = "kafka")]
-// TODO(native-kafka-write): remove once Task 9 exercises producer sends from writer projection.
-#[allow(dead_code)]
 fn to_owned_headers(headers: &[KafkaHeader]) -> Option<OwnedHeaders> {
     if headers.is_empty() {
         return None;
@@ -298,6 +285,7 @@ mod kafka_error_tests {
     }
 }
 
+#[cfg(test)]
 #[async_trait]
 impl KafkaProducer for FakeProducer {
     async fn send(

--- a/src/daft-writers/src/kafka/producer.rs
+++ b/src/daft-writers/src/kafka/producer.rs
@@ -257,6 +257,8 @@ impl KafkaProducer for RdkafkaProducer {
 mod kafka_error_tests {
     use std::{error::Error, io};
 
+    use common_error::DaftError;
+
     use super::KafkaExternalError;
 
     #[test]
@@ -271,6 +273,28 @@ mod kafka_error_tests {
             "[write_kafka] delivery failed for topic \"topic\", partition 1, offset 2: broker unavailable"
         );
         assert_eq!(err.source().unwrap().to_string(), "broker unavailable");
+    }
+
+    #[test]
+    fn daft_external_error_exposes_kafka_wrapper_and_source() {
+        let err = DaftError::External(Box::new(KafkaExternalError::new(
+            "flush failed",
+            io::Error::other("broker unavailable"),
+        )));
+
+        assert_eq!(
+            err.to_string(),
+            "DaftError::External [write_kafka] flush failed: broker unavailable"
+        );
+        let kafka_source = err.source().unwrap();
+        assert_eq!(
+            kafka_source.to_string(),
+            "[write_kafka] flush failed: broker unavailable"
+        );
+        assert_eq!(
+            kafka_source.source().unwrap().to_string(),
+            "broker unavailable"
+        );
     }
 }
 

--- a/src/daft-writers/src/kafka/producer.rs
+++ b/src/daft-writers/src/kafka/producer.rs
@@ -3,20 +3,22 @@ use std::{collections::VecDeque, time::Duration};
 use async_trait::async_trait;
 use common_error::{DaftError, DaftResult};
 use parking_lot::Mutex;
+#[cfg(feature = "kafka")]
+use rdkafka::{
+    Message,
+    message::{Header, OwnedHeaders},
+    producer::{FutureProducer, FutureRecord, Producer},
+};
 
 use super::metrics::KafkaProducerMetrics;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-// TODO(native-kafka-write): remove once Task 8/9 wires outgoing records into the writer integration.
-#[allow(dead_code)]
 pub(crate) struct KafkaHeader {
     pub key: String,
     pub value: Option<Vec<u8>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-// TODO(native-kafka-write): remove once Task 8/9 wires outgoing records into the writer integration.
-#[allow(dead_code)]
 pub(crate) struct KafkaOutgoingRecord {
     pub topic: String,
     pub key: Option<Vec<u8>>,
@@ -27,7 +29,7 @@ pub(crate) struct KafkaOutgoingRecord {
 }
 
 impl KafkaOutgoingRecord {
-    // TODO(native-kafka-write): remove once Task 8/9 records delivery accounting from writer integration.
+    // TODO(native-kafka-write): remove once Task 9 records delivery accounting from writer projection.
     #[allow(dead_code)]
     pub(crate) fn delivered_bytes(&self) -> usize {
         let record_bytes =
@@ -40,8 +42,6 @@ impl KafkaOutgoingRecord {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-// TODO(native-kafka-write): remove once Task 8/9 wires delivery results into the writer integration.
-#[allow(dead_code)]
 pub(crate) struct KafkaDelivery {
     pub topic: String,
     pub partition: i32,
@@ -49,21 +49,40 @@ pub(crate) struct KafkaDelivery {
     pub timestamp_ms: Option<i64>,
 }
 
-// TODO(native-kafka-write): remove once Task 8/9 adds the concrete producer adapter and writer integration.
-#[allow(dead_code)]
 #[async_trait]
 pub(crate) trait KafkaProducer: Send + Sync {
-    async fn send(&self, record: KafkaOutgoingRecord) -> DaftResult<KafkaDelivery>;
+    // TODO(native-kafka-write): remove once Task 9 wires row projection to producer sends.
+    #[allow(dead_code)]
+    async fn send(
+        &self,
+        record: KafkaOutgoingRecord,
+        queue_timeout: Duration,
+    ) -> DaftResult<KafkaDelivery>;
 
     async fn flush(&self, timeout: Duration) -> DaftResult<()>;
 
+    // TODO(native-kafka-write): remove once Task 9 decides producer metrics integration.
+    #[allow(dead_code)]
     fn metrics_snapshot(&self) -> Option<KafkaProducerMetrics> {
         None
     }
 }
 
+#[cfg(feature = "kafka")]
+#[derive(Clone)]
+pub(crate) struct RdkafkaProducer {
+    producer: FutureProducer,
+}
+
+#[cfg(feature = "kafka")]
+impl RdkafkaProducer {
+    pub(crate) fn new(producer: FutureProducer) -> Self {
+        Self { producer }
+    }
+}
+
 #[derive(Debug, Default)]
-// TODO(native-kafka-write): remove once Task 8/9 writer integration consumes the fake in higher-level tests.
+// TODO(native-kafka-write): remove once Task 9 consumes the fake in row-projection tests.
 #[allow(dead_code)]
 pub(crate) struct FakeProducer {
     sent_records: Mutex<Vec<KafkaOutgoingRecord>>,
@@ -73,13 +92,13 @@ pub(crate) struct FakeProducer {
 }
 
 impl FakeProducer {
-    // TODO(native-kafka-write): remove once Task 8/9 writer integration consumes the fake in higher-level tests.
+    // TODO(native-kafka-write): remove once Task 9 consumes the fake in row-projection tests.
     #[allow(dead_code)]
     pub(crate) fn succeeding() -> Self {
         Self::default()
     }
 
-    // TODO(native-kafka-write): remove once Task 8/9 writer integration consumes the fake in higher-level tests.
+    // TODO(native-kafka-write): remove once Task 9 consumes the fake in row-projection tests.
     #[allow(dead_code)]
     pub(crate) fn with_delivery_results(results: Vec<DaftResult<KafkaDelivery>>) -> Self {
         Self {
@@ -88,7 +107,7 @@ impl FakeProducer {
         }
     }
 
-    // TODO(native-kafka-write): remove once Task 8/9 writer integration consumes the fake in higher-level tests.
+    // TODO(native-kafka-write): remove once Task 9 consumes the fake in row-projection tests.
     #[allow(dead_code)]
     pub(crate) fn with_flush_result(result: DaftResult<()>) -> Self {
         Self {
@@ -97,22 +116,101 @@ impl FakeProducer {
         }
     }
 
-    // TODO(native-kafka-write): remove once Task 8/9 writer integration consumes the fake in higher-level tests.
+    // TODO(native-kafka-write): remove once Task 9 consumes the fake in row-projection tests.
     #[allow(dead_code)]
     pub(crate) fn sent_records(&self) -> Vec<KafkaOutgoingRecord> {
         self.sent_records.lock().clone()
     }
 }
 
-// TODO(native-kafka-write): remove once Task 8/9 surfaces producer delivery errors through writer integration.
+// TODO(native-kafka-write): remove once Task 9 consumes fake producer failures from writer tests.
 #[allow(dead_code)]
 pub(crate) fn delivery_error(message: impl Into<String>) -> DaftError {
-    DaftError::ComputeError(format!("[write_kafka] {}", message.into()))
+    DaftError::External(format!("[write_kafka] {}", message.into()).into())
+}
+
+#[cfg(feature = "kafka")]
+fn external_error(message: impl Into<String>) -> DaftError {
+    DaftError::External(format!("[write_kafka] {}", message.into()).into())
+}
+
+#[cfg(feature = "kafka")]
+// TODO(native-kafka-write): remove once Task 9 exercises producer sends from writer projection.
+#[allow(dead_code)]
+fn to_owned_headers(headers: &[KafkaHeader]) -> Option<OwnedHeaders> {
+    if headers.is_empty() {
+        return None;
+    }
+
+    let mut owned_headers = OwnedHeaders::new_with_capacity(headers.len());
+    for header in headers {
+        owned_headers = owned_headers.insert(Header {
+            key: &header.key,
+            value: header.value.as_deref(),
+        });
+    }
+    Some(owned_headers)
+}
+
+#[cfg(feature = "kafka")]
+#[async_trait]
+impl KafkaProducer for RdkafkaProducer {
+    async fn send(
+        &self,
+        record: KafkaOutgoingRecord,
+        queue_timeout: Duration,
+    ) -> DaftResult<KafkaDelivery> {
+        let mut future_record: FutureRecord<'_, [u8], [u8]> = FutureRecord::to(&record.topic);
+
+        if let Some(key) = record.key.as_deref() {
+            future_record = future_record.key(key);
+        }
+        if let Some(value) = record.value.as_deref() {
+            future_record = future_record.payload(value);
+        }
+        if let Some(partition) = record.partition {
+            future_record = future_record.partition(partition);
+        }
+        if let Some(timestamp_ms) = record.timestamp_ms {
+            future_record = future_record.timestamp(timestamp_ms);
+        }
+        if let Some(headers) = to_owned_headers(&record.headers) {
+            future_record = future_record.headers(headers);
+        }
+
+        self.producer
+            .send(future_record, queue_timeout)
+            .await
+            .map(|delivery| KafkaDelivery {
+                topic: record.topic,
+                partition: delivery.partition,
+                offset: delivery.offset,
+                timestamp_ms: delivery.timestamp.to_millis(),
+            })
+            .map_err(|(err, message)| {
+                external_error(format!(
+                    "delivery failed for topic {:?}, partition {}, offset {}: {err}",
+                    message.topic(),
+                    message.partition(),
+                    message.offset()
+                ))
+            })
+    }
+
+    async fn flush(&self, timeout: Duration) -> DaftResult<()> {
+        self.producer
+            .flush(timeout)
+            .map_err(|err| external_error(format!("flush failed: {err}")))
+    }
 }
 
 #[async_trait]
 impl KafkaProducer for FakeProducer {
-    async fn send(&self, record: KafkaOutgoingRecord) -> DaftResult<KafkaDelivery> {
+    async fn send(
+        &self,
+        record: KafkaOutgoingRecord,
+        _queue_timeout: Duration,
+    ) -> DaftResult<KafkaDelivery> {
         self.sent_records.lock().push(record.clone());
 
         if let Some(result) = self.delivery_results.lock().pop_front() {
@@ -141,6 +239,10 @@ mod tests {
     use std::time::Duration;
 
     use super::*;
+
+    fn queue_timeout() -> Duration {
+        Duration::from_millis(10)
+    }
 
     fn record(
         topic: &str,
@@ -189,8 +291,11 @@ mod tests {
         let first = record("topic", Some(2), Some(123));
         let second = record("topic", None, None);
 
-        let first_delivery = producer.send(first.clone()).await.unwrap();
-        let second_delivery = producer.send(second.clone()).await.unwrap();
+        let first_delivery = producer.send(first.clone(), queue_timeout()).await.unwrap();
+        let second_delivery = producer
+            .send(second.clone(), queue_timeout())
+            .await
+            .unwrap();
 
         assert_eq!(producer.sent_records(), vec![first, second]);
         assert_eq!(
@@ -221,12 +326,15 @@ mod tests {
         ]);
 
         assert_eq!(
-            producer.send(record("ignored", None, None)).await.unwrap(),
+            producer
+                .send(record("ignored", None, None), queue_timeout())
+                .await
+                .unwrap(),
             queued
         );
 
         let err = producer
-            .send(record("still-recorded", None, None))
+            .send(record("still-recorded", None, None), queue_timeout())
             .await
             .unwrap_err();
         assert!(err.to_string().contains("[write_kafka] delivery failed"));

--- a/src/daft-writers/src/kafka/producer.rs
+++ b/src/daft-writers/src/kafka/producer.rs
@@ -130,8 +130,54 @@ pub(crate) fn delivery_error(message: impl Into<String>) -> DaftError {
 }
 
 #[cfg(feature = "kafka")]
-fn external_error(message: impl Into<String>) -> DaftError {
-    DaftError::External(format!("[write_kafka] {}", message.into()).into())
+pub(crate) struct KafkaExternalError<E> {
+    context: String,
+    source: E,
+}
+
+#[cfg(feature = "kafka")]
+impl<E> KafkaExternalError<E> {
+    pub(crate) fn new(context: impl Into<String>, source: E) -> Self {
+        Self {
+            context: context.into(),
+            source,
+        }
+    }
+}
+
+#[cfg(feature = "kafka")]
+impl<E: std::fmt::Display> std::fmt::Display for KafkaExternalError<E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "[write_kafka] {}: {}", self.context, self.source)
+    }
+}
+
+#[cfg(feature = "kafka")]
+impl<E: std::fmt::Debug> std::fmt::Debug for KafkaExternalError<E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("KafkaExternalError")
+            .field("context", &self.context)
+            .field("source", &self.source)
+            .finish()
+    }
+}
+
+#[cfg(feature = "kafka")]
+impl<E> std::error::Error for KafkaExternalError<E>
+where
+    E: std::error::Error + Send + Sync + 'static,
+{
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.source)
+    }
+}
+
+#[cfg(feature = "kafka")]
+fn external_error<E>(context: impl Into<String>, source: E) -> DaftError
+where
+    E: std::error::Error + Send + Sync + 'static,
+{
+    DaftError::External(Box::new(KafkaExternalError::new(context, source)))
 }
 
 #[cfg(feature = "kafka")]
@@ -188,19 +234,43 @@ impl KafkaProducer for RdkafkaProducer {
                 timestamp_ms: delivery.timestamp.to_millis(),
             })
             .map_err(|(err, message)| {
-                external_error(format!(
-                    "delivery failed for topic {:?}, partition {}, offset {}: {err}",
-                    message.topic(),
-                    message.partition(),
-                    message.offset()
-                ))
+                external_error(
+                    format!(
+                        "delivery failed for topic {:?}, partition {}, offset {}",
+                        message.topic(),
+                        message.partition(),
+                        message.offset()
+                    ),
+                    err,
+                )
             })
     }
 
     async fn flush(&self, timeout: Duration) -> DaftResult<()> {
         self.producer
             .flush(timeout)
-            .map_err(|err| external_error(format!("flush failed: {err}")))
+            .map_err(|err| external_error("flush failed", err))
+    }
+}
+
+#[cfg(all(test, feature = "kafka"))]
+mod kafka_error_tests {
+    use std::{error::Error, io};
+
+    use super::KafkaExternalError;
+
+    #[test]
+    fn kafka_external_error_preserves_source_and_context() {
+        let err = KafkaExternalError::new(
+            "delivery failed for topic \"topic\", partition 1, offset 2",
+            io::Error::other("broker unavailable"),
+        );
+
+        assert_eq!(
+            err.to_string(),
+            "[write_kafka] delivery failed for topic \"topic\", partition 1, offset 2: broker unavailable"
+        );
+        assert_eq!(err.source().unwrap().to_string(), "broker unavailable");
     }
 }
 

--- a/src/daft-writers/src/kafka/record.rs
+++ b/src/daft-writers/src/kafka/record.rs
@@ -3,7 +3,7 @@ use common_error::{DaftError, DaftResult};
 #[cfg(test)]
 use super::producer::{KafkaHeader, KafkaOutgoingRecord};
 
-// TODO(native-kafka-write): remove once Task 8/9 validates records from writer integration.
+// TODO(native-kafka-write): remove once Task 9 validates records from writer projection.
 #[allow(dead_code)]
 pub(crate) fn validate_topic(topic: &str) -> DaftResult<()> {
     if topic.is_empty() {
@@ -15,7 +15,7 @@ pub(crate) fn validate_topic(topic: &str) -> DaftResult<()> {
     Ok(())
 }
 
-// TODO(native-kafka-write): remove once Task 8/9 validates records from writer integration.
+// TODO(native-kafka-write): remove once Task 9 validates records from writer projection.
 #[allow(dead_code)]
 pub(crate) fn validate_partition(partition: i32) -> DaftResult<()> {
     if partition < 0 {

--- a/src/daft-writers/src/kafka/record.rs
+++ b/src/daft-writers/src/kafka/record.rs
@@ -1,7 +1,10 @@
 use common_error::{DaftError, DaftResult};
 
+#[cfg(test)]
 use super::producer::{KafkaHeader, KafkaOutgoingRecord};
 
+// TODO(native-kafka-write): remove once Task 8/9 validates records from writer integration.
+#[allow(dead_code)]
 pub(crate) fn validate_topic(topic: &str) -> DaftResult<()> {
     if topic.is_empty() {
         return Err(DaftError::ValueError(
@@ -12,6 +15,8 @@ pub(crate) fn validate_topic(topic: &str) -> DaftResult<()> {
     Ok(())
 }
 
+// TODO(native-kafka-write): remove once Task 8/9 validates records from writer integration.
+#[allow(dead_code)]
 pub(crate) fn validate_partition(partition: i32) -> DaftResult<()> {
     if partition < 0 {
         return Err(DaftError::ValueError(format!(

--- a/src/daft-writers/src/kafka/record.rs
+++ b/src/daft-writers/src/kafka/record.rs
@@ -272,8 +272,16 @@ fn projected_timestamp(timestamp: &Series, row_idx: usize) -> DaftResult<Option<
 }
 
 fn literal_to_json_bytes(value: &Literal) -> DaftResult<Option<Vec<u8>>> {
+    if matches!(value, Literal::Null) {
+        return Ok(None);
+    }
+
+    Ok(Some(literal_to_json_string(value)?.into_bytes()))
+}
+
+fn literal_to_json_string(value: &Literal) -> DaftResult<String> {
     let json = match value {
-        Literal::Null => return Ok(None),
+        Literal::Null => "null".to_string(),
         Literal::Boolean(value) => value.to_string(),
         Literal::Utf8(value) => quote_json_string(value),
         Literal::Int8(value) => value.to_string(),
@@ -300,6 +308,30 @@ fn literal_to_json_bytes(value: &Literal) -> DaftResult<Option<Vec<u8>>> {
             }
             value.to_string()
         }
+        Literal::List(values) => {
+            let mut json = String::from("[");
+            for idx in 0..values.len() {
+                if idx > 0 {
+                    json.push(',');
+                }
+                json.push_str(&literal_to_json_string(&values.get_lit(idx))?);
+            }
+            json.push(']');
+            json
+        }
+        Literal::Struct(fields) => {
+            let mut json = String::from("{");
+            for (idx, (key, value)) in fields.iter().enumerate() {
+                if idx > 0 {
+                    json.push(',');
+                }
+                json.push_str(&quote_json_string(key));
+                json.push(':');
+                json.push_str(&literal_to_json_string(value)?);
+            }
+            json.push('}');
+            json
+        }
         other => {
             return Err(DaftError::ValueError(format!(
                 "[write_kafka] kafka JSON value does not yet support {}",
@@ -308,7 +340,7 @@ fn literal_to_json_bytes(value: &Literal) -> DaftResult<Option<Vec<u8>>> {
         }
     };
 
-    Ok(Some(json.into_bytes()))
+    Ok(json)
 }
 
 fn quote_json_string(value: &str) -> String {
@@ -533,6 +565,28 @@ mod tests {
 
         assert_eq!(records[0].value.as_deref(), Some(&b"\"hello\\nworld\""[..]));
         assert_eq!(records[1].value, None);
+    }
+
+    #[test]
+    fn json_struct_and_list_values_are_serialized_recursively() {
+        let list = Int64Array::from_iter(
+            Field::new("scores", DataType::Int64),
+            [Some(10), None, Some(30)],
+        )
+        .into_series();
+        let value = Literal::new_struct([
+            ("id".to_string(), Literal::Int64(1)),
+            ("kind".to_string(), Literal::Utf8("event".to_string())),
+            ("scores".to_string(), Literal::List(list)),
+            ("meta".to_string(), Literal::Null),
+        ]);
+
+        let json = literal_to_json_bytes(&value).unwrap().unwrap();
+
+        assert_eq!(
+            std::str::from_utf8(&json).unwrap(),
+            r#"{"id":1,"kind":"event","scores":[10,null,30],"meta":null}"#
+        );
     }
 
     #[test]

--- a/src/daft-writers/src/kafka/record.rs
+++ b/src/daft-writers/src/kafka/record.rs
@@ -1,10 +1,17 @@
+use std::fmt::Write as _;
+
 use common_error::{DaftError, DaftResult};
+use daft_core::prelude::{DataType, Literal, Series};
+use daft_dsl::expr::bound_expr::BoundExpr;
+use daft_logical_plan::sink_info::{
+    KafkaKeyFormat, KafkaPartition, KafkaTopic, KafkaValueFormat, KafkaWriteInfo,
+};
+use daft_micropartition::MicroPartition;
 
 #[cfg(test)]
-use super::producer::{KafkaHeader, KafkaOutgoingRecord};
+use super::producer::KafkaHeader;
+use super::{headers::headers_for_row, producer::KafkaOutgoingRecord};
 
-// TODO(native-kafka-write): remove once Task 9 validates records from writer projection.
-#[allow(dead_code)]
 pub(crate) fn validate_topic(topic: &str) -> DaftResult<()> {
     if topic.is_empty() {
         return Err(DaftError::ValueError(
@@ -15,8 +22,6 @@ pub(crate) fn validate_topic(topic: &str) -> DaftResult<()> {
     Ok(())
 }
 
-// TODO(native-kafka-write): remove once Task 9 validates records from writer projection.
-#[allow(dead_code)]
 pub(crate) fn validate_partition(partition: i32) -> DaftResult<()> {
     if partition < 0 {
         return Err(DaftError::ValueError(format!(
@@ -25,6 +30,293 @@ pub(crate) fn validate_partition(partition: i32) -> DaftResult<()> {
     }
 
     Ok(())
+}
+
+#[derive(Debug)]
+struct Projection {
+    exprs: Vec<BoundExpr>,
+    topic: Option<usize>,
+    value: usize,
+    key: Option<usize>,
+    headers: Option<usize>,
+    partition: Option<usize>,
+    timestamp_ms: Option<usize>,
+}
+
+impl Projection {
+    fn new(info: &KafkaWriteInfo<BoundExpr>) -> Self {
+        let mut exprs = Vec::new();
+        let topic = match &info.topic {
+            KafkaTopic::Static(_) => None,
+            KafkaTopic::Dynamic(expr) => Some(push_expr(&mut exprs, expr.clone())),
+        };
+        let value = push_expr(&mut exprs, info.value_col.clone());
+        let key = info
+            .key_col
+            .as_ref()
+            .map(|expr| push_expr(&mut exprs, expr.clone()));
+        let headers = info
+            .headers_col
+            .as_ref()
+            .map(|expr| push_expr(&mut exprs, expr.clone()));
+        let partition = match &info.partition {
+            Some(KafkaPartition::Dynamic(expr)) => Some(push_expr(&mut exprs, expr.clone())),
+            Some(KafkaPartition::Static(_)) | None => None,
+        };
+        let timestamp_ms = info
+            .timestamp_ms_col
+            .as_ref()
+            .map(|expr| push_expr(&mut exprs, expr.clone()));
+
+        Self {
+            exprs,
+            topic,
+            value,
+            key,
+            headers,
+            partition,
+            timestamp_ms,
+        }
+    }
+}
+
+fn push_expr(exprs: &mut Vec<BoundExpr>, expr: BoundExpr) -> usize {
+    let idx = exprs.len();
+    exprs.push(expr);
+    idx
+}
+
+pub(crate) fn records_from_micropartition(
+    input: &MicroPartition,
+    info: &KafkaWriteInfo<BoundExpr>,
+) -> DaftResult<Vec<KafkaOutgoingRecord>> {
+    if let KafkaTopic::Static(topic) = &info.topic {
+        validate_topic(topic)?;
+    }
+    if let Some(KafkaPartition::Static(partition)) = info.partition {
+        validate_partition(partition)?;
+    }
+
+    let projection = Projection::new(info);
+    let mut records = Vec::with_capacity(input.len());
+
+    for batch in input.record_batches() {
+        let projected = batch.eval_expression_list(&projection.exprs)?;
+        for row_idx in 0..projected.len() {
+            let topic = projected_topic(info, projection.topic, &projected, row_idx)?;
+            let key = projection
+                .key
+                .map(|idx| projected_key(projected.get_column(idx), row_idx, &info.key_format))
+                .transpose()?
+                .flatten();
+            let value = projected_value(
+                projected.get_column(projection.value),
+                row_idx,
+                &info.value_format,
+            )?;
+            let headers = projection
+                .headers
+                .map(|idx| headers_for_row(projected.get_column(idx), row_idx))
+                .transpose()?
+                .unwrap_or_default();
+            let partition = projected_partition(info, projection.partition, &projected, row_idx)?;
+            let timestamp_ms = projection
+                .timestamp_ms
+                .map(|idx| projected_timestamp(projected.get_column(idx), row_idx))
+                .transpose()?
+                .flatten();
+
+            records.push(KafkaOutgoingRecord {
+                topic,
+                key,
+                value,
+                headers,
+                partition,
+                timestamp_ms,
+            });
+        }
+    }
+
+    Ok(records)
+}
+
+fn projected_topic(
+    info: &KafkaWriteInfo<BoundExpr>,
+    topic_idx: Option<usize>,
+    projected: &daft_recordbatch::RecordBatch,
+    row_idx: usize,
+) -> DaftResult<String> {
+    match (&info.topic, topic_idx) {
+        (KafkaTopic::Static(topic), None) => Ok(topic.clone()),
+        (KafkaTopic::Dynamic(_), Some(idx)) => {
+            let topic = projected
+                .get_column(idx)
+                .utf8()
+                .map_err(|err| {
+                    DaftError::ValueError(format!(
+                        "[write_kafka] kafka dynamic topic must be Utf8: {err}"
+                    ))
+                })?
+                .get(row_idx)
+                .ok_or_else(|| {
+                    DaftError::ValueError(
+                        "[write_kafka] kafka dynamic topic must not be null".to_string(),
+                    )
+                })?;
+            validate_topic(topic)?;
+            Ok(topic.to_string())
+        }
+        _ => unreachable!("topic projection index must match topic configuration"),
+    }
+}
+
+fn projected_value(
+    value: &Series,
+    row_idx: usize,
+    format: &KafkaValueFormat,
+) -> DaftResult<Option<Vec<u8>>> {
+    match format {
+        KafkaValueFormat::Raw => Ok(value
+            .binary()
+            .map_err(|err| {
+                DaftError::ValueError(format!(
+                    "[write_kafka] kafka raw value must be Binary: {err}"
+                ))
+            })?
+            .get(row_idx)
+            .map(<[u8]>::to_vec)),
+        KafkaValueFormat::Utf8 => Ok(value
+            .utf8()
+            .map_err(|err| {
+                DaftError::ValueError(format!(
+                    "[write_kafka] kafka utf8 value must be Utf8: {err}"
+                ))
+            })?
+            .get(row_idx)
+            .map(|value| value.as_bytes().to_vec())),
+        KafkaValueFormat::Json => literal_to_json_bytes(&value.get_lit(row_idx)),
+    }
+}
+
+fn projected_key(
+    key: &Series,
+    row_idx: usize,
+    format: &KafkaKeyFormat,
+) -> DaftResult<Option<Vec<u8>>> {
+    match format {
+        KafkaKeyFormat::Raw => Ok(key
+            .binary()
+            .map_err(|err| {
+                DaftError::ValueError(format!("[write_kafka] kafka raw key must be Binary: {err}"))
+            })?
+            .get(row_idx)
+            .map(<[u8]>::to_vec)),
+        KafkaKeyFormat::Utf8 => Ok(key
+            .utf8()
+            .map_err(|err| {
+                DaftError::ValueError(format!("[write_kafka] kafka utf8 key must be Utf8: {err}"))
+            })?
+            .get(row_idx)
+            .map(|value| value.as_bytes().to_vec())),
+    }
+}
+
+fn projected_partition(
+    info: &KafkaWriteInfo<BoundExpr>,
+    partition_idx: Option<usize>,
+    projected: &daft_recordbatch::RecordBatch,
+    row_idx: usize,
+) -> DaftResult<Option<i32>> {
+    match (&info.partition, partition_idx) {
+        (Some(KafkaPartition::Static(partition)), None) => Ok(Some(*partition)),
+        (Some(KafkaPartition::Dynamic(_)), Some(idx)) => {
+            let partition = projected.get_column(idx);
+            let partition = match partition.data_type() {
+                DataType::Int32 => partition.i32()?.get(row_idx),
+                DataType::Int64 => partition
+                    .i64()?
+                    .get(row_idx)
+                    .map(|value| {
+                        i32::try_from(value).map_err(|_| {
+                            DaftError::ValueError(format!(
+                                "[write_kafka] kafka partition must fit Int32, got {value}"
+                            ))
+                        })
+                    })
+                    .transpose()?,
+                other => {
+                    return Err(DaftError::ValueError(format!(
+                        "[write_kafka] kafka dynamic partition must be Int32 or Int64, got {other}"
+                    )));
+                }
+            };
+            if let Some(partition) = partition {
+                validate_partition(partition)?;
+            }
+            Ok(partition)
+        }
+        (None, None) => Ok(None),
+        _ => unreachable!("partition projection index must match partition configuration"),
+    }
+}
+
+fn projected_timestamp(timestamp: &Series, row_idx: usize) -> DaftResult<Option<i64>> {
+    timestamp
+        .i64()
+        .map_err(|err| {
+            DaftError::ValueError(format!(
+                "[write_kafka] kafka timestamp_ms must be Int64: {err}"
+            ))
+        })
+        .map(|timestamp| timestamp.get(row_idx))
+}
+
+fn literal_to_json_bytes(value: &Literal) -> DaftResult<Option<Vec<u8>>> {
+    let json = match value {
+        Literal::Null => return Ok(None),
+        Literal::Boolean(value) => value.to_string(),
+        Literal::Utf8(value) => quote_json_string(value),
+        Literal::Int8(value) => value.to_string(),
+        Literal::UInt8(value) => value.to_string(),
+        Literal::Int16(value) => value.to_string(),
+        Literal::UInt16(value) => value.to_string(),
+        Literal::Int32(value) => value.to_string(),
+        Literal::UInt32(value) => value.to_string(),
+        Literal::Int64(value) => value.to_string(),
+        Literal::UInt64(value) => value.to_string(),
+        Literal::Float32(value) if value.is_finite() => value.to_string(),
+        Literal::Float64(value) if value.is_finite() => value.to_string(),
+        other => {
+            return Err(DaftError::ValueError(format!(
+                "[write_kafka] kafka JSON value does not yet support {}",
+                other.get_type()
+            )));
+        }
+    };
+
+    Ok(Some(json.into_bytes()))
+}
+
+fn quote_json_string(value: &str) -> String {
+    let mut quoted = String::with_capacity(value.len() + 2);
+    quoted.push('"');
+    for ch in value.chars() {
+        match ch {
+            '"' => quoted.push_str("\\\""),
+            '\\' => quoted.push_str("\\\\"),
+            '\u{08}' => quoted.push_str("\\b"),
+            '\u{0c}' => quoted.push_str("\\f"),
+            '\n' => quoted.push_str("\\n"),
+            '\r' => quoted.push_str("\\r"),
+            '\t' => quoted.push_str("\\t"),
+            ch if ch < '\u{20}' => {
+                write!(quoted, "\\u{:04x}", ch as u32).expect("writing to String cannot fail");
+            }
+            ch => quoted.push(ch),
+        }
+    }
+    quoted.push('"');
+    quoted
 }
 
 #[cfg(test)]
@@ -53,8 +345,39 @@ pub(crate) fn make_test_record(
 
 #[cfg(test)]
 mod tests {
+    use std::{collections::BTreeMap, sync::Arc};
+
+    use daft_core::prelude::{BinaryArray, Field, Int64Array, IntoSeries, Utf8Array};
+    use daft_dsl::bound_col;
+    use daft_logical_plan::sink_info::{KafkaKeyFormat, KafkaTopic};
+    use daft_recordbatch::RecordBatch;
+
     use super::*;
     use crate::kafka::headers::make_header;
+
+    fn bound(index: usize, name: &str, dtype: DataType) -> BoundExpr {
+        BoundExpr::new_unchecked(bound_col(index, Field::new(name, dtype)))
+    }
+
+    fn micropartition(batch: RecordBatch) -> MicroPartition {
+        MicroPartition::new_loaded(batch.schema.clone(), Arc::new(vec![batch]), None)
+    }
+
+    fn kafka_info(value_format: KafkaValueFormat) -> KafkaWriteInfo<BoundExpr> {
+        KafkaWriteInfo {
+            bootstrap_servers: "localhost:9092".to_string(),
+            topic: KafkaTopic::Static("topic".to_string()),
+            value_col: bound(1, "value", DataType::Binary),
+            key_col: Some(bound(0, "key", DataType::Binary)),
+            headers_col: None,
+            partition: None,
+            timestamp_ms_col: None,
+            value_format,
+            key_format: KafkaKeyFormat::Raw,
+            kafka_client_config: BTreeMap::new(),
+            timeout_ms: 10,
+        }
+    }
 
     #[test]
     fn makes_valid_record_and_counts_bytes() {
@@ -98,6 +421,122 @@ mod tests {
     fn rejects_negative_partition() {
         let err =
             make_test_record("topic", None, Some(b"value"), vec![], Some(-1), None).unwrap_err();
+
+        assert!(err.to_string().contains("[write_kafka]"));
+        assert!(err.to_string().contains("partition"));
+    }
+
+    #[test]
+    fn projects_raw_binary_records_from_micropartition() {
+        let batch = RecordBatch::from_nonempty_columns(vec![
+            BinaryArray::from_iter("key", [Some(b"k1".as_slice()), None]).into_series(),
+            BinaryArray::from_iter("value", [Some(b"v1".as_slice()), None]).into_series(),
+        ])
+        .unwrap();
+        let input = micropartition(batch);
+
+        let records =
+            records_from_micropartition(&input, &kafka_info(KafkaValueFormat::Raw)).unwrap();
+
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].topic, "topic");
+        assert_eq!(records[0].key.as_deref(), Some(&b"k1"[..]));
+        assert_eq!(records[0].value.as_deref(), Some(&b"v1"[..]));
+        assert_eq!(records[1].key, None);
+        assert_eq!(records[1].value, None);
+    }
+
+    #[test]
+    fn projects_dynamic_topic_partition_and_timestamp() {
+        let batch = RecordBatch::from_nonempty_columns(vec![
+            Utf8Array::from_iter("topic", [Some("a"), Some("b")]).into_series(),
+            BinaryArray::from_iter("value", [Some(b"v1".as_slice()), Some(b"v2".as_slice())])
+                .into_series(),
+            Int64Array::from_iter(Field::new("partition", DataType::Int64), [Some(2), None])
+                .into_series(),
+            Int64Array::from_iter(Field::new("ts", DataType::Int64), [Some(1000), None])
+                .into_series(),
+        ])
+        .unwrap();
+        let input = micropartition(batch);
+        let mut info = kafka_info(KafkaValueFormat::Raw);
+        info.topic = KafkaTopic::Dynamic(bound(0, "topic", DataType::Utf8));
+        info.value_col = bound(1, "value", DataType::Binary);
+        info.key_col = None;
+        info.partition = Some(KafkaPartition::Dynamic(bound(
+            2,
+            "partition",
+            DataType::Int64,
+        )));
+        info.timestamp_ms_col = Some(bound(3, "ts", DataType::Int64));
+
+        let records = records_from_micropartition(&input, &info).unwrap();
+
+        assert_eq!(records[0].topic, "a");
+        assert_eq!(records[0].partition, Some(2));
+        assert_eq!(records[0].timestamp_ms, Some(1000));
+        assert_eq!(records[1].topic, "b");
+        assert_eq!(records[1].partition, None);
+        assert_eq!(records[1].timestamp_ms, None);
+    }
+
+    #[test]
+    fn rejects_null_or_empty_dynamic_topic() {
+        for topic in [None, Some("")] {
+            let batch = RecordBatch::from_nonempty_columns(vec![
+                Utf8Array::from_iter("topic", [topic]).into_series(),
+                BinaryArray::from_iter("value", [Some(b"value".as_slice())]).into_series(),
+            ])
+            .unwrap();
+            let input = micropartition(batch);
+            let mut info = kafka_info(KafkaValueFormat::Raw);
+            info.topic = KafkaTopic::Dynamic(bound(0, "topic", DataType::Utf8));
+            info.value_col = bound(1, "value", DataType::Binary);
+            info.key_col = None;
+
+            let err = records_from_micropartition(&input, &info).unwrap_err();
+
+            assert!(err.to_string().contains("[write_kafka]"));
+            assert!(err.to_string().contains("topic"));
+        }
+    }
+
+    #[test]
+    fn json_utf8_value_is_quoted_and_null_is_tombstone() {
+        let batch = RecordBatch::from_nonempty_columns(vec![
+            Utf8Array::from_iter("value", [Some("hello\nworld"), None]).into_series(),
+        ])
+        .unwrap();
+        let input = micropartition(batch);
+        let mut info = kafka_info(KafkaValueFormat::Json);
+        info.value_col = bound(0, "value", DataType::Utf8);
+        info.key_col = None;
+
+        let records = records_from_micropartition(&input, &info).unwrap();
+
+        assert_eq!(records[0].value.as_deref(), Some(&b"\"hello\\nworld\""[..]));
+        assert_eq!(records[1].value, None);
+    }
+
+    #[test]
+    fn rejects_negative_dynamic_partition() {
+        let batch = RecordBatch::from_nonempty_columns(vec![
+            BinaryArray::from_iter("value", [Some(b"value".as_slice())]).into_series(),
+            Int64Array::from_iter(Field::new("partition", DataType::Int64), [Some(-1)])
+                .into_series(),
+        ])
+        .unwrap();
+        let input = micropartition(batch);
+        let mut info = kafka_info(KafkaValueFormat::Raw);
+        info.value_col = bound(0, "value", DataType::Binary);
+        info.key_col = None;
+        info.partition = Some(KafkaPartition::Dynamic(bound(
+            1,
+            "partition",
+            DataType::Int64,
+        )));
+
+        let err = records_from_micropartition(&input, &info).unwrap_err();
 
         assert!(err.to_string().contains("[write_kafka]"));
         assert!(err.to_string().contains("partition"));

--- a/src/daft-writers/src/kafka/record.rs
+++ b/src/daft-writers/src/kafka/record.rs
@@ -284,8 +284,22 @@ fn literal_to_json_bytes(value: &Literal) -> DaftResult<Option<Vec<u8>>> {
         Literal::UInt32(value) => value.to_string(),
         Literal::Int64(value) => value.to_string(),
         Literal::UInt64(value) => value.to_string(),
-        Literal::Float32(value) if value.is_finite() => value.to_string(),
-        Literal::Float64(value) if value.is_finite() => value.to_string(),
+        Literal::Float32(value) => {
+            if !value.is_finite() {
+                return Err(DaftError::ValueError(
+                    "[write_kafka] kafka JSON numeric value must be finite".to_string(),
+                ));
+            }
+            value.to_string()
+        }
+        Literal::Float64(value) => {
+            if !value.is_finite() {
+                return Err(DaftError::ValueError(
+                    "[write_kafka] kafka JSON numeric value must be finite".to_string(),
+                ));
+            }
+            value.to_string()
+        }
         other => {
             return Err(DaftError::ValueError(format!(
                 "[write_kafka] kafka JSON value does not yet support {}",
@@ -347,7 +361,10 @@ pub(crate) fn make_test_record(
 mod tests {
     use std::{collections::BTreeMap, sync::Arc};
 
-    use daft_core::prelude::{BinaryArray, Field, Int64Array, IntoSeries, Utf8Array};
+    use daft_core::prelude::{
+        BinaryArray, Field, Float32Array, Float64Array, Int32Array, Int64Array, IntoSeries,
+        Utf8Array,
+    };
     use daft_dsl::bound_col;
     use daft_logical_plan::sink_info::{KafkaKeyFormat, KafkaTopic};
     use daft_recordbatch::RecordBatch;
@@ -516,6 +533,88 @@ mod tests {
 
         assert_eq!(records[0].value.as_deref(), Some(&b"\"hello\\nworld\""[..]));
         assert_eq!(records[1].value, None);
+    }
+
+    #[test]
+    fn rejects_non_finite_json_float_values() {
+        for (value, dtype) in [
+            (
+                Float32Array::from_slice("value", &[f32::NAN]).into_series(),
+                DataType::Float32,
+            ),
+            (
+                Float32Array::from_slice("value", &[f32::INFINITY]).into_series(),
+                DataType::Float32,
+            ),
+            (
+                Float64Array::from_slice("value", &[f64::NEG_INFINITY]).into_series(),
+                DataType::Float64,
+            ),
+        ] {
+            let batch = RecordBatch::from_nonempty_columns(vec![value]).unwrap();
+            let input = micropartition(batch);
+            let mut info = kafka_info(KafkaValueFormat::Json);
+            info.value_col = bound(0, "value", dtype);
+            info.key_col = None;
+
+            let err = records_from_micropartition(&input, &info).unwrap_err();
+
+            assert!(err.to_string().contains("[write_kafka]"));
+            assert!(
+                err.to_string()
+                    .contains("JSON numeric value must be finite")
+            );
+        }
+    }
+
+    #[test]
+    fn projects_int32_dynamic_partition() {
+        let batch = RecordBatch::from_nonempty_columns(vec![
+            BinaryArray::from_iter("value", [Some(b"value".as_slice())]).into_series(),
+            Int32Array::from_iter(Field::new("partition", DataType::Int32), [Some(7)])
+                .into_series(),
+        ])
+        .unwrap();
+        let input = micropartition(batch);
+        let mut info = kafka_info(KafkaValueFormat::Raw);
+        info.value_col = bound(0, "value", DataType::Binary);
+        info.key_col = None;
+        info.partition = Some(KafkaPartition::Dynamic(bound(
+            1,
+            "partition",
+            DataType::Int32,
+        )));
+
+        let records = records_from_micropartition(&input, &info).unwrap();
+
+        assert_eq!(records[0].partition, Some(7));
+    }
+
+    #[test]
+    fn rejects_int64_dynamic_partition_overflow() {
+        let batch = RecordBatch::from_nonempty_columns(vec![
+            BinaryArray::from_iter("value", [Some(b"value".as_slice())]).into_series(),
+            Int64Array::from_iter(
+                Field::new("partition", DataType::Int64),
+                [Some(i64::from(i32::MAX) + 1)],
+            )
+            .into_series(),
+        ])
+        .unwrap();
+        let input = micropartition(batch);
+        let mut info = kafka_info(KafkaValueFormat::Raw);
+        info.value_col = bound(0, "value", DataType::Binary);
+        info.key_col = None;
+        info.partition = Some(KafkaPartition::Dynamic(bound(
+            1,
+            "partition",
+            DataType::Int64,
+        )));
+
+        let err = records_from_micropartition(&input, &info).unwrap_err();
+
+        assert!(err.to_string().contains("[write_kafka]"));
+        assert!(err.to_string().contains("must fit Int32"));
     }
 
     #[test]

--- a/src/daft-writers/src/kafka/record.rs
+++ b/src/daft-writers/src/kafka/record.rs
@@ -1,0 +1,100 @@
+use common_error::{DaftError, DaftResult};
+
+use super::producer::{KafkaHeader, KafkaOutgoingRecord};
+
+pub(crate) fn validate_topic(topic: &str) -> DaftResult<()> {
+    if topic.is_empty() {
+        return Err(DaftError::ValueError(
+            "[write_kafka] kafka topic must not be empty".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+pub(crate) fn validate_partition(partition: i32) -> DaftResult<()> {
+    if partition < 0 {
+        return Err(DaftError::ValueError(format!(
+            "[write_kafka] kafka partition must be non-negative, got {partition}"
+        )));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+pub(crate) fn make_test_record(
+    topic: &str,
+    key: Option<&[u8]>,
+    value: Option<&[u8]>,
+    headers: Vec<KafkaHeader>,
+    partition: Option<i32>,
+    timestamp_ms: Option<i64>,
+) -> DaftResult<KafkaOutgoingRecord> {
+    validate_topic(topic)?;
+    if let Some(partition) = partition {
+        validate_partition(partition)?;
+    }
+
+    Ok(KafkaOutgoingRecord {
+        topic: topic.to_string(),
+        key: key.map(<[u8]>::to_vec),
+        value: value.map(<[u8]>::to_vec),
+        headers,
+        partition,
+        timestamp_ms,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kafka::headers::make_header;
+
+    #[test]
+    fn makes_valid_record_and_counts_bytes() {
+        let record = make_test_record(
+            "topic",
+            Some(b"key"),
+            Some(b"value"),
+            vec![make_header("h", Some(b"v")).unwrap()],
+            Some(3),
+            Some(456),
+        )
+        .unwrap();
+
+        assert_eq!(record.topic, "topic");
+        assert_eq!(record.key.as_deref(), Some(&b"key"[..]));
+        assert_eq!(record.value.as_deref(), Some(&b"value"[..]));
+        assert_eq!(record.partition, Some(3));
+        assert_eq!(record.timestamp_ms, Some(456));
+        assert_eq!(record.delivered_bytes(), 3 + 5 + 1 + 1);
+    }
+
+    #[test]
+    fn supports_tombstone_value() {
+        let record =
+            make_test_record("topic", Some(b"key"), None, vec![], None, Some(789)).unwrap();
+
+        assert_eq!(record.value, None);
+        assert_eq!(record.timestamp_ms, Some(789));
+        assert_eq!(record.delivered_bytes(), 3);
+    }
+
+    #[test]
+    fn rejects_empty_topic() {
+        let err = make_test_record("", None, Some(b"value"), vec![], None, None).unwrap_err();
+
+        assert!(err.to_string().contains("[write_kafka]"));
+        assert!(err.to_string().contains("topic"));
+    }
+
+    #[test]
+    fn rejects_negative_partition() {
+        let err =
+            make_test_record("topic", None, Some(b"value"), vec![], Some(-1), None).unwrap_err();
+
+        assert!(err.to_string().contains("[write_kafka]"));
+        assert!(err.to_string().contains("partition"));
+    }
+}

--- a/src/daft-writers/src/kafka/writer.rs
+++ b/src/daft-writers/src/kafka/writer.rs
@@ -101,8 +101,8 @@ impl<P: KafkaProducer> AsyncFileWriter for KafkaWriter<P> {
         }
 
         Ok(WriteResult {
-            rows_written,
             bytes_written,
+            rows_written,
         })
     }
 

--- a/src/daft-writers/src/kafka/writer.rs
+++ b/src/daft-writers/src/kafka/writer.rs
@@ -11,7 +11,7 @@ use rdkafka::producer::FutureProducer;
 use super::{
     accounting::KafkaWriteAccounting,
     config::build_client_config,
-    producer::{KafkaProducer, RdkafkaProducer},
+    producer::{KafkaExternalError, KafkaProducer, RdkafkaProducer},
 };
 use crate::{AsyncFileWriter, WriteResult, WriterFactory};
 
@@ -40,9 +40,10 @@ impl WriterFactory for KafkaWriterFactory {
         )?
         .create()
         .map_err(|err| {
-            DaftError::External(
-                format!("[write_kafka] failed to create Kafka producer: {err}").into(),
-            )
+            DaftError::External(Box::new(KafkaExternalError::new(
+                "failed to create Kafka producer",
+                err,
+            )))
         })?;
 
         Ok(Box::new(KafkaWriter::new(

--- a/src/daft-writers/src/kafka/writer.rs
+++ b/src/daft-writers/src/kafka/writer.rs
@@ -12,6 +12,7 @@ use super::{
     accounting::KafkaWriteAccounting,
     config::build_client_config,
     producer::{KafkaExternalError, KafkaProducer, RdkafkaProducer},
+    record::records_from_micropartition,
 };
 use crate::{AsyncFileWriter, WriteResult, WriterFactory};
 
@@ -79,10 +80,29 @@ impl<P: KafkaProducer> AsyncFileWriter for KafkaWriter<P> {
     type Input = MicroPartition;
     type Result = Vec<RecordBatch>;
 
-    async fn write(&mut self, _data: Self::Input) -> DaftResult<WriteResult> {
-        Err(DaftError::not_implemented(
-            "[write_kafka] row projection is not wired into KafkaWriter yet",
-        ))
+    async fn write(&mut self, data: Self::Input) -> DaftResult<WriteResult> {
+        let records = records_from_micropartition(&data, &self.kafka_info)?;
+        let queue_timeout = Duration::from_millis(self.kafka_info.timeout_ms);
+        let mut rows_written = 0usize;
+        let mut bytes_written = 0usize;
+
+        for record in records {
+            self.accounting.record_attempt();
+            let delivered_bytes = record.delivered_bytes();
+            if let Err(err) = self.producer.send(record, queue_timeout).await {
+                self.accounting.record_failure(err.to_string());
+                return Err(err);
+            }
+
+            self.accounting.record_delivery(delivered_bytes);
+            rows_written = rows_written.saturating_add(1);
+            bytes_written = bytes_written.saturating_add(delivered_bytes);
+        }
+
+        Ok(WriteResult {
+            rows_written,
+            bytes_written,
+        })
     }
 
     async fn close(&mut self) -> DaftResult<Self::Result> {
@@ -105,7 +125,7 @@ impl<P: KafkaProducer> AsyncFileWriter for KafkaWriter<P> {
 mod tests {
     use std::{collections::BTreeMap, sync::Arc};
 
-    use daft_core::prelude::{DataType, Field, Schema};
+    use daft_core::prelude::{BinaryArray, DataType, Field, IntoSeries};
     use daft_dsl::bound_col;
     use daft_logical_plan::sink_info::{KafkaKeyFormat, KafkaTopic, KafkaValueFormat};
 
@@ -116,8 +136,14 @@ mod tests {
         KafkaWriteInfo {
             bootstrap_servers: "localhost:9092".to_string(),
             topic: KafkaTopic::Static("topic".to_string()),
-            value_col: BoundExpr::new_unchecked(bound_col(0, Field::new("value", DataType::Utf8))),
-            key_col: None,
+            value_col: BoundExpr::new_unchecked(bound_col(
+                1,
+                Field::new("value", DataType::Binary),
+            )),
+            key_col: Some(BoundExpr::new_unchecked(bound_col(
+                0,
+                Field::new("key", DataType::Binary),
+            ))),
             headers_col: None,
             partition: None,
             timestamp_ms_col: None,
@@ -128,23 +154,105 @@ mod tests {
         }
     }
 
+    fn input_partition() -> MicroPartition {
+        let batch = RecordBatch::from_nonempty_columns(vec![
+            BinaryArray::from_iter("key", [Some(b"k1".as_slice()), Some(b"k2".as_slice())])
+                .into_series(),
+            BinaryArray::from_iter("value", [Some(b"v1".as_slice()), None]).into_series(),
+        ])
+        .unwrap();
+        MicroPartition::new_loaded(batch.schema.clone(), Arc::new(vec![batch]), None)
+    }
+
     #[tokio::test]
-    async fn write_returns_not_implemented_until_row_projection_is_wired() {
+    async fn write_sends_projected_records_and_updates_bytes() {
         let mut writer = KafkaWriter::new(kafka_info(1), FakeProducer::succeeding(), 3);
-        let result = writer
-            .write(MicroPartition::empty(Some(Arc::new(Schema::empty()))))
-            .await;
-        let err = match result {
-            Ok(_) => panic!("KafkaWriter::write should fail before row projection is wired"),
+
+        let result = writer.write(input_partition()).await.unwrap();
+
+        assert_eq!(result.rows_written, 2);
+        assert_eq!(result.bytes_written, 6);
+        assert_eq!(writer.bytes_written(), 6);
+        assert_eq!(writer.bytes_per_file(), vec![6]);
+        let sent = writer.producer.sent_records();
+        assert_eq!(sent.len(), 2);
+        assert_eq!(sent[0].topic, "topic");
+        assert_eq!(sent[0].key.as_deref(), Some(&b"k1"[..]));
+        assert_eq!(sent[0].value.as_deref(), Some(&b"v1"[..]));
+        assert_eq!(sent[1].key.as_deref(), Some(&b"k2"[..]));
+        assert_eq!(sent[1].value, None);
+
+        let batches = writer.close().await.unwrap();
+        assert_eq!(
+            batches[0].columns()[1]
+                .as_materialized_series()
+                .i64()
+                .unwrap()
+                .get(0),
+            Some(2)
+        );
+        assert_eq!(
+            batches[0].columns()[2]
+                .as_materialized_series()
+                .i64()
+                .unwrap()
+                .get(0),
+            Some(2)
+        );
+        assert_eq!(
+            batches[0].columns()[4]
+                .as_materialized_series()
+                .i64()
+                .unwrap()
+                .get(0),
+            Some(6)
+        );
+        assert!(!batches[0].columns()[5].as_materialized_series().is_valid(0));
+    }
+
+    #[tokio::test]
+    async fn write_records_failure_accounting_and_returns_error() {
+        let producer =
+            FakeProducer::with_delivery_results(vec![Err(delivery_error("delivery failed"))]);
+        let mut writer = KafkaWriter::new(kafka_info(1), producer, 3);
+
+        let err = match writer.write(input_partition()).await {
+            Ok(_) => panic!("KafkaWriter::write should fail when producer delivery fails"),
             Err(err) => err,
         };
 
-        assert!(
-            err.to_string()
-                .contains("[write_kafka] row projection is not wired")
-        );
+        assert!(err.to_string().contains("[write_kafka] delivery failed"));
         assert_eq!(writer.bytes_written(), 0);
-        assert_eq!(writer.bytes_per_file(), vec![0]);
+        assert_eq!(writer.producer.sent_records().len(), 1);
+        let batches = writer.close().await.unwrap();
+        assert_eq!(
+            batches[0].columns()[1]
+                .as_materialized_series()
+                .i64()
+                .unwrap()
+                .get(0),
+            Some(1)
+        );
+        assert_eq!(
+            batches[0].columns()[2]
+                .as_materialized_series()
+                .i64()
+                .unwrap()
+                .get(0),
+            Some(0)
+        );
+        assert_eq!(
+            batches[0].columns()[3]
+                .as_materialized_series()
+                .i64()
+                .unwrap()
+                .get(0),
+            Some(1)
+        );
+        assert_eq!(
+            batches[0].columns()[5].str_value(0).unwrap(),
+            "DaftError::External [write_kafka] delivery failed"
+        );
     }
 
     #[tokio::test]

--- a/src/daft-writers/src/kafka/writer.rs
+++ b/src/daft-writers/src/kafka/writer.rs
@@ -1,0 +1,178 @@
+use std::{sync::Arc, time::Duration};
+
+use async_trait::async_trait;
+use common_error::{DaftError, DaftResult};
+use daft_dsl::expr::bound_expr::BoundExpr;
+use daft_logical_plan::sink_info::KafkaWriteInfo;
+use daft_micropartition::MicroPartition;
+use daft_recordbatch::RecordBatch;
+use rdkafka::producer::FutureProducer;
+
+use super::{
+    accounting::KafkaWriteAccounting,
+    config::build_client_config,
+    producer::{KafkaProducer, RdkafkaProducer},
+};
+use crate::{AsyncFileWriter, WriteResult, WriterFactory};
+
+pub fn make_kafka_writer_factory(
+    kafka_info: KafkaWriteInfo<BoundExpr>,
+) -> Arc<dyn WriterFactory<Input = MicroPartition, Result = Vec<RecordBatch>>> {
+    Arc::new(KafkaWriterFactory { kafka_info })
+}
+
+pub(crate) struct KafkaWriterFactory {
+    kafka_info: KafkaWriteInfo<BoundExpr>,
+}
+
+impl WriterFactory for KafkaWriterFactory {
+    type Input = MicroPartition;
+    type Result = Vec<RecordBatch>;
+
+    fn create_writer(
+        &self,
+        file_idx: usize,
+        _partition_values: Option<&RecordBatch>,
+    ) -> DaftResult<Box<dyn AsyncFileWriter<Input = Self::Input, Result = Self::Result>>> {
+        let producer: FutureProducer = build_client_config(
+            &self.kafka_info.bootstrap_servers,
+            &self.kafka_info.kafka_client_config,
+        )?
+        .create()
+        .map_err(|err| {
+            DaftError::External(
+                format!("[write_kafka] failed to create Kafka producer: {err}").into(),
+            )
+        })?;
+
+        Ok(Box::new(KafkaWriter::new(
+            self.kafka_info.clone(),
+            RdkafkaProducer::new(producer),
+            file_idx as i64,
+        )))
+    }
+}
+
+pub(crate) struct KafkaWriter<P: KafkaProducer> {
+    kafka_info: KafkaWriteInfo<BoundExpr>,
+    producer: P,
+    accounting: KafkaWriteAccounting,
+}
+
+impl<P: KafkaProducer> KafkaWriter<P> {
+    pub(crate) fn new(kafka_info: KafkaWriteInfo<BoundExpr>, producer: P, task_id: i64) -> Self {
+        Self {
+            kafka_info,
+            producer,
+            accounting: KafkaWriteAccounting::new(task_id),
+        }
+    }
+
+    fn delivered_bytes(&self) -> usize {
+        usize::try_from(self.accounting.bytes_delivered).unwrap_or(usize::MAX)
+    }
+}
+
+#[async_trait]
+impl<P: KafkaProducer> AsyncFileWriter for KafkaWriter<P> {
+    type Input = MicroPartition;
+    type Result = Vec<RecordBatch>;
+
+    async fn write(&mut self, _data: Self::Input) -> DaftResult<WriteResult> {
+        Err(DaftError::not_implemented(
+            "[write_kafka] row projection is not wired into KafkaWriter yet",
+        ))
+    }
+
+    async fn close(&mut self) -> DaftResult<Self::Result> {
+        self.producer
+            .flush(Duration::from_millis(self.kafka_info.timeout_ms))
+            .await?;
+        Ok(vec![self.accounting.to_record_batch()?])
+    }
+
+    fn bytes_written(&self) -> usize {
+        self.delivered_bytes()
+    }
+
+    fn bytes_per_file(&self) -> Vec<usize> {
+        vec![self.delivered_bytes()]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::BTreeMap, sync::Arc};
+
+    use daft_core::prelude::{DataType, Field, Schema};
+    use daft_dsl::bound_col;
+    use daft_logical_plan::sink_info::{KafkaKeyFormat, KafkaTopic, KafkaValueFormat};
+
+    use super::*;
+    use crate::kafka::producer::{FakeProducer, delivery_error};
+
+    fn kafka_info(timeout_ms: u64) -> KafkaWriteInfo<BoundExpr> {
+        KafkaWriteInfo {
+            bootstrap_servers: "localhost:9092".to_string(),
+            topic: KafkaTopic::Static("topic".to_string()),
+            value_col: BoundExpr::new_unchecked(bound_col(0, Field::new("value", DataType::Utf8))),
+            key_col: None,
+            headers_col: None,
+            partition: None,
+            timestamp_ms_col: None,
+            value_format: KafkaValueFormat::Raw,
+            key_format: KafkaKeyFormat::Raw,
+            kafka_client_config: BTreeMap::new(),
+            timeout_ms,
+        }
+    }
+
+    #[tokio::test]
+    async fn write_returns_not_implemented_until_row_projection_is_wired() {
+        let mut writer = KafkaWriter::new(kafka_info(1), FakeProducer::succeeding(), 3);
+        let result = writer
+            .write(MicroPartition::empty(Some(Arc::new(Schema::empty()))))
+            .await;
+        let err = match result {
+            Ok(_) => panic!("KafkaWriter::write should fail before row projection is wired"),
+            Err(err) => err,
+        };
+
+        assert!(
+            err.to_string()
+                .contains("[write_kafka] row projection is not wired")
+        );
+        assert_eq!(writer.bytes_written(), 0);
+        assert_eq!(writer.bytes_per_file(), vec![0]);
+    }
+
+    #[tokio::test]
+    async fn close_flushes_and_returns_accounting_batch() {
+        let mut writer = KafkaWriter::new(kafka_info(25), FakeProducer::succeeding(), 7);
+
+        let batches = writer.close().await.unwrap();
+
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].len(), 1);
+        assert_eq!(
+            batches[0].columns()[0]
+                .as_materialized_series()
+                .i64()
+                .unwrap()
+                .get(0),
+            Some(7)
+        );
+        assert_eq!(writer.bytes_written(), 0);
+        assert_eq!(writer.bytes_per_file(), vec![0]);
+    }
+
+    #[tokio::test]
+    async fn close_surfaces_flush_error() {
+        let producer = FakeProducer::with_flush_result(Err(delivery_error("flush failed")));
+        let mut writer = KafkaWriter::new(kafka_info(25), producer, 7);
+
+        let err = writer.close().await.unwrap_err();
+
+        assert!(err.to_string().contains("[write_kafka] flush failed"));
+    }
+}

--- a/src/daft-writers/src/kafka/writer.rs
+++ b/src/daft-writers/src/kafka/writer.rs
@@ -38,6 +38,7 @@ impl WriterFactory for KafkaWriterFactory {
         let producer: FutureProducer = build_client_config(
             &self.kafka_info.bootstrap_servers,
             &self.kafka_info.kafka_client_config,
+            self.kafka_info.timeout_ms,
         )?
         .create()
         .map_err(|err| {

--- a/src/daft-writers/src/lib.rs
+++ b/src/daft-writers/src/lib.rs
@@ -45,6 +45,8 @@ use daft_micropartition::MicroPartition;
 use daft_recordbatch::RecordBatch;
 use file::TargetFileSizeWriterFactory;
 use ipc::IPCWriterFactory;
+#[cfg(feature = "kafka")]
+pub use kafka::writer::make_kafka_writer_factory;
 #[cfg(feature = "python")]
 pub use lance::make_lance_writer_factory;
 use partition::PartitionedWriterFactory;

--- a/src/daft-writers/src/lib.rs
+++ b/src/daft-writers/src/lib.rs
@@ -4,6 +4,8 @@ mod csv_writer;
 mod file;
 mod ipc;
 mod json_writer;
+#[cfg(feature = "kafka")]
+mod kafka;
 mod parquet_writer;
 mod partition;
 pub mod physical;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,10 @@ def pytest_configure(config):
         "markers",
         "integration: mark test as an integration test that runs with external dependencies",
     )
+    config.addinivalue_line(
+        "markers",
+        "local_e2e: mark opt-in local end-to-end tests",
+    )
 
 
 def get_tests_daft_runner_name() -> Literal["ray"] | Literal["native"]:

--- a/tests/integration/io/test_kafka_integration.py
+++ b/tests/integration/io/test_kafka_integration.py
@@ -4,6 +4,7 @@ import json
 import time
 import uuid
 from collections.abc import Iterator
+from contextlib import suppress
 from datetime import datetime, timezone
 
 import pytest
@@ -14,9 +15,11 @@ import daft
 def _wait_for_kafka_ready(bootstrap: str, timeout_s: int = 60) -> None:
     confluent_kafka = pytest.importorskip("confluent_kafka")
 
+    readiness_errors = (confluent_kafka.KafkaException, OSError, RuntimeError, TimeoutError)
     deadline = time.time() + timeout_s
     last: Exception | None = None
     while time.time() < deadline:
+        consumer = None
         try:
             consumer = confluent_kafka.Consumer(
                 {
@@ -26,11 +29,14 @@ def _wait_for_kafka_ready(bootstrap: str, timeout_s: int = 60) -> None:
                 }
             )
             consumer.list_topics(timeout=5)
-            consumer.close()
             return
-        except confluent_kafka.KafkaException as e:
+        except readiness_errors as e:
             last = e
             time.sleep(1)
+        finally:
+            if consumer is not None:
+                with suppress(*readiness_errors):
+                    consumer.close()
     raise RuntimeError(f"Kafka was not ready after {timeout_s}s: {last}")
 
 
@@ -124,6 +130,35 @@ def _read_topic(*, bootstrap: str, topic: str) -> list[dict]:
         .collect()
         .to_pylist()
     )
+
+
+def _consume_raw_messages(*, bootstrap: str, topic: str, count: int) -> list[object]:
+    confluent_kafka = pytest.importorskip("confluent_kafka")
+    consumer = confluent_kafka.Consumer(
+        {
+            "bootstrap.servers": bootstrap,
+            "group.id": f"daft-kafka-integration-{uuid.uuid4().hex}",
+            "auto.offset.reset": "earliest",
+            "enable.auto.commit": "false",
+        }
+    )
+    consumer.subscribe([topic])
+    deadline = time.time() + 20
+    messages: list[object] = []
+    try:
+        while time.time() < deadline and len(messages) < count:
+            msg = consumer.poll(1)
+            if msg is None:
+                continue
+            if msg.error():
+                raise confluent_kafka.KafkaException(msg.error())
+            messages.append(msg)
+    finally:
+        consumer.close()
+
+    if len(messages) != count:
+        pytest.fail(f"timed out waiting for {count} message(s) from topic {topic!r}")
+    return messages
 
 
 @pytest.fixture(scope="module")
@@ -516,6 +551,7 @@ def test_write_kafka_json_dynamic_topic(kafka_context: dict[str, object]) -> Non
         [
             {"topic": topic_a, "key": "ka", "value": payload_a},
             {"topic": topic_b, "key": "kb", "value": payload_b},
+            {"topic": topic_a, "key": "ka-delete", "value": None},
         ]
     ).write_kafka(
         bootstrap_servers=bootstrap,
@@ -529,13 +565,16 @@ def test_write_kafka_json_dynamic_topic(kafka_context: dict[str, object]) -> Non
     )
 
     delivered, failed = _write_summary_counts(summary)
-    assert delivered == 2
+    assert delivered == 3
     assert failed == 0
 
-    decoded_a = _read_topic(bootstrap=bootstrap, topic=topic_a)
+    raw_a = {
+        msg.key().decode("utf-8"): msg.value()
+        for msg in _consume_raw_messages(bootstrap=bootstrap, topic=topic_a, count=2)
+    }
     decoded_b = _read_topic(bootstrap=bootstrap, topic=topic_b)
-    assert [r["key"] for r in decoded_a] == ["ka"]
-    assert [r["value"] for r in decoded_a] == [payload_a]
+    assert json.loads(raw_a["ka"].decode("utf-8")) == payload_a
+    assert raw_a["ka-delete"] is None
     assert [r["key"] for r in decoded_b] == ["kb"]
     assert [r["value"] for r in decoded_b] == [payload_b]
 

--- a/tests/integration/io/test_kafka_integration.py
+++ b/tests/integration/io/test_kafka_integration.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import time
 import uuid
 from collections.abc import Iterator
@@ -262,7 +263,8 @@ def test_read_kafka_chunk_size_one(kafka_context: dict[str, object]) -> None:
         partitions=[0],
         chunk_size=1,
     ).collect()
-    assert len(list(df_all_p0.iter_partitions())) == 20
+    if os.environ.get("DAFT_RUNNER") == "native":
+        assert len(list(df_all_p0.iter_partitions())) == 20
     decoded = _decode_rows(df_all_p0.to_pylist())
     assert len(decoded) == 20
     assert {r["topic"] for r in decoded} == {topic}

--- a/tests/integration/io/test_kafka_integration.py
+++ b/tests/integration/io/test_kafka_integration.py
@@ -28,7 +28,7 @@ def _wait_for_kafka_ready(bootstrap: str, timeout_s: int = 60) -> None:
             consumer.list_topics(timeout=5)
             consumer.close()
             return
-        except Exception as e:
+        except confluent_kafka.KafkaException as e:
             last = e
             time.sleep(1)
     raise RuntimeError(f"Kafka was not ready after {timeout_s}s: {last}")
@@ -43,9 +43,13 @@ def _ensure_topic(*, bootstrap: str, topic: str, num_partitions: int) -> None:
     try:
         futures[topic].result(timeout=30)
     except confluent_kafka.KafkaException as e:
-        if e.args and hasattr(e.args[0], "code") and callable(e.args[0].code):
-            if e.args[0].code() == confluent_kafka.KafkaError.TOPIC_ALREADY_EXISTS:
-                return
+        if (
+            e.args
+            and hasattr(e.args[0], "code")
+            and callable(e.args[0].code)
+            and e.args[0].code() == confluent_kafka.KafkaError.TOPIC_ALREADY_EXISTS
+        ):
+            return
         raise
 
 
@@ -81,7 +85,11 @@ def _decode_rows(rows: list[dict]) -> list[dict]:
             key = bytes(key).decode("utf-8")
         value = r.get("value")
         if isinstance(value, (bytes, bytearray, memoryview)):
-            value = json.loads(bytes(value).decode("utf-8"))
+            value_text = bytes(value).decode("utf-8")
+            try:
+                value = json.loads(value_text)
+            except json.JSONDecodeError:
+                value = value_text
         decoded.append(
             {
                 "topic": r.get("topic"),
@@ -93,6 +101,29 @@ def _decode_rows(rows: list[dict]) -> list[dict]:
             }
         )
     return decoded
+
+
+def _write_summary_counts(summary: daft.DataFrame) -> tuple[int, int]:
+    rows = summary.to_pylist()
+    return (
+        sum(int(row["messages_delivered"]) for row in rows),
+        sum(int(row["messages_failed"]) for row in rows),
+    )
+
+
+def _read_topic(*, bootstrap: str, topic: str) -> list[dict]:
+    return _decode_rows(
+        daft.read_kafka(
+            bootstrap_servers=bootstrap,
+            topics=topic,
+            group_id=f"daft-kafka-integration-{uuid.uuid4().hex}",
+            timeout_ms=20_000,
+            start="earliest",
+            end="latest",
+        )
+        .collect()
+        .to_pylist()
+    )
 
 
 @pytest.fixture(scope="module")
@@ -437,3 +468,128 @@ def test_read_kafka_missing_partition_offset_raises(kafka_context: dict[str, obj
             start={0: 0},
             end={0: 5},
         ).collect()
+
+
+@pytest.mark.integration()
+def test_write_kafka_raw_roundtrip(kafka_context: dict[str, object]) -> None:
+    bootstrap = str(kafka_context["bootstrap"])
+    topic = f"daft-kafka-write-raw-{uuid.uuid4().hex[:8]}"
+    _ensure_topic(bootstrap=bootstrap, topic=topic, num_partitions=2)
+
+    summary = daft.from_pydict(
+        {
+            "key": [b"k1", b"k2", b"k3"],
+            "value": [b"v1", b"v2", b"v3"],
+            "partition": [0, 1, 0],
+        }
+    ).write_kafka(
+        bootstrap_servers=bootstrap,
+        topic=topic,
+        key_col="key",
+        value_col="value",
+        partition_col="partition",
+        kafka_client_config={"acks": "all", "enable.idempotence": True},
+        timeout_ms=20_000,
+    )
+
+    delivered, failed = _write_summary_counts(summary)
+    assert delivered == 3
+    assert failed == 0
+
+    decoded = _read_topic(bootstrap=bootstrap, topic=topic)
+    assert {r["key"] for r in decoded} == {"k1", "k2", "k3"}
+    assert {r["value"] for r in decoded} == {"v1", "v2", "v3"}
+    assert {r["partition"] for r in decoded} == {0, 1}
+
+
+@pytest.mark.integration()
+def test_write_kafka_json_dynamic_topic(kafka_context: dict[str, object]) -> None:
+    bootstrap = str(kafka_context["bootstrap"])
+    topic_a = f"daft-kafka-write-json-a-{uuid.uuid4().hex[:8]}"
+    topic_b = f"daft-kafka-write-json-b-{uuid.uuid4().hex[:8]}"
+    _ensure_topic(bootstrap=bootstrap, topic=topic_a, num_partitions=1)
+    _ensure_topic(bootstrap=bootstrap, topic=topic_b, num_partitions=1)
+
+    payload_a = {"id": 1, "kind": "a", "tags": ["red", None]}
+    payload_b = {"id": 2, "kind": "b", "tags": ["blue"]}
+    summary = daft.from_pylist(
+        [
+            {"topic": topic_a, "key": "ka", "value": payload_a},
+            {"topic": topic_b, "key": "kb", "value": payload_b},
+        ]
+    ).write_kafka(
+        bootstrap_servers=bootstrap,
+        topic_col="topic",
+        key_col="key",
+        value_col="value",
+        key_format="utf8",
+        value_format="json",
+        kafka_client_config={"acks": "all"},
+        timeout_ms=20_000,
+    )
+
+    delivered, failed = _write_summary_counts(summary)
+    assert delivered == 2
+    assert failed == 0
+
+    decoded_a = _read_topic(bootstrap=bootstrap, topic=topic_a)
+    decoded_b = _read_topic(bootstrap=bootstrap, topic=topic_b)
+    assert [r["key"] for r in decoded_a] == ["ka"]
+    assert [r["value"] for r in decoded_a] == [payload_a]
+    assert [r["key"] for r in decoded_b] == ["kb"]
+    assert [r["value"] for r in decoded_b] == [payload_b]
+
+
+@pytest.mark.integration()
+def test_write_kafka_headers(kafka_context: dict[str, object]) -> None:
+    confluent_kafka = pytest.importorskip("confluent_kafka")
+
+    bootstrap = str(kafka_context["bootstrap"])
+    topic = f"daft-kafka-write-headers-{uuid.uuid4().hex[:8]}"
+    _ensure_topic(bootstrap=bootstrap, topic=topic, num_partitions=1)
+
+    summary = daft.from_pylist(
+        [
+            {
+                "key": b"k",
+                "value": b"v",
+                "headers": [{"key": "trace", "value": b"a"}, {"key": "trace", "value": b"b"}],
+            }
+        ]
+    ).write_kafka(
+        bootstrap_servers=bootstrap,
+        topic=topic,
+        key_col="key",
+        value_col="value",
+        headers_col="headers",
+        kafka_client_config={"acks": "all"},
+        timeout_ms=20_000,
+    )
+    delivered, failed = _write_summary_counts(summary)
+    assert delivered == 1
+    assert failed == 0
+
+    consumer = confluent_kafka.Consumer(
+        {
+            "bootstrap.servers": bootstrap,
+            "group.id": f"daft-kafka-integration-{uuid.uuid4().hex}",
+            "auto.offset.reset": "earliest",
+            "enable.auto.commit": "false",
+        }
+    )
+    consumer.subscribe([topic])
+    deadline = time.time() + 20
+    try:
+        while time.time() < deadline:
+            msg = consumer.poll(1)
+            if msg is None:
+                continue
+            if msg.error():
+                raise confluent_kafka.KafkaException(msg.error())
+
+            assert msg.headers() == [("trace", b"a"), ("trace", b"b")]
+            return
+    finally:
+        consumer.close()
+
+    pytest.fail("timed out waiting for header test message")

--- a/tests/io/test_kafka_write_mock.py
+++ b/tests/io/test_kafka_write_mock.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import pytest
+
+import daft
+
+
+def test_write_kafka_is_exported_on_dataframe() -> None:
+    df = daft.from_pydict({"value": [b"a"]})
+    assert hasattr(df, "write_kafka")
+
+
+@pytest.mark.parametrize(
+    "kwargs,exc,match",
+    [
+        (
+            {"bootstrap_servers": "localhost:9092"},
+            ValueError,
+            "exactly one of topic or topic_col",
+        ),
+        (
+            {"bootstrap_servers": "localhost:9092", "topic": "topic-a", "topic_col": "topic"},
+            ValueError,
+            "exactly one of topic or topic_col",
+        ),
+        (
+            {"bootstrap_servers": "localhost:9092", "topic": ""},
+            ValueError,
+            "topic must be non-empty",
+        ),
+        (
+            {"bootstrap_servers": "localhost:9092", "topic": "topic-a", "partition": -1},
+            ValueError,
+            "partition must be >= 0",
+        ),
+        (
+            {
+                "bootstrap_servers": "localhost:9092",
+                "topic": "topic-a",
+                "partition": 0,
+                "partition_col": "partition",
+            },
+            ValueError,
+            "partition and partition_col are mutually exclusive",
+        ),
+        (
+            {"bootstrap_servers": "localhost:9092", "topic": "topic-a", "timeout_ms": 0},
+            ValueError,
+            "timeout_ms must be > 0",
+        ),
+        (
+            {"bootstrap_servers": "localhost:9092", "topic": "topic-a", "value_format": "avro"},
+            ValueError,
+            "value_format must be one of",
+        ),
+        (
+            {"bootstrap_servers": "localhost:9092", "topic": "topic-a", "key_format": "json"},
+            ValueError,
+            "key_format must be one of",
+        ),
+        (
+            {
+                "bootstrap_servers": "localhost:9092",
+                "topic": "topic-a",
+                "kafka_client_config": {"bootstrap.servers": "other:9092"},
+            },
+            ValueError,
+            "must not override managed key",
+        ),
+        (
+            {
+                "bootstrap_servers": "localhost:9092",
+                "topic": "topic-a",
+                "kafka_client_config": {"transactional.id": "tx-1"},
+            },
+            NotImplementedError,
+            "transactional.id is not supported",
+        ),
+        (
+            {
+                "bootstrap_servers": "localhost:9092",
+                "topic": "topic-a",
+                "kafka_client_config": {"acks": {"nested": "invalid"}},
+            },
+            TypeError,
+            "must be a scalar",
+        ),
+    ],
+)
+def test_write_kafka_rejects_invalid_inputs(
+    kwargs: dict[str, object],
+    exc: type[Exception],
+    match: str,
+) -> None:
+    df = daft.from_pydict({"value": [b"a"]})
+    with pytest.raises(exc, match=match):
+        df.write_kafka(**kwargs)
+
+
+def test_write_kafka_normalization_helpers_accept_valid_values() -> None:
+    from daft.dataframe.dataframe import _normalize_kafka_bootstrap_servers, _validate_kafka_client_config
+
+    assert _normalize_kafka_bootstrap_servers("localhost:9092") == "localhost:9092"
+    assert _normalize_kafka_bootstrap_servers(["a:9092", "b:9092"]) == "a:9092,b:9092"
+    assert _validate_kafka_client_config(
+        {
+            "acks": "all",
+            "enable.idempotence": True,
+            "linger.ms": 10,
+            "queue.buffering.max.kbytes": 1024.5,
+            "client.id": None,
+        }
+    ) == {
+        "acks": "all",
+        "enable.idempotence": True,
+        "linger.ms": 10,
+        "queue.buffering.max.kbytes": 1024.5,
+        "client.id": None,
+    }

--- a/tests/io/test_kafka_write_mock.py
+++ b/tests/io/test_kafka_write_mock.py
@@ -7,7 +7,7 @@ import daft
 
 def test_write_kafka_is_exported_on_dataframe() -> None:
     df = daft.from_pydict({"value": [b"a"]})
-    assert hasattr(df, "write_kafka")
+    assert callable(getattr(df, "write_kafka", None))
 
 
 @pytest.mark.parametrize(
@@ -45,6 +45,11 @@ def test_write_kafka_is_exported_on_dataframe() -> None:
         ),
         (
             {"bootstrap_servers": "localhost:9092", "topic": "topic-a", "timeout_ms": 0},
+            ValueError,
+            "timeout_ms must be > 0",
+        ),
+        (
+            {"bootstrap_servers": "localhost:9092", "topic": "topic-a", "timeout_ms": -1},
             ValueError,
             "timeout_ms must be > 0",
         ),
@@ -97,11 +102,16 @@ def test_write_kafka_rejects_invalid_inputs(
         df.write_kafka(**kwargs)
 
 
-def test_write_kafka_normalization_helpers_accept_valid_values() -> None:
-    from daft.dataframe.dataframe import _normalize_kafka_bootstrap_servers, _validate_kafka_client_config
+def test_normalize_kafka_bootstrap_servers_accepts_valid_values() -> None:
+    from daft.dataframe.dataframe import _normalize_kafka_bootstrap_servers
 
     assert _normalize_kafka_bootstrap_servers("localhost:9092") == "localhost:9092"
     assert _normalize_kafka_bootstrap_servers(["a:9092", "b:9092"]) == "a:9092,b:9092"
+
+
+def test_validate_kafka_client_config_accepts_valid_values() -> None:
+    from daft.dataframe.dataframe import _validate_kafka_client_config
+
     assert _validate_kafka_client_config(
         {
             "acks": "all",

--- a/tests/io/test_kafka_write_mock.py
+++ b/tests/io/test_kafka_write_mock.py
@@ -29,6 +29,26 @@ def test_write_kafka_is_exported_on_dataframe() -> None:
             "topic must be non-empty",
         ),
         (
+            {"bootstrap_servers": "", "topic": "topic-a"},
+            ValueError,
+            "bootstrap_servers must be non-empty",
+        ),
+        (
+            {"bootstrap_servers": [], "topic": "topic-a"},
+            ValueError,
+            "bootstrap_servers sequence must be non-empty",
+        ),
+        (
+            {"bootstrap_servers": b"localhost:9092", "topic": "topic-a"},
+            TypeError,
+            "bootstrap_servers must be a non-empty string or sequence of non-empty strings",
+        ),
+        (
+            {"bootstrap_servers": ["localhost:9092", 9092], "topic": "topic-a"},
+            TypeError,
+            "bootstrap_servers sequence values must be strings",
+        ),
+        (
             {"bootstrap_servers": "localhost:9092", "topic": "topic-a", "partition": -1},
             ValueError,
             "partition must be >= 0",
@@ -90,10 +110,28 @@ def test_write_kafka_is_exported_on_dataframe() -> None:
             TypeError,
             "must be a scalar",
         ),
+        (
+            {
+                "bootstrap_servers": "localhost:9092",
+                "topic": "topic-a",
+                "kafka_client_config": {1: "all"},
+            },
+            TypeError,
+            "kafka_client_config keys must be strings",
+        ),
+        (
+            {
+                "bootstrap_servers": "localhost:9092",
+                "topic": "topic-a",
+                "kafka_client_config": {"": "all"},
+            },
+            ValueError,
+            "kafka_client_config keys must be non-empty",
+        ),
     ],
 )
 def test_write_kafka_rejects_invalid_inputs(
-    kwargs: dict[str, object],
+    kwargs: dict[str, object] | dict[object, object],
     exc: type[Exception],
     match: str,
 ) -> None:

--- a/tests/io/test_kafka_write_mock.py
+++ b/tests/io/test_kafka_write_mock.py
@@ -165,3 +165,15 @@ def test_validate_kafka_client_config_accepts_valid_values() -> None:
         "queue.buffering.max.kbytes": 1024.5,
         "client.id": None,
     }
+
+
+def test_default_timestamp_ms_col_is_opportunistic() -> None:
+    from daft.dataframe.dataframe import _DEFAULT_KAFKA_TIMESTAMP_MS_COL, _resolve_kafka_timestamp_ms_col
+
+    assert (
+        _resolve_kafka_timestamp_ms_col(_DEFAULT_KAFKA_TIMESTAMP_MS_COL, ["value", "timestamp_ms"])
+        == "timestamp_ms"
+    )
+    assert _resolve_kafka_timestamp_ms_col(_DEFAULT_KAFKA_TIMESTAMP_MS_COL, ["value"]) is None
+    assert _resolve_kafka_timestamp_ms_col("event_ts_ms", ["value"]) == "event_ts_ms"
+    assert _resolve_kafka_timestamp_ms_col(None, ["value", "timestamp_ms"]) is None

--- a/tests/io/test_kafka_write_mock.py
+++ b/tests/io/test_kafka_write_mock.py
@@ -170,10 +170,7 @@ def test_validate_kafka_client_config_accepts_valid_values() -> None:
 def test_default_timestamp_ms_col_is_opportunistic() -> None:
     from daft.dataframe.dataframe import _DEFAULT_KAFKA_TIMESTAMP_MS_COL, _resolve_kafka_timestamp_ms_col
 
-    assert (
-        _resolve_kafka_timestamp_ms_col(_DEFAULT_KAFKA_TIMESTAMP_MS_COL, ["value", "timestamp_ms"])
-        == "timestamp_ms"
-    )
+    assert _resolve_kafka_timestamp_ms_col(_DEFAULT_KAFKA_TIMESTAMP_MS_COL, ["value", "timestamp_ms"]) == "timestamp_ms"
     assert _resolve_kafka_timestamp_ms_col(_DEFAULT_KAFKA_TIMESTAMP_MS_COL, ["value"]) is None
     assert _resolve_kafka_timestamp_ms_col("event_ts_ms", ["value"]) == "event_ts_ms"
     assert _resolve_kafka_timestamp_ms_col(None, ["value", "timestamp_ms"]) is None

--- a/tests/local_e2e/test_kafka_write_e2e.py
+++ b/tests/local_e2e/test_kafka_write_e2e.py
@@ -292,12 +292,8 @@ def test_raw_read_transform_write_roundtrip(kafka_e2e_context: KafkaE2EContext) 
         }
         for record in source_records
     ]
-    consumed_tuples = sorted(
-        (row["partition"], row["timestamp_ms"], row["key"], row["value"]) for row in consumed
-    )
-    expected_tuples = sorted(
-        (row["partition"], row["timestamp_ms"], row["key"], row["value"]) for row in expected
-    )
+    consumed_tuples = sorted((row["partition"], row["timestamp_ms"], row["key"], row["value"]) for row in consumed)
+    expected_tuples = sorted((row["partition"], row["timestamp_ms"], row["key"], row["value"]) for row in expected)
     assert consumed_tuples == expected_tuples
 
     daft_rows = read_all_with_daft(bootstrap=ctx.bootstrap, topic=ctx.raw_topic)

--- a/tests/local_e2e/test_kafka_write_e2e.py
+++ b/tests/local_e2e/test_kafka_write_e2e.py
@@ -1,142 +1,3 @@
-# Kafka Write Local E2E Implementation Plan
-
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
-
-**Goal:** Add an opt-in local Docker E2E test that validates Daft native `write_kafka` against a real Redpanda broker.
-
-**Architecture:** Create one local-only pytest module under `tests/local_e2e` with a module-level `skipif` environment gate so it is never run by default. Reuse the existing Redpanda Docker Compose service and local helper functions for broker readiness, topic creation, seed production, exact consumption, Daft readback, summary assertions, and message normalization.
-
-**Tech Stack:** pytest, Daft Python API, `confluent_kafka`, existing Redpanda Docker Compose service, native Daft runner.
-
----
-
-## File Structure
-
-- Create `tests/local_e2e/test_kafka_write_e2e.py`
-  - Owns the full opt-in local Kafka write E2E.
-  - Contains local helpers only; do not import private helpers from existing integration tests.
-  - Marks tests skipped unless `DAFT_RUN_KAFKA_LOCAL_E2E=1`.
-
-- Modify `tests/conftest.py`
-  - Register the `local_e2e` marker next to the existing `integration` marker.
-  - Do not change default `addopts`; the environment gate plus explicit opt-in marker selection are the safety mechanisms.
-
-## Task 1: Opt-In Test Module Skeleton
-
-**Files:**
-- Create: `tests/local_e2e/test_kafka_write_e2e.py`
-
-- [ ] **Step 1: Create the local E2E test directory**
-
-Run:
-
-```bash
-mkdir -p tests/local_e2e
-```
-
-Expected: directory exists and no source files are modified.
-
-- [ ] **Step 2: Add a gated module skeleton**
-
-Create `tests/local_e2e/test_kafka_write_e2e.py` with:
-
-```python
-from __future__ import annotations
-
-import os
-
-import pytest
-
-
-pytestmark = [
-    pytest.mark.integration,
-    pytest.mark.local_e2e,
-    pytest.mark.skipif(
-        os.environ.get("DAFT_RUN_KAFKA_LOCAL_E2E") != "1",
-        reason="local Kafka E2E is opt-in",
-    ),
-]
-
-
-def test_kafka_write_local_e2e_placeholder() -> None:
-    assert True
-```
-
-- [ ] **Step 3: Verify the module is not selected by default**
-
-Run:
-
-```bash
-DAFT_RUNNER=native .venv/bin/python -m pytest tests/local_e2e/test_kafka_write_e2e.py -q -rs; test $? -eq 5
-```
-
-Expected: the repository default marker filter deselects the placeholder test and pytest returns code `5`.
-
-- [ ] **Step 4: Verify explicit marker selection is still env-gated**
-
-Run:
-
-```bash
-DAFT_RUNNER=native .venv/bin/python -m pytest tests/local_e2e/test_kafka_write_e2e.py \
-  -m "integration and local_e2e" -q -rs
-```
-
-Expected: the placeholder test is selected, skipped by the environment gate, and exits with code `0`.
-
-- [ ] **Step 5: Verify the module runs when opted in**
-
-Run:
-
-```bash
-DAFT_RUN_KAFKA_LOCAL_E2E=1 DAFT_RUNNER=native \
-  .venv/bin/python -m pytest tests/local_e2e/test_kafka_write_e2e.py -m "integration and local_e2e" -q
-```
-
-Expected: one placeholder test passes. The explicit `-m` expression overrides the repository default that excludes integration tests.
-
-## Task 2: Marker Registration
-
-**Files:**
-- Modify: `tests/conftest.py`
-
-- [ ] **Step 1: Register `local_e2e` marker**
-
-Modify `pytest_configure` in `tests/conftest.py` to keep the existing `integration` marker and add:
-
-```python
-config.addinivalue_line(
-    "markers",
-    "local_e2e: mark opt-in local end-to-end tests",
-)
-```
-
-Keep the existing default in `pyproject.toml` unchanged:
-
-```toml
-addopts = "-m 'not (integration or benchmark or hypothesis)'"
-```
-
-- [ ] **Step 2: Re-run the explicit env-gate skip check**
-
-Run:
-
-```bash
-DAFT_RUNNER=native .venv/bin/python -m pytest tests/local_e2e/test_kafka_write_e2e.py \
-  -m "integration and local_e2e" -q -rs
-```
-
-Expected: tests are skipped by the environment gate and no unknown marker warning is emitted.
-
-## Task 3: Kafka Helper Layer
-
-**Files:**
-- Modify: `tests/local_e2e/test_kafka_write_e2e.py`
-
-- [ ] **Step 1: Replace the placeholder module with helper imports and constants**
-
-Replace the entire placeholder module with:
-
-```python
 from __future__ import annotations
 
 import json
@@ -151,7 +12,6 @@ from typing import Any
 import pytest
 
 import daft
-
 
 pytestmark = [
     pytest.mark.integration,
@@ -173,13 +33,21 @@ class SeedRecord:
     value: bytes
     partition: int
     timestamp_ms: int
-```
 
-- [ ] **Step 2: Add broker readiness and topic helpers**
 
-Append:
+@dataclass(frozen=True)
+class KafkaE2EContext:
+    bootstrap: str
+    run_id: str
+    base_ts_ms: int
+    source_topic: str
+    raw_topic: str
+    user_topic: str
+    order_topic: str
+    headers_topic: str
+    compact_topic: str
 
-```python
+
 def wait_for_kafka_ready(bootstrap: str, timeout_s: int = 60) -> None:
     confluent_kafka = pytest.importorskip("confluent_kafka")
 
@@ -231,13 +99,8 @@ def create_topic(*, bootstrap: str, topic: str, partitions: int, config: dict[st
         ):
             return
         raise
-```
 
-- [ ] **Step 3: Add producer and consumer helpers**
 
-Append:
-
-```python
 def produce_seed_records(*, bootstrap: str, topic: str, records: Iterable[SeedRecord]) -> None:
     confluent_kafka = pytest.importorskip("confluent_kafka")
 
@@ -282,13 +145,8 @@ def consume_exactly(*, bootstrap: str, topic: str, count: int, timeout_s: int = 
     if len(messages) != count:
         pytest.fail(f"timed out waiting for {count} message(s) from topic {topic!r}; got {len(messages)}")
     return messages
-```
 
-- [ ] **Step 4: Add Daft read and assertion helpers**
 
-Append:
-
-```python
 def read_all_with_daft(*, bootstrap: str, topic: str) -> list[dict[str, Any]]:
     return (
         daft.read_kafka(
@@ -322,24 +180,6 @@ def normalize_message(msg: Any) -> dict[str, Any]:
         "timestamp_ms": msg.timestamp()[1],
         "headers": msg.headers(),
     }
-```
-
-- [ ] **Step 5: Add run context fixture**
-
-Append:
-
-```python
-@dataclass(frozen=True)
-class KafkaE2EContext:
-    bootstrap: str
-    run_id: str
-    base_ts_ms: int
-    source_topic: str
-    raw_topic: str
-    user_topic: str
-    order_topic: str
-    headers_topic: str
-    compact_topic: str
 
 
 @pytest.fixture(scope="module")
@@ -373,35 +213,14 @@ def kafka_e2e_context() -> Iterator[KafkaE2EContext]:
     )
 
     yield ctx
-```
 
-- [ ] **Step 6: Verify helper-only module still imports and runs no tests**
 
-Run:
-
-```bash
-DAFT_RUN_KAFKA_LOCAL_E2E=1 DAFT_RUNNER=native \
-  .venv/bin/python -m pytest tests/local_e2e/test_kafka_write_e2e.py -m "integration and local_e2e" -q
-```
-
-Expected: pytest collects zero tests or only fixture import passes. If pytest exits with "no tests ran" as code `5`, continue to Task 4 without treating this as a functional failure.
-
-## Task 4: Raw Mirror E2E Scenario
-
-**Files:**
-- Modify: `tests/local_e2e/test_kafka_write_e2e.py`
-
-- [ ] **Step 1: Add source record builder**
-
-Append before tests:
-
-```python
 def build_source_records(base_ts_ms: int) -> list[SeedRecord]:
     rows = [
         (1, b"user-001", {"event_id": 1, "kind": "signup", "amount": 0, "note": "hello"}, 0),
         (2, b"order-001", {"event_id": 2, "kind": "purchase", "amount": 19.99, "note": "zstd-path"}, 1),
         (3, b"user-001", {"event_id": 3, "kind": "update", "amount": 0, "note": "duplicate-key"}, 0),
-        (4, "user-004".encode("utf-8"), {"event_id": 4, "kind": "unicode", "note": "hello unicode"}, 2),
+        (4, b"user-004", {"event_id": 4, "kind": "unicode", "note": "hello unicode"}, 2),
         (5, b"user-005", {"event_id": 5, "kind": "logout", "amount": 0, "note": "small"}, 0),
         (6, b"order-006", {"event_id": 6, "kind": "purchase", "amount": 42.5, "note": "medium"}, 1),
         (7, b"user-007", {"event_id": 7, "kind": "profile", "amount": 0, "note": "large-" + "x" * 128}, 2),
@@ -415,19 +234,14 @@ def build_source_records(base_ts_ms: int) -> list[SeedRecord]:
         SeedRecord(
             event_id=event_id,
             key=key,
-            value=json.dumps(value, sort_keys=True).encode("utf-8"),
+            value=json.dumps(value, sort_keys=True).encode(),
             partition=partition,
             timestamp_ms=base_ts_ms + event_id,
         )
         for event_id, key, value, partition in rows
     ]
-```
 
-- [ ] **Step 2: Add raw mirror test**
 
-Append:
-
-```python
 def test_raw_read_transform_write_roundtrip(kafka_e2e_context: KafkaE2EContext) -> None:
     ctx = kafka_e2e_context
     source_records = build_source_records(ctx.base_ts_ms)
@@ -461,11 +275,14 @@ def test_raw_read_transform_write_roundtrip(kafka_e2e_context: KafkaE2EContext) 
 
     assert_summary(summary, attempted=len(source_records), delivered=len(source_records))
 
-    consumed = [normalize_message(msg) for msg in consume_exactly(
-        bootstrap=ctx.bootstrap,
-        topic=ctx.raw_topic,
-        count=len(source_records),
-    )]
+    consumed = [
+        normalize_message(msg)
+        for msg in consume_exactly(
+            bootstrap=ctx.bootstrap,
+            topic=ctx.raw_topic,
+            count=len(source_records),
+        )
+    ]
     expected = [
         {
             "key": record.key,
@@ -485,31 +302,8 @@ def test_raw_read_transform_write_roundtrip(kafka_e2e_context: KafkaE2EContext) 
 
     daft_rows = read_all_with_daft(bootstrap=ctx.bootstrap, topic=ctx.raw_topic)
     assert len(daft_rows) == len(source_records)
-```
 
-- [ ] **Step 3: Run the raw mirror test against Redpanda**
 
-Run:
-
-```bash
-docker compose -f tests/integration/io/docker-compose/docker-compose.yml up -d redpanda
-DAFT_RUN_KAFKA_LOCAL_E2E=1 DAFT_RUNNER=native \
-  .venv/bin/python -m pytest tests/local_e2e/test_kafka_write_e2e.py::test_raw_read_transform_write_roundtrip \
-  -m "integration and local_e2e" -q -s
-```
-
-Expected: test passes and summary counters match the 12 seeded records.
-
-## Task 5: JSON Dynamic Topic And Tombstone Scenario
-
-**Files:**
-- Modify: `tests/local_e2e/test_kafka_write_e2e.py`
-
-- [ ] **Step 1: Add JSON dynamic topic test**
-
-Append:
-
-```python
 def test_json_dynamic_topic_and_tombstone(kafka_e2e_context: KafkaE2EContext) -> None:
     ctx = kafka_e2e_context
     json_rows = [
@@ -564,44 +358,22 @@ def test_json_dynamic_topic_and_tombstone(kafka_e2e_context: KafkaE2EContext) ->
     assert_summary(summary, attempted=3, delivered=3)
 
     user_messages = {
-        msg.key().decode("utf-8"): normalize_message(msg)
+        msg.key().decode(): normalize_message(msg)
         for msg in consume_exactly(bootstrap=ctx.bootstrap, topic=ctx.user_topic, count=2)
     }
     order_messages = {
-        msg.key().decode("utf-8"): normalize_message(msg)
+        msg.key().decode(): normalize_message(msg)
         for msg in consume_exactly(bootstrap=ctx.bootstrap, topic=ctx.order_topic, count=1)
     }
 
-    assert json.loads(user_messages["user-001"]["value"].decode("utf-8")) == json_rows[0]["value"]
+    assert json.loads(user_messages["user-001"]["value"].decode()) == json_rows[0]["value"]
     assert user_messages["user-002"]["value"] is None
-    assert json.loads(order_messages["order-001"]["value"].decode("utf-8")) == json_rows[1]["value"]
+    assert json.loads(order_messages["order-001"]["value"].decode()) == json_rows[1]["value"]
     assert user_messages["user-001"]["partition"] == 0
     assert user_messages["user-002"]["partition"] == 1
     assert order_messages["order-001"]["partition"] == 1
-```
 
-- [ ] **Step 2: Run the JSON dynamic topic test**
 
-Run:
-
-```bash
-DAFT_RUN_KAFKA_LOCAL_E2E=1 DAFT_RUNNER=native \
-  .venv/bin/python -m pytest tests/local_e2e/test_kafka_write_e2e.py::test_json_dynamic_topic_and_tombstone \
-  -m "integration and local_e2e" -q -s
-```
-
-Expected: test passes; top-level `None` is consumed as Kafka null value.
-
-## Task 6: Headers And Compact Tombstone Scenarios
-
-**Files:**
-- Modify: `tests/local_e2e/test_kafka_write_e2e.py`
-
-- [ ] **Step 1: Add headers test**
-
-Append:
-
-```python
 def test_headers_preserve_duplicate_order_and_null(kafka_e2e_context: KafkaE2EContext) -> None:
     ctx = kafka_e2e_context
     summary = daft.from_pylist(
@@ -629,13 +401,8 @@ def test_headers_preserve_duplicate_order_and_null(kafka_e2e_context: KafkaE2ECo
     assert_summary(summary, attempted=1, delivered=1)
     [message] = consume_exactly(bootstrap=ctx.bootstrap, topic=ctx.headers_topic, count=1)
     assert message.headers() == [("trace", b"a"), ("trace", b"b"), ("nullable", None)]
-```
 
-- [ ] **Step 2: Add compact tombstone test**
 
-Append:
-
-```python
 def test_compacted_topic_receives_tombstone(kafka_e2e_context: KafkaE2EContext) -> None:
     ctx = kafka_e2e_context
     summary = daft.from_pylist(
@@ -656,37 +423,13 @@ def test_compacted_topic_receives_tombstone(kafka_e2e_context: KafkaE2EContext) 
 
     assert_summary(summary, attempted=2, delivered=2)
     messages = consume_exactly(bootstrap=ctx.bootstrap, topic=ctx.compact_topic, count=2)
-    assert {msg.key().decode("utf-8") for msg in messages} == {"user-compact-001"}
+    assert {msg.key().decode() for msg in messages} == {"user-compact-001"}
 
     values = [msg.value() for msg in messages]
     assert sum(value is None for value in values) == 1
-    assert [json.loads(value.decode("utf-8")) for value in values if value is not None] == [{"status": "active"}]
-```
+    assert [json.loads(value.decode()) for value in values if value is not None] == [{"status": "active"}]
 
-- [ ] **Step 3: Run headers and compact tests**
 
-Run:
-
-```bash
-DAFT_RUN_KAFKA_LOCAL_E2E=1 DAFT_RUNNER=native \
-  .venv/bin/python -m pytest \
-  tests/local_e2e/test_kafka_write_e2e.py::test_headers_preserve_duplicate_order_and_null \
-  tests/local_e2e/test_kafka_write_e2e.py::test_compacted_topic_receives_tombstone \
-  -m "integration and local_e2e" -q -s
-```
-
-Expected: both tests pass.
-
-## Task 7: Validation Guardrails
-
-**Files:**
-- Modify: `tests/local_e2e/test_kafka_write_e2e.py`
-
-- [ ] **Step 1: Add validation tests**
-
-Append:
-
-```python
 def test_validation_guardrails(kafka_e2e_context: KafkaE2EContext) -> None:
     ctx = kafka_e2e_context
     df = daft.from_pydict({"value": [b"x"]})
@@ -715,85 +458,3 @@ def test_validation_guardrails(kafka_e2e_context: KafkaE2EContext) -> None:
             value_col="value",
             timeout_ms=WRITE_TIMEOUT_MS,
         )
-```
-
-- [ ] **Step 2: Run validation guardrails**
-
-Run:
-
-```bash
-DAFT_RUN_KAFKA_LOCAL_E2E=1 DAFT_RUNNER=native \
-  .venv/bin/python -m pytest tests/local_e2e/test_kafka_write_e2e.py::test_validation_guardrails \
-  -m "integration and local_e2e" -q -s
-```
-
-Expected: test passes without producing misleading success summaries.
-
-## Task 8: Full Verification
-
-**Files:**
-- Verify: `tests/local_e2e/test_kafka_write_e2e.py`
-- Verify: `tests/conftest.py`
-
-- [ ] **Step 1: Run Python syntax check**
-
-Run:
-
-```bash
-.venv/bin/python -m py_compile tests/local_e2e/test_kafka_write_e2e.py
-```
-
-Expected: exit code `0`.
-
-- [ ] **Step 2: Run targeted ruff check**
-
-Run:
-
-```bash
-.venv/bin/python -m ruff check tests/local_e2e/test_kafka_write_e2e.py
-```
-
-Expected: `All checks passed!`
-
-- [ ] **Step 3: Verify default marker filtering and explicit env-gate skip behavior**
-
-Run:
-
-```bash
-DAFT_RUNNER=native .venv/bin/python -m pytest tests/local_e2e/test_kafka_write_e2e.py -q -rs; test $? -eq 5
-DAFT_RUNNER=native .venv/bin/python -m pytest tests/local_e2e/test_kafka_write_e2e.py \
-  -m "integration and local_e2e" -q -rs
-```
-
-Expected: the first command reports `5 deselected` because default `addopts` excludes integration tests; the second reports `5 skipped` because `DAFT_RUN_KAFKA_LOCAL_E2E` is not set.
-
-- [ ] **Step 4: Run full local E2E**
-
-Run:
-
-```bash
-docker compose -f tests/integration/io/docker-compose/docker-compose.yml up -d redpanda
-DAFT_RUN_KAFKA_LOCAL_E2E=1 DAFT_RUNNER=native \
-  .venv/bin/python -m pytest tests/local_e2e/test_kafka_write_e2e.py \
-  -m "integration and local_e2e" -q -s
-```
-
-Expected: all local E2E tests pass against Redpanda.
-
-- [ ] **Step 5: Confirm repository diff hygiene**
-
-Run:
-
-```bash
-git diff --check
-git status --short
-```
-
-Expected: no whitespace errors; `git status --short` shows the expected modified/staged files, including the new `tests/local_e2e/test_kafka_write_e2e.py` before commit.
-
-## Self-Review Checklist
-
-- Spec coverage: Tasks cover opt-in invocation, Redpanda readiness, unique topics, source seed data, raw mirror, Daft readback, JSON dynamic topics, tombstones, headers, compact topic tombstone, null and empty dynamic topic guardrails, and verification commands.
-- Placeholder handling: The placeholder is limited to Task 1 bootstrap and is explicitly replaced before any E2E scenario is added; no task uses `TBD`, `TODO`, `fill in`, or unspecified test commands.
-- Type consistency: Helper names in tests match helper definitions: `wait_for_kafka_ready`, `create_topic`, `produce_seed_records`, `consume_exactly`, `read_all_with_daft`, `assert_summary`, and `normalize_message`.
-- Scope: TLS/SASL and broker-dependent delivery failure remain future extensions, matching the approved v1 design.

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.15' and platform_machine == 'aarch64' and sys_platform == 'linux'",
@@ -1225,6 +1225,42 @@ wheels = [
 ]
 
 [[package]]
+name = "confluent-kafka"
+version = "2.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ff/e5/58ac277094b03a51d9725798d0e53a60c1be69dc4330ae9cedc2d9efa430/confluent_kafka-2.14.2.tar.gz", hash = "sha256:fc827265571a778b1ff560ab2f3ec5dce3c573c29eb4cf6ded9718d55a5e4262", size = 289180, upload-time = "2026-06-03T09:53:37.63Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/64/13d093f6fc6b318c301942f579599cc1cae07a93061442fb1a81e40962e4/confluent_kafka-2.14.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9f6f9718c0cd8d32a61aa58010c34b741dd62ec2ed9f470fcff36f7ac3d1006e", size = 4182303, upload-time = "2026-06-03T09:50:06.591Z" },
+    { url = "https://files.pythonhosted.org/packages/96/9f/44f326e5073b618712b4b52575d72c093da896642233080c208e2ab0025b/confluent_kafka-2.14.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5714f9402ef7e07c42bb1d3e175c9dd811a6b5877b522828630ae800503deaf0", size = 4178833, upload-time = "2026-06-03T09:50:11.668Z" },
+    { url = "https://files.pythonhosted.org/packages/98/a8/4f3136f8f87eda871003aecac8c57f4aabfd9cb600f55699a32c2fb225d8/confluent_kafka-2.14.2-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:4c9b1c4fe8f4364a5828dc35fb481577a7c0b6960876f5e53a0370705ca0247d", size = 4799106, upload-time = "2026-06-03T09:50:18.437Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/b1/37f112f18e7cee6bc90eaadb475e36f80fabb1a9d3d7acbe0310e1c5326e/confluent_kafka-2.14.2-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:4b9d6e0170aed7856553429d1d2b3e9373a4c4ba0c264204e05a947a52cf2c2f", size = 4594717, upload-time = "2026-06-03T09:50:24.869Z" },
+    { url = "https://files.pythonhosted.org/packages/df/88/cf0676e24e99412a4b47c6d90c9a6413d9fd35fd72d32c308f7b82b8fb1e/confluent_kafka-2.14.2-cp310-cp310-win_amd64.whl", hash = "sha256:aafffa6ac16e9b41919bcdc243168f894c8eac543a28f4e0674c525ce5c39132", size = 4391695, upload-time = "2026-06-03T09:50:29.985Z" },
+    { url = "https://files.pythonhosted.org/packages/29/00/b2ceee24d353fd06186be2f6cdd9835926eca5266de3358530c5d11c4af4/confluent_kafka-2.14.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b3470171eb52dc149e3abf7cbcc485f388c0dbd1dd7516e5fd18a35baa39271f", size = 4181908, upload-time = "2026-06-03T09:50:38.285Z" },
+    { url = "https://files.pythonhosted.org/packages/98/78/daf09df7bd45c82c300ab7df0eb4a49bee7609e0b71254e4b9e44f068fb0/confluent_kafka-2.14.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3bcd5dc82ee4b921e1a54e6b9130a0d43de99dd3021ddf3a2557fbf505df8d62", size = 4178406, upload-time = "2026-06-03T09:50:42.843Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/a2/c3c94d893133ad31a2cb8a0444ba5dfe77d066a9d66687775c33068684c9/confluent_kafka-2.14.2-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:c6abedb91fd8fcd0dcea8491f71efd37d136c12c4afa2216fd8d85585f53c4ea", size = 4798777, upload-time = "2026-06-03T09:50:48.276Z" },
+    { url = "https://files.pythonhosted.org/packages/37/86/6e7f2ccb44a069a0789fea9e0ec2d440146dcbe6128be60efda72cfe5de2/confluent_kafka-2.14.2-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:6e4abff7d6c1a27787ece44f3e56bcda9b0fa0a141c9b651a6cd13fbc7f943f9", size = 4594242, upload-time = "2026-06-03T09:50:55.355Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/90/46032c39848155de5f82eb00fde8de290b2808c160eea1caead2cdcb6b62/confluent_kafka-2.14.2-cp311-cp311-win_amd64.whl", hash = "sha256:01399706d1fe314b85b62f86d045fc8696f482bf625064aa7c0ccb7149e629b2", size = 4391698, upload-time = "2026-06-03T09:51:05.432Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/52/274192cfcca6d0b8b8093255f02e61f112dc425024dbb723438272d5f16b/confluent_kafka-2.14.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:35755d6adb2d6ed5b3f517fa8d2cec0e8cb5b668e652cc7a691fe317b727bcb9", size = 4187586, upload-time = "2026-06-03T09:51:09.653Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/85/942ab3188cb252cc0ea43bb8c6b4bce036f8b6168b2d9857e158ec136a09/confluent_kafka-2.14.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:facc957bf97e69e467b1935d96eddced0abb7e7bcd2af025847d42c990116523", size = 4183057, upload-time = "2026-06-03T09:51:14.252Z" },
+    { url = "https://files.pythonhosted.org/packages/64/9a/ed6be7e0874463aa40660903f8b191eb94ea0d21a11d0f07f953bf12319a/confluent_kafka-2.14.2-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:6ea5321c7f3861be9245239514ddcfc8dc21e8046f819a53b0f98c4e79b006d6", size = 4803705, upload-time = "2026-06-03T09:51:21.775Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/58/5c5b84f6f9e6c1d8b50dfa1d8231d77ba1c626d2f4233549a4b81f826620/confluent_kafka-2.14.2-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:7db5f58948eeb7b85b8c5ab440fddbd5a7465fee48185e5ae37bb2c190eb715d", size = 4598707, upload-time = "2026-06-03T09:51:28.351Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/fb/65118d1557599e9e4cbc8bb1ed0f0b9832d2dcbae281ecc285caeb2a7305/confluent_kafka-2.14.2-cp312-cp312-win_amd64.whl", hash = "sha256:b19e4939e1cefe4ed93985e64b121ba492632ad36a23a43f5299402522b24385", size = 4392203, upload-time = "2026-06-03T09:51:34.068Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/27/e1a75e5b7c9caeb61885d10b038d520fec73f21967d763f18f600d917f9f/confluent_kafka-2.14.2-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:590667a106f2f79a1a9412723686e32e5a4a85b911ff2c15ce828c5ac8748f3b", size = 4187857, upload-time = "2026-06-03T09:51:40.099Z" },
+    { url = "https://files.pythonhosted.org/packages/96/6f/1299809f078da711783878486cea966871a02d8b3bdaf126298bc6f778db/confluent_kafka-2.14.2-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:654afcf3d1b29536d098d271a66ef077920759b752a8c9978feee35ce4a174cf", size = 4190988, upload-time = "2026-06-03T09:51:44.265Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/81/d68501702330138f9b0e946674fea60285cf5c231eb70dfcc0459fa7f0c8/confluent_kafka-2.14.2-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:1cbb88bae84c8b0f9247a896bdbb53820bdf0f277aa126bf577108ee70491926", size = 4804040, upload-time = "2026-06-03T09:51:50.225Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/fc/720a0fa7127a6bd23517bb0bc6dc6d2934bf5fe385277ced7bf3c6e9d2d4/confluent_kafka-2.14.2-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:53b5fb5eb0ae89005e572da95f96e95c7d247525d66857748b74012d58f19ef3", size = 4599115, upload-time = "2026-06-03T09:51:58.07Z" },
+    { url = "https://files.pythonhosted.org/packages/13/da/e1679fbe6a4d4dc1172db2ecad7eccef00555fb4f11f432b8e802ad68998/confluent_kafka-2.14.2-cp313-cp313-win_amd64.whl", hash = "sha256:aff0de94a6321eedb6188d121a8001b090d6d5f4d76b3f6754a3c8747fb1847d", size = 4451883, upload-time = "2026-06-03T09:52:06.049Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/7a/0ab7208fd86e7295a83a372c4978ab06d7caa36c925bb3c82fbcb4ff74fd/confluent_kafka-2.14.2-cp314-cp314-macosx_13_0_arm64.whl", hash = "sha256:f42c745e6162905bd16bc2beb6429aef38240ff0e2f1c3edde4a462f121ea9c1", size = 4187700, upload-time = "2026-06-03T09:52:22.147Z" },
+    { url = "https://files.pythonhosted.org/packages/02/de/968c53892abaface22071b306333d83f61d8db5a1eb7224af61cde99e770/confluent_kafka-2.14.2-cp314-cp314-macosx_13_0_x86_64.whl", hash = "sha256:3d1e5f1853a67be1573014ad610874e4e80bdcfb1c7ca1cadaeae5c5bef88a94", size = 4190827, upload-time = "2026-06-03T09:52:27.438Z" },
+    { url = "https://files.pythonhosted.org/packages/99/77/722ce2b8b6e2ad0ffe9d7a042b0d0011edb679ec292203a739d10c483e26/confluent_kafka-2.14.2-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:c5f247f6c046e457f369d3f2b11cb8d133b17e8306ce63c2ae0414469819d3e6", size = 4803806, upload-time = "2026-06-03T09:52:32.392Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/fd/a8466ed8fd6d6f82a13fd852fa14eca8b71cbca192fe82d58677808fcae3/confluent_kafka-2.14.2-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:d61e22e6cd24e518c47b3b608023d2476bca4a7525de7877ca28e323af98f832", size = 4598793, upload-time = "2026-06-03T09:52:37.059Z" },
+    { url = "https://files.pythonhosted.org/packages/45/73/c74394c74541f4c06be482ef03e3d3f668a4df5e4b52bc50e6a43bb9c345/confluent_kafka-2.14.2-cp314-cp314-win_amd64.whl", hash = "sha256:cf18131b6b8137f5ea0de1ff0988eb2af40a372c31f8238b015d70ccd1c0945a", size = 4584051, upload-time = "2026-06-03T09:52:42.226Z" },
+]
+
+[[package]]
 name = "connectorx"
 version = "0.4.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1545,6 +1581,7 @@ all = [
     { name = "av" },
     { name = "boto3" },
     { name = "clickhouse-connect" },
+    { name = "confluent-kafka" },
     { name = "connectorx" },
     { name = "daft-lance" },
     { name = "datasets" },
@@ -1604,6 +1641,9 @@ huggingface = [
 ]
 iceberg = [
     { name = "pyiceberg" },
+]
+kafka = [
+    { name = "confluent-kafka" },
 ]
 lance = [
     { name = "daft-lance" },
@@ -1754,9 +1794,10 @@ requires-dist = [
     { name = "av", marker = "extra == 'video'", specifier = ">=15.0.0,<17.1.0" },
     { name = "boto3", marker = "extra == 'aws'", specifier = "<1.44.0" },
     { name = "clickhouse-connect", marker = "extra == 'clickhouse'", specifier = "<1.1.0" },
+    { name = "confluent-kafka", marker = "extra == 'kafka'" },
     { name = "connectorx", marker = "extra == 'postgres'", specifier = ">=0.4.4,<0.5.0" },
     { name = "connectorx", marker = "extra == 'sql'", specifier = ">=0.4.4,<0.5.0" },
-    { name = "daft", extras = ["aws", "azure", "clickhouse", "deltalake", "gcp", "google", "gravitino", "hudi", "huggingface", "iceberg", "lance", "numpy", "openai", "pandas", "postgres", "ray", "sentence-transformers", "sql", "transformers", "turbopuffer", "unity", "video"], marker = "extra == 'all'" },
+    { name = "daft", extras = ["aws", "azure", "clickhouse", "deltalake", "gcp", "google", "gravitino", "hudi", "huggingface", "iceberg", "kafka", "lance", "numpy", "openai", "pandas", "postgres", "ray", "sentence-transformers", "sql", "transformers", "turbopuffer", "unity", "video"], marker = "extra == 'all'" },
     { name = "daft-lance", marker = "extra == 'lance'" },
     { name = "datasets", marker = "extra == 'huggingface'", specifier = "<4.9.0" },
     { name = "deltalake", marker = "extra == 'deltalake'", specifier = ">=1.5.0,<1.7.0" },
@@ -1797,7 +1838,7 @@ requires-dist = [
     { name = "typing-extensions", marker = "python_full_version < '3.12'", specifier = ">=4.0.0" },
     { name = "unitycatalog", marker = "extra == 'unity'", specifier = "<0.2.0" },
 ]
-provides-extras = ["all", "audio", "aws", "azure", "clickhouse", "deltalake", "gcp", "google", "gravitino", "hudi", "huggingface", "iceberg", "lance", "numpy", "openai", "pandas", "postgres", "ray", "sql", "transformers", "turbopuffer", "unity", "video", "viz"]
+provides-extras = ["all", "audio", "aws", "azure", "clickhouse", "deltalake", "gcp", "google", "gravitino", "hudi", "huggingface", "iceberg", "kafka", "lance", "numpy", "openai", "pandas", "postgres", "ray", "sql", "transformers", "turbopuffer", "unity", "video", "viz"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Changes Made

This draft PR adds native Kafka write support to Daft, linked to the feature/design issue in #7101.

- Adds `DataFrame.write_kafka(...)` for producing Daft rows to Kafka with static or dynamic topics, optional key/headers/partition/timestamp columns, raw/utf8/json formats, and task-level write summaries.
- Adds native Kafka sink planning/execution plumbing through the logical plan, local physical plan, distributed sink translation, and `daft-writers` using `rust-rdkafka`/librdkafka.
- Preserves at-least-once delivery semantics, rejects `transactional.id` for now, lets users pass librdkafka producer config, and maps `timeout_ms` to delivery/enqueue/flush behavior while preserving user overrides.
- Adds broker-free Rust/Python tests, Redpanda-backed Kafka integration coverage, opt-in local Docker E2E coverage, and Kafka connector docs.
- Keeps Kafka support feature-gated for no-default Rust builds while enabling common librdkafka capabilities such as TLS and zstd for the native producer path.

This is opened as a draft because it is a non-trivial connector/core execution feature and should get maintainer feedback on API shape, feature gating, dependency/linking choices, and PR sizing before review-ready status.

Material AI usage: OpenAI Codex was used to research the codebase, draft the design/implementation plan, implement the native Kafka write path, and run the verification commands listed below. I manually reviewed the generated design, diffs, and test outputs before opening this PR.

Validation performed:

- `cargo fmt --check`
- `git diff --check`
- `RUSTC_BOOTSTRAP=1 cargo test -p daft-writers --features kafka kafka::`
- `RUSTC_BOOTSTRAP=1 cargo test -p daft-local-execution --features kafka kafka_write_translates_to_named_pipeline_without_broker`
- `RUSTC_BOOTSTRAP=1 cargo test -p daft-local-execution --features kafka make_state_uses_input_id_as_writer_index`
- `RUSTC_BOOTSTRAP=1 cargo check -p daft-local-execution --features python,kafka`
- `RUSTC_BOOTSTRAP=1 cargo check -p daft-local-execution --no-default-features`
- `cargo tree -p daft-local-execution --no-default-features -e features -i rdkafka` reports no matching package, confirming `rdkafka` is not pulled into that no-default tree
- `DAFT_RUNNER=native .venv/bin/python -m pytest tests/io/test_kafka_write_mock.py -q`
- `DAFT_RUNNER=native .venv/bin/python -m pytest tests/integration/io/test_kafka_integration.py -m integration -q -rs`
- `DAFT_RUN_KAFKA_LOCAL_E2E=1 DAFT_RUNNER=native .venv/bin/python -m pytest tests/local_e2e/test_kafka_write_e2e.py -m 'integration and local_e2e' -q -s`
- `DAFT_RUNNER=native .venv/bin/python -m pytest tests/local_e2e/test_kafka_write_e2e.py -q -rs; test $? -eq 5`
- `DAFT_RUNNER=native .venv/bin/python -m pytest tests/local_e2e/test_kafka_write_e2e.py -m 'integration and local_e2e' -q -rs`
- `JUPYTER_PLATFORM_DIRS=1 .venv/bin/mkdocs build -f mkdocs.yml`

Not tested:

- Full workspace `cargo test`
- Ray/distributed Kafka write execution against a real broker
- TLS/SASL broker E2E scenarios

## Related Issues

Closes #7101
