### PR TITLE
feat(dataframe): with_columns kwargs support and rename method

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -3397,7 +3397,7 @@ class DataFrame:
             <BLANKLINE>
             (Showing first 3 of 3 rows)
         """
-        if columns and named_columns:
+        if columns is not None and named_columns:
             raise ValueError("Can not pass in both dict and keyword columns")
 
         new_columns = []
@@ -3478,7 +3478,8 @@ class DataFrame:
         builder = self._builder.with_columns_renamed(cols_map)
         return DataFrame(builder)
 
-    def rename(self, cols_map: dict[str, str] | None = None, /, **rename_kwargs: str) -> "DataFrame":
+    @DataframePublicAPI
+    def rename(self, cols_map: dict[str, str] | None = None, **rename_kwargs: str) -> "DataFrame":
         """Renames columns in the current DataFrame.
 
         If the columns in the DataFrame schema do not exist, this will be a no-op.
@@ -3487,7 +3488,7 @@ class DataFrame:
 
         Args:
             cols_map (Dict[str, str], optional): Dictionary of columns to rename in the format { existing: new }
-            rename_kwargs (str): Dict of column renamings passed in kwarg style (e.g. existing=new)
+            **rename_kwargs (str): Dict of column renamings passed in kwarg style (e.g. existing=new)
 
         Returns:
             DataFrame: DataFrame with the columns renamed.
@@ -3529,7 +3530,7 @@ class DataFrame:
             <BLANKLINE>
             (Showing first 3 of 3 rows)
         """
-        if cols_map and rename_kwargs:
+        if cols_map is not None and rename_kwargs:
             raise ValueError("Can not pass in columns to rename as both a dict and kwargs")
         elif rename_kwargs:
             cols_map = rename_kwargs

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -3344,17 +3344,22 @@ class DataFrame:
     @DataframePublicAPI
     def with_columns(
         self,
-        columns: dict[str, Expression],
+        columns: dict[str, Expression] | None = None,
+        **named_columns: Expression,
     ) -> "DataFrame":
         """Adds columns to the current DataFrame with Expressions, equivalent to a ``select`` with all current columns and the new ones.
 
+        New columns can be passed in dict style or kwarg style. These different styles should not be mixed together.
+
         Args:
-            columns (Dict[str, Expression]): Dictionary of new columns in the format { name: expression }
+            columns (Dict[str, Expression], optional): Dictionary of new columns in the format { name: expression }
+            **named_columns (Expression): New columns passed in as keyword arguments (e.g. `my_new_col=col("a") * 2`)
 
         Returns:
             DataFrame: DataFrame with new columns.
 
         Examples:
+            Dict style
             >>> import daft
             >>> df = daft.from_pydict({"x": [1, 2, 3], "y": [4, 5, 6]})
             >>> new_df = df.with_columns({"foo": df["x"] + 1, "bar": df["y"] - df["x"]})
@@ -3372,8 +3377,36 @@ class DataFrame:
             ╰───────┴───────┴───────┴───────╯
             <BLANKLINE>
             (Showing first 3 of 3 rows)
+
+            Kwarg style
+            >>> import daft
+            >>> df = daft.from_pydict({"x": [1, 2, 3], "y": [4, 5, 6]})
+            >>> new_df = df.with_columns(foo=df["x"] + 1, bar=df["y"] - df["x"])
+            >>> new_df.show()
+            ╭───────┬───────┬───────┬───────╮
+            │ x     ┆ y     ┆ foo   ┆ bar   │
+            │ ---   ┆ ---   ┆ ---   ┆ ---   │
+            │ Int64 ┆ Int64 ┆ Int64 ┆ Int64 │
+            ╞═══════╪═══════╪═══════╪═══════╡
+            │ 1     ┆ 4     ┆ 2     ┆ 3     │
+            ├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
+            │ 2     ┆ 5     ┆ 3     ┆ 3     │
+            ├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
+            │ 3     ┆ 6     ┆ 4     ┆ 3     │
+            ╰───────┴───────┴───────┴───────╯
+            <BLANKLINE>
+            (Showing first 3 of 3 rows)
         """
-        new_columns = [col.alias(name) for name, col in columns.items()]
+        if columns and named_columns:
+            raise ValueError("Can not pass in both dict and keyword columns")
+
+        new_columns = []
+        if named_columns:
+            new_columns = [col.alias(name) for name, col in named_columns.items()]
+        elif columns is not None:
+            new_columns = [col.alias(name) for name, col in columns.items()]
+        else:
+            raise ValueError("Expected dict or kwargs")
 
         builder = self._builder.with_columns(new_columns)
         return DataFrame(builder)
@@ -3442,6 +3475,67 @@ class DataFrame:
             <BLANKLINE>
             (Showing first 3 of 3 rows)
         """
+        builder = self._builder.with_columns_renamed(cols_map)
+        return DataFrame(builder)
+
+    def rename(self, cols_map: dict[str, str] | None = None, /, **rename_kwargs: str) -> "DataFrame":
+        """Renames columns in the current DataFrame.
+
+        If the columns in the DataFrame schema do not exist, this will be a no-op.
+
+        Columns to rename can be passed in dict style or kwarg style. These different styles should not be mixed together.
+
+        Args:
+            cols_map (Dict[str, str], optional): Dictionary of columns to rename in the format { existing: new }
+            rename_kwargs (str): Dict of column renamings passed in kwarg style (e.g. existing=new)
+
+        Returns:
+            DataFrame: DataFrame with the columns renamed.
+
+        Examples:
+            Dict style
+            >>> import daft
+            >>> df = daft.from_pydict({"x": [1, 2, 3], "y": [4, 5, 6]})
+            >>> df.rename({"x": "foo", "y": "bar"}).show()
+            ╭───────┬───────╮
+            │ foo   ┆ bar   │
+            │ ---   ┆ ---   │
+            │ Int64 ┆ Int64 │
+            ╞═══════╪═══════╡
+            │ 1     ┆ 4     │
+            ├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
+            │ 2     ┆ 5     │
+            ├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
+            │ 3     ┆ 6     │
+            ╰───────┴───────╯
+            <BLANKLINE>
+            (Showing first 3 of 3 rows)
+
+            Kwargs style
+            >>> import daft
+            >>> df = daft.from_pydict({"x": [1, 2, 3], "y": [4, 5, 6]})
+            >>> df.rename(x="foo", y="bar").show()
+            ╭───────┬───────╮
+            │ foo   ┆ bar   │
+            │ ---   ┆ ---   │
+            │ Int64 ┆ Int64 │
+            ╞═══════╪═══════╡
+            │ 1     ┆ 4     │
+            ├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
+            │ 2     ┆ 5     │
+            ├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
+            │ 3     ┆ 6     │
+            ╰───────┴───────╯
+            <BLANKLINE>
+            (Showing first 3 of 3 rows)
+        """
+        if cols_map and rename_kwargs:
+            raise ValueError("Can not pass in columns to rename as both a dict and kwargs")
+        elif rename_kwargs:
+            cols_map = rename_kwargs
+        elif cols_map is None:
+            raise ValueError("rename requires at least 1 argument")
+
         builder = self._builder.with_columns_renamed(cols_map)
         return DataFrame(builder)
 

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -3351,6 +3351,10 @@ class DataFrame:
 
         New columns can be passed in dict style or kwarg style. These different styles should not be mixed together.
 
+        Note:
+            If you are adding a column whose name conflicts with this function's parameter names ("columns"), the added columns must be passed in dict style.
+            E.g. `df.with_columns({"columns": expression})`
+
         Args:
             columns (Dict[str, Expression], optional): Dictionary of new columns in the format { name: expression }
             **named_columns (Expression): New columns passed in as keyword arguments (e.g. `my_new_col=col("a") * 2`)
@@ -3485,6 +3489,10 @@ class DataFrame:
         If the columns in the DataFrame schema do not exist, this will be a no-op.
 
         Columns to rename can be passed in dict style or kwarg style. These different styles should not be mixed together.
+
+        Note:
+            If you are renaming an existing column whose name conflicts with this function's parameter names ("cols_map"), the columns to rename must be passed in dict style.
+            E.g. `df.rename({"cols_map": new_name})`
 
         Args:
             cols_map (Dict[str, str], optional): Dictionary of columns to rename in the format { existing: new }

--- a/tests/dataframe/test_rename.py
+++ b/tests/dataframe/test_rename.py
@@ -33,10 +33,16 @@ def test_rename_kwargs(make_df, valid_data: list[dict[str, float]]) -> None:
     assert df.column_names == ["sepal_length", "sepal_width_2", "petal_length_2", "petal_width", "variety"]
 
 
+def test_rename_cols_map_as_keyword(make_df, valid_data: list[dict[str, float]]) -> None:
+    df = make_df(valid_data)
+    df = df.rename(cols_map={"sepal_width": "sepal_width_2", "petal_length": "petal_length_2"})
+    assert df.column_names == ["sepal_length", "sepal_width_2", "petal_length_2", "petal_width", "variety"]
+
+
 def test_rename_cols_map_as_name(make_df, valid_data: list[dict[str, float]]) -> None:
     df = make_df(valid_data)
     df = df.rename(variety="cols_map")
-    df = df.rename(cols_map="random")
+    df = df.rename(cols_map={"cols_map": "random"})
     assert df.column_names == ["sepal_length", "sepal_width", "petal_length", "petal_width", "random"]
 
 
@@ -47,10 +53,16 @@ def test_rename_dict_and_kwargs(make_df, valid_data: list[dict[str, float]]) -> 
     assert "Can not pass in columns to rename as both a dict and kwargs" in str(excinfo.value)
 
 
+def test_rename_empty_dict_and_kwargs(make_df, valid_data: list[dict[str, float]]) -> None:
+    df = make_df(valid_data)
+    with pytest.raises(ValueError) as excinfo:
+        _ = df.rename({}, sepal_width="sepal_width_2")
+    assert "Can not pass in columns to rename as both a dict and kwargs" in str(excinfo.value)
+
+
 def test_rename_no_args(make_df, valid_data: list[dict[str, float]]) -> None:
     df = make_df(valid_data)
     with pytest.raises(ValueError) as excinfo:
         _ = df.rename()
 
-    print(f"EXCINFO: {excinfo}")
     assert "rename requires at least 1 argument" in str(excinfo.value)

--- a/tests/dataframe/test_rename.py
+++ b/tests/dataframe/test_rename.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import pytest
+
+
+def test_rename(make_df, valid_data: list[dict[str, float]]) -> None:
+    df = make_df(valid_data)
+    df = df.rename({"sepal_width": "sepal_width_2", "petal_length": "petal_length_2"})
+    assert df.column_names == ["sepal_length", "sepal_width_2", "petal_length_2", "petal_width", "variety"]
+
+
+def test_rename_same_name(make_df, valid_data: list[dict[str, float]]) -> None:
+    df = make_df(valid_data)
+    df = df.rename({"sepal_width": "sepal_width"})
+    assert df.column_names == ["sepal_length", "sepal_width", "petal_length", "petal_width", "variety"]
+
+
+def test_rename_empty(make_df, valid_data: list[dict[str, float]]) -> None:
+    df = make_df(valid_data)
+    df = df.rename({})
+    assert df.column_names == ["sepal_length", "sepal_width", "petal_length", "petal_width", "variety"]
+
+
+def test_rename_nonexistent_column(make_df, valid_data: list[dict[str, float]]) -> None:
+    df = make_df(valid_data)
+    df = df.rename({"sepal_length_2": "sepal_length"})
+    assert df.column_names == ["sepal_length", "sepal_width", "petal_length", "petal_width", "variety"]
+
+
+def test_rename_kwargs(make_df, valid_data: list[dict[str, float]]) -> None:
+    df = make_df(valid_data)
+    df = df.rename(sepal_width="sepal_width_2", petal_length="petal_length_2")
+    assert df.column_names == ["sepal_length", "sepal_width_2", "petal_length_2", "petal_width", "variety"]
+
+
+def test_rename_cols_map_as_name(make_df, valid_data: list[dict[str, float]]) -> None:
+    df = make_df(valid_data)
+    df = df.rename(variety="cols_map")
+    df = df.rename(cols_map="random")
+    assert df.column_names == ["sepal_length", "sepal_width", "petal_length", "petal_width", "random"]
+
+
+def test_rename_dict_and_kwargs(make_df, valid_data: list[dict[str, float]]) -> None:
+    df = make_df(valid_data)
+    with pytest.raises(ValueError) as excinfo:
+        _ = df.rename({"sepal_width": "sepal_width_2", "petal_length": "petal_length_2"}, sepal_width="sepal_width_2")
+    assert "Can not pass in columns to rename as both a dict and kwargs" in str(excinfo.value)
+
+
+def test_rename_no_args(make_df, valid_data: list[dict[str, float]]) -> None:
+    df = make_df(valid_data)
+    with pytest.raises(ValueError) as excinfo:
+        _ = df.rename()
+
+    print(f"EXCINFO: {excinfo}")
+    assert "rename requires at least 1 argument" in str(excinfo.value)

--- a/tests/dataframe/test_with_columns.py
+++ b/tests/dataframe/test_with_columns.py
@@ -67,6 +67,18 @@ def test_with_columns_dict_and_kwargs(make_df, valid_data: list[dict[str, float]
     assert "Can not pass in both dict and keyword columns" in str(excinfo.value)
 
 
+def test_with_columns_empty_dict_and_kwargs(make_df, valid_data: list[dict[str, float]]) -> None:
+    df = make_df(valid_data)
+    with pytest.raises(ValueError) as excinfo:
+        _ = df.with_columns(
+            {},
+            foo=df["sepal_width"],
+            bar=df["sepal_width"] + df["petal_length"],
+        )
+
+    assert "Can not pass in both dict and keyword columns" in str(excinfo.value)
+
+
 def test_with_columns_no_args(make_df, valid_data: list[dict[str, float]]) -> None:
     df = make_df(valid_data)
     with pytest.raises(ValueError) as excinfo:

--- a/tests/dataframe/test_with_columns.py
+++ b/tests/dataframe/test_with_columns.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 
 def test_with_columns(make_df, valid_data: list[dict[str, float]]) -> None:
     df = make_df(valid_data)
@@ -32,3 +34,42 @@ def test_with_columns_empty(make_df, valid_data: list[dict[str, float]]) -> None
     expanded_df = df.with_columns({})
     assert expanded_df.column_names == df.column_names
     assert expanded_df.to_pydict() == df.to_pydict()
+
+
+def test_with_columns_dict_as_keyword(make_df, valid_data: list[dict[str, float]]) -> None:
+    # when supporting kwarg style, had to ensure backward compatibility if users previously passed a dict as the keyword argument "columns"
+    df = make_df(valid_data)
+    expanded_df = df.with_columns(columns={"foo": df["sepal_width"], "bar": df["sepal_width"] + df["petal_length"]})
+    data = expanded_df.to_pydict()
+    assert expanded_df.column_names == df.column_names + ["foo", "bar"]
+    assert data["foo"] == data["sepal_width"]
+    assert data["bar"] == [sw + pl for sw, pl in zip(data["sepal_width"], data["petal_length"])]
+
+
+def test_with_columns_kwargs(make_df, valid_data: list[dict[str, float]]) -> None:
+    df = make_df(valid_data)
+    expanded_df = df.with_columns(foo=df["sepal_width"], bar=df["sepal_width"] + df["petal_length"])
+    data = expanded_df.to_pydict()
+    assert expanded_df.column_names == df.column_names + ["foo", "bar"]
+    assert data["foo"] == data["sepal_width"]
+    assert data["bar"] == [sw + pl for sw, pl in zip(data["sepal_width"], data["petal_length"])]
+
+
+def test_with_columns_dict_and_kwargs(make_df, valid_data: list[dict[str, float]]) -> None:
+    df = make_df(valid_data)
+    with pytest.raises(ValueError) as excinfo:
+        _ = df.with_columns(
+            {"foo": df["sepal_width"], "bar": df["sepal_width"] + df["petal_length"]},
+            foo=df["sepal_width"],
+            bar=df["sepal_width"] + df["petal_length"],
+        )
+
+    assert "Can not pass in both dict and keyword columns" in str(excinfo.value)
+
+
+def test_with_columns_no_args(make_df, valid_data: list[dict[str, float]]) -> None:
+    df = make_df(valid_data)
+    with pytest.raises(ValueError) as excinfo:
+        _ = df.with_columns()
+
+    assert "Expected dict or kwargs" in str(excinfo.value)


### PR DESCRIPTION
## Changes Made

- Modified `with_columns` method to support kwarg style args
- Created `rename` method that supports dict or kwargs as alternative to `with_column_renamed` and `with_columns_renamed`

## Questions
- Should both dict and kwarg style arguments be supported?
  - This PR supports both, but there can be edge cases: if user wants to add new column named "columns" or rename an existing column named "cols_map", then they have to pass in a dict
  - #4167 mentions `with_columns` potentially accepting a variadic list of expressions. If keeping backward compatibility, supporting all 3 styles needs some extra checking and is a bit less clean. Do we want to support all 3 styles?
- This PR keeps backward compatibility, but should `with_column`, `with_column_renamed`, and `with_columns_renamed` be marked as deprecated?

## Related Issues

See #4167 
