### PR TITLE
fix(native): prevent async UDF hangs

### DIFF
--- a/daft/event_loop.py
+++ b/daft/event_loop.py
@@ -2,27 +2,54 @@ from __future__ import annotations
 
 import asyncio
 import threading
+from concurrent.futures import Future, TimeoutError
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from collections.abc import Coroutine
 
 
+_KEEPALIVE_INTERVAL_SECONDS = 0.01
+_STARTUP_TIMEOUT_SECONDS = 5.0
+
+
 class BackgroundEventLoop:
     def __init__(self) -> None:
-        self.loop = asyncio.new_event_loop()
+        start_result: Future[asyncio.AbstractEventLoop] = Future()
+
+        def run_loop() -> None:
+            try:
+                self.loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(self.loop)
+                self._schedule_keepalive()
+                start_result.set_result(self.loop)
+            except BaseException as exc:
+                if not start_result.done():
+                    start_result.set_exception(exc)
+                return
+            self.loop.run_forever()
+
         thread = threading.Thread(
-            target=self.loop.run_forever,
+            target=run_loop,
             name="DaftBackgroundEventLoop",
             daemon=True,
         )
         thread.start()
+        try:
+            self.loop = start_result.result(timeout=_STARTUP_TIMEOUT_SECONDS)
+        except TimeoutError as exc:
+            raise RuntimeError("Timed out starting Daft background event loop") from exc
 
     @classmethod
     def from_existing_loop(cls, loop: asyncio.AbstractEventLoop) -> BackgroundEventLoop:
         obj = cls.__new__(cls)
         obj.loop = loop
         return obj
+
+    def _schedule_keepalive(self) -> None:
+        # Keep selector waits finite so cross-thread coroutine submissions are
+        # picked up even on platforms where the wakeup fd does not fire.
+        self.loop.call_later(_KEEPALIVE_INTERVAL_SECONDS, self._schedule_keepalive)
 
     def run(self, future: Coroutine[Any, Any, Any]) -> Any:
         return asyncio.run_coroutine_threadsafe(future, self.loop).result()

--- a/src/daft-local-execution/src/run.rs
+++ b/src/daft-local-execution/src/run.rs
@@ -232,7 +232,8 @@ impl PyNativeExecutor {
         };
 
         let executor = self.executor.clone();
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        let task_locals = pyo3_async_runtimes::tokio::get_current_locals(py)?;
+        pyo3_async_runtimes::tokio::future_into_py_with_locals(py, task_locals, async move {
             let result = enqueue_future.await?;
             Ok(PyResultReceiver {
                 result: Arc::new(tokio::sync::Mutex::new(Some(result))),
@@ -694,7 +695,8 @@ impl PyResultReceiver {
 
     fn __anext__<'a>(&self, py: Python<'a>) -> PyResult<Bound<'a, pyo3::PyAny>> {
         let result = self.result.clone();
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        let task_locals = pyo3_async_runtimes::tokio::get_current_locals(py)?;
+        pyo3_async_runtimes::tokio::future_into_py_with_locals(py, task_locals, async move {
             let mut result = result.lock().await;
             let part = result
                 .as_mut()
@@ -726,7 +728,8 @@ impl PyResultReceiver {
         let executor = self.executor.clone();
         let fingerprint = self.fingerprint;
         let input_id = self.input_id;
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        let task_locals = pyo3_async_runtimes::tokio::get_current_locals(py)?;
+        pyo3_async_runtimes::tokio::future_into_py_with_locals(py, task_locals, async move {
             // Take the result to drop the receiver
             let mut result = result.lock().await;
             let _ = result

--- a/tests/test_event_loop.py
+++ b/tests/test_event_loop.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.timeout(5)
+def test_background_event_loop_runs_coroutine():
+    from daft.event_loop import BackgroundEventLoop
+
+    async def return_value() -> int:
+        return 1
+
+    event_loop = BackgroundEventLoop()
+
+    assert event_loop.run(return_value()) == 1
+
+
+@pytest.mark.timeout(5)
+def test_background_event_loop_startup_errors_propagate(monkeypatch):
+    import asyncio
+
+    from daft.event_loop import BackgroundEventLoop
+
+    def fail_new_event_loop():
+        raise RuntimeError("loop startup failed")
+
+    monkeypatch.setattr(asyncio, "new_event_loop", fail_new_event_loop)
+
+    with pytest.raises(RuntimeError, match="loop startup failed"):
+        BackgroundEventLoop()

--- a/tests/udf/test_row_wise_udf.py
+++ b/tests/udf/test_row_wise_udf.py
@@ -186,6 +186,57 @@ def test_row_wise_async_udf():
     assert sorted(async_df.to_pydict()["x"]) == ["5", "7", "9"]
 
 
+@pytest.mark.skipif(get_tests_daft_runner_name() != "native", reason="requires Native Runner to be in use")
+@pytest.mark.timeout(5)
+def test_row_wise_async_udf_with_limit_completes_native_runner():
+    @daft.func
+    async def add_one(x: int) -> int:
+        await asyncio.sleep(0.01)
+        return x + 1
+
+    result = daft.range(10, partitions=2).with_column("id", add_one(col("id"))).limit(3).to_pydict()
+
+    assert result == {"id": [1, 2, 3]}
+
+
+@pytest.mark.skipif(get_tests_daft_runner_name() != "native", reason="requires Native Runner to be in use")
+@pytest.mark.timeout(5)
+def test_row_wise_async_udf_awaitable_uses_current_loop_native_runner():
+    @daft.func
+    async def add_one(x: int) -> int:
+        await asyncio.sleep(0.01)
+        return x + 1
+
+    # Initialize the shared Rust task locals on Daft's background loop first.
+    assert daft.range(2, partitions=1).with_column("id", add_one(col("id"))).limit(1).to_pydict() == {"id": [1]}
+
+    async def run_native_executor_on_current_loop() -> None:
+        from daft.context import get_context
+        from daft.daft import LocalPhysicalPlan
+        from daft.daft import NativeExecutor as _NativeExecutor
+
+        ctx = get_context()
+        builder = (
+            daft.range(2, partitions=1)
+            .with_column("id", add_one(col("id")))
+            .limit(1)
+            ._builder.optimize(ctx.daft_execution_config)
+        )
+        plan, inputs = LocalPhysicalPlan.from_logical_plan_builder(builder._builder, {})
+        result_future = _NativeExecutor(False, "").run(
+            plan,
+            ctx._ctx,
+            0,
+            dict(inputs),
+            None,
+            ctx.daft_execution_config.maintain_order,
+        )
+        assert result_future.get_loop() is asyncio.get_running_loop()
+        result_future.cancel()
+
+    asyncio.run(run_native_executor_on_current_loop())
+
+
 @pytest.mark.parametrize("max_concurrency", [1, 2])
 def test_row_wise_async_udf_max_concurrency(max_concurrency):
     @daft.func(max_concurrency=max_concurrency)


### PR DESCRIPTION
## Changes Made

- Initialize Daft's background asyncio loop on its owning thread and keep selector waits finite so cross-thread submissions are picked up reliably.
- Bind native executor Python awaitables to Daft's shared task locals with `future_into_py_with_locals`.
- Add regression coverage for the background event loop and the native async UDF + limit hang from the issue.

Root cause: native execution awaited Rust futures through Python awaitables without consistently using Daft's background event loop locals. In environments where asyncio's cross-thread wakeup was not observed promptly, the submitted coroutine could remain parked indefinitely, so native async UDF queries never yielded their first result.

Validation:

- `make build`
- `DAFT_RUNNER=native python -m pytest -q tests/test_event_loop.py tests/udf/test_row_wise_udf.py::test_row_wise_async_udf_with_limit_completes_native_runner tests/udf/test_row_wise_udf.py::test_row_wise_async_udf tests/dataframe/test_async_context.py`
- Manual issue repro with `DAFT_RUNNER=native timeout 10s python ...`, which now prints `{'id': [1, 2, 3]}` and `done`
- `git diff --check`

## Related Issues

Closes #7225