### PR TITLE
fix(io): route oss:// through S3-compatible storage options for write_lance

### DIFF
--- a/daft/io/object_store_options.py
+++ b/daft/io/object_store_options.py
@@ -20,7 +20,10 @@ def io_config_to_storage_options(io_config: IOConfig, table_uri: str | pathlib.P
         table_uri = str(table_uri)
     parsed = urlparse(table_uri)
     scheme = parsed.scheme
-    if scheme == "s3" or scheme == "s3a":
+    if scheme == "s3" or scheme == "s3a" or scheme == "oss":
+        # Alibaba Cloud OSS is S3-compatible, so we reuse the S3 storage options.
+        # OSS requires a custom endpoint and virtual-hosted-style addressing, both
+        # of which are already handled by the S3 helper via the S3Config fields.
         bucket = parsed.netloc
         return _s3_config_to_storage_options(io_config.s3, bucket)
     elif scheme == "gcs" or scheme == "gs":

--- a/daft/io/object_store_options.py
+++ b/daft/io/object_store_options.py
@@ -21,9 +21,9 @@ def io_config_to_storage_options(io_config: IOConfig, table_uri: str | pathlib.P
     parsed = urlparse(table_uri)
     scheme = parsed.scheme
     if scheme == "s3" or scheme == "s3a" or scheme == "oss":
-        # Alibaba Cloud OSS is S3-compatible, so we reuse the S3 storage options.
-        # OSS requires a custom endpoint and virtual-hosted-style addressing, both
-        # of which are already handled by the S3 helper via the S3Config fields.
+        # alibaba oss is s3-compatible - reuse the s3 storage options. oss just needs
+        # a custom endpoint and virtual-hosted-style addressing, both already handled
+        # by the s3 helper via S3Config.
         bucket = parsed.netloc
         return _s3_config_to_storage_options(io_config.s3, bucket)
     elif scheme == "gcs" or scheme == "gs":

--- a/tests/io/test_object_store_options.py
+++ b/tests/io/test_object_store_options.py
@@ -44,3 +44,27 @@ def test_convert_to_s3_config():
     expected_s3_config.update(endpoint_url="https://s3.us-east-2.amazonaws.com")
     expected_s3_config.pop("virtual_hosted_style_request")
     assert config == expected_s3_config
+
+
+def test_convert_oss_to_s3_config():
+    # Alibaba Cloud OSS is S3-compatible and is routed through the S3 storage options.
+    # See: https://github.com/Eventual-Inc/Daft/issues/5539
+    s3_config = S3Config(
+        region_name="oss-cn-hangzhou",
+        endpoint_url="https://oss-cn-hangzhou.aliyuncs.com",
+        key_id="dummy_ak",
+        access_key="dummy_sk",
+        force_virtual_addressing=True,
+    )
+    table_uri = "oss://dummy_bucket/path"
+
+    config = io_config_to_storage_options(IOConfig(s3=s3_config), table_uri=table_uri)
+
+    # OSS must resolve to the S3 storage options (previously returned None).
+    assert config is not None
+    assert config["region"] == "oss-cn-hangzhou"
+    assert config["access_key_id"] == "dummy_ak"
+    assert config["secret_access_key"] == "dummy_sk"
+    # Virtual-hosted-style addressing rewrites the endpoint to include the bucket.
+    assert config["virtual_hosted_style_request"] == "true"
+    assert config["endpoint_url"] == "https://dummy_bucket.oss-cn-hangzhou.aliyuncs.com"

--- a/tests/io/test_object_store_options.py
+++ b/tests/io/test_object_store_options.py
@@ -47,8 +47,8 @@ def test_convert_to_s3_config():
 
 
 def test_convert_oss_to_s3_config():
-    # Alibaba Cloud OSS is S3-compatible and is routed through the S3 storage options.
-    # See: https://github.com/Eventual-Inc/Daft/issues/5539
+    # alibaba oss is s3-compatible - routed through the s3 storage options.
+    # see https://github.com/Eventual-Inc/Daft/issues/5539
     s3_config = S3Config(
         region_name="oss-cn-hangzhou",
         endpoint_url="https://oss-cn-hangzhou.aliyuncs.com",
@@ -60,11 +60,11 @@ def test_convert_oss_to_s3_config():
 
     config = io_config_to_storage_options(IOConfig(s3=s3_config), table_uri=table_uri)
 
-    # OSS must resolve to the S3 storage options (previously returned None).
+    # oss must resolve to the s3 storage options - used to return None.
     assert config is not None
     assert config["region"] == "oss-cn-hangzhou"
     assert config["access_key_id"] == "dummy_ak"
     assert config["secret_access_key"] == "dummy_sk"
-    # Virtual-hosted-style addressing rewrites the endpoint to include the bucket.
+    # virtual-hosted-style addressing rewrites the endpoint to include the bucket.
     assert config["virtual_hosted_style_request"] == "true"
     assert config["endpoint_url"] == "https://dummy_bucket.oss-cn-hangzhou.aliyuncs.com"


### PR DESCRIPTION
Fixes #5539.

## What

`io_config_to_storage_options()` returned `None` for `oss://` URIs, so `write_lance` (and other `object_store`-backed writers) to Alibaba Cloud OSS failed with `LanceError(IO): Operation not yet implemented`.

## Why / How

Alibaba OSS is S3-compatible. This routes the `oss://` scheme through the existing `_s3_config_to_storage_options` helper, which already emits the custom endpoint and virtual-hosted-style addressing OSS needs (via the `S3Config` fields). Three-line change plus a unit test.

## Testing

Added `test_convert_oss_to_s3_config` asserting an `oss://` URI now resolves to the S3 storage-options dict (region/keys carried through, endpoint rewritten to `https://<bucket>.oss-...aliyuncs.com`, `virtual_hosted_style_request=true`). Exercised the mapping directly against the compiled config types; `ruff check`/`ruff format --check` clean. I did not perform a live write against a real OSS bucket.

## AI disclosure

Produced with LLM assistance; I reviewed the change and verified the mapping locally as described.
