### PR TITLE
fix(sql): allow read_parquet file options

### DIFF
--- a/src/daft-sql/src/table_provider/read_parquet.rs
+++ b/src/daft-sql/src/table_provider/read_parquet.rs
@@ -25,7 +25,7 @@ impl TryFrom<SQLFunctionArguments> for ParquetScanBuilder {
         } else if let Some(arg) = args.get_named("path") {
             try_coerce_list(arg.clone())?
         } else {
-            invalid_operation_err!("path is required for `read_json`")
+            invalid_operation_err!("path is required for `read_parquet`")
         };
 
         let infer_schema = args.try_get_named("infer_schema")?.unwrap_or(true);
@@ -77,6 +77,7 @@ impl SQLTableFunction for ReadParquetFunction {
         let builder: ParquetScanBuilder = planner.plan_function_args(
             args.args.as_slice(),
             &[
+                "path",
                 "infer_schema",
                 "coerce_int96_timestamp_unit",
                 "chunk_size",
@@ -85,6 +86,8 @@ impl SQLTableFunction for ReadParquetFunction {
                 // "field_id_mapping",
                 // "row_groups",
                 "io_config",
+                "file_path_column",
+                "hive_partitioning",
             ],
             1, // 1 positional argument (path)
         )?;

--- a/tests/sql/test_sql_table_functions.py
+++ b/tests/sql/test_sql_table_functions.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pyarrow as pa
+import pyarrow.parquet as papq
 import pytest
 
 import daft
@@ -94,6 +96,12 @@ def test_sql_read_parquet():
     assert_eq(actual, expect)
 
 
+def test_sql_read_parquet_named_path():
+    actual = daft.sql("SELECT * FROM read_parquet(path => 'tests/assets/parquet-data/mvp.parquet')")
+    expect = daft.read_parquet("tests/assets/parquet-data/mvp.parquet")
+    assert actual.to_pydict() == expect.to_pydict()
+
+
 def test_sql_read_parquet_path():
     actual = daft.sql("SELECT * FROM 'tests/assets/parquet-data/mvp.parquet'")
     expect = daft.read_parquet("tests/assets/parquet-data/mvp.parquet")
@@ -108,6 +116,20 @@ def test_sql_read_parquet_paths():
     actual = daft.sql(f"SELECT * FROM read_parquet({to_sql_array(paths)})")
     expect = daft.read_parquet(paths)
     assert_eq(actual, expect)
+
+
+def test_sql_read_parquet_file_options(tmp_path):
+    table_dir = tmp_path / "country=us"
+    table_dir.mkdir()
+    file_path = table_dir / "data.parquet"
+    papq.write_table(pa.table({"x": [1, 2]}), file_path)
+
+    glob_path = f"{tmp_path.as_posix()}/**"
+    actual = daft.sql(
+        f"SELECT * FROM read_parquet('{glob_path}', file_path_column => 'filepath', hive_partitioning => true)"
+    )
+    expect = daft.read_parquet(glob_path, file_path_column="filepath", hive_partitioning=True)
+    assert actual.to_pydict() == expect.to_pydict()
 
 
 def test_sql_read_csv(sample_csv_path):


### PR DESCRIPTION
## Changes Made
Allowed SQL read_parquet to accept named path, file_path_column, and hive_partitioning arguments, matching the existing Python API.

## Related Issues
N/A