### PR TITLE
fix: replace unguarded unwraps in progress bar and scan task reader

### DIFF
--- a/src/daft-local-execution/src/runtime_stats/progress_bar.rs
+++ b/src/daft-local-execution/src/runtime_stats/progress_bar.rs
@@ -189,18 +189,27 @@ impl Drop for IndicatifProgressBarManager {
 
 impl ProgressBar for IndicatifProgressBarManager {
     fn initialize_node(&self, node_id: NodeID) {
-        let pb = self.pbars.get(node_id).unwrap();
+        let Some(pb) = self.pbars.get(node_id) else {
+            log::warn!("No progress bar registered for node {node_id}; skipping initialize");
+            return;
+        };
         pb.enable_steady_tick(TICK_INTERVAL);
     }
 
     fn finalize_node(&self, node_id: NodeID, last_snapshot: &StatSnapshot) {
-        let pb = self.pbars.get(node_id).unwrap();
+        let Some(pb) = self.pbars.get(node_id) else {
+            log::warn!("No progress bar registered for node {node_id}; skipping finalize");
+            return;
+        };
         pb.set_message(last_snapshot.to_message());
         pb.finish();
     }
 
     fn handle_event(&self, node_id: NodeID, event: &StatSnapshot) {
-        let pb = self.pbars.get(node_id).unwrap();
+        let Some(pb) = self.pbars.get(node_id) else {
+            log::warn!("No progress bar registered for node {node_id}; skipping event");
+            return;
+        };
         pb.set_message(event.to_message());
     }
 
@@ -318,7 +327,10 @@ mod python {
         fn initialize_node(&self, _: NodeID) {}
 
         fn finalize_node(&self, node_id: NodeID, last_snapshot: &StatSnapshot) {
-            let pb_id = self.node_id_to_pb_id.get(&node_id).unwrap();
+            let Some(pb_id) = self.node_id_to_pb_id.get(&node_id) else {
+                log::warn!("No progress bar registered for node {node_id}; skipping finalize");
+                return;
+            };
             self.update_bar(*pb_id, &last_snapshot.to_message())
                 .expect("Failed to update TQDM progress bar");
 
@@ -326,7 +338,10 @@ mod python {
         }
 
         fn handle_event(&self, node_id: NodeID, event: &StatSnapshot) {
-            let pb_id = self.node_id_to_pb_id.get(&node_id).unwrap();
+            let Some(pb_id) = self.node_id_to_pb_id.get(&node_id) else {
+                log::warn!("No progress bar registered for node {node_id}; skipping event");
+                return;
+            };
             self.update_bar(*pb_id, &event.to_message())
                 .expect("Failed to update TQDM progress bar");
         }
@@ -359,5 +374,36 @@ mod tests {
 
         // This panics in make_new_bar due to byte-level string slicing on multi-byte UTF-8
         let _manager = IndicatifProgressBarManager::new(&node_info_map, false);
+    }
+
+    #[test]
+    fn indicatif_skips_unregistered_node_without_panic() {
+        // Regression for #6991: a node_id dispatched to the progress bar that was never
+        // registered (a construction/dispatch mismatch, or non-consecutive node ids)
+        // must warn and skip rather than panic the running query.
+        use common_metrics::snapshot::DefaultSnapshot;
+
+        let node_info = Arc::new(NodeInfo {
+            name: "node".into(),
+            id: 0,
+            ..Default::default()
+        });
+        let mut node_info_map = HashMap::new();
+        node_info_map.insert(0, node_info);
+        let manager = IndicatifProgressBarManager::new(&node_info_map, false);
+
+        let snapshot = StatSnapshot::Default(DefaultSnapshot {
+            cpu_us: 0,
+            rows_in: 0,
+            rows_out: 0,
+            bytes_in: 0,
+            bytes_out: 0,
+            num_tasks: 0,
+        });
+
+        // node_id 99 was never registered; each of these previously unwrapped and panicked.
+        manager.initialize_node(99);
+        manager.finalize_node(99, &snapshot);
+        manager.handle_event(99, &snapshot);
     }
 }

--- a/src/daft-local-execution/src/sources/scan_task_reader.rs
+++ b/src/daft-local-execution/src/sources/scan_task_reader.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, sync::Arc};
 
-use common_error::DaftResult;
+use common_error::{DaftError, DaftResult};
 use daft_csv::{CsvConvertOptions, CsvParseOptions, CsvReadOptions};
 use daft_dsl::{AggExpr, Expr};
 use daft_io::{GetRange, IOStatsRef};
@@ -104,7 +104,10 @@ async fn read_parquet(
     chunk_size: usize,
     skipped_corrupt_files: SkippedCorruptFilesCollector,
 ) -> DaftResult<BoxStream<'static, DaftResult<RecordBatch>>> {
-    let source = scan_task.sources.first().unwrap();
+    let source = scan_task
+        .sources
+        .first()
+        .ok_or_else(|| DaftError::ValueError("ScanTask has no sources".to_string()))?;
 
     if let Some(aggregation) = &scan_task.pushdowns.aggregation
         && let Expr::Agg(AggExpr::Count(_, _)) = aggregation.as_ref()
@@ -229,7 +232,10 @@ async fn read_json(
     io_stats: IOStatsRef,
     chunk_size: usize,
 ) -> DaftResult<BoxStream<'static, DaftResult<RecordBatch>>> {
-    let source = scan_task.sources.first().unwrap();
+    let source = scan_task
+        .sources
+        .first()
+        .ok_or_else(|| DaftError::ValueError("ScanTask has no sources".to_string()))?;
     let schema_of_file = scan_task.schema.clone();
     let convert_options = JsonConvertOptions::new_internal(
         scan_task.pushdowns.limit,


### PR DESCRIPTION
Closes #6991.

## What

Removes the confirmed panic sites called out in the issue.

## Why

Three unwrap patterns in live query-execution paths can panic a running query with no recovery:

- `IndicatifProgressBarManager::{initialize_node, finalize_node, handle_event}` unwrap `pbars.get(node_id)`. Any construction-vs-dispatch mismatch, or a non-consecutive node id (the consecutive assumption is convention, not enforced), panics.
- `TqdmProgressBarManager::{finalize_node, handle_event}` unwrap `node_id_to_pb_id.get(&node_id)` — same mismatch, on the notebook path.
- `scan_task_reader::{read_parquet, read_json}` unwrap `sources.first()` — an empty `ScanTask.sources` panics with no actionable message.

## How

- Progress bar: an unregistered `node_id` now logs a warning and skips. A missing telemetry bar is not a fatal condition and should never crash a query.
- Scan reader: an empty `sources` returns a typed `DaftError::ValueError("ScanTask has no sources")` so the caller can handle it.

Added a regression test (`indicatif_skips_unregistered_node_without_panic`) covering all three progress-bar methods with an out-of-range node id. `cargo test -p daft-local-execution` passes; the changed files are clippy-clean.