### PR TITLE
fix(scan): make metadata-based scan estimate projection-aware

### DIFF
--- a/src/daft-micropartition/src/micropartition.rs
+++ b/src/daft-micropartition/src/micropartition.rs
@@ -92,7 +92,7 @@ impl MicroPartition {
             chunks: record_batches,
             metadata: TableMetadata {
                 length,
-                size_bytes: None,
+                column_sizes: None,
             },
             statistics,
         }

--- a/src/daft-micropartition/src/ops/concat.rs
+++ b/src/daft-micropartition/src/ops/concat.rs
@@ -34,7 +34,7 @@ impl MicroPartition {
             chunks: Arc::new(all_tables),
             metadata: TableMetadata {
                 length: new_len,
-                size_bytes: None,
+                column_sizes: None,
             },
             statistics: all_stats,
         })

--- a/src/daft-parquet/src/metadata_adapter.rs
+++ b/src/daft-parquet/src/metadata_adapter.rs
@@ -214,9 +214,27 @@ impl DaftRowGroupMetaData {
         self.inner.compressed_size() as usize
     }
 
-    /// Total uncompressed (encoded) size of this row group in bytes.
-    pub fn total_byte_size(&self) -> usize {
-        self.inner.total_byte_size() as usize
+    /// Uncompressed (encoded) size in bytes for each column chunk in this row group,
+    /// keyed by the top-level (root) column name.
+    ///
+    /// Nested columns are flattened to their root: every leaf chunk (e.g.
+    /// `position_ids.list.element`) is attributed to its top-level field
+    /// (`position_ids`). The caller is responsible for summing across row groups.
+    pub fn column_uncompressed_sizes(&self) -> Vec<(String, u64)> {
+        self.inner
+            .columns()
+            .iter()
+            .map(|col| {
+                let root = col
+                    .column_descr()
+                    .path()
+                    .parts()
+                    .first()
+                    .cloned()
+                    .unwrap_or_default();
+                (root, col.uncompressed_size() as u64)
+            })
+            .collect()
     }
 }
 

--- a/src/daft-scan/src/glob.rs
+++ b/src/daft-scan/src/glob.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, vec};
+use std::{collections::BTreeMap, sync::Arc, vec};
 
 use common_error::{DaftError, DaftResult};
 use common_file_formats::FileFormat;
@@ -219,15 +219,20 @@ impl GlobScanOperator {
                         field_id_mapping.clone(),
                     )
                     .await?;
-                    let total_uncompressed_size: usize = metadata
-                        .row_groups()
-                        .map(|(_, rg)| rg.total_byte_size())
-                        .sum();
+                    // Sum the per-column uncompressed sizes across all row groups, keyed by
+                    // top-level column name. Storing per-column (rather than a single total)
+                    // lets size estimates respect column-projection pushdown.
+                    let mut column_sizes: BTreeMap<String, u64> = BTreeMap::new();
+                    for (_, rg) in metadata.row_groups() {
+                        for (name, bytes) in rg.column_uncompressed_sizes() {
+                            *column_sizes.entry(name).or_insert(0) += bytes;
+                        }
+                    }
                     let first_metadata = Some((
                         first_filepath.clone(),
                         TableMetadata {
                             length: metadata.num_rows(),
-                            size_bytes: Some(total_uncompressed_size),
+                            column_sizes: (!column_sizes.is_empty()).then_some(column_sizes),
                         },
                     ));
                     (schema, first_metadata, first_filepath)

--- a/src/daft-scan/src/lib.rs
+++ b/src/daft-scan/src/lib.rs
@@ -404,22 +404,31 @@ impl ScanTask {
                 .all(|s| s.partition_spec == sources.first().unwrap().partition_spec),
             "ScanTask sources must all have the same PartitionSpec at construction",
         );
-        let (length, meta_size_bytes, size_bytes_on_disk, statistics) = sources
+        let (length, column_sizes, size_bytes_on_disk, statistics) = sources
             .iter()
             .map(|s| {
                 (
                     s.metadata.as_ref().map(|m| m.length),
-                    s.metadata.as_ref().and_then(|m| m.size_bytes),
+                    s.metadata.as_ref().and_then(|m| m.column_sizes.clone()),
                     s.size_bytes,
                     s.statistics.clone(),
                 )
             })
             .reduce(
-                |(acc_len, acc_meta_size, acc_size, acc_stats),
-                 (curr_len, curr_meta_size, curr_size, curr_stats)| {
+                |(acc_len, acc_col_sizes, acc_size, acc_stats),
+                 (curr_len, curr_col_sizes, curr_size, curr_stats)| {
                     (
                         acc_len.and_then(|acc_len| curr_len.map(|curr_len| acc_len + curr_len)),
-                        acc_meta_size.and_then(|acc| curr_meta_size.map(|curr| acc + curr)),
+                        // All-or-nothing: only retain per-column sizes if every source has them,
+                        // summing each column across sources.
+                        acc_col_sizes.and_then(|mut acc| {
+                            curr_col_sizes.map(|curr| {
+                                for (name, bytes) in curr {
+                                    *acc.entry(name).or_insert(0) += bytes;
+                                }
+                                acc
+                            })
+                        }),
                         acc_size
                             .and_then(|acc_size| curr_size.map(|curr_size| acc_size + curr_size)),
                         acc_stats.and_then(|acc_stats| {
@@ -442,7 +451,7 @@ impl ScanTask {
             .unwrap();
         let metadata = length.map(|l| TableMetadata {
             length: l,
-            size_bytes: meta_size_bytes,
+            column_sizes,
         });
         Self {
             sources,
@@ -755,10 +764,42 @@ impl ScanTask {
                     })
                 })
                 .or_else(|| {
-                    // Use uncompressed size from file metadata (e.g. Parquet row group totals) when available.
-                    // This is more accurate than the schema-based estimate for data with dictionary encoding
-                    // or low-cardinality columns.
-                    self.metadata.as_ref().and_then(|m| m.size_bytes)
+                    // Use per-column uncompressed sizes from file metadata (e.g. Parquet
+                    // column-chunk totals) when available. This is more accurate than the
+                    // schema-based estimate for data with dictionary encoding, low-cardinality
+                    // columns, or variable-length nested types (e.g. List) where the schema
+                    // heuristic assumes a fixed element count.
+                    //
+                    // We restrict the sum to the materialized (projected) columns so the
+                    // estimate respects column-projection pushdown, and convert to a per-row
+                    // size scaled by `approx_num_rows`, so limit/filter pushdowns are honored
+                    // the same way as the schema-based fallback below.
+                    let metadata = self.metadata.as_ref()?;
+                    let column_sizes = metadata.column_sizes.as_ref()?;
+                    if metadata.length == 0 {
+                        return None;
+                    }
+                    let projected_bytes: u64 = mat_schema
+                        .field_names()
+                        .filter_map(|name| column_sizes.get(name).copied())
+                        .sum();
+                    // No projected column was found in the metadata (e.g. the scan only reads
+                    // generated/partition columns); defer to the schema-based estimate.
+                    if projected_bytes == 0 {
+                        return None;
+                    }
+                    let row_size = (projected_bytes as f64) / (metadata.length as f64);
+                    self.approx_num_rows(config).map(|approx_num_rows| {
+                        let estimate_f64 = approx_num_rows * row_size;
+                        if estimate_f64.is_nan()
+                            || estimate_f64.is_infinite()
+                            || estimate_f64 > REASONABLE_SIZE_BYTES as f64
+                        {
+                            REASONABLE_SIZE_BYTES
+                        } else {
+                            estimate_f64 as usize
+                        }
+                    })
                 })
                 .or_else(|| {
                     // Fall back to approximate number of rows multiplied by an approximate bytes-per-row
@@ -879,7 +920,7 @@ Pushdowns = {pushdowns}
 
 #[cfg(test)]
 mod test {
-    use std::sync::Arc;
+    use std::{collections::BTreeMap, sync::Arc};
 
     use common_display::{DisplayAs, DisplayLevel};
     use common_error::DaftResult;
@@ -1048,7 +1089,7 @@ mod test {
             size_bytes: Some(1_000_000),
             metadata: Some(TableMetadata {
                 length: usize::MAX, // Extremely large row count
-                size_bytes: None,
+                column_sizes: None,
             }),
             statistics: None,
             partition_spec: None,
@@ -1136,7 +1177,7 @@ mod test {
             size_bytes: Some(10_000_000), // 10MB
             metadata: Some(TableMetadata {
                 length: 1000, // 1000 rows
-                size_bytes: None,
+                column_sizes: None,
             }),
             statistics: None,
             partition_spec: None,
@@ -1180,7 +1221,7 @@ mod test {
             size_bytes: Some(1_000_000),
             metadata: Some(TableMetadata {
                 length: usize::MAX, // Extremely large row count
-                size_bytes: None,
+                column_sizes: None,
             }),
             statistics: None,
             partition_spec: None,
@@ -1326,7 +1367,7 @@ mod test {
             size_bytes: Some(1_000_000),
             metadata: Some(TableMetadata {
                 length: 10_000,
-                size_bytes: None,
+                column_sizes: None,
             }),
             statistics: None,
             partition_spec: None,
@@ -1367,6 +1408,134 @@ mod test {
         // 10,000 rows * (8 bytes for Int64 + 8 bytes for Float64) = 160,000 bytes
         assert!(estimate_val > 0);
         assert!(estimate_val < 1_000_000_000); // Less than 1GB is reasonable
+    }
+
+    /// Builds a parquet scan task modeled on the customer's tokenized-sequence dataset:
+    /// four `List(Int64)` columns where `position_ids` dominates the on-disk bytes. The
+    /// per-column uncompressed sizes are taken from row group 0 of `rank_0_train.parquet`.
+    fn make_list_column_scan_task(pushdowns: Pushdowns) -> ScanTask {
+        // Uncompressed byte sizes per column, from the customer's parquet metadata.
+        let column_sizes = BTreeMap::from([
+            ("input_ids".to_string(), 10_760_083u64),
+            ("attention_mask".to_string(), 3_339u64),
+            ("labels".to_string(), 10_760_083u64),
+            ("position_ids".to_string(), 122_969_239u64),
+        ]);
+        let num_rows = 200; // row group 0 num_rows
+
+        let sources = vec![ScanSource {
+            size_bytes: Some(32_418_149), // compressed row group 0 bytes
+            metadata: Some(TableMetadata {
+                length: num_rows,
+                column_sizes: Some(column_sizes),
+            }),
+            statistics: None,
+            partition_spec: None,
+            kind: ScanSourceKind::File {
+                path: "rank_0_train.parquet".to_string(),
+                chunk_spec: None,
+                iceberg_delete_files: None,
+                parquet_metadata: None,
+            },
+        }];
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("input_ids", DataType::List(Box::new(DataType::Int64))),
+            Field::new("attention_mask", DataType::List(Box::new(DataType::Int64))),
+            Field::new("labels", DataType::List(Box::new(DataType::Int64))),
+            Field::new("position_ids", DataType::List(Box::new(DataType::Int64))),
+        ]));
+
+        ScanTask::new(
+            sources,
+            Arc::new(SourceConfig::File(FileFormatConfig::Parquet(
+                ParquetSourceConfig {
+                    coerce_int96_timestamp_unit: TimeUnit::Seconds,
+                    field_id_mapping: None,
+                    row_groups: None,
+                    chunk_size: None,
+                },
+            ))),
+            schema,
+            Arc::new(StorageConfig::new_internal(false, None)),
+            pushdowns,
+            None,
+        )
+    }
+
+    /// Regression test for OOMs caused by under-estimating `List`-typed columns.
+    ///
+    /// The schema-based fallback assumes a fixed list length (`DEFAULT_LIST_LEN = 4`),
+    /// estimating ~130 bytes/row (~26 KB for 200 rows) when the real uncompressed size
+    /// is ~144 MB. Per-column metadata sizes must be used instead.
+    #[test]
+    fn test_list_column_estimation_uses_metadata_not_schema() {
+        let scan_task = make_list_column_scan_task(Pushdowns::default());
+        let estimate = scan_task.estimate_in_memory_size_bytes(None).unwrap();
+
+        // Expect the sum of all four columns' uncompressed sizes (~144 MB).
+        // (Allow a few bytes of slack for the per-row f64 roundtrip.)
+        let expected: i64 = 10_760_083 + 3_339 + 10_760_083 + 122_969_239;
+        assert!((estimate as i64 - expected).abs() <= 4);
+
+        // Sanity check: this must be vastly larger than the schema-based guess, which is
+        // what caused the OOM. DEFAULT_LIST_LEN=4 yields ~130 bytes/row.
+        let schema_based = 200.0 * scan_task.materialized_schema().estimate_row_size_bytes();
+        assert!(schema_based < 30_000.0);
+        assert!((estimate as f64) > 1000.0 * schema_based);
+    }
+
+    /// The metadata-based estimate must respect column-projection pushdown: selecting only
+    /// the small `attention_mask` column should not estimate the whole (position_ids-heavy)
+    /// row group.
+    #[test]
+    fn test_list_column_estimation_respects_projection() {
+        // Project only the small column.
+        let small_pushdowns = Pushdowns::new(
+            None,
+            None,
+            Some(Arc::new(vec!["attention_mask".to_string()])),
+            None,
+            None,
+            None,
+        );
+        let small = make_list_column_scan_task(small_pushdowns)
+            .estimate_in_memory_size_bytes(None)
+            .unwrap();
+        assert!((small as i64 - 3_339).abs() <= 4);
+
+        // Project only the dominant column.
+        let large_pushdowns = Pushdowns::new(
+            None,
+            None,
+            Some(Arc::new(vec!["position_ids".to_string()])),
+            None,
+            None,
+            None,
+        );
+        let large = make_list_column_scan_task(large_pushdowns)
+            .estimate_in_memory_size_bytes(None)
+            .unwrap();
+        assert!((large as i64 - 122_969_239).abs() <= 4);
+
+        // The projected small column must be orders of magnitude smaller than the full scan.
+        assert!(large > 1000 * small);
+    }
+
+    /// A limit pushdown should scale the metadata-based estimate down proportionally,
+    /// rather than returning the full-file size.
+    #[test]
+    fn test_list_column_estimation_respects_limit() {
+        let limit_pushdowns = Pushdowns::new(None, None, None, Some(50), None, None);
+        let estimate = make_list_column_scan_task(limit_pushdowns)
+            .estimate_in_memory_size_bytes(None)
+            .unwrap();
+
+        // 50 of 200 rows => roughly a quarter of the full ~144 MB.
+        let full = 10_760_083 + 3_339 + 10_760_083 + 122_969_239;
+        let expected = full / 4;
+        // Allow for f64 rounding.
+        assert!((estimate as i64 - expected as i64).abs() <= 4);
     }
 
     #[test]

--- a/src/daft-scan/src/python.rs
+++ b/src/daft-scan/src/python.rs
@@ -601,7 +601,7 @@ pub mod pylib {
 
             let metadata = num_rows.map(|n| TableMetadata {
                 length: n as usize,
-                size_bytes: None,
+                column_sizes: None,
             });
 
             let data_source = ScanSource {
@@ -658,7 +658,7 @@ pub mod pylib {
                 size_bytes,
                 metadata: num_rows.map(|n| TableMetadata {
                     length: n as usize,
-                    size_bytes: None,
+                    column_sizes: None,
                 }),
                 statistics,
                 partition_spec: None,
@@ -707,7 +707,7 @@ pub mod pylib {
                 size_bytes,
                 metadata: num_rows.map(|num_rows| TableMetadata {
                     length: num_rows as usize,
-                    size_bytes: None,
+                    column_sizes: None,
                 }),
                 statistics,
                 partition_spec: None,
@@ -799,7 +799,7 @@ pub mod pylib {
             metadata: if has_metadata.unwrap_or(false) {
                 Some(TableMetadata {
                     length: metadata.num_rows(),
-                    size_bytes: None,
+                    column_sizes: None,
                 })
             } else {
                 None

--- a/src/daft-scan/src/test_utils.rs
+++ b/src/daft-scan/src/test_utils.rs
@@ -68,7 +68,7 @@ impl ScanOperator for DummyScanOperator {
             .map(|i| {
                 let metadata = self.num_rows_per_task.map(|n| TableMetadata {
                     length: n,
-                    size_bytes: None,
+                    column_sizes: None,
                 });
                 Arc::new(ScanTask::new(
                     vec![ScanSource {

--- a/src/daft-stats/src/table_metadata.rs
+++ b/src/daft-stats/src/table_metadata.rs
@@ -1,11 +1,16 @@
+use std::collections::BTreeMap;
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub struct TableMetadata {
     pub length: usize,
-    /// Total uncompressed size in bytes, when known from file metadata (e.g. Parquet row group totals).
+    /// Uncompressed size in bytes per top-level column, when known from file metadata
+    /// (e.g. summed Parquet column-chunk totals across row groups). Keyed by column name
+    /// so that size estimates can respect column-projection pushdown. `None` when the
+    /// source does not expose per-column sizes.
     #[serde(default)]
-    pub size_bytes: Option<usize>,
+    pub column_sizes: Option<BTreeMap<String, u64>>,
 }
 
 impl TableMetadata {


### PR DESCRIPTION
Builds on top of #6542.

## Why

#6542 preserves the parquet footer's uncompressed size into `TableMetadata` and uses it as a fallback tier in `estimate_in_memory_size_bytes`, fixing the customer's `List`-column under-estimation (13 MB → ~tens of GB) that was causing OOMs via scan-task under-merging.

The remaining gap: the PR stores a **single whole-row-group total** (all columns), so the new tier ignores **column-projection pushdown**. For the customer's table `position_ids` is ~85% of the row-group bytes — selecting only `attention_mask` would still estimate the whole row group (~40,000× over). It also ignores **limit pushdown**, always returning the full-file size.

## What

- **`metadata_adapter.rs`** — replace `total_byte_size()` with `column_uncompressed_sizes() -> Vec<(String, u64)>`, attributing each leaf chunk (e.g. `position_ids.list.element`) to its top-level field via `column_descr().path().parts()[0]`.
- **`table_metadata.rs`** — `size_bytes: Option<usize>` → `column_sizes: Option<BTreeMap<String, u64>>` (still derives `Hash`/`Eq`/`Serialize`; `#[serde(default)]` retained for back-compat).
- **`glob.rs`** — sum per-column sizes across row groups.
- **`ScanTask::new`** — aggregate the maps across sources (all-or-nothing, matching `size_bytes_on_disk`).
- **`estimate_in_memory_size_bytes`** — tier 2 now sums only the **materialized (projected)** columns, converts to a per-row size, and scales by `approx_num_rows`, so limit/filter pushdowns are honored like the schema fallback. Falls through to the schema estimate if no projected column is found (e.g. scans of only generated/partition columns).

## Tests

Regression tests modeled on the customer's tokenized-sequence dataset (4 `List(Int64)` columns, `position_ids` dominant, using their row-group-0 column sizes):

- `test_list_column_estimation_uses_metadata_not_schema` — full scan ≈ summed column bytes (~144 MB), and >1000× the `DEFAULT_LIST_LEN=4` schema guess that caused the OOM.
- `test_list_column_estimation_respects_projection` — `select("attention_mask")` ≈ 3.3 KB; `select("position_ids")` ≈ 123 MB. (Fails against the base PR, which returns the full row group for either.)
- `test_list_column_estimation_respects_limit` — `limit(50)` of 200 rows ≈ ¼ of full size.

## Known limitation (follow-up)

Tier 2 uses parquet's *uncompressed-encoded* size, which for dictionary/RLE columns (these are `RLE_DICTIONARY`) still under-estimates the materialized Arrow size — the customer measured ~26× compressed vs the ~4.5× parquet-uncompressed ratio. It's conservative enough to fix the OOM-via-under-merging, but not exact. The durable defense is runtime memory-bounding/backpressure, which is a separate effort (the estimate is consumed only at plan/schedule time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)