### PR TITLE
fix(scan): populate per-column sizes when splitting parquet by row groups

### DIFF
--- a/src/daft-scan/src/scan_task_iters/mod.rs
+++ b/src/daft-scan/src/scan_task_iters/mod.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{collections::BTreeMap, sync::Arc};
 
 mod split_jsonl;
 
@@ -6,6 +6,7 @@ use common_daft_config::DaftExecutionConfig;
 use common_error::DaftResult;
 use daft_io::IOStatsContext;
 use daft_parquet::{RowGroupList, read::read_parquet_metadata};
+use daft_stats::TableMetadata;
 use indexmap::IndexMap;
 
 use crate::{
@@ -254,6 +255,10 @@ fn split_by_row_groups(
                         let mut curr_row_groups: RowGroupList = IndexMap::new();
                         let mut curr_size_bytes: usize = 0;
                         let mut curr_num_rows: usize = 0;
+                        // Per-column uncompressed sizes for the row groups in this split, so the
+                        // resulting ScanTask carries an accurate (projection-aware) size estimate
+                        // instead of falling back to the schema heuristic / inflation factor.
+                        let mut curr_column_sizes: BTreeMap<String, u64> = BTreeMap::new();
 
                         let all_row_groups: Vec<_> = file_metadata.row_groups().collect();
                         let last_original_index = all_row_groups.last().map(|(i, _)| *i);
@@ -261,6 +266,9 @@ fn split_by_row_groups(
                             curr_row_group_indices.push(i as i64);
                             curr_size_bytes += rg.compressed_size();
                             curr_num_rows += rg.num_rows();
+                            for (name, bytes) in rg.column_uncompressed_sizes() {
+                                *curr_column_sizes.entry(name).or_insert(0) += bytes;
+                            }
                             curr_row_groups.insert(i, rg);
 
                             if curr_size_bytes >= min_size_bytes || Some(i) == last_original_index {
@@ -282,9 +290,14 @@ fn split_by_row_groups(
                                     unreachable!("Parquet file format should only be used with ScanSourceKind::File");
                                 }
 
-                                if let Some(metadata) = &mut new_source.metadata {
-                                    metadata.length = curr_num_rows;
-                                }
+                                // Attach the exact row count and per-column uncompressed sizes
+                                // for this split (we read the footer above, so this is accurate
+                                // for every file, not just the first one in the scan).
+                                let column_sizes = std::mem::take(&mut curr_column_sizes);
+                                new_source.metadata = Some(TableMetadata {
+                                    length: curr_num_rows,
+                                    column_sizes: (!column_sizes.is_empty()).then_some(column_sizes),
+                                });
 
                                 // Reset accumulators
                                 curr_row_groups = IndexMap::new();

--- a/tests/io/test_split_scan_tasks.py
+++ b/tests/io/test_split_scan_tasks.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import io
+import re
+
 import pyarrow as pa
 import pyarrow.parquet as papq
 import pytest
@@ -31,6 +34,55 @@ def test_split_parquet_read(parquet_files):
         df = daft.read_parquet(str(parquet_files))
         assert df.num_partitions() == 10, "Should have 10 partitions since we will split the file"
         assert df.to_pydict() == {"data": ["aaa"] * 100}
+
+
+def test_split_parquet_estimate_tracks_uncompressed_size(tmpdir):
+    """Each split ScanTask should carry its own per-column sizes.
+
+    Regression test for two related gaps:
+      * split tasks for the first file reused the *whole-file* column sizes (only
+        `length` was updated), so each split estimated the entire file; and
+      * split tasks for the remaining files had no metadata and fell back to
+        `parquet_inflation_factor`.
+
+    With per-split column sizes, the total estimated scan bytes should track the
+    files' real uncompressed size rather than being multiplied by the number of
+    splits or blown up by the inflation factor.
+    """
+    # Two files, each with 20 row groups of low-cardinality data.
+    paths = []
+    uncompressed = 0
+    for f in range(2):
+        tbl = pa.table({"data": [f"val_{i % 4}" for i in range(1000)]})
+        path = tmpdir / f"file_{f}.pq"
+        papq.write_table(tbl, str(path), row_group_size=50, use_dictionary=False)
+        paths.append(str(path))
+        md = papq.ParquetFile(str(path)).metadata
+        uncompressed += sum(md.row_group(i).total_byte_size for i in range(md.num_row_groups))
+
+    with daft.execution_config_ctx(
+        enable_scan_task_split_and_merge=True,
+        scan_tasks_min_size_bytes=1,
+        scan_tasks_max_size_bytes=1,
+        # Absurd inflation factor: if any split fell back to it (i.e. had no
+        # per-column metadata), the estimate would explode well past the bound.
+        parquet_inflation_factor=1000.0,
+    ):
+        df = daft.read_parquet(str(tmpdir))
+        assert df.num_partitions() > 2, "files should split into many tasks"
+        string_io = io.StringIO()
+        df.explain(show_all=True, file=string_io)
+        explain_output = string_io.getvalue()
+
+    match = re.search(r"Estimated Scan Bytes = (\d+)", explain_output)
+    assert match is not None, f"could not find scan bytes in explain output:\n{explain_output}"
+    estimated = int(match.group(1))
+
+    # Should track the real uncompressed size, not N x it (whole-file reuse) nor
+    # compressed x 1000 (inflation fallback).
+    assert 0.3 * uncompressed <= estimated <= 3 * uncompressed, (
+        f"estimated scan bytes {estimated} should be close to uncompressed size {uncompressed}"
+    )
 
 
 @pytest.mark.skip(reason="Not implemented yet")


### PR DESCRIPTION
Follow-up to #6542 — closes "gap 1" from the scan size-estimation work.

## Why

#6542 made the scan-task in-memory size estimate use per-column uncompressed sizes from the Parquet footer (`TableMetadata.column_sizes`), instead of the schema heuristic that assumes a fixed list length. But those sizes were only captured for the **first file** in a glob (during schema inference). Every other file fell back to `parquet_inflation_factor`, so multi-file scans still couldn't be trusted — and the customer who reported the original OOM had to keep tuning `parquet_inflation_factor` to compensate.

`split_by_row_groups` (which runs when `enable_scan_task_split_and_merge=True`) **already reads each file's full footer** at planning time to decide split points. So we can populate `column_sizes` there for **every** file at **zero extra I/O**.

## What

- Accumulate per-column uncompressed sizes alongside the existing compressed-size / row-count accumulators in `split_by_row_groups`, and attach them (plus the exact row count) to each emitted split task's `TableMetadata`.

This also fixes a **latent over-estimate** introduced by the per-file metadata: previously a split of the *first* file reused the whole-file `column_sizes` and only updated `length`, so each split estimated the *entire* file (N splits ⇒ ~N× the real size). We now recompute per-column sizes for exactly the row groups in each split.

## Test

Adds a Ray regression test (`tests/io/test_split_scan_tasks.py`): two multi-row-group files, split into many tasks, with `parquet_inflation_factor=1000`. It asserts the total `Estimated Scan Bytes` tracks the files' real uncompressed size — which fails under both old behaviors (whole-file reuse ⇒ ~N×; inflation fallback ⇒ ~1000×). Verified passing on the Ray runner; `daft-scan` Rust suite and `test_size_estimations.py` still green.

## Known remaining gap (not addressed here)

The estimate uses Parquet's *uncompressed* size, which for dictionary/RLE-encoded columns is still smaller than the fully-materialized Arrow size (e.g. ~4.5× vs ~26× compressed for the reporting customer's int64 token lists). So estimates remain conservative-low for that data; a materialization-aware correction is separate future work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)