### PR TITLE
fix(session): list_tables mirrors get_table resolution and returns Identifier

### DIFF
--- a/src/daft-session/src/python.rs
+++ b/src/daft-session/src/python.rs
@@ -123,8 +123,13 @@ impl PySession {
     }
 
     #[pyo3(signature = (pattern=None))]
-    pub fn list_tables(&self, pattern: Option<&str>) -> PyResult<Vec<String>> {
-        Ok(self.0.list_tables(pattern)?)
+    pub fn list_tables(&self, pattern: Option<&str>) -> PyResult<Vec<PyIdentifier>> {
+        Ok(self
+            .0
+            .list_tables(pattern)?
+            .into_iter()
+            .map(PyIdentifier::from)
+            .collect())
     }
 
     #[pyo3(signature = (ident))]

--- a/src/daft-session/src/session.rs
+++ b/src/daft-session/src/session.rs
@@ -396,9 +396,47 @@ impl Session {
         Ok(self.state().catalogs.list(pattern))
     }
 
-    /// Lists all tables matching the pattern.
-    pub fn list_tables(&self, pattern: Option<&str>) -> CatalogResult<Vec<String>> {
-        Ok(self.state().tables.list(pattern))
+    /// Lists all tables visible to the session, mirroring [`Self::get_table`]'s resolution rules:
+    /// - Rule 0: session-level temp tables.
+    /// - Rules 1+2: current catalog, narrowed to the current namespace when set.
+    /// - Rule 3: `<catalog>.<rest>` dispatches exclusively to that attached catalog.
+    pub fn list_tables(&self, pattern: Option<&str>) -> CatalogResult<Vec<Identifier>> {
+        if let Some(p) = pattern
+            && let Some((head, rest)) = p.split_once('.')
+            && self.has_catalog(head)
+        {
+            let inner = (!rest.is_empty()).then_some(rest);
+            return Ok(self
+                .get_catalog(head)?
+                .list_tables(inner)?
+                .into_iter()
+                .map(|id| id.qualify([head.to_string()]))
+                .collect());
+        }
+
+        let mut out: Vec<Identifier> = self
+            .state()
+            .tables
+            .list(pattern)
+            .into_iter()
+            .map(Identifier::simple)
+            .collect();
+
+        // Qualify with the session alias so identifiers round-trip through `get_table`.
+        let curr_alias = self.state().options.curr_catalog.clone();
+        if let Some(alias) = curr_alias {
+            let catalog = self.get_catalog(&alias)?;
+            let forwarded =
+                forward_pattern_with_namespace(pattern, self.current_namespace()?.as_deref());
+            out.extend(
+                catalog
+                    .list_tables(forwarded.as_deref())?
+                    .into_iter()
+                    .map(|id| id.qualify([alias.clone()])),
+            );
+        }
+
+        Ok(out)
     }
 
     /// Sets the current_catalog.
@@ -600,6 +638,20 @@ impl SessionState {
 impl Default for Session {
     fn default() -> Self {
         Self::empty()
+    }
+}
+
+/// Pass `pattern` through, or narrow to `<namespace>.%` when only a namespace is set.
+fn forward_pattern_with_namespace(
+    pattern: Option<&str>,
+    namespace: Option<&[String]>,
+) -> Option<String> {
+    if let Some(p) = pattern {
+        Some(p.to_string())
+    } else {
+        namespace
+            .filter(|ns| !ns.is_empty())
+            .map(|ns| format!("{}.%", ns.join(".")))
     }
 }
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -136,6 +136,29 @@ def test_list_tables_catalog_qualified_pattern():
     assert sess.list_tables("cat2.%") == [Identifier("cat2", "y")]
 
 
+def test_list_tables_narrows_to_current_namespace():
+    sess = Session()
+    cat = Catalog.from_pydict(
+        {"ns1.t1": {"x": [1]}, "ns1.t2": {"x": [2]}, "ns2.t3": {"x": [3]}},
+        name="cat1",
+    )
+    sess.attach_catalog(cat, alias="cat1")
+    sess.set_namespace("ns1")
+
+    tables = sorted(sess.list_tables(), key=str)
+
+    assert tables == [Identifier("cat1", "ns1", "t1"), Identifier("cat1", "ns1", "t2")]
+
+
+def test_list_tables_only_current_catalog_without_pattern():
+    sess = Session()
+    sess.attach_catalog(Catalog.from_pydict({"a": {"v": [1]}}, name="cat1"), alias="cat1")
+    sess.attach_catalog(Catalog.from_pydict({"b": {"v": [2]}}, name="cat2"), alias="cat2")
+
+    # cat1 is auto-set as current; cat2 is only reachable via `cat2.%` pattern.
+    assert sess.list_tables() == [Identifier("cat1", "a")]
+
+
 def test_attach_view():
     sess = Session()
     view = daft.from_pydict({"x": [1, 2, 3]})

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -95,6 +95,47 @@ def test_attach_table():
         sess.attach_table(view1, alias="tbl1")
 
 
+def test_list_tables_returns_identifiers():
+    # Regression: the Rust layer used to return Vec<String>, breaking `_from_pyidentifier`.
+    sess = Session()
+    sess.attach_table(Table.from_df("v", daft.from_pydict({"x": [1]})), alias="tbl")
+
+    tables = sess.list_tables()
+
+    assert len(tables) == 1
+    assert all(isinstance(t, Identifier) for t in tables)
+    assert tables[0] == Identifier("tbl")
+
+
+def test_list_tables_with_attached_catalog():
+    sess = Session()
+    cat = Catalog.from_pydict({"a": {"x": [1]}, "b": {"y": [2]}}, name="cat1")
+    sess.attach_catalog(cat, alias="cat1")
+
+    tables = sorted(sess.list_tables(), key=str)
+
+    assert tables == [Identifier("cat1", "a"), Identifier("cat1", "b")]
+
+
+def test_list_tables_temp_plus_catalog():
+    sess = Session()
+    sess.attach_table(Table.from_df("v", daft.from_pydict({"x": [1]})), alias="my_tmp")
+    cat = Catalog.from_pydict({"a": {"x": [1]}, "b": {"y": [2]}}, name="cat1")
+    sess.attach_catalog(cat, alias="cat1")
+
+    tables = sorted(sess.list_tables(), key=str)
+
+    assert tables == [Identifier("cat1", "a"), Identifier("cat1", "b"), Identifier("my_tmp")]
+
+
+def test_list_tables_catalog_qualified_pattern():
+    sess = Session()
+    sess.attach_catalog(Catalog.from_pydict({"x": {"v": [1]}}, name="cat1"), alias="cat1")
+    sess.attach_catalog(Catalog.from_pydict({"y": {"v": [2]}}, name="cat2"), alias="cat2")
+
+    assert sess.list_tables("cat2.%") == [Identifier("cat2", "y")]
+
+
 def test_attach_view():
     sess = Session()
     view = daft.from_pydict({"x": [1, 2, 3]})


### PR DESCRIPTION
## Changes Made

`Session::list_tables` only enumerated session-scoped temp tables, ignoring attached catalogs. It now mirrors `Session::get_table`'s resolution rules:

- Rule 0: session temp tables
- Rules 1+2: tables in the current catalog, narrowed to the current namespace when set
- Rule 3: `<catalog>.<rest>` patterns dispatch exclusively to that attached catalog

Return type is now `Vec<Identifier>` (was `Vec<String>`); `PySession::list_tables` correspondingly returns `Vec<PyIdentifier>`. This fixes a latent bug where `daft/session.py` already called `Identifier._from_pyidentifier` on the iteration result — it would have crashed the moment any element was returned. The Python `list_tables(...) -> list[Identifier]` annotation is unchanged.

Catalog tables are qualified with the **session alias** (not `Catalog::name()`), so identifiers returned by `list_tables` round-trip through `get_table` even when alias and catalog name differ.

## Related Issues

Closes #4400