### PR TITLE
fix: detect unschedulable actor UDFs and warn on over-requested concurrency

### DIFF
--- a/daft/execution/ray_actor_pool_udf.py
+++ b/daft/execution/ray_actor_pool_udf.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import uuid
 from typing import TYPE_CHECKING, Any
 
 from daft.expressions.expressions import Expression, ExpressionsProjection
 from daft.recordbatch.micropartition import MicroPartition
 from daft.runners.ray_compat import validate_and_normalize_ray_options
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from ray.actor import ActorHandle as RayActorHandle
@@ -98,6 +101,42 @@ async def start_udf_actors(
             **ray_options,
         }
     )
+
+    # Read from udf_options (not the params) because ray_options can override num_cpus / num_gpus via the spread above.
+    cpus_per_actor = udf_options.get("num_cpus", 1.0)
+    gpus_per_actor = udf_options.get("num_gpus", 0.0)
+    alive_nodes = [n for n in ray.nodes() if n["Alive"]]
+    can_schedule = any(
+        n["Resources"].get("CPU", 0) >= cpus_per_actor and n["Resources"].get("GPU", 0) >= gpus_per_actor
+        for n in alive_nodes
+    )
+    if not can_schedule:
+        raise RuntimeError(
+            f"Actor UDF requires {cpus_per_actor} CPUs and {gpus_per_actor} GPUs per actor, "
+            f"but no single node can satisfy this. "
+            f"No single actor can be scheduled."
+        )
+
+    if cpus_per_actor > 0 or gpus_per_actor > 0:
+        cluster_cpus = ray.cluster_resources().get("CPU", 0)
+        cluster_gpus = ray.cluster_resources().get("GPU", 0)
+        limits = []
+        if cpus_per_actor > 0:
+            limits.append(cluster_cpus / cpus_per_actor)
+        if gpus_per_actor > 0:
+            limits.append(cluster_gpus / gpus_per_actor)
+        max_schedulable = int(min(limits))
+        if num_actors > max_schedulable:
+            logger.warning(
+                "with_concurrency(%d) requested but only %d actors can be scheduled "
+                "(%g CPUs, %g GPUs available). Will proceed with partial actor pool "
+                "after actor_udf_ready_timeout (%ds).",
+                num_actors,
+                max_schedulable,
+                cluster_cpus,
+                cluster_gpus,
+                timeout,
+            )
 
     actors: list[RayActorHandle] = [
         UDFActor.options(  # type: ignore

--- a/tests/expressions/test_legacy_udf.py
+++ b/tests/expressions/test_legacy_udf.py
@@ -688,7 +688,7 @@ def test_udf_fails_with_no_actors_schedulable():
             return data
 
         result = df.select(udf_1(col("a")).alias("udf_1"))
-        with pytest.raises(RuntimeError, match="RuntimeError: UDF actors failed to start within 10 seconds"):
+        with pytest.raises(RuntimeError, match="No single actor can be scheduled"):
             result.collect()
 
 
@@ -718,6 +718,19 @@ def test_actor_udf_with_into_partitions_does_not_deadlock():
 
         result = df.select(udf_1(col("a")).alias("udf_1")).into_partitions(2).to_pydict()
         assert sorted(result["udf_1"]) == [1, 2, 3]
+
+
+@pytest.mark.skipif(get_tests_daft_runner_name() != "ray", reason="Tests Flotilla-specific behavior")
+def test_udf_fails_when_single_actor_exceeds_cluster_capacity():
+    df = daft.from_pydict({"a": [1, 2, 3]})
+
+    @udf(return_dtype=DataType.int64(), concurrency=1, num_cpus=1024)
+    def udf_1(data):
+        return data
+
+    result = df.select(udf_1(col("a")).alias("udf_1"))
+    with pytest.raises(RuntimeError, match="No single actor can be scheduled"):
+        result.collect()
 
 
 def test_udf_error_serialize_err():


### PR DESCRIPTION
Related to #7112

## Summary
- Raise `RuntimeError` when a single actor's resource requirement exceeds
  the largest node's capacity (via `ray.nodes()`), since such an actor
  can never be scheduled
- Emit a warning when `concurrency` exceeds schedulable actor count,
  so users know the pipeline will proceed with a partial actor pool
  after `actor_udf_ready_timeout`
- Preserves existing partial actor pool behavior

## Test plan
- `num_cpus=1024` on 2-CPU cluster → RuntimeError
- `concurrency=100, num_cpus=1` on 2-CPU cluster → warning + partial actors, succeeds
- Updated `test_udf_fails_with_no_actors_schedulable` for new error message