### PR TITLE
fix: Reuse file format config in Iceberg and Delta

### DIFF
--- a/daft/io/delta_lake/delta_lake_scan.py
+++ b/daft/io/delta_lake/delta_lake_scan.py
@@ -217,10 +217,13 @@ class DeltaLakeScanOperator(ScanOperator):
         # lacks the delta.columnMapping.id annotation"), so we can build the mapping
         # without re-checking that here.
         if cm_mode == "none":
-            self._field_id_mapping: dict[int, PyField] | None = None
+            field_id_mapping: dict[int, PyField] | None = None
             self._stats_physical_to_logical: dict[str, str] = {}
         else:
-            self._field_id_mapping, self._stats_physical_to_logical = _column_mapping_maps(delta_schema)
+            field_id_mapping, self._stats_physical_to_logical = _column_mapping_maps(delta_schema)
+        self._file_format_config = FileFormatConfig.from_parquet_config(
+            ParquetSourceConfig(field_id_mapping=field_id_mapping)
+        )
 
         partition_columns = set(self._table.metadata().partition_columns)
         self._partition_keys = [
@@ -323,9 +326,6 @@ class DeltaLakeScanOperator(ScanOperator):
                 size_bytes = add_actions["size_bytes"][task_idx].as_py()
             except KeyError:
                 size_bytes = None
-            file_format_config = FileFormatConfig.from_parquet_config(
-                ParquetSourceConfig(field_id_mapping=self._field_id_mapping)
-            )
 
             if is_partitioned:
                 dtype = add_actions.schema.field(partition_field_name).type
@@ -387,7 +387,7 @@ class DeltaLakeScanOperator(ScanOperator):
                 stats = None
             st = ScanTask.catalog_scan_task(
                 file=path,
-                file_format=file_format_config,
+                file_format=self._file_format_config,
                 schema=self._schema._schema,
                 num_rows=record_count,
                 storage_config=self._storage_config,

--- a/daft/io/iceberg/iceberg_scan.py
+++ b/daft/io/iceberg/iceberg_scan.py
@@ -99,7 +99,7 @@ class IcebergScanOperator(ScanOperator):
         self._storage_config = storage_config
 
         field_id_mapping = visit(iceberg_schema, SchemaFieldIdMappingVisitor())
-        self._parquet_file_format_config = FileFormatConfig.from_parquet_config(
+        self._file_format_config = FileFormatConfig.from_parquet_config(
             ParquetSourceConfig(
                 field_id_mapping=field_id_mapping,
                 ignore_corrupt_files=ignore_corrupt_files,
@@ -207,9 +207,7 @@ class IcebergScanOperator(ScanOperator):
             path = file.file_path
             record_count = file.record_count
             file_format = file.file_format
-            if file_format == "PARQUET":
-                file_format_config = self._parquet_file_format_config
-            else:
+            if file_format != "PARQUET":
                 # TODO: Support ORC and AVRO when we can read it
                 raise NotImplementedError(f"{file_format} for iceberg not implemented!")
 
@@ -219,7 +217,7 @@ class IcebergScanOperator(ScanOperator):
             pspec = self._iceberg_record_to_partition_spec(self._iceberg_table.specs()[file.spec_id], file.partition)
             st = ScanTask.catalog_scan_task(
                 file=path,
-                file_format=file_format_config,
+                file_format=self._file_format_config,
                 schema=self._schema._schema,
                 num_rows=record_count,
                 storage_config=self._storage_config,

--- a/daft/io/iceberg/iceberg_scan.py
+++ b/daft/io/iceberg/iceberg_scan.py
@@ -97,8 +97,15 @@ class IcebergScanOperator(ScanOperator):
         self._iceberg_schema = iceberg_schema
         self._snapshot_id = snapshot_id
         self._storage_config = storage_config
-        self._ignore_corrupt_files = ignore_corrupt_files
-        self._field_id_mapping = visit(iceberg_schema, SchemaFieldIdMappingVisitor())
+
+        field_id_mapping = visit(iceberg_schema, SchemaFieldIdMappingVisitor())
+        self._parquet_file_format_config = FileFormatConfig.from_parquet_config(
+            ParquetSourceConfig(
+                field_id_mapping=field_id_mapping,
+                ignore_corrupt_files=ignore_corrupt_files,
+            )
+        )
+
         self._schema = convert_iceberg_schema(iceberg_schema)
         self._partition_keys = iceberg_partition_spec_to_fields(iceberg_schema, self._iceberg_table.spec())
 
@@ -201,12 +208,7 @@ class IcebergScanOperator(ScanOperator):
             record_count = file.record_count
             file_format = file.file_format
             if file_format == "PARQUET":
-                file_format_config = FileFormatConfig.from_parquet_config(
-                    ParquetSourceConfig(
-                        field_id_mapping=self._field_id_mapping,
-                        ignore_corrupt_files=self._ignore_corrupt_files,
-                    )
-                )
+                file_format_config = self._parquet_file_format_config
             else:
                 # TODO: Support ORC and AVRO when we can read it
                 raise NotImplementedError(f"{file_format} for iceberg not implemented!")


### PR DESCRIPTION
## Changes Made

Rather than creating a new `FileFormatConfig` and `ParquetSourceConfig` per Parquet file, which would unfortunately copy the contents of `field_id_mapping` every time instead of reusing it, we create it once and pass it into the ScanTask creation.

Before, this would accidentally copy the `field_id_mapping` every time when converting from Python to Rust because the `Arc` in Rust isn't compatible with Python reference counting. The wrapped `PyFileFormatConfig` should get around this by storing the Arc internally, so it should be fine