### PR TITLE
fix: normalize HF bucket tree paths

### DIFF
--- a/src/daft-io/src/huggingface/error.rs
+++ b/src/daft-io/src/huggingface/error.rs
@@ -51,6 +51,15 @@ Example:
     #[snafu(display("Unauthorized access to dataset, please check your credentials."))]
     Unauthorized,
 
+    #[snafu(display(
+        "Unauthorized response (HTTP 401) from Hugging Face bucket '{repository}'.
+Hugging Face returns 401 both for private buckets and for buckets that do not exist.
+Note that storage buckets are separate from datasets: a dataset named '{repository}' is not automatically available as a bucket, so check that https://huggingface.co/buckets/{repository} exists.
+To read a dataset, use 'hf://datasets/{repository}/...' instead.
+If the bucket exists but is private, provide a token via `HuggingFaceConfig(token=...)`."
+    ))]
+    BucketUnauthorized { repository: String },
+
     #[snafu(display("Xet error while accessing {}: {}", path, message))]
     XetOperationFailed { path: String, message: String },
 }

--- a/src/daft-io/src/huggingface/mod.rs
+++ b/src/daft-io/src/huggingface/mod.rs
@@ -26,7 +26,7 @@ use crate::{
     http::HttpSource,
     huggingface::{
         error::Error,
-        path::{HFPath, HFPathParts, hf_path_parts_from_uri},
+        path::{HFPath, HFPathParts, HFRepoType, hf_path_parts_from_uri},
     },
     object_io::{FileMetadata, FileType, LSResult},
     range::GetRange,
@@ -432,6 +432,10 @@ impl ObjectSource for HFSource {
         use crate::object_store_glob::glob;
 
         let path = glob_path.parse::<HFPath>()?;
+        let glob_path = match &path {
+            HFPath::Hf(parts) if parts.repo_type == HFRepoType::Buckets => parts.to_string(),
+            _ => glob_path.to_string(),
+        };
 
         // Ensure fanout_limit is None because HTTP ObjectSource does not support prefix listing
         let fanout_limit = None;
@@ -439,7 +443,7 @@ impl ObjectSource for HFSource {
 
         match path {
             HFPath::Http(_) => {
-                glob(self, glob_path, fanout_limit, page_size, limit, io_stats).await
+                glob(self, &glob_path, fanout_limit, page_size, limit, io_stats).await
             }
             HFPath::Hf(parts) => {
                 // Huggingface has a special API for parquet files
@@ -465,7 +469,7 @@ impl ObjectSource for HFSource {
                     }
                 }
 
-                glob(self, glob_path, fanout_limit, page_size, limit, io_stats).await
+                glob(self, &glob_path, fanout_limit, page_size, limit, io_stats).await
             }
         }
     }

--- a/src/daft-io/src/huggingface/mod.rs
+++ b/src/daft-io/src/huggingface/mod.rs
@@ -230,8 +230,7 @@ impl HFSource {
                     Some(StatusCode::RANGE_NOT_SATISFIABLE) => {
                         self.request(uri, true, range, client).await
                     }
-                    Some(StatusCode::UNAUTHORIZED)
-                        if matches!(&path, HFPath::Hf(parts) if parts.repo_type == HFRepoType::Buckets) =>
+                    Some(StatusCode::UNAUTHORIZED) if matches!(&path, HFPath::Hf(parts) if parts.repo_type == HFRepoType::Buckets) =>
                     {
                         let HFPath::Hf(parts) = &path else {
                             unreachable!()
@@ -743,12 +742,10 @@ mod tests {
             )
             .await?;
         assert!(!result.files.is_empty());
-        assert!(
-            result
-                .files
-                .iter()
-                .all(|f| f.filepath.starts_with("hf://buckets/the-hf-stack/zenml-experiments/"))
-        );
+        assert!(result.files.iter().all(|f| {
+            f.filepath
+                .starts_with("hf://buckets/the-hf-stack/zenml-experiments/")
+        }));
 
         Ok(())
     }

--- a/src/daft-io/src/huggingface/mod.rs
+++ b/src/daft-io/src/huggingface/mod.rs
@@ -14,7 +14,7 @@ use futures::{
 use reqwest::StatusCode;
 use reqwest_middleware::{
     ClientWithMiddleware,
-    reqwest::header::{CONTENT_LENGTH, RANGE},
+    reqwest::header::{CONTENT_LENGTH, LINK, RANGE},
 };
 use serde::{Deserialize, Serialize};
 use snafu::{IntoError, ResultExt};
@@ -45,7 +45,9 @@ enum ItemType {
 #[serde(rename_all = "snake_case")]
 struct Item {
     r#type: ItemType,
-    oid: String,
+    // The datasets/models/spaces tree APIs return a git `oid` per entry; the buckets tree
+    // API returns xet metadata instead and has no `oid` field.
+    oid: Option<String>,
     size: u64,
     path: String,
 }
@@ -56,11 +58,45 @@ pub struct HFSource {
     xet: XetContext,
 }
 
+/// Map an HTTP 401 to the right error for the repo type. Hugging Face returns 401 for
+/// buckets that are private *or* nonexistent (e.g. when a user assumes a dataset is also
+/// available as a bucket), so bucket 401s get a dedicated, actionable message.
+fn hf_unauthorized_error(parts: &HFPathParts) -> Error {
+    if parts.repo_type == HFRepoType::Buckets {
+        Error::BucketUnauthorized {
+            repository: parts.repository.clone(),
+        }
+    } else {
+        Error::Unauthorized
+    }
+}
+
+/// Same as [`hf_unauthorized_error`], for call sites that only have the original URI.
+fn hf_unauthorized_error_for_uri(uri: &str) -> Error {
+    match hf_path_parts_from_uri(uri) {
+        Ok(Some(parts)) => hf_unauthorized_error(&parts),
+        _ => Error::Unauthorized,
+    }
+}
+
+/// Extract the `rel="next"` URL from an HTTP `Link` header.
+fn parse_link_header_next(link: &str) -> Option<String> {
+    link.split(',').find_map(|entry| {
+        let (url, params) = entry.split_once(';')?;
+        params.contains("rel=\"next\"").then(|| {
+            url.trim()
+                .trim_start_matches('<')
+                .trim_end_matches('>')
+                .to_string()
+        })
+    })
+}
+
 impl From<Error> for super::Error {
     fn from(error: Error) -> Self {
         use Error::{
-            PrivateDataset, UnableToConnect, UnableToDetermineSize, UnableToOpenFile,
-            UnableToReadBytes, Unauthorized, XetOperationFailed,
+            BucketUnauthorized, PrivateDataset, UnableToConnect, UnableToDetermineSize,
+            UnableToOpenFile, UnableToReadBytes, Unauthorized, XetOperationFailed,
         };
         match error {
             UnableToOpenFile { path, source } => {
@@ -103,6 +139,11 @@ impl From<Error> for super::Error {
             PrivateDataset => Self::Unauthorized {
                 store: super::SourceType::HF,
                 path: String::new(),
+                source: error.into(),
+            },
+            BucketUnauthorized { ref repository } => Self::Unauthorized {
+                store: super::SourceType::HF,
+                path: repository.clone(),
                 source: error.into(),
             },
             XetOperationFailed { path, message } => Self::Generic {
@@ -188,6 +229,14 @@ impl HFSource {
                     // Retry with cache busting to bypass the improperly cached response and get correct file metadata.
                     Some(StatusCode::RANGE_NOT_SATISFIABLE) => {
                         self.request(uri, true, range, client).await
+                    }
+                    Some(StatusCode::UNAUTHORIZED)
+                        if matches!(&path, HFPath::Hf(parts) if parts.repo_type == HFRepoType::Buckets) =>
+                    {
+                        let HFPath::Hf(parts) = &path else {
+                            unreachable!()
+                        };
+                        Err(hf_unauthorized_error(parts).into())
                     }
                     _ => Err(e)
                         .context(error::UnableToOpenFileSnafu::<String> { path: uri.clone() })?,
@@ -328,7 +377,10 @@ impl HFSource {
             .context(error::UnableToConnectSnafu::<String> { path: uri.into() })?;
         let response = response.error_for_status().map_err(|e| {
             if e.status().map(|s| s.as_u16()) == Some(401) {
-                Error::Unauthorized
+                match &path {
+                    HFPath::Hf(parts) => hf_unauthorized_error(parts),
+                    HFPath::Http(_) => Error::Unauthorized,
+                }
             } else {
                 Error::UnableToOpenFile {
                     path: uri.clone(),
@@ -381,7 +433,7 @@ impl ObjectSource for HFSource {
             match self.get_via_xet(uri, range.clone(), io_stats.clone()).await {
                 Ok(Some(result)) => return Ok(result),
                 Ok(None) => {}
-                Err(Error::Unauthorized) => return Err(Error::Unauthorized.into()),
+                Err(Error::Unauthorized) => return Err(hf_unauthorized_error_for_uri(uri).into()),
                 Err(e) => {
                     log::debug!("Xet read failed for {uri}, falling back to HTTP: {e}");
                 }
@@ -410,7 +462,7 @@ impl ObjectSource for HFSource {
             {
                 Ok(Some(resolved)) => return Ok(resolved.file_size as usize),
                 Ok(None) => {}
-                Err(Error::Unauthorized) => return Err(Error::Unauthorized.into()),
+                Err(Error::Unauthorized) => return Err(hf_unauthorized_error_for_uri(uri).into()),
                 Err(e) => {
                     log::debug!("Xet size probe failed for {uri}, falling back to HTTP: {e}");
                 }
@@ -455,7 +507,11 @@ impl ObjectSource for HFSource {
                 // hf://datasets/user/repo
                 // but not
                 // hf://datasets/user/repo/file.parquet
-                if file_format == Some(FileFormat::Parquet) {
+                // Buckets are plain object storage with no parquet-conversion API, so they
+                // always go through regular globbing.
+                if file_format == Some(FileFormat::Parquet)
+                    && parts.repo_type != HFRepoType::Buckets
+                {
                     let res =
                         try_parquet_api(parts, limit, io_stats.clone(), &self.http_source.client)
                             .await;
@@ -495,7 +551,12 @@ impl ObjectSource for HFSource {
                 .await;
         };
 
-        let api_uri = HFPath::Hf(path_parts.clone()).get_api_uri();
+        // The continuation token, when present, is the fully-qualified `rel="next"` URL from
+        // the previous page's `Link` header.
+        let api_uri = match continuation_token {
+            Some(token) => token.to_string(),
+            None => HFPath::Hf(path_parts.clone()).get_api_uri(),
+        };
 
         let request = self.http_source.client.get(api_uri.clone());
         let response = request
@@ -507,7 +568,7 @@ impl ObjectSource for HFSource {
 
         let response = response.error_for_status().map_err(|e| {
             if e.status().map(|s| s.as_u16()) == Some(401) {
-                Error::Unauthorized
+                hf_unauthorized_error(&path_parts)
             } else {
                 Error::UnableToOpenFile {
                     path: api_uri.clone(),
@@ -519,6 +580,13 @@ impl ObjectSource for HFSource {
         if let Some(is) = io_stats.as_ref() {
             is.mark_list_requests(1);
         }
+        // The tree APIs paginate (1000 entries per page) and advertise the next page in the
+        // `Link` header.
+        let continuation_token = response
+            .headers()
+            .get(LINK)
+            .and_then(|v| v.to_str().ok())
+            .and_then(parse_link_header_next);
         let response =
             response
                 .json::<Vec<Item>>()
@@ -557,7 +625,7 @@ impl ObjectSource for HFSource {
             .collect();
         Ok(LSResult {
             files,
-            continuation_token: None,
+            continuation_token,
         })
     }
 
@@ -641,8 +709,98 @@ async fn try_parquet_api(
 #[cfg(test)]
 mod tests {
     use common_io_config::{HTTPConfig, HuggingFaceConfig};
+    use futures::TryStreamExt;
 
     use crate::{huggingface::HFSource, object_io::ObjectSource};
+
+    #[test]
+    fn test_parse_link_header_next() {
+        let link = "<https://huggingface.co/api/buckets/commoncrawl/commoncrawl/tree?limit=1000&cursor=abc>; rel=\"next\"";
+        assert_eq!(
+            super::parse_link_header_next(link).as_deref(),
+            Some(
+                "https://huggingface.co/api/buckets/commoncrawl/commoncrawl/tree?limit=1000&cursor=abc"
+            )
+        );
+        assert_eq!(
+            super::parse_link_header_next("<https://example.com>; rel=\"prev\""),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn test_bucket_ls() -> crate::Result<()> {
+        let config = HuggingFaceConfig::default();
+        let client = HFSource::get_client(&config, &HTTPConfig::default()).await?;
+
+        let result = client
+            .ls(
+                "hf://buckets/the-hf-stack/zenml-experiments/",
+                true,
+                None,
+                None,
+                None,
+            )
+            .await?;
+        assert!(!result.files.is_empty());
+        assert!(
+            result
+                .files
+                .iter()
+                .all(|f| f.filepath.starts_with("hf://buckets/the-hf-stack/zenml-experiments/"))
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_bucket_glob_from_copied_tree_url() -> crate::Result<()> {
+        // The naive flow from #7217: copy the browser URL of a bucket tree page, swap the
+        // scheme for hf://, and glob.
+        let config = HuggingFaceConfig::default();
+        let client = HFSource::get_client(&config, &HTTPConfig::default()).await?;
+
+        let files: Vec<_> = client
+            .glob(
+                "hf://buckets/the-hf-stack/zenml-experiments/tree/trackio/data/*.parquet",
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await?
+            .try_collect()
+            .await?;
+        assert_eq!(files.len(), 1);
+        assert_eq!(
+            files[0].filepath,
+            "hf://buckets/the-hf-stack/zenml-experiments/trackio/data/train-00000-of-00001.parquet"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_bucket_unauthorized_hint_for_dataset_repo() -> crate::Result<()> {
+        // wikimedia/wikipedia is a (public) dataset but not a bucket. Hugging Face answers
+        // 401 for the nonexistent bucket, which must surface the buckets-vs-datasets hint
+        // instead of a bare credentials error.
+        let config = HuggingFaceConfig::default();
+        let client = HFSource::get_client(&config, &HTTPConfig::default()).await?;
+
+        let err = client
+            .get_size("hf://buckets/wikimedia/wikipedia/foo.parquet", None)
+            .await
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("hf://datasets/wikimedia/wikipedia"),
+            "unexpected error: {msg}"
+        );
+
+        Ok(())
+    }
 
     #[tokio::test]
     async fn test_full_get_from_hf() -> crate::Result<()> {

--- a/src/daft-io/src/huggingface/path.rs
+++ b/src/daft-io/src/huggingface/path.rs
@@ -179,6 +179,12 @@ impl FromStr for HFPathParts {
             // ^--------------^
             let mut path = uri.to_string().trim_end_matches('/').to_string();
             if repo_type == HFRepoType::Buckets {
+                // `tree` is a reserved segment in Hugging Face's bucket routing: the browser
+                // page for an object lives at `.../buckets/{repo}/tree/{path}`, and our own
+                // listing API call in `get_api_uri` hits `.../api/buckets/{repo}/tree/{path}`.
+                // It never denotes a real bucket object path. Users regularly copy the browser
+                // URL and swap `https://huggingface.co` for `hf://`, landing here with a leading
+                // `tree/` that isn't part of the object key, so strip it. See #7217.
                 path = path
                     .strip_prefix("tree/")
                     .unwrap_or(path.as_str())

--- a/src/daft-io/src/huggingface/path.rs
+++ b/src/daft-io/src/huggingface/path.rs
@@ -148,6 +148,7 @@ impl FromStr for HFPathParts {
             // [datasets] / {username} / {reponame} @ {revision} / {path from root}
             // ^--------^   !>
             let (repo_type_str, uri) = uri.split_once('/')?;
+            let repo_type = repo_type_str.parse().ok()?;
             // {username} / {reponame} @ {revision} / {path from root}
             // ^--------^   !>
             let (username, uri) = uri.split_once('/')?;
@@ -157,7 +158,7 @@ impl FromStr for HFPathParts {
                 (repo, uri)
             } else {
                 return Some(Self {
-                    repo_type: repo_type_str.parse().ok()?,
+                    repo_type,
                     repository: format!("{username}/{uri}"),
                     revision: "main".to_string(),
                     path: String::new(),
@@ -176,10 +177,16 @@ impl FromStr for HFPathParts {
             let repository = format!("{username}/{repository}");
             // {path from root}
             // ^--------------^
-            let path = uri.to_string().trim_end_matches('/').to_string();
+            let mut path = uri.to_string().trim_end_matches('/').to_string();
+            if repo_type == HFRepoType::Buckets {
+                path = path
+                    .strip_prefix("tree/")
+                    .unwrap_or(path.as_str())
+                    .to_string();
+            }
 
             Some(Self {
-                repo_type: repo_type_str.parse().ok()?,
+                repo_type,
                 repository,
                 revision,
                 path,
@@ -383,6 +390,26 @@ mod tests {
         };
 
         assert_eq!(parts, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_hf_parts_bucket_from_tree_url() -> DaftResult<()> {
+        let uri = "hf://buckets/the-hf-stack/zenml-experiments/tree/trackio/data/train-00000-of-00001.parquet";
+        let parts = uri.parse::<HFPathParts>().unwrap();
+        let expected = HFPathParts {
+            repo_type: HFRepoType::Buckets,
+            repository: "the-hf-stack/zenml-experiments".to_string(),
+            revision: "main".to_string(),
+            path: "trackio/data/train-00000-of-00001.parquet".to_string(),
+        };
+
+        assert_eq!(parts, expected);
+        assert_eq!(
+            parts.resolve_url(),
+            "https://huggingface.co/buckets/the-hf-stack/zenml-experiments/resolve/trackio/data/train-00000-of-00001.parquet"
+        );
 
         Ok(())
     }

--- a/src/daft-io/src/huggingface/path.rs
+++ b/src/daft-io/src/huggingface/path.rs
@@ -180,15 +180,20 @@ impl FromStr for HFPathParts {
             let mut path = uri.to_string().trim_end_matches('/').to_string();
             if repo_type == HFRepoType::Buckets {
                 // `tree` is a reserved segment in Hugging Face's bucket routing: the browser
-                // page for an object lives at `.../buckets/{repo}/tree/{path}`, and our own
-                // listing API call in `get_api_uri` hits `.../api/buckets/{repo}/tree/{path}`.
-                // It never denotes a real bucket object path. Users regularly copy the browser
-                // URL and swap `https://huggingface.co` for `hf://`, landing here with a leading
-                // `tree/` that isn't part of the object key, so strip it. See #7217.
-                path = path
-                    .strip_prefix("tree/")
-                    .unwrap_or(path.as_str())
-                    .to_string();
+                // page for an object lives at `.../buckets/{repo}/tree/{path}` (and the bucket
+                // root at `.../buckets/{repo}/tree`), and our own listing API call in
+                // `get_api_uri` hits `.../api/buckets/{repo}/tree/{path}`. It never denotes a
+                // real bucket object path. Users regularly copy the browser URL and swap
+                // `https://huggingface.co` for `hf://`, landing here with a leading `tree`
+                // segment that isn't part of the object key, so strip it. See #7217.
+                if path == "tree" {
+                    path = String::new();
+                } else {
+                    path = path
+                        .strip_prefix("tree/")
+                        .unwrap_or(path.as_str())
+                        .to_string();
+                }
             }
 
             Some(Self {
@@ -415,6 +420,94 @@ mod tests {
         assert_eq!(
             parts.resolve_url(),
             "https://huggingface.co/buckets/the-hf-stack/zenml-experiments/resolve/trackio/data/train-00000-of-00001.parquet"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_hf_parts_bucket_tree_root() -> DaftResult<()> {
+        // Copied from the bucket root browser page, with and without a trailing slash.
+        for uri in [
+            "hf://buckets/the-hf-stack/zenml-experiments/tree",
+            "hf://buckets/the-hf-stack/zenml-experiments/tree/",
+        ] {
+            let parts = uri.parse::<HFPathParts>().unwrap();
+            assert_eq!(parts.repo_type, HFRepoType::Buckets);
+            assert_eq!(parts.repository, "the-hf-stack/zenml-experiments");
+            assert_eq!(parts.path, "", "uri: {uri}");
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_hf_parts_bucket_tree_directory() -> DaftResult<()> {
+        // Copied from a directory browser page (directory pages end with a trailing slash).
+        let uri = "hf://buckets/the-hf-stack/zenml-experiments/tree/trackio/data/";
+        let parts = uri.parse::<HFPathParts>().unwrap();
+        assert_eq!(parts.path, "trackio/data");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_hf_parts_bucket_glob_under_tree() -> DaftResult<()> {
+        // A wildcard glob written against a copied tree URL.
+        let uri = "hf://buckets/the-hf-stack/zenml-experiments/tree/trackio/**/*.parquet";
+        let parts = uri.parse::<HFPathParts>().unwrap();
+        assert_eq!(parts.path, "trackio/**/*.parquet");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_hf_parts_bucket_tree_like_names_untouched() -> DaftResult<()> {
+        // Object keys that merely start with "tree" (not the reserved segment) must survive.
+        for (uri, expected_path) in [
+            (
+                "hf://buckets/org/repo/treehouse/file.parquet",
+                "treehouse/file.parquet",
+            ),
+            ("hf://buckets/org/repo/tree.parquet", "tree.parquet"),
+            (
+                "hf://buckets/org/repo/data/tree/file.parquet",
+                "data/tree/file.parquet",
+            ),
+        ] {
+            let parts = uri.parse::<HFPathParts>().unwrap();
+            assert_eq!(parts.path, expected_path, "uri: {uri}");
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_bucket_display_canonicalizes_and_is_idempotent() -> DaftResult<()> {
+        // `HFSource::glob` round-trips bucket paths through Display before globbing, and the
+        // glob machinery re-parses the result, so canonicalization must be a fixed point.
+        let uri = "hf://bucket/the-hf-stack/zenml-experiments/tree/trackio/data/file.parquet";
+        let parts = uri.parse::<HFPathParts>().unwrap();
+        let canonical = parts.to_string();
+        assert_eq!(
+            canonical,
+            "hf://buckets/the-hf-stack/zenml-experiments/trackio/data/file.parquet"
+        );
+        let reparsed = canonical.parse::<HFPathParts>().unwrap();
+        assert_eq!(reparsed, parts);
+        assert_eq!(reparsed.to_string(), canonical);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_bucket_api_uri_from_tree_url() -> DaftResult<()> {
+        // The listing API re-inserts the reserved `tree` marker exactly once.
+        let uri = "hf://buckets/the-hf-stack/zenml-experiments/tree/trackio/data";
+        let parts = uri.parse::<HFPathParts>().unwrap();
+        assert_eq!(
+            super::HFPath::Hf(parts).get_api_uri(),
+            "https://huggingface.co/api/buckets/the-hf-stack/zenml-experiments/tree/trackio/data"
         );
 
         Ok(())


### PR DESCRIPTION
## Summary

Normalize `hf://buckets` paths copied from Hugging Face `/tree/` pages before globbing, and harden bucket listing/globbing/errors based on live-API behavior.

Fixes #7217.

- Strip the reserved `tree` segment from copied browser URLs (`hf://buckets/org/repo/tree/{path}`, including the bucket-root `.../tree`), and canonicalize bucket glob paths before globbing.
- Fix bucket listings: the buckets tree API returns entries without the git `oid` field, so every non-empty bucket `ls` failed to deserialize — breaking all wildcard globs on buckets. `Item.oid` is now optional.
- Follow `Link: rel="next"` pagination on tree listings (1000 entries/page); previously large-bucket globs silently truncated. Also benefits dataset listings.
- Actionable error for bucket 401s: Hugging Face returns 401 both for private buckets and buckets that don't exist — including when a user swaps `datasets`→`buckets` in a URI (datasets are **not** automatically exposed as buckets). Previously this surfaced as a bare "check your credentials" error; it now explains buckets vs datasets and points at `hf://datasets/...`.
- Skip the datasets-only parquet-conversion API for buckets (previously produced the same misleading 401 on bucket-root reads).

## Tests

- `cargo test -p daft-io huggingface` — parse-level tests for naive copied-URL patterns (file/dir/root tree URLs, globs under `tree/`, tree-like object keys left untouched, canonicalization idempotence) plus live-API tests for bucket `ls`, tree-URL wildcard glob, and the dataset-as-bucket error hint.
- End-to-end against a local build:
  - original `/tree/` bucket parquet MRE from #7217 (350 rows)
  - wildcard glob through a copied tree URL (previously broken)
  - recursive `**/*.parquet` glob from bucket root
  - `hf://buckets/wikimedia/wikipedia/...` (dataset-as-bucket) surfaces the buckets-vs-datasets hint