### PR TITLE
fix(parquet): Use chunk size for ArrayReader buffer size

### DIFF
--- a/src/daft-parquet/src/reader/field_reader.rs
+++ b/src/daft-parquet/src/reader/field_reader.rs
@@ -59,6 +59,7 @@ pub(super) fn leaves_for_top_fields(
     out
 }
 
+#[allow(clippy::too_many_arguments)]
 fn build_primitive_leaf_reader(
     chunk_bytes: OffsetBytes,
     metadata: &ParquetMetaData,
@@ -67,6 +68,7 @@ fn build_primitive_leaf_reader(
     arrow_type: arrow::datatypes::DataType,
     def_level: i16,
     rep_level: i16,
+    chunk_size: usize,
 ) -> ParquetResult<Box<dyn ArrayReader>> {
     let rg = metadata.row_group(rg_idx);
     let col_chunk = rg.column(leaf_idx);
@@ -102,7 +104,7 @@ fn build_primitive_leaf_reader(
 
     let reader: Box<dyn ArrayReader> = if matches!(arrow_type, arrow::datatypes::DataType::Null) {
         Box::new(NullArrayReader::<Int32Type>::new(
-            pages, col_descr, total_rows,
+            pages, col_descr, chunk_size,
         )?)
     } else {
         match physical_type {
@@ -110,46 +112,46 @@ fn build_primitive_leaf_reader(
                 pages,
                 col_descr,
                 Some(arrow_type),
-                total_rows,
+                chunk_size,
             )?),
             PhysicalType::INT32 => Box::new(PrimitiveArrayReader::<Int32Type>::new(
                 pages,
                 col_descr,
                 Some(arrow_type),
-                total_rows,
+                chunk_size,
             )?),
             PhysicalType::INT64 => Box::new(PrimitiveArrayReader::<Int64Type>::new(
                 pages,
                 col_descr,
                 Some(arrow_type),
-                total_rows,
+                chunk_size,
             )?),
             PhysicalType::FLOAT => Box::new(PrimitiveArrayReader::<FloatType>::new(
                 pages,
                 col_descr,
                 Some(arrow_type),
-                total_rows,
+                chunk_size,
             )?),
             PhysicalType::DOUBLE => Box::new(PrimitiveArrayReader::<DoubleType>::new(
                 pages,
                 col_descr,
                 Some(arrow_type),
-                total_rows,
+                chunk_size,
             )?),
             PhysicalType::INT96 => Box::new(PrimitiveArrayReader::<Int96Type>::new(
                 pages,
                 col_descr,
                 Some(arrow_type),
-                total_rows,
+                chunk_size,
             )?),
             PhysicalType::BYTE_ARRAY => match arrow_type {
                 arrow::datatypes::DataType::Utf8View | arrow::datatypes::DataType::BinaryView => {
-                    make_byte_view_array_reader(pages, col_descr, Some(arrow_type), total_rows)?
+                    make_byte_view_array_reader(pages, col_descr, Some(arrow_type), chunk_size)?
                 }
-                _ => make_byte_array_reader(pages, col_descr, Some(arrow_type), total_rows)?,
+                _ => make_byte_array_reader(pages, col_descr, Some(arrow_type), chunk_size)?,
             },
             PhysicalType::FIXED_LEN_BYTE_ARRAY => {
-                make_fixed_len_byte_array_reader(pages, col_descr, Some(arrow_type), total_rows)?
+                make_fixed_len_byte_array_reader(pages, col_descr, Some(arrow_type), chunk_size)?
             }
         }
     };
@@ -260,6 +262,7 @@ fn build_top_field_reader(
     rg_idx: usize,
     top_field_idx: usize,
     arrow_field: &ArrowField,
+    chunk_size: usize,
 ) -> ParquetResult<(Box<dyn ArrayReader>, usize)> {
     let total_rows = metadata.row_group(rg_idx).num_rows() as usize;
     let mut leaf_idx = leaf_index_for_top_field(metadata, top_field_idx);
@@ -273,6 +276,7 @@ fn build_top_field_reader(
         chunks,
         metadata,
         rg_idx,
+        chunk_size,
     };
     let reader = builder.build(parquet_type, arrow_field.data_type(), 0, 0, &mut leaf_idx)?;
     Ok((reader, total_rows))
@@ -287,6 +291,7 @@ struct FieldReaderBuilder<'a> {
     chunks: &'a HashMap<usize, OffsetBytes>,
     metadata: &'a ParquetMetaData,
     rg_idx: usize,
+    chunk_size: usize,
 }
 
 impl FieldReaderBuilder<'_> {
@@ -375,6 +380,7 @@ impl FieldReaderBuilder<'_> {
                 inner_arrow_type,
                 def_level,
                 rep_level,
+                self.chunk_size,
             )?;
             return Ok(wrap_in_list_like(
                 inner_reader,
@@ -396,6 +402,7 @@ impl FieldReaderBuilder<'_> {
             arrow_type.clone(),
             def_level,
             rep_level,
+            self.chunk_size,
         )
     }
 
@@ -557,6 +564,7 @@ impl FieldReaderBuilder<'_> {
                 inner_arrow_field.data_type().clone(),
                 elem_def_level,
                 elem_rep_level,
+                self.chunk_size,
             )?;
             return Ok(wrap_in_list_like(
                 inner_reader,
@@ -725,6 +733,7 @@ pub(super) async fn decode_one_streaming(
             rg_idx,
             top_field_idx,
             &arrow_field,
+            chunk_size,
         )?;
 
         use parquet::arrow::arrow_reader::RowSelector;

--- a/src/daft-parquet/src/reader/field_reader.rs
+++ b/src/daft-parquet/src/reader/field_reader.rs
@@ -93,6 +93,10 @@ fn build_primitive_leaf_reader(
     let primitive_type = file_col_descr.self_type_ptr();
     let physical_type = file_col_descr.physical_type();
 
+    // Batch size to pass to array readers for initial internal buffer allocations
+    // We do this because for predicate pushdown, we use a chunk size of USIZE_MAX
+    let batch_size = chunk_size.min(total_rows);
+
     // def/rep levels here are the leaf's levels within its wrapping context
     // (may differ from the file-level descriptor's when nested).
     let col_descr = Arc::new(ColumnDescriptor::new(
@@ -104,7 +108,7 @@ fn build_primitive_leaf_reader(
 
     let reader: Box<dyn ArrayReader> = if matches!(arrow_type, arrow::datatypes::DataType::Null) {
         Box::new(NullArrayReader::<Int32Type>::new(
-            pages, col_descr, chunk_size,
+            pages, col_descr, batch_size,
         )?)
     } else {
         match physical_type {
@@ -112,46 +116,46 @@ fn build_primitive_leaf_reader(
                 pages,
                 col_descr,
                 Some(arrow_type),
-                chunk_size,
+                batch_size,
             )?),
             PhysicalType::INT32 => Box::new(PrimitiveArrayReader::<Int32Type>::new(
                 pages,
                 col_descr,
                 Some(arrow_type),
-                chunk_size,
+                batch_size,
             )?),
             PhysicalType::INT64 => Box::new(PrimitiveArrayReader::<Int64Type>::new(
                 pages,
                 col_descr,
                 Some(arrow_type),
-                chunk_size,
+                batch_size,
             )?),
             PhysicalType::FLOAT => Box::new(PrimitiveArrayReader::<FloatType>::new(
                 pages,
                 col_descr,
                 Some(arrow_type),
-                chunk_size,
+                batch_size,
             )?),
             PhysicalType::DOUBLE => Box::new(PrimitiveArrayReader::<DoubleType>::new(
                 pages,
                 col_descr,
                 Some(arrow_type),
-                chunk_size,
+                batch_size,
             )?),
             PhysicalType::INT96 => Box::new(PrimitiveArrayReader::<Int96Type>::new(
                 pages,
                 col_descr,
                 Some(arrow_type),
-                chunk_size,
+                batch_size,
             )?),
             PhysicalType::BYTE_ARRAY => match arrow_type {
                 arrow::datatypes::DataType::Utf8View | arrow::datatypes::DataType::BinaryView => {
-                    make_byte_view_array_reader(pages, col_descr, Some(arrow_type), chunk_size)?
+                    make_byte_view_array_reader(pages, col_descr, Some(arrow_type), batch_size)?
                 }
-                _ => make_byte_array_reader(pages, col_descr, Some(arrow_type), chunk_size)?,
+                _ => make_byte_array_reader(pages, col_descr, Some(arrow_type), batch_size)?,
             },
             PhysicalType::FIXED_LEN_BYTE_ARRAY => {
-                make_fixed_len_byte_array_reader(pages, col_descr, Some(arrow_type), chunk_size)?
+                make_fixed_len_byte_array_reader(pages, col_descr, Some(arrow_type), batch_size)?
             }
         }
     };

--- a/src/daft-parquet/src/reader/mod.rs
+++ b/src/daft-parquet/src/reader/mod.rs
@@ -331,6 +331,9 @@ async fn build_rg_inputs(
     path: &Arc<str>,
 ) -> DaftResult<Vec<RgInputs>> {
     let base_selections = build_base_selections(metadata, rg_indices, opts);
+
+    // If no predicate, then we can just return the base selections for the whole RG immediately.
+    // Otherwise, we can pre-filter based on the predicate
     let Some(prefilter_predicate) = opts
         .predicate
         .as_ref()


### PR DESCRIPTION
## Changes Made

Addressing a comment from https://github.com/Eventual-Inc/Daft/pull/7141 regarding the buffer size that's passed to the Parquet Arrow array readers. Instead of using the size of the row group, we should use the chunk size that we already have laying around.