### PR TITLE
feat: asof_join_aligned distributed

### DIFF
--- a/src/daft-distributed/src/pipeline_node/join/asof_join.rs
+++ b/src/daft-distributed/src/pipeline_node/join/asof_join.rs
@@ -5,10 +5,16 @@ use common_metrics::{
     Meter,
     ops::{NodeCategory, NodeType},
 };
-use daft_dsl::expr::bound_expr::BoundExpr;
+use daft_dsl::{
+    AggExpr, bound_col,
+    expr::bound_expr::{BoundAggExpr, BoundExpr},
+};
 use daft_local_plan::{LocalNodeContext, LocalPhysicalPlan, ShuffleReadBackend};
 use daft_logical_plan::{AsofJoinStrategy, stats::StatsState};
-use daft_schema::schema::SchemaRef;
+use daft_schema::{
+    field::Field,
+    schema::{Schema, SchemaRef},
+};
 use futures::{TryStreamExt, future::try_join_all};
 
 use super::stats::BasicJoinStats;
@@ -43,6 +49,10 @@ pub(crate) struct AsofJoinNode {
     right_on: BoundExpr,
     strategy: AsofJoinStrategy,
     num_partitions: usize,
+    /// Inputs are asserted to be co-partitioned: same partition count, identical range
+    /// boundaries, rows sorted ascending by the on-key. Skips the sample + range shuffle and
+    /// zips input partitions by index instead.
+    assume_aligned: bool,
 
     left: DistributedPipelineNode,
     right: DistributedPipelineNode,
@@ -61,6 +71,7 @@ impl AsofJoinNode {
         right_on: BoundExpr,
         strategy: AsofJoinStrategy,
         num_partitions: usize,
+        assume_aligned: bool,
         left: DistributedPipelineNode,
         right: DistributedPipelineNode,
         output_schema: SchemaRef,
@@ -87,6 +98,7 @@ impl AsofJoinNode {
             right_on,
             strategy,
             num_partitions,
+            assume_aligned,
             left,
             right,
         }
@@ -96,7 +108,7 @@ impl AsofJoinNode {
         self: &Arc<Self>,
         left_partition_group: Vec<MaterializedOutput>,
         right_partition_group: Vec<MaterializedOutput>,
-        carryovers: (Option<MaterializedOutput>, Option<MaterializedOutput>),
+        carryovers: Vec<MaterializedOutput>,
         result_tx: &Sender<SwordfishTaskBuilder>,
     ) -> DaftResult<()> {
         let left_shuffle_read_plan = LocalPhysicalPlan::shuffle_read(
@@ -125,11 +137,7 @@ impl AsofJoinNode {
             .flat_map(|output| output.into_inner().0)
             .collect::<Vec<_>>();
 
-        let (backward_carryover, forward_carryover) = carryovers;
-        if let Some(carryover) = backward_carryover {
-            right_psets.extend(carryover.into_inner().0);
-        }
-        if let Some(carryover) = forward_carryover {
+        for carryover in carryovers {
             right_psets.extend(carryover.into_inner().0);
         }
 
@@ -170,7 +178,7 @@ impl AsofJoinNode {
                 .create_and_submit_join_task(
                     left_materialized,
                     right_materialized,
-                    (None, None),
+                    vec![],
                     result_tx,
                 )
                 .await;
@@ -193,13 +201,55 @@ impl AsofJoinNode {
         )
         .await?;
 
+        let left_partition_groups =
+            crate::utils::transpose::transpose_materialized_outputs_from_vec(
+                left_partitioned_outputs,
+                num_partitions,
+            );
+
+        let right_partition_groups =
+            crate::utils::transpose::transpose_materialized_outputs_from_vec(
+                right_partitioned_outputs,
+                num_partitions,
+            );
+
+        self.join_partition_groups(
+            left_partition_groups,
+            right_partition_groups,
+            task_id_counter,
+            result_tx,
+            scheduler_handle,
+        )
+        .await
+    }
+
+    /// Computes carryovers across the per-partition groups and dispatches one local asof join
+    /// task per partition. Partition `i` joins against right group `i` plus the carryovers from
+    /// its neighbors. Shared by the shuffle path and the aligned (pre-partitioned) path.
+    async fn join_partition_groups(
+        self: &Arc<Self>,
+        left_partition_groups: Vec<Vec<MaterializedOutput>>,
+        right_partition_groups: Vec<Vec<MaterializedOutput>>,
+        task_id_counter: &TaskIDCounter,
+        result_tx: &Sender<SwordfishTaskBuilder>,
+        scheduler_handle: &SchedulerHandle<SwordfishTask>,
+    ) -> DaftResult<()> {
+        let num_partitions = left_partition_groups.len();
+        if num_partitions == 1 {
+            let left_group = left_partition_groups.into_iter().next().unwrap();
+            let right_group = right_partition_groups.into_iter().next().unwrap();
+            return self
+                .create_and_submit_join_task(left_group, right_group, vec![], result_tx)
+                .await;
+        }
+
         // backward_carryovers[i] = max of bucket i (forward-propagated): used as carryover for bucket i+1.
         // forward_carryovers[i]  = min of bucket i (backward-propagated): used as carryover for bucket i-1.
         let (backward_carryovers, forward_carryovers) = match self.strategy {
             AsofJoinStrategy::Backward => {
                 let backward_carryovers = self
                     .compute_carryovers(
-                        right_partitioned_outputs.clone(),
+                        &right_partition_groups,
                         true,
                         task_id_counter,
                         scheduler_handle,
@@ -213,7 +263,7 @@ impl AsofJoinNode {
             AsofJoinStrategy::Forward => {
                 let forward_carryovers = self
                     .compute_carryovers(
-                        right_partitioned_outputs.clone(),
+                        &right_partition_groups,
                         false,
                         task_id_counter,
                         scheduler_handle,
@@ -226,13 +276,13 @@ impl AsofJoinNode {
             }
             AsofJoinStrategy::Nearest => tokio::try_join!(
                 self.compute_carryovers(
-                    right_partitioned_outputs.clone(),
+                    &right_partition_groups,
                     true,
                     task_id_counter,
                     scheduler_handle,
                 ),
                 self.compute_carryovers(
-                    right_partitioned_outputs.clone(),
+                    &right_partition_groups,
                     false,
                     task_id_counter,
                     scheduler_handle,
@@ -240,35 +290,21 @@ impl AsofJoinNode {
             )?,
         };
 
-        let left_partition_groups =
-            crate::utils::transpose::transpose_materialized_outputs_from_vec(
-                left_partitioned_outputs,
-                num_partitions,
-            );
-
-        let right_partition_groups =
-            crate::utils::transpose::transpose_materialized_outputs_from_vec(
-                right_partitioned_outputs,
-                num_partitions,
-            );
-
         for (i, (left_group, right_group)) in left_partition_groups
             .into_iter()
             .zip(right_partition_groups)
             .enumerate()
         {
-            let carryovers = (
-                if i == 0 {
-                    None
-                } else {
-                    backward_carryovers[i - 1].clone()
-                },
-                if i == num_partitions - 1 {
-                    None
-                } else {
-                    forward_carryovers[i + 1].clone()
-                },
-            );
+            // A partition's match can live arbitrarily many partitions away (sparse or
+            // group-sparse neighbors), so offer the extremes of ALL preceding partitions
+            // (backward) and ALL following partitions (forward). Extremes are at most one
+            // row per group per partition; the local join picks the correct match.
+            let carryovers = backward_carryovers[..i]
+                .iter()
+                .chain(forward_carryovers[i + 1..].iter())
+                .flatten()
+                .cloned()
+                .collect();
             self.create_and_submit_join_task(left_group, right_group, carryovers, result_tx)
                 .await?;
         }
@@ -276,22 +312,23 @@ impl AsofJoinNode {
         Ok(())
     }
 
-    /// Runs one top_n carryover pass over the right partitioned outputs.
+    /// Reduces each right partition group to its carryover extreme rows.
     ///
-    /// `is_strategy_backward=true` runs a backward pass: picks the per-partition max and fills gaps left-to-right.
-    /// `is_strategy_backward=false` runs a forward pass: picks the per-partition min and fills gaps right-to-left.
+    /// `is_strategy_backward=true` picks the per-partition (per-group) max;
+    /// `is_strategy_backward=false` picks the min. Entries are `None` for empty partitions.
+    /// Callers combine all extremes on the relevant side of each partition, so no
+    /// cross-partition propagation is needed here.
     async fn compute_carryovers(
         &self,
-        right_partitioned_outputs: Vec<MaterializedOutput>,
+        right_partition_groups: &[Vec<MaterializedOutput>],
         is_strategy_backward: bool,
         task_id_counter: &TaskIDCounter,
         scheduler_handle: &SchedulerHandle<SwordfishTask>,
     ) -> DaftResult<Vec<Option<MaterializedOutput>>> {
         let descending = is_strategy_backward;
-        let propagate_forward = is_strategy_backward;
 
         let partial_carryover_tasks = self.create_partial_carryover_tasks(
-            right_partitioned_outputs,
+            right_partition_groups,
             descending,
             task_id_counter,
             scheduler_handle,
@@ -311,7 +348,7 @@ impl AsofJoinNode {
             scheduler_handle,
         )?;
 
-        let mut final_carryovers: Vec<Option<MaterializedOutput>> =
+        let final_carryovers: Vec<Option<MaterializedOutput>> =
             try_join_all(final_carryover_tasks.into_iter().map(|t| async {
                 match t {
                     Some(task) => task.await.map(|mo| mo.filter(|m| m.num_rows() > 0)),
@@ -319,23 +356,6 @@ impl AsofJoinNode {
                 }
             }))
             .await?;
-
-        let n = final_carryovers.len();
-        if propagate_forward {
-            for i in 1..n {
-                if final_carryovers[i].is_none() {
-                    let prev = final_carryovers[i - 1].clone();
-                    final_carryovers[i] = prev;
-                }
-            }
-        } else {
-            for i in (0..n.saturating_sub(1)).rev() {
-                if final_carryovers[i].is_none() {
-                    let next = final_carryovers[i + 1].clone();
-                    final_carryovers[i] = next;
-                }
-            }
-        }
 
         Ok(final_carryovers)
     }
@@ -348,13 +368,15 @@ impl AsofJoinNode {
         result_tx: Sender<SwordfishTaskBuilder>,
         scheduler_handle: SchedulerHandle<SwordfishTask>,
     ) -> DaftResult<()> {
+        // The aligned path keeps empty partitions: dropping them would break index alignment.
+        let keep_empty = self.assume_aligned;
         let left_materialized = left_inputs
             .materialize(
                 scheduler_handle.clone(),
                 self.context.query_idx,
                 task_id_counter.clone(),
             )
-            .try_filter(|output| future::ready(output.num_rows() > 0))
+            .try_filter(|output| future::ready(keep_empty || output.num_rows() > 0))
             .try_collect::<Vec<_>>()
             .await?;
 
@@ -364,9 +386,33 @@ impl AsofJoinNode {
                 self.context.query_idx,
                 task_id_counter.clone(),
             )
-            .try_filter(|output| future::ready(output.num_rows() > 0))
+            .try_filter(|output| future::ready(keep_empty || output.num_rows() > 0))
             .try_collect::<Vec<_>>()
             .await?;
+
+        if self.assume_aligned {
+            if left_materialized.len() != right_materialized.len() {
+                return Err(common_error::DaftError::InternalError(format!(
+                    "AsofJoin (aligned): partition count mismatch at execution time:                      left={}, right={}. The _assume_sorted_and_aligned guarantee was violated.",
+                    left_materialized.len(),
+                    right_materialized.len(),
+                )));
+            }
+            if left_materialized.is_empty() {
+                return Ok(());
+            }
+            let left_groups = left_materialized.into_iter().map(|mo| vec![mo]).collect();
+            let right_groups = right_materialized.into_iter().map(|mo| vec![mo]).collect();
+            return self
+                .join_partition_groups(
+                    left_groups,
+                    right_groups,
+                    &task_id_counter,
+                    &result_tx,
+                    &scheduler_handle,
+                )
+                .await;
+        }
 
         if left_materialized.is_empty() {
             return Ok(());
@@ -374,7 +420,7 @@ impl AsofJoinNode {
 
         if right_materialized.is_empty() {
             return self
-                .create_and_submit_join_task(left_materialized, vec![], (None, None), &result_tx)
+                .create_and_submit_join_task(left_materialized, vec![], vec![], &result_tx)
                 .await;
         }
 
@@ -404,10 +450,11 @@ impl AsofJoinNode {
             .collect()
     }
 
-    /// Builds and submits a single top_n(limit=1) task over `inputs`,
-    /// using the right-side schema and composite key derived from `self`.
-    /// `descending=true` picks the max row (backward carryover); `false` picks the min (forward carryover).
-    fn submit_top1_carryover_task(
+    /// Builds and submits a task reducing `inputs` to the extreme right row(s) for carryover.
+    /// Without by-keys this is a single top_n(limit=1) row; with by-keys it is the extreme
+    /// row(s) *per group* (window max/min of the on-key over the by-keys, keeping matching rows).
+    /// `descending=true` picks the max (backward carryover); `false` picks the min (forward carryover).
+    fn submit_carryover_task(
         &self,
         inputs: Vec<MaterializedOutput>,
         descending: bool,
@@ -416,27 +463,83 @@ impl AsofJoinNode {
         task_id_counter: &TaskIDCounter,
         scheduler_handle: &SchedulerHandle<SwordfishTask>,
     ) -> DaftResult<SubmittedTask> {
-        let composite_keys = self.right_composite_key();
-        let n_keys = composite_keys.len();
         let node_id = self.node_id();
+        let right_schema = self.right.config().schema.clone();
+        let context = LocalNodeContext::new(Some(node_id as usize)).with_phase(phase);
 
         let (in_memory_scan, psets) = MaterializedOutput::into_in_memory_scan_with_psets_and_phase(
             inputs,
-            self.right.config().schema.clone(),
+            right_schema.clone(),
             node_id,
             phase,
         );
 
-        let plan = LocalPhysicalPlan::top_n(
-            in_memory_scan,
-            composite_keys,
-            vec![descending; n_keys],
-            vec![false; n_keys],
-            1,
-            None,
-            StatsState::NotMaterialized,
-            LocalNodeContext::new(Some(node_id as usize)).with_phase(phase),
-        );
+        let plan = if self.right_by.is_empty() {
+            let composite_keys = self.right_composite_key();
+            let n_keys = composite_keys.len();
+            LocalPhysicalPlan::top_n(
+                in_memory_scan,
+                composite_keys,
+                vec![descending; n_keys],
+                vec![false; n_keys],
+                1,
+                None,
+                StatsState::NotMaterialized,
+                context,
+            )
+        } else {
+            const EXTREME_COL: &str = "__asof_carryover_extreme";
+            let on_expr = self.right_on.inner().clone();
+            let on_field = on_expr.to_field(&right_schema)?;
+            let agg = if descending {
+                AggExpr::Max(on_expr.clone())
+            } else {
+                AggExpr::Min(on_expr.clone())
+            };
+
+            let extreme_field = Field::new(EXTREME_COL, on_field.dtype);
+            let window_schema = Arc::new(Schema::new(
+                right_schema
+                    .fields()
+                    .iter()
+                    .cloned()
+                    .chain(std::iter::once(extreme_field.clone())),
+            ));
+            let window = LocalPhysicalPlan::window_partition_only(
+                in_memory_scan,
+                self.right_by.clone(),
+                window_schema,
+                StatsState::NotMaterialized,
+                vec![BoundAggExpr::new_unchecked(agg)],
+                vec![EXTREME_COL.to_string()],
+                context.clone(),
+            );
+
+            // Rows with a null on-key compare to null and are filtered out, which is correct:
+            // they can never be an asof match.
+            let predicate =
+                BoundExpr::new_unchecked(on_expr.eq(bound_col(right_schema.len(), extreme_field)));
+            let filtered = LocalPhysicalPlan::filter(
+                window,
+                predicate,
+                StatsState::NotMaterialized,
+                context.clone(),
+            );
+
+            let projection = right_schema
+                .fields()
+                .iter()
+                .enumerate()
+                .map(|(i, f)| BoundExpr::new_unchecked(bound_col(i, f.clone())))
+                .collect();
+            LocalPhysicalPlan::project(
+                filtered,
+                projection,
+                right_schema,
+                StatsState::NotMaterialized,
+                context,
+            )
+        };
 
         SwordfishTaskBuilder::new(plan, self, node_id)
             // Forward (min) and backward (max) carryover tasks have identical top_n plans but
@@ -456,52 +559,46 @@ impl AsofJoinNode {
     /// Returns `Vec<Vec<SubmittedTask>>` where outer index = partition_idx, inner = one task per worker.
     fn create_partial_carryover_tasks(
         &self,
-        materialized_outputs: Vec<MaterializedOutput>,
+        right_partition_groups: &[Vec<MaterializedOutput>],
         descending: bool,
         task_id_counter: &TaskIDCounter,
         scheduler_handle: &SchedulerHandle<SwordfishTask>,
     ) -> DaftResult<Vec<Vec<SubmittedTask>>> {
-        let mut worker_groups: HashMap<WorkerId, Vec<Vec<MaterializedOutput>>> = HashMap::new();
-        for mo in materialized_outputs {
-            let worker_id = mo.worker_id().clone();
-            worker_groups
-                .entry(worker_id)
-                .or_default()
-                .push(mo.split_into_materialized_outputs());
-        }
+        let phase = if descending {
+            PARTIAL_CARRYOVER_BACKWARD_PHASE
+        } else {
+            PARTIAL_CARRYOVER_FORWARD_PHASE
+        };
 
-        let mut tasks_by_bucket = Vec::with_capacity(self.num_partitions);
-        for bucket_idx in 0..self.num_partitions {
-            let mut bucket_tasks = vec![];
-            for (worker_id, split_mos) in &worker_groups {
-                let mos_for_bucket: Vec<MaterializedOutput> = split_mos
-                    .iter()
-                    .map(|splits| splits[bucket_idx].clone())
-                    .collect();
+        right_partition_groups
+            .iter()
+            .map(|bucket| {
+                let mut worker_groups: HashMap<WorkerId, Vec<MaterializedOutput>> = HashMap::new();
+                for mo in bucket {
+                    worker_groups
+                        .entry(mo.worker_id().clone())
+                        .or_default()
+                        .push(mo.clone());
+                }
 
-                let phase = if descending {
-                    PARTIAL_CARRYOVER_BACKWARD_PHASE
-                } else {
-                    PARTIAL_CARRYOVER_FORWARD_PHASE
-                };
-                let submitted = self.submit_top1_carryover_task(
-                    mos_for_bucket,
-                    descending,
-                    phase,
-                    Some(SchedulingStrategy::WorkerAffinity {
-                        worker_id: worker_id.clone(),
-                        soft: false,
-                    }),
-                    task_id_counter,
-                    scheduler_handle,
-                )?;
-
-                bucket_tasks.push(submitted);
-            }
-            tasks_by_bucket.push(bucket_tasks);
-        }
-
-        Ok(tasks_by_bucket)
+                worker_groups
+                    .into_iter()
+                    .map(|(worker_id, mos_for_bucket)| {
+                        self.submit_carryover_task(
+                            mos_for_bucket,
+                            descending,
+                            phase,
+                            Some(SchedulingStrategy::WorkerAffinity {
+                                worker_id,
+                                soft: false,
+                            }),
+                            task_id_counter,
+                            scheduler_handle,
+                        )
+                    })
+                    .collect::<DaftResult<Vec<_>>>()
+            })
+            .collect()
     }
 
     /// For each partition, reduces the per-worker partial top_n(1) results into a single global top_n(1).
@@ -532,7 +629,7 @@ impl AsofJoinNode {
                 } else {
                     FINAL_CARRYOVER_FORWARD_PHASE
                 };
-                self.submit_top1_carryover_task(
+                self.submit_carryover_task(
                     non_empty,
                     descending,
                     phase,
@@ -565,7 +662,11 @@ impl PipelineNodeImpl for AsofJoinNode {
 
     fn multiline_display(&self, _verbose: bool) -> Vec<String> {
         use itertools::Itertools;
-        let mut res = vec!["AsofJoin".to_string()];
+        let mut res = vec![if self.assume_aligned {
+            "AsofJoin (assume_sorted_and_aligned)".to_string()
+        } else {
+            "AsofJoin".to_string()
+        }];
         res.push(format!(
             "Left by: [{}]",
             self.left_by.iter().map(|e| e.to_string()).join(", ")

--- a/src/daft-distributed/src/pipeline_node/join/translate_asof_join.rs
+++ b/src/daft-distributed/src/pipeline_node/join/translate_asof_join.rs
@@ -20,6 +20,7 @@ impl LogicalPlanToPipelineNodeTranslator {
         left_on: BoundExpr,
         right_on: BoundExpr,
         strategy: AsofJoinStrategy,
+        assume_aligned: bool,
         output_schema: SchemaRef,
     ) -> DaftResult<DistributedPipelineNode> {
         let num_left_partitions = left.config().clustering_spec.num_partitions();
@@ -38,6 +39,7 @@ impl LogicalPlanToPipelineNodeTranslator {
                 right_on,
                 strategy,
                 num_partitions,
+                assume_aligned,
                 left,
                 right,
                 output_schema,
@@ -76,9 +78,6 @@ impl LogicalPlanToPipelineNodeTranslator {
             &right_node.config().schema,
         )?;
 
-        // TODO: dispatch to an execution path that skips the range shuffle when
-        // `assume_sorted_and_aligned` is set. For now both paths run the regular
-        // shuffle-based asof join, which is correct regardless of input alignment.
         if asof_join.assume_sorted_and_aligned
             && self.plan_config.config.enable_scan_task_split_and_merge
         {
@@ -96,6 +95,7 @@ impl LogicalPlanToPipelineNodeTranslator {
             left_on,
             right_on,
             asof_join.strategy,
+            asof_join.assume_sorted_and_aligned,
             asof_join.output_schema.clone(),
         )
     }

--- a/src/daft-local-execution/src/join/asof_join.rs
+++ b/src/daft-local-execution/src/join/asof_join.rs
@@ -257,8 +257,9 @@ fn search_floor(
 ///
 /// The range covers the floor (last left ≤ right) and ceil (first left ≥ right),
 /// each extended through any adjacent duplicates sharing the same on_key.
-/// Left rows outside this range either have a strictly closer right candidate
-/// elsewhere in the bucket, or will be covered by `nearest_fill`.
+/// Left rows outside this range get their candidates from `nearest_fill`, which
+/// propagates the gap-endpoint matches held by the floor/ceil rows to every row
+/// in between and keeps the nearer one.
 ///
 /// `on_key_cmp(pos, right_idx)` — sorted_left[pos] vs right[right_idx]
 /// `self_cmp(i, j)`             — sorted_left[i]   vs sorted_left[j]
@@ -568,45 +569,92 @@ fn backward_fill(global_best: &mut [Option<(u32, u32)>], grouped_sorted_indices:
     }
 }
 
-/// For left rows that received no direct probe assignment, fill from both directions and keep
-/// whichever candidate is closer to the left row's on_key. Ties prefer the larger (forward)
-/// right value, matching the `is_nearer` tie-break convention.
+/// Reconciles every left row's match against its neighbors' direct matches.
+///
+/// `search_nearest` offers each right row only to its floor/ceil left rows, so a left row
+/// strictly inside a gap between two right values holds at most one side's candidate (the
+/// first row in a gap holds the backward endpoint, the last holds the forward endpoint, and
+/// middle rows hold none). Propagating the original matches from both directions surfaces
+/// both gap endpoints to every row; `is_nearer` picks the winner (ties prefer the larger,
+/// i.e. forward, right value).
 fn nearest_fill(
     global_best: &mut [Option<(u32, u32)>],
     grouped_sorted_indices: &GroupIndices,
     left_on_arr: &dyn Array,
     global_right_on_key_arrs: &[Arc<dyn Array>],
 ) {
-    let mut fwd = global_best.to_owned();
-    forward_fill(&mut fwd, grouped_sorted_indices);
-    let mut bwd = global_best.to_owned();
-    backward_fill(&mut bwd, grouped_sorted_indices);
-
-    for i in 0..global_best.len() {
-        if global_best[i].is_some() {
-            continue;
-        }
-        global_best[i] = match (fwd[i], bwd[i]) {
-            (None, None) => continue,
-            (Some(_), None) => fwd[i],
-            (None, Some(_)) => bwd[i],
-            (Some((fwd_rb, fwd_row)), Some((bwd_rb, bwd_row))) => {
-                let fwd_arr = global_right_on_key_arrs[fwd_rb as usize].as_ref();
-                let bwd_arr = global_right_on_key_arrs[bwd_rb as usize].as_ref();
+    let nearer_of =
+        |best: Option<(u32, u32)>, candidate: Option<(u32, u32)>, left_idx: usize| match (
+            best, candidate,
+        ) {
+            (best, None) => best,
+            (None, candidate) => candidate,
+            (Some((b_rb, b_row)), Some((c_rb, c_row))) => {
                 if is_nearer(
-                    fwd_arr,
-                    fwd_row as usize,
-                    bwd_arr,
-                    bwd_row as usize,
+                    global_right_on_key_arrs[c_rb as usize].as_ref(),
+                    c_row as usize,
+                    global_right_on_key_arrs[b_rb as usize].as_ref(),
+                    b_row as usize,
                     left_on_arr,
-                    i,
+                    left_idx,
                 ) {
-                    fwd[i]
+                    candidate
                 } else {
-                    bwd[i]
+                    best
                 }
             }
         };
+
+    // A run of equal left on-keys receives the same direct match, so the nearest neighboring
+    // match can be the row's own match mirrored by a duplicate, shadowing the other gap
+    // endpoint. Track the two nearest *distinct* matches per direction and skip the candidate
+    // when it is the row's own.
+    let pick = |first: Option<(u32, u32)>, second: Option<(u32, u32)>, own: Option<(u32, u32)>| {
+        if own.is_some() && first == own {
+            second
+        } else {
+            first
+        }
+    };
+
+    for bucket in grouped_sorted_indices {
+        let mut prev1 = Vec::with_capacity(bucket.len());
+        let mut prev2 = Vec::with_capacity(bucket.len());
+        let (mut r1, mut r2) = (None, None);
+        for &idx in bucket {
+            prev1.push(r1);
+            prev2.push(r2);
+            if let Some(m) = global_best[idx as usize]
+                && r1 != Some(m)
+            {
+                r2 = r1;
+                r1 = Some(m);
+            }
+        }
+        let mut next1 = vec![None; bucket.len()];
+        let mut next2 = vec![None; bucket.len()];
+        let (mut r1, mut r2) = (None, None);
+        for (pos, &idx) in bucket.iter().enumerate().rev() {
+            next1[pos] = r1;
+            next2[pos] = r2;
+            if let Some(m) = global_best[idx as usize]
+                && r1 != Some(m)
+            {
+                r2 = r1;
+                r1 = Some(m);
+            }
+        }
+
+        for (pos, &idx) in bucket.iter().enumerate() {
+            let idx = idx as usize;
+            let own = global_best[idx];
+            let reconciled = nearer_of(
+                nearer_of(own, pick(prev1[pos], prev2[pos], own), idx),
+                pick(next1[pos], next2[pos], own),
+                idx,
+            );
+            global_best[idx] = reconciled;
+        }
     }
 }
 

--- a/tests/dataframe/test_asof_join_aligned.py
+++ b/tests/dataframe/test_asof_join_aligned.py
@@ -513,9 +513,6 @@ def test_matches_reference_implementation(strategy, by, num_partitions):
 
 
 class TestAlignedAsofJoinValidation:
-    @pytest.mark.skip(
-        reason="the shuffle-based fallback silently equalises partition counts; enable once the aligned execution path lands"
-    )
     def test_mismatched_partition_counts_raises(self):
         """Left and right with different partition counts raise at execution time."""
         left = value_aligned(pa.table({"ts": [1, 2, 3, 4], "v": [1, 2, 3, 4]}), "ts", [3], name="left")

--- a/tests/dataframe/test_asof_join_aligned.py
+++ b/tests/dataframe/test_asof_join_aligned.py
@@ -431,23 +431,7 @@ def reference_asof_match(left_ts: int, right_ts: list[int], strategy: str) -> in
     return forward if forward - left_ts <= left_ts - backward else backward
 
 
-@pytest.mark.parametrize(
-    "strategy",
-    [
-        "backward",
-        "forward",
-        pytest.param(
-            "nearest",
-            marks=pytest.mark.xfail(
-                reason="local nearest asof join: a left row that gets a one-sided direct offer "
-                "(search_nearest floor/ceil) is skipped by nearest_fill and never sees its "
-                "other-side candidate. Repro: left=[593, 597], right=[577, 608] -> 593 matches "
-                "577 (dist 16) instead of 608 (dist 15).",
-                strict=False,
-            ),
-        ),
-    ],
-)
+@pytest.mark.parametrize("strategy", STRATEGIES)
 @pytest.mark.parametrize("by", [None, "entity"], ids=["no_by", "by"])
 @pytest.mark.parametrize("num_partitions", [1, 3, 5])
 def test_matches_reference_implementation(strategy, by, num_partitions):


### PR DESCRIPTION
Re-opens #7107. Same branch and commits, recreated as a fresh PR.

Implements the shuffle-skipping execution path for `join_asof(..., _assume_sorted_and_aligned=True)`.

- Instead of a separate `AsofJoinAlignedNode`, `AsofJoinNode` takes an `assume_aligned` flag: the aligned path zips input partitions by index (validating partition counts at execution time) and skips sampling + range shuffle entirely. Both paths share the carryover and join-dispatch machinery.
- Fixes a latent carryover bug in the shuffle path along the way: the per-bucket `top_n(1)` reduction kept only one row per bucket (the lexicographically extreme `(by, on)` tuple), losing other groups' cross-partition matches. Carryovers are now per-group extreme rows, and each partition's join task receives the extremes of all preceding/following partitions, so matches survive empty and group-sparse partitions. The ≥3-partition tests fail without this and pass with it.
- Re-enables the partition-count-mismatch validation test.

Note: for very high cardinality `by` keys over many partitions, shipping all per-partition extremes to every join task is O(P²·G) rows worst case; a cumulative per-group merge (O(P·G), but a sequential task chain) is a profile-first follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
