### PR TITLE
feat(iceberg): support SQL read_iceberg ignore_corrupt_files

### DIFF
--- a/src/daft-logical-plan/src/scan_builder.rs
+++ b/src/daft-logical-plan/src/scan_builder.rs
@@ -404,6 +404,7 @@ pub fn iceberg_scan<T: AsRef<str>>(
     branch: Option<String>,
     tag: Option<String>,
     io_config: Option<IOConfig>,
+    ignore_corrupt_files: bool,
 ) -> DaftResult<LogicalPlanBuilder> {
     use pyo3::IntoPyObjectExt;
     let storage_config: StorageConfig = io_config.unwrap_or_default().into();
@@ -419,7 +420,12 @@ pub fn iceberg_scan<T: AsRef<str>>(
         let iceberg_scan_module = PyModule::import(py, "daft.io.iceberg.iceberg_scan")?;
         let iceberg_scan_class = iceberg_scan_module.getattr("IcebergScanOperator")?;
         let iceberg_scan = iceberg_scan_class
-            .call1((iceberg_table, snapshot_id, storage_config))?
+            .call1((
+                iceberg_table,
+                snapshot_id,
+                storage_config,
+                ignore_corrupt_files,
+            ))?
             .into_py_any(py)?;
         Ok(ScanOperatorHandle::from_python_scan_operator(
             iceberg_scan,
@@ -436,6 +442,7 @@ pub fn iceberg_scan<T: AsRef<str>>(
     _branch: Option<String>,
     _tag: Option<String>,
     _io_config: Option<IOConfig>,
+    _ignore_corrupt_files: bool,
 ) -> DaftResult<LogicalPlanBuilder> {
     panic!("Iceberg scan requires the 'python' feature to be enabled.")
 }

--- a/src/daft-sql/src/table_provider/read_iceberg.rs
+++ b/src/daft-sql/src/table_provider/read_iceberg.rs
@@ -19,6 +19,7 @@ struct SqlReadIcebergArgs {
     branch: Option<String>,
     tag: Option<String>,
     io_config: Option<IOConfig>,
+    ignore_corrupt_files: bool,
 }
 
 impl SqlReadIcebergArgs {
@@ -26,7 +27,13 @@ impl SqlReadIcebergArgs {
     fn try_from(planner: &SQLPlanner, args: &TableFunctionArgs) -> SQLPlannerResult<Self> {
         planner.plan_function_args(
             &args.args,
-            &["snapshot_id", "branch", "tag", "io_config"],
+            &[
+                "snapshot_id",
+                "branch",
+                "tag",
+                "io_config",
+                "ignore_corrupt_files",
+            ],
             1,
         )
     }
@@ -44,12 +51,14 @@ impl TryFrom<SQLFunctionArguments> for SqlReadIcebergArgs {
         let branch: Option<String> = args.try_get_named("branch")?;
         let tag: Option<String> = args.try_get_named("tag")?;
         let io_config: Option<IOConfig> = functions::args::parse_io_config(&args)?.into();
+        let ignore_corrupt_files = args.try_get_named("ignore_corrupt_files")?.unwrap_or(false);
         Ok(Self {
             metadata_location,
             snapshot_id,
             branch,
             tag,
             io_config,
+            ignore_corrupt_files,
         })
     }
 }
@@ -69,6 +78,7 @@ impl SQLTableFunction for SqlReadIceberg {
             args.branch,
             args.tag,
             args.io_config,
+            args.ignore_corrupt_files,
         )?)
     }
 }

--- a/tests/sql/test_sql_read_iceberg.py
+++ b/tests/sql/test_sql_read_iceberg.py
@@ -127,7 +127,7 @@ def test_sql_read_iceberg_ignore_corrupt_files_skips_data_file(tmp_path):
 
         result = sorted(df.to_pydict()["id"])
         assert len(result) == 3
-        assert set(result).issubset({1, 2, 3, 4, 5, 6})
+        assert result in ([1, 2, 3], [4, 5, 6])
 
         skipped = df.skipped_corrupt_files
         assert len(skipped) == 1

--- a/tests/sql/test_sql_read_iceberg.py
+++ b/tests/sql/test_sql_read_iceberg.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from urllib.parse import unquote, urlparse
 
 import pyarrow as pa
@@ -17,6 +18,15 @@ from pyiceberg.types import LongType, NestedField, StringType
 def _metadata_path(metadata_location: str) -> str:
     parsed = urlparse(metadata_location)
     return unquote(parsed.path) if parsed.scheme == "file" else metadata_location
+
+
+def _local_path(path: str) -> str:
+    parsed = urlparse(path)
+    return unquote(parsed.path) if parsed.scheme else path
+
+
+def _iceberg_data_file_local_paths(table) -> list[str]:
+    return sorted(_local_path(task.file.file_path) for task in table.scan().plan_files())
 
 
 def test_sql_read_iceberg_branch_and_tag_with_schema_evolution(tmp_path):
@@ -84,6 +94,47 @@ def test_sql_read_iceberg_branch_and_tag_with_schema_evolution(tmp_path):
             with pytest.raises(Exception, match=f"Iceberg {ref_kind} 'does_not_exist' does not exist") as exc_info:
                 daft.sql(f"SELECT * FROM read_iceberg('{metadata_location}', {ref_kind} => 'does_not_exist')")
             assert exc_info.type.__name__ == "InvalidSQLException"
+    finally:
+        catalog.engine.dispose()
+
+
+def test_sql_read_iceberg_ignore_corrupt_files_skips_data_file(tmp_path):
+    catalog = SqlCatalog(
+        "default",
+        uri=f"sqlite:///{tmp_path}/pyiceberg_catalog.db",
+        warehouse=f"file://{tmp_path}",
+    )
+    try:
+        catalog.create_namespace("default")
+        table = catalog.create_table("default.t_corrupt", Schema(NestedField(1, "id", LongType())))
+
+        table.append(pa.table({"id": pa.array([1, 2, 3], type=pa.int64())}))
+        table.append(pa.table({"id": pa.array([4, 5, 6], type=pa.int64())}))
+
+        data_files = _iceberg_data_file_local_paths(table)
+        assert len(data_files) == 2
+
+        with open(data_files[0], "wb") as f:
+            f.write(b"PAR1" + b"\x00" * 20 + b"PAR1")
+
+        metadata_location = _metadata_path(table.metadata_location)
+
+        with pytest.raises(Exception):
+            daft.sql(f"SELECT * FROM read_iceberg('{metadata_location}')").collect()
+
+        df = daft.sql(f"SELECT * FROM read_iceberg('{metadata_location}', ignore_corrupt_files => true)")
+        df.collect()
+
+        result = sorted(df.to_pydict()["id"])
+        assert len(result) == 3
+        assert set(result).issubset({1, 2, 3, 4, 5, 6})
+
+        skipped = df.skipped_corrupt_files
+        assert len(skipped) == 1
+        path, reason, partial = skipped[0]
+        assert os.path.basename(_local_path(path)) == os.path.basename(data_files[0])
+        assert reason
+        assert not partial
     finally:
         catalog.engine.dispose()
 


### PR DESCRIPTION
## Changes Made
Adds `ignore_corrupt_files` support for SQL `read_iceberg` by passing the option through the Rust scan builder into the existing Python Iceberg scan operator. Includes SQL coverage for skipping a corrupt Iceberg data file.

## Related Issues
Closes #7129
