### PR TITLE
fix: add pillow to video extra

### DIFF
--- a/daft/file/video.py
+++ b/daft/file/video.py
@@ -29,6 +29,10 @@ class VideoFile(File):
     def __init__(self, url: str, io_config: IOConfig | None = None) -> None:
         if not av.module_available():
             raise ImportError("The 'av' module is required to create video files.")
+        if not pil_image.module_available():
+            raise ImportError(
+                "The 'pillow' module is required to create video files. Install it with `pip install daft[video]`."
+            )
         super().__init__(url, io_config, MediaType.video())
 
     def __post_init__(self) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ transformers = ["transformers<5.10.0", "sentence-transformers<5.6.0", "torch<2.1
 sql = ["connectorx>=0.4.4,<0.5.0", "sqlalchemy<2.1.0", "sqlglot<30.9.0"]
 turbopuffer = ["turbopuffer<2.2.0"]
 unity = ["httpx<=0.28.1", "unitycatalog<0.2.0", "deltalake>=1.5.0,<1.7.0"]
-video = ["av >= 15.0.0,< 17.1.0"]
+video = ["av >= 15.0.0,< 17.1.0", "pillow==12.2.0"]
 audio = ["soundfile >= 0.13.0,<0.14.0", "librosa >= 0.11.0,<0.12.0"]
 viz = []
 

--- a/tests/file/test_video.py
+++ b/tests/file/test_video.py
@@ -130,11 +130,17 @@ def test_video_keyframes_start_time_beyond_duration_returns_empty(sample_video_p
     assert frames == []
 
 
-def test_keyframes_raises_informative_error_when_pillow_missing(sample_video_path, monkeypatch):
-    """Regression test for issue #6064: ensure informative error when pillow is missing."""
+def test_videofile_init_without_pillow(monkeypatch):
     monkeypatch.setattr(dependencies.pil_image, "module_available", lambda: False)
 
+    with pytest.raises(ImportError, match="pillow.*required.*pip install daft\\[video\\]"):
+        daft.VideoFile("dummy.mp4")
+
+
+def test_keyframes_raises_informative_error_when_pillow_missing(sample_video_path, monkeypatch):
+    """Regression test for issue #6064: ensure informative error when pillow is missing."""
     file = daft.VideoFile(sample_video_path)
+    monkeypatch.setattr(dependencies.pil_image, "module_available", lambda: False)
 
     with pytest.raises(ImportError, match="pillow.*required.*pip install daft\\[video\\]"):
         list(file.keyframes())
@@ -280,9 +286,8 @@ def test_video_frames_expression_with_resize(sample_video_path):
 
 
 def test_frames_raises_informative_error_when_pillow_missing(sample_video_path, monkeypatch):
-    monkeypatch.setattr(dependencies.pil_image, "module_available", lambda: False)
-
     file = daft.VideoFile(sample_video_path)
+    monkeypatch.setattr(dependencies.pil_image, "module_available", lambda: False)
 
     with pytest.raises(ImportError, match="pillow.*required.*pip install daft\\[video\\]"):
         list(file.frames())

--- a/uv.lock
+++ b/uv.lock
@@ -1612,6 +1612,7 @@ unity = [
 ]
 video = [
     { name = "av" },
+    { name = "pillow" },
 ]
 
 [package.dev-dependencies]
@@ -1737,6 +1738,7 @@ requires-dist = [
     { name = "pillow", marker = "extra == 'google'", specifier = "==12.2.0" },
     { name = "pillow", marker = "extra == 'openai'", specifier = "==12.2.0" },
     { name = "pillow", marker = "extra == 'transformers'", specifier = "==12.2.0" },
+    { name = "pillow", marker = "extra == 'video'", specifier = "==12.2.0" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'postgres'", specifier = "<3.4.0" },
     { name = "pyarrow", specifier = ">=16.0.0,<25.0.0" },
     { name = "pyarrow", marker = "extra == 'hudi'", specifier = ">=16.0.0,<25.0.0" },


### PR DESCRIPTION
## Summary

- Add `pillow==12.2.0` to the `video` optional dependency extra.
- Regenerate `uv.lock` so the `video` extra includes Pillow.
- Raise an informative error when `VideoFile` is constructed without Pillow.
- Add/update tests for the missing-Pillow video paths now that construction performs the dependency check.

## Testing

- `uv lock --check`
- `DAFT_RUNNER=native make test EXTRA_ARGS="-v tests/file/test_video.py"`
- `pre-commit run ruff-check --files daft/file/video.py tests/file/test_video.py`
- `pre-commit run ruff-format --files daft/file/video.py tests/file/test_video.py`
- `pre-commit run uv-lock --files pyproject.toml uv.lock`

## AI usage

Used Codex to update the dependency metadata, regenerate the lockfile, add the regression test, and run the checks listed above.