### PR TITLE
fix(io): decode video with a single PyAV generator so .mkv/.webm yield frames

### DIFF
--- a/daft/io/av/_read_video_frames.py
+++ b/daft/io/av/_read_video_frames.py
@@ -156,13 +156,10 @@ class _VideoFramesSourceTask(DataSourceTask):
             # Small tolerance for floating point comparisons
             epsilon: float = 1e-9 if sample_interval is None else max(1e-9, sample_interval * 1e-6)
 
-            # Decode the selected stream with a single generator. Recreating the
-            # generator on every iteration (``next(container.decode(stream))``) is
-            # unsupported by PyAV: it drops buffered frames and, depending on the
-            # container, can raise ``EOFError`` immediately, which the loop below
-            # would treat as a clean end-of-stream and silently return zero frames.
-            # This is what caused ``.mkv``/``.webm`` files to yield an empty
-            # DataFrame while ``.mp4`` happened to survive it (see #5172).
+            # recreating the decode generator each iteration (next(container.decode(stream)))
+            # is unsupported by pyav - it drops buffered frames and can raise EOFError early,
+            # which the loop below treated as clean EOF and returned nothing. so .mkv/.webm
+            # gave an empty dataframe while .mp4 happened to survive it (see #5172). create it once.
             frame_iter = container.decode(stream)
 
             frame_index: int = 0

--- a/daft/io/av/_read_video_frames.py
+++ b/daft/io/av/_read_video_frames.py
@@ -156,14 +156,21 @@ class _VideoFramesSourceTask(DataSourceTask):
             # Small tolerance for floating point comparisons
             epsilon: float = 1e-9 if sample_interval is None else max(1e-9, sample_interval * 1e-6)
 
+            # Decode the selected stream with a single generator. Recreating the
+            # generator on every iteration (``next(container.decode(stream))``) is
+            # unsupported by PyAV: it drops buffered frames and, depending on the
+            # container, can raise ``EOFError`` immediately, which the loop below
+            # would treat as a clean end-of-stream and silently return zero frames.
+            # This is what caused ``.mkv``/``.webm`` files to yield an empty
+            # DataFrame while ``.mp4`` happened to survive it (see #5172).
+            frame_iter = container.decode(stream)
+
             frame_index: int = 0
             frame: VideoFrame
             while True:
                 try:
-                    frame = next(container.decode(stream))
-                except av.EOFError:
-                    break
-                except StopIteration:
+                    frame = next(frame_iter)
+                except (av.EOFError, StopIteration):
                     break
 
                 frame_time = frame.time

--- a/daft/io/av/_read_video_frames.py
+++ b/daft/io/av/_read_video_frames.py
@@ -156,10 +156,6 @@ class _VideoFramesSourceTask(DataSourceTask):
             # Small tolerance for floating point comparisons
             epsilon: float = 1e-9 if sample_interval is None else max(1e-9, sample_interval * 1e-6)
 
-            # recreating the decode generator each iteration (next(container.decode(stream)))
-            # is unsupported by pyav - it drops buffered frames and can raise EOFError early,
-            # which the loop below treated as clean EOF and returned nothing. so .mkv/.webm
-            # gave an empty dataframe while .mp4 happened to survive it (see #5172). create it once.
             frame_iter = container.decode(stream)
 
             frame_index: int = 0

--- a/tests/io/av/test_video.py
+++ b/tests/io/av/test_video.py
@@ -31,9 +31,6 @@ def _make_mock_container(frame_times: list[float], key_frames: list[bool] | None
         frame.to_ndarray.return_value = np.zeros((2, 2, 3), dtype="uint8")
         frames.append(frame)
 
-    # pyav's container.decode(stream) returns one generator iterated to completion,
-    # so the mock hands back a single iterator over all frames, not a fresh
-    # one-frame iterator per call.
     mock_container.decode.return_value = iter(frames)
 
     return mock_container

--- a/tests/io/av/test_video.py
+++ b/tests/io/av/test_video.py
@@ -31,14 +31,10 @@ def _make_mock_container(frame_times: list[float], key_frames: list[bool] | None
         frame.to_ndarray.return_value = np.zeros((2, 2, 3), dtype="uint8")
         frames.append(frame)
 
-    def decode_side_effect(*args, **kwargs):  # type: ignore[override]
-        if decode_side_effect.frames:
-            frame = decode_side_effect.frames.pop(0)
-            return iter([frame])
-        raise StopIteration
-
-    decode_side_effect.frames = frames.copy()  # type: ignore[attr-defined]
-    mock_container.decode.side_effect = decode_side_effect
+    # PyAV's ``container.decode(stream)`` returns a single generator that is
+    # iterated to completion, so the mock returns one iterator over all frames
+    # rather than a fresh one-frame iterator per call.
+    mock_container.decode.return_value = iter(frames)
 
     return mock_container
 
@@ -51,7 +47,14 @@ def test_read_video_eof():
     mock_stream.type = "video"
     mock_stream.codec_context = MagicMock()
     mock_container.streams = [mock_stream]
-    mock_container.decode.side_effect = av.EOFError(0, "mock message", "mock.mp4")
+
+    # PyAV raises EOFError while iterating the decode generator, so model the
+    # error on iteration rather than on the ``decode()`` call itself.
+    def _raise_eof():
+        raise av.EOFError(0, "mock message", "mock.mp4")
+        yield  # pragma: no cover - makes this a generator
+
+    mock_container.decode.return_value = _raise_eof()
 
     # Create single task because we only want to test `_list_frames`.
     task = _VideoFramesSourceTask(
@@ -133,6 +136,33 @@ def test_list_frames_no_sampling_returns_all_frames():
 
     assert [f.frame_time for f in frames] == frame_times
     assert [f.frame_index for f in frames] == list(range(len(frame_times)))
+
+
+def test_list_frames_uses_single_decode_generator():
+    """Regression test for #5172.
+
+    ``_list_frames`` must decode the stream with a single generator. Recreating
+    ``container.decode(stream)`` on every iteration drops buffered frames and, for
+    some containers (e.g. .mkv/.webm), yields zero frames while .mp4 survives it.
+    """
+    frame_times = [0.0, 0.5, 1.0, 1.5, 2.0]
+    mock_container = _make_mock_container(frame_times)
+
+    task = _VideoFramesSourceTask(
+        path="test.mkv",
+        image_height=480,
+        image_width=640,
+        is_key_frame=None,
+        io_config=None,
+        sample_interval_seconds=None,
+    )
+
+    with patch("av.open", return_value=mock_container):
+        frames = list(task._list_frames("test.mkv", "dummy_file"))
+
+    # All frames are returned, and decode() is invoked exactly once.
+    assert [f.frame_time for f in frames] == frame_times
+    assert mock_container.decode.call_count == 1
 
 
 def test_list_frames_sampling_by_seconds_filters_frames():

--- a/tests/io/av/test_video.py
+++ b/tests/io/av/test_video.py
@@ -31,9 +31,9 @@ def _make_mock_container(frame_times: list[float], key_frames: list[bool] | None
         frame.to_ndarray.return_value = np.zeros((2, 2, 3), dtype="uint8")
         frames.append(frame)
 
-    # PyAV's ``container.decode(stream)`` returns a single generator that is
-    # iterated to completion, so the mock returns one iterator over all frames
-    # rather than a fresh one-frame iterator per call.
+    # pyav's container.decode(stream) returns one generator iterated to completion,
+    # so the mock hands back a single iterator over all frames, not a fresh
+    # one-frame iterator per call.
     mock_container.decode.return_value = iter(frames)
 
     return mock_container
@@ -48,8 +48,8 @@ def test_read_video_eof():
     mock_stream.codec_context = MagicMock()
     mock_container.streams = [mock_stream]
 
-    # PyAV raises EOFError while iterating the decode generator, so model the
-    # error on iteration rather than on the ``decode()`` call itself.
+    # pyav raises EOFError while iterating the decode generator, not on the
+    # decode() call itself - so model it on iteration.
     def _raise_eof():
         raise av.EOFError(0, "mock message", "mock.mp4")
         yield  # pragma: no cover - makes this a generator
@@ -141,9 +141,9 @@ def test_list_frames_no_sampling_returns_all_frames():
 def test_list_frames_uses_single_decode_generator():
     """Regression test for #5172.
 
-    ``_list_frames`` must decode the stream with a single generator. Recreating
-    ``container.decode(stream)`` on every iteration drops buffered frames and, for
-    some containers (e.g. .mkv/.webm), yields zero frames while .mp4 survives it.
+    _list_frames must decode with a single generator. recreating
+    container.decode(stream) each iteration drops buffered frames and, for some
+    containers (.mkv/.webm), yields zero frames while .mp4 survives it.
     """
     frame_times = [0.0, 0.5, 1.0, 1.5, 2.0]
     mock_container = _make_mock_container(frame_times)
@@ -160,7 +160,7 @@ def test_list_frames_uses_single_decode_generator():
     with patch("av.open", return_value=mock_container):
         frames = list(task._list_frames("test.mkv", "dummy_file"))
 
-    # All frames are returned, and decode() is invoked exactly once.
+    # all frames returned, decode() called exactly once.
     assert [f.frame_time for f in frames] == frame_times
     assert mock_container.decode.call_count == 1
 


### PR DESCRIPTION
Fixes #5172.

## What

`read_video_frames` returned an empty DataFrame for `.mkv`/`.webm` while `.mp4` worked.

## Root cause

The decode loop recreated the PyAV decode generator on every iteration:

```python
while True:
    frame = next(container.decode(stream))   # new generator each time
```

Recreating `container.decode(stream)` per frame is unsupported by PyAV — it drops buffered frames and, depending on the container, raises `EOFError` on the freshly-created generator, which the loop treated as a clean end-of-stream. `.mp4` happened to survive this; `.mkv`/`.webm` did not.

## How

Create the decode generator once, before the loop, and iterate it to completion.

## Testing

- Verified locally by decoding generated `.mp4`/`.mkv`/`.webm` fixtures with PyAV: the old per-iteration pattern lost frames, the single-generator fix decodes the full set from all three containers.
- Updated the test mocks to model PyAV's real contract — `container.decode(stream)` returns **one** generator iterated to completion (the previous mocks returned a fresh one-frame iterator per call, which only matched the buggy code path), and `EOFError` is now raised while iterating rather than from the `decode()` call. Existing behavior (graceful empty result on EOF) is preserved.
- Added `test_list_frames_uses_single_decode_generator` (all frames returned, `decode()` called exactly once).

**Verification limits (honest):** I could not run the full `read_video_frames` path end-to-end (needs a native maturin build), and could not reproduce a *literally* empty result on synthetic fixtures — the exact zero-frame symptom is codec/container specific — but the per-iteration generator recreation is unambiguously incorrect PyAV usage and the direct cause of container-dependent frame loss. I did **not** add a hard error on zero decoded frames, to preserve the graceful-empty-on-EOF behavior from #5343.

## AI disclosure

Produced with LLM assistance; I reviewed the change and verified it as described above.
