### PR TITLE
feat(sql): support CREATE TABLE statement

### DIFF
--- a/src/daft-sql/src/exec.rs
+++ b/src/daft-sql/src/exec.rs
@@ -29,6 +29,7 @@ pub(crate) fn execute_statement(
         Statement::Set(set) => execute_set(sess, set),
         Statement::Use(use_) => execute_use(sess, use_),
         Statement::ShowTables(show_tables) => execute_show_tables(sess, show_tables),
+        Statement::CreateTable(create_table) => execute_create_table(sess, create_table),
     }
 }
 
@@ -43,6 +44,69 @@ fn execute_set(_: &Session, _: statement::Set) -> SQLPlannerResult<Option<DataFr
 fn execute_use(sess: &Session, use_: statement::Use) -> SQLPlannerResult<Option<DataFrame>> {
     sess.set_catalog(Some(&use_.catalog))?;
     sess.set_namespace(use_.namespace.as_ref())?;
+    Ok(None)
+}
+
+fn execute_create_table(
+    sess: &Session,
+    create_table: statement::CreateTable,
+) -> SQLPlannerResult<Option<DataFrame>> {
+    let name = &create_table.name;
+    let schema = create_table.schema;
+
+    // Resolve the catalog and identifier.
+    let (catalog, ident) = if name.has_qualifier() {
+        if sess.has_catalog(name.get(0)) {
+            // Catalog-qualified: dispatch to the named catalog.
+            let catalog = sess.get_catalog(name.get(0))?;
+            let ident = name.drop(1);
+            (catalog, ident)
+        } else if name.len() >= 3 {
+            // 3+ parts where the first is not a known catalog: error.
+            return Err(PlannerError::invalid_operation(format!(
+                "Catalog '{}' not found",
+                name.get(0)
+            )));
+        } else {
+            // 2-part name where the first is not a catalog: schema-qualified.
+            let catalog = sess.current_catalog()?.ok_or_else(|| {
+                PlannerError::invalid_operation(
+                    "Cannot create a table without a current catalog. Use 'USE <catalog>' or provide a catalog-qualified name.".to_string(),
+                )
+            })?;
+            // Keep the full name as ident (schema.table).
+            (catalog, name.clone())
+        }
+    } else {
+        // Unqualified: prepend the current namespace.
+        let catalog = sess.current_catalog()?.ok_or_else(|| {
+            PlannerError::invalid_operation(
+                "Cannot create a table without a current catalog. Use 'USE <catalog>' or provide a catalog-qualified name.".to_string(),
+            )
+        })?;
+        let ident = {
+            let namespace = sess.current_namespace()?;
+            if let Some(ref namespace) = namespace {
+                if !namespace.is_empty() {
+                    name.qualify(namespace.clone())
+                } else {
+                    name.clone()
+                }
+            } else {
+                name.clone()
+            }
+        };
+        (catalog, ident)
+    };
+
+    // Handle IF NOT EXISTS.
+    if create_table.if_not_exists && catalog.has_table(&ident)? {
+        return Ok(None);
+    }
+
+    // Create the table.
+    catalog.create_table(&ident, Arc::new(schema))?;
+
     Ok(None)
 }
 

--- a/src/daft-sql/src/statement.rs
+++ b/src/daft-sql/src/statement.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use daft_catalog::Identifier;
 use daft_core::prelude::Schema;
 use daft_logical_plan::{LogicalPlanBuilder, LogicalPlanRef};
@@ -347,6 +349,10 @@ impl SQLPlanner<'_> {
             .columns
             .iter()
             .map(|col| {
+                // Reject column-level constraints (NOT NULL, DEFAULT, UNIQUE, etc.).
+                if !col.options.is_empty() {
+                    unsupported_sql_err!("Column constraints on '{}' are not supported", col.name);
+                }
                 let dtype = sql_dtype_to_dtype(&col.data_type)?;
                 Ok(daft_core::prelude::Field::new(
                     col.name.value.clone(),
@@ -357,7 +363,7 @@ impl SQLPlanner<'_> {
 
         // Reject duplicate column names per SQL spec.
         {
-            let mut seen = std::collections::HashSet::new();
+            let mut seen = HashSet::new();
             for field in &fields {
                 if !seen.insert(field.name.as_ref()) {
                     unsupported_sql_err!("Duplicate column name: {}", field.name);

--- a/src/daft-sql/src/statement.rs
+++ b/src/daft-sql/src/statement.rs
@@ -1,8 +1,9 @@
 use daft_catalog::Identifier;
+use daft_core::prelude::Schema;
 use daft_logical_plan::{LogicalPlanBuilder, LogicalPlanRef};
 use sqlparser::ast;
 
-use crate::{SQLPlanner, error::SQLPlannerResult, unsupported_sql_err};
+use crate::{SQLPlanner, error::SQLPlannerResult, schema::sql_dtype_to_dtype, unsupported_sql_err};
 
 /// Top-level planning structure
 #[derive(Clone)]
@@ -16,6 +17,8 @@ pub enum Statement {
     ShowTables(ShowTables),
     /// use a catalog and optional namespace
     Use(Use),
+    /// create table
+    CreateTable(CreateTable),
 }
 
 /// SELECT ...
@@ -43,6 +46,15 @@ pub struct ShowTables {
 pub struct Use {
     pub catalog: String,
     pub namespace: Option<Identifier>,
+}
+
+/// CREATE TABLE [IF NOT EXISTS] <name> (<columns>)
+#[derive(Clone)]
+#[cfg_attr(debug_assertions, derive(Debug))]
+pub struct CreateTable {
+    pub name: Identifier,
+    pub schema: Schema,
+    pub if_not_exists: bool,
 }
 
 /// Daft-SQL statement planning.
@@ -87,6 +99,7 @@ impl SQLPlanner<'_> {
                 external: _,
             } => self.plan_show_tables(*extended, *full, show_options),
             ast::Statement::Use(use_) => self.plan_use(use_),
+            ast::Statement::CreateTable(create_table) => self.plan_create_table(create_table),
             other => unsupported_sql_err!("unsupported statement, {}", other),
         }
     }
@@ -292,6 +305,75 @@ impl SQLPlanner<'_> {
         }
     }
 
+    /// CREATE TABLE [IF NOT EXISTS] <name> (<columns>)
+    fn plan_create_table(&self, create_table: &ast::CreateTable) -> SQLPlannerResult<Statement> {
+        // Reject unsupported flags and features.
+        if create_table.or_replace {
+            unsupported_sql_err!("CREATE OR REPLACE TABLE is not supported");
+        }
+        if create_table.temporary {
+            unsupported_sql_err!("CREATE TEMPORARY TABLE is not supported");
+        }
+        if create_table.external {
+            unsupported_sql_err!("CREATE EXTERNAL TABLE is not supported");
+        }
+        if create_table.query.is_some() {
+            unsupported_sql_err!("CREATE TABLE AS SELECT is not supported");
+        }
+        if !create_table.constraints.is_empty() {
+            unsupported_sql_err!("Table constraints are not supported");
+        }
+        if create_table.location.is_some() {
+            unsupported_sql_err!("LOCATION is not supported");
+        }
+        if create_table.like.is_some() {
+            unsupported_sql_err!("LIKE is not supported");
+        }
+        if create_table.clone.is_some() {
+            unsupported_sql_err!("CLONE is not supported");
+        }
+        if create_table.file_format.is_some() {
+            unsupported_sql_err!("File format is not supported");
+        }
+        if !matches!(create_table.table_options, ast::CreateTableOptions::None) {
+            unsupported_sql_err!("Table options are not supported");
+        }
+
+        // Parse the table name into an identifier.
+        let name = self.normalize(&create_table.name)?;
+
+        // Convert column definitions to a Daft schema.
+        let fields = create_table
+            .columns
+            .iter()
+            .map(|col| {
+                let dtype = sql_dtype_to_dtype(&col.data_type)?;
+                Ok(daft_core::prelude::Field::new(
+                    col.name.value.clone(),
+                    dtype,
+                ))
+            })
+            .collect::<SQLPlannerResult<Vec<_>>>()?;
+
+        // Reject duplicate column names per SQL spec.
+        {
+            let mut seen = std::collections::HashSet::new();
+            for field in &fields {
+                if !seen.insert(field.name.as_ref()) {
+                    unsupported_sql_err!("Duplicate column name: {}", field.name);
+                }
+            }
+        }
+
+        let schema = Schema::new(fields);
+
+        Ok(Statement::CreateTable(CreateTable {
+            name,
+            schema,
+            if_not_exists: create_table.if_not_exists,
+        }))
+    }
+
     fn plan_use(&self, use_: &ast::Use) -> SQLPlannerResult<Statement> {
         if let ast::Use::Object(name) = use_ {
             let idents = &name.0;
@@ -450,5 +532,76 @@ mod test {
         } else {
             panic!("Expected ShowTables statement");
         }
+    }
+
+    // ---- CREATE TABLE ----
+
+    #[test]
+    fn test_create_table_with_catalog_qualified_name() {
+        let sql = "CREATE TABLE mycatalog.myschema.mytable (a int, b string)";
+        let statement = parse_sql(sql);
+        let session = Session::default();
+        let mut planner = SQLPlanner::new(&session);
+        let plan = planner.plan_statement(&statement).unwrap();
+
+        if let Statement::CreateTable(ct) = plan {
+            assert_eq!(ct.name.to_string(), "mycatalog.myschema.mytable");
+            assert!(!ct.if_not_exists);
+            assert_eq!(ct.schema.len(), 2);
+            let field_names: Vec<&str> = ct.schema.field_names().collect();
+            assert_eq!(field_names, vec!["a", "b"]);
+        } else {
+            panic!("Expected CreateTable statement");
+        }
+    }
+
+    #[test]
+    fn test_create_table_if_not_exists() {
+        let sql = "CREATE TABLE IF NOT EXISTS tbl (a int)";
+        let statement = parse_sql(sql);
+        let session = Session::default();
+        let mut planner = SQLPlanner::new(&session);
+        let plan = planner.plan_statement(&statement).unwrap();
+
+        if let Statement::CreateTable(ct) = plan {
+            assert!(ct.if_not_exists);
+            assert_eq!(ct.name.to_string(), "tbl");
+            assert_eq!(ct.schema.len(), 1);
+            let field_names: Vec<&str> = ct.schema.field_names().collect();
+            assert_eq!(field_names, vec!["a"]);
+        } else {
+            panic!("Expected CreateTable statement");
+        }
+    }
+
+    #[test]
+    fn test_create_table_empty_columns() {
+        let sql = "CREATE TABLE tbl ()";
+        let statement = parse_sql(sql);
+        let session = Session::default();
+        let mut planner = SQLPlanner::new(&session);
+        let plan = planner.plan_statement(&statement).unwrap();
+
+        if let Statement::CreateTable(ct) = plan {
+            assert_eq!(ct.schema.len(), 0);
+        } else {
+            panic!("Expected CreateTable statement");
+        }
+    }
+
+    #[test]
+    fn test_create_table_duplicate_columns() {
+        let sql = "CREATE TABLE tbl (a int, a string)";
+        let statement = parse_sql(sql);
+        let session = Session::default();
+        let mut planner = SQLPlanner::new(&session);
+        let result = planner.plan_statement(&statement);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Duplicate column name: a")
+        );
     }
 }

--- a/tests/sql/test_sql_create_table.py
+++ b/tests/sql/test_sql_create_table.py
@@ -63,7 +63,7 @@ def test_create_table_no_catalog_errors():
     """CREATE TABLE without a catalog-qualified name and no current catalog should error."""
     sess = Session()
     with pytest.raises(Exception, match="without a current catalog|catalog"):
-        sess.sql("CREATE TABLE tbl (a int)").collect()
+        sess.sql("CREATE TABLE tbl (a int)")
 
 
 def test_create_table_show_tables(sess: Session):

--- a/tests/sql/test_sql_create_table.py
+++ b/tests/sql/test_sql_create_table.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import pytest
+
+from daft import Catalog, Session
+
+
+@pytest.fixture()
+def sess() -> Session:
+    """Create a session with a memory catalog attached."""
+    sess = Session()
+    cat = Catalog.from_pydict({}, name="mem")
+    sess.attach_catalog(cat, alias="mem")
+    # Pre-create the "default" namespace.
+    sess.set_catalog("mem")
+    sess.create_namespace("default")
+    return sess
+
+
+def test_create_table_catalog_qualified(sess: Session):
+    """CREATE TABLE with catalog-qualified identifier."""
+    assert sess.sql("CREATE TABLE mem.default.tbl (a int, b string)") is None
+    res = sess.sql("SELECT * FROM mem.default.tbl").collect()
+    assert res.column_names == ["a", "b"]
+
+
+def test_create_table_schema_qualified(sess: Session):
+    """CREATE TABLE with schema-qualified identifier using current catalog."""
+    sess.set_catalog("mem")
+    assert sess.sql("CREATE TABLE default.tbl (x int64, y float64)") is None
+    res = sess.sql("SELECT * FROM mem.default.tbl").collect()
+    assert res.column_names == ["x", "y"]
+
+
+def test_create_table_unqualified(sess: Session):
+    """CREATE TABLE with unqualified identifier using current catalog and namespace."""
+    sess.set_catalog("mem")
+    sess.set_namespace("default")
+    assert sess.sql("CREATE TABLE tbl (id int)") is None
+    res = sess.sql("SELECT * FROM mem.default.tbl").collect()
+    assert res.column_names == ["id"]
+
+
+def test_create_table_if_not_exists(sess: Session):
+    """CREATE TABLE IF NOT EXISTS should be idempotent."""
+    assert sess.sql("CREATE TABLE IF NOT EXISTS mem.default.dup (a int)") is None
+    # Second call should not error.
+    assert sess.sql("CREATE TABLE IF NOT EXISTS mem.default.dup (a int)") is None
+    res = sess.sql("SELECT * FROM mem.default.dup").collect()
+    assert res.column_names == ["a"]
+
+
+def test_create_table_if_not_exists_preserves_original(sess: Session):
+    """IF NOT EXISTS should not overwrite the existing table."""
+    assert sess.sql("CREATE TABLE IF NOT EXISTS mem.default.tbl (a int)") is None
+    # Attempt with different schema -- should be ignored.
+    assert sess.sql("CREATE TABLE IF NOT EXISTS mem.default.tbl (x string, y string)") is None
+    res = sess.sql("SELECT * FROM mem.default.tbl").collect()
+    assert res.column_names == ["a"]
+
+
+def test_create_table_no_catalog_errors():
+    """CREATE TABLE without a catalog-qualified name and no current catalog should error."""
+    sess = Session()
+    with pytest.raises(Exception, match="without a current catalog|catalog"):
+        sess.sql("CREATE TABLE tbl (a int)").collect()
+
+
+def test_create_table_show_tables(sess: Session):
+    """Table created via SQL should appear in SHOW TABLES."""
+    sess.set_catalog("mem")
+    assert sess.sql("CREATE TABLE default.show_test (a int)") is None
+    res = sess.sql("SHOW TABLES IN mem.default").to_pydict()
+    assert "show_test" in res["table"]
+
+
+def test_create_table_multiple_columns(sess: Session):
+    """CREATE TABLE with multiple columns of different types."""
+    assert sess.sql("CREATE TABLE mem.default.multi (  id int64,   name string,   value float64,   flag bool)") is None
+    res = sess.sql("SELECT * FROM mem.default.multi").collect()
+    assert res.column_names == ["id", "name", "value", "flag"]
+
+
+def test_create_table_empty_columns(sess: Session):
+    """CREATE TABLE with no columns should succeed (empty schema)."""
+    assert sess.sql("CREATE TABLE mem.default.empty ()") is None
+    res = sess.sql("SELECT * FROM mem.default.empty").collect()
+    assert res.column_names == []
+
+
+def test_create_table_duplicate_columns(sess: Session):
+    """CREATE TABLE with duplicate column names should be rejected."""
+    with pytest.raises(Exception, match="Duplicate column name"):
+        sess.sql("CREATE TABLE mem.default.bad (a int, a string)").collect()


### PR DESCRIPTION
## Changes Made
<!-- Describe what changes were made and why. Include implementation details if necessary. -->

- Added `CREATE TABLE [IF NOT EXISTS]` statement parsing and execution in daft-sql
- Supports catalog-qualified, schema-qualified, and unqualified table names resolved via Session
- `IF NOT EXISTS` skips creation when the table already exists
- Added Python and Rust tests
## Related Issues
<!-- Link to related GitHub issues, e.g., "Closes #123" -->

Closes #4232

