### PR TITLE
refactor(shuffle): dedup local shuffle backend enums for gather and into_partitions

### DIFF
--- a/src/daft-local-execution/src/sinks/gather.rs
+++ b/src/daft-local-execution/src/sinks/gather.rs
@@ -11,8 +11,11 @@ use daft_shuffles::{
 };
 use tracing::{Span, instrument};
 
-use super::blocking_sink::{
-    BlockingSink, BlockingSinkFinalizeResult, BlockingSinkOutput, BlockingSinkSinkResult,
+use super::{
+    blocking_sink::{
+        BlockingSink, BlockingSinkFinalizeResult, BlockingSinkOutput, BlockingSinkSinkResult,
+    },
+    shuffle_backend::{FlightShuffleContext, LocalShuffleBackend},
 };
 use crate::{
     ExecutionTaskSpawner,
@@ -29,19 +32,8 @@ impl RayGatherState {
     }
 }
 
-/// Shared config for all Flight gather states produced by a single GatherSink.
-struct FlightShared {
-    shuffle_id: u64,
-    shuffle_dirs: Vec<String>,
-    compression: Option<String>,
-    local_server: Arc<ShuffleFlightServer>,
-    shuffle_address: String,
-    target_in_memory_size_per_partition: usize,
-    schema: SchemaRef,
-}
-
 pub(crate) struct FlightGatherState {
-    shared: Arc<FlightShared>,
+    shared: Arc<FlightShuffleContext>,
     input_id: InputId,
     refs: Vec<FlightPartitionRef>,
 }
@@ -96,53 +88,37 @@ impl GatherState {
     }
 }
 
-// TODO: unify shuffle backends in all local operations
-#[derive(Clone)]
-enum GatherBackend {
-    Ray,
-    Flight(Arc<FlightShared>),
-}
-
-impl GatherBackend {
-    fn name(&self) -> &'static str {
-        match self {
-            Self::Ray => "Ray",
-            Self::Flight(_) => "Flight",
-        }
-    }
-
-    fn collect_output(&self, states: Vec<GatherState>) -> BlockingSinkOutput {
-        match self {
-            Self::Ray => BlockingSinkOutput::Partitions(
-                states
-                    .into_iter()
-                    .flat_map(|s| match s {
-                        GatherState::Ray(s) => s.partitions,
-                        GatherState::Flight(_) => unreachable!("GatherSink state/backend mismatch"),
-                    })
-                    .collect(),
-            ),
-            Self::Flight(_) => BlockingSinkOutput::FlightPartitionRefs(
-                states
-                    .into_iter()
-                    .flat_map(|s| match s {
-                        GatherState::Flight(s) => s.refs,
-                        GatherState::Ray(_) => unreachable!("GatherSink state/backend mismatch"),
-                    })
-                    .collect(),
-            ),
-        }
+fn collect_output(backend: &LocalShuffleBackend, states: Vec<GatherState>) -> BlockingSinkOutput {
+    match backend {
+        LocalShuffleBackend::Ray => BlockingSinkOutput::Partitions(
+            states
+                .into_iter()
+                .flat_map(|s| match s {
+                    GatherState::Ray(s) => s.partitions,
+                    GatherState::Flight(_) => unreachable!("GatherSink state/backend mismatch"),
+                })
+                .collect(),
+        ),
+        LocalShuffleBackend::Flight(_) => BlockingSinkOutput::FlightPartitionRefs(
+            states
+                .into_iter()
+                .flat_map(|s| match s {
+                    GatherState::Flight(s) => s.refs,
+                    GatherState::Ray(_) => unreachable!("GatherSink state/backend mismatch"),
+                })
+                .collect(),
+        ),
     }
 }
 
 pub struct GatherSink {
-    backend: GatherBackend,
+    backend: LocalShuffleBackend,
 }
 
 impl GatherSink {
     pub fn new_ray() -> Self {
         Self {
-            backend: GatherBackend::Ray,
+            backend: LocalShuffleBackend::Ray,
         }
     }
 
@@ -159,7 +135,7 @@ impl GatherSink {
         // `RepartitionSink`'s per-partition clamp so the two sinks spill at similar sizes.
         const TARGET_IN_MEMORY_SIZE_BYTES: usize = 1024 * 1024 * 128;
         Ok(Self {
-            backend: GatherBackend::Flight(Arc::new(FlightShared {
+            backend: LocalShuffleBackend::Flight(Arc::new(FlightShuffleContext {
                 shuffle_id,
                 shuffle_dirs,
                 compression,
@@ -203,7 +179,7 @@ impl BlockingSink for GatherSink {
         let backend = self.backend.clone();
         spawner
             .spawn(
-                async move { Ok(backend.collect_output(states)) },
+                async move { Ok(collect_output(&backend, states)) },
                 Span::current(),
             )
             .into()
@@ -223,10 +199,10 @@ impl BlockingSink for GatherSink {
 
     fn make_state(&self, input_id: InputId) -> DaftResult<Self::State> {
         match &self.backend {
-            GatherBackend::Ray => Ok(GatherState::Ray(RayGatherState {
+            LocalShuffleBackend::Ray => Ok(GatherState::Ray(RayGatherState {
                 partitions: Vec::new(),
             })),
-            GatherBackend::Flight(shared) => Ok(GatherState::Flight(FlightGatherState {
+            LocalShuffleBackend::Flight(shared) => Ok(GatherState::Flight(FlightGatherState {
                 shared: shared.clone(),
                 input_id,
                 refs: Vec::new(),

--- a/src/daft-local-execution/src/sinks/into_partitions.rs
+++ b/src/daft-local-execution/src/sinks/into_partitions.rs
@@ -11,8 +11,11 @@ use daft_shuffles::{
 };
 use tracing::{Span, instrument};
 
-use super::blocking_sink::{
-    BlockingSink, BlockingSinkFinalizeResult, BlockingSinkOutput, BlockingSinkSinkResult,
+use super::{
+    blocking_sink::{
+        BlockingSink, BlockingSinkFinalizeResult, BlockingSinkOutput, BlockingSinkSinkResult,
+    },
+    shuffle_backend::{FlightShuffleContext, LocalShuffleBackend},
 };
 use crate::{
     ExecutionTaskSpawner,
@@ -55,14 +58,14 @@ impl RayIntoPartitionsState {
 }
 
 pub(crate) struct FlightIntoPartitionsState {
-    shared: Arc<FlightShared>,
+    shared: Arc<FlightShuffleContext>,
     caches: Vec<InProgressShuffleCache>,
     rotation_offset: usize,
 }
 
 impl FlightIntoPartitionsState {
     fn try_new(
-        shared: Arc<FlightShared>,
+        shared: Arc<FlightShuffleContext>,
         input_id: InputId,
         num_partitions: usize,
     ) -> DaftResult<Self> {
@@ -156,45 +159,18 @@ impl IntoPartitionsState {
     }
 }
 
-/// Shared Flight config for all states produced by one IntoPartitionsSink.
-struct FlightShared {
-    shuffle_id: u64,
-    shuffle_dirs: Vec<String>,
-    compression: Option<String>,
-    local_server: Arc<ShuffleFlightServer>,
-    shuffle_address: String,
-    target_in_memory_size_per_partition: usize,
-    schema: SchemaRef,
-}
-
-// Mirrors the pattern in `sinks/gather.rs::GatherBackend` and
-// `sinks/repartition.rs::RepartitionBackend` — a runtime enum that picks
-// between the Ray path and the Flight path and carries Flight's runtime handles.
-#[derive(Clone)]
-enum IntoPartitionsBackend {
-    Ray { schema: SchemaRef },
-    Flight(Arc<FlightShared>),
-}
-
-impl IntoPartitionsBackend {
-    fn name(&self) -> &'static str {
-        match self {
-            Self::Ray { .. } => "Ray",
-            Self::Flight(_) => "Flight",
-        }
-    }
-}
-
 pub struct IntoPartitionsSink {
     num_partitions: usize,
-    backend: IntoPartitionsBackend,
+    schema: SchemaRef,
+    backend: LocalShuffleBackend,
 }
 
 impl IntoPartitionsSink {
     pub fn new_ray(num_partitions: usize, schema: SchemaRef) -> Self {
         Self {
             num_partitions,
-            backend: IntoPartitionsBackend::Ray { schema },
+            schema,
+            backend: LocalShuffleBackend::Ray,
         }
     }
 
@@ -216,7 +192,8 @@ impl IntoPartitionsSink {
         .clamp(1024 * 1024 * 8, 1024 * 1024 * 128);
         Ok(Self {
             num_partitions,
-            backend: IntoPartitionsBackend::Flight(Arc::new(FlightShared {
+            schema: schema.clone(),
+            backend: LocalShuffleBackend::Flight(Arc::new(FlightShuffleContext {
                 shuffle_id,
                 shuffle_dirs,
                 compression,
@@ -259,12 +236,13 @@ impl BlockingSink for IntoPartitionsSink {
     ) -> BlockingSinkFinalizeResult {
         let backend = self.backend.clone();
         let num_partitions = self.num_partitions;
+        let schema = self.schema.clone();
 
         spawner
             .spawn(
                 async move {
                     match backend {
-                        IntoPartitionsBackend::Ray { schema } => {
+                        LocalShuffleBackend::Ray => {
                             let ray_states = states
                                 .into_iter()
                                 .map(|s| match s {
@@ -279,7 +257,7 @@ impl BlockingSink for IntoPartitionsSink {
                             )?;
                             Ok(BlockingSinkOutput::Partitions(outputs))
                         }
-                        IntoPartitionsBackend::Flight(_) => {
+                        LocalShuffleBackend::Flight(_) => {
                             debug_assert_eq!(
                                 states.len(),
                                 1,
@@ -321,12 +299,10 @@ impl BlockingSink for IntoPartitionsSink {
 
     fn make_state(&self, input_id: InputId) -> DaftResult<Self::State> {
         match &self.backend {
-            IntoPartitionsBackend::Ray { .. } => {
-                Ok(IntoPartitionsState::Ray(RayIntoPartitionsState {
-                    partitions: Vec::new(),
-                }))
-            }
-            IntoPartitionsBackend::Flight(shared) => Ok(IntoPartitionsState::Flight(
+            LocalShuffleBackend::Ray => Ok(IntoPartitionsState::Ray(RayIntoPartitionsState {
+                partitions: Vec::new(),
+            })),
+            LocalShuffleBackend::Flight(shared) => Ok(IntoPartitionsState::Flight(
                 FlightIntoPartitionsState::try_new(shared.clone(), input_id, self.num_partitions)?,
             )),
         }

--- a/src/daft-local-execution/src/sinks/mod.rs
+++ b/src/daft-local-execution/src/sinks/mod.rs
@@ -7,6 +7,7 @@ pub mod grouped_aggregate;
 pub mod into_partitions;
 pub mod pivot;
 pub mod repartition;
+pub mod shuffle_backend;
 pub mod sort;
 pub mod top_n;
 pub mod window_base;

--- a/src/daft-local-execution/src/sinks/shuffle_backend.rs
+++ b/src/daft-local-execution/src/sinks/shuffle_backend.rs
@@ -1,0 +1,34 @@
+use std::sync::Arc;
+
+use daft_core::prelude::SchemaRef;
+use daft_shuffles::server::flight_server::ShuffleFlightServer;
+
+/// Runtime config shared by all Flight-backed states of a single shuffle sink.
+pub(crate) struct FlightShuffleContext {
+    pub(crate) shuffle_id: u64,
+    pub(crate) shuffle_dirs: Vec<String>,
+    pub(crate) compression: Option<String>,
+    pub(crate) local_server: Arc<ShuffleFlightServer>,
+    pub(crate) shuffle_address: String,
+    pub(crate) target_in_memory_size_per_partition: usize,
+    pub(crate) schema: SchemaRef,
+}
+
+/// Picks between the Ray path and the Flight path for local shuffle operators
+/// and carries Flight's runtime handles.
+// TODO: unify shuffle backends in all local operations. Remaining:
+// `sinks/repartition.rs` and the dispatch blocks in `pipeline.rs`.
+#[derive(Clone)]
+pub(crate) enum LocalShuffleBackend {
+    Ray,
+    Flight(Arc<FlightShuffleContext>),
+}
+
+impl LocalShuffleBackend {
+    pub(crate) fn name(&self) -> &'static str {
+        match self {
+            Self::Ray => "Ray",
+            Self::Flight(_) => "Flight",
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Extracts a shared `LocalShuffleBackend` runtime enum and `FlightShuffleContext` struct in `daft-local-execution` and migrates `GatherSink` and `IntoPartitionsSink` onto them. This is the first of two PRs resolving the `// TODO: unify shuffle backends in all local operations` markers (#7212); the second migrates `RepartitionSink` and collapses the backend dispatch in `pipeline.rs`.

## Why

`sinks/gather.rs` and `sinks/into_partitions.rs` each defined their own Ray/Flight backend enum plus a `FlightShared` struct that was duplicated field-for-field between the two files. Every operator added to the flight shuffle backend (e.g. Sort or Pre-Shuffle Merge from the #6472 phase 2 checklist) currently has to copy this pattern again. See #7212 for the full plan.

## Changes Made

- Add `sinks/shuffle_backend.rs` with `LocalShuffleBackend { Ray, Flight(Arc<FlightShuffleContext>) }` and `FlightShuffleContext` holding the formerly duplicated fields (`shuffle_id`, `shuffle_dirs`, `compression`, `local_server`, `shuffle_address`, `target_in_memory_size_per_partition`, `schema`)
- `sinks/gather.rs`: delete `GatherBackend` and `FlightShared`, use the shared types; `collect_output` becomes a free function over `LocalShuffleBackend`
- `sinks/into_partitions.rs`: delete `IntoPartitionsBackend` and `FlightShared`; `schema` moves from the `Ray` enum variant onto `IntoPartitionsSink` itself
- Net -13 lines (+87/-100)

## Behavior

Functionally equivalent for all inputs. Constructor signatures (`new_ray` / `try_new_flight`), spill thresholds, state machines, and node display names (`Gather(Ray)`, `IntoPartitions(Flight)`) are all unchanged.

## Test Plan

- `cargo check -p daft-local-execution --lib` clean
- `cargo fmt -p daft-local-execution` clean
- `cargo clippy -p daft-local-execution --lib --no-deps` clean for the touched files (pre-existing warnings elsewhere in the crate unchanged)
- No Rust unit tests exist for these sinks; ran the Python integration suite locally: `DAFT_RUNNER=ray pytest tests/dataframe/test_shuffles.py`, 39 passed, covering gather / into_partitions / repartition under both the Ray and Flight backends including empty-input edge cases

## Related Issues

First of two PRs for #7212. Part of #6472.