### PR TITLE
docs: add ruff, uv badges and custom daft badge assets

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 |Banner|
 
-|CI| |PyPI| |Latest Tag| |Coverage| |Slack|
+|CI| |PyPI| |Latest Tag| |Coverage| |Slack| |Ruff| |uv|
 
 `Website <https://www.daft.ai>`_ • `Docs <https://docs.daft.ai>`_ • `Installation <https://docs.daft.ai/en/stable/install/>`_ • `Daft Quickstart <https://docs.daft.ai/en/stable/quickstart/>`_ • `Community and Support <https://github.com/Eventual-Inc/Daft/discussions>`_
 
@@ -127,6 +127,14 @@ Daft has an Apache 2.0 license - please see the LICENSE file.
 .. |Slack| image:: https://img.shields.io/badge/slack-@distdata-purple.svg?logo=slack
    :target: https://daft.ai/slack
    :alt: slack community
+
+.. |Ruff| image:: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json
+   :target: https://github.com/astral-sh/ruff
+   :alt: Ruff
+
+.. |uv| image:: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json
+   :target: https://github.com/astral-sh/uv
+   :alt: uv
 
 .. |TrendShift| image:: https://trendshift.io/api/badge/repositories/8239
    :target: https://trendshift.io/repositories/8239

--- a/assets/badge/logo.svg
+++ b/assets/badge/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 40">
+  <text x="0" y="33" font-family="Helvetica Neue, Helvetica, Arial, sans-serif" font-size="36" font-weight="300" fill="white">daft</text>
+  <rect x="86" y="3" width="32" height="34" fill="#FF00FF" rx="1"/>
+</svg>

--- a/assets/badge/v1.json
+++ b/assets/badge/v1.json
@@ -1,0 +1,9 @@
+{
+  "schemaVersion": 1,
+  "label": "",
+  "message": "daft",
+  "logoSvg": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 12 16\"><rect width=\"12\" height=\"16\" rx=\"1\" fill=\"#FF00FF\"/></svg>",
+  "logoWidth": 10,
+  "labelColor": "grey",
+  "color": "#130f40"
+}


### PR DESCRIPTION
## Summary
- Add **Ruff** and **uv** badges to the README badge row (using official shields.io endpoint URLs from astral-sh)
- Create a custom **daft** shields.io endpoint badge at `assets/badge/v1.json` — other projects can embed it with:
  ```
  [![daft](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Eventual-Inc/Daft/main/assets/badge/v1.json)](https://www.daft.ai)
  ```
- Add a full wordmark SVG logo at `assets/badge/logo.svg` for general use

## Test plan
- [ ] Verify Ruff and uv badge images render on the GitHub README
- [ ] Verify the custom daft badge renders via the shields.io endpoint URL after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)