### PR TITLE
chore: upgrade arrow-rs from 57.1.0 to 59.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,35 +173,35 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arrow"
-version = "57.3.0"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4754a624e5ae42081f464514be454b39711daae0458906dacde5f4c632f33a8"
+checksum = "ffaaa3e009861fd829d0a24dd6f115aa8e4634324bb092147d43baafe69ca4a7"
 dependencies = [
  "arrow-arith",
- "arrow-array 57.3.0",
- "arrow-buffer 57.3.0",
+ "arrow-array 59.0.0",
+ "arrow-buffer 59.0.0",
  "arrow-cast",
  "arrow-csv",
- "arrow-data 57.3.0",
+ "arrow-data 59.0.0",
  "arrow-ipc",
  "arrow-json",
  "arrow-ord",
  "arrow-row",
- "arrow-schema 57.3.0",
+ "arrow-schema 59.0.0",
  "arrow-select",
  "arrow-string",
 ]
 
 [[package]]
 name = "arrow-arith"
-version = "57.3.0"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7b3141e0ec5145a22d8694ea8b6d6f69305971c4fa1c1a13ef0195aef2d678b"
+checksum = "3ac95125e1d71c4a252b5a9c729aef111e80418f08aaa6dbabd1ba66918247fc"
 dependencies = [
- "arrow-array 57.3.0",
- "arrow-buffer 57.3.0",
- "arrow-data 57.3.0",
- "arrow-schema 57.3.0",
+ "arrow-array 59.0.0",
+ "arrow-buffer 59.0.0",
+ "arrow-data 59.0.0",
+ "arrow-schema 59.0.0",
  "chrono",
  "num-traits",
 ]
@@ -233,7 +233,6 @@ dependencies = [
  "arrow-data 57.3.0",
  "arrow-schema 57.3.0",
  "chrono",
- "chrono-tz",
  "half",
  "hashbrown 0.16.1",
  "num-complex",
@@ -252,6 +251,25 @@ dependencies = [
  "arrow-data 58.2.0",
  "arrow-schema 58.2.0",
  "chrono",
+ "half",
+ "hashbrown 0.17.1",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-array"
+version = "59.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c60c79628e9a97cb90d7a0dc3e944f216a902f837d4ecabc14d524bddbbc137"
+dependencies = [
+ "ahash",
+ "arrow-buffer 59.0.0",
+ "arrow-data 59.0.0",
+ "arrow-schema 59.0.0",
+ "chrono",
+ "chrono-tz",
  "half",
  "hashbrown 0.17.1",
  "num-complex",
@@ -295,16 +313,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrow-cast"
-version = "57.3.0"
+name = "arrow-buffer"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "646bbb821e86fd57189c10b4fcdaa941deaf4181924917b0daa92735baa6ada5"
+checksum = "6026f638c400e9878c1b1cc05c3cfd46fbf381285916ab408678701c1df46c1a"
 dependencies = [
- "arrow-array 57.3.0",
- "arrow-buffer 57.3.0",
- "arrow-data 57.3.0",
+ "bytes",
+ "half",
+ "num-bigint",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "59.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c82c236c3caf8df5664284f3f1fbe89938852163998c3fdbf37e84ac220445e9"
+dependencies = [
+ "arrow-array 59.0.0",
+ "arrow-buffer 59.0.0",
+ "arrow-data 59.0.0",
  "arrow-ord",
- "arrow-schema 57.3.0",
+ "arrow-schema 59.0.0",
  "arrow-select",
  "atoi",
  "base64 0.22.1",
@@ -317,13 +347,13 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
-version = "57.3.0"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da746f4180004e3ce7b83c977daf6394d768332349d3d913998b10a120b790a"
+checksum = "12714e5fb7954159af1e26d4e0d37108bcf1a2ad5ee5c5bf02a944d564d588b7"
 dependencies = [
- "arrow-array 57.3.0",
+ "arrow-array 59.0.0",
  "arrow-cast",
- "arrow-schema 57.3.0",
+ "arrow-schema 59.0.0",
  "chrono",
  "csv",
  "csv-core",
@@ -369,16 +399,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrow-flight"
-version = "57.3.0"
+name = "arrow-data"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58c5b083668e6230eae3eab2fc4b5fb989974c845d0aa538dde61a4327c78675"
+checksum = "7bd568aa70c4ec5947027b0d5caee94877433b661a0bb9e8ddceeeb5f0c9b1ab"
 dependencies = [
- "arrow-array 57.3.0",
- "arrow-buffer 57.3.0",
+ "arrow-buffer 59.0.0",
+ "arrow-schema 59.0.0",
+ "half",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-flight"
+version = "59.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68365401e834743d708094927e2ca727a32d639fe900df04b936e07a36701b74"
+dependencies = [
+ "arrow-array 59.0.0",
+ "arrow-buffer 59.0.0",
  "arrow-cast",
  "arrow-ipc",
- "arrow-schema 57.3.0",
+ "arrow-schema 59.0.0",
  "base64 0.22.1",
  "bytes",
  "futures",
@@ -390,14 +433,14 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "57.3.0"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abf7df950701ab528bf7c0cf7eeadc0445d03ef5d6ffc151eaae6b38a58feff1"
+checksum = "e57ee4d470eab1a021bc4b63fa2b2c15d572892bf227b0a982d3b755a6c662b5"
 dependencies = [
- "arrow-array 57.3.0",
- "arrow-buffer 57.3.0",
- "arrow-data 57.3.0",
- "arrow-schema 57.3.0",
+ "arrow-array 59.0.0",
+ "arrow-buffer 59.0.0",
+ "arrow-data 59.0.0",
+ "arrow-schema 59.0.0",
  "arrow-select",
  "flatbuffers",
  "lz4_flex",
@@ -406,15 +449,16 @@ dependencies = [
 
 [[package]]
 name = "arrow-json"
-version = "57.3.0"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ff8357658bedc49792b13e2e862b80df908171275f8e6e075c460da5ee4bf86"
+checksum = "38f47e0e7a284e1f3707a780dc8cd5451b1614e9e398ea2d9ca03c7a2fe9a9ed"
 dependencies = [
- "arrow-array 57.3.0",
- "arrow-buffer 57.3.0",
+ "arrow-array 59.0.0",
+ "arrow-buffer 59.0.0",
  "arrow-cast",
- "arrow-data 57.3.0",
- "arrow-schema 57.3.0",
+ "arrow-ord",
+ "arrow-schema 59.0.0",
+ "arrow-select",
  "chrono",
  "half",
  "indexmap",
@@ -430,27 +474,27 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "57.3.0"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d8f1870e03d4cbed632959498bcc84083b5a24bded52905ae1695bd29da45b"
+checksum = "a79cf73ad2eba8686ec2aa9bbf8671208e509025f166afc040cedbd94ffe4983"
 dependencies = [
- "arrow-array 57.3.0",
- "arrow-buffer 57.3.0",
- "arrow-data 57.3.0",
- "arrow-schema 57.3.0",
+ "arrow-array 59.0.0",
+ "arrow-buffer 59.0.0",
+ "arrow-data 59.0.0",
+ "arrow-schema 59.0.0",
  "arrow-select",
 ]
 
 [[package]]
 name = "arrow-row"
-version = "57.3.0"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18228633bad92bff92a95746bbeb16e5fc318e8382b75619dec26db79e4de4c0"
+checksum = "cea0f7d8ed6182f14952761e2c0f989852d5aa334fcbc49f73a9f2247c25b879"
 dependencies = [
- "arrow-array 57.3.0",
- "arrow-buffer 57.3.0",
- "arrow-data 57.3.0",
- "arrow-schema 57.3.0",
+ "arrow-array 59.0.0",
+ "arrow-buffer 59.0.0",
+ "arrow-data 59.0.0",
+ "arrow-schema 59.0.0",
  "half",
 ]
 
@@ -470,8 +514,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c872d36b7bf2a6a6a2b40de9156265f0242910791db366a2c17476ba8330d68"
 dependencies = [
  "bitflags 2.11.0",
- "serde_core",
- "serde_json",
 ]
 
 [[package]]
@@ -484,29 +526,40 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrow-select"
-version = "57.3.0"
+name = "arrow-schema"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68bf3e3efbd1278f770d67e5dc410257300b161b93baedb3aae836144edcaf4b"
+checksum = "80b3e786a0dd9103acd583a6fb486dbf2f3268466cc0bd571dcf34cef231c1f1"
+dependencies = [
+ "bitflags 2.11.0",
+ "serde_core",
+ "serde_json",
+]
+
+[[package]]
+name = "arrow-select"
+version = "59.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "067a67e0361f6c31f4a7248759f36ca4ca71b187a941ed4d49da1c7d3d4db624"
 dependencies = [
  "ahash",
- "arrow-array 57.3.0",
- "arrow-buffer 57.3.0",
- "arrow-data 57.3.0",
- "arrow-schema 57.3.0",
+ "arrow-array 59.0.0",
+ "arrow-buffer 59.0.0",
+ "arrow-data 59.0.0",
+ "arrow-schema 59.0.0",
  "num-traits",
 ]
 
 [[package]]
 name = "arrow-string"
-version = "57.3.0"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e968097061b3c0e9fe3079cf2e703e487890700546b5b0647f60fca1b5a8d8"
+checksum = "99bc95847f3ff62a2b03d6f8ce2e3e78f01362060549a2a311898dd442f6256d"
 dependencies = [
- "arrow-array 57.3.0",
- "arrow-buffer 57.3.0",
- "arrow-data 57.3.0",
- "arrow-schema 57.3.0",
+ "arrow-array 59.0.0",
+ "arrow-buffer 59.0.0",
+ "arrow-data 59.0.0",
+ "arrow-schema 59.0.0",
  "arrow-select",
  "memchr",
  "num-traits",
@@ -1523,12 +1576,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "byteorder-lite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1747,7 +1794,7 @@ name = "common-arrow-ffi"
 version = "0.3.0-dev0"
 dependencies = [
  "arrow",
- "arrow-schema 57.3.0",
+ "arrow-schema 59.0.0",
  "pyo3",
 ]
 
@@ -1788,7 +1835,7 @@ dependencies = [
 name = "common-error"
 version = "0.3.0-dev0"
 dependencies = [
- "arrow-schema 57.3.0",
+ "arrow-schema 59.0.0",
  "pyo3",
  "regex",
  "serde_json",
@@ -2388,8 +2435,8 @@ dependencies = [
 name = "daft-checkpoint"
 version = "0.3.0-dev0"
 dependencies = [
- "arrow-array 57.3.0",
- "arrow-schema 57.3.0",
+ "arrow-array 59.0.0",
+ "arrow-schema 59.0.0",
  "async-trait",
  "bincode",
  "bytes",
@@ -2505,7 +2552,7 @@ dependencies = [
 name = "daft-csv"
 version = "0.3.0-dev0"
 dependencies = [
- "arrow-schema 57.3.0",
+ "arrow-schema 59.0.0",
  "async-compat",
  "async-stream",
  "common-error",
@@ -2562,8 +2609,8 @@ dependencies = [
 name = "daft-decoding"
 version = "0.3.0-dev0"
 dependencies = [
- "arrow-array 57.3.0",
- "arrow-schema 57.3.0",
+ "arrow-array 59.0.0",
+ "arrow-schema 59.0.0",
  "atoi_simd",
  "chrono",
  "csv",
@@ -2654,12 +2701,15 @@ dependencies = [
  "arrow-array 56.2.0",
  "arrow-array 57.3.0",
  "arrow-array 58.2.0",
+ "arrow-array 59.0.0",
  "arrow-data 56.2.0",
  "arrow-data 57.3.0",
  "arrow-data 58.2.0",
+ "arrow-data 59.0.0",
  "arrow-schema 56.2.0",
  "arrow-schema 57.3.0",
  "arrow-schema 58.2.0",
+ "arrow-schema 59.0.0",
  "daft-ext-macros",
 ]
 
@@ -2668,8 +2718,8 @@ name = "daft-ext-internal"
 version = "0.3.0-dev0"
 dependencies = [
  "arrow",
- "arrow-array 57.3.0",
- "arrow-schema 57.3.0",
+ "arrow-array 59.0.0",
+ "arrow-schema 59.0.0",
  "common-error",
  "daft-core",
  "daft-dsl",
@@ -2710,8 +2760,8 @@ dependencies = [
 name = "daft-functions"
 version = "0.3.0-dev0"
 dependencies = [
- "arrow-array 57.3.0",
- "arrow-buffer 57.3.0",
+ "arrow-array 59.0.0",
+ "arrow-buffer 59.0.0",
  "chrono",
  "common-error",
  "daft-core",
@@ -2791,7 +2841,7 @@ dependencies = [
 name = "daft-functions-temporal"
 version = "0.3.0-dev0"
 dependencies = [
- "arrow-array 57.3.0",
+ "arrow-array 59.0.0",
  "chrono",
  "chrono-tz",
  "common-error",
@@ -2846,7 +2896,7 @@ version = "0.3.0-dev0"
 dependencies = [
  "aho-corasick",
  "arrow",
- "arrow-buffer 57.3.0",
+ "arrow-buffer 59.0.0",
  "chrono",
  "chrono-tz",
  "common-error",
@@ -2865,7 +2915,7 @@ dependencies = [
 name = "daft-geo"
 version = "0.3.0-dev0"
 dependencies = [
- "arrow-buffer 57.3.0",
+ "arrow-buffer 59.0.0",
  "daft-core",
  "daft-dsl",
  "serde",
@@ -3002,10 +3052,10 @@ version = "0.3.0-dev0"
 dependencies = [
  "arc-swap",
  "arrow",
- "arrow-array 57.3.0",
- "arrow-buffer 57.3.0",
+ "arrow-array 59.0.0",
+ "arrow-buffer 59.0.0",
  "arrow-ipc",
- "arrow-schema 57.3.0",
+ "arrow-schema 59.0.0",
  "async-trait",
  "common-checkpoint-config",
  "common-daft-config",
@@ -3068,8 +3118,8 @@ dependencies = [
 name = "daft-local-plan"
 version = "0.3.0-dev0"
 dependencies = [
- "arrow-array 57.3.0",
- "arrow-schema 57.3.0",
+ "arrow-array 59.0.0",
+ "arrow-schema 59.0.0",
  "bincode",
  "common-checkpoint-config",
  "common-error",
@@ -3143,7 +3193,7 @@ name = "daft-micropartition"
 version = "0.3.0-dev0"
 dependencies = [
  "arrow",
- "arrow-array 57.3.0",
+ "arrow-array 59.0.0",
  "arrow-ipc",
  "bincode",
  "common-arrow-ffi",
@@ -3227,7 +3277,7 @@ name = "daft-recordbatch"
 version = "0.3.0-dev0"
 dependencies = [
  "arrow",
- "arrow-array 57.3.0",
+ "arrow-array 59.0.0",
  "arrow-ipc",
  "async-recursion",
  "comfy-table",
@@ -3272,7 +3322,7 @@ dependencies = [
 name = "daft-scan"
 version = "0.3.0-dev0"
 dependencies = [
- "arrow-schema 57.3.0",
+ "arrow-schema 59.0.0",
  "async-trait",
  "common-daft-config",
  "common-display",
@@ -3314,7 +3364,7 @@ name = "daft-schema"
 version = "0.3.0-dev0"
 dependencies = [
  "arrow",
- "arrow-schema 57.3.0",
+ "arrow-schema 59.0.0",
  "chrono",
  "chrono-tz",
  "common-arrow-ffi",
@@ -3356,10 +3406,10 @@ dependencies = [
 name = "daft-shuffles"
 version = "0.3.0-dev0"
 dependencies = [
- "arrow-array 57.3.0",
+ "arrow-array 59.0.0",
  "arrow-flight",
  "arrow-ipc",
- "arrow-schema 57.3.0",
+ "arrow-schema 59.0.0",
  "async-channel 2.5.0",
  "async-stream",
  "common-error",
@@ -3379,8 +3429,8 @@ dependencies = [
 name = "daft-sketch"
 version = "0.3.0-dev0"
 dependencies = [
- "arrow-array 57.3.0",
- "arrow-schema 57.3.0",
+ "arrow-array 59.0.0",
+ "arrow-schema 59.0.0",
  "common-error",
  "serde_arrow",
  "sketches-ddsketch",
@@ -3450,7 +3500,7 @@ dependencies = [
 name = "daft-warc"
 version = "0.3.0-dev0"
 dependencies = [
- "arrow-array 57.3.0",
+ "arrow-array 59.0.0",
  "chrono",
  "common-error",
  "common-runtime",
@@ -3473,11 +3523,11 @@ dependencies = [
 name = "daft-writers"
 version = "0.3.0-dev0"
 dependencies = [
- "arrow-array 57.3.0",
+ "arrow-array 59.0.0",
  "arrow-csv",
  "arrow-ipc",
  "arrow-json",
- "arrow-schema 57.3.0",
+ "arrow-schema 59.0.0",
  "async-trait",
  "bytes",
  "chrono",
@@ -4826,12 +4876,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "integer-encoding"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
-
-[[package]]
 name = "inventory"
 version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5162,9 +5206,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4_flex"
-version = "0.12.2"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90071f8077f8e40adfc4b7fe9cd495ce316263f19e75c2211eeff3fdf475a3d9"
+checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
 dependencies = [
  "twox-hash",
 ]
@@ -5186,10 +5230,10 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48b7541d9bd6781e25b0dfe7d638e5a8aa7950d5cdbf86f97537b5672768f7c4"
 dependencies = [
- "arrow-array 57.3.0",
- "arrow-buffer 57.3.0",
- "arrow-data 57.3.0",
- "arrow-schema 57.3.0",
+ "arrow-array 59.0.0",
+ "arrow-buffer 59.0.0",
+ "arrow-data 59.0.0",
+ "arrow-schema 59.0.0",
  "bytemuck",
  "half",
  "serde",
@@ -5768,15 +5812,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ordered-float"
-version = "2.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "ordered-multimap"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5859,17 +5894,16 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "57.3.0"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ee96b29972a257b855ff2341b37e61af5f12d6af1158b6dcdb5b31ea07bb3cb"
+checksum = "970dff83e97d953c827ae8176f6bf4e9f77bf62daacc01ec5df348ec5eacd913"
 dependencies = [
  "ahash",
- "arrow-array 57.3.0",
- "arrow-buffer 57.3.0",
- "arrow-cast",
- "arrow-data 57.3.0",
+ "arrow-array 59.0.0",
+ "arrow-buffer 59.0.0",
+ "arrow-data 59.0.0",
  "arrow-ipc",
- "arrow-schema 57.3.0",
+ "arrow-schema 59.0.0",
  "arrow-select",
  "base64 0.22.1",
  "brotli 8.0.2",
@@ -5878,7 +5912,7 @@ dependencies = [
  "flate2",
  "futures",
  "half",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "lz4_flex",
  "num-bigint",
  "num-integer",
@@ -5890,7 +5924,6 @@ dependencies = [
  "seq-macro",
  "simdutf8",
  "snap",
- "thrift",
  "tokio",
  "twox-hash",
  "zstd",
@@ -5898,41 +5931,44 @@ dependencies = [
 
 [[package]]
 name = "parquet-variant"
-version = "57.3.0"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6c31f8f9bfefb9dbf67b0807e00fd918676954a7477c889be971ac904103184"
+checksum = "561ead3e7c0acda5214ddc8e52645cfc9dd5bdf93cfcd7513715adf63f0bd2ce"
 dependencies = [
- "arrow-schema 57.3.0",
+ "arrow",
+ "arrow-schema 59.0.0",
  "chrono",
  "half",
  "indexmap",
+ "num-traits",
  "simdutf8",
  "uuid",
 ]
 
 [[package]]
 name = "parquet-variant-compute"
-version = "57.3.0"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "196cd9f7178fed3ac8d5e6d2b51193818e896bbc3640aea3fde3440114a8f39c"
+checksum = "8ece7aa9410b47d8bf3e0bf77529287ed4ccdd2b12c20978f8e9a8f09a48712d"
 dependencies = [
  "arrow",
- "arrow-schema 57.3.0",
+ "arrow-schema 59.0.0",
  "chrono",
  "half",
  "indexmap",
  "parquet-variant",
  "parquet-variant-json",
+ "serde_json",
  "uuid",
 ]
 
 [[package]]
 name = "parquet-variant-json"
-version = "57.3.0"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed23d7acc90ef60f7fdbcc473fa2fdaefa33542ed15b84388959346d52c839be"
+checksum = "57b4abded29d8a7d1b450795aace3e06577399a35eef0023fb03ce6acd6c23e8"
 dependencies = [
- "arrow-schema 57.3.0",
+ "arrow-schema 59.0.0",
  "base64 0.22.1",
  "chrono",
  "parquet-variant",
@@ -7277,8 +7313,8 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f7168b019016101c432501f4cffb94869bed2ba1083ca9df06e90e10bd6f998"
 dependencies = [
- "arrow-array 57.3.0",
- "arrow-schema 57.3.0",
+ "arrow-array 59.0.0",
+ "arrow-schema 59.0.0",
  "bytemuck",
  "chrono",
  "half",
@@ -7817,17 +7853,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "thrift"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
-dependencies = [
- "byteorder",
- "integer-encoding",
- "ordered-float",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -242,17 +242,17 @@ exclude = [
 ]
 
 [workspace.dependencies]
-arrow = "57.1.0"
-arrow-array = {version = "57.1.0", features = ["chrono-tz"]}
-arrow-buffer = "57.1.0"
-arrow-csv = "57.1.0"
-arrow-data = "57.1.0"
-arrow-flight = "57.1.0"
-arrow-ipc = {version = "57.1.0", features = ["lz4", "zstd"]}
-arrow-json = "57.1.0"
-arrow-row = "57.1.0"
-arrow-schema = "57.1.0"
-arrow-select = "57.1.0"
+arrow = "59.0.0"
+arrow-array = {version = "59.0.0", features = ["chrono-tz"]}
+arrow-buffer = "59.0.0"
+arrow-csv = "59.0.0"
+arrow-data = "59.0.0"
+arrow-flight = "59.0.0"
+arrow-ipc = {version = "59.0.0", features = ["lz4", "zstd"]}
+arrow-json = "59.0.0"
+arrow-row = "59.0.0"
+arrow-schema = "59.0.0"
+arrow-select = "59.0.0"
 approx = "0.5.1"
 arc-swap = "1.7.1"
 async-compat = "0.2.5"
@@ -334,7 +334,7 @@ opentelemetry = {version = "0.31", features = ["trace", "metrics", "logs"]}
 opentelemetry-otlp = {version = "0.31", features = ["grpc-tonic", "logs"]}
 opentelemetry_sdk = {version = "0.31", features = ["logs"]}
 parking_lot = "0.12.5"
-parquet = "57.1.0"
+parquet = "59.0.0"
 path_macro = "1.0.0"
 pretty_assertions = "1.4.1"
 proptest = "1.9.0"

--- a/src/daft-ext/Cargo.toml
+++ b/src/daft-ext/Cargo.toml
@@ -14,18 +14,22 @@ ignored = [
   "arrow-data-56",
   "arrow-data-57",
   "arrow-data-58",
+  "arrow-data-59",
   "arrow-schema-56",
   "arrow-schema-57",
   "arrow-schema-58",
+  "arrow-schema-59",
   "arrow-array-56",
   "arrow-array-57",
-  "arrow-array-58"
+  "arrow-array-58",
+  "arrow-array-59"
 ]
 
 [features]
 arrow-56 = ["dep:arrow-schema-56", "dep:arrow-data-56", "dep:arrow-array-56"]
 arrow-57 = ["dep:arrow-schema-57", "dep:arrow-data-57", "dep:arrow-array-57"]
 arrow-58 = ["dep:arrow-schema-58", "dep:arrow-data-58", "dep:arrow-array-58"]
+arrow-59 = ["dep:arrow-schema-59", "dep:arrow-data-59", "dep:arrow-array-59"]
 
 [dependencies]
 daft-ext-macros = {path = "../daft-ext-macros", version = "0.1.1"}
@@ -39,6 +43,9 @@ arrow-array-57 = {package = "arrow-array", version = "57", features = ["ffi"], o
 arrow-schema-58 = {package = "arrow-schema", version = "58", features = ["ffi"], optional = true}
 arrow-data-58 = {package = "arrow-data", version = "58", features = ["ffi"], optional = true}
 arrow-array-58 = {package = "arrow-array", version = "58", features = ["ffi"], optional = true}
+arrow-schema-59 = {package = "arrow-schema", version = "59", features = ["ffi"], optional = true}
+arrow-data-59 = {package = "arrow-data", version = "59", features = ["ffi"], optional = true}
+arrow-array-59 = {package = "arrow-array", version = "59", features = ["ffi"], optional = true}
 
 [lints]
 workspace = true

--- a/src/daft-ext/src/abi/compat.rs
+++ b/src/daft-ext/src/abi/compat.rs
@@ -1,6 +1,6 @@
 //! Feature-gated conversions for arrow-rs FFI types.
 //!
-//! Enable one of `arrow-56`, `arrow-57`, or `arrow-58` to get:
+//! Enable one of `arrow-56`, `arrow-57`, `arrow-58`, or `arrow-59` to get:
 //! - Safe `.into()` between `FFI_ArrowArray`/`FFI_ArrowSchema` and our types
 //! - `TryFrom` between `arrow_schema::Field` and our `ArrowSchema`
 
@@ -105,3 +105,6 @@ impl_arrow_conversions!(arrow_schema_57, arrow_data_57);
 
 #[cfg(feature = "arrow-58")]
 impl_arrow_conversions!(arrow_schema_58, arrow_data_58);
+
+#[cfg(feature = "arrow-59")]
+impl_arrow_conversions!(arrow_schema_59, arrow_data_59);

--- a/src/daft-ext/src/helpers.rs
+++ b/src/daft-ext/src/helpers.rs
@@ -1,6 +1,6 @@
 //! Convenience helpers for converting between `daft-ext` FFI types and arrow-rs types.
 //!
-//! Requires one of the `arrow-56`, `arrow-57`, or `arrow-58` feature flags.
+//! Requires one of the `arrow-56`, `arrow-57`, `arrow-58`, or `arrow-59` feature flags.
 
 #[allow(unused_macros)]
 macro_rules! impl_helpers {
@@ -97,15 +97,23 @@ macro_rules! impl_helpers {
 
 // When multiple arrow features are enabled (e.g. --all-features), pick exactly one.
 // Prefer the highest version.
-#[cfg(feature = "arrow-58")]
+#[cfg(feature = "arrow-59")]
+impl_helpers!(arrow_schema_59, arrow_data_59, arrow_array_59);
+
+#[cfg(all(feature = "arrow-58", not(feature = "arrow-59")))]
 impl_helpers!(arrow_schema_58, arrow_data_58, arrow_array_58);
 
-#[cfg(all(feature = "arrow-57", not(feature = "arrow-58")))]
+#[cfg(all(
+    feature = "arrow-57",
+    not(feature = "arrow-58"),
+    not(feature = "arrow-59")
+))]
 impl_helpers!(arrow_schema_57, arrow_data_57, arrow_array_57);
 
 #[cfg(all(
     feature = "arrow-56",
     not(feature = "arrow-57"),
-    not(feature = "arrow-58")
+    not(feature = "arrow-58"),
+    not(feature = "arrow-59")
 ))]
 impl_helpers!(arrow_schema_56, arrow_data_56, arrow_array_56);

--- a/src/daft-ext/src/lib.rs
+++ b/src/daft-ext/src/lib.rs
@@ -7,6 +7,11 @@ pub mod session;
 
 mod ffi;
 
-#[cfg(any(feature = "arrow-56", feature = "arrow-57", feature = "arrow-58"))]
+#[cfg(any(
+    feature = "arrow-56",
+    feature = "arrow-57",
+    feature = "arrow-58",
+    feature = "arrow-59"
+))]
 pub mod helpers;
 pub use daft_ext_macros::*;

--- a/src/daft-ext/src/prelude.rs
+++ b/src/daft-ext/src/prelude.rs
@@ -1,6 +1,11 @@
 pub use daft_ext_macros::{daft_extension, daft_func, daft_func_batch};
 
-#[cfg(any(feature = "arrow-56", feature = "arrow-57", feature = "arrow-58"))]
+#[cfg(any(
+    feature = "arrow-56",
+    feature = "arrow-57",
+    feature = "arrow-58",
+    feature = "arrow-59"
+))]
 pub use crate::helpers::{export_array, export_field, import_array, import_field};
 pub use crate::{
     abi::{ArrowArray, ArrowArrayStream, ArrowData, ArrowSchema, ffi::strings::free_string},

--- a/src/daft-parquet/benches/parquet_read.rs
+++ b/src/daft-parquet/benches/parquet_read.rs
@@ -119,7 +119,7 @@ fn write_single_col_int64(compression: Compression) -> PathBuf {
     let schema = Arc::new(Schema::new(vec![Field::new("col", DataType::Int64, false)]));
     let props = WriterProperties::builder()
         .set_compression(compression)
-        .set_max_row_group_size(NUM_ROWS)
+        .set_max_row_group_row_count(Some(NUM_ROWS))
         .build();
     let file = fs::File::create(&path).unwrap();
     let mut writer = ArrowWriter::try_new(file, schema.clone(), Some(props)).unwrap();
@@ -154,7 +154,7 @@ fn write_wide_table() -> PathBuf {
     let schema = Arc::new(Schema::new(fields));
     let props = WriterProperties::builder()
         .set_compression(Compression::SNAPPY)
-        .set_max_row_group_size(NUM_ROWS)
+        .set_max_row_group_row_count(Some(NUM_ROWS))
         .build();
     let file = fs::File::create(&path).unwrap();
     let mut writer = ArrowWriter::try_new(file, schema.clone(), Some(props)).unwrap();
@@ -185,7 +185,7 @@ fn write_string_dict_encoded() -> PathBuf {
     let schema = Arc::new(Schema::new(vec![Field::new("col", DataType::Utf8, false)]));
     let props = WriterProperties::builder()
         .set_compression(Compression::SNAPPY)
-        .set_max_row_group_size(NUM_ROWS)
+        .set_max_row_group_row_count(Some(NUM_ROWS))
         .build();
     let file = fs::File::create(&path).unwrap();
     let mut writer = ArrowWriter::try_new(file, schema.clone(), Some(props)).unwrap();
@@ -215,7 +215,7 @@ fn write_nested_list_of_int() -> PathBuf {
     )]));
     let props = WriterProperties::builder()
         .set_compression(Compression::SNAPPY)
-        .set_max_row_group_size(NUM_ROWS)
+        .set_max_row_group_row_count(Some(NUM_ROWS))
         .build();
     let file = fs::File::create(&path).unwrap();
     let mut writer = ArrowWriter::try_new(file, schema.clone(), Some(props)).unwrap();
@@ -246,7 +246,7 @@ fn write_nested_struct() -> PathBuf {
     )]));
     let props = WriterProperties::builder()
         .set_compression(Compression::SNAPPY)
-        .set_max_row_group_size(NUM_ROWS)
+        .set_max_row_group_row_count(Some(NUM_ROWS))
         .build();
     let file = fs::File::create(&path).unwrap();
     let mut writer = ArrowWriter::try_new(file, schema.clone(), Some(props)).unwrap();
@@ -273,7 +273,7 @@ fn write_boolean_column() -> PathBuf {
     )]));
     let props = WriterProperties::builder()
         .set_compression(Compression::SNAPPY)
-        .set_max_row_group_size(NUM_ROWS)
+        .set_max_row_group_row_count(Some(NUM_ROWS))
         .build();
     let file = fs::File::create(&path).unwrap();
     let mut writer = ArrowWriter::try_new(file, schema.clone(), Some(props)).unwrap();

--- a/src/daft-parquet/src/reader/field_reader.rs
+++ b/src/daft-parquet/src/reader/field_reader.rs
@@ -101,47 +101,55 @@ fn build_primitive_leaf_reader(
     ));
 
     let reader: Box<dyn ArrayReader> = if matches!(arrow_type, arrow::datatypes::DataType::Null) {
-        Box::new(NullArrayReader::<Int32Type>::new(pages, col_descr)?)
+        Box::new(NullArrayReader::<Int32Type>::new(
+            pages, col_descr, total_rows,
+        )?)
     } else {
         match physical_type {
             PhysicalType::BOOLEAN => Box::new(PrimitiveArrayReader::<BoolType>::new(
                 pages,
                 col_descr,
                 Some(arrow_type),
+                total_rows,
             )?),
             PhysicalType::INT32 => Box::new(PrimitiveArrayReader::<Int32Type>::new(
                 pages,
                 col_descr,
                 Some(arrow_type),
+                total_rows,
             )?),
             PhysicalType::INT64 => Box::new(PrimitiveArrayReader::<Int64Type>::new(
                 pages,
                 col_descr,
                 Some(arrow_type),
+                total_rows,
             )?),
             PhysicalType::FLOAT => Box::new(PrimitiveArrayReader::<FloatType>::new(
                 pages,
                 col_descr,
                 Some(arrow_type),
+                total_rows,
             )?),
             PhysicalType::DOUBLE => Box::new(PrimitiveArrayReader::<DoubleType>::new(
                 pages,
                 col_descr,
                 Some(arrow_type),
+                total_rows,
             )?),
             PhysicalType::INT96 => Box::new(PrimitiveArrayReader::<Int96Type>::new(
                 pages,
                 col_descr,
                 Some(arrow_type),
+                total_rows,
             )?),
             PhysicalType::BYTE_ARRAY => match arrow_type {
                 arrow::datatypes::DataType::Utf8View | arrow::datatypes::DataType::BinaryView => {
-                    make_byte_view_array_reader(pages, col_descr, Some(arrow_type))?
+                    make_byte_view_array_reader(pages, col_descr, Some(arrow_type), total_rows)?
                 }
-                _ => make_byte_array_reader(pages, col_descr, Some(arrow_type))?,
+                _ => make_byte_array_reader(pages, col_descr, Some(arrow_type), total_rows)?,
             },
             PhysicalType::FIXED_LEN_BYTE_ARRAY => {
-                make_fixed_len_byte_array_reader(pages, col_descr, Some(arrow_type))?
+                make_fixed_len_byte_array_reader(pages, col_descr, Some(arrow_type), total_rows)?
             }
         }
     };

--- a/src/daft-parquet/src/statistics/column_range.rs
+++ b/src/daft-parquet/src/statistics/column_range.rs
@@ -179,15 +179,11 @@ fn convert_int64_arrowrs(
     upper: i64,
     col_descr: &ArrowColumnDescriptor,
 ) -> super::Result<ColumnRangeStatistics> {
-    if let Some(ArrowLogicalType::Timestamp {
-        is_adjusted_to_u_t_c,
-        unit,
-    }) = col_descr.logical_type_ref()
-    {
-        let daft_tu = timeunit_to_daft(*unit);
+    if let Some(ArrowLogicalType::Timestamp(ts)) = col_descr.logical_type_ref() {
+        let daft_tu = timeunit_to_daft(ts.unit);
         return make_timestamp_column_range_statistics(
             daft_tu,
-            *is_adjusted_to_u_t_c,
+            ts.is_adjusted_to_u_t_c,
             lower,
             upper,
         );
@@ -229,17 +225,13 @@ fn convert_int96_arrowrs(
     let lower_raw: [u32; 3] = [lower_data[0], lower_data[1], lower_data[2]];
     let upper_raw: [u32; 3] = [upper_data[0], upper_data[1], upper_data[2]];
 
-    if let Some(ArrowLogicalType::Timestamp {
-        is_adjusted_to_u_t_c,
-        unit,
-    }) = col_descr.logical_type_ref()
-    {
-        let daft_tu = timeunit_to_daft(*unit);
+    if let Some(ArrowLogicalType::Timestamp(ts)) = col_descr.logical_type_ref() {
+        let daft_tu = timeunit_to_daft(ts.unit);
         let lower_ts = convert_i96_to_i64_timestamp(lower_raw, daft_tu);
         let upper_ts = convert_i96_to_i64_timestamp(upper_raw, daft_tu);
         return make_timestamp_column_range_statistics(
             daft_tu,
-            *is_adjusted_to_u_t_c,
+            ts.is_adjusted_to_u_t_c,
             lower_ts,
             upper_ts,
         );
@@ -289,10 +281,10 @@ fn convert_byte_array_arrowrs(
                     Utf8Array::from_slice("upper", [upper_str.as_str()].as_slice()).into_series();
                 return Ok(ColumnRangeStatistics::new(Some(lower), Some(upper))?);
             }
-            ArrowLogicalType::Decimal { precision, scale } => {
+            ArrowLogicalType::Decimal(d) => {
                 return make_decimal_column_range_statistics(
-                    *precision as usize,
-                    *scale as usize,
+                    d.precision as usize,
+                    d.scale as usize,
                     lower_bytes,
                     upper_bytes,
                 );
@@ -335,10 +327,10 @@ fn convert_fixed_len_arrowrs(
     let lower_bytes = lower.data();
     let upper_bytes = upper.data();
 
-    if let Some(ArrowLogicalType::Decimal { precision, scale }) = col_descr.logical_type_ref() {
+    if let Some(ArrowLogicalType::Decimal(d)) = col_descr.logical_type_ref() {
         return make_decimal_column_range_statistics(
-            *precision as usize,
-            *scale as usize,
+            d.precision as usize,
+            d.scale as usize,
             lower_bytes,
             upper_bytes,
         );

--- a/src/daft-sketch/Cargo.toml
+++ b/src/daft-sketch/Cargo.toml
@@ -2,7 +2,7 @@
 arrow-array = {workspace = true}
 arrow-schema = {workspace = true}
 common-error = {path = "../common/error", default-features = false}
-serde_arrow = {version = "0.14.2", features = ["arrow-57"]}
+serde_arrow = {version = "0.14.2", features = ["arrow-59"]}
 sketches-ddsketch = {workspace = true}
 snafu = {workspace = true}
 


### PR DESCRIPTION
## Summary

- Upgrade all arrow-rs workspace dependencies from 57.1.0 to 59.0.0
- Update Cargo.lock with surgical arrow/parquet-only dependency resolution
- Fix daft-parquet API compatibility with arrow-rs 59.0.0:
  - Add batch_size parameter to PrimitiveArrayReader::new, NullArrayReader::new, make_byte_view_array_reader, make_byte_array_reader, and make_fixed_len_byte_array_reader calls
  - Update LogicalType::Timestamp and LogicalType::Decimal pattern matching from struct variants to tuple variants (wrapping TimestampType and DecimalType)
- Update daft-sketch serde_arrow feature from arrow-57 to arrow-59
- Add arrow-59 feature to daft-ext extension SDK for FFI compatibility

## Motivation

arrow-rs 59.0.0 includes an architecture-aware size assertion for the parquet-variant Variant enum, which fixes a compile-time failure on s390x (IBM Z). The previous assertion expected 80 bytes on all 64-bit platforms, but s390x produces 72 bytes due to different
alignment/padding rules on big-endian architectures.

## Test plan

- [ ] CI passes on all platforms
- [ ] Existing arrow-dependent tests (daft-sketch, daft-parquet, daft-ext) pass
- [ ] s390x cross-compilation succeeds without parquet-variant patching
