### PR TITLE
fix(dashboard): support OUT_DIR on a different filesystem from the source tree

### DIFF
--- a/src/daft-dashboard/build.rs
+++ b/src/daft-dashboard/build.rs
@@ -1,4 +1,37 @@
-use std::process::Command;
+use std::{io, path::Path, process::Command};
+
+/// Recursively copy the contents of `src` into `dst`.
+fn copy_dir_all(src: &Path, dst: &Path) -> io::Result<()> {
+    std::fs::create_dir_all(dst)?;
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let dst = dst.join(entry.file_name());
+        if entry.file_type()?.is_dir() {
+            copy_dir_all(&entry.path(), &dst)?;
+        } else {
+            std::fs::copy(entry.path(), &dst)?;
+        }
+    }
+    Ok(())
+}
+
+/// Move `src` to `dst`, falling back to a recursive copy across filesystems.
+///
+/// `OUT_DIR` lives under the cargo target directory, which is routinely on a
+/// different filesystem from the source tree: `CARGO_TARGET_DIR` pointed at a
+/// separate mount or tmpfs, a container with the source bind-mounted and the
+/// target on a volume, a CI cache mount, or a distinct btrfs subvolume. In all
+/// of those cases `rename(2)` fails with `EXDEV` rather than moving the
+/// directory, so fall back to copy-then-remove.
+fn move_dir(src: &Path, dst: &Path) -> io::Result<()> {
+    match std::fs::rename(src, dst) {
+        Err(e) if e.kind() == io::ErrorKind::CrossesDevices => {
+            copy_dir_all(src, dst)?;
+            std::fs::remove_dir_all(src)
+        }
+        result => result,
+    }
+}
 
 fn ci_main(out_dir: &str) -> Result<(), Box<dyn std::error::Error>> {
     let frontend_dir = std::env::var("CARGO_MANIFEST_DIR")? + "/frontend/out";
@@ -19,7 +52,7 @@ fn ci_main(out_dir: &str) -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // move the frontend assets to the output directory
-    std::fs::rename(frontend_dir, out_dir)?;
+    move_dir(Path::new(&frontend_dir), Path::new(out_dir))?;
     Ok(())
 }
 
@@ -90,7 +123,7 @@ fn default_main(out_dir: &str) -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // move the frontend assets to the output directory
-    std::fs::rename(frontend_dir, out_dir)?;
+    move_dir(Path::new(&frontend_dir), Path::new(out_dir))?;
     Ok(())
 }
 

--- a/src/daft-dashboard/build.rs
+++ b/src/daft-dashboard/build.rs
@@ -1,12 +1,17 @@
 use std::{io, path::Path, process::Command};
 
-/// Recursively copy the contents of `src` into `dst`.
+/// Recursively copy the contents of `src` into `dst`, resolving symlinks.
+///
+/// `Path::is_dir` follows symlinks, where `DirEntry::file_type` does not. That
+/// matters because `std::fs::copy` also follows them, and refuses a directory:
+/// testing the entry type directly would send a symlinked directory down the
+/// copy branch and fail.
 fn copy_dir_all(src: &Path, dst: &Path) -> io::Result<()> {
     std::fs::create_dir_all(dst)?;
     for entry in std::fs::read_dir(src)? {
         let entry = entry?;
         let dst = dst.join(entry.file_name());
-        if entry.file_type()?.is_dir() {
+        if entry.path().is_dir() {
             copy_dir_all(&entry.path(), &dst)?;
         } else {
             std::fs::copy(entry.path(), &dst)?;


### PR DESCRIPTION
## Problem Description

The dashboard build script moves the generated frontend assets into `OUT_DIR` with `std::fs::rename`, at both call sites (`ci_main` and `default_main`). `rename(2)` fails with `EXDEV` when source and destination live on different filesystems, which is routine for cargo: `CARGO_TARGET_DIR` pointed at a separate mount or tmpfs, a container with the source bind-mounted and the target on a volume, a CI cache mount, or a distinct btrfs subvolume.

The build then fails outright:

```
error: failed to run custom build command for `daft-dashboard v0.3.0-dev0`
  Error: Os { code: 18, kind: CrossesDevices, message: "Invalid cross-device link" }
```

Reproduction on a stock Linux box, where `/tmp` is tmpfs and therefore a different device from the checkout:

```console
$ CARGO_TARGET_DIR=/tmp/daft-target cargo build -p daft-dashboard
```

## Changes Made

Fall back to a recursive copy followed by removing the source when rename reports `ErrorKind::CrossesDevices`. The fallback is not atomic, unlike `rename(2)`, and it resolves symlinks rather than recreating them; neither matters for the generated asset tree, which is regular files and directories only. The rename fast path is unchanged, so behaviour is identical for anyone whose build already worked. No new dependencies.

## Verification

A/B on one machine against one target directory, with the patch as the only variable:

| | result |
|---|---|
| without patch | `exit 101`, `Error: Os { code: 18, kind: CrossesDevices, ... }` |
| with patch | `exit 0` |

- `make build` end to end: wheel built and installed editable.
- Asset tree in `OUT_DIR` after the copy fallback matches `frontend/out`: 56 files, 1.5 MB, `index.html` present, nested `_next/` preserved, and the source directory removed as `rename` would have left it.
- `cargo clippy -p daft-dashboard` and `cargo fmt -p daft-dashboard -- --check` are clean.

No automated test is included: `build.rs` is not compiled into any test target, so `move_dir` has no `cargo test` seam without restructuring the crate, and a meaningful CI test would need two filesystems. Happy to extract the helper if you would like one.

## Related Issues

None. This is a clearly scoped bugfix, so per `CONTRIBUTING.md` it may qualify for the `no-issue-needed` label. Glad to open an issue first if you would rather.

---

This PR was made with the assistance of Opus 4.8.
