### PR TITLE
fix(scan): estimate scan size from materialized buffer, not encoded size

### DIFF
--- a/src/daft-parquet/src/metadata_adapter.rs
+++ b/src/daft-parquet/src/metadata_adapter.rs
@@ -202,27 +202,43 @@ impl DaftRowGroupMetaData {
         self.inner.compressed_size() as usize
     }
 
-    /// Uncompressed (encoded) size in bytes for each column chunk in this row group,
-    /// keyed by the top-level (root) column name.
+    /// Estimated in-memory (materialized) size in bytes for each column chunk in this
+    /// row group, keyed by the top-level (root) column name.
+    ///
+    /// For fixed-width physical types we use `num_values * physical_width`, which is the
+    /// size of the decoded Arrow buffer and is *independent of the on-disk encoding*. This
+    /// matters for dictionary/RLE-encoded data, where the Parquet "uncompressed" size is
+    /// the encoded (dictionary index) size and can be many times smaller than the
+    /// materialized buffer. For variable-width `BYTE_ARRAY` (e.g. Utf8/Binary) the byte
+    /// count is not derivable from `num_values`, so we fall back to the uncompressed size.
     ///
     /// Nested columns are flattened to their root: every leaf chunk (e.g.
-    /// `position_ids.list.element`) is attributed to its top-level field
-    /// (`position_ids`). The caller is responsible for summing across row groups.
-    pub fn column_uncompressed_sizes(&self) -> Vec<(String, u64)> {
+    /// `position_ids.list.element`) is attributed to its top-level field (`position_ids`).
+    /// Offset/validity buffers are not added (they are negligible next to the value
+    /// buffers). The caller is responsible for summing across row groups.
+    pub fn column_materialized_sizes(&self) -> Vec<(String, u64)> {
+        use parquet::basic::Type;
+
         self.inner
             .columns()
             .iter()
             .map(|col| {
-                let root = col
-                    .column_descr()
-                    .path()
-                    .parts()
-                    .first()
-                    .cloned()
-                    .unwrap_or_default();
-                // `uncompressed_size()` is an i64 and is always non-negative in practice;
-                // clamp defensively so a malformed (negative) value can't wrap to a huge u64.
-                (root, col.uncompressed_size().max(0) as u64)
+                let descr = col.column_descr();
+                let root = descr.path().parts().first().cloned().unwrap_or_default();
+                // `num_values()` is an i64 and always non-negative in practice; clamp
+                // defensively so a malformed (negative) value can't wrap to a huge u64.
+                let num_values = col.num_values().max(0) as u64;
+                let bytes = match descr.physical_type() {
+                    Type::BOOLEAN => num_values.div_ceil(8), // 1 bit per value
+                    Type::INT32 | Type::FLOAT => num_values * 4,
+                    Type::INT64 | Type::DOUBLE => num_values * 8,
+                    Type::INT96 => num_values * 12,
+                    Type::FIXED_LEN_BYTE_ARRAY => num_values * descr.type_length().max(0) as u64,
+                    // Variable-width: byte count isn't derivable from num_values, so fall
+                    // back to the uncompressed (encoded) size as a proxy.
+                    Type::BYTE_ARRAY => col.uncompressed_size().max(0) as u64,
+                };
+                (root, bytes)
             })
             .collect()
     }
@@ -275,5 +291,75 @@ mod tests {
 
         let m3 = DaftParquetMetadata::from_arrowrs(make_test_metadata(1000));
         assert_ne!(m1, m3);
+    }
+
+    #[test]
+    fn test_column_materialized_sizes() {
+        use std::collections::BTreeMap;
+
+        use parquet::{
+            basic::Type as PhysicalType,
+            file::metadata::{ColumnChunkMetaData, RowGroupMetaData},
+            schema::types::{SchemaDescriptor, Type as SchemaType},
+        };
+
+        let schema = SchemaType::group_type_builder("schema")
+            .with_fields(vec![
+                Arc::new(
+                    SchemaType::primitive_type_builder("ids", PhysicalType::INT64)
+                        .build()
+                        .unwrap(),
+                ),
+                Arc::new(
+                    SchemaType::primitive_type_builder("flag", PhysicalType::BOOLEAN)
+                        .build()
+                        .unwrap(),
+                ),
+                Arc::new(
+                    SchemaType::primitive_type_builder("name", PhysicalType::BYTE_ARRAY)
+                        .build()
+                        .unwrap(),
+                ),
+            ])
+            .build()
+            .unwrap();
+        let descr = Arc::new(SchemaDescriptor::new(Arc::new(schema)));
+
+        let rg = RowGroupMetaData::builder(descr.clone())
+            .set_num_rows(100)
+            .set_column_metadata(vec![
+                // INT64: dictionary-encoded so its uncompressed size would be small, but
+                // the materialized buffer is num_values * 8.
+                ColumnChunkMetaData::builder(descr.column(0))
+                    .set_num_values(100)
+                    .set_total_uncompressed_size(40) // encoded; deliberately tiny
+                    .build()
+                    .unwrap(),
+                ColumnChunkMetaData::builder(descr.column(1))
+                    .set_num_values(64)
+                    .build()
+                    .unwrap(),
+                // BYTE_ARRAY: byte count isn't derivable from num_values, so fall back to
+                // the uncompressed size.
+                ColumnChunkMetaData::builder(descr.column(2))
+                    .set_num_values(100)
+                    .set_total_uncompressed_size(777)
+                    .build()
+                    .unwrap(),
+            ])
+            .build()
+            .unwrap();
+
+        let sizes: BTreeMap<String, u64> = DaftRowGroupMetaData::from_arrowrs(rg)
+            .column_materialized_sizes()
+            .into_iter()
+            .collect();
+
+        // INT64 uses num_values * 8, NOT the tiny encoded size.
+        assert_eq!(sizes["ids"], 100 * 8);
+        // BOOLEAN is 1 bit per value.
+        assert_eq!(sizes["flag"], 64 / 8);
+        // BYTE_ARRAY falls back to the uncompressed size.
+        assert_eq!(sizes["name"], 777);
     }
 }

--- a/src/daft-parquet/src/metadata_adapter.rs
+++ b/src/daft-parquet/src/metadata_adapter.rs
@@ -336,7 +336,7 @@ mod tests {
                     .build()
                     .unwrap(),
                 ColumnChunkMetaData::builder(descr.column(1))
-                    .set_num_values(64)
+                    .set_num_values(65) // not a multiple of 8 -> exercises div_ceil rounding
                     .build()
                     .unwrap(),
                 // BYTE_ARRAY: byte count isn't derivable from num_values, so fall back to
@@ -357,8 +357,8 @@ mod tests {
 
         // INT64 uses num_values * 8, NOT the tiny encoded size.
         assert_eq!(sizes["ids"], 100 * 8);
-        // BOOLEAN is 1 bit per value.
-        assert_eq!(sizes["flag"], 64 / 8);
+        // BOOLEAN is 1 bit per value, rounded up to whole bytes (65 bits -> 9 bytes).
+        assert_eq!(sizes["flag"], 9);
         // BYTE_ARRAY falls back to the uncompressed size.
         assert_eq!(sizes["name"], 777);
     }

--- a/src/daft-scan/src/glob.rs
+++ b/src/daft-scan/src/glob.rs
@@ -288,12 +288,13 @@ impl GlobScanOperator {
                         Err(e) => return Err(e),
                     };
 
-                    // Sum the per-column uncompressed sizes across all row groups, keyed by
-                    // top-level column name. Storing per-column (rather than a single total)
-                    // lets size estimates respect column-projection pushdown.
+                    // Sum the per-column materialized (in-memory) sizes across all row
+                    // groups, keyed by top-level column name. Storing per-column (rather
+                    // than a single total) lets size estimates respect column-projection
+                    // pushdown.
                     let mut column_sizes: BTreeMap<String, u64> = BTreeMap::new();
                     for (_, rg) in metadata.row_groups() {
-                        for (name, bytes) in rg.column_uncompressed_sizes() {
+                        for (name, bytes) in rg.column_materialized_sizes() {
                             *column_sizes.entry(name).or_insert(0) += bytes;
                         }
                     }

--- a/src/daft-scan/src/scan_task_iters/mod.rs
+++ b/src/daft-scan/src/scan_task_iters/mod.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{collections::BTreeMap, sync::Arc};
 
 mod split_jsonl;
 
@@ -6,6 +6,7 @@ use common_daft_config::DaftExecutionConfig;
 use common_error::DaftResult;
 use daft_io::IOStatsContext;
 use daft_parquet::{RowGroupList, read::read_parquet_metadata};
+use daft_stats::TableMetadata;
 use indexmap::IndexMap;
 
 use crate::{
@@ -254,6 +255,11 @@ fn split_by_row_groups(
                         let mut curr_row_groups: RowGroupList = IndexMap::new();
                         let mut curr_size_bytes: usize = 0;
                         let mut curr_num_rows: usize = 0;
+                        // Per-column materialized sizes for the row groups in this split, so
+                        // the resulting ScanTask carries an accurate (projection-aware) size
+                        // estimate for every file — not just the first file in the scan, and
+                        // not the whole-file sizes reused across splits.
+                        let mut curr_column_sizes: BTreeMap<String, u64> = BTreeMap::new();
 
                         let all_row_groups: Vec<_> = file_metadata.row_groups().collect();
                         let last_original_index = all_row_groups.last().map(|(i, _)| *i);
@@ -261,6 +267,9 @@ fn split_by_row_groups(
                             curr_row_group_indices.push(i as i64);
                             curr_size_bytes += rg.compressed_size();
                             curr_num_rows += rg.num_rows();
+                            for (name, bytes) in rg.column_materialized_sizes() {
+                                *curr_column_sizes.entry(name).or_insert(0) += bytes;
+                            }
                             curr_row_groups.insert(i, rg);
 
                             if curr_size_bytes >= min_size_bytes || Some(i) == last_original_index {
@@ -282,9 +291,14 @@ fn split_by_row_groups(
                                     unreachable!("Parquet file format should only be used with ScanSourceKind::File");
                                 }
 
-                                if let Some(metadata) = &mut new_source.metadata {
-                                    metadata.length = curr_num_rows;
-                                }
+                                // Attach the exact row count and per-column materialized
+                                // sizes for this split (we read the footer above, so this is
+                                // accurate for every file).
+                                let column_sizes = std::mem::take(&mut curr_column_sizes);
+                                new_source.metadata = Some(TableMetadata {
+                                    length: curr_num_rows,
+                                    column_sizes: (!column_sizes.is_empty()).then_some(column_sizes),
+                                });
 
                                 // Reset accumulators
                                 curr_row_groups = IndexMap::new();

--- a/src/daft-stats/src/table_metadata.rs
+++ b/src/daft-stats/src/table_metadata.rs
@@ -5,10 +5,10 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub struct TableMetadata {
     pub length: usize,
-    /// Uncompressed size in bytes per top-level column, when known from file metadata
-    /// (e.g. summed Parquet column-chunk totals across row groups). Keyed by column name
-    /// so that size estimates can respect column-projection pushdown. `None` when the
-    /// source does not expose per-column sizes.
+    /// Estimated in-memory (materialized) size in bytes per top-level column, when known
+    /// from file metadata (e.g. derived from Parquet row-group value counts and column
+    /// types). Keyed by column name so that size estimates can respect column-projection
+    /// pushdown. `None` when the source does not expose per-column sizes.
     #[serde(default)]
     pub column_sizes: Option<BTreeMap<String, u64>>,
 }

--- a/tests/io/test_split_scan_tasks.py
+++ b/tests/io/test_split_scan_tasks.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import io
+import re
+
 import pyarrow as pa
 import pyarrow.parquet as papq
 import pytest
@@ -31,6 +34,59 @@ def test_split_parquet_read(parquet_files):
         df = daft.read_parquet(str(parquet_files))
         assert df.num_partitions() == 10, "Should have 10 partitions since we will split the file"
         assert df.to_pydict() == {"data": ["aaa"] * 100}
+
+
+def test_split_parquet_estimate_uses_materialized_size(tmpdir):
+    """The scan size estimate must reflect the materialized buffer size, not encoded size.
+
+    For dictionary/RLE-encoded int64 lists, the encoded size is many times smaller than
+    the decoded Arrow buffer. The estimate is derived from value counts and column types
+    (num_values * 8 for int64), so it should track the materialized size. This also guards
+    against the split path either reusing whole-file sizes (N x over-estimate) or dropping
+    metadata and falling back to the inflation factor.
+    """
+    n_rows = 5000
+    seq = list(range(128))  # repetitive -> highly dictionary-compressible
+    tbl = pa.table(
+        {"position_ids": [seq for _ in range(n_rows)]},
+        schema=pa.schema([("position_ids", pa.list_(pa.int64()))]),
+    )
+    path = tmpdir / "file.pq"
+    papq.write_table(tbl, str(path), use_dictionary=True, row_group_size=1000)
+
+    md = papq.ParquetFile(str(path)).metadata
+    uncompressed = 0
+    num_values = 0
+    for i in range(md.num_row_groups):
+        rg = md.row_group(i)
+        for c in range(rg.num_columns):
+            uncompressed += rg.column(c).total_uncompressed_size
+            num_values += rg.column(c).num_values
+    materialized = num_values * 8  # int64 leaf buffer
+
+    # Tiny byte thresholds: splitting is gated on the (small, dictionary-compressed)
+    # on-disk size, so use 1 to force one split per row group.
+    with daft.execution_config_ctx(
+        enable_scan_task_split_and_merge=True,
+        scan_tasks_min_size_bytes=1,
+        scan_tasks_max_size_bytes=1,
+    ):
+        df = daft.read_parquet(str(path))
+        assert df.num_partitions() > 1, "file should split into multiple tasks"
+        string_io = io.StringIO()
+        df.explain(show_all=True, file=string_io)
+        explain_output = string_io.getvalue()
+
+    match = re.search(r"Estimated Scan Bytes = (\d+)", explain_output)
+    assert match is not None, f"could not find scan bytes in explain output:\n{explain_output}"
+    estimated = int(match.group(1))
+
+    # Tracks the materialized buffer size...
+    assert 0.8 * materialized <= estimated <= 1.2 * materialized, (
+        f"estimated {estimated} should be ~materialized {materialized}"
+    )
+    # ...and is far larger than the encoded size we used to report.
+    assert estimated > 3 * uncompressed, f"estimated {estimated} should be >> uncompressed {uncompressed}"
 
 
 @pytest.mark.skip(reason="Not implemented yet")


### PR DESCRIPTION
Follow-up to #6542. **Supersedes #7155** (which I'll close).

## The problem #6542 left

#6542 made scan-size estimates use the Parquet footer's per-column **uncompressed** (`total_byte_size`) sizes instead of the `DEFAULT_LIST_LEN=4` schema heuristic. But "uncompressed" in Parquet is the **encoded** size (dictionary indices + RLE runs) — for dictionary/RLE columns that's far smaller than the decoded Arrow buffer.

For the reporting customer's dictionary-encoded int64 token lists, the encoded size under-counts the materialized size by **~9×**, so the estimate was still wrong in the dangerous (under-estimate) direction — which drives scan-task under-merging and scheduler memory under-reservation → the original OOM.

## The fix

Estimate the **materialized** size from the footer's per-column **value counts × physical width**:

- Fixed-width (`Int*`/`Float*`/`Bool`/`FixedLenByteArray`): `num_values × width` — exactly the decoded buffer size, **independent of on-disk encoding**.
- Variable-width (`BYTE_ARRAY` / Utf8 / Binary): byte count isn't derivable from `num_values`, so fall back to the uncompressed size (documented residual approximation).

No extra I/O — the footer is already read during planning. The estimate is already projection- and limit-aware (from #6542), so it composes.

Also populate these per-column sizes when **splitting** a Parquet file by row groups (`split_by_row_groups`). Previously only the first file in a glob carried sizes at all, and the first file's splits reused *whole-file* sizes (an N× over-estimate). Now every split task carries accurate per-split sizes. (This folds in #7155's plumbing, done right.)

## Validation

End-to-end on Ray, 5000 rows of dictionary-encoded `int64[128]` lists:

```
uncompressed (encoded) =   591,880   <- what #6542 reported
materialized (nv * 8)  = 5,120,000
daft estimate (this PR)= 5,120,000   <- exact
```

- New `metadata_adapter` unit test (`column_materialized_sizes`: INT64 width, BOOLEAN bit-width, BYTE_ARRAY fallback).
- New Ray integration test asserting the estimate tracks materialized size **and** is ≫ the encoded size (catches the encoded-size under-estimate, the whole-file-reuse over-estimate, and the inflation-fallback case in one assertion).
- `daft-scan` (53), `daft-parquet` (15), `daft-stats` (8) Rust suites and `test_size_estimations.py` all green.

## Residual (documented, future work)

Dictionary-encoded **string** columns still fall back to the encoded size (no value-width to multiply), so they can under-estimate. The customer's case is int64 (fully fixed by this); strings would need value-length stats or sampling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)