### PR TITLE
fix(telemetry): prevent interpreter-shutdown segfault from Scarf telemetry

### DIFF
--- a/daft/scarf_telemetry.py
+++ b/daft/scarf_telemetry.py
@@ -3,11 +3,10 @@ from __future__ import annotations
 import os
 import platform
 import threading
-import urllib.parse
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    import ssl
+    from ssl import SSLContext
 
 _ANALYTICS_REQUEST_TIMEOUT_SECONDS = 2.0
 
@@ -19,7 +18,7 @@ _ssl_context = None
 _ssl_context_lock = threading.Lock()
 
 
-def _get_ssl_context() -> ssl.SSLContext:
+def _get_ssl_context() -> SSLContext:
     import ssl
 
     global _ssl_context
@@ -74,6 +73,7 @@ def _track_on_scarf(
         return None, result_container
 
     def send_request(result_container: dict[str, str | None]) -> None:
+        import urllib.parse
         import urllib.request
 
         response_status = None

--- a/daft/scarf_telemetry.py
+++ b/daft/scarf_telemetry.py
@@ -61,8 +61,13 @@ def _track_on_scarf(
     if build_type == "dev" or opted_out():
         return None, result_container
 
-    # Build/reuse the shared SSLContext on the calling (main) thread.
-    ssl_context = _get_ssl_context()
+    # Build/reuse the shared SSLContext on the calling (main) thread. Telemetry is
+    # best-effort, so if SSL setup fails here we skip this event rather than let the
+    # error propagate into the user's import or query execution.
+    try:
+        ssl_context = _get_ssl_context()
+    except Exception:
+        return None, result_container
 
     def send_request(result_container: dict[str, str | None]) -> None:
         response_status = None

--- a/daft/scarf_telemetry.py
+++ b/daft/scarf_telemetry.py
@@ -2,9 +2,28 @@ from __future__ import annotations
 
 import os
 import platform
+import ssl
 import threading
 import urllib.parse
 import urllib.request
+
+_ANALYTICS_REQUEST_TIMEOUT_SECONDS = 2.0
+
+# A single SSLContext is built on the main thread and reused by the telemetry
+# worker threads. Building it here (rather than letting each urlopen create one)
+# keeps all OpenSSL global initialization on the main thread, so the daemon
+# worker never races the interpreter's OpenSSL teardown at shutdown.
+_ssl_context = None
+_ssl_context_lock = threading.Lock()
+
+
+def _get_ssl_context() -> ssl.SSLContext:
+    global _ssl_context
+    if _ssl_context is None:
+        with _ssl_context_lock:
+            if _ssl_context is None:
+                _ssl_context = ssl.create_default_context()
+    return _ssl_context
 
 
 def opted_out() -> bool:
@@ -42,6 +61,9 @@ def _track_on_scarf(
     if build_type == "dev" or opted_out():
         return None, result_container
 
+    # Build/reuse the shared SSLContext on the calling (main) thread.
+    ssl_context = _get_ssl_context()
+
     def send_request(result_container: dict[str, str | None]) -> None:
         response_status = None
         extra_value = extra_params.get("runner") if extra_params else None
@@ -65,7 +87,9 @@ def _track_on_scarf(
 
             # Make the GET request to Scarf
             url = f"https://daft.gateway.scarf.sh/{endpoint}?{query_string}"
-            with urllib.request.urlopen(url) as response:
+            with urllib.request.urlopen(
+                url, timeout=_ANALYTICS_REQUEST_TIMEOUT_SECONDS, context=ssl_context
+            ) as response:
                 response_status = f"Response status: {response.status}"
         except Exception as e:
             response_status = f"Analytics error: {e}"
@@ -79,7 +103,7 @@ def _track_on_scarf(
             ot_params.update(params)
             ot_query_string = urllib.parse.urlencode(ot_params)
             ot_url = f"https://osstelemetry.io/data?{ot_query_string}"
-            with urllib.request.urlopen(ot_url):
+            with urllib.request.urlopen(ot_url, timeout=_ANALYTICS_REQUEST_TIMEOUT_SECONDS, context=ssl_context):
                 pass
         except Exception:
             pass

--- a/daft/scarf_telemetry.py
+++ b/daft/scarf_telemetry.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import os
 import platform
-import ssl
 import threading
 import urllib.parse
-import urllib.request
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import ssl
 
 _ANALYTICS_REQUEST_TIMEOUT_SECONDS = 2.0
 
@@ -18,6 +20,8 @@ _ssl_context_lock = threading.Lock()
 
 
 def _get_ssl_context() -> ssl.SSLContext:
+    import ssl
+
     global _ssl_context
     if _ssl_context is None:
         with _ssl_context_lock:
@@ -70,6 +74,8 @@ def _track_on_scarf(
         return None, result_container
 
     def send_request(result_container: dict[str, str | None]) -> None:
+        import urllib.request
+
         response_status = None
         extra_value = extra_params.get("runner") if extra_params else None
 

--- a/tests/test_scarf_telemetry.py
+++ b/tests/test_scarf_telemetry.py
@@ -224,3 +224,86 @@ def test_scarf_telemetry_error_handling(
     request_thread.join()
 
     assert result_container["response_status"].startswith("Analytics error:")
+
+
+@pytest.mark.parametrize(
+    "telemetry_fn,extra_params",
+    [
+        (track_runner_on_scarf, {"runner": "ray"}),
+        (track_import_on_scarf, None),
+    ],
+)
+@patch("daft.get_build_type")
+@patch("daft.get_version")
+@patch("urllib.request.urlopen")
+def test_scarf_telemetry_reuses_shared_ssl_context(
+    mock_urlopen: MagicMock,
+    mock_version: MagicMock,
+    mock_build_type: MagicMock,
+    telemetry_fn,
+    extra_params,
+    ensure_analytics_enabled,
+):
+    # Every request must reuse the shared SSLContext built on the main thread, so
+    # the daemon worker never initializes OpenSSL global state itself and thus
+    # cannot race the interpreter's OpenSSL teardown at shutdown (which can
+    # SIGSEGV after all user work has completed).
+    os.environ.pop("SCARF_NO_ANALYTICS", None)
+    os.environ.pop("DO_NOT_TRACK", None)
+
+    mock_version.return_value = "0.0.0"
+    mock_build_type.return_value = "release"
+    mock_response = MagicMock()
+    mock_response.status = 200
+    mock_urlopen.return_value.__enter__.return_value = mock_response
+
+    if extra_params:
+        request_thread, _ = telemetry_fn(**extra_params)
+    else:
+        request_thread, _ = telemetry_fn()
+    request_thread.join()
+
+    contexts = [call.kwargs.get("context") for call in mock_urlopen.call_args_list]
+    assert contexts, "expected telemetry requests to be issued"
+    assert all(ctx is not None for ctx in contexts), "telemetry request missing shared SSLContext"
+    assert len(set(id(ctx) for ctx in contexts)) == 1, "telemetry requests should reuse one SSLContext"
+
+
+@pytest.mark.parametrize(
+    "telemetry_fn,extra_params",
+    [
+        (track_runner_on_scarf, {"runner": "ray"}),
+        (track_import_on_scarf, None),
+    ],
+)
+@patch("daft.get_build_type")
+@patch("daft.get_version")
+@patch("urllib.request.urlopen")
+def test_scarf_telemetry_requests_use_timeout(
+    mock_urlopen: MagicMock,
+    mock_version: MagicMock,
+    mock_build_type: MagicMock,
+    telemetry_fn,
+    extra_params,
+    ensure_analytics_enabled,
+):
+    # Every request must pass a timeout so a slow/unreachable endpoint cannot keep
+    # the worker thread alive inside the SSL stack indefinitely.
+    os.environ.pop("SCARF_NO_ANALYTICS", None)
+    os.environ.pop("DO_NOT_TRACK", None)
+
+    mock_version.return_value = "0.0.0"
+    mock_build_type.return_value = "release"
+    mock_response = MagicMock()
+    mock_response.status = 200
+    mock_urlopen.return_value.__enter__.return_value = mock_response
+
+    if extra_params:
+        request_thread, _ = telemetry_fn(**extra_params)
+    else:
+        request_thread, _ = telemetry_fn()
+    request_thread.join()
+
+    assert mock_urlopen.call_args_list, "expected telemetry requests to be issued"
+    for call in mock_urlopen.call_args_list:
+        assert call.kwargs.get("timeout") is not None, "telemetry request missing timeout"

--- a/tests/test_scarf_telemetry.py
+++ b/tests/test_scarf_telemetry.py
@@ -307,3 +307,41 @@ def test_scarf_telemetry_requests_use_timeout(
     assert mock_urlopen.call_args_list, "expected telemetry requests to be issued"
     for call in mock_urlopen.call_args_list:
         assert call.kwargs.get("timeout") is not None, "telemetry request missing timeout"
+
+
+@pytest.mark.parametrize(
+    "telemetry_fn,extra_params",
+    [
+        (track_runner_on_scarf, {"runner": "ray"}),
+        (track_import_on_scarf, None),
+    ],
+)
+@patch("daft.get_build_type")
+@patch("daft.get_version")
+@patch("daft.scarf_telemetry._get_ssl_context")
+def test_scarf_telemetry_ssl_setup_failure_is_best_effort(
+    mock_get_ssl_context: MagicMock,
+    mock_version: MagicMock,
+    mock_build_type: MagicMock,
+    telemetry_fn,
+    extra_params,
+    ensure_analytics_enabled,
+):
+    # Telemetry must stay best-effort: if building the SSLContext on the main
+    # thread fails, the event is skipped instead of propagating into the caller's
+    # import (track_import_on_scarf) or query execution (track_runner_on_scarf).
+    os.environ.pop("SCARF_NO_ANALYTICS", None)
+    os.environ.pop("DO_NOT_TRACK", None)
+
+    mock_version.return_value = "0.0.0"
+    mock_build_type.return_value = "release"
+    mock_get_ssl_context.side_effect = OSError("cannot load CA certificates")
+
+    if extra_params:
+        request_thread, result_container = telemetry_fn(**extra_params)
+    else:
+        request_thread, result_container = telemetry_fn()
+
+    assert request_thread is None
+    assert result_container["response_status"] is None
+    assert result_container["extra_value"] is None


### PR DESCRIPTION
## Problem

Scarf telemetry runs its request in a **daemon thread** that makes HTTPS calls via `urllib` (`daft/scarf_telemetry.py`). At interpreter shutdown the daemon thread can still be inside the SSL/OpenSSL stack — creating an `SSLContext` and loading CA certificates — while the main thread starts finalizing. The two then race on OpenSSL global state and the process **SIGSEGVs (exit code 139) after all user work has already completed successfully**.

This is easy to hit:

- Reproduces with plain repeated daft usage — even pure compute with **no IO and no external packages**.
- Especially reliable on interpreters that **statically link OpenSSL**, e.g. the [python-build-standalone](https://github.com/astral-sh/python-build-standalone) builds used by `uv` / `pyenv`. Observed on Python 3.11.13 (uv), OpenSSL 3.0.16, macOS arm64, daft 0.7.14.
- The crash is at shutdown, so data is written correctly, but the 139 exit code makes CI / Airflow / K8s Jobs / cron treat the run as a **failure and retry it**.

### Minimal reproducer

```python
import os, tempfile, daft
tmp = tempfile.mkdtemp()
for i in range(8):
    daft.from_pydict({"id": list(range(i + 1))}).where(daft.col("id") >= 0).collect()
print("all work done")   # prints, then the process crashes on exit
```

Crash rate scales with the number of daft operations per process (each `track_runner_on_scarf` spawns another telemetry thread): 0/3 at N=1, ~1/3 at N=3, 3/3 at N≥4 in my environment.

### Faulting stack (macOS crash report, faulting thread)

```
_ssl__SSLContext_set_default_verify_paths_impl   <- ssl.SSLContext() init
X509_STORE_set_default_paths_ex
X509_load_cert_crl_file_ex
OSSL_DECODER_CTX_new_for_pkey
ossl_method_store_do_all
OPENSSL_sk_value                                  <- SIGSEGV
```

`python -X faulthandler` shows an empty main-thread traceback — the crash is below Python, in the daemon telemetry thread racing interpreter teardown.

## Fix

Build the `SSLContext` **once on the main thread** and reuse it for the telemetry requests, so the daemon worker never initializes OpenSSL global state itself and cannot race teardown. Also pass an explicit request **timeout** so a slow/unreachable endpoint can't keep the worker alive inside the SSL stack.

Telemetry stays **non-blocking** (still a daemon thread), so process shutdown is not slowed.

## Verification

Patched module tested against the reproducer and the existing suite:

- Reproducer (N=8): **8/8 crashes → 0/12**; N=12: **0/6**.
- Process exit time unchanged: ~0.07s (vs ~0.06s baseline) — daemon thread still doesn't block exit.
- `tests/test_scarf_telemetry.py`: **14 passed** (12 existing + 2 new, verifying the shared context is reused and requests carry a timeout).

### Alternative considered

Making the thread **non-daemon + timeout** also fixes the crash (the interpreter then joins it on exit), but it regresses process exit time from ~0.06s to ~2s because shutdown waits on the live HTTPS requests. The shared-context approach keeps shutdown non-blocking, so it was preferred.

## Note

Setting `DAFT_ANALYTICS_ENABLED=0` (or `DO_NOT_TRACK=1` / `SCARF_NO_ANALYTICS=1`) already avoids the crash by disabling telemetry entirely; this PR fixes it for the default (telemetry-on) path.