### PR TITLE
fix: propagate list-return UDF errors instead of a cryptic concat error

### DIFF
--- a/src/daft-core/src/series/from_lit.rs
+++ b/src/daft-core/src/series/from_lit.rs
@@ -262,7 +262,17 @@ pub fn series_from_literals_iter<I: ExactSizeIterator<Item = DaftResult<Literal>
                         .transpose()
                 })
                 .collect::<DaftResult<Vec<_>>>()?;
-            ListArray::from_series("literal", data)?.into_series()
+            // When every element is null, `ListArray::from_series` has no child series to concat and
+            // fails with a cryptic "Need at least 1 series to perform concat". This happens when all
+            // rows of a list-return UDF produced null: either they errored under `on_error="raise"`
+            // (whose real error is still reported by the `errs` check at the end of this function) or
+            // under `on_error="ignore"`/`"log"` (which should yield an all-null column, not an error).
+            // Build the all-null list directly in that case. See issue #7196.
+            if data.iter().all(Option::is_none) {
+                Series::full_null("literal", &downcasted, len)
+            } else {
+                ListArray::from_series("literal", data)?.into_series()
+            }
         }
         DataType::Struct(ref fields) => {
             let values = values.collect::<Vec<_>>();
@@ -335,14 +345,20 @@ pub fn series_from_literals_iter<I: ExactSizeIterator<Item = DaftResult<Literal>
                 })
                 .collect::<(Vec<_>, Vec<_>)>();
 
-            let data_array = ListArray::from_series("data", data)?.into_series();
-            let shape_array = ListArray::from_vec("shape", shapes).into_series();
+            // See the `DataType::List` arm: when every row is null there is no child series to
+            // concat, so build the all-null column directly. See issue #7196.
+            if data.iter().all(Option::is_none) {
+                Series::full_null("literal", &downcasted, len)
+            } else {
+                let data_array = ListArray::from_series("data", data)?.into_series();
+                let shape_array = ListArray::from_vec("shape", shapes).into_series();
 
-            let nulls = data_array.nulls().cloned();
-            let physical =
-                StructArray::new(field.to_physical(), vec![data_array, shape_array], nulls);
+                let nulls = data_array.nulls().cloned();
+                let physical =
+                    StructArray::new(field.to_physical(), vec![data_array, shape_array], nulls);
 
-            TensorArray::new(field, physical).into_series()
+                TensorArray::new(field, physical).into_series()
+            }
         }
         DataType::SparseTensor(..) => {
             let (values, indices, shapes) = values
@@ -355,18 +371,24 @@ pub fn series_from_literals_iter<I: ExactSizeIterator<Item = DaftResult<Literal>
                 })
                 .collect::<(Vec<_>, Vec<_>, Vec<_>)>();
 
-            let values_array = ListArray::from_series("values", values)?.into_series();
-            let indices_array = ListArray::from_series("indices", indices)?.into_series();
-            let shape_array = ListArray::from_vec("shape", shapes).into_series();
+            // See the `DataType::List` arm: when every row is null there is no child series to
+            // concat, so build the all-null column directly. See issue #7196.
+            if values.iter().all(Option::is_none) {
+                Series::full_null("literal", &downcasted, len)
+            } else {
+                let values_array = ListArray::from_series("values", values)?.into_series();
+                let indices_array = ListArray::from_series("indices", indices)?.into_series();
+                let shape_array = ListArray::from_vec("shape", shapes).into_series();
 
-            let nulls = values_array.nulls().cloned();
-            let physical = StructArray::new(
-                field.to_physical(),
-                vec![values_array, indices_array, shape_array],
-                nulls,
-            );
+                let nulls = values_array.nulls().cloned();
+                let physical = StructArray::new(
+                    field.to_physical(),
+                    vec![values_array, indices_array, shape_array],
+                    nulls,
+                );
 
-            SparseTensorArray::new(field, physical).into_series()
+                SparseTensorArray::new(field, physical).into_series()
+            }
         }
         DataType::Embedding(ref inner_dtype, ref size) => {
             let (nulls, data): (Vec<_>, Vec<_>) = values
@@ -412,9 +434,14 @@ pub fn series_from_literals_iter<I: ExactSizeIterator<Item = DaftResult<Literal>
                 })
                 .collect::<DaftResult<Vec<_>>>()?;
 
-            let physical = ListArray::from_series("literal", data)?;
-
-            MapArray::new(field, physical).into_series()
+            // See the `DataType::List` arm: when every row is null there is no child series to
+            // concat, so build the all-null column directly. See issue #7196.
+            if data.iter().all(Option::is_none) {
+                Series::full_null("literal", &downcasted, len)
+            } else {
+                let physical = ListArray::from_series("literal", data)?;
+                MapArray::new(field, physical).into_series()
+            }
         }
         DataType::Image(image_mode) => {
             let data =
@@ -624,5 +651,49 @@ mod test {
         let values = vec![Literal::UInt64(1), Literal::Utf8("test".to_string())];
         let actual = Series::from_literals(values);
         assert!(actual.is_err());
+    }
+
+    #[test]
+    fn test_list_literals_iter_surfaces_row_error() {
+        use common_error::{DaftError, DaftResult};
+
+        // A raising list-return UDF makes every row an `Err`; building the list series must surface
+        // the recorded row error, not a cryptic "Need at least 1 series to perform concat". (#7196)
+        let values: Vec<DaftResult<Literal>> =
+            vec![Err(DaftError::ComputeError("boom".to_string()))];
+        let err = super::series_from_literals_iter(
+            values.into_iter(),
+            Some(DataType::List(Box::new(DataType::Int64))),
+        )
+        .expect_err("expected the row error to be surfaced");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("boom"),
+            "should surface the original row error, got: {msg}"
+        );
+        assert!(
+            !msg.contains("at least 1 series"),
+            "should not leak the cryptic concat error, got: {msg}"
+        );
+    }
+
+    #[rstest]
+    #[case::list(DataType::List(Box::new(DataType::Int64)))]
+    #[case::map(DataType::Map { key: Box::new(DataType::Utf8), value: Box::new(DataType::Int64) })]
+    #[case::tensor(DataType::Tensor(Box::new(DataType::Int64)))]
+    #[case::sparse_tensor(DataType::SparseTensor(Box::new(DataType::Int64), false))]
+    fn test_all_null_list_like_builds_null_column(#[case] dtype: DataType) {
+        use common_error::DaftResult;
+
+        // Every row null (e.g. an all-error list-like-return UDF under `on_error="ignore"`) must build
+        // an all-null column, not fail with "Need at least 1 series to perform concat". (#7196)
+        let values: Vec<DaftResult<Literal>> = vec![Ok(Literal::Null), Ok(Literal::Null)];
+        let series = super::series_from_literals_iter(values.into_iter(), Some(dtype))
+            .expect("all-null list-like column should build successfully");
+
+        assert_eq!(series.len(), 2);
+        let actual = series.to_literals().collect::<Vec<_>>();
+        assert_eq!(actual, vec![Literal::Null, Literal::Null]);
     }
 }

--- a/src/daft-core/src/series/from_lit.rs
+++ b/src/daft-core/src/series/from_lit.rs
@@ -520,6 +520,7 @@ impl From<Literal> for Series {
 
 #[cfg(test)]
 mod test {
+    use common_error::{DaftError, DaftResult};
     use common_image::Image;
     use image::{GrayImage, RgbaImage};
     use indexmap::indexmap;
@@ -655,8 +656,6 @@ mod test {
 
     #[test]
     fn test_list_literals_iter_surfaces_row_error() {
-        use common_error::{DaftError, DaftResult};
-
         // A raising list-return UDF makes every row an `Err`; building the list series must surface
         // the recorded row error, not a cryptic "Need at least 1 series to perform concat". (#7196)
         let values: Vec<DaftResult<Literal>> =
@@ -684,8 +683,6 @@ mod test {
     #[case::tensor(DataType::Tensor(Box::new(DataType::Int64)))]
     #[case::sparse_tensor(DataType::SparseTensor(Box::new(DataType::Int64), false))]
     fn test_all_null_list_like_builds_null_column(#[case] dtype: DataType) {
-        use common_error::DaftResult;
-
         // Every row null (e.g. an all-error list-like-return UDF under `on_error="ignore"`) must build
         // an all-null column, not fail with "Need at least 1 series to perform concat". (#7196)
         let values: Vec<DaftResult<Literal>> = vec![Ok(Literal::Null), Ok(Literal::Null)];

--- a/tests/udf/test_row_wise_udf.py
+++ b/tests/udf/test_row_wise_udf.py
@@ -271,6 +271,43 @@ def test_async_rowwise_on_err_ignore():
     assert actual == expected
 
 
+def test_rowwise_list_return_udf_surfaces_error():
+    # Regression test for #7196: a raising UDF with a `list[...]` return dtype used to surface a
+    # cryptic "Need at least 1 series to perform concat" instead of the underlying error, unlike
+    # scalar-return UDFs which propagate it correctly.
+    @daft.func(return_dtype=DataType.int64())
+    def scalar_raise(x) -> int:
+        raise ValueError("boom-marker")
+
+    @daft.func(return_dtype=DataType.list(DataType.int64()))
+    def list_raise(x) -> list[int]:
+        raise ValueError("boom-marker")
+
+    df = daft.from_pydict({"value": [1]})
+
+    # Control: the scalar-return UDF already propagated the original error.
+    with pytest.raises(Exception, match="boom-marker"):
+        df.select(scalar_raise(col("value"))).to_pydict()
+
+    # The list-return UDF must now propagate the same error, not the cryptic concat error.
+    with pytest.raises(Exception, match="boom-marker") as exc_info:
+        df.select(list_raise(col("value"))).to_pydict()
+    assert "at least 1 series" not in str(exc_info.value)
+
+
+def test_rowwise_list_return_udf_all_null_on_error_ignore():
+    # Regression test for #7196: with on_error="ignore", a list-return UDF that raises on every row
+    # must yield an all-null column, not a cryptic "Need at least 1 series to perform concat".
+    @daft.func(return_dtype=DataType.list(DataType.int64()), on_error="ignore")
+    def list_raise(x) -> list[int]:
+        raise ValueError("boom")
+
+    df = daft.from_pydict({"x": [1, 2]})
+
+    actual = df.select(list_raise(col("x"))).to_pydict()
+    assert actual == {"x": [None, None]}
+
+
 def test_rowwise_retry():
     class RetryState:
         def __init__(self):


### PR DESCRIPTION
## Changes Made

When a UDF with a `list[...]` return dtype raises, Daft swallowed the original exception and
surfaced

```
DaftError::ValueError Need at least 1 series to perform concat
```

instead of the underlying error, while scalar-return UDFs propagated it correctly. The same cryptic
error also appeared for `on_error="ignore"`/`"log"` when every row produced null (that case should
just yield an all-null column).

### Root cause

Row-wise UDF results are turned into a Series by `series_from_literals_iter`
(`src/daft-core/src/series/from_lit.rs`). The `DataType::List` arm builds the column via
`ListArray::from_series(data)`, which concatenates the per-row child series. When **every** element is
null, there are zero child series to concat, so it fails with `Need at least 1 series to perform
concat`. Every element is null exactly when all rows produced null, which happens when a list-return
UDF fails on every row:

- under the default `on_error="raise"`, each failing row is recorded into the function's `errs` map
  and replaced with a null. For scalar dtypes the array builds fine and the real error is reported by
  the `errs` check at the end of the function — but the `List` arm's `from_series` fails first and its
  `?` short-circuits before that check, so the real error is lost.
- under `on_error="ignore"`/`"log"`, the failures are already turned into nulls, so the column should
  be all-null — but `from_series` errors on the empty concat instead.

### Fix

In the `List` arm, when all elements are null, build the all-null list column directly with
`Series::full_null` (using the known child dtype) instead of going through the empty concat. This
resolves both cases:

- `on_error="raise"`: the all-null series builds, execution reaches the end-of-function `errs` check,
  and the real per-row error is reported — identical to how a scalar-return UDF reports it.
- `on_error="ignore"`/`"log"`: the column is correctly all-null.

The non-empty and no-error paths are unchanged.

### Before / after (minimal repro from the issue)

```python
import daft
from daft import col

@daft.func(return_dtype=daft.DataType.list(daft.DataType.int64()))
def list_import_error(x):
    raise ImportError("The 'pillow' module is required. Install daft[video].")

daft.from_pydict({"x": [1]}).with_column("y", list_import_error(col("x"))).collect()
```

- Before: `DaftError::ValueError Need at least 1 series to perform concat`
- After: `DaftError::ComputeError Error processing some rows:\n0: DaftError::PyO3Error ImportError: The 'pillow' module is required. …` (same shape as the scalar-return case)

And with `on_error="ignore"`, a list-return UDF that raises on every row now returns an all-null
column instead of erroring.

### Scope

The `List` fix covers the reported case, including `list[struct]` / `list[image]` (all go through the
`List` arm). The sibling arms `Tensor`, `SparseTensor`, and `Map` build their columns the same way
(`ListArray::from_series` over possibly-all-null data) and had the identical latent bug for those UDF
return dtypes, so the same all-null guard is applied to them too.

## Testing

- **Rust unit tests** (`from_lit.rs`):
  - `test_list_literals_iter_surfaces_row_error` — a `List(Int64)` iterator containing an `Err` now
    returns the recorded error and no longer leaks the concat message.
  - `test_all_null_list_like_builds_null_column` — parametrized over `List` / `Map` / `Tensor` /
    `SparseTensor`: an all-null iterator builds an all-null column instead of failing.
- **Python regression tests** (`tests/udf/test_row_wise_udf.py`):
  - `test_rowwise_list_return_udf_surfaces_error` — a raising `list[int]` UDF propagates the original
    error (asserting the `"at least 1 series"` message is gone), with a scalar-return control.
  - `test_rowwise_list_return_udf_all_null_on_error_ignore` — a raising `list[int]` UDF with
    `on_error="ignore"` yields an all-null column.

Verified locally with `DAFT_RUNNER=native` against a `maturin develop` build (the issue's minimal
repro now prints the original `ImportError`); full `from_lit` Rust suite and the row-wise UDF Python
suite pass.

## AI usage disclosure

This change was developed with the help of an AI coding assistant. I reviewed the diff and verified the
behavior myself: reproduced the original bug against the released wheel, confirmed the fix on a local
`maturin develop` build using the issue's minimal repro (and the `on_error="ignore"` variant), and added
the Rust unit tests and Python regression tests described above — all passing under `DAFT_RUNNER=native`,
alongside the existing `from_lit` and row-wise UDF suites.

## Related Issues

Closes #7196
