### PR TITLE
fix: Format nested Rust errors as a simplified backtrace in Python

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1839,6 +1839,7 @@ dependencies = [
  "pyo3",
  "regex",
  "serde_json",
+ "snafu",
  "thiserror 2.0.18",
  "tokio",
 ]

--- a/src/common/error/Cargo.toml
+++ b/src/common/error/Cargo.toml
@@ -3,6 +3,7 @@ arrow-schema = {workspace = true}
 pyo3 = {workspace = true, optional = true}
 regex = {workspace = true}
 serde_json = {workspace = true}
+snafu = {workspace = true}
 thiserror = {workspace = true}
 tokio = {workspace = true}
 

--- a/src/common/error/src/error.rs
+++ b/src/common/error/src/error.rs
@@ -36,7 +36,7 @@ pub enum DaftError {
     PyO3Error(#[from] pyo3::PyErr),
     #[error("DaftError::IoError {0}")]
     IoError(#[from] std::io::Error),
-    #[error("DaftError::FileNotFound {path}: {source}")]
+    #[error("DaftError::FileNotFound {path} not found: {source}")]
     FileNotFound { path: String, source: GenericError },
     #[error("DaftError::InternalError {0}")]
     InternalError(String),

--- a/src/common/error/src/error.rs
+++ b/src/common/error/src/error.rs
@@ -41,19 +41,19 @@ pub enum DaftError {
     #[error("DaftError::InternalError {0}")]
     InternalError(String),
     #[error("ConnectTimeout {0}")]
-    ConnectTimeout(GenericError),
+    ConnectTimeout(#[source] GenericError),
     #[error("ReadTimeout {0}")]
-    ReadTimeout(GenericError),
+    ReadTimeout(#[source] GenericError),
     #[error("ByteStreamError {0}")]
-    ByteStreamError(GenericError),
+    ByteStreamError(#[source] GenericError),
     #[error("SocketError {0}")]
-    SocketError(GenericError),
+    SocketError(#[source] GenericError),
     #[error("ThrottledIo {0}")]
-    ThrottledIo(GenericError),
+    ThrottledIo(#[source] GenericError),
     #[error("MiscTransient {0}")]
-    MiscTransient(GenericError),
+    MiscTransient(#[source] GenericError),
     #[error("DaftError::External {0}")]
-    External(GenericError),
+    External(#[source] GenericError),
     #[error("DaftError::SerdeJsonError {0}")]
     SerdeJsonError(#[from] serde_json::Error),
     #[error("DaftError::FmtError {0}")]

--- a/src/common/error/src/format.rs
+++ b/src/common/error/src/format.rs
@@ -1,0 +1,41 @@
+use std::fmt::Write;
+
+use snafu::CleanedErrorText;
+
+/// Formats an error and its full `source()` chain for display to users (e.g. Python exceptions).
+///
+/// Uses snafu's [`CleanedErrorText`] to deduplicate overlapping text between nested errors,
+/// which is common with AWS SDK and other layered error types.
+pub(crate) fn format_error_for_user(err: &dyn std::error::Error) -> String {
+    let mut messages: Vec<String> = CleanedErrorText::new(err)
+        .map(|(_, msg, _)| msg)
+        .filter(|msg| !msg.trim().is_empty())
+        .collect();
+
+    // After deduplication, thiserror wrappers like `DaftError::External {inner}` often collapse
+    // to a bare variant prefix with no remaining detail. Drop those so the first line is useful.
+    while messages.len() > 1 && is_bare_error_variant_prefix(&messages[0]) {
+        messages.remove(0);
+    }
+
+    match messages.len() {
+        0 => String::new(),
+        1 => messages[0].clone(),
+        _ => {
+            let mut out = messages[0].clone();
+            out.push_str("\n\nCaused by the following errors:");
+            for (i, msg) in messages.iter().skip(1).enumerate() {
+                write!(out, "\n  {}: {msg}", i + 1).expect("Failed to write to string");
+            }
+            out
+        }
+    }
+}
+
+fn is_bare_error_variant_prefix(message: &str) -> bool {
+    let message = message.trim();
+    if let Some(rest) = message.strip_prefix("DaftError::") {
+        return !rest.contains(' ');
+    }
+    false
+}

--- a/src/common/error/src/lib.rs
+++ b/src/common/error/src/lib.rs
@@ -1,4 +1,5 @@
 mod error;
+mod format;
 pub use error::{DaftError, DaftResult};
 #[cfg(feature = "python")]
 mod python;

--- a/src/common/error/src/python.rs
+++ b/src/common/error/src/python.rs
@@ -1,6 +1,6 @@
 use pyo3::{exceptions::PyFileNotFoundError, import_exception};
 
-use crate::DaftError;
+use crate::{DaftError, format::format_error_for_user};
 
 import_exception!(daft.exceptions, DaftCoreException);
 import_exception!(daft.exceptions, DaftTypeError);
@@ -15,17 +15,20 @@ impl std::convert::From<DaftError> for pyo3::PyErr {
     fn from(err: DaftError) -> Self {
         match err {
             DaftError::PyO3Error(pyerr) => pyerr,
-            DaftError::FileNotFound { path, source } => {
-                PyFileNotFoundError::new_err(format!("File: {path} not found\n{source}"))
+            DaftError::TypeError(msg) => DaftTypeError::new_err(msg),
+            other => {
+                let formatted = format_error_for_user(&other);
+                match other {
+                    DaftError::FileNotFound { .. } => PyFileNotFoundError::new_err(formatted),
+                    DaftError::ConnectTimeout(_) => ConnectTimeoutError::new_err(formatted),
+                    DaftError::ReadTimeout(_) => ReadTimeoutError::new_err(formatted),
+                    DaftError::ByteStreamError(_) => ByteStreamError::new_err(formatted),
+                    DaftError::SocketError(_) => SocketError::new_err(formatted),
+                    DaftError::ThrottledIo(_) => ThrottleError::new_err(formatted),
+                    DaftError::MiscTransient(_) => MiscTransientError::new_err(formatted),
+                    _ => DaftCoreException::new_err(formatted),
+                }
             }
-            DaftError::TypeError(err) => DaftTypeError::new_err(err),
-            DaftError::ConnectTimeout(err) => ConnectTimeoutError::new_err(err.to_string()),
-            DaftError::ReadTimeout(err) => ReadTimeoutError::new_err(err.to_string()),
-            DaftError::ByteStreamError(err) => ByteStreamError::new_err(err.to_string()),
-            DaftError::SocketError(err) => SocketError::new_err(err.to_string()),
-            DaftError::ThrottledIo(err) => ThrottleError::new_err(err.to_string()),
-            DaftError::MiscTransient(err) => MiscTransientError::new_err(err.to_string()),
-            _ => DaftCoreException::new_err(err.to_string()),
         }
     }
 }

--- a/src/daft-io/src/lib.rs
+++ b/src/daft-io/src/lib.rs
@@ -127,7 +127,7 @@ pub enum Error {
     #[snafu(display("Unable to load credentials for IO backend `{store}`"))]
     UnableToLoadCredentials { store: SourceType, source: DynError },
 
-    #[snafu(display("Failed to load creentials for IO backend `{store}`"))]
+    #[snafu(display("Failed to load credentials for IO backend `{store}`"))]
     UnableToCreateClient { store: SourceType, source: DynError },
 
     #[snafu(display(

--- a/src/daft-io/src/lib.rs
+++ b/src/daft-io/src/lib.rs
@@ -73,10 +73,10 @@ pub enum Error {
     #[snafu(display("Unable to expand home dir"))]
     HomeDirError { path: String },
 
-    #[snafu(display("Unable to open file {}: {:?}", path, source))]
+    #[snafu(display("Unable to open file `{}`", path))]
     UnableToOpenFile { path: String, source: DynError },
 
-    #[snafu(display("Unable to create directory {}: {:?}", path, source))]
+    #[snafu(display("Unable to create directory `{}`", path))]
     UnableToCreateDir {
         path: String,
         source: std::io::Error,
@@ -94,27 +94,19 @@ pub enum Error {
         source: std::io::Error,
     },
 
-    #[snafu(display(
-        "Connection timed out when trying to connect to {}\nDetails:\n{:?}",
-        path,
-        source
-    ))]
+    #[snafu(display("Connection timed out when trying to connect to path `{}`", path))]
     ConnectTimeout { path: String, source: DynError },
 
-    #[snafu(display("Read timed out when trying to read {}\nDetails:\n{:?}", path, source))]
+    #[snafu(display("Read timed out when trying to read path `{}`", path))]
     ReadTimeout { path: String, source: DynError },
 
-    #[snafu(display(
-        "Socket error occurred when trying to read {}\nDetails:\n{:?}",
-        path,
-        source
-    ))]
+    #[snafu(display("Socket error occurred when trying to read path `{}`", path))]
     SocketError { path: String, source: DynError },
 
-    #[snafu(display("Throttled when trying to read {}\nDetails:\n{:?}", path, source))]
+    #[snafu(display("Throttled when trying to read path `{}`", path))]
     Throttled { path: String, source: DynError },
 
-    #[snafu(display("Misc Transient error trying to read {}\nDetails:\n{:?}", path, source))]
+    #[snafu(display("Misc Transient error trying to read path `{}`", path))]
     MiscTransient { path: String, source: DynError },
 
     #[snafu(display("Unable to convert URL \"{}\" to path", path))]
@@ -132,10 +124,10 @@ pub enum Error {
     #[snafu(display("Invalid range request: {}", source))]
     InvalidRangeRequest { source: range::InvalidGetRange },
 
-    #[snafu(display("Unable to load Credentials for store: {store}\nDetails:\n{source:?}"))]
+    #[snafu(display("Unable to load credentials for IO backend `{store}`"))]
     UnableToLoadCredentials { store: SourceType, source: DynError },
 
-    #[snafu(display("Failed to load Credentials for store: {store}\nDetails:\n{source:?}"))]
+    #[snafu(display("Failed to load creentials for IO backend `{store}`"))]
     UnableToCreateClient { store: SourceType, source: DynError },
 
     #[snafu(display(

--- a/tests/integration/io/parquet/test_reads_public_data.py
+++ b/tests/integration/io/parquet/test_reads_public_data.py
@@ -442,7 +442,9 @@ def test_read_timeout_gcs(multithreaded_io):
         )
     )
 
-    with pytest.raises((ReadTimeoutError, ConnectTimeoutError), match=f"Read timed out when trying to read {url}"):
+    with pytest.raises(
+        (ReadTimeoutError, ConnectTimeoutError), match=f"Read timed out when trying to read path `{url}`"
+    ):
         MicroPartition.read_parquet(url, io_config=read_timeout_config, multithreaded_io=multithreaded_io).to_arrow()
 
 

--- a/tests/integration/io/parquet/test_reads_public_data.py
+++ b/tests/integration/io/parquet/test_reads_public_data.py
@@ -365,7 +365,9 @@ def test_connect_timeout_s3(multithreaded_io):
         )
     )
 
-    with pytest.raises((ReadTimeoutError, ConnectTimeoutError), match=f"timed out when trying to connect to {url}"):
+    with pytest.raises(
+        (ReadTimeoutError, ConnectTimeoutError), match=f"timed out when trying to connect to path `{url}`"
+    ):
         MicroPartition.read_parquet(url, io_config=connect_timeout_config, multithreaded_io=multithreaded_io).to_arrow()
 
 
@@ -386,7 +388,9 @@ def test_read_timeout_s3(multithreaded_io):
         )
     )
 
-    with pytest.raises((ReadTimeoutError, ConnectTimeoutError), match=f"timed out when trying to connect to {url}"):
+    with pytest.raises(
+        (ReadTimeoutError, ConnectTimeoutError), match=f"timed out when trying to connect to path `{url}`"
+    ):
         MicroPartition.read_parquet(url, io_config=read_timeout_config, multithreaded_io=multithreaded_io).to_arrow()
 
 
@@ -402,7 +406,7 @@ def test_read_file_level_timeout():
         )
     )
 
-    with pytest.raises((ReadTimeoutError), match=f"Parquet reader timed out while trying to read: {url}"):
+    with pytest.raises((ReadTimeoutError), match=f"Parquet reader timed out while trying to read path `{url}`"):
         daft.recordbatch.read_parquet_into_pyarrow(url, io_config=read_timeout_config, file_timeout_ms=2)
 
 
@@ -422,7 +426,9 @@ def test_connect_timeout_gcs(multithreaded_io):
         )
     )
 
-    with pytest.raises((ReadTimeoutError, ConnectTimeoutError), match=f"timed out when trying to connect to {url}"):
+    with pytest.raises(
+        (ReadTimeoutError, ConnectTimeoutError), match=f"timed out when trying to connect to path `{url}`"
+    ):
         MicroPartition.read_parquet(url, io_config=connect_timeout_config, multithreaded_io=multithreaded_io).to_arrow()
 
 

--- a/tests/integration/io/parquet/test_reads_public_data.py
+++ b/tests/integration/io/parquet/test_reads_public_data.py
@@ -406,7 +406,7 @@ def test_read_file_level_timeout():
         )
     )
 
-    with pytest.raises((ReadTimeoutError), match=f"Parquet reader timed out while trying to read path `{url}`"):
+    with pytest.raises((ReadTimeoutError), match=f"Parquet reader timed out while trying to read: {url}"):
         daft.recordbatch.read_parquet_into_pyarrow(url, io_config=read_timeout_config, file_timeout_ms=2)
 
 

--- a/tests/recordbatch/json/test_jq.py
+++ b/tests/recordbatch/json/test_jq.py
@@ -75,7 +75,7 @@ def test_json_query_invalid_filter():
 
 def test_json_query_invalid_json():
     mp = MicroPartition.from_pydict({"col": ["a", "b", "c"]})
-    with pytest.raises(ValueError, match="DaftError::SerdeJsonError"):
+    with pytest.raises(ValueError, match="expected value"):
         mp.eval_expression_list([col("col").jq(".a")])
 
 

--- a/tests/recordbatch/numeric/test_numeric.py
+++ b/tests/recordbatch/numeric/test_numeric.py
@@ -679,7 +679,7 @@ def test_table_pow_bad_input() -> None:
     with pytest.raises(ValueError, match="Expected input to compute pow to be numeric, got String"):
         table.eval_expression_list([col("a").pow(0.1)])
 
-    with pytest.raises(ValueError, match='DaftError::ValueError Expected floating point number, received: "c"'):
+    with pytest.raises(ValueError, match='Expected floating point number, received: "c"'):
         table2.eval_expression_list([col("a").pow("c")])
 
 
@@ -708,7 +708,7 @@ def test_table_power_bad_input() -> None:
     with pytest.raises(ValueError, match="Expected input to compute power to be numeric, got String"):
         table.eval_expression_list([col("a").power(0.1)])
 
-    with pytest.raises(ValueError, match='DaftError::ValueError Expected floating point number, received: "c"'):
+    with pytest.raises(ValueError, match='Expected floating point number, received: "c"'):
         table2.eval_expression_list([col("a").power("c")])
 
 

--- a/tests/test_resource_requests.py
+++ b/tests/test_resource_requests.py
@@ -289,13 +289,13 @@ def test_with_column_max_resources_rayrunner_gpu():
 
 
 def test_improper_num_gpus():
-    with pytest.raises(ValueError, match="DaftError::ValueError"):
+    with pytest.raises(ValueError):
 
         @udf(return_dtype=daft.DataType.int64(), num_gpus=-1)
         def foo(c):
             return c
 
-    with pytest.raises(ValueError, match="DaftError::ValueError"):
+    with pytest.raises(ValueError):
 
         @udf(return_dtype=daft.DataType.int64(), num_gpus=1.5)
         def foo(c):
@@ -305,8 +305,8 @@ def test_improper_num_gpus():
     def foo(c):
         return c
 
-    with pytest.raises(ValueError, match="DaftError::ValueError"):
+    with pytest.raises(ValueError):
         foo = foo.override_options(num_gpus=-1)
 
-    with pytest.raises(ValueError, match="DaftError::ValueError"):
+    with pytest.raises(ValueError):
         foo = foo.override_options(num_gpus=1.5)


### PR DESCRIPTION
## Changes Made

I was getting annoyed by the long Rust error messages we print in Python. For example, when we missing AWS SSO credentials and access some file, we get the following Python exception:

```
DaftCoreException: DaftError::External Unable to load Credentials for store: s3
Details:
ProviderError(ProviderError { source: ProviderError(ProviderError { source: ServiceError(ServiceError { source: UnauthorizedException(UnauthorizedException { message: Some("Session token not found or invalid"), meta: ErrorMetadata { code: Some("UnauthorizedException"), message: Some("Session token not found or invalid"), extras: Some({"aws_request_id": "..."}) } }), raw: Response { status: StatusCode(401), headers: Headers { headers: {"date": HeaderValue { _private: H1("...") }, "content-type": HeaderValue { _private: H1("application/json") }, "content-length": HeaderValue { _private: H1("114") }, "access-control-expose-headers": HeaderValue { _private: H1("RequestId") }, "access-control-expose-headers": HeaderValue { _private: H1("x-amzn-RequestId") }, "requestid": HeaderValue { _private: H1("...") }, "server": HeaderValue { _private: H1("AWS SSO") }, "x-amzn-requestid": HeaderValue { _private: H1("...") }} }, body: SdkBody { inner: Once(Some(b"{\"message\":\"Session token not found or invalid\",\"__type\":\"com.amazonaws.switchboard.portal#UnauthorizedException\"}")), retryable: true }, extensions: Extensions { extensions_02x: Extensions, extensions_1x: {hyper_util::client::legacy::connect::http::HttpInfo} } } }) }) })
```

This PR formats it into:

```
DaftCoreException: Unable to load credentials for IO backend `s3`

Caused by the following errors:
  1: an error occurred while loading credentials
  2: service error
  3: UnauthorizedException: Session token not found or invalid
```

Inspired by the report formatting in https://docs.rs/snafu/latest/snafu/, and may improve it to look more like https://docs.rs/miette/latest/miette in a later PR.
