### PR TITLE
feat(file): add native MCAP metadata inspection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,6 +166,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "array-init"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1410,6 +1416,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bimap"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
+
+[[package]]
 name = "bincode"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1427,6 +1439,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
 dependencies = [
  "virtue",
+]
+
+[[package]]
+name = "binrw"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53195f985e88ab94d1cc87e80049dd2929fd39e4a772c5ae96a7e5c4aad3642"
+dependencies = [
+ "array-init",
+ "binrw_derive",
+ "bytemuck",
+]
+
+[[package]]
+name = "binrw_derive"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5910da05ee556b789032c8ff5a61fb99239580aa3fd0bfaa8f4d094b2aee00ad"
+dependencies = [
+ "either",
+ "owo-colors",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1594,6 +1630,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "byteorder-lite"
@@ -2863,6 +2905,7 @@ dependencies = [
  "daft-io",
  "daft-schema",
  "futures",
+ "mcap",
  "mime_guess",
  "pyo3",
  "serde",
@@ -3669,6 +3712,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3946,6 +4023,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
 dependencies = [
  "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "enumset"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "839c4174b41e75c8f7306110b2c51996a293b8d1d850edd529011841d9fede7d"
+dependencies = [
+ "enumset_derive",
+]
+
+[[package]]
+name = "enumset_derive"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd536557b58c682b217b8fb199afdff47cd3eff260623f19e77074eb073d63a"
+dependencies = [
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5033,6 +5131,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5627,6 +5731,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "mcap"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b215e79631de2a19ed76fda13cd52950c3057b487a2f41d9dc85c4079b969c40"
+dependencies = [
+ "bimap",
+ "binrw",
+ "byteorder",
+ "crc32fast",
+ "enumset",
+ "log",
+ "num_cpus",
+ "paste",
+ "static_assertions",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5867,6 +5989,16 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -6249,6 +6381,12 @@ name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
+name = "owo-colors"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "p256"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -327,6 +327,7 @@ jaq-core = "2.2.1"
 jaq-json = {version = "1.1.3", features = ["serde_json"]}
 jaq-std = "2.1.2"
 libloading = "0.9"
+mcap = {version = "0.25.0", default-features = false}
 mur3 = "0.1.0"
 ndarray = "0.17"
 num-derive = "0.4.2"

--- a/daft/daft/__init__.pyi
+++ b/daft/daft/__init__.pyi
@@ -2985,4 +2985,10 @@ class PyMediaType:
     @staticmethod
     def mcap() -> PyMediaType: ...
 
+def _read_mcap_metadata(
+    file: PyFileReference,
+    include_schema_data: bool = True,
+    include_metadata_records: bool = True,
+    include_chunk_indexes: bool = True,
+) -> dict[str, Any]: ...
 def guess_mimetype_from_content(bytes: bytes) -> str | None: ...

--- a/daft/expressions/expressions.py
+++ b/daft/expressions/expressions.py
@@ -3126,6 +3126,24 @@ class Expression:
 
         return hdf5_attrs(self, h5path=h5path)
 
+    def mcap_topics(self) -> Expression:
+        """Return topics declared in the MCAP summary."""
+        from daft.functions import mcap_topics
+
+        return mcap_topics(self)
+
+    def mcap_message_count(self) -> Expression:
+        """Return the MCAP summary message count."""
+        from daft.functions import mcap_message_count
+
+        return mcap_message_count(self)
+
+    def mcap_time_range(self) -> Expression:
+        """Return MCAP summary start/end log-time bounds."""
+        from daft.functions import mcap_time_range
+
+        return mcap_time_range(self)
+
 
 class WhenExpr(Expression):
     """Helper class for building a SQL-style CASE WHEN expression.

--- a/daft/file/mcap.py
+++ b/daft/file/mcap.py
@@ -1,20 +1,37 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
+from daft.daft import _read_mcap_metadata
 from daft.datatype import MediaType
 from daft.file.file import File
+from daft.file.typing import (
+    McapAttachmentMetadata,
+    McapChannelMetadata,
+    McapChunkMetadata,
+    McapFileMetadata,
+    McapHeader,
+    McapMetadataRecord,
+    McapSchemaMetadata,
+    McapStatistics,
+    McapTimeRange,
+)
 
 if TYPE_CHECKING:
     from daft.daft import PyDaftFile, PyFileReference
     from daft.io import IOConfig
 
 
-MCAP_BUFFER_SIZE = 1024 * 1024
+MCAP_METADATA_BUFFER_SIZE = 1024 * 1024
 
 
 class McapFile(File):
-    """An MCAP container backed by Daft's range-readable file interface."""
+    """An MCAP container backed by Daft's range-readable file interface.
+
+    Metadata access reads the leading header and the footer/summary ranges when
+    the storage backend supports range requests. It does not materialize the
+    complete file on range-capable remote object stores.
+    """
 
     @staticmethod
     def _from_file_reference(reference: PyFileReference) -> McapFile:
@@ -27,5 +44,81 @@ class McapFile(File):
         if not self.is_mcap():
             raise ValueError(f"File {self} is not an MCAP file")
 
-    def open(self, buffer_size: int | None = MCAP_BUFFER_SIZE) -> PyDaftFile:
+    def open(self, buffer_size: int | None = MCAP_METADATA_BUFFER_SIZE) -> PyDaftFile:
         return super().open(buffer_size=buffer_size)
+
+    def _read_metadata(
+        self,
+        *,
+        include_schema_data: bool = False,
+        include_metadata_records: bool = False,
+        include_chunk_indexes: bool = False,
+    ) -> McapFileMetadata:
+        return cast(
+            "McapFileMetadata",
+            _read_mcap_metadata(
+                self._inner,
+                include_schema_data,
+                include_metadata_records,
+                include_chunk_indexes,
+            ),
+        )
+
+    def metadata(self) -> McapFileMetadata:
+        """Read the header, summary indexes, and indexed metadata records.
+
+        MCAP summary sections are optional. ``has_summary`` reports whether one
+        exists. ``has_chunk_indexes`` and ``has_message_indexes`` report the
+        two index levels used for read and count pushdown; ``indexed`` is a
+        shorthand for ``has_chunk_indexes``. A summary can contain channels or
+        statistics without either index. This method never falls back to
+        scanning the complete data section.
+        """
+        return self._read_metadata(
+            include_schema_data=True,
+            include_metadata_records=True,
+            include_chunk_indexes=True,
+        )
+
+    def summary(self) -> McapFileMetadata:
+        """Read the MCAP summary without following metadata-record indexes."""
+        return self._read_metadata(include_schema_data=True, include_chunk_indexes=True)
+
+    def header(self) -> McapHeader:
+        return self._read_metadata()["header"]
+
+    def statistics(self) -> McapStatistics | None:
+        return self._read_metadata()["statistics"]
+
+    def schemas(self) -> list[McapSchemaMetadata]:
+        return self._read_metadata(include_schema_data=True)["schemas"]
+
+    def channels(self) -> list[McapChannelMetadata]:
+        return self._read_metadata()["channels"]
+
+    def chunks(self) -> list[McapChunkMetadata]:
+        return self._read_metadata(include_chunk_indexes=True)["chunks"]
+
+    def attachments(self) -> list[McapAttachmentMetadata]:
+        return self._read_metadata()["attachments"]
+
+    def metadata_records(self) -> list[McapMetadataRecord]:
+        return self._read_metadata(include_metadata_records=True)["metadata"]
+
+    def topics(self) -> list[str]:
+        """Return unique topics in channel-id order."""
+        return list(dict.fromkeys(channel["topic"] for channel in self.channels()))
+
+    def message_count(self) -> int | None:
+        statistics = self.statistics()
+        return None if statistics is None else statistics["message_count"]
+
+    def time_range(self) -> McapTimeRange:
+        """Return the inclusive file time bounds reported by MCAP statistics."""
+        statistics = self.statistics()
+        if statistics is None or statistics["message_count"] == 0:
+            return McapTimeRange(start_time=None, end_time=None)
+        return McapTimeRange(
+            start_time=statistics["message_start_time"],
+            end_time=statistics["message_end_time"],
+        )

--- a/daft/file/typing.py
+++ b/daft/file/typing.py
@@ -48,3 +48,94 @@ class Hdf5ObjectMetadata(TypedDict):
     dtype: str
     chunks: list[int]
     compression: str
+
+
+# MCAP Types ------------------------------------------------------------
+class McapHeader(TypedDict):
+    profile: str
+    library: str
+
+
+class McapStatistics(TypedDict):
+    message_count: int
+    schema_count: int
+    channel_count: int
+    attachment_count: int
+    metadata_count: int
+    chunk_count: int
+    message_start_time: int
+    message_end_time: int
+
+
+class McapSchemaMetadata(TypedDict):
+    id: int
+    name: str
+    encoding: str
+    data_size: int
+    data: bytes | None
+
+
+class McapChannelMetadata(TypedDict):
+    id: int
+    topic: str
+    message_encoding: str
+    schema_id: int | None
+    schema_name: str | None
+    message_count: int | None
+    metadata: dict[str, str]
+
+
+class McapMessageIndexMetadata(TypedDict):
+    channel_id: int
+    position: int
+
+
+class McapChunkMetadata(TypedDict):
+    message_start_time: int
+    message_end_time: int
+    position: int
+    size: int
+    compression: str
+    compressed_size: int
+    uncompressed_size: int
+    message_index_length: int
+    message_index_offsets: list[McapMessageIndexMetadata]
+    channel_ids: list[int]
+    topics: list[str]
+
+
+class McapAttachmentMetadata(TypedDict):
+    position: int
+    size: int
+    log_time: int
+    create_time: int
+    data_size: int
+    name: str
+    media_type: str
+
+
+class McapMetadataRecord(TypedDict):
+    name: str
+    metadata: dict[str, str]
+    position: int
+    size: int
+
+
+class McapFileMetadata(TypedDict):
+    file_size: int
+    has_summary: bool
+    indexed: bool
+    has_chunk_indexes: bool
+    has_message_indexes: bool
+    header: McapHeader
+    statistics: McapStatistics | None
+    schemas: list[McapSchemaMetadata]
+    channels: list[McapChannelMetadata]
+    chunks: list[McapChunkMetadata]
+    attachments: list[McapAttachmentMetadata]
+    metadata: list[McapMetadataRecord]
+
+
+class McapTimeRange(TypedDict):
+    start_time: int | None
+    end_time: int | None

--- a/daft/functions/__init__.py
+++ b/daft/functions/__init__.py
@@ -110,6 +110,7 @@ from .hdf5 import (
     hdf5_keys,
     hdf5_metadata,
 )
+from .mcap import mcap_message_count, mcap_time_range, mcap_topics
 from .file_ import (
     file,
     file_path,
@@ -512,6 +513,9 @@ __all__ = [
     "map_keys",
     "max",
     "mcap_file",
+    "mcap_message_count",
+    "mcap_time_range",
+    "mcap_topics",
     "mean",
     "median",
     "microsecond",

--- a/daft/functions/mcap.py
+++ b/daft/functions/mcap.py
@@ -1,0 +1,31 @@
+"""MCAP file metadata expressions."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from daft import Expression
+
+
+def _mcap_summary_projection(file_expr: Expression) -> Expression:
+    # Keep the inexpensive helpers as projections of one identical expression.
+    # Daft factors that common subexpression when several helpers share a select.
+    from daft.expressions import Expression
+
+    return Expression._call_builtin_scalar_fn("_mcap_summary_projection", file_expr)
+
+
+def mcap_topics(file_expr: Expression) -> Expression:
+    """Return topics declared by the channels in an MCAP summary."""
+    return _mcap_summary_projection(file_expr).get("topics")
+
+
+def mcap_message_count(file_expr: Expression) -> Expression:
+    """Return the MCAP summary message count, or null without statistics."""
+    return _mcap_summary_projection(file_expr).get("message_count")
+
+
+def mcap_time_range(file_expr: Expression) -> Expression:
+    """Return inclusive MCAP log-time bounds, or null bounds for no messages."""
+    return _mcap_summary_projection(file_expr).get("time_range")

--- a/docs/modalities/files.md
+++ b/docs/modalities/files.md
@@ -191,6 +191,65 @@ df.show(5)
 (Showing first 5 rows)
 ```
 
+## Inspecting MCAP metadata
+
+`daft.McapFile` reads the MCAP header and optional footer/summary indexes through
+Daft's native range-readable file interface. On backends that support range
+requests, remote recordings do not need to be copied to a temporary file or
+downloaded in full just to discover their topics, time bounds, schemas, message
+counts, chunk indexes, or metadata records.
+
+```python
+import daft
+
+recording = daft.McapFile("s3://robot-logs/episode.mcap")
+print(recording.topics())
+print(recording.message_count())
+print(recording.time_range())
+```
+
+The same operations are available as lazy expressions. The inexpensive planning
+helpers share one summary read when used together:
+
+```python
+from daft.functions import mcap_file
+
+files = (
+    daft.from_glob_path("s3://robot-logs/**/*.mcap")
+    .with_column("mcap", mcap_file(daft.col("path")))
+    .with_columns(
+        {
+            "topics": daft.col("mcap").mcap_topics(),
+            "message_count": daft.col("mcap").mcap_message_count(),
+            "time_range": daft.col("mcap").mcap_time_range(),
+        }
+    )
+)
+```
+
+For uncommon catalog fields, call `McapFile.metadata()` from a Python UDF and
+project only the values your application needs:
+
+```python
+@daft.func
+def schema_names(recording: daft.McapFile) -> list[str]:
+    return [schema["name"] for schema in recording.metadata()["schemas"]]
+
+files = files.with_column("schema_names", schema_names(daft.col("mcap")))
+```
+
+`metadata()` includes schema bytes, chunk indexes, attachments, and indexed
+metadata records. The range reads and MCAP parsing remain native; Python only
+selects the application-specific result.
+
+MCAP summaries are optional. `has_summary` reports whether one exists.
+`has_chunk_indexes` and `has_message_indexes` report the two index levels used
+for read and count pushdown; `indexed` is shorthand for `has_chunk_indexes`.
+An unindexed summary may still contain schemas, channels, and statistics. Daft
+does not fall back to a full data scan when summary metadata is absent.
+`McapFile` does not decode or scan messages; use `daft.read_mcap` when you need
+message rows.
+
 ## Byte-Range Reads
 
 When working with files that pack multiple records into a single blob (e.g. Paimon blob files), you can specify `offset` and `length` to read only a specific byte range instead of the entire file. Both parameters must be provided together.

--- a/src/daft-file/Cargo.toml
+++ b/src/daft-file/Cargo.toml
@@ -8,6 +8,7 @@ daft-schema = {path = "../daft-schema", default-features = false}
 futures = {workspace = true, features = ["async-await"]}
 mime_guess = "2.0.5"
 pyo3 = {workspace = true, optional = true}
+mcap.workspace = true
 common-runtime.workspace = true
 serde.workspace = true
 typetag.workspace = true

--- a/src/daft-file/src/file.rs
+++ b/src/daft-file/src/file.rs
@@ -414,16 +414,6 @@ const MCAP_MAGIC: &[u8] = b"\x89MCAP0\r\n";
 pub(crate) const MCAP_MIME: &str = "application/x-mcap";
 const MIME_SNIFF_BYTES: usize = 4 * 1024 + HDF5_MAGIC.len();
 
-pub(crate) fn has_mcap_magic(file: &mut DaftFile) -> DaftResult<bool> {
-    file.seek(SeekFrom::Start(0))?;
-    let mut magic = [0_u8; MCAP_MAGIC.len()];
-    match file.read_exact(&mut magic) {
-        Ok(()) => Ok(magic == MCAP_MAGIC),
-        Err(error) if error.kind() == io::ErrorKind::UnexpectedEof => Ok(false),
-        Err(error) => Err(error.into()),
-    }
-}
-
 fn guess_mimetype_from_url(url: &str) -> Option<String> {
     let url = Url::parse(url).ok()?;
     let path = url.path();

--- a/src/daft-file/src/functions.rs
+++ b/src/daft-file/src/functions.rs
@@ -14,7 +14,8 @@ use daft_schema::media_type::MediaType;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    file::{BUFFER_SIZE_SNIFF, DaftFile, HDF5_MIME, has_mcap_magic},
+    file::{BUFFER_SIZE_SNIFF, DaftFile, HDF5_MIME},
+    mcap::has_magic as has_mcap_magic,
     meta::file_exists,
 };
 

--- a/src/daft-file/src/lib.rs
+++ b/src/daft-file/src/lib.rs
@@ -1,9 +1,11 @@
 mod file;
 mod functions;
+pub mod mcap;
 mod meta;
 
 pub(crate) use file::guess_mimetype_from_content;
 pub use functions::*;
+pub use mcap::functions::*;
 
 pub use crate::file::{BUFFER_SIZE_FULL, BUFFER_SIZE_METADATA, BUFFER_SIZE_SNIFF, DaftFile};
 

--- a/src/daft-file/src/mcap/functions.rs
+++ b/src/daft-file/src/mcap/functions.rs
@@ -1,0 +1,276 @@
+use std::collections::BTreeSet;
+
+use common_error::{DaftError, DaftResult};
+use daft_core::{
+    file::{MediaType, MediaTypeMcap},
+    lit::Literal,
+    prelude::*,
+    series::from_lit::series_from_literals_iter,
+};
+use daft_dsl::{
+    ExprRef,
+    functions::{FunctionArgs, ScalarUDF, UnaryArg},
+};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    DaftFile,
+    mcap::{
+        BUFFER_SIZE_MCAP_METADATA, McapMetadata as ParsedMcapMetadata, ReadMetadataOptions,
+        read_metadata_with_options,
+    },
+};
+
+fn time_range_dtype() -> DataType {
+    DataType::Struct(vec![
+        Field::new("start_time", DataType::UInt64),
+        Field::new("end_time", DataType::UInt64),
+    ])
+}
+
+fn summary_projection_dtype() -> DataType {
+    DataType::Struct(vec![
+        Field::new("topics", DataType::List(Box::new(DataType::Utf8))),
+        Field::new("message_count", DataType::UInt64),
+        Field::new("time_range", time_range_dtype()),
+    ])
+}
+
+fn struct_literal<const N: usize>(entries: [(String, Literal); N]) -> Literal {
+    Literal::Struct(entries.into_iter().collect())
+}
+
+fn list_literal(values: Vec<Literal>, child_dtype: DataType) -> DaftResult<Literal> {
+    let values =
+        series_from_literals_iter(values.into_iter().map(DaftResult::Ok), Some(child_dtype))?;
+    Ok(Literal::List(values))
+}
+
+fn summary_projection_literal(metadata: ParsedMcapMetadata) -> DaftResult<Literal> {
+    let mut seen = BTreeSet::new();
+    let topics = metadata
+        .channels
+        .into_iter()
+        .filter_map(|channel| seen.insert(channel.topic.clone()).then_some(channel.topic))
+        .map(Literal::Utf8)
+        .collect();
+    let topics = list_literal(topics, DataType::Utf8)?;
+
+    let (message_count, start_time, end_time) = metadata.statistics.map_or_else(
+        || (Literal::Null, Literal::Null, Literal::Null),
+        |statistics| {
+            let (start_time, end_time) = if statistics.message_count == 0 {
+                (Literal::Null, Literal::Null)
+            } else {
+                (
+                    Literal::UInt64(statistics.message_start_time),
+                    Literal::UInt64(statistics.message_end_time),
+                )
+            };
+            (
+                Literal::UInt64(statistics.message_count),
+                start_time,
+                end_time,
+            )
+        },
+    );
+    let time_range = struct_literal([
+        ("start_time".to_string(), start_time),
+        ("end_time".to_string(), end_time),
+    ]);
+
+    Ok(struct_literal([
+        ("topics".to_string(), topics),
+        ("message_count".to_string(), message_count),
+        ("time_range".to_string(), time_range),
+    ]))
+}
+
+fn read_metadata(
+    file_ref: daft_core::file::FileReference,
+    options: ReadMetadataOptions,
+) -> DaftResult<ParsedMcapMetadata> {
+    let mut file = DaftFile::load_blocking(file_ref, false, Some(BUFFER_SIZE_MCAP_METADATA))?;
+    read_metadata_with_options(&mut file, options)
+}
+
+fn validate_mcap_input(field: &Field, function_name: &str) -> DaftResult<()> {
+    if matches!(field.dtype, DataType::File(MediaType::Mcap)) {
+        Ok(())
+    } else {
+        Err(DaftError::TypeError(format!(
+            "{function_name} requires a File(Mcap) input, got {field}"
+        )))
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct McapSummaryProjection;
+
+#[typetag::serde]
+impl ScalarUDF for McapSummaryProjection {
+    fn name(&self) -> &'static str {
+        "_mcap_summary_projection"
+    }
+
+    fn call(
+        &self,
+        args: FunctionArgs<Series>,
+        _ctx: &daft_dsl::functions::scalar::EvalContext,
+    ) -> DaftResult<Series> {
+        let UnaryArg { input } = args.try_into()?;
+        let files = input.file::<MediaTypeMcap>()?;
+        let values = files
+            .into_iter()
+            .map(|file_ref| {
+                file_ref.map_or(Ok(Literal::Null), |file_ref| {
+                    let metadata = read_metadata(
+                        file_ref,
+                        ReadMetadataOptions {
+                            include_schema_data: false,
+                            include_metadata_records: false,
+                            include_chunk_indexes: false,
+                        },
+                    )?;
+                    summary_projection_literal(metadata)
+                })
+            })
+            .collect::<Vec<_>>();
+        Ok(
+            series_from_literals_iter(values.into_iter(), Some(summary_projection_dtype()))?
+                .rename(input.name()),
+        )
+    }
+
+    fn get_return_field(&self, args: FunctionArgs<ExprRef>, schema: &Schema) -> DaftResult<Field> {
+        let UnaryArg { input } = args.try_into()?;
+        let field = input.to_field(schema)?;
+        validate_mcap_input(&field, self.name())?;
+        Ok(Field::new(field.name, summary_projection_dtype()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mcap::{ChannelMetadata, HeaderMetadata, StatisticsMetadata};
+
+    fn channel(id: u16, topic: &str) -> ChannelMetadata {
+        ChannelMetadata {
+            id,
+            topic: topic.to_string(),
+            message_encoding: "protobuf".to_string(),
+            schema_id: None,
+            schema_name: None,
+            message_count: None,
+            metadata: Default::default(),
+        }
+    }
+
+    fn metadata(
+        channels: Vec<ChannelMetadata>,
+        statistics: Option<StatisticsMetadata>,
+    ) -> ParsedMcapMetadata {
+        ParsedMcapMetadata {
+            file_size: 0,
+            has_summary: true,
+            indexed: false,
+            has_chunk_indexes: false,
+            has_message_indexes: false,
+            header: HeaderMetadata {
+                profile: String::new(),
+                library: String::new(),
+            },
+            statistics,
+            schemas: vec![],
+            channels,
+            chunks: vec![],
+            attachments: vec![],
+            metadata: vec![],
+        }
+    }
+
+    fn statistics(message_count: u64) -> StatisticsMetadata {
+        StatisticsMetadata {
+            message_count,
+            schema_count: 0,
+            channel_count: 0,
+            attachment_count: 0,
+            metadata_count: 0,
+            chunk_count: 0,
+            message_start_time: 100,
+            message_end_time: 200,
+        }
+    }
+
+    #[test]
+    fn summary_projection_deduplicates_topics_and_reports_statistics() {
+        let projection = summary_projection_literal(metadata(
+            vec![
+                channel(1, "/state"),
+                channel(2, "/camera"),
+                channel(3, "/state"),
+            ],
+            Some(statistics(3)),
+        ))
+        .unwrap();
+
+        let Literal::Struct(fields) = projection else {
+            panic!("summary projection must be a struct");
+        };
+        let Literal::List(topics) = fields.get("topics").unwrap() else {
+            panic!("topics must be a list");
+        };
+        assert_eq!(
+            (0..topics.len())
+                .map(|index| topics.get_lit(index))
+                .collect::<Vec<_>>(),
+            vec![
+                Literal::Utf8("/state".to_string()),
+                Literal::Utf8("/camera".to_string()),
+            ]
+        );
+        assert_eq!(fields.get("message_count"), Some(&Literal::UInt64(3)));
+        assert_eq!(
+            fields.get("time_range"),
+            Some(&struct_literal([
+                ("start_time".to_string(), Literal::UInt64(100)),
+                ("end_time".to_string(), Literal::UInt64(200)),
+            ]))
+        );
+    }
+
+    #[test]
+    fn summary_projection_has_null_counts_and_bounds_without_statistics() {
+        let projection = summary_projection_literal(metadata(vec![], None)).unwrap();
+
+        let Literal::Struct(fields) = projection else {
+            panic!("summary projection must be a struct");
+        };
+        assert_eq!(fields.get("message_count"), Some(&Literal::Null));
+        assert_eq!(
+            fields.get("time_range"),
+            Some(&struct_literal([
+                ("start_time".to_string(), Literal::Null),
+                ("end_time".to_string(), Literal::Null),
+            ]))
+        );
+    }
+
+    #[test]
+    fn summary_projection_has_null_bounds_for_an_empty_file() {
+        let projection = summary_projection_literal(metadata(vec![], Some(statistics(0)))).unwrap();
+
+        let Literal::Struct(fields) = projection else {
+            panic!("summary projection must be a struct");
+        };
+        assert_eq!(fields.get("message_count"), Some(&Literal::UInt64(0)));
+        assert_eq!(
+            fields.get("time_range"),
+            Some(&struct_literal([
+                ("start_time".to_string(), Literal::Null),
+                ("end_time".to_string(), Literal::Null),
+            ]))
+        );
+    }
+}

--- a/src/daft-file/src/mcap/mod.rs
+++ b/src/daft-file/src/mcap/mod.rs
@@ -3,13 +3,15 @@ pub mod functions;
 #[cfg(feature = "python")]
 mod python;
 
-use std::io::{Read, Seek, SeekFrom};
+use std::{
+    collections::HashMap,
+    io::{Read, Seek, SeekFrom},
+};
 
 use common_error::{DaftError, DaftResult};
 use mcap::{
-    MAGIC, Summary,
-    records::Record,
-    sans_io::{SummaryReadEvent, SummaryReader, SummaryReaderOptions},
+    MAGIC, Schema,
+    records::{self, Record},
 };
 #[cfg(feature = "python")]
 pub(crate) use python::register_modules as register_python_modules;
@@ -17,6 +19,8 @@ pub(crate) use python::register_modules as register_python_modules;
 use crate::DaftFile;
 
 const MAX_METADATA_RECORD_SIZE: usize = 256 * 1024 * 1024;
+const RECORD_HEADER_SIZE: u64 = 9;
+const FOOTER_RECORD_SIZE: u64 = RECORD_HEADER_SIZE + 20;
 pub const BUFFER_SIZE_MCAP_METADATA: usize = 1024 * 1024;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -164,18 +168,18 @@ pub fn has_magic(file: &mut DaftFile) -> DaftResult<bool> {
     }
 }
 
-fn read_record_at(
+fn read_record_with_size_at(
     file: &mut DaftFile,
     file_size: u64,
     position: u64,
     expected_length: Option<u64>,
-) -> DaftResult<Record<'static>> {
+) -> DaftResult<(Record<'static>, u64)> {
     let remaining = file_size.checked_sub(position).ok_or_else(|| {
         mcap_error(format!(
             "record position {position} exceeds file size {file_size}"
         ))
     })?;
-    if remaining < 9 {
+    if remaining < RECORD_HEADER_SIZE {
         return Err(mcap_error(format!(
             "record at byte {position} does not contain a complete record header"
         )));
@@ -183,7 +187,7 @@ fn read_record_at(
 
     file.seek(SeekFrom::Start(position)).map_err(mcap_error)?;
 
-    let mut record_header = [0_u8; 9];
+    let mut record_header = [0_u8; RECORD_HEADER_SIZE as usize];
     file.read_exact(&mut record_header).map_err(mcap_error)?;
     let opcode = record_header[0];
     let body_size = u64::from_le_bytes(
@@ -192,7 +196,7 @@ fn read_record_at(
             .expect("record header always contains an eight-byte size"),
     );
     let record_size = body_size
-        .checked_add(9)
+        .checked_add(RECORD_HEADER_SIZE)
         .ok_or_else(|| mcap_error(format!("record at byte {position} is too large")))?;
     if record_size > remaining {
         return Err(mcap_error(format!(
@@ -218,9 +222,21 @@ fn read_record_at(
 
     let mut body = vec![0_u8; body_size];
     file.read_exact(&mut body).map_err(mcap_error)?;
-    Ok(mcap::parse_record(opcode, &body)
-        .map_err(mcap_error)?
-        .into_owned())
+    Ok((
+        mcap::parse_record(opcode, &body)
+            .map_err(mcap_error)?
+            .into_owned(),
+        record_size,
+    ))
+}
+
+fn read_record_at(
+    file: &mut DaftFile,
+    file_size: u64,
+    position: u64,
+    expected_length: Option<u64>,
+) -> DaftResult<Record<'static>> {
+    read_record_with_size_at(file, file_size, position, expected_length).map(|(record, _)| record)
 }
 
 fn read_header(file: &mut DaftFile, file_size: u64) -> DaftResult<HeaderMetadata> {
@@ -240,36 +256,120 @@ fn read_header(file: &mut DaftFile, file_size: u64) -> DaftResult<HeaderMetadata
     }
 }
 
-fn read_summary_with_size(file: &mut DaftFile, file_size: u64) -> DaftResult<Option<Summary>> {
-    let mut reader = SummaryReader::new_with_options(
-        SummaryReaderOptions::default()
-            .with_file_size(file_size)
-            .with_record_length_limit(MAX_METADATA_RECORD_SIZE),
-    );
-
-    while let Some(event) = reader.next_event() {
-        match event.map_err(mcap_error)? {
-            SummaryReadEvent::ReadRequest(size) => {
-                let bytes_read = file.read(reader.insert(size)).map_err(mcap_error)?;
-                reader.notify_read(bytes_read);
-            }
-            SummaryReadEvent::SeekRequest(position) => {
-                let position = file.seek(position).map_err(mcap_error)?;
-                reader.notify_seeked(position);
-            }
-        }
-    }
-
-    Ok(reader.finish())
+struct ParsedSummary {
+    stats: Option<records::Statistics>,
+    channels: HashMap<u16, records::Channel>,
+    schemas: HashMap<u16, Schema<'static>>,
+    chunk_indexes: Vec<records::ChunkIndex>,
+    attachment_indexes: Vec<records::AttachmentIndex>,
+    metadata_indexes: Vec<records::MetadataIndex>,
 }
 
-/// Read the optional MCAP summary using bounded seeks and reads.
-pub fn read_summary(file: &mut DaftFile) -> DaftResult<Option<Summary>> {
-    let file_size: u64 = file
-        .size()?
-        .try_into()
-        .map_err(|_| mcap_error("file size does not fit in u64"))?;
-    read_summary_with_size(file, file_size)
+fn read_summary_with_size(
+    file: &mut DaftFile,
+    file_size: u64,
+) -> DaftResult<Option<ParsedSummary>> {
+    let footer_position = file_size
+        .checked_sub(FOOTER_RECORD_SIZE + MAGIC.len() as u64)
+        .ok_or_else(|| mcap_error("file is too small to contain an MCAP footer"))?;
+
+    file.seek(SeekFrom::Start(footer_position + FOOTER_RECORD_SIZE))
+        .map_err(mcap_error)?;
+    let mut trailing_magic = [0_u8; MAGIC.len()];
+    file.read_exact(&mut trailing_magic).map_err(mcap_error)?;
+    if trailing_magic != MAGIC {
+        return Err(mcap_error("bad trailing magic"));
+    }
+
+    let footer = match read_record_at(file, file_size, footer_position, Some(FOOTER_RECORD_SIZE))? {
+        Record::Footer(footer) => footer,
+        other => {
+            return Err(mcap_error(format!(
+                "expected a footer record, found opcode {:#04x}",
+                other.opcode()
+            )));
+        }
+    };
+    if footer.summary_start == 0 {
+        return Ok(None);
+    }
+
+    let summary_end = if footer.summary_offset_start == 0 {
+        footer_position
+    } else {
+        footer.summary_offset_start
+    };
+    if footer.summary_start > summary_end || summary_end > footer_position {
+        return Err(mcap_error(format!(
+            "invalid summary range {}..{summary_end} for footer at byte {footer_position}",
+            footer.summary_start
+        )));
+    }
+
+    let mut summary = ParsedSummary {
+        stats: None,
+        channels: HashMap::new(),
+        schemas: HashMap::new(),
+        chunk_indexes: Vec::new(),
+        attachment_indexes: Vec::new(),
+        metadata_indexes: Vec::new(),
+    };
+    let mut position = footer.summary_start;
+    while position < summary_end {
+        let (record, record_size) = read_record_with_size_at(file, file_size, position, None)?;
+        let next_position = position
+            .checked_add(record_size)
+            .ok_or_else(|| mcap_error(format!("record at byte {position} is too large")))?;
+        if next_position > summary_end {
+            return Err(mcap_error(format!(
+                "summary record at byte {position} extends past the summary boundary at byte {summary_end}"
+            )));
+        }
+
+        match record {
+            Record::AttachmentIndex(index) => summary.attachment_indexes.push(index),
+            Record::MetadataIndex(index) => summary.metadata_indexes.push(index),
+            Record::Statistics(statistics) => summary.stats = Some(statistics),
+            Record::Schema { header, data } => {
+                if header.id == 0 {
+                    return Err(mcap_error("schema records cannot use ID 0"));
+                }
+                let schema = Schema {
+                    id: header.id,
+                    name: header.name,
+                    encoding: header.encoding,
+                    data,
+                };
+                if let Some(existing) = summary.schemas.get(&schema.id) {
+                    if existing != &schema {
+                        return Err(mcap_error(format!(
+                            "conflicting schema records use ID {}",
+                            schema.id
+                        )));
+                    }
+                } else {
+                    summary.schemas.insert(schema.id, schema);
+                }
+            }
+            Record::Channel(channel) => {
+                if let Some(existing) = summary.channels.get(&channel.id) {
+                    if existing != &channel {
+                        return Err(mcap_error(format!(
+                            "conflicting channel records use ID {}",
+                            channel.id
+                        )));
+                    }
+                } else {
+                    summary.channels.insert(channel.id, channel);
+                }
+            }
+            Record::ChunkIndex(index) => summary.chunk_indexes.push(index),
+            _ => {}
+        }
+        position = next_position;
+    }
+
+    Ok(Some(summary))
 }
 
 pub fn read_metadata(file: &mut DaftFile) -> DaftResult<McapMetadata> {
@@ -334,8 +434,11 @@ pub fn read_metadata_with_options(
             id: channel.id,
             topic: channel.topic.clone(),
             message_encoding: channel.message_encoding.clone(),
-            schema_id: channel.schema.as_ref().map(|schema| schema.id),
-            schema_name: channel.schema.as_ref().map(|schema| schema.name.clone()),
+            schema_id: (channel.schema_id != 0).then_some(channel.schema_id),
+            schema_name: summary
+                .schemas
+                .get(&channel.schema_id)
+                .map(|schema| schema.name.clone()),
             message_count: summary
                 .stats
                 .as_ref()
@@ -568,6 +671,23 @@ mod tests {
         assert!(metadata.metadata.is_empty());
         assert!(metadata.has_chunk_indexes);
         assert_eq!(metadata.statistics.unwrap().metadata_count, 1);
+    }
+
+    #[test]
+    fn preserves_schema_id_when_summary_omits_schemas() {
+        let bytes = sample_mcap(
+            WriteOptions::default()
+                .repeat_channels(true)
+                .repeat_schemas(false),
+            true,
+        );
+        let mut file = DaftFile::from_bytes(MediaType::Mcap, bytes);
+
+        let metadata = read_metadata(&mut file).unwrap();
+
+        assert!(metadata.schemas.is_empty());
+        assert_eq!(metadata.channels[0].schema_id, Some(1));
+        assert_eq!(metadata.channels[0].schema_name, None);
     }
 
     #[test]

--- a/src/daft-file/src/mcap/mod.rs
+++ b/src/daft-file/src/mcap/mod.rs
@@ -1,0 +1,613 @@
+pub mod functions;
+
+#[cfg(feature = "python")]
+mod python;
+
+use std::io::{Read, Seek, SeekFrom};
+
+use common_error::{DaftError, DaftResult};
+use mcap::{
+    MAGIC, Summary,
+    records::Record,
+    sans_io::{SummaryReadEvent, SummaryReader, SummaryReaderOptions},
+};
+#[cfg(feature = "python")]
+pub(crate) use python::register_modules as register_python_modules;
+
+use crate::DaftFile;
+
+const MAX_METADATA_RECORD_SIZE: usize = 256 * 1024 * 1024;
+pub const BUFFER_SIZE_MCAP_METADATA: usize = 1024 * 1024;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "python", derive(pyo3::IntoPyObject))]
+pub struct HeaderMetadata {
+    pub profile: String,
+    pub library: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "python", derive(pyo3::IntoPyObject))]
+pub struct StatisticsMetadata {
+    pub message_count: u64,
+    pub schema_count: u16,
+    pub channel_count: u32,
+    pub attachment_count: u32,
+    pub metadata_count: u32,
+    pub chunk_count: u32,
+    pub message_start_time: u64,
+    pub message_end_time: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "python", derive(pyo3::IntoPyObject))]
+pub struct SchemaMetadata {
+    pub id: u16,
+    pub name: String,
+    pub encoding: String,
+    pub data_size: u64,
+    pub data: Option<Vec<u8>>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "python", derive(pyo3::IntoPyObject))]
+pub struct ChannelMetadata {
+    pub id: u16,
+    pub topic: String,
+    pub message_encoding: String,
+    pub schema_id: Option<u16>,
+    pub schema_name: Option<String>,
+    pub message_count: Option<u64>,
+    pub metadata: std::collections::BTreeMap<String, String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "python", derive(pyo3::IntoPyObject))]
+pub struct ChunkMetadata {
+    pub message_start_time: u64,
+    pub message_end_time: u64,
+    pub position: u64,
+    pub size: u64,
+    pub compression: String,
+    pub compressed_size: u64,
+    pub uncompressed_size: u64,
+    pub message_index_length: u64,
+    pub message_index_offsets: Vec<MessageIndexMetadata>,
+    pub channel_ids: Vec<u16>,
+    pub topics: Vec<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "python", derive(pyo3::IntoPyObject))]
+pub struct MessageIndexMetadata {
+    pub channel_id: u16,
+    pub position: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "python", derive(pyo3::IntoPyObject))]
+pub struct AttachmentIndexMetadata {
+    pub position: u64,
+    pub size: u64,
+    pub log_time: u64,
+    pub create_time: u64,
+    pub data_size: u64,
+    pub name: String,
+    pub media_type: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "python", derive(pyo3::IntoPyObject))]
+pub struct MetadataRecord {
+    pub name: String,
+    pub metadata: std::collections::BTreeMap<String, String>,
+    pub position: u64,
+    pub size: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "python", derive(pyo3::IntoPyObject))]
+pub struct McapMetadata {
+    pub file_size: u64,
+    pub has_summary: bool,
+    /// Compatibility shorthand for `has_chunk_indexes`.
+    pub indexed: bool,
+    pub has_chunk_indexes: bool,
+    pub has_message_indexes: bool,
+    pub header: HeaderMetadata,
+    pub statistics: Option<StatisticsMetadata>,
+    pub schemas: Vec<SchemaMetadata>,
+    pub channels: Vec<ChannelMetadata>,
+    pub chunks: Vec<ChunkMetadata>,
+    pub attachments: Vec<AttachmentIndexMetadata>,
+    pub metadata: Vec<MetadataRecord>,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct ReadMetadataOptions {
+    pub include_schema_data: bool,
+    pub include_metadata_records: bool,
+    pub include_chunk_indexes: bool,
+}
+
+impl Default for ReadMetadataOptions {
+    fn default() -> Self {
+        Self {
+            include_schema_data: false,
+            include_metadata_records: false,
+            include_chunk_indexes: true,
+        }
+    }
+}
+
+impl ReadMetadataOptions {
+    pub const fn full() -> Self {
+        Self {
+            include_schema_data: true,
+            include_metadata_records: true,
+            include_chunk_indexes: true,
+        }
+    }
+}
+
+fn mcap_error(error: impl std::fmt::Display) -> DaftError {
+    DaftError::ComputeError(format!("Failed to read MCAP metadata: {error}"))
+}
+
+pub fn has_magic(file: &mut DaftFile) -> DaftResult<bool> {
+    file.seek(SeekFrom::Start(0)).map_err(mcap_error)?;
+    let mut magic = [0_u8; 8];
+    match file.read_exact(&mut magic) {
+        Ok(()) => Ok(magic == MAGIC),
+        Err(error) if error.kind() == std::io::ErrorKind::UnexpectedEof => Ok(false),
+        Err(error) => Err(mcap_error(error)),
+    }
+}
+
+fn read_record_at(
+    file: &mut DaftFile,
+    file_size: u64,
+    position: u64,
+    expected_length: Option<u64>,
+) -> DaftResult<Record<'static>> {
+    let remaining = file_size.checked_sub(position).ok_or_else(|| {
+        mcap_error(format!(
+            "record position {position} exceeds file size {file_size}"
+        ))
+    })?;
+    if remaining < 9 {
+        return Err(mcap_error(format!(
+            "record at byte {position} does not contain a complete record header"
+        )));
+    }
+
+    file.seek(SeekFrom::Start(position)).map_err(mcap_error)?;
+
+    let mut record_header = [0_u8; 9];
+    file.read_exact(&mut record_header).map_err(mcap_error)?;
+    let opcode = record_header[0];
+    let body_size = u64::from_le_bytes(
+        record_header[1..]
+            .try_into()
+            .expect("record header always contains an eight-byte size"),
+    );
+    let record_size = body_size
+        .checked_add(9)
+        .ok_or_else(|| mcap_error(format!("record at byte {position} is too large")))?;
+    if record_size > remaining {
+        return Err(mcap_error(format!(
+            "record at byte {position} extends past the end of the {file_size}-byte file"
+        )));
+    }
+    if let Some(expected_length) = expected_length
+        && record_size != expected_length
+    {
+        return Err(mcap_error(format!(
+            "record at byte {position} has length {record_size}, but its index declares {expected_length}"
+        )));
+    }
+
+    let body_size: usize = body_size
+        .try_into()
+        .map_err(|_| mcap_error(format!("record at byte {position} is too large")))?;
+    if body_size > MAX_METADATA_RECORD_SIZE {
+        return Err(mcap_error(format!(
+            "record at byte {position} exceeds the {MAX_METADATA_RECORD_SIZE}-byte metadata limit"
+        )));
+    }
+
+    let mut body = vec![0_u8; body_size];
+    file.read_exact(&mut body).map_err(mcap_error)?;
+    Ok(mcap::parse_record(opcode, &body)
+        .map_err(mcap_error)?
+        .into_owned())
+}
+
+fn read_header(file: &mut DaftFile, file_size: u64) -> DaftResult<HeaderMetadata> {
+    if !has_magic(file)? {
+        return Err(mcap_error("bad leading magic"));
+    }
+
+    match read_record_at(file, file_size, MAGIC.len() as u64, None)? {
+        Record::Header(header) => Ok(HeaderMetadata {
+            profile: header.profile,
+            library: header.library,
+        }),
+        other => Err(mcap_error(format!(
+            "expected a header record, found opcode {:#04x}",
+            other.opcode()
+        ))),
+    }
+}
+
+fn read_summary_with_size(file: &mut DaftFile, file_size: u64) -> DaftResult<Option<Summary>> {
+    let mut reader = SummaryReader::new_with_options(
+        SummaryReaderOptions::default()
+            .with_file_size(file_size)
+            .with_record_length_limit(MAX_METADATA_RECORD_SIZE),
+    );
+
+    while let Some(event) = reader.next_event() {
+        match event.map_err(mcap_error)? {
+            SummaryReadEvent::ReadRequest(size) => {
+                let bytes_read = file.read(reader.insert(size)).map_err(mcap_error)?;
+                reader.notify_read(bytes_read);
+            }
+            SummaryReadEvent::SeekRequest(position) => {
+                let position = file.seek(position).map_err(mcap_error)?;
+                reader.notify_seeked(position);
+            }
+        }
+    }
+
+    Ok(reader.finish())
+}
+
+/// Read the optional MCAP summary using bounded seeks and reads.
+pub fn read_summary(file: &mut DaftFile) -> DaftResult<Option<Summary>> {
+    let file_size: u64 = file
+        .size()?
+        .try_into()
+        .map_err(|_| mcap_error("file size does not fit in u64"))?;
+    read_summary_with_size(file, file_size)
+}
+
+pub fn read_metadata(file: &mut DaftFile) -> DaftResult<McapMetadata> {
+    read_metadata_with_options(file, ReadMetadataOptions::default())
+}
+
+pub fn read_metadata_with_options(
+    file: &mut DaftFile,
+    options: ReadMetadataOptions,
+) -> DaftResult<McapMetadata> {
+    let file_size: u64 = file
+        .size()?
+        .try_into()
+        .map_err(|_| mcap_error("file size does not fit in u64"))?;
+
+    let header = read_header(file, file_size)?;
+    let Some(summary) = read_summary_with_size(file, file_size)? else {
+        return Ok(McapMetadata {
+            file_size,
+            has_summary: false,
+            indexed: false,
+            has_chunk_indexes: false,
+            has_message_indexes: false,
+            header,
+            statistics: None,
+            schemas: vec![],
+            channels: vec![],
+            chunks: vec![],
+            attachments: vec![],
+            metadata: vec![],
+        });
+    };
+
+    let statistics = summary.stats.as_ref().map(|stats| StatisticsMetadata {
+        message_count: stats.message_count,
+        schema_count: stats.schema_count,
+        channel_count: stats.channel_count,
+        attachment_count: stats.attachment_count,
+        metadata_count: stats.metadata_count,
+        chunk_count: stats.chunk_count,
+        message_start_time: stats.message_start_time,
+        message_end_time: stats.message_end_time,
+    });
+
+    let mut schemas = summary
+        .schemas
+        .values()
+        .map(|schema| SchemaMetadata {
+            id: schema.id,
+            name: schema.name.clone(),
+            encoding: schema.encoding.clone(),
+            data_size: schema.data.len() as u64,
+            data: options.include_schema_data.then(|| schema.data.to_vec()),
+        })
+        .collect::<Vec<_>>();
+    schemas.sort_by_key(|schema| schema.id);
+
+    let mut channels = summary
+        .channels
+        .values()
+        .map(|channel| ChannelMetadata {
+            id: channel.id,
+            topic: channel.topic.clone(),
+            message_encoding: channel.message_encoding.clone(),
+            schema_id: channel.schema.as_ref().map(|schema| schema.id),
+            schema_name: channel.schema.as_ref().map(|schema| schema.name.clone()),
+            message_count: summary
+                .stats
+                .as_ref()
+                .and_then(|stats| stats.channel_message_counts.get(&channel.id).copied()),
+            metadata: channel.metadata.clone(),
+        })
+        .collect::<Vec<_>>();
+    channels.sort_by_key(|channel| channel.id);
+
+    let has_chunk_indexes = !summary.chunk_indexes.is_empty();
+    let has_message_indexes = summary
+        .chunk_indexes
+        .iter()
+        .any(|chunk| !chunk.message_index_offsets.is_empty());
+
+    let chunks = if options.include_chunk_indexes {
+        summary
+            .chunk_indexes
+            .iter()
+            .map(|chunk| {
+                let channel_ids = chunk
+                    .message_index_offsets
+                    .keys()
+                    .copied()
+                    .collect::<Vec<_>>();
+                let topics = channel_ids
+                    .iter()
+                    .filter_map(|channel_id| summary.channels.get(channel_id))
+                    .map(|channel| channel.topic.clone())
+                    .collect::<Vec<_>>();
+                ChunkMetadata {
+                    message_start_time: chunk.message_start_time,
+                    message_end_time: chunk.message_end_time,
+                    position: chunk.chunk_start_offset,
+                    size: chunk.chunk_length,
+                    compression: chunk.compression.clone(),
+                    compressed_size: chunk.compressed_size,
+                    uncompressed_size: chunk.uncompressed_size,
+                    message_index_length: chunk.message_index_length,
+                    message_index_offsets: chunk
+                        .message_index_offsets
+                        .iter()
+                        .map(|(channel_id, position)| MessageIndexMetadata {
+                            channel_id: *channel_id,
+                            position: *position,
+                        })
+                        .collect(),
+                    channel_ids,
+                    topics,
+                }
+            })
+            .collect()
+    } else {
+        vec![]
+    };
+
+    let attachments = summary
+        .attachment_indexes
+        .iter()
+        .map(|attachment| AttachmentIndexMetadata {
+            position: attachment.offset,
+            size: attachment.length,
+            log_time: attachment.log_time,
+            create_time: attachment.create_time,
+            data_size: attachment.data_size,
+            name: attachment.name.clone(),
+            media_type: attachment.media_type.clone(),
+        })
+        .collect();
+
+    let mut metadata = Vec::with_capacity(summary.metadata_indexes.len());
+    if options.include_metadata_records {
+        for index in &summary.metadata_indexes {
+            match read_record_at(file, file_size, index.offset, Some(index.length))? {
+                Record::Metadata(record) => {
+                    if record.name != index.name {
+                        return Err(mcap_error(format!(
+                            "metadata index at byte {} names {:?}, but the record names {:?}",
+                            index.offset, index.name, record.name
+                        )));
+                    }
+                    metadata.push(MetadataRecord {
+                        name: record.name,
+                        metadata: record.metadata,
+                        position: index.offset,
+                        size: index.length,
+                    });
+                }
+                other => {
+                    return Err(mcap_error(format!(
+                        "metadata index at byte {} points to opcode {:#04x}",
+                        index.offset,
+                        other.opcode()
+                    )));
+                }
+            }
+        }
+    }
+
+    Ok(McapMetadata {
+        file_size,
+        has_summary: true,
+        indexed: has_chunk_indexes,
+        has_chunk_indexes,
+        has_message_indexes,
+        header,
+        statistics,
+        schemas,
+        channels,
+        chunks,
+        attachments,
+        metadata,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{borrow::Cow, io::Cursor, sync::Arc};
+
+    use daft_schema::media_type::MediaType;
+    use mcap::{Attachment, Channel, Message, Schema, WriteOptions, records};
+
+    use super::*;
+
+    fn sample_mcap(options: WriteOptions, include_message: bool) -> Vec<u8> {
+        let mut output = Cursor::new(Vec::new());
+        {
+            let mut writer = options
+                .compression(None)
+                .profile("test-profile")
+                .library("test-library")
+                .create(&mut output)
+                .unwrap();
+
+            if include_message {
+                let schema = Arc::new(Schema {
+                    id: 1,
+                    name: "example.Message".to_string(),
+                    encoding: "protobuf".to_string(),
+                    data: Cow::Borrowed(b"schema-bytes"),
+                });
+                let channel = Arc::new(Channel {
+                    id: 1,
+                    schema: Some(schema),
+                    topic: "/state".to_string(),
+                    message_encoding: "protobuf".to_string(),
+                    metadata: [("role".to_string(), "state".to_string())].into(),
+                });
+                writer
+                    .write(&Message {
+                        channel,
+                        sequence: 7,
+                        log_time: 100,
+                        publish_time: 101,
+                        data: Cow::Borrowed(b"payload"),
+                    })
+                    .unwrap();
+                writer
+                    .write_metadata(&records::Metadata {
+                        name: "session".to_string(),
+                        metadata: [("episode".to_string(), "one".to_string())].into(),
+                    })
+                    .unwrap();
+                writer
+                    .attach(&Attachment {
+                        log_time: 100,
+                        create_time: 90,
+                        name: "calibration.json".to_string(),
+                        media_type: "application/json".to_string(),
+                        data: Cow::Borrowed(b"{}"),
+                    })
+                    .unwrap();
+            }
+
+            writer.finish().unwrap();
+        }
+        output.into_inner()
+    }
+
+    #[test]
+    fn reads_header_summary_and_indexed_metadata() {
+        let bytes = sample_mcap(WriteOptions::default(), true);
+        let mut file = DaftFile::from_bytes(MediaType::Mcap, bytes);
+
+        let metadata = read_metadata_with_options(&mut file, ReadMetadataOptions::full()).unwrap();
+
+        assert_eq!(
+            metadata.header,
+            HeaderMetadata {
+                profile: "test-profile".to_string(),
+                library: "test-library".to_string(),
+            }
+        );
+        assert_eq!(metadata.statistics.as_ref().unwrap().message_count, 1);
+        assert_eq!(
+            metadata.statistics.as_ref().unwrap().message_start_time,
+            100
+        );
+        assert_eq!(
+            metadata.schemas[0].data.as_deref(),
+            Some(b"schema-bytes".as_slice())
+        );
+        assert_eq!(metadata.channels[0].topic, "/state");
+        assert_eq!(metadata.channels[0].message_count, Some(1));
+        assert!(metadata.has_chunk_indexes);
+        assert!(metadata.has_message_indexes);
+        assert_eq!(metadata.attachments[0].name, "calibration.json");
+        assert_eq!(metadata.attachments[0].data_size, 2);
+        assert_eq!(metadata.metadata[0].name, "session");
+        assert_eq!(metadata.metadata[0].metadata["episode"], "one");
+    }
+
+    #[test]
+    fn options_only_control_materialized_catalog_fields() {
+        let bytes = sample_mcap(WriteOptions::default(), true);
+        let mut file = DaftFile::from_bytes(MediaType::Mcap, bytes);
+
+        let metadata = read_metadata_with_options(
+            &mut file,
+            ReadMetadataOptions {
+                include_schema_data: false,
+                include_metadata_records: false,
+                include_chunk_indexes: false,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(metadata.schemas[0].data, None);
+        assert!(metadata.chunks.is_empty());
+        assert!(metadata.metadata.is_empty());
+        assert!(metadata.has_chunk_indexes);
+        assert_eq!(metadata.statistics.unwrap().metadata_count, 1);
+    }
+
+    #[test]
+    fn reports_absent_summary_without_scanning_data() {
+        let bytes = sample_mcap(
+            WriteOptions::default()
+                .emit_summary_records(false)
+                .emit_summary_offsets(false),
+            true,
+        );
+        let mut file = DaftFile::from_bytes(MediaType::Mcap, bytes);
+
+        let metadata = read_metadata(&mut file).unwrap();
+
+        assert!(!metadata.has_summary);
+        assert!(metadata.statistics.is_none());
+        assert!(metadata.channels.is_empty());
+        assert!(metadata.chunks.is_empty());
+    }
+
+    #[test]
+    fn rejects_records_that_extend_past_end_of_file_before_allocating() {
+        let mut bytes = vec![0_u8; 17];
+        bytes[8] = records::op::METADATA;
+        bytes[9..17].copy_from_slice(&100_u64.to_le_bytes());
+        let mut file = DaftFile::from_bytes(MediaType::Mcap, bytes);
+
+        let error = read_record_at(&mut file, 17, 8, None).unwrap_err();
+
+        assert!(error.to_string().contains("extends past the end"));
+    }
+
+    #[test]
+    fn rejects_records_whose_index_length_disagrees() {
+        let mut bytes = vec![0_u8; 17];
+        bytes[8] = records::op::METADATA;
+        let mut file = DaftFile::from_bytes(MediaType::Mcap, bytes);
+
+        let error = read_record_at(&mut file, 17, 8, Some(10)).unwrap_err();
+
+        assert!(error.to_string().contains("its index declares 10"));
+    }
+}

--- a/src/daft-file/src/mcap/python.rs
+++ b/src/daft-file/src/mcap/python.rs
@@ -1,0 +1,37 @@
+use pyo3::prelude::*;
+
+use crate::{
+    DaftFile,
+    mcap::{
+        BUFFER_SIZE_MCAP_METADATA, McapMetadata, ReadMetadataOptions, read_metadata_with_options,
+    },
+    python::PyFileReference,
+};
+
+#[pyfunction]
+#[pyo3(signature = (file, include_schema_data=true, include_metadata_records=true, include_chunk_indexes=true))]
+fn _read_mcap_metadata(
+    py: Python<'_>,
+    file: &PyFileReference,
+    include_schema_data: bool,
+    include_metadata_records: bool,
+    include_chunk_indexes: bool,
+) -> PyResult<McapMetadata> {
+    let file_ref = file.file_reference();
+    py.detach(move || {
+        let mut file = DaftFile::load_blocking(file_ref, false, Some(BUFFER_SIZE_MCAP_METADATA))?;
+        Ok(read_metadata_with_options(
+            &mut file,
+            ReadMetadataOptions {
+                include_schema_data,
+                include_metadata_records,
+                include_chunk_indexes,
+            },
+        )?)
+    })
+}
+
+pub(crate) fn register_modules(parent: &Bound<PyModule>) -> PyResult<()> {
+    parent.add_function(wrap_pyfunction!(_read_mcap_metadata, parent)?)?;
+    Ok(())
+}

--- a/src/daft-file/src/python.rs
+++ b/src/daft-file/src/python.rs
@@ -21,8 +21,14 @@ type SeekResult = Result<(u64, FileCursor), (PyErr, FileCursor)>;
 
 #[pyclass(from_py_object)]
 #[derive(Clone)]
-struct PyFileReference {
+pub(crate) struct PyFileReference {
     inner: Arc<FileReference>,
+}
+
+impl PyFileReference {
+    pub(crate) fn file_reference(&self) -> FileReference {
+        self.inner.as_ref().clone()
+    }
 }
 
 #[pymethods]
@@ -33,7 +39,7 @@ impl PyFileReference {
         Ok(Self { inner: Arc::new(f) })
     }
 
-    pub fn __enter__(&self, py: Python<'_>) -> PyResult<PyDaftFile> {
+    fn __enter__(&self, py: Python<'_>) -> PyResult<PyDaftFile> {
         let file_ref = self.inner.as_ref().clone();
         py.detach(move || Ok(DaftFile::load_blocking(file_ref, true, None)?.into()))
     }
@@ -336,6 +342,7 @@ pub fn register_modules(parent: &Bound<PyModule>) -> PyResult<()> {
     parent.add_class::<PyDaftFile>()?;
     parent.add_class::<PyFileReference>()?;
     parent.add_function(wrap_pyfunction!(guess_mimetype_from_content, parent)?)?;
+    crate::mcap::register_python_modules(parent)?;
 
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,6 +185,7 @@ pub mod pylib {
         functions_registry.add_fn(daft_file::ImageFile);
         functions_registry.add_fn(daft_file::Hdf5File);
         functions_registry.add_fn(daft_file::McapFile);
+        functions_registry.add_fn(daft_file::McapSummaryProjection);
         functions_registry.add_fn(daft_file::GuessMimeType);
         functions_registry
             .add_fn(daft_functions::monotonically_increasing_id::MonotonicallyIncreasingId);

--- a/tests/file/test_mcap_file.py
+++ b/tests/file/test_mcap_file.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import ClassVar
+
 import pytest
 
 pytest.importorskip("mcap")
 
-from mcap.writer import Writer
+from mcap.writer import CompressionType, IndexType, Writer
 
 import daft
 from daft.exceptions import DaftCoreException
@@ -14,25 +18,170 @@ from daft.exceptions import DaftCoreException
 def sample_mcap_path(tmp_path):
     path = tmp_path / "sample.mcap"
     with path.open("wb") as output:
-        writer = Writer(output)
-        writer.start()
+        writer = Writer(output, chunk_size=128)
+        writer.start(profile="test-profile", library="test-writer")
+        schema_id = writer.register_schema("example.Message", "protobuf", b"schema-bytes")
+        state_channel = writer.register_channel(
+            topic="/state",
+            message_encoding="protobuf",
+            schema_id=schema_id,
+            metadata={"role": "state"},
+        )
+        video_channel = writer.register_channel(
+            topic="/camera",
+            message_encoding="protobuf",
+            schema_id=schema_id,
+            metadata={"codec": "h264"},
+        )
+        writer.register_channel(
+            topic="/raw",
+            message_encoding="json",
+            schema_id=0,
+            metadata={"schema": "none"},
+        )
+
+        for sequence in range(10):
+            writer.add_message(
+                channel_id=state_channel,
+                log_time=1_000 + sequence * 10,
+                publish_time=1_001 + sequence * 10,
+                sequence=sequence,
+                data=f"state-{sequence}".encode(),
+            )
+            writer.add_message(
+                channel_id=video_channel,
+                log_time=1_005 + sequence * 10,
+                publish_time=1_006 + sequence * 10,
+                sequence=sequence,
+                data=b"\x00\x00\x00\x01\x65",
+            )
+
+        writer.add_metadata("session", {"episode_id": "episode-1"})
+        writer.add_attachment(
+            create_time=900,
+            log_time=1_000,
+            name="calibration.json",
+            media_type="application/json",
+            data=b'{"camera":"front"}',
+        )
         writer.finish()
     return str(path)
 
 
-def test_mcap_file_type(sample_mcap_path):
+def test_mcap_file_native_metadata(sample_mcap_path):
     file = daft.McapFile(sample_mcap_path)
-    assert file.is_mcap()
+    metadata = file.metadata()
 
+    assert metadata["indexed"] is True
+    assert metadata["has_chunk_indexes"] is True
+    assert metadata["has_message_indexes"] is True
+    assert metadata["header"] == {"profile": "test-profile", "library": "test-writer"}
+    assert metadata["statistics"] == {
+        "message_count": 20,
+        "schema_count": 1,
+        "channel_count": 3,
+        "attachment_count": 1,
+        "metadata_count": 1,
+        "chunk_count": len(metadata["chunks"]),
+        "message_start_time": 1_000,
+        "message_end_time": 1_095,
+    }
+    assert file.topics() == ["/state", "/camera", "/raw"]
+    assert file.message_count() == 20
+    assert file.time_range() == {"start_time": 1_000, "end_time": 1_095}
+
+    channels = {channel["topic"]: channel for channel in metadata["channels"]}
+    assert channels["/state"]["message_count"] == 10
+    assert channels["/camera"]["metadata"] == {"codec": "h264"}
+    assert channels["/raw"]["schema_id"] is None
+    assert channels["/raw"]["schema_name"] is None
+    assert channels["/raw"]["message_count"] is None
+    assert metadata["schemas"][0]["name"] == "example.Message"
+    assert metadata["schemas"][0]["data"] == b"schema-bytes"
+    assert metadata["metadata"] == [
+        {
+            "name": "session",
+            "metadata": {"episode_id": "episode-1"},
+            "position": metadata["metadata"][0]["position"],
+            "size": metadata["metadata"][0]["size"],
+        }
+    ]
+    assert metadata["attachments"] == [
+        {
+            "position": metadata["attachments"][0]["position"],
+            "size": metadata["attachments"][0]["size"],
+            "log_time": 1_000,
+            "create_time": 900,
+            "data_size": len(b'{"camera":"front"}'),
+            "name": "calibration.json",
+            "media_type": "application/json",
+        }
+    ]
+    assert len(metadata["chunks"]) > 1
+    assert all(chunk["position"] >= 0 and chunk["size"] > 0 for chunk in metadata["chunks"])
+
+
+def test_mcap_file_dtype_and_expressions(sample_mcap_path, monkeypatch):
     df = daft.from_pydict({"path": [sample_mcap_path]}).select(
         daft.functions.mcap_file(daft.col("path"), verify=True).alias("recording")
     )
     assert df.schema()["recording"].dtype == daft.DataType.file(daft.MediaType.mcap())
-    assert isinstance(df.collect().to_pydict()["recording"][0], daft.McapFile)
+
+    def fail_if_python_metadata_is_used(_self, **_kwargs):
+        raise AssertionError("MCAP expressions must execute in Rust")
+
+    monkeypatch.setattr(daft.McapFile, "_read_metadata", fail_if_python_metadata_is_used)
+
+    result = (
+        df.select(
+            daft.col("recording").mcap_topics().alias("topics"),
+            daft.col("recording").mcap_message_count().alias("message_count"),
+            daft.col("recording").mcap_time_range().alias("time_range"),
+        )
+        .collect()
+        .to_pydict()
+    )
+
+    assert result["topics"] == [["/state", "/camera", "/raw"]]
+    assert result["message_count"] == [20]
+    assert result["time_range"] == [{"start_time": 1_000, "end_time": 1_095}]
+
+
+def test_mcap_metadata_can_be_projected_in_python_udf(sample_mcap_path):
+    @daft.func
+    def schema_names(recording: daft.McapFile) -> list[str]:
+        return [schema["name"] for schema in recording.metadata()["schemas"]]
+
+    df = daft.from_pydict({"path": [sample_mcap_path]}).select(
+        daft.functions.mcap_file(daft.col("path")).alias("recording")
+    )
+    result = df.select(schema_names(daft.col("recording")).alias("schema_names")).collect().to_pydict()
+
+    assert result["schema_names"] == [["example.Message"]]
+
+
+def test_empty_mcap_has_null_time_bounds(tmp_path):
+    path = tmp_path / "empty.mcap"
+    with path.open("wb") as output:
+        writer = Writer(output)
+        writer.start()
+        writer.finish()
+
+    file = daft.McapFile(str(path))
+    assert file.message_count() == 0
+    assert file.time_range() == {"start_time": None, "end_time": None}
+
+    result = (
+        daft.from_pydict({"path": [str(path)]})
+        .select(daft.functions.mcap_file(daft.col("path")).mcap_time_range().alias("time_range"))
+        .collect()
+        .to_pydict()
+    )
+    assert result["time_range"] == [{"start_time": None, "end_time": None}]
 
 
 def test_as_mcap_from_generic_file(sample_mcap_path):
-    assert isinstance(daft.File(sample_mcap_path).as_mcap(), daft.McapFile)
+    assert daft.File(sample_mcap_path).as_mcap().message_count() == 20
 
     df = daft.from_pydict({"path": [sample_mcap_path]})
     df = df.select(daft.functions.mcap_file(daft.functions.file(df["path"]), verify=True))
@@ -49,3 +198,116 @@ def test_mcap_file_rejects_invalid_magic(tmp_path):
     df = daft.from_pydict({"path": [str(path)]})
     with pytest.raises(DaftCoreException, match="Invalid MCAP file"):
         df.select(daft.functions.mcap_file(daft.col("path"), verify=True)).collect()
+
+
+def test_mcap_metadata_does_not_scan_unindexed_data(tmp_path):
+    path = tmp_path / "unindexed.mcap"
+    with path.open("wb") as output:
+        writer = Writer(
+            output,
+            index_types=IndexType.NONE,
+            repeat_channels=False,
+            repeat_schemas=False,
+            use_statistics=False,
+            use_summary_offsets=False,
+        )
+        writer.start()
+        schema_id = writer.register_schema("example.Message", "protobuf", b"schema")
+        channel_id = writer.register_channel("/state", "protobuf", schema_id)
+        writer.add_message(channel_id, log_time=1, publish_time=1, sequence=0, data=b"payload")
+        writer.finish()
+
+    metadata = daft.McapFile(str(path)).metadata()
+    assert metadata["indexed"] is False
+    assert metadata["has_chunk_indexes"] is False
+    assert metadata["has_message_indexes"] is False
+    assert metadata["statistics"] is None
+    assert metadata["chunks"] == []
+
+
+def test_mcap_summary_without_chunk_indexes(tmp_path):
+    path = tmp_path / "summary-only.mcap"
+    with path.open("wb") as output:
+        writer = Writer(output, index_types=IndexType.NONE)
+        writer.start()
+        schema_id = writer.register_schema("example.Message", "protobuf", b"schema")
+        channel_id = writer.register_channel("/state", "protobuf", schema_id)
+        writer.add_message(channel_id, log_time=1, publish_time=1, sequence=0, data=b"payload")
+        writer.finish()
+
+    metadata = daft.McapFile(str(path)).metadata()
+    assert metadata["has_summary"] is True
+    assert metadata["has_chunk_indexes"] is False
+    assert metadata["has_message_indexes"] is False
+    assert metadata["statistics"]["message_count"] == 1
+    assert [channel["topic"] for channel in metadata["channels"]] == ["/state"]
+
+
+def test_mcap_metadata_uses_remote_ranges(tmp_path):
+    path = tmp_path / "large.mcap"
+    with path.open("wb") as output:
+        writer = Writer(output, chunk_size=32 * 1024 * 1024, compression=CompressionType.NONE)
+        writer.start()
+        schema_id = writer.register_schema("example.Message", "protobuf", b"schema")
+        channel_id = writer.register_channel("/state", "protobuf", schema_id)
+        writer.add_message(
+            channel_id,
+            log_time=1,
+            publish_time=1,
+            sequence=0,
+            data=b"\x00" * (20 * 1024 * 1024),
+        )
+        writer.finish()
+    contents = path.read_bytes()
+
+    class RangeHandler(BaseHTTPRequestHandler):
+        bytes_served = 0
+        ranges: ClassVar[list[str | None]] = []
+
+        def log_message(self, format, *args):
+            pass
+
+        def do_HEAD(self):
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(contents)))
+            self.send_header("Accept-Ranges", "bytes")
+            self.end_headers()
+
+        def do_GET(self):
+            range_header = self.headers.get("Range")
+            type(self).ranges.append(range_header)
+            if range_header is None:
+                start, end = 0, len(contents) - 1
+                status = 200
+            else:
+                units, requested = range_header.split("=", 1)
+                assert units == "bytes"
+                start_text, end_text = requested.split("-", 1)
+                start = int(start_text)
+                end = min(int(end_text) if end_text else len(contents) - 1, len(contents) - 1)
+                status = 206
+
+            payload = contents[start : end + 1]
+            type(self).bytes_served += len(payload)
+            self.send_response(status)
+            self.send_header("Content-Length", str(len(payload)))
+            self.send_header("Accept-Ranges", "bytes")
+            if status == 206:
+                self.send_header("Content-Range", f"bytes {start}-{end}/{len(contents)}")
+            self.end_headers()
+            self.wfile.write(payload)
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), RangeHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        url = f"http://127.0.0.1:{server.server_port}/large.mcap"
+        metadata = daft.McapFile(url).metadata()
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert metadata["statistics"]["message_count"] == 1
+    assert RangeHandler.ranges and all(request is not None for request in RangeHandler.ranges)
+    assert RangeHandler.bytes_served < len(contents) // 4


### PR DESCRIPTION
## Changes Made

- Parse MCAP headers and footer summaries natively with the official Rust `mcap` crate and Daft's range-readable file interface.
- Expose the complete catalog through `McapFile.metadata()` and focused object helpers without serializing through JSON or adding MCAP-specific methods to the generic file bridge.
- Add native `mcap_topics`, `mcap_message_count`, and `mcap_time_range` expressions backed by one private summary projection.
- Keep uncommon catalog projections in Python UDFs over `McapFile.metadata()` instead of exposing a full-catalog DataFrame UDF.
- Add Rust parser/projection tests plus indexed, unindexed, empty-file, custom-UDF, and remote range-read coverage.

This PR is stacked on #7314, which contains only the `File[Mcap]` type and construction plumbing.

## Related Issues

- Depends on #7314

## Validation

- `make build`
- `cargo test -p daft-file mcap::` (8 passed)
- `DAFT_RUNNER=native make test EXTRA_ARGS='-v tests/file/test_mcap_file.py'` (9 passed)
- `cargo fmt --all -- --check`
- `git diff --check`