### PR TITLE
feat(ai): add transformers provider for prompt()

### DIFF
--- a/daft/ai/transformers/protocols/prompter.py
+++ b/daft/ai/transformers/protocols/prompter.py
@@ -88,11 +88,15 @@ class TransformersPrompter(Prompter):
         # consumed by get_udf_options, everything else is forwarded to the call.
         opts: dict[str, Any] = dict(prompt_options or {})
         pipeline_kwargs: dict[str, Any] = opts.pop("pipeline_kwargs", {})
+        opts.pop("return_full_text", None)  # always set to False in _sync_prompt
         for udf_only_key in UDFOptions.__annotations__:
             opts.pop(udf_only_key, None)
         self.generation_kwargs: dict[str, Any] = opts
 
-        pipeline_init: dict[str, Any] = {"device": get_torch_device(), **pipeline_kwargs}
+        # device and device_map are mutually exclusive.
+        pipeline_init: dict[str, Any] = dict(pipeline_kwargs)
+        if "device" not in pipeline_init and "device_map" not in pipeline_init:
+            pipeline_init["device"] = get_torch_device()
         with _model_loading_lock:
             self._pipeline = pipeline(task="text-generation", model=model_name, **pipeline_init)
 

--- a/daft/ai/transformers/protocols/prompter.py
+++ b/daft/ai/transformers/protocols/prompter.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+import warnings
+from dataclasses import dataclass, field
+from functools import singledispatchmethod
+from typing import TYPE_CHECKING, Any
+
+from transformers import pipeline
+
+from daft.ai.protocols import Prompter, PrompterDescriptor
+from daft.ai.typing import Options, PromptOptions, UDFOptions
+from daft.ai.utils import get_gpu_udf_options, get_torch_device
+
+# Global lock to prevent concurrent model loading which can cause meta tensor issues
+_model_loading_lock = threading.Lock()
+
+if TYPE_CHECKING:
+    from pydantic import BaseModel
+
+
+class TransformersPromptOptions(PromptOptions, total=False):
+    """Options for the Transformers prompter.
+
+    Attributes:
+        pipeline_kwargs (dict): Forwarded to the ``transformers.pipeline``
+            constructor (e.g. ``dtype``, ``device_map``, ``trust_remote_code``).
+
+    Note:
+        Any other kwargs (``temperature``, ``max_new_tokens``, ``top_p``, ...)
+        are forwarded to the pipeline call.
+    """
+
+    pipeline_kwargs: dict[str, Any]
+
+
+@dataclass
+class TransformersPrompterDescriptor(PrompterDescriptor):
+    provider_name: str
+    model_name: str
+    prompt_options: TransformersPromptOptions = field(default_factory=lambda: TransformersPromptOptions())
+    system_message: str | None = None
+    return_format: BaseModel | None = None
+
+    def get_provider(self) -> str:
+        return self.provider_name
+
+    def get_model(self) -> str:
+        return self.model_name
+
+    def get_options(self) -> Options:
+        return dict(self.prompt_options)
+
+    def get_udf_options(self) -> UDFOptions:
+        udf_options = get_gpu_udf_options()
+        for key, value in self.prompt_options.items():
+            if key in udf_options.__annotations__.keys():
+                setattr(udf_options, key, value)
+        return udf_options
+
+    def instantiate(self) -> Prompter:
+        if self.return_format is not None:
+            raise NotImplementedError("return_format is not yet supported for the 'transformers' provider.")
+        return TransformersPrompter(
+            provider_name=self.provider_name,
+            model_name=self.model_name,
+            system_message=self.system_message,
+            prompt_options=self.prompt_options,
+        )
+
+
+class TransformersPrompter(Prompter):
+    """Pipeline based text generation."""
+
+    def __init__(
+        self,
+        provider_name: str,
+        model_name: str,
+        system_message: str | None = None,
+        prompt_options: TransformersPromptOptions | None = None,
+    ) -> None:
+        self.provider_name = provider_name
+        self.model = model_name
+        self.system_message = system_message
+
+        # Split options: pipeline_kwargs go to the constructor, UDF-level keys are
+        # consumed by get_udf_options, everything else is forwarded to the call.
+        opts: dict[str, Any] = dict(prompt_options or {})
+        pipeline_kwargs: dict[str, Any] = opts.pop("pipeline_kwargs", {})
+        for udf_only_key in UDFOptions.__annotations__:
+            opts.pop(udf_only_key, None)
+        self.generation_kwargs: dict[str, Any] = opts
+
+        pipeline_init: dict[str, Any] = {"device": get_torch_device(), **pipeline_kwargs}
+        with _model_loading_lock:
+            self._pipeline = pipeline(task="text-generation", model=model_name, **pipeline_init)
+
+        self._has_chat_template = getattr(self._pipeline.tokenizer, "chat_template", None) is not None
+        if not self._has_chat_template:
+            warnings.warn(
+                f"Model '{model_name}' has no chat template; falling back to plain-text "
+                "concatenation. Use an instruction-tuned model for better results.",
+                stacklevel=2,
+            )
+
+    @singledispatchmethod
+    def _process_message(self, msg: Any) -> str:
+        raise NotImplementedError(
+            f"The 'transformers' provider currently only supports str inputs, got {type(msg).__name__}."
+        )
+
+    @_process_message.register
+    def _(self, msg: str) -> str:
+        return msg
+
+    def _build_inputs(self, messages: tuple[Any, ...]) -> list[dict[str, str]] | str:
+        user_content = "\n".join(self._process_message(m) for m in messages)
+        if not self._has_chat_template:
+            return f"{self.system_message}\n\n{user_content}" if self.system_message else user_content
+        chat: list[dict[str, str]] = []
+        if self.system_message:
+            chat.append({"role": "system", "content": self.system_message})
+        chat.append({"role": "user", "content": user_content})
+        return chat
+
+    def _sync_prompt(self, messages: tuple[Any, ...]) -> str:
+        inputs = self._build_inputs(messages)
+        # return_full_text=False strips the prompt from string-mode outputs.
+        outputs = self._pipeline(inputs, return_full_text=False, **self.generation_kwargs)
+        generated = outputs[0]["generated_text"]
+        if isinstance(generated, list):
+            return generated[-1]["content"]
+        return generated
+
+    async def prompt(self, messages: tuple[Any, ...]) -> Any:
+        return await asyncio.to_thread(self._sync_prompt, messages)

--- a/daft/ai/transformers/provider.py
+++ b/daft/ai/transformers/provider.py
@@ -11,12 +11,16 @@ else:
 from daft.ai.provider import Provider, ProviderImportError
 
 if TYPE_CHECKING:
+    from pydantic import BaseModel
+
     from daft.ai.protocols import (
         ImageClassifierDescriptor,
         ImageEmbedderDescriptor,
+        PrompterDescriptor,
         TextClassifierDescriptor,
         TextEmbedderDescriptor,
     )
+    from daft.ai.transformers.protocols.prompter import TransformersPromptOptions
     from daft.ai.typing import (
         ClassifyImageOptions,
         ClassifyTextOptions,
@@ -33,6 +37,7 @@ class TransformersProvider(Provider):
     DEFAULT_TEXT_EMBEDDER = "sentence-transformers/all-MiniLM-L6-v2"
     DEFAULT_TEXT_CLASSIFIER = "facebook/bart-large-mnli"
     DEFAULT_IMAGE_CLASSIFIER = "openai/clip-vit-base-patch32"
+    DEFAULT_PROMPTER = "HuggingFaceTB/SmolLM2-360M-Instruct"
 
     def __init__(self, name: str | None = None, **options: Any):
         self._name = name if name else "transformers"
@@ -116,4 +121,21 @@ class TransformersProvider(Provider):
             provider_name=self._name,
             model_name=(model or self.DEFAULT_IMAGE_CLASSIFIER),
             classify_options=classify_options,
+        )
+
+    def get_prompter(
+        self,
+        model: str | None = None,
+        return_format: BaseModel | None = None,
+        system_message: str | None = None,
+        **options: Unpack[TransformersPromptOptions],
+    ) -> PrompterDescriptor:
+        from daft.ai.transformers.protocols.prompter import TransformersPrompterDescriptor
+
+        return TransformersPrompterDescriptor(
+            provider_name=self._name,
+            model_name=(model or self.DEFAULT_PROMPTER),
+            prompt_options=options,
+            system_message=system_message,
+            return_format=return_format,
         )

--- a/docs/ai-functions/prompt.md
+++ b/docs/ai-functions/prompt.md
@@ -69,6 +69,7 @@ df.show()
 1. **OpenAI** (Default) - Leverage models from OpenAI or any OpenAI-compatible provider.
 2. **Google** - Take advantage of Google's latests models like *Gemini 3 Pro*.
 3. **vLLM Prefix Caching** (Beta) - Distributed batch inference on vLLM [built by the Daft Cloud team](https://www.daft.ai/blog/cutting-llm-batch-inference-time-in-half-dynamic-prefix-bucketing-at-scale).
+4. **Transformers** - Run open-weight instruction-tuned models locally via [HuggingFace Transformers](https://huggingface.co/docs/transformers).
 
 
 ## Prompt Basics
@@ -134,6 +135,35 @@ df.show(format="fancy", max_width=120)
 ```
 
 For more details on how to use OpenAI-compatible providers with the `prompt` function like OpenRouter, Hugging Face Inference Providers, Databricks, and more, check out the [Prompting OpenAI-Compatible Providers](providers.md#prompting-with-openai-compatible-providers) section. Additionally, check out the [Prompting with vLLM Online Serving](providers.md#prompting-with-vllm-online-serving) section for more details on how to use vLLM Online Serving.
+
+### Running models locally with the Transformers provider
+
+The `transformers` provider runs open-weight instruction-tuned models locally via HuggingFace [`pipeline("text-generation")`](https://huggingface.co/docs/transformers/main/en/main_classes/pipelines#transformers.TextGenerationPipeline). Useful for offline batch inference without standing up a separate inference service.
+
+```bash
+pip install 'daft[transformers]'
+```
+
+```python
+import daft
+from daft.functions import prompt
+
+df = daft.from_pydict({"quote": ["I am going to be the king of the pirates!"]})
+
+df = df.with_column(
+    "response",
+    prompt(
+        daft.col("quote"),
+        provider="transformers",
+        model="HuggingFaceTB/SmolLM2-360M-Instruct",
+        system_message="Classify the anime from the quote in one short sentence.",
+        max_new_tokens=100,
+    ),
+)
+df.show()
+```
+
+Generation kwargs (`max_new_tokens`, `temperature`, `top_p`, ...) are forwarded to the pipeline call. Constructor-time options (`dtype`, `device_map`, `trust_remote_code`, `device`, ...) go through `pipeline_kwargs`. The provider auto-selects `cuda` > `mps` > `cpu`.
 
 ### Building Prompt Templates with the `format` function
 

--- a/tests/ai/transformers/test_transformers_prompter.py
+++ b/tests/ai/transformers/test_transformers_prompter.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+import asyncio
+import warnings
+from typing import Any
+from unittest.mock import Mock, patch
+
+import pytest
+
+pytest.importorskip("transformers")
+
+from daft.ai.protocols import Prompter
+from daft.ai.transformers.protocols.prompter import (
+    TransformersPrompter,
+    TransformersPrompterDescriptor,
+)
+
+
+def _make_pipeline(*, chat_template: str | None = "{{messages}}", output: Any | None = None) -> Mock:
+    pipe = Mock()
+    pipe.tokenizer = Mock()
+    pipe.tokenizer.chat_template = chat_template
+    pipe.return_value = output if output is not None else [{"generated_text": "ok"}]
+    return pipe
+
+
+def _make_prompter(mock_pipeline: Mock, **kwargs: Any) -> TransformersPrompter:
+    with patch("daft.ai.transformers.protocols.prompter.pipeline", return_value=mock_pipeline):
+        return TransformersPrompter(
+            provider_name=kwargs.pop("provider_name", "transformers"),
+            model_name=kwargs.pop("model_name", "fake/model"),
+            system_message=kwargs.pop("system_message", None),
+            prompt_options=kwargs.pop("prompt_options", None),
+        )
+
+
+def test_descriptor_default_fields():
+    d = TransformersPrompterDescriptor(provider_name="transformers", model_name="fake/model")
+    assert d.get_provider() == "transformers"
+    assert d.get_model() == "fake/model"
+    assert d.get_options() == {}
+    assert d.return_format is None
+    assert d.system_message is None
+
+
+def test_descriptor_carries_prompt_options():
+    d = TransformersPrompterDescriptor(
+        provider_name="transformers",
+        model_name="fake/model",
+        prompt_options={"max_new_tokens": 32, "temperature": 0.5},
+    )
+    assert d.get_options() == {"max_new_tokens": 32, "temperature": 0.5}
+
+
+def test_descriptor_get_udf_options_picks_up_udf_keys():
+    d = TransformersPrompterDescriptor(
+        provider_name="transformers",
+        model_name="fake/model",
+        prompt_options={"max_retries": 7, "max_new_tokens": 32},
+    )
+    udf_options = d.get_udf_options()
+    assert udf_options.max_retries == 7
+
+
+def test_descriptor_instantiate_rejects_return_format():
+    class Dummy:
+        pass
+
+    d = TransformersPrompterDescriptor(
+        provider_name="transformers",
+        model_name="fake/model",
+        return_format=Dummy,
+    )
+    with pytest.raises(NotImplementedError, match=r"return_format"):
+        d.instantiate()
+
+
+def test_provider_get_prompter_default():
+    from daft.ai.transformers.provider import TransformersProvider
+
+    provider = TransformersProvider()
+    descriptor = provider.get_prompter()
+    assert isinstance(descriptor, TransformersPrompterDescriptor)
+    assert descriptor.get_provider() == "transformers"
+    assert descriptor.get_model() == TransformersProvider.DEFAULT_PROMPTER
+
+
+def test_provider_get_prompter_with_overrides():
+    from daft.ai.transformers.provider import TransformersProvider
+
+    provider = TransformersProvider()
+    descriptor = provider.get_prompter(
+        model="custom/model",
+        system_message="be brief",
+        max_new_tokens=64,
+        pipeline_kwargs={"dtype": "auto"},
+    )
+    assert descriptor.get_model() == "custom/model"
+    assert descriptor.system_message == "be brief"
+    assert descriptor.get_options() == {
+        "max_new_tokens": 64,
+        "pipeline_kwargs": {"dtype": "auto"},
+    }
+
+
+def test_prompt_chat_template_basic():
+    pipe = _make_pipeline(
+        chat_template="...",
+        output=[{"generated_text": [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "hello!"}]}],
+    )
+    prompter = _make_prompter(pipe)
+
+    result = asyncio.run(prompter.prompt(("hi",)))
+
+    assert result == "hello!"
+    sent_inputs, sent_kwargs = pipe.call_args.args, pipe.call_args.kwargs
+    assert sent_inputs[0] == [{"role": "user", "content": "hi"}]
+    assert sent_kwargs.get("return_full_text") is False
+
+
+def test_prompt_chat_template_with_system_message():
+    pipe = _make_pipeline(
+        chat_template="...",
+        output=[{"generated_text": [{"role": "assistant", "content": "ack"}]}],
+    )
+    prompter = _make_prompter(pipe, system_message="be terse")
+
+    asyncio.run(prompter.prompt(("ping",)))
+
+    chat = pipe.call_args.args[0]
+    assert chat == [
+        {"role": "system", "content": "be terse"},
+        {"role": "user", "content": "ping"},
+    ]
+
+
+def test_prompt_chat_joins_multiple_text_parts_with_newline():
+    pipe = _make_pipeline(
+        chat_template="...",
+        output=[{"generated_text": [{"role": "assistant", "content": "ack"}]}],
+    )
+    prompter = _make_prompter(pipe)
+
+    asyncio.run(prompter.prompt(("first", "second", "third")))
+
+    chat = pipe.call_args.args[0]
+    assert chat == [{"role": "user", "content": "first\nsecond\nthird"}]
+
+
+def test_prompt_base_model_returns_string_output():
+    pipe = _make_pipeline(chat_template=None, output=[{"generated_text": "world"}])
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        prompter = _make_prompter(pipe, model_name="base/no-template")
+    assert any("no chat template" in str(w.message) for w in caught)
+
+    result = asyncio.run(prompter.prompt(("hello",)))
+
+    assert result == "world"
+    assert pipe.call_args.args[0] == "hello"
+
+
+def test_prompt_base_model_prepends_system_message():
+    pipe = _make_pipeline(chat_template=None, output=[{"generated_text": "ok"}])
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        prompter = _make_prompter(pipe, system_message="be terse")
+
+    asyncio.run(prompter.prompt(("ping",)))
+
+    assert pipe.call_args.args[0] == "be terse\n\nping"
+
+
+def test_generation_kwargs_forwarded_to_pipeline_call():
+    pipe = _make_pipeline(chat_template="...", output=[{"generated_text": [{"role": "assistant", "content": "x"}]}])
+    prompter = _make_prompter(
+        pipe,
+        prompt_options={"max_new_tokens": 20, "temperature": 0.7, "top_p": 0.9},
+    )
+
+    asyncio.run(prompter.prompt(("q",)))
+
+    kwargs = pipe.call_args.kwargs
+    assert kwargs["max_new_tokens"] == 20
+    assert kwargs["temperature"] == 0.7
+    assert kwargs["top_p"] == 0.9
+
+
+def test_udf_keys_stripped_from_generation_kwargs():
+    """`max_retries` etc. are UDF-level; they must not leak to pipeline.__call__."""
+    pipe = _make_pipeline(chat_template="...", output=[{"generated_text": [{"role": "assistant", "content": "x"}]}])
+    prompter = _make_prompter(
+        pipe,
+        prompt_options={"max_retries": 5, "on_error": "log", "max_new_tokens": 16},
+    )
+
+    asyncio.run(prompter.prompt(("q",)))
+
+    kwargs = pipe.call_args.kwargs
+    assert "max_retries" not in kwargs
+    assert "on_error" not in kwargs
+    assert kwargs["max_new_tokens"] == 16
+
+
+def test_pipeline_kwargs_forwarded_to_pipeline_constructor():
+    pipe = _make_pipeline()
+    with patch("daft.ai.transformers.protocols.prompter.pipeline", return_value=pipe) as mock_pipeline_ctor:
+        TransformersPrompter(
+            provider_name="transformers",
+            model_name="fake/model",
+            prompt_options={"pipeline_kwargs": {"dtype": "auto", "trust_remote_code": True}},
+        )
+
+    init_kwargs = mock_pipeline_ctor.call_args.kwargs
+    assert init_kwargs["dtype"] == "auto"
+    assert init_kwargs["trust_remote_code"] is True
+    assert init_kwargs["model"] == "fake/model"
+
+
+def test_pipeline_kwargs_can_override_device():
+    pipe = _make_pipeline()
+    with patch("daft.ai.transformers.protocols.prompter.pipeline", return_value=pipe) as mock_pipeline_ctor:
+        TransformersPrompter(
+            provider_name="transformers",
+            model_name="fake/model",
+            prompt_options={"pipeline_kwargs": {"device": "cpu"}},
+        )
+    assert mock_pipeline_ctor.call_args.kwargs["device"] == "cpu"
+
+
+def test_pipeline_kwargs_not_in_generation_kwargs():
+    pipe = _make_pipeline(chat_template="...", output=[{"generated_text": [{"role": "assistant", "content": "x"}]}])
+    prompter = _make_prompter(
+        pipe,
+        prompt_options={"pipeline_kwargs": {"dtype": "auto"}, "max_new_tokens": 8},
+    )
+
+    asyncio.run(prompter.prompt(("q",)))
+
+    assert "pipeline_kwargs" not in pipe.call_args.kwargs
+    assert "dtype" not in pipe.call_args.kwargs
+
+
+@pytest.mark.parametrize(
+    "bad_input",
+    [
+        b"raw bytes",
+        12345,
+        [1, 2, 3],
+    ],
+    ids=["bytes", "int", "list"],
+)
+def test_prompt_raises_on_unsupported_input_types(bad_input: Any):
+    pipe = _make_pipeline(chat_template="...")
+    prompter = _make_prompter(pipe)
+    with pytest.raises(NotImplementedError, match=r"only supports str inputs"):
+        asyncio.run(prompter.prompt((bad_input,)))
+
+
+def test_prompt_raises_on_numpy_input():
+    np = pytest.importorskip("numpy")
+    pipe = _make_pipeline(chat_template="...")
+    prompter = _make_prompter(pipe)
+    with pytest.raises(NotImplementedError, match=r"only supports str inputs"):
+        asyncio.run(prompter.prompt((np.zeros((4, 4), dtype=np.uint8),)))
+
+
+def test_protocol_compliance():
+    pipe = _make_pipeline(chat_template="...")
+    prompter = _make_prompter(pipe)
+    assert isinstance(prompter, Prompter)
+    assert callable(prompter.prompt)
+
+
+def test_provider_name_preserved():
+    pipe = _make_pipeline(chat_template="...", output=[{"generated_text": [{"role": "assistant", "content": "x"}]}])
+    prompter = _make_prompter(pipe, provider_name="my-custom-name")
+    assert prompter.provider_name == "my-custom-name"

--- a/tests/ai/transformers/test_transformers_prompter.py
+++ b/tests/ai/transformers/test_transformers_prompter.py
@@ -9,7 +9,6 @@ import pytest
 
 pytest.importorskip("transformers")
 
-from daft.ai.protocols import Prompter
 from daft.ai.transformers.protocols.prompter import (
     TransformersPrompter,
     TransformersPrompterDescriptor,
@@ -228,6 +227,35 @@ def test_pipeline_kwargs_can_override_device():
     assert mock_pipeline_ctor.call_args.kwargs["device"] == "cpu"
 
 
+def test_device_map_in_pipeline_kwargs_skips_default_device():
+    """Device and device_map are mutually exclusive in transformers.pipeline."""
+    pipe = _make_pipeline()
+    with patch("daft.ai.transformers.protocols.prompter.pipeline", return_value=pipe) as mock_pipeline_ctor:
+        TransformersPrompter(
+            provider_name="transformers",
+            model_name="fake/model",
+            prompt_options={"pipeline_kwargs": {"device_map": "auto"}},
+        )
+    init_kwargs = mock_pipeline_ctor.call_args.kwargs
+    assert "device" not in init_kwargs
+    assert init_kwargs["device_map"] == "auto"
+
+
+def test_return_full_text_in_options_is_stripped():
+    """`return_full_text` is fixed in _sync_prompt; user-supplied value must not collide."""
+    pipe = _make_pipeline(chat_template="...", output=[{"generated_text": [{"role": "assistant", "content": "x"}]}])
+    prompter = _make_prompter(
+        pipe,
+        prompt_options={"return_full_text": True, "max_new_tokens": 8},
+    )
+
+    asyncio.run(prompter.prompt(("q",)))
+
+    kwargs = pipe.call_args.kwargs
+    assert kwargs["return_full_text"] is False
+    assert kwargs["max_new_tokens"] == 8
+
+
 def test_pipeline_kwargs_not_in_generation_kwargs():
     pipe = _make_pipeline(chat_template="...", output=[{"generated_text": [{"role": "assistant", "content": "x"}]}])
     prompter = _make_prompter(
@@ -255,24 +283,3 @@ def test_prompt_raises_on_unsupported_input_types(bad_input: Any):
     prompter = _make_prompter(pipe)
     with pytest.raises(NotImplementedError, match=r"only supports str inputs"):
         asyncio.run(prompter.prompt((bad_input,)))
-
-
-def test_prompt_raises_on_numpy_input():
-    np = pytest.importorskip("numpy")
-    pipe = _make_pipeline(chat_template="...")
-    prompter = _make_prompter(pipe)
-    with pytest.raises(NotImplementedError, match=r"only supports str inputs"):
-        asyncio.run(prompter.prompt((np.zeros((4, 4), dtype=np.uint8),)))
-
-
-def test_protocol_compliance():
-    pipe = _make_pipeline(chat_template="...")
-    prompter = _make_prompter(pipe)
-    assert isinstance(prompter, Prompter)
-    assert callable(prompter.prompt)
-
-
-def test_provider_name_preserved():
-    pipe = _make_pipeline(chat_template="...", output=[{"generated_text": [{"role": "assistant", "content": "x"}]}])
-    prompter = _make_prompter(pipe, provider_name="my-custom-name")
-    assert prompter.provider_name == "my-custom-name"


### PR DESCRIPTION
## Changes Made

Adds a `transformers` provider for `daft.functions.ai.prompt()`, enabling local LLM inference via HuggingFace `transformers.pipeline("text-generation")`.
- `TransformersPrompter` + `TransformersPrompterDescriptor` under `daft/ai/transformers/protocols/prompter.py`; wired into `TransformersProvider.get_prompter()`. Default model: `HuggingFaceTB/SmolLM2-360M-Instruct`.
- Supports instruction-tuned (chat template) and base models; auto-detects device (cuda > mps > cpu) with a `pipeline_kwargs` escape hatch for `dtype` / `device_map` / `trust_remote_code` / etc.
- Sync `pipeline` call wrapped with `asyncio.to_thread` to satisfy the async `Prompter` protocol without blocking the event loop.
- Mocked unit tests under `tests/ai/transformers/test_transformers_prompter.py`; usage example added to `docs/ai-functions/prompt.md`.


## Related Issues
Part of #5620