### PR TITLE
feat(ai): support text file inputs in transformers prompter

### DIFF
--- a/daft/ai/transformers/protocols/prompter.py
+++ b/daft/ai/transformers/protocols/prompter.py
@@ -12,6 +12,7 @@ from transformers import pipeline
 from daft.ai.protocols import Prompter, PrompterDescriptor
 from daft.ai.typing import Options, PromptOptions, UDFOptions
 from daft.ai.utils import get_gpu_udf_options, get_torch_device
+from daft.file import File
 
 # Global lock to prevent concurrent model loading which can cause meta tensor issues
 _model_loading_lock = threading.Lock()
@@ -110,13 +111,48 @@ class TransformersPrompter(Prompter):
 
     @singledispatchmethod
     def _process_message(self, msg: Any) -> str:
-        raise NotImplementedError(
-            f"The 'transformers' provider currently only supports str inputs, got {type(msg).__name__}."
-        )
+        raise NotImplementedError(f"The 'transformers' provider does not support input of type {type(msg).__name__}.")
 
     @_process_message.register
     def _(self, msg: str) -> str:
         return msg
+
+    @_process_message.register
+    def _(self, msg: File) -> str:
+        mime_type = msg.mime_type()
+        if not self._is_text_mime_type(mime_type):
+            raise NotImplementedError(
+                f"The 'transformers' provider currently only supports text/* File inputs, got '{mime_type}'."
+            )
+        return self._wrap_filetag(mime_type, self._read_text_content(msg))
+
+    @_process_message.register
+    def _(self, msg: bytes) -> str:
+        from daft.daft import guess_mimetype_from_content
+
+        mime_type = guess_mimetype_from_content(msg) or "application/octet-stream"
+        if not self._is_text_mime_type(mime_type):
+            raise NotImplementedError(
+                f"The 'transformers' provider currently only supports text/* bytes inputs, got '{mime_type}'."
+            )
+        return self._wrap_filetag(mime_type, msg.decode("utf-8", errors="replace"))
+
+    @staticmethod
+    def _is_text_mime_type(mime_type: str) -> bool:
+        return mime_type.split(";")[0].strip().lower().startswith("text/")
+
+    @staticmethod
+    def _read_text_content(file_obj: File) -> str:
+        with file_obj.open() as f:
+            data = f.read()
+        if isinstance(data, str):
+            return data
+        return data.decode("utf-8", errors="replace")
+
+    @staticmethod
+    def _wrap_filetag(mime_type: str, text: str) -> str:
+        tag = f"file_{mime_type.split(';')[0].strip().replace('/', '_')}"
+        return f"<{tag}>{text}</{tag}>"
 
     def _build_inputs(self, messages: tuple[Any, ...]) -> list[dict[str, str]] | str:
         user_content = "\n".join(self._process_message(m) for m in messages)

--- a/daft/ai/transformers/protocols/prompter.py
+++ b/daft/ai/transformers/protocols/prompter.py
@@ -12,6 +12,7 @@ from transformers import pipeline
 from daft.ai.protocols import Prompter, PrompterDescriptor
 from daft.ai.typing import Options, PromptOptions, UDFOptions
 from daft.ai.utils import get_gpu_udf_options, get_torch_device
+from daft.daft import guess_mimetype_from_content
 from daft.file import File
 
 # Global lock to prevent concurrent model loading which can cause meta tensor issues
@@ -128,9 +129,12 @@ class TransformersPrompter(Prompter):
 
     @_process_message.register
     def _(self, msg: bytes) -> str:
-        from daft.daft import guess_mimetype_from_content
-
-        mime_type = guess_mimetype_from_content(msg) or "application/octet-stream"
+        mime_type = guess_mimetype_from_content(msg)
+        if mime_type is None:
+            try:
+                return self._wrap_filetag("text/plain", msg.decode("utf-8"))
+            except UnicodeDecodeError:
+                raise NotImplementedError("The 'transformers' provider currently only supports text/* bytes inputs.")
         if not self._is_text_mime_type(mime_type):
             raise NotImplementedError(
                 f"The 'transformers' provider currently only supports text/* bytes inputs, got '{mime_type}'."

--- a/docs/ai-functions/prompt.md
+++ b/docs/ai-functions/prompt.md
@@ -165,6 +165,20 @@ df.show()
 
 Generation kwargs (`max_new_tokens`, `temperature`, `top_p`, ...) are forwarded to the pipeline call. Constructor-time options (`dtype`, `device_map`, `trust_remote_code`, `device`, ...) go through `pipeline_kwargs`. The provider auto-selects `cuda` > `mps` > `cpu`.
 
+You can also pass text-file columns (`daft.File` or raw `bytes` with a `text/*` MIME type) directly. The file contents are read and inlined into the prompt wrapped in a `<file_*>...</file_*>` tag derived from the MIME type, so the model can distinguish file content from your instructions:
+
+```python
+df = daft.from_glob_path("s3://my-bucket/docs/*.md")
+df = df.with_column(
+    "summary",
+    prompt(
+        [daft.col("path"), "Summarize this document in 3 bullets."],
+        provider="transformers",
+        model="HuggingFaceTB/SmolLM2-360M-Instruct",
+    ),
+)
+```
+
 ### Building Prompt Templates with the `format` function
 
 In addition to passing plain strings, you can build dynamic prompt templates using Daft's `format` function. This works similarly to Python's `format`, but works with Daft expressions. You can also define prompt templates with user-defined functions. With `@daft.func` you can pass in expressions or plain python strings for more flexible composition.

--- a/docs/ai-functions/prompt.md
+++ b/docs/ai-functions/prompt.md
@@ -168,11 +168,11 @@ Generation kwargs (`max_new_tokens`, `temperature`, `top_p`, ...) are forwarded 
 You can also pass text-file columns (`daft.File` or raw `bytes` with a `text/*` MIME type) directly. The file contents are read and inlined into the prompt wrapped in a `<file_*>...</file_*>` tag derived from the MIME type, so the model can distinguish file content from your instructions:
 
 ```python
-df = daft.from_glob_path("s3://my-bucket/docs/*.md")
+df = daft.from_files("s3://my-bucket/docs/*.md")
 df = df.with_column(
     "summary",
     prompt(
-        [daft.col("path"), "Summarize this document in 3 bullets."],
+        [daft.col("file"), "Summarize this document in 3 bullets."],
         provider="transformers",
         model="HuggingFaceTB/SmolLM2-360M-Instruct",
     ),

--- a/tests/ai/transformers/test_transformers_prompter.py
+++ b/tests/ai/transformers/test_transformers_prompter.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import warnings
 from typing import Any
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
@@ -13,6 +13,19 @@ from daft.ai.transformers.protocols.prompter import (
     TransformersPrompter,
     TransformersPrompterDescriptor,
 )
+from daft.file import File
+
+
+def _make_text_file(content: bytes | str, mime_type: str = "text/plain") -> Mock:
+    """Mock a daft.File with a given MIME and content."""
+    file = Mock(spec=File)
+    file.mime_type.return_value = mime_type
+    handle = MagicMock()
+    handle.read.return_value = content
+    cm = MagicMock()
+    cm.__enter__.return_value = handle
+    file.open.return_value = cm
+    return file
 
 
 def _make_pipeline(*, chat_template: str | None = "{{messages}}", output: Any | None = None) -> Mock:
@@ -272,14 +285,68 @@ def test_pipeline_kwargs_not_in_generation_kwargs():
 @pytest.mark.parametrize(
     "bad_input",
     [
-        b"raw bytes",
         12345,
         [1, 2, 3],
     ],
-    ids=["bytes", "int", "list"],
+    ids=["int", "list"],
 )
 def test_prompt_raises_on_unsupported_input_types(bad_input: Any):
     pipe = _make_pipeline(chat_template="...")
     prompter = _make_prompter(pipe)
-    with pytest.raises(NotImplementedError, match=r"only supports str inputs"):
+    with pytest.raises(NotImplementedError, match=r"does not support input of type"):
         asyncio.run(prompter.prompt((bad_input,)))
+
+
+def test_prompt_accepts_text_file_inlined_with_tag():
+    pipe = _make_pipeline(chat_template="...", output=[{"generated_text": [{"role": "assistant", "content": "ok"}]}])
+    prompter = _make_prompter(pipe)
+    text_file = _make_text_file(b"hello from file", mime_type="text/plain")
+
+    asyncio.run(prompter.prompt((text_file, "summarize")))
+
+    chat = pipe.call_args.args[0]
+    user_content = chat[-1]["content"]
+    assert "<file_text_plain>hello from file</file_text_plain>" in user_content
+    assert "summarize" in user_content
+
+
+def test_prompt_accepts_text_bytes_via_mime_sniff():
+    pipe = _make_pipeline(chat_template="...", output=[{"generated_text": [{"role": "assistant", "content": "ok"}]}])
+    prompter = _make_prompter(pipe)
+    payload = b"<html><body>hi</body></html>"  # sniffed as text/html
+
+    asyncio.run(prompter.prompt((payload,)))
+
+    user_content = pipe.call_args.args[0][-1]["content"]
+    assert "<file_text_html>" in user_content
+    assert "hi" in user_content
+
+
+def test_prompt_file_with_image_mime_raises():
+    pipe = _make_pipeline(chat_template="...")
+    prompter = _make_prompter(pipe)
+    image_file = _make_text_file(b"\x89PNG\r\n...", mime_type="image/png")
+
+    with pytest.raises(NotImplementedError, match=r"text/\* File inputs"):
+        asyncio.run(prompter.prompt((image_file,)))
+
+
+def test_prompt_bytes_with_binary_mime_raises():
+    pipe = _make_pipeline(chat_template="...")
+    prompter = _make_prompter(pipe)
+    png_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32  # sniffed as image/png
+
+    with pytest.raises(NotImplementedError, match=r"text/\* bytes inputs"):
+        asyncio.run(prompter.prompt((png_bytes,)))
+
+
+def test_prompt_file_text_replaces_invalid_utf8():
+    pipe = _make_pipeline(chat_template="...", output=[{"generated_text": [{"role": "assistant", "content": "ok"}]}])
+    prompter = _make_prompter(pipe)
+    file = _make_text_file(b"valid \xff\xfe invalid", mime_type="text/plain")
+
+    asyncio.run(prompter.prompt((file,)))
+
+    user_content = pipe.call_args.args[0][-1]["content"]
+    assert "valid " in user_content
+    assert "invalid" in user_content

--- a/tests/ai/transformers/test_transformers_prompter.py
+++ b/tests/ai/transformers/test_transformers_prompter.py
@@ -322,6 +322,17 @@ def test_prompt_accepts_text_bytes_via_mime_sniff():
     assert "hi" in user_content
 
 
+def test_prompt_accepts_plain_text_bytes_via_utf8_fallback():
+    """Raw ASCII / Markdown / JSON aren't recognized by the MIME sniffer; UTF-8 decode fallback should accept them."""
+    pipe = _make_pipeline(chat_template="...", output=[{"generated_text": [{"role": "assistant", "content": "ok"}]}])
+    prompter = _make_prompter(pipe)
+
+    asyncio.run(prompter.prompt((b"# Title\n\nhello world",)))
+
+    user_content = pipe.call_args.args[0][-1]["content"]
+    assert "<file_text_plain># Title\n\nhello world</file_text_plain>" in user_content
+
+
 def test_prompt_file_with_image_mime_raises():
     pipe = _make_pipeline(chat_template="...")
     prompter = _make_prompter(pipe)


### PR DESCRIPTION
## Changes Made

Extends the Transformers prompter to accept `daft.File` and `bytes` inputs whose MIME type is `text/*`, so file columns can be passed to `prompt()` directly without a separate `read_text` step.

- New `singledispatchmethod` branches on `_process_message` for `File` and `bytes`; content is read and inlined into the user prompt wrapped in a `<file_*>...</file_*>` tag derived from the MIME type, so the model can distinguish file content from instructions.
- Non-text File/bytes raise `NotImplementedError`; image/audio/video support is left to follow-ups.
- 5 new mocked unit tests; usage example added under the Transformers section of `docs/ai-functions/prompt.md`.

## Related Issues

Part of #5620