### PR TITLE
fix(daft-file): release GIL in PyDaftFile methods to prevent deadlock

### DIFF
--- a/src/daft-file/src/python.rs
+++ b/src/daft-file/src/python.rs
@@ -151,7 +151,11 @@ impl PyDaftFile {
 impl PyDaftFile {
     #[staticmethod]
     #[pyo3(signature=(f, buffer_size=None))]
-    fn _from_file_reference(py: Python<'_>, f: PyFileReference, buffer_size: Option<usize>) -> PyResult<Self> {
+    fn _from_file_reference(
+        py: Python<'_>,
+        f: PyFileReference,
+        buffer_size: Option<usize>,
+    ) -> PyResult<Self> {
         let file_ref = f.inner.as_ref().clone();
         py.detach(move || Ok(DaftFile::load_blocking(file_ref, false, buffer_size)?.into()))
     }
@@ -230,11 +234,9 @@ impl PyDaftFile {
             .take()
             .ok_or_else(|| PyValueError::new_err("File not open"))?;
 
-        let result: SeekResult = py.detach(move || {
-            match cursor.seek(seek_from) {
-                Ok(new_pos) => Ok((new_pos, cursor)),
-                Err(e) => Err((PyIOError::new_err(e.to_string()), cursor)),
-            }
+        let result: SeekResult = py.detach(move || match cursor.seek(seek_from) {
+            Ok(new_pos) => Ok((new_pos, cursor)),
+            Err(e) => Err((PyIOError::new_err(e.to_string()), cursor)),
         });
 
         match result {

--- a/src/daft-file/src/python.rs
+++ b/src/daft-file/src/python.rs
@@ -16,6 +16,9 @@ use pyo3::{
 
 use crate::file::{DaftFile, FileCursor};
 
+type ReadResult = Result<(Vec<u8>, usize, bool, FileCursor), (PyErr, FileCursor)>;
+type SeekResult = Result<(u64, FileCursor), (PyErr, FileCursor)>;
+
 #[pyclass(from_py_object)]
 #[derive(Clone)]
 struct PyFileReference {
@@ -164,7 +167,7 @@ impl PyDaftFile {
         let current_position = self.inner.position;
         let current_size = cursor.size();
 
-        let result: Result<(Vec<u8>, usize, bool, FileCursor), (PyErr, FileCursor)> = py.detach(move || {
+        let result: ReadResult = py.detach(move || {
             if size == -1 {
                 let mut buffer = Vec::new();
                 match cursor.read_to_end(&mut buffer) {
@@ -227,7 +230,7 @@ impl PyDaftFile {
             .take()
             .ok_or_else(|| PyValueError::new_err("File not open"))?;
 
-        let result: Result<(u64, FileCursor), (PyErr, FileCursor)> = py.detach(move || {
+        let result: SeekResult = py.detach(move || {
             match cursor.seek(seek_from) {
                 Ok(new_pos) => Ok((new_pos, cursor)),
                 Err(e) => Err((PyIOError::new_err(e.to_string()), cursor)),

--- a/src/daft-file/src/python.rs
+++ b/src/daft-file/src/python.rs
@@ -30,8 +30,9 @@ impl PyFileReference {
         Ok(Self { inner: Arc::new(f) })
     }
 
-    pub fn __enter__(&self) -> PyResult<PyDaftFile> {
-        Ok(DaftFile::load_blocking(self.inner.as_ref().clone(), true, None)?.into())
+    pub fn __enter__(&self, py: Python<'_>) -> PyResult<PyDaftFile> {
+        let file_ref = self.inner.as_ref().clone();
+        py.detach(move || Ok(DaftFile::load_blocking(file_ref, true, None)?.into()))
     }
 
     pub fn _get_file(&self) -> FileReference {
@@ -147,52 +148,61 @@ impl PyDaftFile {
 impl PyDaftFile {
     #[staticmethod]
     #[pyo3(signature=(f, buffer_size=None))]
-    fn _from_file_reference(f: PyFileReference, buffer_size: Option<usize>) -> PyResult<Self> {
-        Ok(DaftFile::load_blocking(f.inner.as_ref().clone(), false, buffer_size)?.into())
+    fn _from_file_reference(py: Python<'_>, f: PyFileReference, buffer_size: Option<usize>) -> PyResult<Self> {
+        let file_ref = f.inner.as_ref().clone();
+        py.detach(move || Ok(DaftFile::load_blocking(file_ref, false, buffer_size)?.into()))
     }
 
     #[pyo3(signature=(size=-1))]
-    fn read(&mut self, size: isize) -> PyResult<Vec<u8>> {
+    fn read(&mut self, py: Python<'_>, size: isize) -> PyResult<Vec<u8>> {
         self.check_context()?;
-        let cursor = self
+        let mut cursor = self
             .inner
             .cursor
-            .as_mut()
+            .take()
             .ok_or_else(|| PyIOError::new_err("File not open"))?;
+        let current_position = self.inner.position;
+        let current_size = cursor.size();
 
-        if size == -1 {
-            let mut buffer = Vec::new();
-            let bytes_read = cursor
-                .read_to_end(&mut buffer)
-                .map_err(|e| PyIOError::new_err(e.to_string()))?;
-
-            buffer.truncate(bytes_read);
-            self.inner.position = bytes_read;
-
-            Ok(buffer)
-        } else {
-            let mut buffer = vec![0u8; size as usize];
-
-            if self.inner.position == cursor.size() {
-                return Ok(vec![]);
+        let result = py.detach(move || {
+            if size == -1 {
+                let mut buffer = Vec::new();
+                let bytes_read = cursor
+                    .read_to_end(&mut buffer)
+                    .map_err(|e| PyIOError::new_err(e.to_string()))?;
+                buffer.truncate(bytes_read);
+                Ok((buffer, bytes_read, true, cursor))
+            } else {
+                if current_position == current_size {
+                    return Ok((vec![], 0usize, false, cursor));
+                }
+                let mut buffer = vec![0u8; size as usize];
+                let bytes_read = cursor
+                    .read(&mut buffer)
+                    .map_err(|e| PyIOError::new_err(e.to_string()))?;
+                buffer.truncate(bytes_read);
+                Ok((buffer, bytes_read, false, cursor))
             }
+        });
 
-            let bytes_read = cursor
-                .read(&mut buffer)
-                .map_err(|e| PyIOError::new_err(e.to_string()))?;
-
-            buffer.truncate(bytes_read);
-            self.position += bytes_read;
-
-            Ok(buffer)
+        match result {
+            Ok((buffer, bytes_read, is_read_all, cursor_back)) => {
+                self.inner.cursor = Some(cursor_back);
+                if is_read_all {
+                    self.inner.position = bytes_read;
+                } else {
+                    self.inner.position += bytes_read;
+                }
+                Ok(buffer)
+            }
+            Err(e) => Err(e),
         }
     }
 
-    // Seek to position
     #[pyo3(signature=(offset, whence=Some(0)))]
-    fn seek(&mut self, offset: i64, whence: Option<usize>) -> PyResult<u64> {
+    fn seek(&mut self, py: Python<'_>, offset: i64, whence: Option<usize>) -> PyResult<u64> {
         self.check_context()?;
-        let whence = match whence.unwrap_or(0) {
+        let seek_from = match whence.unwrap_or(0) {
             0 => {
                 if offset < 0 {
                     return Err(PyValueError::new_err("Seek offset cannot be negative"));
@@ -204,17 +214,27 @@ impl PyDaftFile {
             _ => return Err(PyValueError::new_err("Invalid whence value")),
         };
 
-        let cursor = self
+        let mut cursor = self
+            .inner
             .cursor
-            .as_mut()
+            .take()
             .ok_or_else(|| PyValueError::new_err("File not open"))?;
 
-        let new_pos = cursor
-            .seek(whence)
-            .map_err(|e| PyIOError::new_err(e.to_string()))?;
+        let result = py.detach(move || {
+            let new_pos = cursor
+                .seek(seek_from)
+                .map_err(|e| PyIOError::new_err(e.to_string()))?;
+            Ok((new_pos, cursor))
+        });
 
-        self.position = new_pos as usize;
-        Ok(new_pos)
+        match result {
+            Ok((new_pos, cursor_back)) => {
+                self.inner.cursor = Some(cursor_back);
+                self.inner.position = new_pos as usize;
+                Ok(new_pos)
+            }
+            Err(e) => Err(e),
+        }
     }
 
     // Return current position
@@ -257,28 +277,28 @@ impl PyDaftFile {
         Ok(self.cursor.is_none())
     }
 
-    fn _supports_range_requests(&mut self) -> PyResult<bool> {
+    fn _supports_range_requests(&mut self, py: Python<'_>) -> PyResult<bool> {
         let cursor = self
+            .inner
             .cursor
             .as_mut()
             .ok_or_else(|| PyIOError::new_err("File not open"))?;
 
-        // Try to read a single byte from the beginning
-        let supports_range = match cursor {
+        match cursor {
             FileCursor::ObjectReader(reader) => {
                 let rt = common_runtime::get_io_runtime(true);
                 let inner_reader = reader.get_ref();
                 let uri = inner_reader.uri.clone();
                 let source = inner_reader.source.clone();
 
-                rt.block_within_async_context(async move {
-                    source.supports_range(&uri).await.map_err(DaftError::from)
-                })??
+                Ok(py.detach(move || {
+                    rt.block_within_async_context(async move {
+                        source.supports_range(&uri).await.map_err(DaftError::from)
+                    })
+                })??)
             }
-            FileCursor::Memory(_) => true,
-        };
-
-        Ok(supports_range)
+            FileCursor::Memory(_) => Ok(true),
+        }
     }
 
     #[pyo3(name = "size")]

--- a/src/daft-file/src/python.rs
+++ b/src/daft-file/src/python.rs
@@ -164,24 +164,28 @@ impl PyDaftFile {
         let current_position = self.inner.position;
         let current_size = cursor.size();
 
-        let result = py.detach(move || {
+        let result: Result<(Vec<u8>, usize, bool, FileCursor), (PyErr, FileCursor)> = py.detach(move || {
             if size == -1 {
                 let mut buffer = Vec::new();
-                let bytes_read = cursor
-                    .read_to_end(&mut buffer)
-                    .map_err(|e| PyIOError::new_err(e.to_string()))?;
-                buffer.truncate(bytes_read);
-                Ok((buffer, bytes_read, true, cursor))
+                match cursor.read_to_end(&mut buffer) {
+                    Ok(bytes_read) => {
+                        buffer.truncate(bytes_read);
+                        Ok((buffer, bytes_read, true, cursor))
+                    }
+                    Err(e) => Err((PyIOError::new_err(e.to_string()), cursor)),
+                }
             } else {
                 if current_position == current_size {
                     return Ok((vec![], 0usize, false, cursor));
                 }
                 let mut buffer = vec![0u8; size as usize];
-                let bytes_read = cursor
-                    .read(&mut buffer)
-                    .map_err(|e| PyIOError::new_err(e.to_string()))?;
-                buffer.truncate(bytes_read);
-                Ok((buffer, bytes_read, false, cursor))
+                match cursor.read(&mut buffer) {
+                    Ok(bytes_read) => {
+                        buffer.truncate(bytes_read);
+                        Ok((buffer, bytes_read, false, cursor))
+                    }
+                    Err(e) => Err((PyIOError::new_err(e.to_string()), cursor)),
+                }
             }
         });
 
@@ -195,7 +199,10 @@ impl PyDaftFile {
                 }
                 Ok(buffer)
             }
-            Err(e) => Err(e),
+            Err((e, cursor_back)) => {
+                self.inner.cursor = Some(cursor_back);
+                Err(e)
+            }
         }
     }
 
@@ -220,11 +227,11 @@ impl PyDaftFile {
             .take()
             .ok_or_else(|| PyValueError::new_err("File not open"))?;
 
-        let result = py.detach(move || {
-            let new_pos = cursor
-                .seek(seek_from)
-                .map_err(|e| PyIOError::new_err(e.to_string()))?;
-            Ok((new_pos, cursor))
+        let result: Result<(u64, FileCursor), (PyErr, FileCursor)> = py.detach(move || {
+            match cursor.seek(seek_from) {
+                Ok(new_pos) => Ok((new_pos, cursor)),
+                Err(e) => Err((PyIOError::new_err(e.to_string()), cursor)),
+            }
         });
 
         match result {
@@ -233,7 +240,10 @@ impl PyDaftFile {
                 self.inner.position = new_pos as usize;
                 Ok(new_pos)
             }
-            Err(e) => Err(e),
+            Err((e, cursor_back)) => {
+                self.inner.cursor = Some(cursor_back);
+                Err(e)
+            }
         }
     }
 

--- a/tests/file/test_file_basics.py
+++ b/tests/file/test_file_basics.py
@@ -530,3 +530,86 @@ def test_size_with_small_buffer(tmp_path: Path):
 
     f = daft.File(str(temp_file.absolute()))
     assert f.size() == 1024
+
+
+@pytest.mark.skipif(get_tests_daft_runner_name() == "ray", reason="local only test")
+def test_read_seek_roundtrip_after_gil_fix(tmp_path: Path):
+    """Basic read/seek still works after py.detach() changes."""
+    data = b"abcdefghij"
+    temp_file = tmp_path / "roundtrip.bin"
+    temp_file.write_bytes(data)
+
+    f = daft.File(str(temp_file.absolute()))
+    with f.open() as fh:
+        assert fh.read(3) == b"abc"
+        assert fh.tell() == 3
+        fh.seek(0)
+        assert fh.tell() == 0
+        assert fh.read() == data
+        fh.seek(5)
+        assert fh.read(3) == b"fgh"
+
+
+@pytest.mark.skipif(get_tests_daft_runner_name() == "ray", reason="local only test")
+def test_seek_end_works(tmp_path: Path):
+    """SeekFrom::End calls block_within_async_context — verify it still works."""
+    data = b"0123456789"
+    temp_file = tmp_path / "seek_end.bin"
+    temp_file.write_bytes(data)
+
+    f = daft.File(str(temp_file.absolute()))
+    with f.open() as fh:
+        fh.seek(0, 2)  # seek to end
+        pos = fh.tell()
+        assert pos == len(data)
+
+
+@pytest.mark.skipif(get_tests_daft_runner_name() == "ray", reason="local only test")
+def test_multiple_files_concurrent_read(tmp_path: Path):
+    """Multiple files opened and read from threads — exercises GIL release under concurrency."""
+    import threading
+
+    files = []
+    for i in range(8):
+        p = tmp_path / f"file_{i}.bin"
+        p.write_bytes(bytes(range(256)) * 4)
+        files.append(str(p.absolute()))
+
+    results = {}
+    errors = []
+
+    def read_file(path, idx):
+        try:
+            f = daft.File(path)
+            with f.open() as fh:
+                data = fh.read()
+                results[idx] = len(data)
+        except Exception as e:
+            errors.append((idx, e))
+
+    threads = [threading.Thread(target=read_file, args=(p, i)) for i, p in enumerate(files)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+
+    assert not errors, f"Errors during concurrent read: {errors}"
+    assert len(results) == 8
+    assert all(v == 1024 for v in results.values())
+
+
+@pytest.mark.skipif(get_tests_daft_runner_name() == "ray", reason="local only test")
+def test_read_after_eof_returns_empty(tmp_path: Path):
+    """Reading at EOF should return empty bytes, not error — cursor preserved."""
+    data = b"short"
+    temp_file = tmp_path / "eof.bin"
+    temp_file.write_bytes(data)
+
+    f = daft.File(str(temp_file.absolute()))
+    with f.open() as fh:
+        fh.read()  # read all
+        again = fh.read()  # read at EOF
+        assert again == b""
+        # file should still be usable
+        fh.seek(0)
+        assert fh.read() == data

--- a/tests/file/test_file_basics.py
+++ b/tests/file/test_file_basics.py
@@ -584,7 +584,7 @@ def test_multiple_files_concurrent_read(tmp_path: Path):
             with f.open() as fh:
                 data = fh.read()
                 results[idx] = len(data)
-        except Exception as e:
+        except (OSError, RuntimeError) as e:
             errors.append((idx, e))
 
     threads = [threading.Thread(target=read_file, args=(p, i)) for i, p in enumerate(files)]


### PR DESCRIPTION
PyDaftFile's #[pymethods] (_from_file_reference, read, seek, _supports_range_requests) and PyFileReference::__enter__ hold the Python GIL while calling block_within_async_context, which blocks via rx.recv() waiting for async S3 I/O on DAFTIO tokio threads. When concurrent scan tasks need the GIL on the same DAFTIO threads (via Python::attach), all threads deadlock — the GIL holder waits for a DAFTIO thread to execute the S3 request, while all DAFTIO threads wait for the GIL.

The fix wraps the blocking I/O calls in py.detach() to release the GIL before blocking, following the existing pattern used by the exists() method in the same file. For read() and seek(), cursor ownership is temporarily moved into the detach closure via take() and restored after completion.

Deadlock conditions: Ray distributed mode + multiple concurrent scan tasks per worker + S3 latency >= ~50ms + DAFTIO threads >= 8 (os.cpu_count() >= 8). The official AWS benchmark (4 vCPU, S3 <1ms) does not trigger this due to low thread count and latency.

## Changes Made

Modified `src/daft-file/src/python.rs` — added `py.detach()` to 5 methods that
hold the GIL while calling `block_within_async_context`:

- `PyFileReference::__enter__`: added `py: Python<'_>`, wrapped `load_blocking()`
  in `py.detach()` with cloned `FileReference`.
- `PyDaftFile::_from_file_reference`: same pattern — clone data, `py.detach()`,
  call `load_blocking()` inside.
- `PyDaftFile::read`: added `py: Python<'_>`, used `cursor.take()` to move cursor
  into `py.detach()` closure (Rust ownership requirement), performed read without
  GIL, restored cursor after completion.
- `PyDaftFile::seek`: same take/restore pattern as `read()`.
- `PyDaftFile::_supports_range_requests`: added `py: Python<'_>`, wrapped
  `block_within_async_context` call in `py.detach()` with cloned `uri` and `source`.

All changes follow the existing `py.detach()` pattern used by `exists()` at
line 102 in the same file. No behavioral changes — same inputs, same outputs,
only the GIL hold timing differs.

## Related Issues

Closes #7256