### PR TITLE
feat(scan): expose StorageConfig.multiline_display() to Python

### DIFF
--- a/daft/daft/__init__.pyi
+++ b/daft/daft/__init__.pyi
@@ -1078,6 +1078,7 @@ class StorageConfig:
     io_config: IOConfig
 
     def __init__(self, multithreaded_io: bool, io_config: IOConfig | None): ...
+    def multiline_display(self) -> list[str]: ...
 
 class ScanTask:
     """A batch of scan tasks for reading data from an external source."""

--- a/daft/io/delta_lake/delta_lake_scan.py
+++ b/daft/io/delta_lake/delta_lake_scan.py
@@ -245,8 +245,7 @@ class DeltaLakeScanOperator(ScanOperator):
             self.display_name(),
             f"Schema = {self._schema}",
             f"Partitioning keys = {self.partitioning_keys()}",
-            # TODO(Clark): Improve repr of storage config here.
-            f"Storage config = {self._storage_config}",
+            *self._storage_config.multiline_display(),
         ]
 
     def to_scan_tasks(self, pushdowns: PyPushdowns) -> Iterator[ScanTask]:

--- a/daft/io/hudi/hudi_scan.py
+++ b/daft/io/hudi/hudi_scan.py
@@ -45,7 +45,7 @@ class HudiScanOperator(ScanOperator):
             self.display_name(),
             f"Schema = {self._schema}",
             f"Partitioning keys = {self.partitioning_keys()}",
-            f"Storage config = {self._storage_config}",
+            *self._storage_config.multiline_display(),
         ]
 
     def to_scan_tasks(self, pushdowns: PyPushdowns) -> Iterator[ScanTask]:

--- a/daft/io/iceberg/iceberg_scan.py
+++ b/daft/io/iceberg/iceberg_scan.py
@@ -138,8 +138,7 @@ class IcebergScanOperator(ScanOperator):
             self.display_name(),
             f"Schema = {self._schema}",
             f"Partitioning keys = {self.partitioning_keys}",
-            # TODO(Clark): Improve repr of storage config here.
-            f"Storage config = {self._storage_config}",
+            *self._storage_config.multiline_display(),
         ]
 
     def to_scan_tasks(self, pushdowns: PyPushdowns) -> Iterator[ScanTask]:

--- a/src/daft-scan/src/storage_config.rs
+++ b/src/daft-scan/src/storage_config.rs
@@ -96,7 +96,7 @@ impl StorageConfig {
     #[must_use]
     #[pyo3(name = "multiline_display")]
     pub fn py_multiline_display(&self) -> Vec<String> {
-        Self::multiline_display(self)
+        self.multiline_display()
     }
 }
 

--- a/src/daft-scan/src/storage_config.rs
+++ b/src/daft-scan/src/storage_config.rs
@@ -92,6 +92,12 @@ impl StorageConfig {
     pub fn multithreaded_io(&self) -> bool {
         self.multithreaded_io
     }
+
+    #[must_use]
+    #[pyo3(name = "multiline_display")]
+    pub fn py_multiline_display(&self) -> Vec<String> {
+        Self::multiline_display(self)
+    }
 }
 
 impl_bincode_py_state_serialization!(StorageConfig);

--- a/tests/io/test_storage_config.py
+++ b/tests/io/test_storage_config.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from daft.daft import IOConfig, S3Config, StorageConfig
+
+
+def test_storage_config_multiline_display_default():
+    """multiline_display() should return only multithreading line when no IO config is set."""
+    config = StorageConfig(multithreaded_io=True)
+
+    result = config.multiline_display()
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0] == "Use multithreading = true"
+
+
+def test_storage_config_multiline_display_with_io_config():
+    """multiline_display() should include IO config line when io_config is provided."""
+    s3_config = S3Config(region_name="us-east-1")
+    io_config = IOConfig(s3=s3_config)
+    config = StorageConfig(multithreaded_io=True, io_config=io_config)
+
+    result = config.multiline_display()
+    assert isinstance(result, list)
+    assert len(result) == 2
+    assert result[0].startswith("IO config = ")
+    assert "us-east-1" in result[0]
+    assert result[1] == "Use multithreading = true"
+
+
+def test_storage_config_multiline_display_multithreading_false():
+    """multiline_display() should reflect multithreaded_io=False."""
+    config = StorageConfig(multithreaded_io=False)
+
+    result = config.multiline_display()
+    assert len(result) == 1
+    assert result[0] == "Use multithreading = false"
+
+
+def test_storage_config_multiline_display_in_scan_operator_context():
+    """Simulate how scan operators use multiline_display() in their list literals."""
+    s3_config = S3Config(region_name="us-west-2")
+    io_config = IOConfig(s3=s3_config)
+    config = StorageConfig(multithreaded_io=True, io_config=io_config)
+
+    # This is how scan operators use it: [..., *config.multiline_display()]
+    display_lines = [
+        "SomeScanOperator(table_name)",
+        "Schema = ...",
+        "Partitioning keys = [...]",
+        *config.multiline_display(),
+    ]
+
+    assert len(display_lines) == 5
+    assert display_lines[3].startswith("IO config = ")
+    assert display_lines[4] == "Use multithreading = true"


### PR DESCRIPTION
## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

- Exposed `StorageConfig.multiline_display()` from Rust to Python via `#[pymethods]` in storage_config.rs
- Updated `multiline_display()` in iceberg, delta, and hudi scan operators to use `*self._storage_config.multiline_display()` instead of f-string
- Added corresponding type stub in `__init__.pyi`
- Added tests in tests/io/test_storage_config.py

After:
```
IO config = S3 config = { Region name = us-west-2, Max connections = 8, ... }, 
            HTTP config = { User agent = daft/0.0.1, ... }, ...
Use multithreading = false
```
## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
Closes #7180