### PR TITLE
fix(ci): pin maturin <1.14 to keep --timings=html working

### DIFF
--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -349,7 +349,8 @@ jobs:
         uv venv --seed .venv
         echo "$GITHUB_WORKSPACE/.venv/bin" >> $GITHUB_PATH
         source .venv/bin/activate
-        uv pip install -U twine toml maturin
+        # Pin maturin <1.14: 1.14 rejects `--timings=html` (used in the Build wheels step below).
+        uv pip install -U twine toml 'maturin<1.14'
     - uses: moonrepo/setup-rust@v1
       with:
         cache: false


### PR DESCRIPTION
maturin 1.14.1 (released today) made `--timings` a boolean flag, rejecting `--timings=html` which `integration-test-build` uses. Every new PR fails this step and skips all downstream integration jobs (tpch, sql, ray, ai, catalogs, io).

Pin `maturin<1.14` as a one-line workaround. Drop the pin once the `--timings=html` call site is migrated to 1.14's new flag shape.

```
error: unexpected value 'html' for '--timings' found; no more were expected
```
