### PR TITLE
fix(core): handle all-null list literals

### DIFF
--- a/src/daft-core/src/series/from_lit.rs
+++ b/src/daft-core/src/series/from_lit.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use arrow::buffer::{NullBuffer, OffsetBuffer};
 use common_error::{DaftError, DaftResult};
 use common_image::CowImage;
 use indexmap::IndexMap;
@@ -262,7 +263,16 @@ pub fn series_from_literals_iter<I: ExactSizeIterator<Item = DaftResult<Literal>
                         .transpose()
                 })
                 .collect::<DaftResult<Vec<_>>>()?;
-            ListArray::from_series("literal", data)?.into_series()
+            if data.iter().all(Option::is_none) {
+                let offsets = OffsetBuffer::from_lengths((0..data.len()).map(|_| 0));
+                let nulls = NullBuffer::from_iter((0..data.len()).map(|_| false));
+                let flat_child =
+                    Series::empty("literal", &child_dtype.to_physical()).cast(child_dtype)?;
+
+                ListArray::new(field, flat_child, offsets, Some(nulls)).into_series()
+            } else {
+                ListArray::from_series("literal", data)?.into_series()
+            }
         }
         DataType::Struct(ref fields) => {
             let values = values.collect::<Vec<_>>();

--- a/tests/series/test_series.py
+++ b/tests/series/test_series.py
@@ -118,6 +118,27 @@ def test_series_pylist_round_trip_null() -> None:
     assert words["None"] == 2
 
 
+def test_series_pylist_round_trip_all_null_list_with_explicit_dtype() -> None:
+    s = Series.from_pylist([None, None], dtype=DataType.list(DataType.string()))
+
+    assert s.datatype() == DataType.list(DataType.string())
+    assert s.to_pylist() == [None, None]
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        DataType.list(DataType.extension("test.tags", DataType.string())),
+        DataType.list(DataType.list(DataType.extension("test.tags", DataType.string()))),
+    ],
+)
+def test_series_pylist_round_trip_all_null_extension_list_with_explicit_dtype(dtype) -> None:
+    s = Series.from_pylist([None, None], dtype=dtype)
+
+    assert s.datatype() == dtype
+    assert s.to_pylist() == [None, None]
+
+
 @pytest.mark.parametrize("type", [pa.binary(), pa.binary(1)])
 def test_series_pylist_round_trip_binary(type) -> None:
     data = pa.array([b"a", b"b", b"c", None, b"d", None], type=type)


### PR DESCRIPTION
## Changes Made

- Handle explicit list dtype construction when every list literal is null by creating an empty child series with the requested child dtype instead of concatenating an empty set of child series.
- Build the all-null list child from the child physical dtype before casting back to the declared child dtype, so extension-typed children do not trigger a Rust panic.
- Add regression tests for `Series.from_pylist([None, None], dtype=DataType.list(...))`, including string, extension, and nested extension child dtypes.

This fixes the same conversion path used by legacy `@daft.udf` when a batch returns only `None` values for a declared list return dtype.

## Related Issues

Closes #7167

## Validation

- `DAFT_RUNNER=native make test EXTRA_ARGS="-q tests/series/test_series.py"` passed: 69 tests.
- Manual legacy UDF post-processing check via `daft.udf.legacy.run_udf` returned `List[String]` with `[None, None]`.

Note: local full dataframe legacy UDF `collect()` timed out in this environment even for this minimal case, matching earlier local executor behavior unrelated to this conversion fix; the failing traceback path is covered by the regression test and `run_udf` check.