### PR TITLE
feat(rotation): native quaternion, 6D, and SO(3) expressions for pose data

### DIFF
--- a/daft/functions/__init__.py
+++ b/daft/functions/__init__.py
@@ -320,6 +320,15 @@ from .window import (
     first_value,
     last_value,
 )
+from .rotation import (
+    matrix_to_quat,
+    quat_inverse,
+    quat_multiply,
+    quat_rotate,
+    quat_to_matrix,
+    rot6d_to_matrix,
+    rotation_geodesic_angle,
+)
 
 __all__ = [
     "abs",
@@ -508,6 +517,7 @@ __all__ = [
     "make_timestamp_ltz",
     "map_get",
     "map_keys",
+    "matrix_to_quat",
     "max",
     "mean",
     "median",
@@ -542,6 +552,10 @@ __all__ = [
     "product",
     "prompt",
     "quarter",
+    "quat_inverse",
+    "quat_multiply",
+    "quat_rotate",
+    "quat_to_matrix",
     "radians",
     "random_int",
     "rank",
@@ -558,6 +572,8 @@ __all__ = [
     "resize",
     "reverse",
     "right",
+    "rot6d_to_matrix",
+    "rotation_geodesic_angle",
     "round",
     "row_number",
     "rpad",

--- a/daft/functions/rotation.py
+++ b/daft/functions/rotation.py
@@ -12,9 +12,9 @@ The argument is case-insensitive.
 Rotation matrices are ``Tensor[Float64; [3, 3]]``, in row-major order.
 
 Every function here returns null for a row that does not denote a rotation: a null
-input, a value that is ``NaN`` or infinite, a zero quaternion, a 6D pair whose two
-vectors are zero or parallel, or a matrix that is not in ``SO(3)``. Nothing is
-silently coerced into a plausible rotation.
+input, a null component within a row, a value that is ``NaN`` or infinite, a zero
+quaternion, a 6D pair whose two vectors are zero or parallel, or a matrix that is
+not in ``SO(3)``. Nothing is silently coerced into a plausible rotation.
 """
 
 from __future__ import annotations
@@ -87,9 +87,9 @@ def matrix_to_quat(matrix: Expression, *, order: QuatOrder = "xyzw") -> Expressi
     naive trace formula loses precision. The sign is not canonicalized, since a
     quaternion and its negation denote the same rotation.
 
-    Shepperd's method yields a unit quaternion exactly when its input lies in ``SO(3)``,
-    so a matrix that is scaled, is a reflection, or holds a non-finite value produces
-    null rather than a plausible quaternion.
+    The matrix is tested for membership in ``SO(3)`` first, so one that is scaled, is a
+    shear, is a reflection, or holds a non-finite value produces null rather than a
+    plausible quaternion.
 
     Args:
         matrix (Tensor[Float64, [3, 3]] Expression): The rotation matrix.
@@ -160,9 +160,9 @@ def rotation_geodesic_angle(left: Expression, right: Expression) -> Expression:
     which lies in ``[0, pi]``. This is the bi-invariant Riemannian metric, so it is
     symmetric and unchanged by rotating both arguments.
 
-    Rounding is absorbed by clamping the cosine into ``[-1, 1]``. A row where either
-    argument is not a rotation, and so the cosine lies well outside that range, produces
-    null rather than a plausible angle.
+    Both arguments are tested for membership in ``SO(3)``, since the angle is only
+    defined between rotations: a row where either is not a rotation produces null rather
+    than a plausible angle. Rounding is absorbed by clamping the cosine into ``[-1, 1]``.
 
     Applied to consecutive frames of a trajectory, it measures how much a body turned
     between them.

--- a/daft/functions/rotation.py
+++ b/daft/functions/rotation.py
@@ -7,8 +7,14 @@ rotations does not require a Python UDF.
 Quaternions are fixed-size lists of four floats. The component order defaults to
 ``"xyzw"``, matching ROS, tf2, and ``scipy.spatial.transform.Rotation``. Pass
 ``order="wxyz"`` for the scalar-first convention used by Eigen, MuJoCo, and Isaac Sim.
+The argument is case-insensitive.
 
 Rotation matrices are ``Tensor[Float64; [3, 3]]``, in row-major order.
+
+Every function here returns null for a row that does not denote a rotation: a null
+input, a value that is ``NaN`` or infinite, a zero quaternion, a 6D pair whose two
+vectors are zero or parallel, or a matrix that is not in ``SO(3)``. Nothing is
+silently coerced into a plausible rotation.
 """
 
 from __future__ import annotations
@@ -38,7 +44,8 @@ def rot6d_to_matrix(rot6d: Expression) -> Expression:
     in SO(3). This is the representation of Zhou et al. (2019), widely used as a network
     output because it is continuous, unlike quaternions and Euler angles.
 
-    Rows whose two vectors are zero or parallel produce null, since they determine no rotation.
+    Rows whose two vectors are zero or parallel, or which hold a non-finite value,
+    produce null, since they determine no rotation.
 
     Args:
         rot6d (FixedSizeList[Float64, 6] Expression): The 6D rotation representation.
@@ -60,11 +67,12 @@ def rot6d_to_matrix(rot6d: Expression) -> Expression:
 def quat_to_matrix(quat: Expression, *, order: QuatOrder = "xyzw") -> Expression:
     """Converts a quaternion into a 3x3 rotation matrix.
 
-    The quaternion is normalized first. Zero quaternions produce null.
+    The quaternion is normalized first. Zero quaternions, and rows holding a
+    non-finite value, produce null.
 
     Args:
         quat (FixedSizeList[Float64, 4] Expression): The quaternion.
-        order (str, default="xyzw"): Component order, either "xyzw" or "wxyz".
+        order (str, default="xyzw"): Component order, either "xyzw" or "wxyz". Case-insensitive.
 
     Returns:
         Expression (Tensor[Float64, [3, 3]] Expression): The rotation matrix.
@@ -79,9 +87,13 @@ def matrix_to_quat(matrix: Expression, *, order: QuatOrder = "xyzw") -> Expressi
     naive trace formula loses precision. The sign is not canonicalized, since a
     quaternion and its negation denote the same rotation.
 
+    Shepperd's method yields a unit quaternion exactly when its input lies in ``SO(3)``,
+    so a matrix that is scaled, is a reflection, or holds a non-finite value produces
+    null rather than a plausible quaternion.
+
     Args:
         matrix (Tensor[Float64, [3, 3]] Expression): The rotation matrix.
-        order (str, default="xyzw"): Component order, either "xyzw" or "wxyz".
+        order (str, default="xyzw"): Component order, either "xyzw" or "wxyz". Case-insensitive.
 
     Returns:
         Expression (FixedSizeList[Float64, 4] Expression): The quaternion.
@@ -93,12 +105,13 @@ def quat_multiply(left: Expression, right: Expression, *, order: QuatOrder = "xy
     """Hamilton product of two quaternions.
 
     The result applies `right` first and then `left`, matching composition of the
-    corresponding rotation matrices. Neither input is normalized.
+    corresponding rotation matrices. Neither input is normalized. Rows holding a
+    non-finite value produce null.
 
     Args:
         left (FixedSizeList[Float64, 4] Expression): The left quaternion.
         right (FixedSizeList[Float64, 4] Expression): The right quaternion.
-        order (str, default="xyzw"): Component order, either "xyzw" or "wxyz".
+        order (str, default="xyzw"): Component order, either "xyzw" or "wxyz". Case-insensitive.
 
     Returns:
         Expression (FixedSizeList[Float64, 4] Expression): The product.
@@ -110,11 +123,11 @@ def quat_inverse(quat: Expression, *, order: QuatOrder = "xyzw") -> Expression:
     """Inverse of a quaternion, the conjugate divided by the squared norm.
 
     For unit quaternions this is the conjugate, and it undoes the rotation.
-    Zero quaternions produce null.
+    Zero quaternions, and rows holding a non-finite value, produce null.
 
     Args:
         quat (FixedSizeList[Float64, 4] Expression): The quaternion.
-        order (str, default="xyzw"): Component order, either "xyzw" or "wxyz".
+        order (str, default="xyzw"): Component order, either "xyzw" or "wxyz". Case-insensitive.
 
     Returns:
         Expression (FixedSizeList[Float64, 4] Expression): The inverse.
@@ -126,12 +139,13 @@ def quat_rotate(quat: Expression, vector: Expression, *, order: QuatOrder = "xyz
     """Rotates a 3-vector by a quaternion.
 
     The quaternion is normalized first, so the length of the vector is preserved.
-    Zero quaternions produce null.
+    Zero quaternions, and rows where the quaternion or the vector holds a non-finite
+    value, produce null.
 
     Args:
         quat (FixedSizeList[Float64, 4] Expression): The quaternion.
         vector (FixedSizeList[Float64, 3] Expression): The vector to rotate.
-        order (str, default="xyzw"): Component order, either "xyzw" or "wxyz".
+        order (str, default="xyzw"): Component order, either "xyzw" or "wxyz". Case-insensitive.
 
     Returns:
         Expression (FixedSizeList[Float64, 3] Expression): The rotated vector.
@@ -145,6 +159,10 @@ def rotation_geodesic_angle(left: Expression, right: Expression) -> Expression:
     Computes ``arccos((trace(A @ B.T) - 1) / 2)``, the geodesic distance on SO(3),
     which lies in ``[0, pi]``. This is the bi-invariant Riemannian metric, so it is
     symmetric and unchanged by rotating both arguments.
+
+    Rounding is absorbed by clamping the cosine into ``[-1, 1]``. A row where either
+    argument is not a rotation, and so the cosine lies well outside that range, produces
+    null rather than a plausible angle.
 
     Applied to consecutive frames of a trajectory, it measures how much a body turned
     between them.

--- a/daft/functions/rotation.py
+++ b/daft/functions/rotation.py
@@ -1,0 +1,159 @@
+"""Rotation functions.
+
+Robot trajectories, camera extrinsics, and hand-tracking datasets carry rotations.
+These functions operate on them natively, so composing, inverting, and comparing
+rotations does not require a Python UDF.
+
+Quaternions are fixed-size lists of four floats. The component order defaults to
+``"xyzw"``, matching ROS, tf2, and ``scipy.spatial.transform.Rotation``. Pass
+``order="wxyz"`` for the scalar-first convention used by Eigen, MuJoCo, and Isaac Sim.
+
+Rotation matrices are ``Tensor[Float64; [3, 3]]``, in row-major order.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from daft.expressions import Expression
+
+__all__ = [
+    "matrix_to_quat",
+    "quat_inverse",
+    "quat_multiply",
+    "quat_rotate",
+    "quat_to_matrix",
+    "rot6d_to_matrix",
+    "rotation_geodesic_angle",
+]
+
+QuatOrder = Literal["xyzw", "wxyz"]
+
+
+def rot6d_to_matrix(rot6d: Expression) -> Expression:
+    """Converts the 6D continuous rotation representation into a 3x3 rotation matrix.
+
+    The six values are the first two columns of the matrix. They are orthonormalized by
+    Gram-Schmidt, and the third column is their cross product, so the result always lies
+    in SO(3). This is the representation of Zhou et al. (2019), widely used as a network
+    output because it is continuous, unlike quaternions and Euler angles.
+
+    Rows whose two vectors are zero or parallel produce null, since they determine no rotation.
+
+    Args:
+        rot6d (FixedSizeList[Float64, 6] Expression): The 6D rotation representation.
+
+    Returns:
+        Expression (Tensor[Float64, [3, 3]] Expression): The rotation matrix.
+
+    Examples:
+        >>> import daft
+        >>> from daft.functions import rot6d_to_matrix
+        >>> df = daft.from_pydict({"r": [[1.0, 0.0, 0.0, 0.0, 1.0, 0.0]]})
+        >>> df = df.select(rot6d_to_matrix(df["r"].cast(daft.DataType.fixed_size_list(daft.DataType.float64(), 6))))
+        >>> df.to_pydict()["r"][0].tolist()
+        [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+    """
+    return Expression._call_builtin_scalar_fn("rot6d_to_matrix", rot6d)
+
+
+def quat_to_matrix(quat: Expression, *, order: QuatOrder = "xyzw") -> Expression:
+    """Converts a quaternion into a 3x3 rotation matrix.
+
+    The quaternion is normalized first. Zero quaternions produce null.
+
+    Args:
+        quat (FixedSizeList[Float64, 4] Expression): The quaternion.
+        order (str, default="xyzw"): Component order, either "xyzw" or "wxyz".
+
+    Returns:
+        Expression (Tensor[Float64, [3, 3]] Expression): The rotation matrix.
+    """
+    return Expression._call_builtin_scalar_fn("quat_to_matrix", quat, order=order)
+
+
+def matrix_to_quat(matrix: Expression, *, order: QuatOrder = "xyzw") -> Expression:
+    """Converts a 3x3 rotation matrix into a quaternion.
+
+    Uses Shepperd's method, which stays numerically stable near a half turn where the
+    naive trace formula loses precision. The sign is not canonicalized, since a
+    quaternion and its negation denote the same rotation.
+
+    Args:
+        matrix (Tensor[Float64, [3, 3]] Expression): The rotation matrix.
+        order (str, default="xyzw"): Component order, either "xyzw" or "wxyz".
+
+    Returns:
+        Expression (FixedSizeList[Float64, 4] Expression): The quaternion.
+    """
+    return Expression._call_builtin_scalar_fn("matrix_to_quat", matrix, order=order)
+
+
+def quat_multiply(left: Expression, right: Expression, *, order: QuatOrder = "xyzw") -> Expression:
+    """Hamilton product of two quaternions.
+
+    The result applies `right` first and then `left`, matching composition of the
+    corresponding rotation matrices. Neither input is normalized.
+
+    Args:
+        left (FixedSizeList[Float64, 4] Expression): The left quaternion.
+        right (FixedSizeList[Float64, 4] Expression): The right quaternion.
+        order (str, default="xyzw"): Component order, either "xyzw" or "wxyz".
+
+    Returns:
+        Expression (FixedSizeList[Float64, 4] Expression): The product.
+    """
+    return Expression._call_builtin_scalar_fn("quat_multiply", left, right, order=order)
+
+
+def quat_inverse(quat: Expression, *, order: QuatOrder = "xyzw") -> Expression:
+    """Inverse of a quaternion, the conjugate divided by the squared norm.
+
+    For unit quaternions this is the conjugate, and it undoes the rotation.
+    Zero quaternions produce null.
+
+    Args:
+        quat (FixedSizeList[Float64, 4] Expression): The quaternion.
+        order (str, default="xyzw"): Component order, either "xyzw" or "wxyz".
+
+    Returns:
+        Expression (FixedSizeList[Float64, 4] Expression): The inverse.
+    """
+    return Expression._call_builtin_scalar_fn("quat_inverse", quat, order=order)
+
+
+def quat_rotate(quat: Expression, vector: Expression, *, order: QuatOrder = "xyzw") -> Expression:
+    """Rotates a 3-vector by a quaternion.
+
+    The quaternion is normalized first, so the length of the vector is preserved.
+    Zero quaternions produce null.
+
+    Args:
+        quat (FixedSizeList[Float64, 4] Expression): The quaternion.
+        vector (FixedSizeList[Float64, 3] Expression): The vector to rotate.
+        order (str, default="xyzw"): Component order, either "xyzw" or "wxyz".
+
+    Returns:
+        Expression (FixedSizeList[Float64, 3] Expression): The rotated vector.
+    """
+    return Expression._call_builtin_scalar_fn("quat_rotate", quat, vector, order=order)
+
+
+def rotation_geodesic_angle(left: Expression, right: Expression) -> Expression:
+    """Angle in radians of the relative rotation between two 3x3 rotation matrices.
+
+    Computes ``arccos((trace(A @ B.T) - 1) / 2)``, the geodesic distance on SO(3),
+    which lies in ``[0, pi]``. This is the bi-invariant Riemannian metric, so it is
+    symmetric and unchanged by rotating both arguments.
+
+    Applied to consecutive frames of a trajectory, it measures how much a body turned
+    between them.
+
+    Args:
+        left (Tensor[Float64, [3, 3]] Expression): The first rotation matrix.
+        right (Tensor[Float64, [3, 3]] Expression): The second rotation matrix.
+
+    Returns:
+        Expression (Float64 Expression): The angle in radians.
+    """
+    return Expression._call_builtin_scalar_fn("rotation_geodesic_angle", left, right)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,7 +187,7 @@ docs = [
 [tool.codespell]
 check-filenames = true
 check-hidden = true
-ignore-words-list = "crate,arithmetics,ser,acter,MOR,NotIn"
+ignore-words-list = "crate,arithmetics,ser,acter,MOR,NotIn,shepperd"
 # Feel free to un-skip examples, and experimental, you will just need to
 # work through many typos (--write-changes and --interactive will help)
 skip = "tests/series/*,target,.git,.venv,venv,data,*.csv,*.csv.*,*.html,*.json,*.jsonl,*.pdf,*.txt,*.ipynb,*.tiktoken,*.sql,tests/table/utf8/*,tests/table/binary/*,*.warc,tests/ai/*"

--- a/src/daft-functions/src/lib.rs
+++ b/src/daft-functions/src/lib.rs
@@ -14,6 +14,7 @@ pub mod numeric;
 #[cfg(feature = "python")]
 pub mod python;
 pub mod random;
+pub mod rotation;
 pub mod simhash;
 pub mod similarity;
 pub mod slice;

--- a/src/daft-functions/src/rotation/functions.rs
+++ b/src/daft-functions/src/rotation/functions.rs
@@ -34,9 +34,8 @@ fn parse_order(fname: &str, order: Option<String>) -> DaftResult<QuatOrder> {
 }
 
 /// Check that `field` holds `size` floats per row, and name the output field.
-///
-/// Both `FixedSizeList` and the tensor types are accepted, since a fixed-shape
-/// tensor lowers to a fixed size list of the product of its shape.
+/// Tensors are accepted alongside `FixedSizeList`, since a fixed-shape tensor
+/// lowers to a fixed size list of the product of its shape.
 fn validate(fname: &str, field: &Field, size: usize, out: DataType) -> DaftResult<Field> {
     match field.dtype.to_physical() {
         DataType::FixedSizeList(inner, n)
@@ -87,14 +86,16 @@ fn align(fname: &str, a: Series, b: Series) -> DaftResult<(Series, Series)> {
     }
 }
 
-/// A fixed size list of `Float64`, viewed as one contiguous slice plus a validity mask.
+/// A fixed size list of `Float64`, viewed as one contiguous slice plus validity.
 ///
-/// Iterating a `FixedSizeListArray` yields `Option<Series>`, which allocates a
-/// `Series` per row. These expressions run over the flat child instead, so a
-/// column of a million rotations costs no allocation at all.
+/// Iterating a `FixedSizeListArray` yields `Option<Series>`, allocating a `Series`
+/// per row. These expressions run over the flat child instead, so a column of a
+/// million rotations costs no allocation at all.
 struct Rows<'a> {
     values: &'a [f64],
     nulls: Option<&'a NullBuffer>,
+    // A row may be valid while one of its numbers is null. That null lives here.
+    child_nulls: Option<&'a NullBuffer>,
     width: usize,
     len: usize,
 }
@@ -104,21 +105,30 @@ impl<'a> Rows<'a> {
         Ok(Self {
             values: list.flat_child.try_as_slice::<f64>()?,
             nulls: list.nulls(),
+            child_nulls: list.flat_child.nulls(),
             width,
             len: list.len(),
         })
     }
 
-    /// The `i`th row, or `None` when it is null or holds a non-finite value.
+    /// The `i`th row, or `None` when it denotes no rotation: a null row, a null
+    /// component, or a `NaN` or infinity. All three produce a null result.
     ///
-    /// A quaternion or matrix containing `NaN` or an infinity denotes no rotation,
-    /// so every expression here treats it the way it treats a null: the result is
-    /// null. Propagating the `NaN` instead would let it masquerade as a rotation.
+    /// The null component matters. The value buffer still holds a number under a
+    /// null slot, usually a zero, so reading it without the child validity would
+    /// quietly turn `[1, null, 0, 0]` into a half turn about x.
     fn get(&self, i: usize) -> Option<&'a [f64]> {
         if self.nulls.is_some_and(|n| n.is_null(i)) {
             return None;
         }
-        let row = self.values.get(i * self.width..(i + 1) * self.width)?;
+        let (start, end) = (i * self.width, (i + 1) * self.width);
+        if self
+            .child_nulls
+            .is_some_and(|n| (start..end).any(|j| n.is_null(j)))
+        {
+            return None;
+        }
+        let row = self.values.get(start..end)?;
         row.iter().all(|v| v.is_finite()).then_some(row)
     }
 }
@@ -326,7 +336,7 @@ impl ScalarUDF for MatrixToQuat {
     }
 
     fn docstring(&self) -> &'static str {
-        "Converts a 3x3 rotation matrix into a quaternion, using Shepperd's method for numerical stability near a half turn.\n\nThe sign is not canonicalized: a quaternion and its negation denote the same rotation. Pass order='wxyz' for the scalar-first convention; the default is 'xyzw', and the argument is case-insensitive. Rows whose matrix is not a rotation, because it is scaled, is a reflection, or holds a non-finite value, produce null."
+        "Converts a 3x3 rotation matrix into a quaternion, using Shepperd's method for numerical stability near a half turn.\n\nThe sign is not canonicalized: a quaternion and its negation denote the same rotation. Pass order='wxyz' for the scalar-first convention; the default is 'xyzw', and the argument is case-insensitive. Rows whose matrix is not a rotation, because it is scaled, is a shear, is a reflection, or holds a non-finite value, produce null."
     }
 }
 
@@ -560,7 +570,7 @@ impl ScalarUDF for RotationGeodesicAngle {
     }
 
     fn docstring(&self) -> &'static str {
-        "Angle in radians of the relative rotation between two 3x3 rotation matrices.\n\nComputes arccos((trace(A B^T) - 1) / 2), the geodesic distance on SO(3), which lies in [0, pi]. This is the bi-invariant Riemannian metric, so it is symmetric and unchanged by rotating both arguments. Rounding is absorbed by clamping the cosine into [-1, 1]. Rows where either argument is not a rotation, and so the cosine lies well outside that range, produce null rather than a plausible angle."
+        "Angle in radians of the relative rotation between two 3x3 rotation matrices.\n\nComputes arccos((trace(A B^T) - 1) / 2), the geodesic distance on SO(3), which lies in [0, pi]. This is the bi-invariant Riemannian metric, so it is symmetric and unchanged by rotating both arguments. Rounding is absorbed by clamping the cosine into [-1, 1]. Rows where either argument is not a rotation produce null rather than a plausible angle, since the angle is only defined between rotations."
     }
 }
 

--- a/src/daft-functions/src/rotation/functions.rs
+++ b/src/daft-functions/src/rotation/functions.rs
@@ -578,3 +578,32 @@ impl ScalarUDF for RotationGeodesicAngle {
 pub fn rotation_geodesic_angle(left: ExprRef, right: ExprRef) -> ExprRef {
     ScalarFn::builtin(RotationGeodesicAngle {}, vec![left, right]).into()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Reading the flat child by `i * width` is only sound because `slice` slices the
+    /// child with it, leaving no offset to carry. Row validity and component validity
+    /// are sliced alongside. A regression here would silently read a neighbouring row.
+    #[test]
+    fn a_sliced_column_reads_from_its_own_first_row() {
+        let field = Field::new("v", DataType::Float64);
+        // Four rows of three, with a null row and, in another row, a null component.
+        let values = (0..12).map(|i| (i != 10).then_some(f64::from(i)));
+        let child = Float64Array::from_iter(field, values).into_series();
+        let rows = FixedSizeListArray::new(
+            Field::new("v", list_dtype(3)),
+            child,
+            Some(NullBuffer::from(vec![true, false, true, true])),
+        );
+
+        let sliced = rows.slice(1, 4).unwrap();
+        let rows = Rows::new(&sliced, 3).unwrap();
+
+        assert_eq!(rows.len, 3);
+        assert_eq!(rows.get(0), None, "the null row, now first");
+        assert_eq!(rows.get(1), Some([6.0, 7.0, 8.0].as_slice()));
+        assert_eq!(rows.get(2), None, "holds the null component");
+    }
+}

--- a/src/daft-functions/src/rotation/functions.rs
+++ b/src/daft-functions/src/rotation/functions.rs
@@ -109,12 +109,17 @@ impl<'a> Rows<'a> {
         })
     }
 
-    /// The `i`th row, or `None` when it is null.
+    /// The `i`th row, or `None` when it is null or holds a non-finite value.
+    ///
+    /// A quaternion or matrix containing `NaN` or an infinity denotes no rotation,
+    /// so every expression here treats it the way it treats a null: the result is
+    /// null. Propagating the `NaN` instead would let it masquerade as a rotation.
     fn get(&self, i: usize) -> Option<&'a [f64]> {
         if self.nulls.is_some_and(|n| n.is_null(i)) {
             return None;
         }
-        self.values.get(i * self.width..(i + 1) * self.width)
+        let row = self.values.get(i * self.width..(i + 1) * self.width)?;
+        row.iter().all(|v| v.is_finite()).then_some(row)
     }
 }
 
@@ -231,7 +236,7 @@ impl ScalarUDF for Rot6dToMatrix {
     }
 
     fn docstring(&self) -> &'static str {
-        "Converts the 6D continuous rotation representation of Zhou et al. (2019) into a 3x3 rotation matrix.\n\nThe six values are the first two columns of the matrix. They are orthonormalized by Gram-Schmidt, and the third column is their cross product, so the result always lies in SO(3). Rows whose two vectors are zero or parallel produce null, since they determine no rotation."
+        "Converts the 6D continuous rotation representation of Zhou et al. (2019) into a 3x3 rotation matrix.\n\nThe six values are the first two columns of the matrix. They are orthonormalized by Gram-Schmidt, and the third column is their cross product, so the result always lies in SO(3). Rows whose two vectors are zero or parallel, or which hold a non-finite value, produce null, since they determine no rotation."
     }
 }
 
@@ -273,7 +278,7 @@ impl ScalarUDF for QuatToMatrix {
     }
 
     fn docstring(&self) -> &'static str {
-        "Converts a quaternion into a 3x3 rotation matrix.\n\nThe quaternion is normalized first. Pass order='wxyz' for the scalar-first convention used by Eigen, MuJoCo, and Isaac Sim; the default 'xyzw' matches ROS, tf2, and scipy. Zero quaternions produce null."
+        "Converts a quaternion into a 3x3 rotation matrix.\n\nThe quaternion is normalized first. Pass order='wxyz' for the scalar-first convention used by Eigen, MuJoCo, and Isaac Sim; the default 'xyzw' matches ROS, tf2, and scipy, and the argument is case-insensitive. Zero quaternions, and rows holding a non-finite value, produce null."
     }
 }
 
@@ -300,7 +305,7 @@ impl ScalarUDF for MatrixToQuat {
         let order = parse_order(self.name(), order)?;
         let list = unary(input.name(), &input, MAT3, |m| {
             let m: [f64; MAT3] = m.try_into().ok()?;
-            Some(order.write(math::mat_to_quat(m)))
+            math::mat_to_quat(m).map(|q| order.write(q))
         })?;
         Ok(list.into_series())
     }
@@ -321,7 +326,7 @@ impl ScalarUDF for MatrixToQuat {
     }
 
     fn docstring(&self) -> &'static str {
-        "Converts a 3x3 rotation matrix into a quaternion, using Shepperd's method for numerical stability near a half turn.\n\nThe sign is not canonicalized: a quaternion and its negation denote the same rotation. Pass order='wxyz' for the scalar-first convention; the default is 'xyzw'."
+        "Converts a 3x3 rotation matrix into a quaternion, using Shepperd's method for numerical stability near a half turn.\n\nThe sign is not canonicalized: a quaternion and its negation denote the same rotation. Pass order='wxyz' for the scalar-first convention; the default is 'xyzw', and the argument is case-insensitive. Rows whose matrix is not a rotation, because it is scaled, is a reflection, or holds a non-finite value, produce null."
     }
 }
 
@@ -374,7 +379,7 @@ impl ScalarUDF for QuatMultiply {
     }
 
     fn docstring(&self) -> &'static str {
-        "Hamilton product of two quaternions.\n\nThe result applies the right rotation first, then the left, matching composition of the corresponding rotation matrices. Neither input is normalized."
+        "Hamilton product of two quaternions.\n\nThe result applies the right rotation first, then the left, matching composition of the corresponding rotation matrices. Neither input is normalized. Rows holding a non-finite value produce null."
     }
 }
 
@@ -421,7 +426,7 @@ impl ScalarUDF for QuatInverse {
     }
 
     fn docstring(&self) -> &'static str {
-        "Inverse of a quaternion, the conjugate divided by the squared norm.\n\nFor unit quaternions this is the conjugate, and it undoes the rotation. Zero quaternions produce null."
+        "Inverse of a quaternion, the conjugate divided by the squared norm.\n\nFor unit quaternions this is the conjugate, and it undoes the rotation. Zero quaternions, and rows holding a non-finite value, produce null."
     }
 }
 
@@ -490,7 +495,7 @@ impl ScalarUDF for QuatRotate {
     }
 
     fn docstring(&self) -> &'static str {
-        "Rotates a 3-vector by a quaternion.\n\nThe quaternion is normalized first, so the length of the vector is preserved. Zero quaternions produce null."
+        "Rotates a 3-vector by a quaternion.\n\nThe quaternion is normalized first, so the length of the vector is preserved. Zero quaternions, and rows where the quaternion or the vector holds a non-finite value, produce null."
     }
 }
 
@@ -527,7 +532,7 @@ impl ScalarUDF for RotationGeodesicAngle {
             .map(|i| {
                 a.get(i)
                     .zip(b.get(i))
-                    .map(|(x, y)| math::geodesic_angle(x, y))
+                    .and_then(|(x, y)| math::geodesic_angle(x, y))
             })
             .collect::<Float64Array>()
             .rename(&name);
@@ -555,7 +560,7 @@ impl ScalarUDF for RotationGeodesicAngle {
     }
 
     fn docstring(&self) -> &'static str {
-        "Angle in radians of the relative rotation between two 3x3 rotation matrices.\n\nComputes arccos((trace(A B^T) - 1) / 2), the geodesic distance on SO(3), which lies in [0, pi]. This is the bi-invariant Riemannian metric, so it is symmetric and unchanged by rotating both arguments."
+        "Angle in radians of the relative rotation between two 3x3 rotation matrices.\n\nComputes arccos((trace(A B^T) - 1) / 2), the geodesic distance on SO(3), which lies in [0, pi]. This is the bi-invariant Riemannian metric, so it is symmetric and unchanged by rotating both arguments. Rounding is absorbed by clamping the cosine into [-1, 1]. Rows where either argument is not a rotation, and so the cosine lies well outside that range, produce null rather than a plausible angle."
     }
 }
 

--- a/src/daft-functions/src/rotation/functions.rs
+++ b/src/daft-functions/src/rotation/functions.rs
@@ -1,0 +1,565 @@
+use arrow_buffer::NullBuffer;
+use common_error::{DaftError, DaftResult, value_err};
+use daft_core::prelude::*;
+use daft_dsl::functions::{
+    prelude::*,
+    scalar::{EvalContext, ScalarFn},
+};
+use serde::{Deserialize, Serialize};
+
+use super::math::{self, QuatOrder};
+
+const QUAT: usize = 4;
+const VEC3: usize = 3;
+const ROT6D: usize = 6;
+const MAT3: usize = 9;
+
+fn matrix_dtype() -> DataType {
+    DataType::FixedShapeTensor(Box::new(DataType::Float64), vec![3, 3])
+}
+
+fn list_dtype(size: usize) -> DataType {
+    DataType::FixedSizeList(Box::new(DataType::Float64), size)
+}
+
+fn parse_order(fname: &str, order: Option<String>) -> DaftResult<QuatOrder> {
+    match order {
+        None => Ok(QuatOrder::Xyzw),
+        Some(s) => QuatOrder::parse(&s).ok_or_else(|| {
+            DaftError::ValueError(format!(
+                "Expected 'order' for '{fname}' to be 'xyzw' or 'wxyz', instead got '{s}'"
+            ))
+        }),
+    }
+}
+
+/// Check that `field` holds `size` floats per row, and name the output field.
+///
+/// Both `FixedSizeList` and the tensor types are accepted, since a fixed-shape
+/// tensor lowers to a fixed size list of the product of its shape.
+fn validate(fname: &str, field: &Field, size: usize, out: DataType) -> DaftResult<Field> {
+    match field.dtype.to_physical() {
+        DataType::FixedSizeList(inner, n)
+            if n == size && matches!(*inner, DataType::Float32 | DataType::Float64) =>
+        {
+            Ok(Field::new(field.name.clone(), out))
+        }
+        _ => value_err!(
+            "Expected input '{}' to '{}' to hold {} floats per row, instead got {}",
+            field.name,
+            fname,
+            size,
+            field.dtype
+        ),
+    }
+}
+
+/// Reduce any accepted input to a `FixedSizeList(Float64, size)` series.
+fn to_f64_list(input: &Series, size: usize) -> DaftResult<Series> {
+    let physical = input.as_physical()?;
+    let want = list_dtype(size);
+    if physical.data_type() == &want {
+        Ok(physical)
+    } else {
+        physical.cast(&want)
+    }
+}
+
+fn build_list(name: &str, size: usize, values: Vec<f64>, valid: Vec<bool>) -> FixedSizeListArray {
+    let nulls = (!valid.iter().all(|v| *v)).then(|| NullBuffer::from(valid));
+    let child = Float64Array::from_values(name, values.into_iter()).into_series();
+    FixedSizeListArray::new(Field::new(name, list_dtype(size)), child, nulls)
+}
+
+fn as_matrix(name: &str, list: FixedSizeListArray) -> Series {
+    FixedShapeTensorArray::new(Field::new(name, matrix_dtype()), list).into_series()
+}
+
+/// Align two inputs to a common row count, broadcasting a single row when needed.
+fn align(fname: &str, a: Series, b: Series) -> DaftResult<(Series, Series)> {
+    match (a.len(), b.len()) {
+        (x, y) if x == y => Ok((a, b)),
+        (1, y) => Ok((a.broadcast(y)?, b)),
+        (x, 1) => Ok((a, b.broadcast(x)?)),
+        (x, y) => Err(DaftError::ValueError(format!(
+            "Expected inputs to '{fname}' to have equal lengths or length 1, instead got {x} and {y}"
+        ))),
+    }
+}
+
+/// A fixed size list of `Float64`, viewed as one contiguous slice plus a validity mask.
+///
+/// Iterating a `FixedSizeListArray` yields `Option<Series>`, which allocates a
+/// `Series` per row. These expressions run over the flat child instead, so a
+/// column of a million rotations costs no allocation at all.
+struct Rows<'a> {
+    values: &'a [f64],
+    nulls: Option<&'a NullBuffer>,
+    width: usize,
+    len: usize,
+}
+
+impl<'a> Rows<'a> {
+    fn new(list: &'a FixedSizeListArray, width: usize) -> DaftResult<Self> {
+        Ok(Self {
+            values: list.flat_child.try_as_slice::<f64>()?,
+            nulls: list.nulls(),
+            width,
+            len: list.len(),
+        })
+    }
+
+    /// The `i`th row, or `None` when it is null.
+    fn get(&self, i: usize) -> Option<&'a [f64]> {
+        if self.nulls.is_some_and(|n| n.is_null(i)) {
+            return None;
+        }
+        self.values.get(i * self.width..(i + 1) * self.width)
+    }
+}
+
+fn unary<const OUT: usize>(
+    name: &str,
+    input: &Series,
+    size: usize,
+    f: impl Fn(&[f64]) -> Option<[f64; OUT]>,
+) -> DaftResult<FixedSizeListArray> {
+    let list = to_f64_list(input, size)?;
+    let list = list.fixed_size_list()?;
+    let rows = Rows::new(list, size)?;
+
+    let mut values = vec![0.0; rows.len * OUT];
+    let mut valid = Vec::with_capacity(rows.len);
+    for i in 0..rows.len {
+        match rows.get(i).and_then(&f) {
+            Some(out) => {
+                values[i * OUT..(i + 1) * OUT].copy_from_slice(&out);
+                valid.push(true);
+            }
+            None => valid.push(false),
+        }
+    }
+    Ok(build_list(name, OUT, values, valid))
+}
+
+fn binary<const OUT: usize>(
+    fname: &str,
+    name: &str,
+    a: &Series,
+    b: &Series,
+    sizes: (usize, usize),
+    f: impl Fn(&[f64], &[f64]) -> Option<[f64; OUT]>,
+) -> DaftResult<FixedSizeListArray> {
+    let (a, b) = align(fname, to_f64_list(a, sizes.0)?, to_f64_list(b, sizes.1)?)?;
+    let (a, b) = (a.fixed_size_list()?, b.fixed_size_list()?);
+    let (a, b) = (Rows::new(a, sizes.0)?, Rows::new(b, sizes.1)?);
+
+    let mut values = vec![0.0; a.len * OUT];
+    let mut valid = Vec::with_capacity(a.len);
+    for i in 0..a.len {
+        match a.get(i).zip(b.get(i)).and_then(|(x, y)| f(x, y)) {
+            Some(out) => {
+                values[i * OUT..(i + 1) * OUT].copy_from_slice(&out);
+                valid.push(true);
+            }
+            None => valid.push(false),
+        }
+    }
+    Ok(build_list(name, OUT, values, valid))
+}
+
+#[derive(FunctionArgs)]
+struct OneQuat<T> {
+    input: T,
+    #[arg(optional)]
+    order: Option<String>,
+}
+
+#[derive(FunctionArgs)]
+struct TwoQuats<T> {
+    left: T,
+    right: T,
+    #[arg(optional)]
+    order: Option<String>,
+}
+
+#[derive(FunctionArgs)]
+struct QuatAndVector<T> {
+    input: T,
+    vector: T,
+    #[arg(optional)]
+    order: Option<String>,
+}
+
+#[derive(FunctionArgs)]
+struct OneInput<T> {
+    input: T,
+}
+
+#[derive(FunctionArgs)]
+struct TwoMatrices<T> {
+    left: T,
+    right: T,
+}
+
+// ---------------------------------------------------------------------------
+// rot6d_to_matrix
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct Rot6dToMatrix;
+
+#[typetag::serde]
+impl ScalarUDF for Rot6dToMatrix {
+    fn name(&self) -> &'static str {
+        "rot6d_to_matrix"
+    }
+
+    fn call(&self, inputs: FunctionArgs<Series>, _ctx: &EvalContext) -> DaftResult<Series> {
+        let OneInput { input } = inputs.try_into()?;
+        let list = unary(input.name(), &input, ROT6D, math::rot6d_to_mat)?;
+        Ok(as_matrix(input.name(), list))
+    }
+
+    fn get_return_field(
+        &self,
+        inputs: FunctionArgs<ExprRef>,
+        schema: &Schema,
+    ) -> DaftResult<Field> {
+        let OneInput { input } = inputs.try_into()?;
+        validate(self.name(), &input.to_field(schema)?, ROT6D, matrix_dtype())
+    }
+
+    fn docstring(&self) -> &'static str {
+        "Converts the 6D continuous rotation representation of Zhou et al. (2019) into a 3x3 rotation matrix.\n\nThe six values are the first two columns of the matrix. They are orthonormalized by Gram-Schmidt, and the third column is their cross product, so the result always lies in SO(3). Rows whose two vectors are zero or parallel produce null, since they determine no rotation."
+    }
+}
+
+#[must_use]
+pub fn rot6d_to_matrix(input: ExprRef) -> ExprRef {
+    ScalarFn::builtin(Rot6dToMatrix {}, vec![input]).into()
+}
+
+// ---------------------------------------------------------------------------
+// quat_to_matrix
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct QuatToMatrix;
+
+#[typetag::serde]
+impl ScalarUDF for QuatToMatrix {
+    fn name(&self) -> &'static str {
+        "quat_to_matrix"
+    }
+
+    fn call(&self, inputs: FunctionArgs<Series>, _ctx: &EvalContext) -> DaftResult<Series> {
+        let OneQuat { input, order } = inputs.try_into()?;
+        let order = parse_order(self.name(), order)?;
+        let list = unary(input.name(), &input, QUAT, |q| {
+            math::quat_to_mat(order.read(q))
+        })?;
+        Ok(as_matrix(input.name(), list))
+    }
+
+    fn get_return_field(
+        &self,
+        inputs: FunctionArgs<ExprRef>,
+        schema: &Schema,
+    ) -> DaftResult<Field> {
+        let OneQuat { input, order } = inputs.try_into()?;
+        parse_order(self.name(), order)?;
+        validate(self.name(), &input.to_field(schema)?, QUAT, matrix_dtype())
+    }
+
+    fn docstring(&self) -> &'static str {
+        "Converts a quaternion into a 3x3 rotation matrix.\n\nThe quaternion is normalized first. Pass order='wxyz' for the scalar-first convention used by Eigen, MuJoCo, and Isaac Sim; the default 'xyzw' matches ROS, tf2, and scipy. Zero quaternions produce null."
+    }
+}
+
+#[must_use]
+pub fn quat_to_matrix(input: ExprRef) -> ExprRef {
+    ScalarFn::builtin(QuatToMatrix {}, vec![input]).into()
+}
+
+// ---------------------------------------------------------------------------
+// matrix_to_quat
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct MatrixToQuat;
+
+#[typetag::serde]
+impl ScalarUDF for MatrixToQuat {
+    fn name(&self) -> &'static str {
+        "matrix_to_quat"
+    }
+
+    fn call(&self, inputs: FunctionArgs<Series>, _ctx: &EvalContext) -> DaftResult<Series> {
+        let OneQuat { input, order } = inputs.try_into()?;
+        let order = parse_order(self.name(), order)?;
+        let list = unary(input.name(), &input, MAT3, |m| {
+            let m: [f64; MAT3] = m.try_into().ok()?;
+            Some(order.write(math::mat_to_quat(m)))
+        })?;
+        Ok(list.into_series())
+    }
+
+    fn get_return_field(
+        &self,
+        inputs: FunctionArgs<ExprRef>,
+        schema: &Schema,
+    ) -> DaftResult<Field> {
+        let OneQuat { input, order } = inputs.try_into()?;
+        parse_order(self.name(), order)?;
+        validate(
+            self.name(),
+            &input.to_field(schema)?,
+            MAT3,
+            list_dtype(QUAT),
+        )
+    }
+
+    fn docstring(&self) -> &'static str {
+        "Converts a 3x3 rotation matrix into a quaternion, using Shepperd's method for numerical stability near a half turn.\n\nThe sign is not canonicalized: a quaternion and its negation denote the same rotation. Pass order='wxyz' for the scalar-first convention; the default is 'xyzw'."
+    }
+}
+
+#[must_use]
+pub fn matrix_to_quat(input: ExprRef) -> ExprRef {
+    ScalarFn::builtin(MatrixToQuat {}, vec![input]).into()
+}
+
+// ---------------------------------------------------------------------------
+// quat_multiply
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct QuatMultiply;
+
+#[typetag::serde]
+impl ScalarUDF for QuatMultiply {
+    fn name(&self) -> &'static str {
+        "quat_multiply"
+    }
+
+    fn call(&self, inputs: FunctionArgs<Series>, _ctx: &EvalContext) -> DaftResult<Series> {
+        let TwoQuats { left, right, order } = inputs.try_into()?;
+        let order = parse_order(self.name(), order)?;
+        let list = binary(
+            self.name(),
+            left.name(),
+            &left,
+            &right,
+            (QUAT, QUAT),
+            |a, b| Some(order.write(math::multiply(order.read(a), order.read(b)))),
+        )?;
+        Ok(list.into_series())
+    }
+
+    fn get_return_field(
+        &self,
+        inputs: FunctionArgs<ExprRef>,
+        schema: &Schema,
+    ) -> DaftResult<Field> {
+        let TwoQuats { left, right, order } = inputs.try_into()?;
+        parse_order(self.name(), order)?;
+        validate(
+            self.name(),
+            &right.to_field(schema)?,
+            QUAT,
+            list_dtype(QUAT),
+        )?;
+        validate(self.name(), &left.to_field(schema)?, QUAT, list_dtype(QUAT))
+    }
+
+    fn docstring(&self) -> &'static str {
+        "Hamilton product of two quaternions.\n\nThe result applies the right rotation first, then the left, matching composition of the corresponding rotation matrices. Neither input is normalized."
+    }
+}
+
+#[must_use]
+pub fn quat_multiply(left: ExprRef, right: ExprRef) -> ExprRef {
+    ScalarFn::builtin(QuatMultiply {}, vec![left, right]).into()
+}
+
+// ---------------------------------------------------------------------------
+// quat_inverse
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct QuatInverse;
+
+#[typetag::serde]
+impl ScalarUDF for QuatInverse {
+    fn name(&self) -> &'static str {
+        "quat_inverse"
+    }
+
+    fn call(&self, inputs: FunctionArgs<Series>, _ctx: &EvalContext) -> DaftResult<Series> {
+        let OneQuat { input, order } = inputs.try_into()?;
+        let order = parse_order(self.name(), order)?;
+        let list = unary(input.name(), &input, QUAT, |q| {
+            math::inverse(order.read(q)).map(|r| order.write(r))
+        })?;
+        Ok(list.into_series())
+    }
+
+    fn get_return_field(
+        &self,
+        inputs: FunctionArgs<ExprRef>,
+        schema: &Schema,
+    ) -> DaftResult<Field> {
+        let OneQuat { input, order } = inputs.try_into()?;
+        parse_order(self.name(), order)?;
+        validate(
+            self.name(),
+            &input.to_field(schema)?,
+            QUAT,
+            list_dtype(QUAT),
+        )
+    }
+
+    fn docstring(&self) -> &'static str {
+        "Inverse of a quaternion, the conjugate divided by the squared norm.\n\nFor unit quaternions this is the conjugate, and it undoes the rotation. Zero quaternions produce null."
+    }
+}
+
+#[must_use]
+pub fn quat_inverse(input: ExprRef) -> ExprRef {
+    ScalarFn::builtin(QuatInverse {}, vec![input]).into()
+}
+
+// ---------------------------------------------------------------------------
+// quat_rotate
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct QuatRotate;
+
+#[typetag::serde]
+impl ScalarUDF for QuatRotate {
+    fn name(&self) -> &'static str {
+        "quat_rotate"
+    }
+
+    fn call(&self, inputs: FunctionArgs<Series>, _ctx: &EvalContext) -> DaftResult<Series> {
+        let QuatAndVector {
+            input,
+            vector,
+            order,
+        } = inputs.try_into()?;
+        let order = parse_order(self.name(), order)?;
+        let list = binary(
+            self.name(),
+            input.name(),
+            &input,
+            &vector,
+            (QUAT, VEC3),
+            |q, v| {
+                let v: [f64; VEC3] = v.try_into().ok()?;
+                math::rotate(order.read(q), v)
+            },
+        )?;
+        Ok(list.into_series())
+    }
+
+    fn get_return_field(
+        &self,
+        inputs: FunctionArgs<ExprRef>,
+        schema: &Schema,
+    ) -> DaftResult<Field> {
+        let QuatAndVector {
+            input,
+            vector,
+            order,
+        } = inputs.try_into()?;
+        parse_order(self.name(), order)?;
+        validate(
+            self.name(),
+            &vector.to_field(schema)?,
+            VEC3,
+            list_dtype(VEC3),
+        )?;
+        validate(
+            self.name(),
+            &input.to_field(schema)?,
+            QUAT,
+            list_dtype(VEC3),
+        )
+    }
+
+    fn docstring(&self) -> &'static str {
+        "Rotates a 3-vector by a quaternion.\n\nThe quaternion is normalized first, so the length of the vector is preserved. Zero quaternions produce null."
+    }
+}
+
+#[must_use]
+pub fn quat_rotate(input: ExprRef, vector: ExprRef) -> ExprRef {
+    ScalarFn::builtin(QuatRotate {}, vec![input, vector]).into()
+}
+
+// ---------------------------------------------------------------------------
+// rotation_geodesic_angle
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct RotationGeodesicAngle;
+
+#[typetag::serde]
+impl ScalarUDF for RotationGeodesicAngle {
+    fn name(&self) -> &'static str {
+        "rotation_geodesic_angle"
+    }
+
+    fn call(&self, inputs: FunctionArgs<Series>, _ctx: &EvalContext) -> DaftResult<Series> {
+        let TwoMatrices { left, right } = inputs.try_into()?;
+        let name = left.name().to_string();
+        let (a, b) = align(
+            self.name(),
+            to_f64_list(&left, MAT3)?,
+            to_f64_list(&right, MAT3)?,
+        )?;
+        let (a, b) = (a.fixed_size_list()?, b.fixed_size_list()?);
+        let (a, b) = (Rows::new(a, MAT3)?, Rows::new(b, MAT3)?);
+
+        let out = (0..a.len)
+            .map(|i| {
+                a.get(i)
+                    .zip(b.get(i))
+                    .map(|(x, y)| math::geodesic_angle(x, y))
+            })
+            .collect::<Float64Array>()
+            .rename(&name);
+        Ok(out.into_series())
+    }
+
+    fn get_return_field(
+        &self,
+        inputs: FunctionArgs<ExprRef>,
+        schema: &Schema,
+    ) -> DaftResult<Field> {
+        let TwoMatrices { left, right } = inputs.try_into()?;
+        validate(
+            self.name(),
+            &right.to_field(schema)?,
+            MAT3,
+            DataType::Float64,
+        )?;
+        validate(
+            self.name(),
+            &left.to_field(schema)?,
+            MAT3,
+            DataType::Float64,
+        )
+    }
+
+    fn docstring(&self) -> &'static str {
+        "Angle in radians of the relative rotation between two 3x3 rotation matrices.\n\nComputes arccos((trace(A B^T) - 1) / 2), the geodesic distance on SO(3), which lies in [0, pi]. This is the bi-invariant Riemannian metric, so it is symmetric and unchanged by rotating both arguments."
+    }
+}
+
+#[must_use]
+pub fn rotation_geodesic_angle(left: ExprRef, right: ExprRef) -> ExprRef {
+    ScalarFn::builtin(RotationGeodesicAngle {}, vec![left, right]).into()
+}

--- a/src/daft-functions/src/rotation/math.rs
+++ b/src/daft-functions/src/rotation/math.rs
@@ -1,0 +1,428 @@
+//! Rotation mathematics on plain slices, free of any Daft types.
+//!
+//! Quaternions are canonically `(w, x, y, z)` inside this module. The public
+//! expressions accept either component order and convert on the boundary.
+//!
+//! Rotation matrices are row-major: `m[3 * i + j]` is row `i`, column `j`.
+
+/// Component order of a quaternion as it is laid out in a column.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum QuatOrder {
+    /// `(x, y, z, w)`, used by ROS, tf2, and `scipy.spatial.transform.Rotation`.
+    Xyzw,
+    /// `(w, x, y, z)`, used by Eigen constructors, MuJoCo, and Isaac Sim.
+    Wxyz,
+}
+
+impl QuatOrder {
+    pub(super) fn parse(s: &str) -> Option<Self> {
+        match s.to_ascii_lowercase().as_str() {
+            "xyzw" => Some(Self::Xyzw),
+            "wxyz" => Some(Self::Wxyz),
+            _ => None,
+        }
+    }
+
+    /// Read a quaternion from a column slice into canonical `(w, x, y, z)`.
+    pub(super) fn read(self, s: &[f64]) -> [f64; 4] {
+        match self {
+            Self::Xyzw => [s[3], s[0], s[1], s[2]],
+            Self::Wxyz => [s[0], s[1], s[2], s[3]],
+        }
+    }
+
+    /// Write a canonical `(w, x, y, z)` quaternion out in this order.
+    pub(super) fn write(self, q: [f64; 4]) -> [f64; 4] {
+        let [w, x, y, z] = q;
+        match self {
+            Self::Xyzw => [x, y, z, w],
+            Self::Wxyz => [w, x, y, z],
+        }
+    }
+}
+
+fn norm3(v: [f64; 3]) -> f64 {
+    dot3(v, v).sqrt()
+}
+
+fn dot3(a: [f64; 3], b: [f64; 3]) -> f64 {
+    a.iter().zip(&b).map(|(x, y)| x * y).sum()
+}
+
+fn cross(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
+    [
+        [a[1] * b[2], -(a[2] * b[1])],
+        [a[2] * b[0], -(a[0] * b[2])],
+        [a[0] * b[1], -(a[1] * b[0])],
+    ]
+    .map(|terms| terms.iter().sum())
+}
+
+fn scale(k: f64, v: [f64; 3]) -> [f64; 3] {
+    v.map(|c| k * c)
+}
+
+fn add3(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
+    [a[0] + b[0], a[1] + b[1], a[2] + b[2]]
+}
+
+/// Normalize a quaternion. `None` when the norm is zero or non-finite.
+pub(super) fn normalize(q: [f64; 4]) -> Option<[f64; 4]> {
+    let n = q.iter().map(|c| c * c).sum::<f64>().sqrt();
+    (n.is_finite() && n > 0.0).then(|| q.map(|c| c / n))
+}
+
+/// Quaternion inverse, `conjugate / |q|^2`. `None` when the norm is zero.
+pub(super) fn inverse(q: [f64; 4]) -> Option<[f64; 4]> {
+    let n2 = q.iter().map(|c| c * c).sum::<f64>();
+    (n2.is_finite() && n2 > 0.0).then(|| [q[0] / n2, -q[1] / n2, -q[2] / n2, -q[3] / n2])
+}
+
+/// Hamilton product `a * b`, applying `b` first when acting on vectors.
+///
+/// Each row below is one component of the product, written as the four terms
+/// that sum to it.
+pub(super) fn multiply(a: [f64; 4], b: [f64; 4]) -> [f64; 4] {
+    let [aw, ax, ay, az] = a;
+    let [bw, bx, by, bz] = b;
+    [
+        [aw * bw, -(ax * bx), -(ay * by), -(az * bz)],
+        [aw * bx, ax * bw, ay * bz, -(az * by)],
+        [aw * by, -(ax * bz), ay * bw, az * bx],
+        [aw * bz, ax * by, -(ay * bx), az * bw],
+    ]
+    .map(|terms| terms.iter().sum())
+}
+
+/// Rotate `v` by `q`. The quaternion is normalized first. `None` when `q` is zero.
+pub(super) fn rotate(q: [f64; 4], v: [f64; 3]) -> Option<[f64; 3]> {
+    let [w, x, y, z] = normalize(q)?;
+    let u = [x, y, z];
+    // v + 2 * (u x (u x v + w * v)), the rotation of a vector by a unit quaternion.
+    let inner = add3(cross(u, v), scale(w, v));
+    Some(add3(v, scale(2.0, cross(u, inner))))
+}
+
+/// Rotation matrix of a quaternion, row-major. The quaternion is normalized first.
+pub(super) fn quat_to_mat(q: [f64; 4]) -> Option<[f64; 9]> {
+    let [w, x, y, z] = normalize(q)?;
+
+    let (xx, yy, zz) = (x * x, y * y, z * z);
+    let (xy, xz, yz) = (x * y, x * z, y * z);
+    let (wx, wy, wz) = (w * x, w * y, w * z);
+
+    // Bind each doubled term before combining, so no expression is a fused
+    // multiply-add in disguise.
+    let diag = [yy + zz, xx + zz, xx + yy].map(|s| {
+        let doubled = 2.0 * s;
+        1.0 - doubled
+    });
+    let off = [xy - wz, xz + wy, xy + wz, yz - wx, xz - wy, yz + wx].map(|s| 2.0 * s);
+
+    Some([
+        diag[0], off[0], off[1], //
+        off[2], diag[1], off[3], //
+        off[4], off[5], diag[2],
+    ])
+}
+
+/// Quaternion of a rotation matrix, via Shepperd's method.
+///
+/// Branching on the largest diagonal term keeps the divisor away from zero, which
+/// the naive trace formula does not do for rotations near a half turn.
+pub(super) fn mat_to_quat(m: [f64; 9]) -> [f64; 4] {
+    let (m00, m01, m02) = (m[0], m[1], m[2]);
+    let (m10, m11, m12) = (m[3], m[4], m[5]);
+    let (m20, m21, m22) = (m[6], m[7], m[8]);
+    let trace = m00 + m11 + m22;
+
+    if trace > 0.0 {
+        let s = (trace + 1.0).sqrt() * 2.0;
+        [0.25 * s, (m21 - m12) / s, (m02 - m20) / s, (m10 - m01) / s]
+    } else if m00 > m11 && m00 > m22 {
+        let s = (1.0 + m00 - m11 - m22).sqrt() * 2.0;
+        [(m21 - m12) / s, 0.25 * s, (m01 + m10) / s, (m02 + m20) / s]
+    } else if m11 > m22 {
+        let s = (1.0 + m11 - m00 - m22).sqrt() * 2.0;
+        [(m02 - m20) / s, (m01 + m10) / s, 0.25 * s, (m12 + m21) / s]
+    } else {
+        let s = (1.0 + m22 - m00 - m11).sqrt() * 2.0;
+        [(m10 - m01) / s, (m02 + m20) / s, (m12 + m21) / s, 0.25 * s]
+    }
+}
+
+/// Rotation matrix from the 6D continuous representation of Zhou et al. (2019).
+///
+/// The two input vectors are the first two columns of the matrix, up to
+/// Gram-Schmidt orthonormalization. The third column is their cross product, so
+/// the result always has determinant `+1`. `None` when the inputs are parallel
+/// or either is zero, in which case no rotation is determined.
+pub(super) fn rot6d_to_mat(r: &[f64]) -> Option<[f64; 9]> {
+    let a1 = [r[0], r[1], r[2]];
+    let a2 = [r[3], r[4], r[5]];
+
+    let n1 = norm3(a1);
+    if !(n1.is_finite() && n1 > 0.0) {
+        return None;
+    }
+    let c1 = a1.map(|c| c / n1);
+
+    let proj = dot3(c1, a2);
+    let u = [
+        proj.mul_add(-c1[0], a2[0]),
+        proj.mul_add(-c1[1], a2[1]),
+        proj.mul_add(-c1[2], a2[2]),
+    ];
+    let n2 = norm3(u);
+    if !(n2.is_finite() && n2 > 0.0) {
+        return None;
+    }
+    let c2 = u.map(|c| c / n2);
+    let c3 = cross(c1, c2);
+
+    // Columns c1, c2, c3 laid out row-major.
+    Some([
+        c1[0], c2[0], c3[0], //
+        c1[1], c2[1], c3[1], //
+        c1[2], c2[2], c3[2],
+    ])
+}
+
+/// Geodesic (angular) distance between two rotations, in radians on `[0, pi]`.
+///
+/// `arccos((tr(A B^T) - 1) / 2)`, the angle of the relative rotation `A B^T`.
+pub(super) fn geodesic_angle(a: &[f64], b: &[f64]) -> f64 {
+    // tr(A B^T) is the elementwise inner product of A and B.
+    let trace: f64 = a.iter().zip(b).map(|(x, y)| x * y).sum();
+    (0.5 * (trace - 1.0)).clamp(-1.0, 1.0).acos()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const EPS: f64 = 1e-12;
+
+    fn approx(a: f64, b: f64, eps: f64) -> bool {
+        (a - b).abs() < eps
+    }
+
+    /// Determinant by cofactor expansion along the first row.
+    fn det3(m: [f64; 9]) -> f64 {
+        let cofactors = [
+            [m[4] * m[8], -(m[5] * m[7])],
+            [m[3] * m[8], -(m[5] * m[6])],
+            [m[3] * m[7], -(m[4] * m[6])],
+        ]
+        .map(|terms| terms.iter().sum::<f64>());
+        [
+            m[0] * cofactors[0],
+            -(m[1] * cofactors[1]),
+            m[2] * cofactors[2],
+        ]
+        .iter()
+        .sum()
+    }
+
+    /// A few rotations spanning identity, small angles, half turns, and generic ones.
+    fn sample_quats() -> Vec<[f64; 4]> {
+        vec![
+            [1.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0, 1.0],
+            [0.5, 0.5, 0.5, 0.5],
+            [0.9999999, 1e-7, 0.0, 0.0],
+            [0.3, -0.2, 0.8, 0.1],
+            [-0.6, 0.1, -0.3, 0.7],
+        ]
+        .into_iter()
+        .map(|q| normalize(q).unwrap())
+        .collect()
+    }
+
+    #[test]
+    fn normalize_yields_unit_norm() {
+        for q in sample_quats() {
+            let n = q.iter().map(|c| c * c).sum::<f64>().sqrt();
+            assert!(approx(n, 1.0, EPS), "norm {n} for {q:?}");
+        }
+    }
+
+    #[test]
+    fn normalize_rejects_zero() {
+        assert!(normalize([0.0; 4]).is_none());
+        assert!(inverse([0.0; 4]).is_none());
+    }
+
+    #[test]
+    fn multiply_by_inverse_is_identity() {
+        for q in sample_quats() {
+            let r = multiply(q, inverse(q).unwrap());
+            assert!(approx(r[0].abs(), 1.0, 1e-9), "{r:?}");
+            for c in &r[1..] {
+                assert!(approx(*c, 0.0, 1e-9), "{r:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn multiplication_is_associative() {
+        let qs = sample_quats();
+        for a in &qs {
+            for b in &qs {
+                for c in &qs {
+                    let lhs = multiply(multiply(*a, *b), *c);
+                    let rhs = multiply(*a, multiply(*b, *c));
+                    for (l, r) in lhs.iter().zip(&rhs) {
+                        assert!(approx(*l, *r, 1e-12), "{lhs:?} vs {rhs:?}");
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn rotation_preserves_norm() {
+        let v = [0.3, -1.7, 2.1];
+        let n = norm3(v);
+        for q in sample_quats() {
+            let r = rotate(q, v).unwrap();
+            assert!(approx(norm3(r), n, 1e-12), "{r:?}");
+        }
+    }
+
+    #[test]
+    fn double_cover_q_and_negative_q_agree() {
+        let v = [0.3, -1.7, 2.1];
+        for q in sample_quats() {
+            let a = rotate(q, v).unwrap();
+            let b = rotate(q.map(|c| -c), v).unwrap();
+            for (x, y) in a.iter().zip(&b) {
+                assert!(approx(*x, *y, 1e-12), "{a:?} vs {b:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn quat_to_mat_round_trips_up_to_sign() {
+        for q in sample_quats() {
+            let back = normalize(mat_to_quat(quat_to_mat(q).unwrap())).unwrap();
+            // q and -q are the same rotation, so compare up to a global sign.
+            let same = q.iter().zip(&back).all(|(a, b)| approx(*a, *b, 1e-9));
+            let flipped = q.iter().zip(&back).all(|(a, b)| approx(*a, -*b, 1e-9));
+            assert!(same || flipped, "{q:?} -> {back:?}");
+        }
+    }
+
+    #[test]
+    fn mat_to_quat_is_stable_near_half_turn() {
+        // Trace is -1 here, which is exactly where the naive formula divides by zero.
+        for q in [
+            [0.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0, 1.0],
+        ] {
+            let m = quat_to_mat(q).unwrap();
+            let back = normalize(mat_to_quat(m)).unwrap();
+            assert!(back.iter().all(|c| c.is_finite()), "{back:?}");
+            let same = q.iter().zip(&back).all(|(a, b)| approx(*a, *b, 1e-9));
+            let flipped = q.iter().zip(&back).all(|(a, b)| approx(*a, -*b, 1e-9));
+            assert!(same || flipped, "{q:?} -> {back:?}");
+        }
+    }
+
+    #[test]
+    fn rotation_matrices_are_special_orthogonal() {
+        for q in sample_quats() {
+            let m = quat_to_mat(q).unwrap();
+            // Columns are orthonormal.
+            for j in 0..3 {
+                let col = [m[j], m[3 + j], m[6 + j]];
+                assert!(approx(norm3(col), 1.0, 1e-12));
+            }
+            // Determinant is +1.
+            let det = det3(m);
+            assert!(approx(det, 1.0, 1e-12), "det {det}");
+        }
+    }
+
+    #[test]
+    fn rot6d_orthonormalizes_and_matches_columns() {
+        // Deliberately non-orthogonal, non-unit inputs.
+        let r = [2.0, 0.0, 0.0, 1.0, 3.0, 0.0];
+        let m = rot6d_to_mat(&r).unwrap();
+        // First column is the normalized first input vector.
+        assert!(approx(m[0], 1.0, EPS) && approx(m[3], 0.0, EPS) && approx(m[6], 0.0, EPS));
+        // Second column is orthogonal to the first and unit length.
+        let c1 = [m[0], m[3], m[6]];
+        let c2 = [m[1], m[4], m[7]];
+        assert!(approx(dot3(c1, c2), 0.0, 1e-12));
+        assert!(approx(norm3(c2), 1.0, 1e-12));
+        // Third column is the cross product, so the determinant is +1.
+        let det = det3(m);
+        assert!(approx(det, 1.0, 1e-12), "det {det}");
+    }
+
+    #[test]
+    fn rot6d_rejects_degenerate_inputs() {
+        assert!(rot6d_to_mat(&[0.0, 0.0, 0.0, 1.0, 0.0, 0.0]).is_none());
+        // Parallel inputs leave the second column undetermined.
+        assert!(rot6d_to_mat(&[1.0, 0.0, 0.0, 2.0, 0.0, 0.0]).is_none());
+    }
+
+    #[test]
+    fn geodesic_angle_is_zero_on_the_diagonal_and_symmetric() {
+        for q in sample_quats() {
+            let m = quat_to_mat(q).unwrap();
+            assert!(approx(geodesic_angle(&m, &m), 0.0, 1e-7));
+        }
+        let a = quat_to_mat(sample_quats()[4]).unwrap();
+        let b = quat_to_mat(sample_quats()[6]).unwrap();
+        assert!(approx(
+            geodesic_angle(&a, &b),
+            geodesic_angle(&b, &a),
+            1e-12
+        ));
+    }
+
+    #[test]
+    fn geodesic_angle_recovers_a_known_rotation_angle() {
+        // A rotation of theta about z, compared against the identity.
+        for theta in [0.0, 0.1, 1.0, std::f64::consts::FRAC_PI_2, 3.0] {
+            let (s, c) = (theta / 2.0).sin_cos();
+            let m = quat_to_mat([c, 0.0, 0.0, s]).unwrap();
+            let identity = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0];
+            assert!(
+                approx(geodesic_angle(&m, &identity), theta, 1e-7),
+                "theta {theta}"
+            );
+        }
+    }
+
+    #[test]
+    fn geodesic_angle_is_bounded_by_pi_under_numerical_noise() {
+        // trace slightly above 3 must not produce NaN from acos.
+        let m = [1.0 + 1e-15, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0];
+        let identity = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0];
+        assert!(geodesic_angle(&m, &identity).is_finite());
+    }
+
+    #[test]
+    fn quat_order_round_trips() {
+        let canonical = [0.1, 0.2, 0.3, 0.4];
+        for order in [QuatOrder::Xyzw, QuatOrder::Wxyz] {
+            assert_eq!(order.read(&order.write(canonical)), canonical);
+        }
+        // xyzw places the scalar part last.
+        assert_eq!(QuatOrder::Xyzw.write(canonical), [0.2, 0.3, 0.4, 0.1]);
+        assert_eq!(QuatOrder::Wxyz.write(canonical), canonical);
+    }
+
+    #[test]
+    fn quat_order_parse() {
+        assert_eq!(QuatOrder::parse("XYZW"), Some(QuatOrder::Xyzw));
+        assert_eq!(QuatOrder::parse("wxyz"), Some(QuatOrder::Wxyz));
+        assert_eq!(QuatOrder::parse("wxzy"), None);
+    }
+}

--- a/src/daft-functions/src/rotation/math.rs
+++ b/src/daft-functions/src/rotation/math.rs
@@ -126,11 +126,27 @@ pub(super) fn quat_to_mat(q: [f64; 4]) -> Option<[f64; 9]> {
     ])
 }
 
+/// How far a quantity may drift from its exact value before its input is judged
+/// not to be a rotation. Rounding in `Float64` costs a few units in the last
+/// place, and single precision inputs, which are widened on the way in, cost
+/// about `1e-7`. A larger excursion means a scaling, a reflection, or noise.
+const TOL: f64 = 1e-6;
+
 /// Quaternion of a rotation matrix, via Shepperd's method.
 ///
 /// Branching on the largest diagonal term keeps the divisor away from zero, which
 /// the naive trace formula does not do for rotations near a half turn.
-pub(super) fn mat_to_quat(m: [f64; 9]) -> [f64; 4] {
+///
+/// `None` when `m` is not a rotation. Shepperd's method yields a unit quaternion
+/// exactly when its input lies in `SO(3)`, so the norm of the result is a cheap
+/// test: a scaled matrix, a reflection, and arbitrary numbers all fail it.
+pub(super) fn mat_to_quat(m: [f64; 9]) -> Option<[f64; 4]> {
+    let q = shepperd(m);
+    let norm_sq = q.iter().map(|c| c * c).sum::<f64>();
+    ((norm_sq - 1.0).abs() <= TOL).then_some(q)
+}
+
+fn shepperd(m: [f64; 9]) -> [f64; 4] {
     let (m00, m01, m02) = (m[0], m[1], m[2]);
     let (m10, m11, m12) = (m[3], m[4], m[5]);
     let (m20, m21, m22) = (m[6], m[7], m[8]);
@@ -191,10 +207,16 @@ pub(super) fn rot6d_to_mat(r: &[f64]) -> Option<[f64; 9]> {
 /// Geodesic (angular) distance between two rotations, in radians on `[0, pi]`.
 ///
 /// `arccos((tr(A B^T) - 1) / 2)`, the angle of the relative rotation `A B^T`.
-pub(super) fn geodesic_angle(a: &[f64], b: &[f64]) -> f64 {
+///
+/// For genuine rotations the cosine can land a hair outside `[-1, 1]` through
+/// rounding, so it is clamped. A larger excursion means the arguments are not
+/// both rotations, and the angle between them is undefined: report `None` rather
+/// than let the clamp turn nonsense into a plausible `0` or `pi`.
+pub(super) fn geodesic_angle(a: &[f64], b: &[f64]) -> Option<f64> {
     // tr(A B^T) is the elementwise inner product of A and B.
     let trace: f64 = a.iter().zip(b).map(|(x, y)| x * y).sum();
-    (0.5 * (trace - 1.0)).clamp(-1.0, 1.0).acos()
+    let cos = 0.5 * (trace - 1.0);
+    (cos.abs() <= 1.0 + TOL).then(|| cos.clamp(-1.0, 1.0).acos())
 }
 
 #[cfg(test)]
@@ -307,7 +329,7 @@ mod tests {
     #[test]
     fn quat_to_mat_round_trips_up_to_sign() {
         for q in sample_quats() {
-            let back = normalize(mat_to_quat(quat_to_mat(q).unwrap())).unwrap();
+            let back = normalize(mat_to_quat(quat_to_mat(q).unwrap()).unwrap()).unwrap();
             // q and -q are the same rotation, so compare up to a global sign.
             let same = q.iter().zip(&back).all(|(a, b)| approx(*a, *b, 1e-9));
             let flipped = q.iter().zip(&back).all(|(a, b)| approx(*a, -*b, 1e-9));
@@ -324,7 +346,7 @@ mod tests {
             [0.0, 0.0, 0.0, 1.0],
         ] {
             let m = quat_to_mat(q).unwrap();
-            let back = normalize(mat_to_quat(m)).unwrap();
+            let back = normalize(mat_to_quat(m).unwrap()).unwrap();
             assert!(back.iter().all(|c| c.is_finite()), "{back:?}");
             let same = q.iter().zip(&back).all(|(a, b)| approx(*a, *b, 1e-9));
             let flipped = q.iter().zip(&back).all(|(a, b)| approx(*a, -*b, 1e-9));
@@ -375,13 +397,13 @@ mod tests {
     fn geodesic_angle_is_zero_on_the_diagonal_and_symmetric() {
         for q in sample_quats() {
             let m = quat_to_mat(q).unwrap();
-            assert!(approx(geodesic_angle(&m, &m), 0.0, 1e-7));
+            assert!(approx(geodesic_angle(&m, &m).unwrap(), 0.0, 1e-7));
         }
         let a = quat_to_mat(sample_quats()[4]).unwrap();
         let b = quat_to_mat(sample_quats()[6]).unwrap();
         assert!(approx(
-            geodesic_angle(&a, &b),
-            geodesic_angle(&b, &a),
+            geodesic_angle(&a, &b).unwrap(),
+            geodesic_angle(&b, &a).unwrap(),
             1e-12
         ));
     }
@@ -394,7 +416,7 @@ mod tests {
             let m = quat_to_mat([c, 0.0, 0.0, s]).unwrap();
             let identity = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0];
             assert!(
-                approx(geodesic_angle(&m, &identity), theta, 1e-7),
+                approx(geodesic_angle(&m, &identity).unwrap(), theta, 1e-7),
                 "theta {theta}"
             );
         }
@@ -405,7 +427,7 @@ mod tests {
         // trace slightly above 3 must not produce NaN from acos.
         let m = [1.0 + 1e-15, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0];
         let identity = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0];
-        assert!(geodesic_angle(&m, &identity).is_finite());
+        assert!(geodesic_angle(&m, &identity).unwrap().is_finite());
     }
 
     #[test]
@@ -424,5 +446,67 @@ mod tests {
         assert_eq!(QuatOrder::parse("XYZW"), Some(QuatOrder::Xyzw));
         assert_eq!(QuatOrder::parse("wxyz"), Some(QuatOrder::Wxyz));
         assert_eq!(QuatOrder::parse("wxzy"), None);
+    }
+
+    #[test]
+    fn mat_to_quat_rejects_matrices_outside_so3() {
+        let identity = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0];
+        // Arbitrary numbers. Shepperd's method used to return finite nonsense here.
+        assert!(mat_to_quat([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]).is_none());
+        // A uniform scaling of a rotation is not a rotation.
+        assert!(mat_to_quat(identity.map(|c| 2.0 * c)).is_none());
+        // A reflection has determinant -1.
+        assert!(mat_to_quat([1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, -1.0]).is_none());
+        assert!(mat_to_quat(identity.map(|c| -c)).is_none());
+        // Genuine rotations still pass.
+        for q in sample_quats() {
+            assert!(mat_to_quat(quat_to_mat(q).unwrap()).is_some());
+        }
+    }
+
+    #[test]
+    fn mat_to_quat_tolerates_single_precision_rounding() {
+        // Widen a rotation matrix that has been through f32, as the expressions do.
+        for q in sample_quats() {
+            let m = quat_to_mat(q).unwrap();
+            let rounded = m.map(|c| f64::from(c as f32));
+            assert!(mat_to_quat(rounded).is_some(), "{rounded:?}");
+        }
+    }
+
+    #[test]
+    fn geodesic_angle_rejects_arguments_outside_so3() {
+        let identity = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0];
+        // trace(A B^T) = 15, so the cosine is 7: the clamp used to turn this into 0.
+        assert!(
+            geodesic_angle(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0], &identity).is_none()
+        );
+        // A scaled rotation.
+        let scaled: Vec<f64> = identity.iter().map(|c| 2.0 * c).collect();
+        assert!(geodesic_angle(&scaled, &identity).is_none());
+    }
+
+    #[test]
+    fn geodesic_angle_rejects_non_finite_arguments() {
+        let identity = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0];
+        let mut nan = identity;
+        nan[0] = f64::NAN;
+        assert!(geodesic_angle(&nan, &identity).is_none());
+        let mut inf = identity;
+        inf[4] = f64::INFINITY;
+        assert!(geodesic_angle(&inf, &identity).is_none());
+    }
+
+    #[test]
+    fn geodesic_angle_absorbs_rounding_at_the_endpoints() {
+        // Nearly identical rotations: the cosine drifts just past 1 and must clamp.
+        let identity = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0];
+        let nudged = identity.map(|c| c * (1.0 + 1e-13));
+        let angle = geodesic_angle(&nudged, &identity).expect("rounding must not reject");
+        assert!(angle.is_finite() && angle < 1e-5, "{angle}");
+        // A half turn: the cosine drifts just past -1.
+        let flip = quat_to_mat([0.0, 1.0, 0.0, 0.0]).unwrap();
+        let angle = geodesic_angle(&flip, &identity).unwrap();
+        assert!(approx(angle, std::f64::consts::PI, 1e-7), "{angle}");
     }
 }

--- a/src/daft-functions/src/rotation/math.rs
+++ b/src/daft-functions/src/rotation/math.rs
@@ -1,9 +1,7 @@
 //! Rotation mathematics on plain slices, free of any Daft types.
 //!
-//! Quaternions are canonically `(w, x, y, z)` inside this module. The public
-//! expressions accept either component order and convert on the boundary.
-//!
-//! Rotation matrices are row-major: `m[3 * i + j]` is row `i`, column `j`.
+//! Quaternions are canonically `(w, x, y, z)` here; the expressions convert on the
+//! boundary. Matrices are row-major: `m[3 * i + j]` is row `i`, column `j`.
 
 /// Component order of a quaternion as it is laid out in a column.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -79,9 +77,6 @@ pub(super) fn inverse(q: [f64; 4]) -> Option<[f64; 4]> {
 }
 
 /// Hamilton product `a * b`, applying `b` first when acting on vectors.
-///
-/// Each row below is one component of the product, written as the four terms
-/// that sum to it.
 pub(super) fn multiply(a: [f64; 4], b: [f64; 4]) -> [f64; 4] {
     let [aw, ax, ay, az] = a;
     let [bw, bx, by, bz] = b;
@@ -111,8 +106,7 @@ pub(super) fn quat_to_mat(q: [f64; 4]) -> Option<[f64; 9]> {
     let (xy, xz, yz) = (x * y, x * z, y * z);
     let (wx, wy, wz) = (w * x, w * y, w * z);
 
-    // Bind each doubled term before combining, so no expression is a fused
-    // multiply-add in disguise.
+    // Bind each doubled term before combining, so none of these is an FMA in disguise.
     let diag = [yy + zz, xx + zz, xx + yy].map(|s| {
         let doubled = 2.0 * s;
         1.0 - doubled
@@ -126,24 +120,48 @@ pub(super) fn quat_to_mat(q: [f64; 4]) -> Option<[f64; 9]> {
     ])
 }
 
-/// How far a quantity may drift from its exact value before its input is judged
-/// not to be a rotation. Rounding in `Float64` costs a few units in the last
-/// place, and single precision inputs, which are widened on the way in, cost
-/// about `1e-7`. A larger excursion means a scaling, a reflection, or noise.
+/// How far a quantity may drift before its input is judged not to be a rotation.
+/// `Float64` rounding costs a few ulps; `Float32` inputs, widened on the way in,
+/// cost about `1e-7`. More than this means a scaling, a reflection, or noise.
 const TOL: f64 = 1e-6;
 
-/// Quaternion of a rotation matrix, via Shepperd's method.
+/// Whether `m` is a rotation: `m^T m = I` with determinant `+1`. Both halves are
+/// needed, since orthonormality alone admits reflections and the determinant alone
+/// admits any volume-preserving shear.
+///
+/// Testing instead that Shepperd's method returns a unit quaternion looks
+/// equivalent and is not: on its principal branch it reads only the trace and the
+/// antisymmetric part, so a trace-free symmetric perturbation is invisible to it.
+/// `[[1, 5, 0], [5, 1, 0], [0, 0, 1]]` has determinant `-24` and still yields the
+/// identity quaternion, of unit norm.
+pub(super) fn is_rotation(m: &[f64]) -> bool {
+    let col = |j: usize| [m[j], m[3 + j], m[6 + j]];
+    let (c0, c1, c2) = (col(0), col(1), col(2));
+
+    let gram = [
+        (dot3(c0, c0), 1.0),
+        (dot3(c1, c1), 1.0),
+        (dot3(c2, c2), 1.0),
+        (dot3(c0, c1), 0.0),
+        (dot3(c0, c2), 0.0),
+        (dot3(c1, c2), 0.0),
+    ];
+    if !gram.iter().all(|(got, want)| (got - want).abs() <= TOL) {
+        return false;
+    }
+
+    // The frame is orthonormal, so its determinant is +-1 and only the handedness
+    // is left to check.
+    (dot3(cross(c0, c1), c2) - 1.0).abs() <= TOL
+}
+
+/// Quaternion of a rotation matrix, via Shepperd's method. `None` when `m` is not
+/// a rotation.
 ///
 /// Branching on the largest diagonal term keeps the divisor away from zero, which
 /// the naive trace formula does not do for rotations near a half turn.
-///
-/// `None` when `m` is not a rotation. Shepperd's method yields a unit quaternion
-/// exactly when its input lies in `SO(3)`, so the norm of the result is a cheap
-/// test: a scaled matrix, a reflection, and arbitrary numbers all fail it.
 pub(super) fn mat_to_quat(m: [f64; 9]) -> Option<[f64; 4]> {
-    let q = shepperd(m);
-    let norm_sq = q.iter().map(|c| c * c).sum::<f64>();
-    ((norm_sq - 1.0).abs() <= TOL).then_some(q)
+    is_rotation(&m).then(|| shepperd(m))
 }
 
 fn shepperd(m: [f64; 9]) -> [f64; 4] {
@@ -169,10 +187,9 @@ fn shepperd(m: [f64; 9]) -> [f64; 4] {
 
 /// Rotation matrix from the 6D continuous representation of Zhou et al. (2019).
 ///
-/// The two input vectors are the first two columns of the matrix, up to
-/// Gram-Schmidt orthonormalization. The third column is their cross product, so
-/// the result always has determinant `+1`. `None` when the inputs are parallel
-/// or either is zero, in which case no rotation is determined.
+/// The two input vectors are the first two columns, up to Gram-Schmidt; the third
+/// is their cross product, so the result always has determinant `+1`. `None` when
+/// they are parallel or either is zero, which determines no rotation.
 pub(super) fn rot6d_to_mat(r: &[f64]) -> Option<[f64; 9]> {
     let a1 = [r[0], r[1], r[2]];
     let a2 = [r[3], r[4], r[5]];
@@ -204,19 +221,21 @@ pub(super) fn rot6d_to_mat(r: &[f64]) -> Option<[f64; 9]> {
     ])
 }
 
-/// Geodesic (angular) distance between two rotations, in radians on `[0, pi]`.
-///
+/// Geodesic distance between two rotations, in radians on `[0, pi]`:
 /// `arccos((tr(A B^T) - 1) / 2)`, the angle of the relative rotation `A B^T`.
 ///
-/// For genuine rotations the cosine can land a hair outside `[-1, 1]` through
-/// rounding, so it is clamped. A larger excursion means the arguments are not
-/// both rotations, and the angle between them is undefined: report `None` rather
-/// than let the clamp turn nonsense into a plausible `0` or `pi`.
+/// The angle is only defined between rotations, so an argument outside `SO(3)`
+/// gives `None`. Range-checking the cosine would not be enough: a non-rotation can
+/// land it inside `[-1, 1]`, where the formula reports a plausible angle. Rounding
+/// can push it a hair outside for genuine rotations, which the clamp absorbs.
 pub(super) fn geodesic_angle(a: &[f64], b: &[f64]) -> Option<f64> {
+    if !(is_rotation(a) && is_rotation(b)) {
+        return None;
+    }
     // tr(A B^T) is the elementwise inner product of A and B.
     let trace: f64 = a.iter().zip(b).map(|(x, y)| x * y).sum();
     let cos = 0.5 * (trace - 1.0);
-    (cos.abs() <= 1.0 + TOL).then(|| cos.clamp(-1.0, 1.0).acos())
+    Some(cos.clamp(-1.0, 1.0).acos())
 }
 
 #[cfg(test)]
@@ -229,7 +248,7 @@ mod tests {
         (a - b).abs() < eps
     }
 
-    /// Determinant by cofactor expansion along the first row.
+    // Determinant by cofactor expansion along the first row.
     fn det3(m: [f64; 9]) -> f64 {
         let cofactors = [
             [m[4] * m[8], -(m[5] * m[7])],
@@ -246,7 +265,7 @@ mod tests {
         .sum()
     }
 
-    /// A few rotations spanning identity, small angles, half turns, and generic ones.
+    // Identity, half turns (trace = -1, the hard case), small angles, generic ones.
     fn sample_quats() -> Vec<[f64; 4]> {
         vec![
             [1.0, 0.0, 0.0, 0.0],
@@ -462,6 +481,48 @@ mod tests {
         for q in sample_quats() {
             assert!(mat_to_quat(quat_to_mat(q).unwrap()).is_some());
         }
+    }
+
+    #[test]
+    fn so3_test_sees_trace_free_symmetric_perturbations() {
+        // Determinant -24, and shepperd maps it to the identity quaternion.
+        let shear = [1.0, 5.0, 0.0, 5.0, 1.0, 0.0, 0.0, 0.0, 1.0];
+        assert!(approx(det3(shear), -24.0, 1e-9));
+        let q = shepperd(shear);
+        assert!(
+            approx(q.iter().map(|c| c * c).sum::<f64>(), 1.0, 1e-12),
+            "the norm test passes on this non-rotation: {q:?}"
+        );
+
+        assert!(!is_rotation(&shear));
+        assert!(mat_to_quat(shear).is_none());
+
+        let identity = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0];
+        assert!(geodesic_angle(&shear, &identity).is_none());
+        assert!(geodesic_angle(&identity, &shear).is_none());
+    }
+
+    #[test]
+    fn so3_test_accepts_rotations_and_rejects_the_usual_impostors() {
+        let identity = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0];
+        for q in sample_quats() {
+            let m = quat_to_mat(q).unwrap();
+            assert!(is_rotation(&m), "{m:?}");
+            // Single precision inputs are widened on the way in, and must survive.
+            assert!(is_rotation(&m.map(|c| f64::from(c as f32))), "{m:?}");
+        }
+        // Orthonormal but left handed: the determinant is the only thing that says so.
+        assert!(!is_rotation(&[
+            1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, -1.0
+        ]));
+        // Determinant +1 but not orthonormal: a volume-preserving shear.
+        let shear = [1.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0];
+        assert!(approx(det3(shear), 1.0, 1e-12));
+        assert!(!is_rotation(&shear));
+        // Scalings, in both directions.
+        assert!(!is_rotation(&identity.map(|c| 2.0 * c)));
+        assert!(!is_rotation(&identity.map(|c| 0.5 * c)));
+        assert!(!is_rotation(&[0.0; 9]));
     }
 
     #[test]

--- a/src/daft-functions/src/rotation/mod.rs
+++ b/src/daft-functions/src/rotation/mod.rs
@@ -1,0 +1,31 @@
+//! Rotation expressions for pose data.
+//!
+//! Robot trajectories, camera extrinsics, and hand-tracking datasets all carry
+//! rotations. Daft reads that data today (`daft.datasets.droid`,
+//! `daft.datasets.lerobot`, `daft.datasets.egodex`, `daft.read_mcap`) but stores
+//! rotations as untyped float columns, so composing or comparing them means
+//! dropping into a per-row Python UDF. These expressions do the algebra natively.
+
+mod functions;
+mod math;
+
+use daft_dsl::functions::{FunctionModule, FunctionRegistry};
+pub use functions::{
+    MatrixToQuat, QuatInverse, QuatMultiply, QuatRotate, QuatToMatrix, Rot6dToMatrix,
+    RotationGeodesicAngle, matrix_to_quat, quat_inverse, quat_multiply, quat_rotate,
+    quat_to_matrix, rot6d_to_matrix, rotation_geodesic_angle,
+};
+
+pub struct RotationFunctions;
+
+impl FunctionModule for RotationFunctions {
+    fn register(parent: &mut FunctionRegistry) {
+        parent.add_fn(MatrixToQuat);
+        parent.add_fn(QuatInverse);
+        parent.add_fn(QuatMultiply);
+        parent.add_fn(QuatRotate);
+        parent.add_fn(QuatToMatrix);
+        parent.add_fn(Rot6dToMatrix);
+        parent.add_fn(RotationGeodesicAngle);
+    }
+}

--- a/src/daft-functions/src/rotation/mod.rs
+++ b/src/daft-functions/src/rotation/mod.rs
@@ -1,10 +1,9 @@
 //! Rotation expressions for pose data.
 //!
-//! Robot trajectories, camera extrinsics, and hand-tracking datasets all carry
-//! rotations. Daft reads that data today (`daft.datasets.droid`,
-//! `daft.datasets.lerobot`, `daft.datasets.egodex`, `daft.read_mcap`) but stores
-//! rotations as untyped float columns, so composing or comparing them means
-//! dropping into a per-row Python UDF. These expressions do the algebra natively.
+//! Daft already reads rotations (`daft.datasets.droid`, `daft.datasets.lerobot`,
+//! `daft.datasets.egodex`, `daft.read_mcap`) but stores them as untyped float
+//! columns, so composing or comparing them means a per-row Python UDF. These
+//! expressions do the algebra natively.
 
 mod functions;
 mod math;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,6 +173,7 @@ pub mod pylib {
         functions_registry.register::<daft_functions::similarity::SimilarityFunctions>();
         functions_registry.register::<daft_functions_tokenize::TokenizeFunctions>();
         functions_registry.register::<daft_functions::random::RandomFunctions>();
+        functions_registry.register::<daft_functions::rotation::RotationFunctions>();
         functions_registry.register::<daft_geo::SpatialFunctions>();
 
         functions_registry.add_fn(daft_functions::coalesce::Coalesce);

--- a/tests/expressions/test_rotation.py
+++ b/tests/expressions/test_rotation.py
@@ -363,6 +363,8 @@ def test_filtered_input_reads_the_right_rows():
         ([2.0, 0, 0, 0, 2, 0, 0, 0, 2], "a scaled rotation"),
         ([1.0, 0, 0, 0, 1, 0, 0, 0, -1], "a reflection"),
         ([-1.0, 0, 0, 0, -1, 0, 0, 0, -1], "negated identity, determinant -1"),
+        ([1.0, 5, 0, 5, 1, 0, 0, 0, 1], "identity plus a trace-free symmetric part, determinant -24"),
+        ([1.0, 1, 0, 0, 1, 0, 0, 0, 1], "a volume-preserving shear, determinant +1"),
     ],
 )
 def test_matrix_to_quat_rejects_matrices_outside_so3(matrix, reason):
@@ -375,10 +377,17 @@ def test_matrix_to_quat_rejects_matrices_outside_so3(matrix, reason):
     [
         ([1.0, 2, 3, 4, 5, 6, 7, 8, 9], "cosine is 7, far outside [-1, 1]"),
         ([2.0, 0, 0, 0, 2, 0, 0, 0, 2], "a scaled rotation"),
+        ([1.0, 5, 0, 5, 1, 0, 0, 0, 1], "determinant -24, yet the cosine lands on exactly 1"),
+        ([1.0, 1, 0, 0, 1, 0, 0, 0, 1], "a shear, whose cosine also lands inside [-1, 1]"),
     ],
 )
 def test_geodesic_angle_rejects_arguments_outside_so3(matrix, reason):
-    """The clamp that absorbs rounding must not turn nonsense into a plausible angle."""
+    """The clamp that absorbs rounding must not turn nonsense into a plausible angle.
+
+    The last two cases are the ones a cosine-range check cannot catch: they sit far
+    outside SO(3) and still put the cosine inside [-1, 1], where the formula would
+    happily report an angle of 0.
+    """
     identity = [1.0, 0, 0, 0, 1, 0, 0, 0, 1]
     df = _frame(a=[matrix], b=[identity]).select(col("a").cast(MAT3), col("b").cast(MAT3))
     got = df.select(rotation_geodesic_angle(col("a"), col("b"))).to_pydict()["a"]
@@ -442,6 +451,60 @@ def test_non_finite_inputs_produce_null_everywhere(bad):
     for name, df in cases.items():
         got = next(iter(df.to_pydict().values()))[0]
         assert got is None, f"{name} returned {got!r} for a {bad} input, expected null"
+
+
+def test_null_component_within_a_row_produces_null_everywhere():
+    """A row can be valid while one of its numbers is null.
+
+    The value buffer still holds a number under a null slot, usually a zero, so
+    reading the row without its validity mask turns [1, null, 0, 0] into a perfectly
+    plausible half turn about x. It is not a rotation, and the answer is null.
+    """
+    identity_q = [0.0, 0.0, 0.0, 1.0]
+    identity_m = [1.0, 0, 0, 0, 1, 0, 0, 0, 1]
+    q_bad = [1.0, None, 0.0, 0.0]
+    m_bad = [1.0, None] + [0.0] * 7
+
+    cases = {
+        "quat_inverse": _quat_col("q", [q_bad]).select(quat_inverse(col("q"))),
+        "quat_to_matrix": _quat_col("q", [q_bad]).select(quat_to_matrix(col("q"))),
+        "matrix_to_quat": _frame(m=[m_bad]).select(col("m").cast(MAT3)).select(matrix_to_quat(col("m"))),
+        "quat_multiply": (
+            _frame(a=[q_bad], b=[identity_q])
+            .select(col("a").cast(QUAT), col("b").cast(QUAT))
+            .select(quat_multiply(col("a"), col("b")))
+        ),
+        "quat_rotate_bad_quat": (
+            _frame(q=[q_bad], v=[[1.0, 0.0, 0.0]])
+            .select(col("q").cast(QUAT), col("v").cast(VEC3))
+            .select(quat_rotate(col("q"), col("v")))
+        ),
+        "quat_rotate_bad_vector": (
+            _frame(q=[identity_q], v=[[None, 0.0, 0.0]])
+            .select(col("q").cast(QUAT), col("v").cast(VEC3))
+            .select(quat_rotate(col("q"), col("v")))
+        ),
+        "rot6d_to_matrix": (
+            _frame(r=[[None, 0.0, 0.0, 0.0, 1.0, 0.0]]).select(col("r").cast(ROT6D)).select(rot6d_to_matrix(col("r")))
+        ),
+        "rotation_geodesic_angle": (
+            _frame(a=[m_bad], b=[identity_m])
+            .select(col("a").cast(MAT3), col("b").cast(MAT3))
+            .select(rotation_geodesic_angle(col("a"), col("b")))
+        ),
+    }
+    for name, df in cases.items():
+        got = next(iter(df.to_pydict().values()))[0]
+        assert got is None, f"{name} returned {got!r} for a row with a null component, expected null"
+
+
+def test_null_component_does_not_disturb_its_neighbours():
+    """The offending row goes null; the rows either side of it are untouched."""
+    rows = [UNIT_QUATS_XYZW[6], [1.0, None, 0.0, 0.0], UNIT_QUATS_XYZW[7]]
+    got = _quat_col("q", rows).select(quat_to_matrix(col("q"))).to_pydict()["q"]
+    assert got[1] is None
+    want = scipy_rotation.from_quat(np.asarray([UNIT_QUATS_XYZW[6], UNIT_QUATS_XYZW[7]])).as_matrix()
+    np.testing.assert_allclose(np.asarray([np.asarray(got[0]), np.asarray(got[2])]), want, atol=1e-12)
 
 
 def test_order_is_case_insensitive():

--- a/tests/expressions/test_rotation.py
+++ b/tests/expressions/test_rotation.py
@@ -193,7 +193,9 @@ def test_double_cover_negated_quaternion_is_the_same_rotation():
     negated = [[-c for c in q] for q in UNIT_QUATS_XYZW]
     a = _quat_col("q", UNIT_QUATS_XYZW).select(quat_to_matrix(col("q"))).to_pydict()["q"]
     b = _quat_col("q", negated).select(quat_to_matrix(col("q"))).to_pydict()["q"]
-    np.testing.assert_allclose(np.asarray([np.asarray(m) for m in a]), np.asarray([np.asarray(m) for m in b]), atol=1e-12)
+    np.testing.assert_allclose(
+        np.asarray([np.asarray(m) for m in a]), np.asarray([np.asarray(m) for m in b]), atol=1e-12
+    )
 
 
 def test_matrices_are_special_orthogonal():
@@ -236,7 +238,9 @@ def test_wxyz_order_agrees_with_xyzw_on_the_same_rotation():
     wxyz = [[q[3], q[0], q[1], q[2]] for q in UNIT_QUATS_XYZW]
     a = _quat_col("q", UNIT_QUATS_XYZW).select(quat_to_matrix(col("q"))).to_pydict()["q"]
     b = _quat_col("q", wxyz).select(quat_to_matrix(col("q"), order="wxyz")).to_pydict()["q"]
-    np.testing.assert_allclose(np.asarray([np.asarray(m) for m in a]), np.asarray([np.asarray(m) for m in b]), atol=1e-12)
+    np.testing.assert_allclose(
+        np.asarray([np.asarray(m) for m in a]), np.asarray([np.asarray(m) for m in b]), atol=1e-12
+    )
 
 
 def test_matrix_to_quat_respects_order():
@@ -316,11 +320,7 @@ def test_literal_vector_is_broadcast():
 def test_literal_quaternion_is_broadcast():
     quat = [0.5, 0.5, 0.5, 0.5]
     vectors = VECTORS
-    df = (
-        _frame(v=vectors)
-        .select(col("v").cast(VEC3))
-        .select(quat_rotate(lit(quat).cast(QUAT), col("v")).alias("r"))
-    )
+    df = _frame(v=vectors).select(col("v").cast(VEC3)).select(quat_rotate(lit(quat).cast(QUAT), col("v")).alias("r"))
     got = np.asarray([np.asarray(v) for v in df.to_pydict()["r"]])
     assert len(got) == len(vectors)
     want = scipy_rotation.from_quat(np.asarray([quat] * len(vectors))).apply(np.asarray(vectors))
@@ -440,7 +440,7 @@ def test_non_finite_inputs_produce_null_everywhere(bad):
         ),
     }
     for name, df in cases.items():
-        got = list(df.to_pydict().values())[0][0]
+        got = next(iter(df.to_pydict().values()))[0]
         assert got is None, f"{name} returned {got!r} for a {bad} input, expected null"
 
 

--- a/tests/expressions/test_rotation.py
+++ b/tests/expressions/test_rotation.py
@@ -356,6 +356,100 @@ def test_filtered_input_reads_the_right_rows():
     np.testing.assert_allclose(got, want, atol=1e-12)
 
 
+@pytest.mark.parametrize(
+    "matrix,reason",
+    [
+        ([1.0, 2, 3, 4, 5, 6, 7, 8, 9], "arbitrary numbers"),
+        ([2.0, 0, 0, 0, 2, 0, 0, 0, 2], "a scaled rotation"),
+        ([1.0, 0, 0, 0, 1, 0, 0, 0, -1], "a reflection"),
+        ([-1.0, 0, 0, 0, -1, 0, 0, 0, -1], "negated identity, determinant -1"),
+    ],
+)
+def test_matrix_to_quat_rejects_matrices_outside_so3(matrix, reason):
+    got = _frame(m=[matrix]).select(col("m").cast(MAT3)).select(matrix_to_quat(col("m"))).to_pydict()["m"]
+    assert got[0] is None, f"{reason} should not yield a quaternion, got {got[0]}"
+
+
+@pytest.mark.parametrize(
+    "matrix,reason",
+    [
+        ([1.0, 2, 3, 4, 5, 6, 7, 8, 9], "cosine is 7, far outside [-1, 1]"),
+        ([2.0, 0, 0, 0, 2, 0, 0, 0, 2], "a scaled rotation"),
+    ],
+)
+def test_geodesic_angle_rejects_arguments_outside_so3(matrix, reason):
+    """The clamp that absorbs rounding must not turn nonsense into a plausible angle."""
+    identity = [1.0, 0, 0, 0, 1, 0, 0, 0, 1]
+    df = _frame(a=[matrix], b=[identity]).select(col("a").cast(MAT3), col("b").cast(MAT3))
+    got = df.select(rotation_geodesic_angle(col("a"), col("b"))).to_pydict()["a"]
+    assert got[0] is None, f"{reason} should yield null, got {got[0]}"
+
+
+def test_geodesic_angle_still_absorbs_rounding_for_real_rotations():
+    rotations = scipy_rotation.random(64, random_state=3)
+    left = [m.flatten().tolist() for m in rotations.as_matrix()]
+    df = _frame(a=left, b=left).select(col("a").cast(MAT3), col("b").cast(MAT3))
+    got = df.select(rotation_geodesic_angle(col("a"), col("b"))).to_pydict()["a"]
+    assert all(v is not None for v in got), "rounding must not reject genuine rotations"
+    np.testing.assert_allclose(np.asarray(got), 0.0, atol=1e-6)
+
+
+def test_float32_rotations_are_not_rejected_by_the_tolerance():
+    """f32 rounding costs about 1e-7, well inside the 1e-6 tolerance."""
+    dtype = DataType.tensor(DataType.float32(), (3, 3))
+    rotations = scipy_rotation.random(64, random_state=5)
+    rows = [m.flatten().tolist() for m in rotations.as_matrix()]
+    got = _frame(m=rows).select(col("m").cast(dtype)).select(matrix_to_quat(col("m"))).to_pydict()["m"]
+    assert all(q is not None for q in got), "f32 rotation matrices must survive"
+
+
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+def test_non_finite_inputs_produce_null_everywhere(bad):
+    """One policy across the module: a row that is not a rotation is null, never NaN."""
+    identity_q = [0.0, 0.0, 0.0, 1.0]
+    identity_m = [1.0, 0, 0, 0, 1, 0, 0, 0, 1]
+    q_bad = [bad, 0.0, 0.0, 1.0]
+    m_bad = [bad] + [0.0] * 8
+
+    cases = {
+        "quat_inverse": _quat_col("q", [q_bad]).select(quat_inverse(col("q"))),
+        "quat_to_matrix": _quat_col("q", [q_bad]).select(quat_to_matrix(col("q"))),
+        "matrix_to_quat": _frame(m=[m_bad]).select(col("m").cast(MAT3)).select(matrix_to_quat(col("m"))),
+        "quat_multiply": (
+            _frame(a=[q_bad], b=[identity_q])
+            .select(col("a").cast(QUAT), col("b").cast(QUAT))
+            .select(quat_multiply(col("a"), col("b")))
+        ),
+        "quat_rotate_bad_quat": (
+            _frame(q=[q_bad], v=[[1.0, 0.0, 0.0]])
+            .select(col("q").cast(QUAT), col("v").cast(VEC3))
+            .select(quat_rotate(col("q"), col("v")))
+        ),
+        "quat_rotate_bad_vector": (
+            _frame(q=[identity_q], v=[[bad, 0.0, 0.0]])
+            .select(col("q").cast(QUAT), col("v").cast(VEC3))
+            .select(quat_rotate(col("q"), col("v")))
+        ),
+        "rot6d_to_matrix": (
+            _frame(r=[[bad, 0.0, 0.0, 0.0, 1.0, 0.0]]).select(col("r").cast(ROT6D)).select(rot6d_to_matrix(col("r")))
+        ),
+        "rotation_geodesic_angle": (
+            _frame(a=[m_bad], b=[identity_m])
+            .select(col("a").cast(MAT3), col("b").cast(MAT3))
+            .select(rotation_geodesic_angle(col("a"), col("b")))
+        ),
+    }
+    for name, df in cases.items():
+        got = list(df.to_pydict().values())[0][0]
+        assert got is None, f"{name} returned {got!r} for a {bad} input, expected null"
+
+
+def test_order_is_case_insensitive():
+    upper = _quat_col("q", UNIT_QUATS_XYZW).select(quat_inverse(col("q"), order="XYZW")).to_pydict()["q"]
+    lower = _quat_col("q", UNIT_QUATS_XYZW).select(quat_inverse(col("q"), order="xyzw")).to_pydict()["q"]
+    np.testing.assert_allclose(np.asarray(upper), np.asarray(lower), atol=0.0)
+
+
 def test_wrong_length_is_rejected():
     wrong = DataType.fixed_size_list(DataType.float64(), 3)
     with pytest.raises(Exception, match="4 floats"):

--- a/tests/expressions/test_rotation.py
+++ b/tests/expressions/test_rotation.py
@@ -1,0 +1,367 @@
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+import daft
+from daft.datatype import DataType
+from daft.expressions import col, lit
+from daft.functions import (
+    matrix_to_quat,
+    quat_inverse,
+    quat_multiply,
+    quat_rotate,
+    quat_to_matrix,
+    rot6d_to_matrix,
+    rotation_geodesic_angle,
+)
+
+scipy_rotation = pytest.importorskip("scipy.spatial.transform").Rotation
+
+QUAT = DataType.fixed_size_list(DataType.float64(), 4)
+VEC3 = DataType.fixed_size_list(DataType.float64(), 3)
+ROT6D = DataType.fixed_size_list(DataType.float64(), 6)
+MAT3 = DataType.tensor(DataType.float64(), (3, 3))
+
+# Identity, three half turns about the axes (trace = -1, the numerically hard case),
+# an equal-weight quaternion, a near-identity rotation, and two generic ones.
+# Stored xyzw.
+QUATS_XYZW = [
+    [0.0, 0.0, 0.0, 1.0],
+    [1.0, 0.0, 0.0, 0.0],
+    [0.0, 1.0, 0.0, 0.0],
+    [0.0, 0.0, 1.0, 0.0],
+    [0.5, 0.5, 0.5, 0.5],
+    [1e-7, 0.0, 0.0, 0.9999999],
+    [-0.2, 0.8, 0.1, 0.3],
+    [0.1, -0.3, 0.7, -0.6],
+]
+
+VECTORS = [[1.0, 0.0, 0.0], [0.0, 2.0, -1.0], [0.3, -1.7, 2.1], [1.0, 1.0, 1.0]]
+
+
+def _normalize(q):
+    return (np.asarray(q) / np.linalg.norm(q)).tolist()
+
+
+UNIT_QUATS_XYZW = [_normalize(q) for q in QUATS_XYZW]
+
+
+def _frame(**cols):
+    return daft.from_pydict(cols)
+
+
+def _quat_col(name, values, dtype=QUAT):
+    return _frame(**{name: values}).select(col(name).cast(dtype))
+
+
+def _rotations():
+    """The same rotations as scipy objects, for use as an independent oracle."""
+    return scipy_rotation.from_quat(np.asarray(UNIT_QUATS_XYZW))
+
+
+def test_repr():
+    assert repr(quat_inverse(col("q"))) == 'quat_inverse(col(q), lit("xyzw"))'
+    assert repr(rot6d_to_matrix(col("r"))) == "rot6d_to_matrix(col(r))"
+
+
+# ---------------------------------------------------------------------------
+# Differential tests against scipy
+# ---------------------------------------------------------------------------
+
+
+def test_quat_to_matrix_matches_scipy():
+    df = _quat_col("q", UNIT_QUATS_XYZW).select(quat_to_matrix(col("q")))
+    got = np.asarray([np.asarray(m) for m in df.to_pydict()["q"]])
+    want = _rotations().as_matrix()
+    np.testing.assert_allclose(got, want, atol=1e-12)
+
+
+def test_matrix_to_quat_matches_scipy_up_to_sign():
+    matrices = [m.flatten().tolist() for m in _rotations().as_matrix()]
+    df = _frame(m=matrices).select(col("m").cast(MAT3)).select(matrix_to_quat(col("m")))
+    got = np.asarray([np.asarray(q) for q in df.to_pydict()["m"]])
+    got = got / np.linalg.norm(got, axis=1, keepdims=True)
+    want = np.asarray(UNIT_QUATS_XYZW)
+    # A quaternion and its negation are the same rotation, so align signs first.
+    signs = np.sign(np.sum(got * want, axis=1))[:, None]
+    np.testing.assert_allclose(got * signs, want, atol=1e-9)
+
+
+def test_quat_multiply_matches_scipy():
+    left, right = UNIT_QUATS_XYZW, list(reversed(UNIT_QUATS_XYZW))
+    df = (
+        _frame(a=left, b=right)
+        .select(col("a").cast(QUAT), col("b").cast(QUAT))
+        .select(quat_multiply(col("a"), col("b")))
+    )
+    got = np.asarray([np.asarray(q) for q in df.to_pydict()["a"]])
+    # scipy composes left * right the same way, applying right first.
+    want = (scipy_rotation.from_quat(np.asarray(left)) * scipy_rotation.from_quat(np.asarray(right))).as_quat()
+    signs = np.sign(np.sum(got * want, axis=1))[:, None]
+    np.testing.assert_allclose(got * signs, want, atol=1e-12)
+
+
+def test_quat_inverse_matches_scipy():
+    df = _quat_col("q", UNIT_QUATS_XYZW).select(quat_inverse(col("q")))
+    got = np.asarray([np.asarray(q) for q in df.to_pydict()["q"]])
+    want = _rotations().inv().as_quat()
+    signs = np.sign(np.sum(got * want, axis=1))[:, None]
+    np.testing.assert_allclose(got * signs, want, atol=1e-12)
+
+
+@pytest.mark.parametrize("vector", VECTORS)
+def test_quat_rotate_matches_scipy(vector):
+    n = len(UNIT_QUATS_XYZW)
+    df = (
+        _frame(q=UNIT_QUATS_XYZW, v=[vector] * n)
+        .select(col("q").cast(QUAT), col("v").cast(VEC3))
+        .select(quat_rotate(col("q"), col("v")))
+    )
+    got = np.asarray([np.asarray(v) for v in df.to_pydict()["q"]])
+    want = _rotations().apply(np.asarray([vector] * n))
+    np.testing.assert_allclose(got, want, atol=1e-12)
+
+
+def test_rot6d_to_matrix_matches_gram_schmidt_reference():
+    # The reference implementation from the literature, and from Eventual's own
+    # EgoDex blog post: normalize the first column, orthogonalize the second
+    # against it, take the cross product for the third.
+    rng = np.random.default_rng(0)
+    raw = rng.normal(size=(16, 6))
+
+    def reference(r):
+        a1, a2 = r[:3], r[3:]
+        c1 = a1 / np.linalg.norm(a1)
+        u = a2 - np.dot(c1, a2) * c1
+        c2 = u / np.linalg.norm(u)
+        return np.stack([c1, c2, np.cross(c1, c2)], axis=1)
+
+    want = np.asarray([reference(r) for r in raw])
+    df = _frame(r=raw.tolist()).select(col("r").cast(ROT6D)).select(rot6d_to_matrix(col("r")))
+    got = np.asarray([np.asarray(m) for m in df.to_pydict()["r"]])
+    np.testing.assert_allclose(got, want, atol=1e-12)
+
+
+def test_rotation_geodesic_angle_matches_scipy_magnitude():
+    a = _rotations()
+    b = scipy_rotation.from_quat(np.asarray(list(reversed(UNIT_QUATS_XYZW))))
+    left = [m.flatten().tolist() for m in a.as_matrix()]
+    right = [m.flatten().tolist() for m in b.as_matrix()]
+
+    df = (
+        _frame(a=left, b=right)
+        .select(col("a").cast(MAT3), col("b").cast(MAT3))
+        .select(rotation_geodesic_angle(col("a"), col("b")))
+    )
+    got = np.asarray(df.to_pydict()["a"])
+    want = (a * b.inv()).magnitude()
+    np.testing.assert_allclose(got, want, atol=1e-7)
+
+
+# ---------------------------------------------------------------------------
+# Algebraic properties
+# ---------------------------------------------------------------------------
+
+
+def test_multiply_by_inverse_is_identity():
+    df = (
+        _quat_col("q", UNIT_QUATS_XYZW)
+        .with_column("inv", quat_inverse(col("q")))
+        .select(quat_multiply(col("q"), col("inv")).alias("r"))
+    )
+    got = np.asarray([np.asarray(q) for q in df.to_pydict()["r"]])
+    identity = np.tile([0.0, 0.0, 0.0, 1.0], (len(UNIT_QUATS_XYZW), 1))
+    np.testing.assert_allclose(np.abs(got), np.abs(identity), atol=1e-9)
+
+
+def test_rotation_preserves_vector_norm():
+    vector = [0.3, -1.7, 2.1]
+    n = len(UNIT_QUATS_XYZW)
+    df = (
+        _frame(q=UNIT_QUATS_XYZW, v=[vector] * n)
+        .select(col("q").cast(QUAT), col("v").cast(VEC3))
+        .select(quat_rotate(col("q"), col("v")))
+    )
+    got = np.asarray([np.asarray(v) for v in df.to_pydict()["q"]])
+    np.testing.assert_allclose(np.linalg.norm(got, axis=1), np.linalg.norm(vector), atol=1e-12)
+
+
+def test_double_cover_negated_quaternion_is_the_same_rotation():
+    negated = [[-c for c in q] for q in UNIT_QUATS_XYZW]
+    a = _quat_col("q", UNIT_QUATS_XYZW).select(quat_to_matrix(col("q"))).to_pydict()["q"]
+    b = _quat_col("q", negated).select(quat_to_matrix(col("q"))).to_pydict()["q"]
+    np.testing.assert_allclose(np.asarray([np.asarray(m) for m in a]), np.asarray([np.asarray(m) for m in b]), atol=1e-12)
+
+
+def test_matrices_are_special_orthogonal():
+    df = _quat_col("q", UNIT_QUATS_XYZW).select(quat_to_matrix(col("q")))
+    for m in df.to_pydict()["q"]:
+        m = np.asarray(m)
+        np.testing.assert_allclose(m @ m.T, np.eye(3), atol=1e-12)
+        assert math.isclose(float(np.linalg.det(m)), 1.0, abs_tol=1e-12)
+
+
+def test_geodesic_angle_is_zero_on_the_diagonal():
+    matrices = [m.flatten().tolist() for m in _rotations().as_matrix()]
+    df = (
+        _frame(a=matrices, b=matrices)
+        .select(col("a").cast(MAT3), col("b").cast(MAT3))
+        .select(rotation_geodesic_angle(col("a"), col("b")))
+    )
+    np.testing.assert_allclose(np.asarray(df.to_pydict()["a"]), 0.0, atol=1e-7)
+
+
+def test_geodesic_angle_recovers_a_known_rotation_angle():
+    thetas = [0.0, 0.1, 1.0, math.pi / 2, 3.0]
+    rotations = scipy_rotation.from_rotvec([[0.0, 0.0, t] for t in thetas])
+    left = [m.flatten().tolist() for m in rotations.as_matrix()]
+    right = [np.eye(3).flatten().tolist()] * len(thetas)
+    df = (
+        _frame(a=left, b=right)
+        .select(col("a").cast(MAT3), col("b").cast(MAT3))
+        .select(rotation_geodesic_angle(col("a"), col("b")))
+    )
+    np.testing.assert_allclose(np.asarray(df.to_pydict()["a"]), thetas, atol=1e-7)
+
+
+# ---------------------------------------------------------------------------
+# Component order
+# ---------------------------------------------------------------------------
+
+
+def test_wxyz_order_agrees_with_xyzw_on_the_same_rotation():
+    wxyz = [[q[3], q[0], q[1], q[2]] for q in UNIT_QUATS_XYZW]
+    a = _quat_col("q", UNIT_QUATS_XYZW).select(quat_to_matrix(col("q"))).to_pydict()["q"]
+    b = _quat_col("q", wxyz).select(quat_to_matrix(col("q"), order="wxyz")).to_pydict()["q"]
+    np.testing.assert_allclose(np.asarray([np.asarray(m) for m in a]), np.asarray([np.asarray(m) for m in b]), atol=1e-12)
+
+
+def test_matrix_to_quat_respects_order():
+    matrices = [m.flatten().tolist() for m in _rotations().as_matrix()]
+    df = _frame(m=matrices).select(col("m").cast(MAT3))
+    xyzw = np.asarray([np.asarray(q) for q in df.select(matrix_to_quat(col("m"))).to_pydict()["m"]])
+    wxyz = np.asarray([np.asarray(q) for q in df.select(matrix_to_quat(col("m"), order="wxyz")).to_pydict()["m"]])
+    np.testing.assert_allclose(xyzw, wxyz[:, [1, 2, 3, 0]], atol=1e-12)
+
+
+def test_invalid_order_is_rejected():
+    with pytest.raises(Exception, match="xyzw"):
+        _quat_col("q", UNIT_QUATS_XYZW).select(quat_inverse(col("q"), order="wxzy")).collect()
+
+
+# ---------------------------------------------------------------------------
+# Nulls, degenerate input, broadcasting, and schema errors
+# ---------------------------------------------------------------------------
+
+
+def test_zero_quaternion_produces_null():
+    df = _quat_col("q", [[0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 1.0]]).select(quat_inverse(col("q")))
+    got = df.to_pydict()["q"]
+    assert got[0] is None
+    assert got[1] is not None
+
+
+def test_null_row_propagates():
+    df = _quat_col("q", [None, [0.0, 0.0, 0.0, 1.0]]).select(quat_to_matrix(col("q")))
+    got = df.to_pydict()["q"]
+    assert got[0] is None
+    assert got[1] is not None
+
+
+def test_degenerate_rot6d_produces_null():
+    rows = [
+        [0.0, 0.0, 0.0, 1.0, 0.0, 0.0],  # first vector is zero
+        [1.0, 0.0, 0.0, 2.0, 0.0, 0.0],  # parallel vectors
+        [1.0, 0.0, 0.0, 0.0, 1.0, 0.0],  # valid
+    ]
+    got = _frame(r=rows).select(col("r").cast(ROT6D)).select(rot6d_to_matrix(col("r"))).to_pydict()["r"]
+    assert got[0] is None
+    assert got[1] is None
+    assert got[2] is not None
+
+
+def test_broadcast_against_a_single_row():
+    n = 3
+    quats = UNIT_QUATS_XYZW[:n]
+    df = (
+        _frame(q=quats, v=[[1.0, 0.0, 0.0]] * n)
+        .select(col("q").cast(QUAT), col("v").cast(VEC3))
+        .select(quat_rotate(col("q"), col("v")))
+    )
+    want = np.asarray([np.asarray(v) for v in df.to_pydict()["q"]])
+
+    broadcast = (
+        _frame(q=quats)
+        .select(col("q").cast(QUAT))
+        .with_column("v", daft.lit([1.0, 0.0, 0.0]).cast(VEC3))
+        .select(quat_rotate(col("q"), col("v")))
+    )
+    got = np.asarray([np.asarray(v) for v in broadcast.to_pydict()["q"]])
+    np.testing.assert_allclose(got, want, atol=1e-12)
+
+
+def test_literal_vector_is_broadcast():
+    """A literal arrives as a length-1 series and must broadcast, not truncate."""
+    vector = [0.3, -1.7, 2.1]
+    df = _quat_col("q", UNIT_QUATS_XYZW).select(quat_rotate(col("q"), lit(vector).cast(VEC3)))
+    got = np.asarray([np.asarray(v) for v in df.to_pydict()["q"]])
+    assert len(got) == len(UNIT_QUATS_XYZW)
+    want = _rotations().apply(np.asarray([vector] * len(UNIT_QUATS_XYZW)))
+    np.testing.assert_allclose(got, want, atol=1e-12)
+
+
+def test_literal_quaternion_is_broadcast():
+    quat = [0.5, 0.5, 0.5, 0.5]
+    vectors = VECTORS
+    df = (
+        _frame(v=vectors)
+        .select(col("v").cast(VEC3))
+        .select(quat_rotate(lit(quat).cast(QUAT), col("v")).alias("r"))
+    )
+    got = np.asarray([np.asarray(v) for v in df.to_pydict()["r"]])
+    assert len(got) == len(vectors)
+    want = scipy_rotation.from_quat(np.asarray([quat] * len(vectors))).apply(np.asarray(vectors))
+    np.testing.assert_allclose(got, want, atol=1e-12)
+
+
+def test_float32_input_is_accepted():
+    dtype = DataType.fixed_size_list(DataType.float32(), 4)
+    df = _quat_col("q", UNIT_QUATS_XYZW, dtype=dtype).select(quat_to_matrix(col("q")))
+    got = np.asarray([np.asarray(m) for m in df.to_pydict()["q"]])
+    np.testing.assert_allclose(got, _rotations().as_matrix(), atol=1e-6)
+
+
+@pytest.mark.parametrize("k", [1, 3, 7, 8])
+def test_sliced_input_reads_the_right_rows(k):
+    """These expressions index the flat child directly, so a sliced array must stay aligned."""
+    df = _quat_col("q", UNIT_QUATS_XYZW).limit(k).select(quat_to_matrix(col("q")))
+    got = np.asarray([np.asarray(m) for m in df.to_pydict()["q"]])
+    want = scipy_rotation.from_quat(np.asarray(UNIT_QUATS_XYZW[:k])).as_matrix()
+    np.testing.assert_allclose(got, want, atol=1e-12)
+
+
+def test_filtered_input_reads_the_right_rows():
+    n = len(UNIT_QUATS_XYZW)
+    df = (
+        _frame(q=UNIT_QUATS_XYZW, i=list(range(n)))
+        .select(col("q").cast(QUAT), col("i"))
+        .where(col("i") >= 5)
+        .select(quat_to_matrix(col("q")))
+    )
+    got = np.asarray([np.asarray(m) for m in df.to_pydict()["q"]])
+    want = scipy_rotation.from_quat(np.asarray(UNIT_QUATS_XYZW[5:])).as_matrix()
+    np.testing.assert_allclose(got, want, atol=1e-12)
+
+
+def test_wrong_length_is_rejected():
+    wrong = DataType.fixed_size_list(DataType.float64(), 3)
+    with pytest.raises(Exception, match="4 floats"):
+        _frame(q=[[1.0, 0.0, 0.0]]).select(col("q").cast(wrong)).select(quat_inverse(col("q"))).collect()
+
+
+def test_non_list_input_is_rejected():
+    with pytest.raises(Exception, match="4 floats"):
+        _frame(q=[1.0]).select(quat_inverse(col("q"))).collect()


### PR DESCRIPTION
## Changes Made

Adds a `rotation` module to `daft-functions` with seven native expressions for pose data:

<!-- linear:table-colwidths:266,266,266 -->
| function | input | output |
| -- | -- | -- |
| `rot6d_to_matrix(r)` | `FixedSizeList[Float64, 6]` | `Tensor[Float64, [3,3]]` |
| `quat_to_matrix(q, order=)` | `FixedSizeList[Float64, 4]` | `Tensor[Float64, [3,3]]` |
| `matrix_to_quat(m, order=)` | `Tensor[Float64, [3,3]]` | `FixedSizeList[Float64, 4]` |
| `quat_multiply(a, b, order=)` | two quaternions | quaternion |
| `quat_inverse(q, order=)` | quaternion | quaternion |
| `quat_rotate(q, v, order=)` | quaternion, `FixedSizeList[Float64, 3]` | vector |
| `rotation_geodesic_angle(a, b)` | two matrices | `Float64` |

Rationale, the datasets involved, and the corner cases are in Eventual-Inc/Daft#7250.

**Placement.** A module inside the existing `daft-functions` crate, not a new crate. `daft-geo` is separate because it pulls `h3` and `geo`; this is arithmetic and **adds no dependencies**.

**Design decisions.**

* Quaternion component order is an explicit `order` argument, defaulting to `"xyzw"` (ROS, tf2, `scipy.spatial.transform.Rotation`), with `"wxyz"` for the scalar-first convention (Eigen, MuJoCo, Isaac Sim). The ecosystem is split and this is a one-way API door, so picking silently seemed wrong.
* `matrix_to_quat` uses Shepperd's method, branching on the largest diagonal term, rather than the naive trace formula which loses precision near a half turn.
* `matrix_to_quat` and `rotation_geodesic_angle` return null outside `SO(3)`. Membership is tested directly, as `m^T m = I` with determinant `+1`. Checking that Shepperd's method returns a unit quaternion is not equivalent: on its principal branch it reads only the trace and the antisymmetric part, so a trace-free symmetric perturbation is invisible to it. `[[1, 5, 0], [5, 1, 0], [0, 0, 1]]` has determinant `-24` and still yields the identity quaternion, of unit norm.
* `rotation_geodesic_angle` clamps before `arccos`, so rounding cannot produce NaN for nearly-identical frames. A cosine range check would not be enough on its own: a non-rotation can land the cosine inside `[-1, 1]`, where the formula returns a plausible angle.
* **One null policy across the module.** A row is null if it is null, holds a null component, holds `NaN` or an infinity, is a zero quaternion, is a 6D pair that is zero or parallel, or is a matrix that is not a rotation. Nothing is coerced into a plausible rotation. A null component matters because the value buffer still holds a number under a null slot, usually a zero, so reading it without the child validity turns `[1, null, 0, 0]` into a half turn about x. The tolerance is `1e-6`, above `Float64` rounding and above the roughly `1e-7` cost of widening a `Float32` rotation matrix.
* `Float32` inputs are accepted and computed in `Float64`.
* `order` is case-insensitive.
* Rotation matrices are `Tensor[Float64; [3,3]]`, which lowers to a physical `FixedSizeList(Float64, 9)`, so no new physical representation is introduced.

**Performance.** The expressions read `flat_child` as one contiguous slice rather than iterating the `FixedSizeListArray`, whose `IntoIterator` yields `Option<Series>` and therefore allocates a `Series` per row. On a million rows that change alone took the native path from 13.3M to 42M rows/s.

## Verification

**Two independent oracles, neither of them this implementation.**

1. `scipy.spatial.transform.Rotation`, for every function, in `tests/expressions/test_rotation.py`.
2. An independent Clifford-algebra rotor implementation (rotors in the even subalgebra of `Cl(3,0)`, acting by the sandwich product `R v R̃`, a different derivation from the quaternion formulas here). Over eight rotations and three operations:

```
quat_to_matrix   vs Rotor3::to_matrix    max |d| = 2.22e-16
quat_rotate      vs Rotor3::rotate_vec   max |d| = 8.88e-16
quat_multiply    vs Rotor3::compose      max |d| = 0.00e+00
```

**Algebraic property tests** (Rust, in `math.rs`): unit-norm preservation, `q ⊗ q⁻¹ = 1`, associativity of composition, rotation preserves `‖v‖`, the `q ≡ -q` double cover, `SO(3)` membership (orthonormal columns, determinant `+1`), round-trip through the matrix up to sign, stability at a half turn (trace `-1`), symmetry of the geodesic metric, recovery of a known rotation angle, and no NaN under trace overshoot.

**Python tests**: the differential tests above, plus nulls, degenerate 6D rows, invalid `order`, broadcasting against a length-1 side and against literals, `Float32` inputs, wrong fixed-size length, non-list input, and sliced and filtered inputs. That last group matters because indexing `flat_child` directly is only sound if `slice()` keeps the child aligned, which it does.

**Rejection tests**: matrices outside `SO(3)` (arbitrary numbers, a scaling, a reflection, negated identity, a trace-free symmetric perturbation of determinant `-24`, a volume-preserving shear of determinant `+1`), null components through all seven functions, and `NaN` / `±inf` through all seven. The last two `SO(3)` cases are the ones a cosine range check cannot catch, since both put the cosine inside `[-1, 1]`. Three guards in the other direction: 64 random rotations must not be rejected by the tolerance, 64 `Float32` rotation matrices must survive `matrix_to_quat`, and a null component must null its own row without disturbing its neighbours.

**Results**

* `cargo test -p daft-functions`: 39 passed.
* `pytest tests/expressions/test_rotation.py`: 46 passed.
* `pytest tests/expressions`: 28,175 passed, 7 skipped, no regressions.
* `pre-commit run --all-files`: clean. Worth noting for anyone else contributing: `make lint` runs only `ruff-check` and `clippy`, so `codespell`, `ruff-format`, and `mypy` go unexercised until CI. `codespell` reads `shepperd` as a misspelling of `shepherd`; since it is the surname of the author of the method, it is added to `ignore-words-list` in `pyproject.toml`.
* Doctest on the new module passes. The docs generator picks it up as a "Rotation functions" category.

**Benchmark.** The EgoDex `forearm_roll` quantity over 1,000,000 rows, release build, aggregate sink, all four paths agreeing on the mean angle to twelve decimals:

<!-- linear:table-colwidths:266,266,266 -->
| implementation | throughput | vs native |
| -- | -- | -- |
| per-row `@daft.func` (as in the blog post) | 0.03M rows/s | \~1400x slower |
| `@daft.func.batch`, NumPy via `to_pylist()` | 0.45M rows/s | 94x slower |
| `@daft.func.batch`, NumPy via Arrow, zero copy | 12.4M rows/s | 3.4x slower |
| native expressions | 42.2M rows/s |  |

The number worth quoting is **3.4x over an Arrow-fed NumPy UDF**, because that is the baseline a careful user writes. It moves by about 10% with machine load; the validation described above costs nothing measurable. The \~1400x is a fact about the per-row UDF, not about the engine. Performance is the smaller half of the argument; the larger half is that the fast baseline requires the user to know to route through Arrow, to know Shepperd's method, to know to clamp before `arccos`, and to know which quaternion convention their data uses.

## Related Issues

Closes Eventual-Inc/Daft#7250

## Notes for reviewers

* **This PR does not build on a machine whose cargo target directory is on a different filesystem from the checkout, without** [#7246](<https://github.com/Eventual-Inc/Daft/issues/7246>)**.** A release build of it also hangs for tens of minutes in LLVM's SLP vectorizer without [#7249](<https://github.com/Eventual-Inc/Daft/issues/7249>). Both are separate PRs; mentioning it so they are not reviewed out of order.
* This is larger than the typical contribution (roughly 950 lines of implementation, 690 of tests). Glad to split conversions from operations, or to move `rot6d_to_matrix` and `rotation_geodesic_angle` into a follow-up, if you would rather review in smaller pieces.
* If you would prefer this out of tree as a `daft-ext` extension in the manner of `daft-h3`, say so and I will move it. The in-tree argument is that `daft-geo` is in tree, this adds no dependencies, and rotations are core to the datasets Daft already reads.
* `slerp` and an `SE(3)` rigid-transform type are the obvious next steps and are deliberately absent here.

---

This PR was made with the assistance of Opus 4.8.