### PR TITLE
build: strip symbols from release wheels

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,6 +156,11 @@ inherits = "release"
 lto = 'thin'
 strip = "none"  # dont strip
 
+[profile.release]
+# Strip symbol tables from the shipped extension module (~4MB off the wheel download,
+# ~16MB uncompressed). No DWARF is emitted in release, so this only drops symbols.
+strip = "symbols"
+
 # LLVM's SLP vectorizer takes 75+ min on this crate at opt-level=3.
 # opt-level=2 disables it, bringing compile time down to ~15s.
 [profile.release.package.daft-parquet]

--- a/scripts/verify_wheel_strip.sh
+++ b/scripts/verify_wheel_strip.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Verify the wheel-slimming impact of `strip = "symbols"`.
+#
+# Measures the real shipped artifact: strips the daft.abi3.so from an
+# already-published wheel (built by CI with the release-lto profile) and reports
+# the before/after delta. cargo's strip="symbols" is a deterministic post-link
+# `strip` call, so this reproduces exactly what the release profile now emits --
+# no local rebuild, and no release-vs-release-lto profile mismatch.
+#
+# Usage: scripts/verify_wheel_strip.sh [wheel.whl | daft.abi3.so]
+#        (no arg -> downloads the latest daft wheel from PyPI)
+set -euo pipefail
+tmp=$(mktemp -d); trap 'rm -rf "$tmp"' EXIT
+
+in=${1:-}
+if [ -z "$in" ]; then
+  echo "no input -> downloading latest daft wheel from PyPI..." >&2
+  python3 -m pip download daft --no-deps --only-binary=:all: -d "$tmp/dl" >&2
+  in=$(ls "$tmp/dl"/*.whl | head -1)
+fi
+
+case "$in" in
+  *.whl) unzip -q -o "$in" -d "$tmp" 'daft/daft.abi3.so'; so="$tmp/daft/daft.abi3.so" ;;
+  *)     so="$in" ;;
+esac
+
+# Match cargo strip="symbols" per platform: macOS `strip -x`, Linux `strip --strip-unneeded`.
+cp "$so" "$tmp/after.so"
+case "$(uname)" in
+  Darwin) strip -x "$tmp/after.so" ;;
+  *)      strip --strip-unneeded "$tmp/after.so" ;;
+esac
+
+row() { printf "%-8s  binary=%4s MB  gzip=%5.1f MB  symbols=%s\n" \
+  "$1" "$(du -m "$2" | cut -f1)" \
+  "$(gzip -c "$2" | wc -c | awk '{print $1/1048576}')" \
+  "$(nm "$2" 2>/dev/null | wc -l | tr -d ' ')"; }
+
+echo "input: $(basename "$in")"
+row before "$so"
+row after  "$tmp/after.so"


### PR DESCRIPTION
Just a prototype PR opened mostly for discussion. While it reduces binary size error reporting may become harder.

## Changes Made

Adds `strip = "symbols"` to `[profile.release]` in `Cargo.toml` (inherited by `release-lto`, the profile CI ships with), so the published extension module no longer carries its symbol table.

The wheel is ~99% a single `daft.abi3.so`, and that binary was shipping unstripped (~158k symbols). cargo's `strip = "symbols"` is a deterministic post-link `strip` call on the final artifact, so this is a pure size win with no behavior change:

- abi3 export symbols (e.g. `PyInit_daft`) are preserved — `import daft` and all runtime behavior are byte-identical.
- No DWARF debug info exists in release builds, so only the symbol table is removed (the one cost is slightly less detailed native panic/crash symbolication).

Measured on the published `daft-0.7.16` wheel (`release-lto`):

| | binary | download (gzip) | symbols |
|---|---|---|---|
| before | 115 MB | 44.3 MB | 158,540 |
| after | 99 MB | 40.2 MB | 459 |

≈ **−16 MB uncompressed, −4 MB download (−9%)**.

`scripts/verify_wheel_strip.sh` reproduces the measurement: it builds the wheel unstripped and applies the same post-link strip to show the before/after. (`dev-bench` keeps its explicit `strip = "none"` so profiling is unaffected.)

## Related Issues

N/A