### PR TITLE
fix(distributed): use build_in_memory_task_builder in coalesce_tasks to avoid Flight panic

### DIFF
--- a/src/daft-distributed/src/pipeline_node/into_partitions.rs
+++ b/src/daft-distributed/src/pipeline_node/into_partitions.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use common_error::DaftResult;
 use common_metrics::ops::{NodeCategory, NodeType};
 use common_runtime::OrderedJoinSet;
-use daft_local_plan::{LocalNodeContext, LocalPhysicalPlan};
+use daft_local_plan::{LocalNodeContext, LocalPhysicalPlan, ShuffleBackend as LocalShuffleBackend};
 use daft_logical_plan::stats::StatsState;
 use daft_schema::schema::SchemaRef;
 use futures::StreamExt;
@@ -132,15 +132,18 @@ impl IntoPartitionsNode {
                 .collect::<Vec<_>>();
 
             let node_id = self.node_id();
-            let shuffle_backend = self.shuffle_backend.local_shuffle_backend();
-            let builder = self.shuffle_backend.build_refs_task_builder(
+            // The refs here come from executing the input scan tasks, so they are always
+            // RayPartitionRef. Use in-memory scan with LocalShuffleBackend::Ray to coalesce
+            // them: flight shuffle only applies when reading data written to a flight server,
+            // not when reading from intermediate in-memory scan task outputs.
+            let builder = self.shuffle_backend.build_in_memory_task_builder(
                 partition_refs,
                 self.as_ref(),
                 move |input| {
                     LocalPhysicalPlan::into_partitions(
                         input,
                         1,
-                        shuffle_backend,
+                        LocalShuffleBackend::Ray,
                         StatsState::NotMaterialized,
                         LocalNodeContext::new(Some(node_id as usize)),
                     )

--- a/src/daft-distributed/src/pipeline_node/shuffles/backends/mod.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/backends/mod.rs
@@ -93,10 +93,37 @@ impl ShuffleBackend {
         }
     }
 
+    /// Build a `SwordfishTaskBuilder` from Ray partition refs using `in_memory_scan`,
+    /// regardless of the configured distributed shuffle backend. Use this when the
+    /// refs come from intermediate task execution (e.g. scan tasks), not from a
+    /// flight shuffle write step — in that case they are always `RayPartitionRef`
+    /// and must be read back via `in_memory_scan` + `with_psets`.
+    pub(crate) fn build_in_memory_task_builder<F>(
+        &self,
+        partition_refs: Vec<PartitionRef>,
+        node: &dyn PipelineNodeImpl,
+        wrap_plan: F,
+    ) -> SwordfishTaskBuilder
+    where
+        F: FnOnce(LocalPhysicalPlanRef) -> LocalPhysicalPlanRef,
+    {
+        let node_id = self.node_id;
+        let total_size_bytes = partition_refs.iter().map(|p| p.size_bytes()).sum::<usize>();
+        let in_memory_scan = LocalPhysicalPlan::in_memory_scan(
+            node_id,
+            self.schema.clone(),
+            total_size_bytes,
+            StatsState::NotMaterialized,
+            LocalNodeContext::new(Some(node_id as usize)),
+        );
+        let plan = wrap_plan(in_memory_scan);
+        SwordfishTaskBuilder::new(plan, node, node_id).with_psets(node_id, partition_refs)
+    }
+
     /// Build a `SwordfishTaskBuilder` whose plan reads from already-materialized
     /// partition refs (`in_memory_scan` for Ray, `shuffle_read(Flight)` for Flight)
     /// and then applies `wrap_plan` on top. The partition refs are attached to
-    /// the task via the backend-appropriate API (`with_psets` /
+    /// the task via the backend-appropriate AP I (`with_psets` /
     /// `with_flight_shuffle_reads`).
     pub(crate) fn build_refs_task_builder<F>(
         &self,

--- a/src/daft-distributed/src/pipeline_node/shuffles/backends/mod.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/backends/mod.rs
@@ -123,7 +123,7 @@ impl ShuffleBackend {
     /// Build a `SwordfishTaskBuilder` whose plan reads from already-materialized
     /// partition refs (`in_memory_scan` for Ray, `shuffle_read(Flight)` for Flight)
     /// and then applies `wrap_plan` on top. The partition refs are attached to
-    /// the task via the backend-appropriate AP I (`with_psets` /
+    /// the task via the backend-appropriate API (`with_psets` /
     /// `with_flight_shuffle_reads`).
     pub(crate) fn build_refs_task_builder<F>(
         &self,


### PR DESCRIPTION
## Changes Made

In `coalesce_tasks` (into_partitions.rs), when there are more input tasks than output partitions, scan tasks are executed via Ray and their results are always `RayPartitionRef`. Previously, `build_refs_task_builder` was called with those refs — but when the Flight shuffle backend is active, it takes the `DistributedShuffleBackend::Flight` arm and calls `flight::read_inputs_from_refs()`, which tries to downcast each `PartitionRef` to `FlightPartitionRef`. Since the refs are always `RayPartitionRef` in this path, this causes a panic.

There is also a second bug: even if the downcast didn't panic, using the Flight backend in `into_partitions(1)` would produce `FlightPartitionRef` output, but the downstream `write_parquet` expects `MicroPartition` — causing a type mismatch.

**Fix:**
- Added `build_in_memory_task_builder` to `ShuffleBackend`, which always uses `in_memory_scan` + `with_psets` regardless of the configured shuffle backend.
- In `coalesce_tasks`, replaced `build_refs_task_builder` with `build_in_memory_task_builder` using `LocalShuffleBackend::Ray`, since refs in this path are always `RayPartitionRef` from scan tasks, not from a Flight write step.

## Related Issues

https://github.com/Eventual-Inc/Daft/issues/7002
