### PR TITLE
feat: add egodex dataset API

### DIFF
--- a/daft/datasets/__init__.py
+++ b/daft/datasets/__init__.py
@@ -1,5 +1,6 @@
 from daft.datasets.common_crawl import common_crawl
 from daft.datasets import droid
+from daft.datasets import egodex
 from daft.datasets import lerobot
 
-__all__ = ["common_crawl", "droid", "lerobot"]
+__all__ = ["common_crawl", "droid", "egodex", "lerobot"]

--- a/daft/datasets/egodex.py
+++ b/daft/datasets/egodex.py
@@ -1,0 +1,455 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any, cast
+
+import daft
+from daft.api_annotations import PublicAPI
+from daft.datatype import DataType
+from daft.expressions import col, lit
+from daft.functions import (
+    file_exists,
+    hdf5_file,
+    regexp_replace,
+    video_file,
+    video_frames,
+    when,
+)
+
+if TYPE_CHECKING:
+    from daft.dataframe import DataFrame
+    from daft.file.hdf5 import Hdf5File
+    from daft.io import IOConfig
+
+
+# The 68 upper-body and hand joints tracked with a per-frame confidence score.
+JOINTS: tuple[str, ...] = (
+    "hip",
+    "leftArm",
+    "leftForearm",
+    "leftHand",
+    "leftIndexFingerIntermediateBase",
+    "leftIndexFingerIntermediateTip",
+    "leftIndexFingerKnuckle",
+    "leftIndexFingerMetacarpal",
+    "leftIndexFingerTip",
+    "leftLittleFingerIntermediateBase",
+    "leftLittleFingerIntermediateTip",
+    "leftLittleFingerKnuckle",
+    "leftLittleFingerMetacarpal",
+    "leftLittleFingerTip",
+    "leftMiddleFingerIntermediateBase",
+    "leftMiddleFingerIntermediateTip",
+    "leftMiddleFingerKnuckle",
+    "leftMiddleFingerMetacarpal",
+    "leftMiddleFingerTip",
+    "leftRingFingerIntermediateBase",
+    "leftRingFingerIntermediateTip",
+    "leftRingFingerKnuckle",
+    "leftRingFingerMetacarpal",
+    "leftRingFingerTip",
+    "leftShoulder",
+    "leftThumbIntermediateBase",
+    "leftThumbIntermediateTip",
+    "leftThumbKnuckle",
+    "leftThumbTip",
+    "neck1",
+    "neck2",
+    "neck3",
+    "neck4",
+    "rightArm",
+    "rightForearm",
+    "rightHand",
+    "rightIndexFingerIntermediateBase",
+    "rightIndexFingerIntermediateTip",
+    "rightIndexFingerKnuckle",
+    "rightIndexFingerMetacarpal",
+    "rightIndexFingerTip",
+    "rightLittleFingerIntermediateBase",
+    "rightLittleFingerIntermediateTip",
+    "rightLittleFingerKnuckle",
+    "rightLittleFingerMetacarpal",
+    "rightLittleFingerTip",
+    "rightMiddleFingerIntermediateBase",
+    "rightMiddleFingerIntermediateTip",
+    "rightMiddleFingerKnuckle",
+    "rightMiddleFingerMetacarpal",
+    "rightMiddleFingerTip",
+    "rightRingFingerIntermediateBase",
+    "rightRingFingerIntermediateTip",
+    "rightRingFingerKnuckle",
+    "rightRingFingerMetacarpal",
+    "rightRingFingerTip",
+    "rightShoulder",
+    "rightThumbIntermediateBase",
+    "rightThumbIntermediateTip",
+    "rightThumbKnuckle",
+    "rightThumbTip",
+    "spine1",
+    "spine2",
+    "spine3",
+    "spine4",
+    "spine5",
+    "spine6",
+    "spine7",
+)
+
+# The 69 SE(3) transform datasets: every joint plus the egocentric camera pose.
+TRANSFORM_JOINTS: tuple[str, ...] = ("camera", *JOINTS)
+
+# All 138 HDF5 dataset paths present in every EgoDex episode file, in file order.
+TRAJECTORY_FIELDS: tuple[str, ...] = (
+    "camera/intrinsic",
+    *(f"confidences/{joint}" for joint in JOINTS),
+    *(f"transforms/{joint}" for joint in TRANSFORM_JOINTS),
+)
+
+# Every EgoDex dataset is float32: intrinsics are (3, 3), confidences are (N,),
+# and transforms are (N, 4, 4) where N is the episode's frame count.
+_TRAJECTORY_DTYPES: dict[str, DataType] = {field: DataType.tensor(DataType.float32()) for field in TRAJECTORY_FIELDS}
+
+_DEFAULT_TRAJECTORY_FIELDS: tuple[str, ...] = (
+    "camera/intrinsic",
+    "transforms/camera",
+    "transforms/leftHand",
+    "transforms/rightHand",
+    "confidences/leftHand",
+    "confidences/rightHand",
+)
+DEFAULT_TRAJECTORY_FIELDS = _DEFAULT_TRAJECTORY_FIELDS
+
+# Root attributes attached to each episode HDF5 file. Some keys are absent on
+# older files; missing attributes surface as nulls in the metadata struct.
+_METADATA_FIELD_DTYPES: dict[str, DataType] = {
+    "task": DataType.string(),
+    "llm_description": DataType.string(),
+    "llm_description2": DataType.string(),
+    "which_llm_description": DataType.string(),
+    "llm_type": DataType.string(),
+    "llm_verbs": DataType.list(DataType.string()),
+    "llm_objects": DataType.list(DataType.string()),
+    "environment": DataType.string(),
+    "object": DataType.string(),
+    "session_name": DataType.string(),
+    "annotated": DataType.bool(),
+    "annotator_version": DataType.string(),
+    "extra": DataType.string(),
+    "description": DataType.string(),
+    "description2": DataType.string(),
+    "type": DataType.string(),
+}
+
+_METADATA_DTYPE = DataType.struct(_METADATA_FIELD_DTYPES)
+
+_METADATA_FIELDS: tuple[str, ...] = tuple(_METADATA_FIELD_DTYPES)
+
+_LIST_METADATA_FIELDS: frozenset[str] = frozenset(("llm_verbs", "llm_objects"))
+
+
+def _attr_value(value: object) -> object:
+    """Coerce h5py attribute values (NumPy scalars/arrays, bytes) to plain Python."""
+    if value is None:
+        return None
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    if hasattr(value, "ndim"):
+        array_value = cast("Any", value)
+        if array_value.ndim == 0:
+            return _attr_value(array_value.item())
+        return [_attr_value(item) for item in array_value.tolist()]
+    if hasattr(value, "item"):
+        scalar_value = cast("Any", value)
+        return _attr_value(scalar_value.item())
+    return value
+
+
+def _as_str_list(value: str | Sequence[str] | None) -> list[str] | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return [value]
+    return list(value)
+
+
+def _as_int_list(value: int | Sequence[int] | None) -> list[int] | None:
+    if value is None:
+        return None
+    if isinstance(value, int):
+        return [value]
+    return list(value)
+
+
+@PublicAPI
+def raw(
+    path: str,
+    io_config: IOConfig | None = None,
+    *,
+    tasks: str | Sequence[str] | None = None,
+    episode_ids: int | Sequence[int] | None = None,
+) -> DataFrame:
+    r"""Load a local copy of the raw EgoDex dataset as a lazy episode-level DataFrame.
+
+    `EgoDex https://github.com/apple/ml-egodex` is a large-scale egocentric
+    dexterous manipulation dataset from Apple, with 829 hours of Apple Vision Pro
+    video across 194 tabletop tasks, paired with 3D upper-body and hand pose
+    annotations. Each episode is one ``<n>.hdf5`` pose/annotation file plus a
+    sibling ``<n>.mp4`` egocentric video, grouped in one directory per task.
+
+    This function discovers episodes by globbing ``*.hdf5`` files under the provided
+    dataset root, derives ``task`` and ``episode_id`` from the file path, optionally
+    filters by those path-derived fields, reads the episode-level annotation
+    attributes, and attaches lazy file references to the trajectory HDF5 file and
+    its sibling MP4 video.
+
+    Note:
+        The EgoDex dataset is released under CC-BY-NC-ND terms, which prohibit
+        redistribution, so Daft cannot host it or default to a public copy — you
+        must download it yourself and pass the extracted root path. The archives
+        (``part1.zip`` … ``part5.zip`` for train, ``test.zip``, and ``extra.zip``)
+        are hosted on Apple's CDN::
+
+            curl -O https://ml-site.cdn-apple.com/datasets/egodex/test.zip
+
+        See https://github.com/apple/ml-egodex for the full download and license
+        details. ``path`` may point at the extracted root, a single part, or a
+        single task directory; episodes are discovered recursively.
+
+    Args:
+        path: Root path of a downloaded EgoDex extraction. Supports local paths
+            and remote object stores (for private copies you host yourself).
+        io_config: IO configuration for accessing remote storage.
+        tasks: Optional task name or names to keep. This filter is applied before
+            HDF5 metadata attributes are read.
+        episode_ids: Optional episode id or ids to keep. This filter is applied
+            before HDF5 metadata attributes are read.
+
+    Returns:
+        A DataFrame with one row per episode:
+
+        - ``task``: task name, derived from the episode's parent directory
+        - ``episode_id``: integer episode id, derived from the file stem
+        - ``metadata``: struct of episode-level HDF5 root attributes (natural
+          language descriptions, annotation provenance, etc.)
+        - ``trajectory``: lazy ``daft.Hdf5File`` reference to the pose HDF5 file
+        - ``video``: lazy ``daft.VideoFile`` reference to the egocentric MP4,
+          or null if the sibling video is missing
+
+    Examples:
+        >>> import daft
+        >>> df = daft.datasets.egodex.raw("/data/egodex")  # doctest: +SKIP
+        >>> towels = daft.datasets.egodex.raw("/data/egodex", tasks="fold_towel")  # doctest: +SKIP
+        >>> df.select("task", "episode_id", "video").show()  # doctest: +SKIP
+    """
+    hdf5_glob = f"{path.rstrip('/')}/**/*.hdf5"
+    task_values = _as_str_list(tasks)
+    episode_id_values = _as_int_list(episode_ids)
+
+    @daft.func(
+        return_dtype=_METADATA_DTYPE,
+        use_process=False,
+    )
+    def read_egodex_metadata(file: Hdf5File) -> dict[str, object]:
+        attrs = file.attrs()
+        values = {name: _attr_value(attrs.get(name)) for name in _METADATA_FIELDS}
+        # Daft cannot yet build a struct series when a list-typed field is null on
+        # every row of a batch, so missing list attributes become empty lists.
+        for name in _LIST_METADATA_FIELDS:
+            if values[name] is None:
+                values[name] = []
+        return values
+
+    episode_paths = daft.from_glob_path(hdf5_glob, io_config=io_config).select(
+        "path",
+        col("path").split("/")[-2].alias("task"),
+        col("path").split("/")[-1].split(".")[0].cast(DataType.int64()).alias("episode_id"),
+    )
+    if task_values is not None:
+        episode_paths = episode_paths.where(col("task").is_in(task_values))
+    if episode_id_values is not None:
+        episode_paths = episode_paths.where(col("episode_id").is_in(episode_id_values))
+
+    episodes = (
+        episode_paths.select(
+            "task",
+            "episode_id",
+            hdf5_file(col("path"), io_config=io_config).alias("trajectory"),
+            video_file(
+                regexp_replace(col("path"), r"\.hdf5$", ".mp4"),
+                io_config=io_config,
+            ).alias("video"),
+        )
+        .with_column(
+            "video",
+            when(file_exists(col("video")), col("video")).otherwise(lit(None)),
+        )
+        .with_column("metadata", read_egodex_metadata(col("trajectory")))
+    )
+
+    return episodes.select(
+        "task",
+        "episode_id",
+        "metadata",
+        "trajectory",
+        "video",
+    )
+
+
+@PublicAPI
+def trajectory(
+    episodes: DataFrame,
+    fields: Sequence[str] = _DEFAULT_TRAJECTORY_FIELDS,
+) -> DataFrame:
+    r"""Read selected pose datasets from episode-level EgoDex HDF5 files.
+
+    This helper takes the lazy episode catalog produced by :func:`raw` and adds
+    tensor columns for the requested HDF5 datasets. Each output row still
+    corresponds to one episode; use filters such as ``limit`` on ``episodes``
+    before calling this function to avoid reading more data than needed.
+
+    Every EgoDex episode file contains 138 float32 datasets (see
+    ``daft.datasets.egodex.TRAJECTORY_FIELDS``):
+
+    - ``camera/intrinsic``: the ``(3, 3)`` camera intrinsic matrix
+    - ``transforms/<joint>``: ``(N, 4, 4)`` world-frame SE(3) poses per frame,
+      for the camera and each of the 68 tracked joints
+    - ``confidences/<joint>``: ``(N,)`` per-frame tracking confidence per joint
+
+    Args:
+        episodes: Episode-level DataFrame from :func:`raw` containing a
+            ``trajectory`` ``Hdf5File`` column.
+        fields: HDF5 dataset paths to read, such as ``"transforms/leftHand"``.
+            Defaults to a curated set covering the camera intrinsics and pose,
+            and both hand poses with their confidences.
+
+    Returns:
+        The input DataFrame with one tensor column per requested field. Rows with
+        a null ``trajectory`` file are skipped before reading.
+
+    Examples:
+        >>> import daft
+        >>> from daft.datasets.egodex import raw, trajectory
+        >>> episodes = raw("/data/egodex").where(daft.col("task") == "fold_towel").limit(4)  # doctest: +SKIP
+        >>> traj = trajectory(  # doctest: +SKIP
+        ...     episodes,
+        ...     fields=["transforms/leftHand", "transforms/rightHand"],
+        ... )
+        >>> traj.select("task", "episode_id", "transforms/rightHand").collect()  # doctest: +SKIP
+    """
+    from daft.dependencies import h5py
+
+    if not h5py.module_available():  # ty:ignore[unresolved-attribute]
+        raise ImportError(
+            "The 'daft[hdf5]' extra is required to read EgoDex HDF5 trajectory files. "
+            "Please install it with: pip install 'daft[hdf5]'"
+        )
+
+    # Validation checks
+    fields = tuple(fields)
+    if "trajectory" not in episodes.schema().column_names():
+        raise ValueError("Expected an episode DataFrame with a `trajectory` column.")
+
+    if len(fields) == 0:
+        raise ValueError("fields must contain at least one HDF5 dataset path")
+
+    unknown = [f for f in fields if f not in _TRAJECTORY_DTYPES]
+    if unknown:
+        raise ValueError(f"Unknown trajectory field(s): {unknown}")
+
+    # Build the UDF that will read the trajectory data and return a struct of the requested fields
+    @daft.func(
+        return_dtype=DataType.struct({field: _TRAJECTORY_DTYPES[field] for field in fields}),
+        use_process=False,
+        unnest=True,
+    )
+    def read_egodex_trajectory(file: Hdf5File) -> dict[str, object]:
+        with file.to_tempfile() as tmp, h5py.File(tmp.name, "r") as h5:
+            return {field: h5[field][()] for field in fields}
+
+    # Select the columns we need and apply the UDF to the trajectory column
+    return episodes.where(col("trajectory").not_null()).select(
+        "task",
+        "episode_id",
+        "metadata",
+        read_egodex_trajectory(col("trajectory")),
+        "video",
+    )
+
+
+@PublicAPI
+def camera_frames(
+    episodes: DataFrame,
+    *,
+    start_time: float = 0,
+    end_time: float | None = None,
+    width: int | None = None,
+    height: int | None = None,
+    is_key_frame: bool | None = None,
+    sample_interval_seconds: float | None = None,
+) -> DataFrame:
+    r"""Decode EgoDex egocentric videos into a per-episode frame-list column.
+
+    This helper takes an episode-level DataFrame from :func:`raw` or
+    :func:`trajectory` and appends a ``video_frames`` column. It keeps one row
+    per episode; the frame-list column contains the structs returned by
+    :func:`daft.functions.video_frames`, including frame metadata and image data.
+
+    EgoDex videos are 1080p at 30fps, matching the pose annotations frame for
+    frame; pass ``sample_interval_seconds`` and/or ``width``/``height`` to keep
+    decode volume manageable.
+
+    Args:
+        episodes: Episode-level DataFrame containing an EgoDex ``video``
+            ``VideoFile`` column.
+        start_time: Start of the time range in seconds. Defaults to 0.
+        end_time: End of the time range in seconds. Defaults to None, meaning all frames.
+        width: Target width for resizing frames. Must be provided with ``height``.
+        height: Target height for resizing frames. Must be provided with ``width``.
+        is_key_frame: If True, decode only keyframes. If False, decode only non-keyframes.
+            If None, decode all frames.
+        sample_interval_seconds: If provided, sample frames at approximately this time
+            interval in seconds.
+
+    Returns:
+        The input DataFrame with a ``video_frames`` column appended.
+
+    Examples:
+        >>> import daft
+        >>> from daft.datasets.egodex import camera_frames, raw
+        >>> episodes = raw("/data/egodex").limit(1)  # doctest: +SKIP
+        >>> frames = camera_frames(episodes, width=224, height=224, sample_interval_seconds=1.0)  # doctest: +SKIP
+        >>> frames.select("task", "episode_id", "video_frames").collect()  # doctest: +SKIP
+    """
+    from daft.dependencies import av
+
+    if not cast("Any", av).module_available():
+        raise ImportError(
+            "The 'daft[video]' extra is required to decode EgoDex video frames. "
+            "Please install it with: pip install 'daft[video]'"
+        )
+
+    if "video" not in episodes.schema().column_names():
+        raise ValueError("Expected an episode DataFrame with an EgoDex `video` column.")
+
+    return episodes.with_column(
+        "video_frames",
+        video_frames(
+            col("video"),
+            start_time=start_time,
+            end_time=end_time,
+            width=width,
+            height=height,
+            is_key_frame=is_key_frame,
+            sample_interval_seconds=sample_interval_seconds,
+        ),
+    )
+
+
+__all__ = [
+    "DEFAULT_TRAJECTORY_FIELDS",
+    "JOINTS",
+    "TRAJECTORY_FIELDS",
+    "TRANSFORM_JOINTS",
+    "camera_frames",
+    "raw",
+    "trajectory",
+]

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -34,6 +34,7 @@
         * [Common Crawl](datasets/common-crawl.md)
         * [LeRobot v3](datasets/lerobot.md)
         * [DROID](datasets/droid.md)
+        * [EgoDex](datasets/egodex.md)
     * Data Connectors
         * [Overview](connectors/index.md)
         * Object Storage
@@ -112,6 +113,7 @@
     * [Window Functions](examples/window-functions.md)
     * [Working with Common Crawl Data](examples/common-crawl-daft-tutorial.md)
     * [Document Processing](examples/document-processing.md)
+    * [EgoDex Pose Curation](examples/egodex-pose-features.md)
 * Python API
     * [Python API](api/index.md)
     * [AI](api/ai.md)

--- a/docs/api/datasets.md
+++ b/docs/api/datasets.md
@@ -1,6 +1,6 @@
 # Datasets
 
-Daft provides simple, performant, and responsible ways to access useful datasets like [Common Crawl](https://commoncrawl.org/get-started) and [DROID](https://droid-dataset.github.io/).
+Daft provides simple, performant, and responsible ways to access useful datasets like [Common Crawl](https://commoncrawl.org/get-started), [DROID](https://droid-dataset.github.io/), and [EgoDex](https://github.com/apple/ml-egodex).
 
 ## Common Crawl
 
@@ -52,6 +52,25 @@ Check out our [DROID dataset guide](../datasets/droid.md) for more examples!
         heading_level: 3
 
 ::: daft.datasets.droid.camera_frames
+    options:
+        filters: ["!^_"]
+        heading_level: 3
+
+## EgoDex
+
+Check out our [EgoDex dataset guide](../datasets/egodex.md) for more examples!
+
+::: daft.datasets.egodex.raw
+    options:
+        filters: ["!^_"]
+        heading_level: 3
+
+::: daft.datasets.egodex.trajectory
+    options:
+        filters: ["!^_"]
+        heading_level: 3
+
+::: daft.datasets.egodex.camera_frames
     options:
         filters: ["!^_"]
         heading_level: 3

--- a/docs/datasets/egodex.md
+++ b/docs/datasets/egodex.md
@@ -1,0 +1,151 @@
+# How to use EgoDex with Daft
+
+[EgoDex](https://github.com/apple/ml-egodex) is a large-scale egocentric dexterous manipulation dataset from Apple, with 829 hours of Apple Vision Pro video across 194 tabletop tasks. Each episode pairs an egocentric 1080p/30fps video with frame-aligned 3D pose annotations: SE(3) transforms for the camera and 68 upper-body and hand joints, per-joint tracking confidences, the camera intrinsics, and natural language task descriptions.
+
+Daft provides a simple way to explore a downloaded EgoDex release as a lazy, episode-level DataFrame with the annotation HDF5 files attached as [`daft.Hdf5File`](../modalities/tensors.md#hdf5-files) and the egocentric videos as [`daft.VideoFile`](../modalities/videos.md) columns.
+
+## Prerequisites: downloading EgoDex
+
+The EgoDex dataset is released under CC-BY-NC-ND terms, which prohibit redistribution — so Daft cannot host a copy or default to a public bucket. Download the archives directly from Apple's CDN and extract them locally (or to an object store you control):
+
+```bash
+# Test split (~16 GB) — a good starting point
+curl -O https://ml-site.cdn-apple.com/datasets/egodex/test.zip
+
+# Training splits (5 parts, ~300 GB each)
+curl -O https://ml-site.cdn-apple.com/datasets/egodex/part1.zip
+# ... part2.zip through part5.zip
+
+# Additional data (~200 GB)
+curl -O https://ml-site.cdn-apple.com/datasets/egodex/extra.zip
+```
+
+!!! note
+    See the [official EgoDex repository](https://github.com/apple/ml-egodex) for the full download list and license terms. The license also prohibits distributing derivative datasets, such as converted copies — with Daft you can query the raw release in place, so no conversion or re-hosting is required.
+
+## Quickstart
+
+Point [`daft.datasets.egodex.raw()`](../api/datasets.md#daft.datasets.egodex.raw) at your extracted root (the root, a single part, or a single task directory all work):
+
+```python
+import daft
+
+df = daft.datasets.egodex.raw("/data/egodex")
+df.select("task", "episode_id", "metadata", "video").show(3)
+```
+
+**Each row corresponds to one EgoDex episode.** Episodes are discovered by globbing `*.hdf5` files; `task` and `episode_id` are derived from the file path, and the episode-level annotation attributes are read into a typed `metadata` struct.
+
+For fast iteration, filter by path-derived fields directly in `raw()` so Daft can narrow the catalog before reading HDF5 attributes:
+
+```python
+towels = daft.datasets.egodex.raw(
+    "/data/egodex",
+    tasks="fold_towel",
+    episode_ids=[0, 1, 2],
+)
+```
+
+## API scope
+
+The first-class `daft.datasets.egodex` API is intentionally centered on stable dataset access patterns:
+
+- `raw()` catalogs downloaded episodes and attaches lazy `Hdf5File` / `VideoFile` columns.
+- `trajectory()` reads selected known HDF5 datasets into typed tensor columns.
+- `camera_frames()` decodes frame-aligned egocentric video when pixels are needed.
+- `JOINTS`, `TRANSFORM_JOINTS`, `TRAJECTORY_FIELDS`, and `DEFAULT_TRAJECTORY_FIELDS` expose the stable EgoDex field catalogs.
+
+Higher-level curation logic such as hand-pose feature engineering, motion trimming, tracking-quality scoring, visual overlays, embeddings, reward models, and scenario queries is kept in examples. Those pieces are built out of normal Daft expressions and UDFs, so teams can copy, tune, and version them without locking task-specific heuristics into the dataset reader API.
+
+## Episode layout
+
+EgoDex stores episodes as sibling file pairs inside one directory per task:
+
+```
+<root>/
+|---- part1/
+|       |---- fold_towel/
+|       |       |---- 0.hdf5    # Pose annotations + episode metadata attributes
+|       |       |---- 0.mp4     # Egocentric 1080p 30fps video
+|       |       |---- 1.hdf5
+|       |       |---- 1.mp4
+|       |---- stack_cups/
+|               |---- ...
+|---- test/
+        |---- ...
+```
+
+## Data schema
+
+`raw()` returns one row per episode:
+
+| Column        | Type      | Description                                                        |
+| ------------- | --------- | ------------------------------------------------------------------ |
+| `task`        | String    | Task name, derived from the episode's parent directory             |
+| `episode_id`  | Int64     | Episode id, derived from the file stem                             |
+| `metadata`    | Struct    | Episode annotation attributes (see below)                          |
+| `trajectory`  | File      | Lazy reference to the episode's pose annotation HDF5 file          |
+| `video`       | VideoFile | Lazy reference to the egocentric MP4, or null if missing           |
+
+The `metadata` struct carries the HDF5 root attributes, including the natural language `llm_description` / `llm_description2`, the extracted `llm_verbs` and `llm_objects`, and annotation provenance fields such as `annotated` and `annotator_version`. Attributes absent from older files surface as nulls.
+
+## Reading pose trajectories
+
+Every episode file contains 138 float32 datasets, cataloged in `daft.datasets.egodex.TRAJECTORY_FIELDS`:
+
+- `camera/intrinsic`: the `(3, 3)` camera intrinsic matrix
+- `transforms/<joint>`: `(N, 4, 4)` world-frame SE(3) poses per frame, for the camera and each of the 68 joints in `daft.datasets.egodex.JOINTS`
+- `confidences/<joint>`: `(N,)` per-frame tracking confidence per joint
+
+[`trajectory()`](../api/datasets.md#daft.datasets.egodex.trajectory) reads a selected set of fields as tensor columns, one row per episode. The default field set, exposed as `daft.datasets.egodex.DEFAULT_TRAJECTORY_FIELDS`, covers the camera intrinsics and pose plus both hand poses and confidences:
+
+```python
+from daft.datasets.egodex import raw, trajectory
+
+episodes = raw("/data/egodex").where(daft.col("task") == "fold_towel").limit(4)
+traj = trajectory(episodes, fields=["transforms/leftHand", "transforms/rightHand"])
+traj.select("task", "episode_id", "transforms/rightHand").collect()
+```
+
+Filter and `limit` the episode DataFrame *before* calling `trajectory()` so only the episodes you need are read.
+
+## Decoding video frames
+
+[`camera_frames()`](../api/datasets.md#daft.datasets.egodex.camera_frames) appends a `video_frames` column of decoded frames. Videos are 1080p at 30fps and frame-aligned with the pose annotations, so use `sample_interval_seconds` and `width`/`height` to keep decode volume manageable:
+
+```python
+from daft.datasets.egodex import camera_frames, raw
+
+episodes = raw("/data/egodex").limit(1)
+frames = camera_frames(episodes, width=224, height=224, sample_interval_seconds=1.0)
+frames.select("task", "episode_id", "video_frames").collect()
+```
+
+## Putting it together
+
+Find episodes by language description, then load poses and subsampled frames for just those episodes:
+
+```python
+import daft
+from daft.datasets.egodex import camera_frames, raw, trajectory
+
+matches = raw("/data/egodex", tasks="fold_towel").where(
+    daft.col("metadata")["llm_description"].contains("towel")
+).limit(8)
+
+df = camera_frames(
+    trajectory(matches, fields=["transforms/leftHand", "transforms/rightHand"]),
+    width=224,
+    height=224,
+    sample_interval_seconds=1.0,
+)
+df.collect()
+```
+
+## Next steps
+
+- Follow the [EgoDex pose curation tutorial](../examples/egodex-pose-features.md) to compute hand-motion features, trim idle frames, score tracking quality, and mine grasping episodes — or run it directly via [`examples/egodex_pose_features.py`](https://github.com/Eventual-Inc/Daft/blob/main/examples/egodex_pose_features.py).
+- See the [Videos modality guide](../modalities/videos.md) for decoding frames with [`video_frames`][daft.functions.video_frames] and working with [`daft.VideoFile`](../api/datatypes/file_types.md).
+- See the [Files modality guide](../modalities/files.md) for reading annotation HDF5 files with [`daft.File`](../api/datatypes/file_types.md).
+- Visit the [official EgoDex repository](https://github.com/apple/ml-egodex) for the dataset paper, download links, and license terms.
+- See the [EgoDex Dataset API reference](../api/datasets.md#egodex) for complete parameter documentation.

--- a/docs/examples/egodex-pose-features.md
+++ b/docs/examples/egodex-pose-features.md
@@ -1,0 +1,202 @@
+# Curating EgoDex Episodes with Pose Features
+
+Every [EgoDex](../datasets/egodex.md) episode carries frame-aligned SE(3) poses for the egocentric camera and 68 upper-body and hand joints, plus per-joint tracking confidences. That's enough signal to run the episode operations that dataset curation usually requires — **motion trimming**, **tracking-quality scoring**, and **grasp detection** — directly on the raw release, with no conversion pipeline and no separate tooling. Filter to the episodes you want, compute features with one Daft UDF, and write a curated table.
+
+This tutorial mirrors the runnable script at [`examples/egodex_pose_features.py`](https://github.com/Eventual-Inc/Daft/blob/main/examples/egodex_pose_features.py).
+
+## Setup
+
+```bash
+pip install "daft[hdf5]" numpy
+```
+
+You'll need a local EgoDex download — the CC-BY-NC-ND license prohibits redistribution, so there is no hosted copy. See the [EgoDex dataset guide](../datasets/egodex.md#prerequisites-downloading-egodex) for download instructions.
+
+## 1. Catalog the episodes
+
+[`daft.datasets.egodex.raw()`](../api/datasets.md#daft.datasets.egodex.raw) lazily catalogs one row per episode, with the annotation attributes in a typed `metadata` struct. You can filter on language descriptions before reading any pose data:
+
+```python
+import daft
+from daft import col
+from daft.datasets import egodex
+
+episodes = egodex.raw("/data/egodex")
+
+# Optional: narrow the catalog by task or language description first.
+episodes = episodes.where(col("metadata")["llm_description"].contains("towel"))
+```
+
+## 2. Read just the pose fields you need
+
+Each episode file holds 138 datasets; [`trajectory()`](../api/datasets.md#daft.datasets.egodex.trajectory) reads only the fields you request. For hand-centric curation we need the wrists, the thumb and index fingertips, and the hand confidences:
+
+```python
+POSE_FIELDS = (
+    "transforms/leftHand",
+    "transforms/rightHand",
+    "transforms/leftThumbTip",
+    "transforms/leftIndexFingerTip",
+    "transforms/rightThumbTip",
+    "transforms/rightIndexFingerTip",
+    "confidences/leftHand",
+    "confidences/rightHand",
+)
+
+trajectories = egodex.trajectory(episodes, fields=POSE_FIELDS)
+```
+
+Each field arrives as a tensor column — transforms are `(N, 4, 4)` pose stacks and confidences are `(N,)` tracks, where `N` is the episode's frame count at 30fps.
+
+## 3. Compute pose features in one pass
+
+A single [`@daft.func`](../api/udf.md) turns the pose tensors into per-frame feature tracks and per-episode summary statistics. With `unnest=True`, each struct field becomes its own column:
+
+```python
+import numpy as np
+from daft import DataType
+
+FPS = 30.0  # EgoDex videos and pose annotations are captured at 30fps.
+SPEED_THRESHOLD_M_S = 0.05  # Below this wrist speed, a frame counts as idle.
+PINCH_THRESHOLD_M = 0.03  # Below this thumb-index distance, a frame counts as a grasp.
+
+_POSE_FEATURES_DTYPE = DataType.struct(
+    {
+        "num_frames": DataType.int64(),
+        "duration_s": DataType.float32(),
+        "mean_confidence": DataType.float32(),
+        "left_wrist_pos": DataType.tensor(DataType.float32()),
+        "right_wrist_pos": DataType.tensor(DataType.float32()),
+        "right_hand_speed": DataType.tensor(DataType.float32()),
+        "hands_distance": DataType.tensor(DataType.float32()),
+        "left_pinch_aperture": DataType.tensor(DataType.float32()),
+        "right_pinch_aperture": DataType.tensor(DataType.float32()),
+        "active_start": DataType.int64(),
+        "active_end": DataType.int64(),
+        "active_fraction": DataType.float32(),
+        "grasp_frames": DataType.int64(),
+    }
+)
+
+
+def _translations(transforms: np.ndarray) -> np.ndarray:
+    """Extract the (N, 3) translation track from an (N, 4, 4) SE(3) pose tensor."""
+    return np.asarray(transforms, dtype=np.float32)[:, :3, 3]
+
+
+@daft.func(return_dtype=_POSE_FEATURES_DTYPE, unnest=True)
+def pose_features(
+    left_hand: np.ndarray,
+    right_hand: np.ndarray,
+    left_thumb_tip: np.ndarray,
+    left_index_tip: np.ndarray,
+    right_thumb_tip: np.ndarray,
+    right_index_tip: np.ndarray,
+    left_confidence: np.ndarray,
+    right_confidence: np.ndarray,
+) -> dict[str, object]:
+    left_wrist = _translations(left_hand)
+    right_wrist = _translations(right_hand)
+    num_frames = len(right_wrist)
+
+    # Wrist speed in m/s from frame-to-frame displacement.
+    speed = np.zeros(num_frames, dtype=np.float32)
+    if num_frames > 1:
+        speed[1:] = np.linalg.norm(np.diff(right_wrist, axis=0), axis=1) * FPS
+
+    # Grasp proxy: distance between thumb tip and index fingertip.
+    left_pinch = np.linalg.norm(_translations(left_thumb_tip) - _translations(left_index_tip), axis=1)
+    right_pinch = np.linalg.norm(_translations(right_thumb_tip) - _translations(right_index_tip), axis=1)
+
+    # Motion trimming: the span between the first and last non-idle frame.
+    active = speed > SPEED_THRESHOLD_M_S
+    if active.any():
+        active_start = int(np.argmax(active))
+        active_end = int(num_frames - 1 - np.argmax(active[::-1]))
+    else:
+        active_start = None
+        active_end = None
+
+    return {
+        "num_frames": num_frames,
+        "duration_s": num_frames / FPS,
+        "mean_confidence": float(np.mean([left_confidence, right_confidence])),
+        "left_wrist_pos": left_wrist,
+        "right_wrist_pos": right_wrist,
+        "right_hand_speed": speed,
+        "hands_distance": np.linalg.norm(left_wrist - right_wrist, axis=1).astype(np.float32),
+        "left_pinch_aperture": left_pinch.astype(np.float32),
+        "right_pinch_aperture": right_pinch.astype(np.float32),
+        "active_start": active_start,
+        "active_end": active_end,
+        "active_fraction": float(active.mean()),
+        "grasp_frames": int((right_pinch < PINCH_THRESHOLD_M).sum()),
+    }
+
+
+features = trajectories.select(
+    "task",
+    "episode_id",
+    col("metadata")["llm_description"].alias("description"),
+    pose_features(
+        col("transforms/leftHand"),
+        col("transforms/rightHand"),
+        col("transforms/leftThumbTip"),
+        col("transforms/leftIndexFingerTip"),
+        col("transforms/rightThumbTip"),
+        col("transforms/rightIndexFingerTip"),
+        col("confidences/leftHand"),
+        col("confidences/rightHand"),
+    ),
+)
+```
+
+Because everything is lazy, the HDF5 files are read exactly once, when the query below executes — and only the eight requested datasets per file.
+
+## 4. Trim, score, and filter
+
+The feature columns are now ordinary Daft columns, so curation is plain DataFrame code. Drop poorly tracked episodes, drop episodes with no motion, and compute the trimmed duration implied by each episode's active segment:
+
+```python
+curated = features.where(
+    (col("mean_confidence") > 0.5) & col("active_start").not_null()
+).with_column(
+    "trimmed_duration_s",
+    (col("active_end") - col("active_start") + 1) / FPS,
+)
+```
+
+`active_start` and `active_end` are the motion-trim bounds: slice frame-aligned data (poses or decoded video frames) to `[active_start, active_end]` to cut idle lead-in and lead-out from every episode.
+
+## 5. Query for training scenarios
+
+Scenario mining is a filter. For example, rank episodes by how much grasping they contain:
+
+```python
+grasping = curated.where(col("grasp_frames") > 0).sort("grasp_frames", desc=True)
+grasping.select(
+    "task",
+    "episode_id",
+    "description",
+    "grasp_frames",
+    "active_fraction",
+    "trimmed_duration_s",
+    "mean_confidence",
+).show(8)
+```
+
+## 6. Write the curated table
+
+Persist the features for training-set assembly and later queries:
+
+```python
+curated.write_parquet("egodex_pose_features.parquet")
+```
+
+The Parquet table keys on `task` and `episode_id`, so you can join it back to [`camera_frames()`](../api/datasets.md#daft.datasets.egodex.camera_frames) output whenever a downstream step needs pixels — for example, decoding only the trimmed active segment of the grasping episodes you selected above.
+
+## Next steps
+
+- See the [EgoDex dataset guide](../datasets/egodex.md) for the full reading API, including video decoding.
+- See [UDF Patterns](udf-patterns.md) for more ways to structure user-defined functions like `pose_features`.
+- See the [EgoDex API reference](../api/datasets.md#egodex) for complete parameter documentation.

--- a/examples/egodex_pose_features.py
+++ b/examples/egodex_pose_features.py
@@ -1,0 +1,171 @@
+"""Curate EgoDex episodes with pose features computed in Daft.
+
+EgoDex episodes carry frame-aligned SE(3) poses for the camera and 68 joints.
+This example reads a downloaded EgoDex release in place with
+``daft.datasets.egodex`` and derives episode-curation signals directly from the
+pose tensors — no dataset conversion required:
+
+- per-frame wrist positions, hand speed, and thumb-index pinch apertures
+- motion trimming: the active segment of each episode, minus idle lead-in/out
+- tracking-quality scores from the per-joint confidences
+- grasp detection from pinch aperture, for scenario filtering
+
+The curated per-episode feature table is written to Parquet at the end, ready
+for supervised-learning dataset prep or further querying.
+
+Requires a local EgoDex download (the CC-BY-NC-ND license prohibits
+redistribution; see https://github.com/apple/ml-egodex):
+
+    pip install "daft[hdf5]" numpy
+    python examples/egodex_pose_features.py /data/egodex [features.parquet]
+"""
+
+from __future__ import annotations
+
+import sys
+
+import numpy as np
+
+import daft
+from daft import DataType, col
+from daft.datasets import egodex
+
+FPS = 30.0  # EgoDex videos and pose annotations are captured at 30fps.
+SPEED_THRESHOLD_M_S = 0.05  # Below this wrist speed, a frame counts as idle.
+PINCH_THRESHOLD_M = 0.03  # Below this thumb-index distance, a frame counts as a grasp.
+
+POSE_FIELDS = (
+    "transforms/leftHand",
+    "transforms/rightHand",
+    "transforms/leftThumbTip",
+    "transforms/leftIndexFingerTip",
+    "transforms/rightThumbTip",
+    "transforms/rightIndexFingerTip",
+    "confidences/leftHand",
+    "confidences/rightHand",
+)
+
+_POSE_FEATURES_DTYPE = DataType.struct(
+    {
+        "num_frames": DataType.int64(),
+        "duration_s": DataType.float32(),
+        "mean_confidence": DataType.float32(),
+        "left_wrist_pos": DataType.tensor(DataType.float32()),
+        "right_wrist_pos": DataType.tensor(DataType.float32()),
+        "right_hand_speed": DataType.tensor(DataType.float32()),
+        "hands_distance": DataType.tensor(DataType.float32()),
+        "left_pinch_aperture": DataType.tensor(DataType.float32()),
+        "right_pinch_aperture": DataType.tensor(DataType.float32()),
+        "active_start": DataType.int64(),
+        "active_end": DataType.int64(),
+        "active_fraction": DataType.float32(),
+        "grasp_frames": DataType.int64(),
+    }
+)
+
+
+def _translations(transforms: np.ndarray) -> np.ndarray:
+    """Extract the (N, 3) translation track from an (N, 4, 4) SE(3) pose tensor."""
+    return np.asarray(transforms, dtype=np.float32)[:, :3, 3]
+
+
+@daft.func(return_dtype=_POSE_FEATURES_DTYPE, unnest=True)
+def pose_features(
+    left_hand: np.ndarray,
+    right_hand: np.ndarray,
+    left_thumb_tip: np.ndarray,
+    left_index_tip: np.ndarray,
+    right_thumb_tip: np.ndarray,
+    right_index_tip: np.ndarray,
+    left_confidence: np.ndarray,
+    right_confidence: np.ndarray,
+) -> dict[str, object]:
+    left_wrist = _translations(left_hand)
+    right_wrist = _translations(right_hand)
+    num_frames = len(right_wrist)
+
+    # Wrist speed in m/s from frame-to-frame displacement.
+    speed = np.zeros(num_frames, dtype=np.float32)
+    if num_frames > 1:
+        speed[1:] = np.linalg.norm(np.diff(right_wrist, axis=0), axis=1) * FPS
+
+    # Grasp proxy: distance between thumb tip and index fingertip.
+    left_pinch = np.linalg.norm(_translations(left_thumb_tip) - _translations(left_index_tip), axis=1)
+    right_pinch = np.linalg.norm(_translations(right_thumb_tip) - _translations(right_index_tip), axis=1)
+
+    # Motion trimming: the span between the first and last non-idle frame.
+    active = speed > SPEED_THRESHOLD_M_S
+    if active.any():
+        active_start = int(np.argmax(active))
+        active_end = int(num_frames - 1 - np.argmax(active[::-1]))
+    else:
+        active_start = None
+        active_end = None
+
+    return {
+        "num_frames": num_frames,
+        "duration_s": num_frames / FPS,
+        "mean_confidence": float(np.mean([left_confidence, right_confidence])),
+        "left_wrist_pos": left_wrist,
+        "right_wrist_pos": right_wrist,
+        "right_hand_speed": speed,
+        "hands_distance": np.linalg.norm(left_wrist - right_wrist, axis=1).astype(np.float32),
+        "left_pinch_aperture": left_pinch.astype(np.float32),
+        "right_pinch_aperture": right_pinch.astype(np.float32),
+        "active_start": active_start,
+        "active_end": active_end,
+        "active_fraction": float(active.mean()),
+        "grasp_frames": int((right_pinch < PINCH_THRESHOLD_M).sum()),
+    }
+
+
+def main(egodex_root: str, output_path: str) -> None:
+    # 1. Catalog the episodes and read the pose fields we need — nothing else.
+    episodes = egodex.raw(egodex_root)
+    trajectories = egodex.trajectory(episodes, fields=POSE_FIELDS)
+
+    # 2. Compute per-frame features and per-episode summaries in one pass.
+    features = trajectories.select(
+        "task",
+        "episode_id",
+        col("metadata")["llm_description"].alias("description"),
+        pose_features(
+            col("transforms/leftHand"),
+            col("transforms/rightHand"),
+            col("transforms/leftThumbTip"),
+            col("transforms/leftIndexFingerTip"),
+            col("transforms/rightThumbTip"),
+            col("transforms/rightIndexFingerTip"),
+            col("confidences/leftHand"),
+            col("confidences/rightHand"),
+        ),
+    )
+
+    # 3. Curate: drop poorly tracked episodes and episodes with no motion,
+    #    and add the trimmed duration implied by the active segment.
+    curated = features.where((col("mean_confidence") > 0.5) & col("active_start").not_null()).with_column(
+        "trimmed_duration_s",
+        (col("active_end") - col("active_start") + 1) / FPS,
+    )
+
+    # 4. Query the curated table, e.g. for grasp-heavy episodes to train on.
+    grasping = curated.where(col("grasp_frames") > 0).sort("grasp_frames", desc=True)
+    grasping.select(
+        "task",
+        "episode_id",
+        "description",
+        "grasp_frames",
+        "active_fraction",
+        "trimmed_duration_s",
+        "mean_confidence",
+    ).show(8)
+
+    # 5. Persist the feature table for training-set assembly and later queries.
+    curated.write_parquet(output_path)
+    print(f"Wrote curated pose features to {output_path}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        sys.exit(f"Usage: {sys.argv[0]} <egodex_root> [output.parquet]")
+    main(sys.argv[1], sys.argv[2] if len(sys.argv) > 2 else "egodex_pose_features.parquet")

--- a/tests/datasets/test_egodex.py
+++ b/tests/datasets/test_egodex.py
@@ -1,0 +1,424 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+import daft
+import daft.datasets.egodex as egodex_module
+from daft import DataType, MediaType
+from daft.datasets.egodex import (
+    DEFAULT_TRAJECTORY_FIELDS,
+    JOINTS,
+    TRAJECTORY_FIELDS,
+    TRANSFORM_JOINTS,
+    camera_frames,
+    raw,
+    trajectory,
+)
+from daft.expressions import col
+
+NUM_FRAMES = 4
+
+_DEFAULT_ATTRS = {
+    "task": "fold_towel",
+    "llm_description": "Fold the towel in half.",
+    "llm_verbs": ["fold", "grasp"],
+    "llm_objects": ["towel"],
+    "annotated": True,
+}
+
+
+def _write_episode(
+    root: Path,
+    task: str = "fold_towel",
+    episode_id: int = 0,
+    *,
+    with_video: bool = True,
+    num_frames: int = NUM_FRAMES,
+    attrs: dict | None = None,
+) -> Path:
+    h5py = pytest.importorskip("h5py")
+    np = pytest.importorskip("numpy")
+
+    task_dir = root / task
+    task_dir.mkdir(parents=True, exist_ok=True)
+    hdf5_path = task_dir / f"{episode_id}.hdf5"
+
+    intrinsic = np.eye(3, dtype=np.float32) * 736.0
+    confidences = np.linspace(0.0, 1.0, num_frames, dtype=np.float32)
+    transforms = np.tile(np.eye(4, dtype=np.float32), (num_frames, 1, 1))
+
+    with h5py.File(hdf5_path, "w") as f:
+        f.create_dataset("camera/intrinsic", data=intrinsic)
+        for joint in JOINTS:
+            f.create_dataset(f"confidences/{joint}", data=confidences)
+        for joint in TRANSFORM_JOINTS:
+            f.create_dataset(f"transforms/{joint}", data=transforms)
+        for key, value in (_DEFAULT_ATTRS if attrs is None else attrs).items():
+            f.attrs[key] = value
+
+    if with_video:
+        (task_dir / f"{episode_id}.mp4").write_bytes(b"")
+
+    return hdf5_path
+
+
+def _write_playable_video(path: Path, num_frames: int = 6, width: int = 64, height: int = 48) -> None:
+    av = pytest.importorskip("av")
+    np = pytest.importorskip("numpy")
+
+    with av.open(str(path), "w") as container:
+        stream = container.add_stream("mpeg4", rate=30)
+        stream.width = width
+        stream.height = height
+        stream.pix_fmt = "yuv420p"
+        for i in range(num_frames):
+            image = np.full((height, width, 3), (i * 37) % 256, dtype=np.uint8)
+            frame = av.VideoFrame.from_ndarray(image, format="rgb24")
+            for packet in stream.encode(frame):
+                container.mux(packet)
+        for packet in stream.encode():
+            container.mux(packet)
+
+
+def _daft_file_uri(path: Path) -> str:
+    return f"file://{path}"
+
+
+def _as_list(value):
+    return value.tolist() if hasattr(value, "tolist") else value
+
+
+def test_egodex_raw_local_schema_order_and_file_columns(tmp_path) -> None:
+    _write_episode(tmp_path, task="fold_towel", episode_id=0)
+    _write_episode(tmp_path, task="stack_cups", episode_id=3)
+
+    df = raw(str(tmp_path))
+
+    assert [field.name for field in df.schema()] == [
+        "task",
+        "episode_id",
+        "metadata",
+        "trajectory",
+        "video",
+    ]
+
+    schema = {field.name: field.dtype for field in df.schema()}
+    assert schema["task"] == DataType.string()
+    assert schema["episode_id"] == DataType.int64()
+    assert schema["metadata"] == egodex_module._METADATA_DTYPE
+    assert schema["trajectory"] == DataType.file(MediaType.hdf5())
+    assert schema["video"] == DataType.file(MediaType.video())
+
+    result = (
+        df.select(
+            "task",
+            "episode_id",
+            col("trajectory").file_path().alias("trajectory_path"),
+            col("video").file_path().alias("video_path"),
+        )
+        .sort(["task", "episode_id"])
+        .collect()
+        .to_pydict()
+    )
+
+    assert result["task"] == ["fold_towel", "stack_cups"]
+    assert result["episode_id"] == [0, 3]
+    assert result["trajectory_path"] == [
+        _daft_file_uri(tmp_path / "fold_towel" / "0.hdf5"),
+        _daft_file_uri(tmp_path / "stack_cups" / "3.hdf5"),
+    ]
+    assert result["video_path"] == [
+        _daft_file_uri(tmp_path / "fold_towel" / "0.mp4"),
+        _daft_file_uri(tmp_path / "stack_cups" / "3.mp4"),
+    ]
+
+
+def test_egodex_raw_derives_task_from_parent_directory_at_any_depth(tmp_path) -> None:
+    _write_episode(tmp_path / "part1", task="open_drawer", episode_id=12)
+
+    result = raw(str(tmp_path)).select("task", "episode_id").collect().to_pydict()
+
+    assert result["task"] == ["open_drawer"]
+    assert result["episode_id"] == [12]
+
+
+def test_egodex_raw_reads_metadata_attrs(tmp_path) -> None:
+    _write_episode(tmp_path)
+
+    result = raw(str(tmp_path)).select("metadata").collect().to_pydict()
+    metadata = result["metadata"][0]
+
+    assert metadata["task"] == "fold_towel"
+    assert metadata["llm_description"] == "Fold the towel in half."
+    assert metadata["llm_verbs"] == ["fold", "grasp"]
+    assert metadata["llm_objects"] == ["towel"]
+    assert metadata["annotated"] is True
+    # Attributes absent from the file surface as nulls.
+    assert metadata["llm_description2"] is None
+    assert metadata["environment"] is None
+
+
+def test_egodex_raw_handles_minimal_metadata_attrs(tmp_path) -> None:
+    # Older EgoDex files carry only a subset of attributes.
+    _write_episode(tmp_path, attrs={"llm_description": "minimal episode"})
+
+    result = raw(str(tmp_path)).select("metadata").collect().to_pydict()
+    metadata = result["metadata"][0]
+
+    assert metadata["llm_description"] == "minimal episode"
+    assert metadata["task"] is None
+    assert metadata["annotated"] is None
+    # Missing list-valued attributes surface as empty lists.
+    assert metadata["llm_verbs"] == []
+    assert metadata["llm_objects"] == []
+
+
+def test_egodex_metadata_attr_value_coerces_h5py_values() -> None:
+    np = pytest.importorskip("numpy")
+
+    assert egodex_module._attr_value(None) is None
+    assert egodex_module._attr_value(b"fold_towel") == "fold_towel"
+    assert egodex_module._attr_value(np.array(b"stack_cups")) == "stack_cups"
+    assert egodex_module._attr_value(np.array([b"fold", b"grasp"])) == ["fold", "grasp"]
+    assert egodex_module._attr_value(np.float32(1.5)) == pytest.approx(1.5)
+    assert egodex_module._attr_value("plain") == "plain"
+
+
+def test_egodex_raw_sets_missing_video_to_null(tmp_path) -> None:
+    _write_episode(tmp_path, task="fold_towel", episode_id=0, with_video=False)
+    _write_episode(tmp_path, task="fold_towel", episode_id=1)
+
+    result = (
+        raw(str(tmp_path))
+        .select("episode_id", col("video").file_path().alias("video_path"))
+        .sort("episode_id")
+        .collect()
+        .to_pydict()
+    )
+
+    assert result["video_path"] == [None, _daft_file_uri(tmp_path / "fold_towel" / "1.mp4")]
+
+
+def test_egodex_raw_filters_by_single_task_before_returning_catalog(tmp_path) -> None:
+    _write_episode(tmp_path, task="fold_towel", episode_id=0)
+    _write_episode(tmp_path, task="stack_cups", episode_id=1)
+
+    result = raw(str(tmp_path), tasks="stack_cups").select("task", "episode_id").collect().to_pydict()
+
+    assert result["task"] == ["stack_cups"]
+    assert result["episode_id"] == [1]
+
+
+def test_egodex_raw_filters_by_task_list_and_episode_id_list(tmp_path) -> None:
+    _write_episode(tmp_path, task="fold_towel", episode_id=0)
+    _write_episode(tmp_path, task="fold_towel", episode_id=1)
+    _write_episode(tmp_path, task="stack_cups", episode_id=0)
+    _write_episode(tmp_path, task="open_drawer", episode_id=4)
+
+    result = (
+        raw(str(tmp_path), tasks=["fold_towel", "stack_cups"], episode_ids=[0, 2])
+        .select("task", "episode_id")
+        .sort("task")
+        .collect()
+        .to_pydict()
+    )
+
+    assert result["task"] == ["fold_towel", "stack_cups"]
+    assert result["episode_id"] == [0, 0]
+
+
+def test_egodex_raw_filters_by_single_episode_id(tmp_path) -> None:
+    _write_episode(tmp_path, task="fold_towel", episode_id=0)
+    _write_episode(tmp_path, task="fold_towel", episode_id=1)
+
+    result = raw(str(tmp_path), episode_ids=1).select("task", "episode_id").collect().to_pydict()
+
+    assert result["task"] == ["fold_towel"]
+    assert result["episode_id"] == [1]
+
+
+@pytest.fixture
+def sample_episodes_df(tmp_path):
+    _write_episode(tmp_path)
+    return raw(str(tmp_path))
+
+
+def test_trajectory_reads_selected_fields(sample_episodes_df) -> None:
+    result = (
+        trajectory(
+            sample_episodes_df,
+            fields=["camera/intrinsic", "transforms/leftHand", "confidences/leftHand"],
+        )
+        .collect()
+        .to_pydict()
+    )
+
+    assert _as_list(result["camera/intrinsic"][0]) == [
+        [736.0, 0.0, 0.0],
+        [0.0, 736.0, 0.0],
+        [0.0, 0.0, 736.0],
+    ]
+    assert (
+        _as_list(result["transforms/leftHand"][0])
+        == [
+            [
+                [1.0, 0.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 0.0],
+                [0.0, 0.0, 0.0, 1.0],
+            ]
+        ]
+        * NUM_FRAMES
+    )
+    confidences = _as_list(result["confidences/leftHand"][0])
+    assert len(confidences) == NUM_FRAMES
+    assert confidences[0] == pytest.approx(0.0)
+    assert confidences[-1] == pytest.approx(1.0)
+
+
+def test_trajectory_default_fields_and_column_order(sample_episodes_df) -> None:
+    result = trajectory(sample_episodes_df)
+
+    assert [field.name for field in result.schema()] == [
+        "task",
+        "episode_id",
+        "metadata",
+        "camera/intrinsic",
+        "transforms/camera",
+        "transforms/leftHand",
+        "transforms/rightHand",
+        "confidences/leftHand",
+        "confidences/rightHand",
+        "video",
+    ]
+
+
+def test_trajectory_schema_uses_known_hdf5_dtypes(sample_episodes_df) -> None:
+    result = trajectory(sample_episodes_df, fields=["transforms/rightHand", "confidences/hip"])
+
+    schema = result.schema()
+    assert schema["transforms/rightHand"].dtype == DataType.tensor(DataType.float32())
+    assert schema["confidences/hip"].dtype == DataType.tensor(DataType.float32())
+
+
+def test_trajectory_filters_missing_trajectory(sample_episodes_df) -> None:
+    episodes = sample_episodes_df.collect().with_column(
+        "trajectory",
+        daft.lit(None).cast(DataType.file(MediaType.hdf5())),
+    )
+
+    result = trajectory(episodes, fields=["confidences/hip"]).collect().to_pydict()
+
+    assert result["confidences/hip"] == []
+
+
+def test_trajectory_requires_trajectory_column() -> None:
+    episodes = daft.from_pydict({"task": ["fold_towel"]})
+    with pytest.raises(ValueError, match="trajectory"):
+        trajectory(episodes, fields=["confidences/hip"])
+
+
+def test_trajectory_rejects_empty_fields(sample_episodes_df) -> None:
+    with pytest.raises(ValueError, match="at least one"):
+        trajectory(sample_episodes_df, fields=[])
+
+
+def test_trajectory_rejects_unknown_fields(sample_episodes_df) -> None:
+    with pytest.raises(ValueError, match="Unknown trajectory field"):
+        trajectory(sample_episodes_df, fields=["transforms/notAJoint"])
+
+
+def test_trajectory_requires_hdf5_extra(sample_episodes_df, monkeypatch) -> None:
+    from daft.dependencies import h5py
+
+    monkeypatch.setattr(h5py, "module_available", lambda: False)
+
+    with pytest.raises(ImportError, match=r"daft\[hdf5\]"):
+        trajectory(sample_episodes_df, fields=["confidences/hip"])
+
+
+@pytest.fixture
+def sample_camera_episodes_df(tmp_path):
+    pytest.importorskip("av")
+    _write_episode(tmp_path, with_video=False)
+    _write_playable_video(tmp_path / "fold_towel" / "0.mp4")
+    return raw(str(tmp_path))
+
+
+def test_camera_frames_appends_video_frames_column(sample_camera_episodes_df) -> None:
+    result = camera_frames(sample_camera_episodes_df, width=32, height=24)
+    schema = [field.name for field in result.schema()]
+
+    assert schema == ["task", "episode_id", "metadata", "trajectory", "video", "video_frames"]
+
+
+def test_camera_frames_decodes_local_video(sample_camera_episodes_df) -> None:
+    result = (
+        camera_frames(sample_camera_episodes_df, width=32, height=24)
+        .select("episode_id", "video_frames")
+        .collect()
+        .to_pydict()
+    )
+
+    frames = result["video_frames"][0]
+    assert len(frames) > 0
+
+
+def test_camera_frames_returns_empty_frames_for_missing_video(sample_camera_episodes_df) -> None:
+    episodes = sample_camera_episodes_df.with_column(
+        "video",
+        daft.lit(None).cast(DataType.file(MediaType.video())),
+    )
+
+    result = camera_frames(episodes).select("video_frames").collect().to_pydict()
+
+    assert result["video_frames"] == [[]]
+
+
+def test_camera_frames_requires_video_column() -> None:
+    pytest.importorskip("av")
+    episodes = daft.from_pydict({"task": ["fold_towel"]})
+    with pytest.raises(ValueError, match="video"):
+        camera_frames(episodes)
+
+
+def test_camera_frames_requires_video_extra(sample_camera_episodes_df, monkeypatch) -> None:
+    from daft.dependencies import av
+
+    monkeypatch.setattr(av, "module_available", lambda: False)
+
+    with pytest.raises(ImportError, match=r"daft\[video\]"):
+        camera_frames(sample_camera_episodes_df)
+
+
+def test_joint_and_field_catalogs_match_egodex_layout() -> None:
+    assert len(JOINTS) == 68
+    assert TRANSFORM_JOINTS[0] == "camera"
+    assert len(TRANSFORM_JOINTS) == 69
+    assert len(TRAJECTORY_FIELDS) == 1 + 68 + 69
+    assert "camera/intrinsic" in TRAJECTORY_FIELDS
+    assert "transforms/leftHand" in TRAJECTORY_FIELDS
+    assert "confidences/rightThumbTip" in TRAJECTORY_FIELDS
+    assert set(DEFAULT_TRAJECTORY_FIELDS) <= set(TRAJECTORY_FIELDS)
+    assert DEFAULT_TRAJECTORY_FIELDS == egodex_module._DEFAULT_TRAJECTORY_FIELDS
+
+
+EGODEX_DATA_DIR = os.environ.get("EGODEX_DATA_DIR")
+
+
+@pytest.mark.integration()
+@pytest.mark.skipif(
+    not EGODEX_DATA_DIR,
+    reason="EGODEX_DATA_DIR must point at a local EgoDex download (the CC-BY-NC-ND license prohibits hosting a copy)",
+)
+def test_egodex_reads_real_local_download() -> None:
+    episodes = raw(EGODEX_DATA_DIR).limit(1)
+    result = trajectory(episodes).collect().to_pydict()
+
+    assert len(result["task"]) == 1
+    transforms = result["transforms/camera"][0]
+    assert transforms.shape[1:] == (4, 4)
+    assert result["camera/intrinsic"][0].shape == (3, 3)


### PR DESCRIPTION
## Summary

Adds a first-class `daft.datasets.egodex` module for working with local or privately hosted EgoDex downloads in place.

The API intentionally keeps the stable dataset surface narrow:

- `raw()` catalogs EgoDex episodes and attaches lazy `Hdf5File` / `VideoFile` columns
- `trajectory()` reads selected known HDF5 pose datasets into typed tensor columns
- `camera_frames()` decodes frame-aligned egocentric video frames when pixels are needed
- `JOINTS`, `TRANSFORM_JOINTS`, `TRAJECTORY_FIELDS`, and `DEFAULT_TRAJECTORY_FIELDS` expose the stable field catalogs

The higher-level hand-pose feature, motion-trimming, tracking-quality, grasp-mining, and reward/query patterns are documented as examples rather than locked into the dataset reader API.

## Validation

- `.venv/bin/mypy daft/datasets/egodex.py`
- `.venv/bin/ruff check daft/datasets/egodex.py tests/datasets/test_egodex.py examples/egodex_pose_features.py`
- `DAFT_RUNNER=native make test EXTRA_ARGS="-v tests/datasets/test_egodex.py"`