### PR TITLE
feat(ai): support image-text-to-text in transformers prompter

### DIFF
--- a/daft/ai/transformers/protocols/__init__.py
+++ b/daft/ai/transformers/protocols/__init__.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+import threading
+
+# Serializes HuggingFace model loading to avoid meta tensor races.
+model_loading_lock = threading.Lock()

--- a/daft/ai/transformers/protocols/prompter.py
+++ b/daft/ai/transformers/protocols/prompter.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import threading
 import warnings
 from dataclasses import dataclass, field
 from functools import singledispatchmethod
@@ -10,13 +9,11 @@ from typing import TYPE_CHECKING, Any
 from transformers import pipeline
 
 from daft.ai.protocols import Prompter, PrompterDescriptor
+from daft.ai.transformers.protocols import model_loading_lock
 from daft.ai.typing import Options, PromptOptions, UDFOptions
 from daft.ai.utils import get_gpu_udf_options, get_torch_device
 from daft.daft import guess_mimetype_from_content
 from daft.file import File
-
-# Global lock to prevent concurrent model loading which can cause meta tensor issues
-_model_loading_lock = threading.Lock()
 
 if TYPE_CHECKING:
     from pydantic import BaseModel
@@ -99,7 +96,7 @@ class TransformersPrompter(Prompter):
         pipeline_init: dict[str, Any] = dict(pipeline_kwargs)
         if "device" not in pipeline_init and "device_map" not in pipeline_init:
             pipeline_init["device"] = get_torch_device()
-        with _model_loading_lock:
+        with model_loading_lock:
             self._pipeline = pipeline(task="text-generation", model=model_name, **pipeline_init)
 
         self._has_chat_template = getattr(self._pipeline.tokenizer, "chat_template", None) is not None

--- a/daft/ai/transformers/protocols/vision_prompter.py
+++ b/daft/ai/transformers/protocols/vision_prompter.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import asyncio
+import io
+import threading
+import warnings
+from dataclasses import dataclass, field
+from functools import singledispatchmethod
+from typing import TYPE_CHECKING, Any
+
+from transformers import pipeline
+
+from daft.ai.protocols import Prompter, PrompterDescriptor
+from daft.ai.typing import Options, PromptOptions, UDFOptions
+from daft.ai.utils import get_gpu_udf_options, get_torch_device
+from daft.daft import guess_mimetype_from_content
+from daft.dependencies import np, pil_image
+from daft.file import File
+
+# Global lock to prevent concurrent model loading which can cause meta tensor issues
+_model_loading_lock = threading.Lock()
+
+if TYPE_CHECKING:
+    from pydantic import BaseModel
+
+
+class TransformersVisionPromptOptions(PromptOptions, total=False):
+    """Options for the Transformers vision prompter.
+
+    Attributes:
+        pipeline_kwargs (dict): Forwarded to the ``transformers.pipeline``
+            constructor (e.g. ``dtype``, ``device_map``, ``trust_remote_code``).
+
+    Note:
+        Any other kwargs (``temperature``, ``max_new_tokens``, ``top_p``, ...)
+        are forwarded to the pipeline call.
+    """
+
+    pipeline_kwargs: dict[str, Any]
+
+
+@dataclass
+class TransformersVisionPrompterDescriptor(PrompterDescriptor):
+    provider_name: str
+    model_name: str
+    prompt_options: TransformersVisionPromptOptions = field(default_factory=lambda: TransformersVisionPromptOptions())
+    system_message: str | None = None
+    return_format: BaseModel | None = None
+
+    def get_provider(self) -> str:
+        return self.provider_name
+
+    def get_model(self) -> str:
+        return self.model_name
+
+    def get_options(self) -> Options:
+        return dict(self.prompt_options)
+
+    def get_udf_options(self) -> UDFOptions:
+        udf_options = get_gpu_udf_options()
+        for key, value in self.prompt_options.items():
+            if key in udf_options.__annotations__.keys():
+                setattr(udf_options, key, value)
+        return udf_options
+
+    def instantiate(self) -> Prompter:
+        if self.return_format is not None:
+            raise NotImplementedError("return_format is not yet supported for the 'transformers' provider.")
+        return TransformersVisionPrompter(
+            provider_name=self.provider_name,
+            model_name=self.model_name,
+            system_message=self.system_message,
+            prompt_options=self.prompt_options,
+        )
+
+
+class TransformersVisionPrompter(Prompter):
+    """Pipeline based image-text-to-text generation."""
+
+    def __init__(
+        self,
+        provider_name: str,
+        model_name: str,
+        system_message: str | None = None,
+        prompt_options: TransformersVisionPromptOptions | None = None,
+    ) -> None:
+        self.provider_name = provider_name
+        self.model = model_name
+        self.system_message = system_message
+
+        opts: dict[str, Any] = dict(prompt_options or {})
+        pipeline_kwargs: dict[str, Any] = opts.pop("pipeline_kwargs", {})
+        opts.pop("return_full_text", None)  # always set to False in _sync_prompt
+        for udf_only_key in UDFOptions.__annotations__:
+            opts.pop(udf_only_key, None)
+        self.generation_kwargs: dict[str, Any] = opts
+
+        pipeline_init: dict[str, Any] = dict(pipeline_kwargs)
+        if "device" not in pipeline_init and "device_map" not in pipeline_init:
+            pipeline_init["device"] = get_torch_device()
+        with _model_loading_lock:
+            self._pipeline = pipeline(task="image-text-to-text", model=model_name, **pipeline_init)
+
+        # Vision chat template lives on the processor, not the tokenizer.
+        self._has_chat_template = getattr(self._pipeline.processor, "chat_template", None) is not None
+        if not self._has_chat_template:
+            warnings.warn(
+                f"Model '{model_name}' has no chat template; multimodal prompting requires an "
+                "instruction-tuned vision-language model.",
+                stacklevel=2,
+            )
+
+    @singledispatchmethod
+    def _process_message(self, msg: Any) -> dict[str, Any]:
+        raise NotImplementedError(
+            f"The 'transformers' vision prompter does not support input of type {type(msg).__name__}."
+        )
+
+    @_process_message.register
+    def _(self, msg: str) -> dict[str, Any]:
+        return {"type": "text", "text": msg}
+
+    @_process_message.register
+    def _(self, msg: np.ndarray) -> dict[str, Any]:
+        return {"type": "image", "image": pil_image.fromarray(msg)}
+
+    @_process_message.register
+    def _(self, msg: File) -> dict[str, Any]:
+        mime_type = msg.mime_type()
+        if mime_type.startswith("image/"):
+            with msg.open() as f:
+                return {"type": "image", "image": pil_image.open(io.BytesIO(f.read()))}
+        if self._is_text_mime_type(mime_type):
+            return {"type": "text", "text": self._wrap_filetag(mime_type, self._read_text_content(msg))}
+        raise NotImplementedError(
+            f"The 'transformers' vision prompter only supports image/* or text/* File inputs, got '{mime_type}'."
+        )
+
+    @_process_message.register
+    def _(self, msg: bytes) -> dict[str, Any]:
+        mime_type = guess_mimetype_from_content(msg)
+        if mime_type and mime_type.startswith("image/"):
+            return {"type": "image", "image": pil_image.open(io.BytesIO(msg))}
+        if mime_type is None:
+            try:
+                return {"type": "text", "text": self._wrap_filetag("text/plain", msg.decode("utf-8"))}
+            except UnicodeDecodeError:
+                raise NotImplementedError(
+                    "The 'transformers' vision prompter only supports image/* or text/* bytes inputs."
+                )
+        if self._is_text_mime_type(mime_type):
+            return {"type": "text", "text": self._wrap_filetag(mime_type, msg.decode("utf-8", errors="replace"))}
+        raise NotImplementedError(
+            f"The 'transformers' vision prompter only supports image/* or text/* bytes inputs, got '{mime_type}'."
+        )
+
+    @staticmethod
+    def _is_text_mime_type(mime_type: str) -> bool:
+        return mime_type.split(";")[0].strip().lower().startswith("text/")
+
+    @staticmethod
+    def _read_text_content(file_obj: File) -> str:
+        with file_obj.open() as f:
+            data = f.read()
+        if isinstance(data, str):
+            return data
+        return data.decode("utf-8", errors="replace")
+
+    @staticmethod
+    def _wrap_filetag(mime_type: str, text: str) -> str:
+        tag = f"file_{mime_type.split(';')[0].strip().replace('/', '_')}"
+        return f"<{tag}>{text}</{tag}>"
+
+    def _build_inputs(self, messages: tuple[Any, ...]) -> list[dict[str, Any]]:
+        content = [self._process_message(m) for m in messages]
+        chat: list[dict[str, Any]] = []
+        if self.system_message:
+            chat.append({"role": "system", "content": [{"type": "text", "text": self.system_message}]})
+        chat.append({"role": "user", "content": content})
+        return chat
+
+    def _sync_prompt(self, messages: tuple[Any, ...]) -> str:
+        chat = self._build_inputs(messages)
+        outputs = self._pipeline(text=chat, return_full_text=False, **self.generation_kwargs)
+        return outputs[0]["generated_text"]
+
+    async def prompt(self, messages: tuple[Any, ...]) -> Any:
+        return await asyncio.to_thread(self._sync_prompt, messages)
+
+
+if pil_image.module_available():
+
+    @TransformersVisionPrompter._process_message.register(pil_image.Image)  # type: ignore[attr-defined, untyped-decorator]
+    def _(self: TransformersVisionPrompter, msg: Any) -> dict[str, Any]:
+        return {"type": "image", "image": msg}

--- a/daft/ai/transformers/protocols/vision_prompter.py
+++ b/daft/ai/transformers/protocols/vision_prompter.py
@@ -118,7 +118,7 @@ class TransformersVisionPrompter(Prompter):
         return {"type": "text", "text": msg}
 
     @_process_message.register
-    def _(self, msg: np.ndarray) -> dict[str, Any]:
+    def _(self, msg: np.ndarray) -> dict[str, Any]:  # type: ignore[type-arg,unused-ignore]
         return {"type": "image", "image": pil_image.fromarray(msg)}
 
     @_process_message.register

--- a/daft/ai/transformers/protocols/vision_prompter.py
+++ b/daft/ai/transformers/protocols/vision_prompter.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import io
-import threading
 import warnings
 from dataclasses import dataclass, field
 from functools import singledispatchmethod
@@ -11,14 +10,12 @@ from typing import TYPE_CHECKING, Any
 from transformers import pipeline
 
 from daft.ai.protocols import Prompter, PrompterDescriptor
+from daft.ai.transformers.protocols import model_loading_lock
 from daft.ai.typing import Options, PromptOptions, UDFOptions
 from daft.ai.utils import get_gpu_udf_options, get_torch_device
 from daft.daft import guess_mimetype_from_content
 from daft.dependencies import np, pil_image
 from daft.file import File
-
-# Global lock to prevent concurrent model loading which can cause meta tensor issues
-_model_loading_lock = threading.Lock()
 
 if TYPE_CHECKING:
     from pydantic import BaseModel
@@ -98,7 +95,7 @@ class TransformersVisionPrompter(Prompter):
         pipeline_init: dict[str, Any] = dict(pipeline_kwargs)
         if "device" not in pipeline_init and "device_map" not in pipeline_init:
             pipeline_init["device"] = get_torch_device()
-        with _model_loading_lock:
+        with model_loading_lock:
             self._pipeline = pipeline(task="image-text-to-text", model=model_name, **pipeline_init)
 
         # Vision chat template lives on the processor, not the tokenizer.
@@ -182,7 +179,10 @@ class TransformersVisionPrompter(Prompter):
     def _sync_prompt(self, messages: tuple[Any, ...]) -> str:
         chat = self._build_inputs(messages)
         outputs = self._pipeline(text=chat, return_full_text=False, **self.generation_kwargs)
-        return outputs[0]["generated_text"]
+        generated = outputs[0]["generated_text"]
+        if isinstance(generated, list):
+            return generated[-1]["content"]
+        return generated
 
     async def prompt(self, messages: tuple[Any, ...]) -> Any:
         return await asyncio.to_thread(self._sync_prompt, messages)

--- a/daft/ai/transformers/provider.py
+++ b/daft/ai/transformers/provider.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sys
+import warnings
 from typing import TYPE_CHECKING, Any
 
 if sys.version_info < (3, 11):
@@ -156,18 +157,22 @@ class TransformersProvider(Provider):
 
     @staticmethod
     def _is_vision_model(model_name: str) -> bool:
-        """Returns True if the given HF model is an image-text-to-text (vision-language) model.
-
-        Falls back to False on any config lookup failure (offline, invalid model name, etc.),
-        which routes the request to the text-only prompter.
-        """
+        """Warn and return False on any lookup failure so the caller falls back to text."""
         try:
             from transformers import AutoConfig
+
+            # The names mapping is not publicly re-exported; use the same internal path as HF's AutoModel dispatch.
             from transformers.models.auto.modeling_auto import (
                 MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES,
             )
 
             config = AutoConfig.from_pretrained(model_name)
             return config.model_type in MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES
-        except Exception:
+        except Exception as e:
+            warnings.warn(
+                f"Could not determine vision capability for model '{model_name}' ({e!r}); "
+                "falling back to the text-only prompter. Pass an instruction-tuned VLM name "
+                "if you need image support.",
+                stacklevel=3,
+            )
             return False

--- a/daft/ai/transformers/provider.py
+++ b/daft/ai/transformers/provider.py
@@ -130,12 +130,44 @@ class TransformersProvider(Provider):
         system_message: str | None = None,
         **options: Unpack[TransformersPromptOptions],
     ) -> PrompterDescriptor:
+        model_name = model or self.DEFAULT_PROMPTER
+        if self._is_vision_model(model_name):
+            from daft.ai.transformers.protocols.vision_prompter import (
+                TransformersVisionPrompterDescriptor,
+            )
+
+            return TransformersVisionPrompterDescriptor(
+                provider_name=self._name,
+                model_name=model_name,
+                prompt_options=options,
+                system_message=system_message,
+                return_format=return_format,
+            )
+
         from daft.ai.transformers.protocols.prompter import TransformersPrompterDescriptor
 
         return TransformersPrompterDescriptor(
             provider_name=self._name,
-            model_name=(model or self.DEFAULT_PROMPTER),
+            model_name=model_name,
             prompt_options=options,
             system_message=system_message,
             return_format=return_format,
         )
+
+    @staticmethod
+    def _is_vision_model(model_name: str) -> bool:
+        """Returns True if the given HF model is an image-text-to-text (vision-language) model.
+
+        Falls back to False on any config lookup failure (offline, invalid model name, etc.),
+        which routes the request to the text-only prompter.
+        """
+        try:
+            from transformers import AutoConfig
+            from transformers.models.auto.modeling_auto import (
+                MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES,
+            )
+
+            config = AutoConfig.from_pretrained(model_name)
+            return config.model_type in MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES
+        except Exception:
+            return False

--- a/daft/ai/transformers/provider.py
+++ b/daft/ai/transformers/provider.py
@@ -157,7 +157,11 @@ class TransformersProvider(Provider):
 
     @staticmethod
     def _is_vision_model(model_name: str) -> bool:
-        """Warn and return False on any lookup failure so the caller falls back to text."""
+        """Warn and return False on any lookup failure so the caller falls back to text.
+
+        Tries the local HF cache first so repeat / offline calls avoid a Hub round-trip;
+        only reaches out to the Hub when the config has never been downloaded.
+        """
         try:
             from transformers import AutoConfig
 
@@ -166,7 +170,10 @@ class TransformersProvider(Provider):
                 MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES,
             )
 
-            config = AutoConfig.from_pretrained(model_name)
+            try:
+                config = AutoConfig.from_pretrained(model_name, local_files_only=True)
+            except OSError:
+                config = AutoConfig.from_pretrained(model_name)
             return config.model_type in MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES
         except Exception as e:
             warnings.warn(

--- a/docs/ai-functions/prompt.md
+++ b/docs/ai-functions/prompt.md
@@ -179,6 +179,28 @@ df = df.with_column(
 )
 ```
 
+#### Image inputs (Vision-Language Models)
+
+Passing an instruction-tuned vision-language model routes the request to HuggingFace [`pipeline("image-text-to-text")`](https://huggingface.co/docs/transformers/main/en/main_classes/pipelines#transformers.ImageTextToTextPipeline) automatically. Images can be supplied as `daft.DataType.Image()` columns, `daft.File`s with an `image/*` MIME type, or raw `bytes`:
+
+```python
+import daft
+from daft.functions import prompt, decode_image
+
+df = daft.from_pydict({"image_url": ["https://.../cat.png", "https://.../dog.jpg"]})
+df = df.with_column("image", decode_image(daft.col("image_url").download()))
+
+df = df.with_column(
+    "caption",
+    prompt(
+        [daft.col("image"), "Describe this image in one short sentence."],
+        provider="transformers",
+        model="HuggingFaceTB/SmolVLM-256M-Instruct",
+        max_new_tokens=64,
+    ),
+)
+```
+
 ### Building Prompt Templates with the `format` function
 
 In addition to passing plain strings, you can build dynamic prompt templates using Daft's `format` function. This works similarly to Python's `format`, but works with Daft expressions. You can also define prompt templates with user-defined functions. With `@daft.func` you can pass in expressions or plain python strings for more flexible composition.

--- a/tests/ai/transformers/test_transformers_prompter.py
+++ b/tests/ai/transformers/test_transformers_prompter.py
@@ -97,6 +97,7 @@ def test_provider_get_prompter_default():
     assert descriptor.get_model() == TransformersProvider.DEFAULT_PROMPTER
 
 
+@pytest.mark.filterwarnings("ignore:Could not determine vision capability")
 def test_provider_get_prompter_with_overrides():
     from daft.ai.transformers.provider import TransformersProvider
 

--- a/tests/ai/transformers/test_transformers_vision_prompter.py
+++ b/tests/ai/transformers/test_transformers_vision_prompter.py
@@ -78,16 +78,19 @@ def test_descriptor_instantiate_rejects_return_format():
         d.instantiate()
 
 
+_FAKE_MAPPING_PATH = "transformers.models.auto.modeling_auto.MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES"
+
+
 def test_provider_auto_detects_vlm_returns_vision_descriptor():
     from daft.ai.transformers.provider import TransformersProvider
 
     fake_config = Mock()
-    fake_config.model_type = "smolvlm"
-    with patch(
-        "transformers.AutoConfig.from_pretrained",
-        return_value=fake_config,
+    fake_config.model_type = "fakevlm"
+    with (
+        patch("transformers.AutoConfig.from_pretrained", return_value=fake_config),
+        patch(_FAKE_MAPPING_PATH, new={"fakevlm": "FakeVLMForConditionalGeneration"}),
     ):
-        descriptor = TransformersProvider().get_prompter(model="HuggingFaceTB/SmolVLM-256M-Instruct")
+        descriptor = TransformersProvider().get_prompter(model="any/vlm-name")
 
     assert isinstance(descriptor, TransformersVisionPrompterDescriptor)
 
@@ -97,25 +100,23 @@ def test_provider_non_vlm_returns_text_descriptor():
     from daft.ai.transformers.provider import TransformersProvider
 
     fake_config = Mock()
-    fake_config.model_type = "llama"
-    with patch(
-        "transformers.AutoConfig.from_pretrained",
-        return_value=fake_config,
+    fake_config.model_type = "faketext"
+    with (
+        patch("transformers.AutoConfig.from_pretrained", return_value=fake_config),
+        patch(_FAKE_MAPPING_PATH, new={"fakevlm": "FakeVLMForConditionalGeneration"}),
     ):
-        descriptor = TransformersProvider().get_prompter(model="meta-llama/Llama-3-8B-Instruct")
+        descriptor = TransformersProvider().get_prompter(model="any/text-name")
 
     assert isinstance(descriptor, TransformersPrompterDescriptor)
 
 
-def test_provider_autoconfig_failure_falls_back_to_text():
+def test_provider_autoconfig_failure_warns_and_falls_back_to_text():
     from daft.ai.transformers.protocols.prompter import TransformersPrompterDescriptor
     from daft.ai.transformers.provider import TransformersProvider
 
-    with patch(
-        "transformers.AutoConfig.from_pretrained",
-        side_effect=OSError("offline"),
-    ):
-        descriptor = TransformersProvider().get_prompter(model="some/unknown-model")
+    with patch("transformers.AutoConfig.from_pretrained", side_effect=OSError("offline")):
+        with pytest.warns(UserWarning, match="vision capability"):
+            descriptor = TransformersProvider().get_prompter(model="some/unknown-model")
 
     assert isinstance(descriptor, TransformersPrompterDescriptor)
 

--- a/tests/ai/transformers/test_transformers_vision_prompter.py
+++ b/tests/ai/transformers/test_transformers_vision_prompter.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import asyncio
+import io
+import warnings
+from typing import Any
+from unittest.mock import MagicMock, Mock, patch
+
+import numpy as np
+import pytest
+
+pytest.importorskip("transformers")
+pytest.importorskip("PIL")
+
+from PIL import Image as PILImage
+
+from daft.ai.transformers.protocols.vision_prompter import (
+    TransformersVisionPrompter,
+    TransformersVisionPrompterDescriptor,
+)
+from daft.file import File
+
+
+def _make_pipeline(*, chat_template: str | None = "{{messages}}") -> Mock:
+    pipe = Mock()
+    pipe.processor = Mock()
+    pipe.processor.chat_template = chat_template
+    pipe.return_value = [{"generated_text": "ok"}]
+    return pipe
+
+
+def _make_prompter(mock_pipeline: Mock, **kwargs: Any) -> TransformersVisionPrompter:
+    with patch("daft.ai.transformers.protocols.vision_prompter.pipeline", return_value=mock_pipeline):
+        return TransformersVisionPrompter(
+            provider_name=kwargs.pop("provider_name", "transformers"),
+            model_name=kwargs.pop("model_name", "fake/vlm"),
+            system_message=kwargs.pop("system_message", None),
+            prompt_options=kwargs.pop("prompt_options", None),
+        )
+
+
+def _make_file(content: bytes | str, mime_type: str) -> Mock:
+    """Mock a daft.File with a given MIME and content."""
+    file = Mock(spec=File)
+    file.mime_type.return_value = mime_type
+    handle = MagicMock()
+    handle.read.return_value = content
+    cm = MagicMock()
+    cm.__enter__.return_value = handle
+    file.open.return_value = cm
+    return file
+
+
+def _png_bytes() -> bytes:
+    buf = io.BytesIO()
+    PILImage.new("RGB", (2, 2), color=(255, 0, 0)).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def test_descriptor_default_fields():
+    d = TransformersVisionPrompterDescriptor(provider_name="transformers", model_name="fake/vlm")
+    assert d.get_provider() == "transformers"
+    assert d.get_model() == "fake/vlm"
+    assert d.get_options() == {}
+    assert d.return_format is None
+
+
+def test_descriptor_instantiate_rejects_return_format():
+    class Dummy:
+        pass
+
+    d = TransformersVisionPrompterDescriptor(
+        provider_name="transformers",
+        model_name="fake/vlm",
+        return_format=Dummy,
+    )
+    with pytest.raises(NotImplementedError, match=r"return_format"):
+        d.instantiate()
+
+
+def test_provider_auto_detects_vlm_returns_vision_descriptor():
+    from daft.ai.transformers.provider import TransformersProvider
+
+    fake_config = Mock()
+    fake_config.model_type = "smolvlm"
+    with patch(
+        "transformers.AutoConfig.from_pretrained",
+        return_value=fake_config,
+    ):
+        descriptor = TransformersProvider().get_prompter(model="HuggingFaceTB/SmolVLM-256M-Instruct")
+
+    assert isinstance(descriptor, TransformersVisionPrompterDescriptor)
+
+
+def test_provider_non_vlm_returns_text_descriptor():
+    from daft.ai.transformers.protocols.prompter import TransformersPrompterDescriptor
+    from daft.ai.transformers.provider import TransformersProvider
+
+    fake_config = Mock()
+    fake_config.model_type = "llama"
+    with patch(
+        "transformers.AutoConfig.from_pretrained",
+        return_value=fake_config,
+    ):
+        descriptor = TransformersProvider().get_prompter(model="meta-llama/Llama-3-8B-Instruct")
+
+    assert isinstance(descriptor, TransformersPrompterDescriptor)
+
+
+def test_provider_autoconfig_failure_falls_back_to_text():
+    from daft.ai.transformers.protocols.prompter import TransformersPrompterDescriptor
+    from daft.ai.transformers.provider import TransformersProvider
+
+    with patch(
+        "transformers.AutoConfig.from_pretrained",
+        side_effect=OSError("offline"),
+    ):
+        descriptor = TransformersProvider().get_prompter(model="some/unknown-model")
+
+    assert isinstance(descriptor, TransformersPrompterDescriptor)
+
+
+def test_prompt_str_input_produces_text_block():
+    pipe = _make_pipeline()
+    prompter = _make_prompter(pipe)
+
+    asyncio.run(prompter.prompt(("hello",)))
+
+    chat = pipe.call_args.kwargs["text"]
+    assert chat == [{"role": "user", "content": [{"type": "text", "text": "hello"}]}]
+    assert pipe.call_args.kwargs["return_full_text"] is False
+
+
+def test_prompt_numpy_image_produces_image_block():
+    pipe = _make_pipeline()
+    prompter = _make_prompter(pipe)
+    image_array = np.zeros((4, 4, 3), dtype=np.uint8)
+
+    asyncio.run(prompter.prompt((image_array, "what is it?")))
+
+    content = pipe.call_args.kwargs["text"][0]["content"]
+    assert content[0]["type"] == "image"
+    assert isinstance(content[0]["image"], PILImage.Image)
+    assert content[1] == {"type": "text", "text": "what is it?"}
+
+
+def test_prompt_pil_image_passes_through():
+    pipe = _make_pipeline()
+    prompter = _make_prompter(pipe)
+    img = PILImage.new("RGB", (2, 2))
+
+    asyncio.run(prompter.prompt((img,)))
+
+    content = pipe.call_args.kwargs["text"][0]["content"]
+    assert content == [{"type": "image", "image": img}]
+
+
+def test_prompt_file_image_opens_pil():
+    pipe = _make_pipeline()
+    prompter = _make_prompter(pipe)
+    image_file = _make_file(_png_bytes(), mime_type="image/png")
+
+    asyncio.run(prompter.prompt((image_file, "describe")))
+
+    content = pipe.call_args.kwargs["text"][0]["content"]
+    assert content[0]["type"] == "image"
+    assert isinstance(content[0]["image"], PILImage.Image)
+    assert content[1] == {"type": "text", "text": "describe"}
+
+
+def test_prompt_file_text_wraps_with_tag():
+    pipe = _make_pipeline()
+    prompter = _make_prompter(pipe)
+    text_file = _make_file(b"# doc\n\ncontents", mime_type="text/markdown")
+
+    asyncio.run(prompter.prompt((text_file,)))
+
+    content = pipe.call_args.kwargs["text"][0]["content"]
+    assert content == [{"type": "text", "text": "<file_text_markdown># doc\n\ncontents</file_text_markdown>"}]
+
+
+def test_prompt_file_unsupported_mime_raises():
+    pipe = _make_pipeline()
+    prompter = _make_prompter(pipe)
+    file = _make_file(b"...", mime_type="application/pdf")
+
+    with pytest.raises(NotImplementedError, match=r"image/\* or text/\* File inputs"):
+        asyncio.run(prompter.prompt((file,)))
+
+
+def test_prompt_bytes_image_via_mime_sniff():
+    pipe = _make_pipeline()
+    prompter = _make_prompter(pipe)
+
+    asyncio.run(prompter.prompt((_png_bytes(),)))
+
+    content = pipe.call_args.kwargs["text"][0]["content"]
+    assert content[0]["type"] == "image"
+    assert isinstance(content[0]["image"], PILImage.Image)
+
+
+def test_prompt_bytes_plain_text_via_utf8_fallback():
+    pipe = _make_pipeline()
+    prompter = _make_prompter(pipe)
+
+    asyncio.run(prompter.prompt((b"raw markdown text",)))
+
+    content = pipe.call_args.kwargs["text"][0]["content"]
+    assert content == [{"type": "text", "text": "<file_text_plain>raw markdown text</file_text_plain>"}]
+
+
+def test_prompt_mixed_image_and_text_in_user_content():
+    pipe = _make_pipeline()
+    prompter = _make_prompter(pipe)
+    img = PILImage.new("RGB", (2, 2))
+
+    asyncio.run(prompter.prompt((img, "first", "second")))
+
+    content = pipe.call_args.kwargs["text"][0]["content"]
+    assert len(content) == 3
+    assert content[0]["type"] == "image"
+    assert content[1] == {"type": "text", "text": "first"}
+    assert content[2] == {"type": "text", "text": "second"}
+
+
+def test_prompt_system_message_prepended_as_chat_message():
+    pipe = _make_pipeline()
+    prompter = _make_prompter(pipe, system_message="be terse")
+
+    asyncio.run(prompter.prompt(("hi",)))
+
+    chat = pipe.call_args.kwargs["text"]
+    assert chat[0] == {"role": "system", "content": [{"type": "text", "text": "be terse"}]}
+    assert chat[1]["role"] == "user"
+
+
+def test_prompt_unsupported_input_raises():
+    pipe = _make_pipeline()
+    prompter = _make_prompter(pipe)
+
+    with pytest.raises(NotImplementedError, match=r"does not support input of type"):
+        asyncio.run(prompter.prompt((12345,)))
+
+
+def test_no_chat_template_warns():
+    pipe = _make_pipeline(chat_template=None)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _make_prompter(pipe)
+    assert any("no chat template" in str(w.message) for w in caught)


### PR DESCRIPTION
## Changes Made

Adds image-text-to-text support to the `transformers` prompter.

- `TransformersProvider.get_prompter` now inspects the model via `AutoConfig` and, if it matches `MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES`, returns a new `TransformersVisionPrompterDescriptor` that drives `pipeline(task="image-text-to-text")`. 
- Non-VLM models keep using the existing text prompter; any config lookup failure falls back to text.


## Related Issues

Part of #5620