### PR TITLE
feat: add to_map expression constructor

### DIFF
--- a/daft/functions/__init__.py
+++ b/daft/functions/__init__.py
@@ -306,7 +306,7 @@ from .str import (
     chr_func,
     space,
 )
-from .struct import unnest, to_struct
+from .struct import unnest, to_map, to_struct
 from .url import download, upload, parse_url
 from .audio import audio_metadata, resample
 from .video import video_metadata, video_keyframes, video_frames
@@ -598,6 +598,7 @@ __all__ = [
     "to_datetime",
     "to_kebab_case",
     "to_list",
+    "to_map",
     "to_snake_case",
     "to_struct",
     "to_title_case",

--- a/daft/functions/struct.py
+++ b/daft/functions/struct.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from daft.expressions import Expression
 
 
@@ -90,9 +92,7 @@ def to_map(*items: Expression, **named_items: Expression) -> Expression:
         >>> from daft.functions import to_map
         >>>
         >>> df = daft.from_pydict({"k1": ["a", "b"], "v1": [1, 2], "k2": ["c", "d"], "v2": [3, 4]})
-        >>> df.select(to_map(df["k1"], df["v1"], df["k2"], df["v2"]).alias("my_map")).to_pydict(
-        ...     maps_as_pydicts="lossy"
-        ... )
+        >>> df.select(to_map(df["k1"], df["v1"], df["k2"], df["v2"]).alias("my_map")).to_pydict(maps_as_pydicts="lossy")
         {'my_map': [{'a': 1, 'c': 3}, {'b': 2, 'd': 4}]}
     """
     if not items and not named_items:
@@ -102,7 +102,7 @@ def to_map(*items: Expression, **named_items: Expression) -> Expression:
         msg = "Map constructor requires an even number of positional key/value arguments"
         raise ValueError(msg)
 
-    all_items = list(items)
+    all_items: list[Any] = list(items)
     for name, item in named_items.items():
         all_items.extend([name, item])
     return Expression._call_builtin_scalar_fn("map", *all_items)

--- a/daft/functions/struct.py
+++ b/daft/functions/struct.py
@@ -73,3 +73,36 @@ def to_struct(*fields: Expression, **named_fields: Expression) -> Expression:
     """
     all_fields = list(fields) + [Expression._to_expression(field).alias(name) for name, field in named_fields.items()]
     return Expression._call_builtin_scalar_fn("struct", *all_fields)
+
+
+def to_map(*items: Expression, **named_items: Expression) -> Expression:
+    """Constructs a map from key/value expressions.
+
+    Args:
+        items: Alternating key and value expressions to use as map entries.
+        named_items: Values to use as map entries, using keyword names as literal string keys.
+
+    Returns:
+        An expression for a map column with the input key/value entries.
+
+    Examples:
+        >>> import daft
+        >>> from daft.functions import to_map
+        >>>
+        >>> df = daft.from_pydict({"k1": ["a", "b"], "v1": [1, 2], "k2": ["c", "d"], "v2": [3, 4]})
+        >>> df.select(to_map(df["k1"], df["v1"], df["k2"], df["v2"]).alias("my_map")).to_pydict(
+        ...     maps_as_pydicts="lossy"
+        ... )
+        {'my_map': [{'a': 1, 'c': 3}, {'b': 2, 'd': 4}]}
+    """
+    if not items and not named_items:
+        msg = "Map constructor requires at least one key/value pair"
+        raise ValueError(msg)
+    if len(items) % 2 != 0:
+        msg = "Map constructor requires an even number of positional key/value arguments"
+        raise ValueError(msg)
+
+    all_items = list(items)
+    for name, item in named_items.items():
+        all_items.extend([name, item])
+    return Expression._call_builtin_scalar_fn("map", *all_items)

--- a/src/daft-functions/src/lib.rs
+++ b/src/daft-functions/src/lib.rs
@@ -17,6 +17,7 @@ pub mod random;
 pub mod simhash;
 pub mod similarity;
 pub mod slice;
+pub mod to_map;
 pub mod to_struct;
 pub mod uuid;
 pub mod vector_utils;
@@ -30,6 +31,7 @@ use minhash::MinHashFunction;
 pub use python::register as register_modules;
 use simhash::SimHashFunction;
 use snafu::Snafu;
+use to_map::ToMapFunction;
 use to_struct::ToStructFunction;
 use uuid::{
     ExtractDayUuid7, ExtractHourUuid7, ExtractMinuteUuid7, ExtractMonthUuid7, Uuid, UuidV7,
@@ -73,6 +75,7 @@ impl FunctionModule for MiscFunctions {
         parent.add_fn(MinHashFunction);
         parent.add_fn(SimHashFunction);
         parent.add_fn(Length);
+        parent.add_fn(ToMapFunction);
         parent.add_fn(ToStructFunction);
         parent.add_fn(Slice);
         parent.add_fn(Uuid);

--- a/src/daft-functions/src/to_map.rs
+++ b/src/daft-functions/src/to_map.rs
@@ -1,0 +1,124 @@
+use common_error::{DaftError, DaftResult};
+use daft_core::{prelude::*, utils::supertype::try_get_collection_supertype};
+use daft_dsl::functions::{prelude::*, scalar::ScalarFn};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub(super) struct ToMapFunction;
+
+#[typetag::serde]
+impl ScalarUDF for ToMapFunction {
+    fn name(&self) -> &'static str {
+        "map"
+    }
+
+    fn call(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+        ctx: &daft_dsl::functions::scalar::EvalContext,
+    ) -> DaftResult<Series> {
+        let inputs = inputs.into_inner();
+        if inputs.is_empty() {
+            return Err(DaftError::ValueError(
+                "Cannot call map with no inputs".to_string(),
+            ));
+        }
+        if inputs.len() % 2 != 0 {
+            return Err(DaftError::ValueError(
+                "Map constructor requires an even number of key/value inputs".to_string(),
+            ));
+        }
+
+        let target_len = ctx.row_count;
+        let inputs = inputs
+            .into_iter()
+            .map(|s| {
+                if s.len() == 1 && target_len > 1 {
+                    s.broadcast(target_len)
+                } else {
+                    Ok(s)
+                }
+            })
+            .collect::<DaftResult<Vec<_>>>()?;
+
+        let key_dtype =
+            try_get_collection_supertype(inputs.iter().step_by(2).map(|s| s.data_type()))?;
+        let value_dtype =
+            try_get_collection_supertype(inputs.iter().skip(1).step_by(2).map(|s| s.data_type()))?;
+        let struct_field = Field::new(
+            "entries",
+            DataType::Struct(vec![
+                Field::new("key", key_dtype.clone()),
+                Field::new("value", value_dtype.clone()),
+            ]),
+        );
+
+        let entries = inputs
+            .chunks_exact(2)
+            .map(|pair| {
+                Ok(StructArray::new(
+                    struct_field.clone(),
+                    vec![
+                        pair[0].cast(&key_dtype)?.rename("key"),
+                        pair[1].cast(&value_dtype)?.rename("value"),
+                    ],
+                    None,
+                )
+                .into_series())
+            })
+            .collect::<DaftResult<Vec<_>>>()?;
+
+        let list_field = Field::new("map", DataType::List(Box::new(struct_field.dtype.clone())));
+        let entry_refs = entries.iter().collect::<Vec<_>>();
+        let physical = Series::zip(list_field, &entry_refs)?.list()?.clone();
+        let map_field = Field::new(
+            "map",
+            DataType::Map {
+                key: Box::new(key_dtype),
+                value: Box::new(value_dtype),
+            },
+        );
+
+        Ok(MapArray::new(map_field, physical).into_series())
+    }
+
+    fn get_return_field(
+        &self,
+        inputs: FunctionArgs<ExprRef>,
+        schema: &Schema,
+    ) -> DaftResult<Field> {
+        let inputs = inputs.into_inner();
+        if inputs.is_empty() {
+            return Err(DaftError::ValueError(
+                "Cannot call map with no inputs".to_string(),
+            ));
+        }
+        if inputs.len() % 2 != 0 {
+            return Err(DaftError::ValueError(
+                "Map constructor requires an even number of key/value inputs".to_string(),
+            ));
+        }
+
+        let input_fields = inputs
+            .iter()
+            .map(|e| e.to_field(schema))
+            .collect::<DaftResult<Vec<_>>>()?;
+        let key_dtype =
+            try_get_collection_supertype(input_fields.iter().step_by(2).map(|f| &f.dtype))?;
+        let value_dtype =
+            try_get_collection_supertype(input_fields.iter().skip(1).step_by(2).map(|f| &f.dtype))?;
+
+        Ok(Field::new(
+            "map",
+            DataType::Map {
+                key: Box::new(key_dtype),
+                value: Box::new(value_dtype),
+            },
+        ))
+    }
+}
+
+#[must_use]
+pub fn to_map(inputs: Vec<ExprRef>) -> ExprRef {
+    ScalarFn::builtin(ToMapFunction, inputs).into()
+}

--- a/src/daft-functions/src/to_map.rs
+++ b/src/daft-functions/src/to_map.rs
@@ -68,7 +68,7 @@ impl ScalarUDF for ToMapFunction {
             })
             .collect::<DaftResult<Vec<_>>>()?;
 
-        let list_field = Field::new("map", DataType::List(Box::new(struct_field.dtype.clone())));
+        let list_field = Field::new("map", DataType::List(Box::new(struct_field.dtype)));
         let entry_refs = entries.iter().collect::<Vec<_>>();
         let physical = Series::zip(list_field, &entry_refs)?.list()?.clone();
         let map_field = Field::new(

--- a/src/daft-functions/src/to_map.rs
+++ b/src/daft-functions/src/to_map.rs
@@ -33,7 +33,7 @@ impl ScalarUDF for ToMapFunction {
         let inputs = inputs
             .into_iter()
             .map(|s| {
-                if s.len() == 1 && target_len > 1 {
+                if s.len() == 1 && target_len != 1 {
                     s.broadcast(target_len)
                 } else {
                     Ok(s)

--- a/src/daft-functions/src/to_map.rs
+++ b/src/daft-functions/src/to_map.rs
@@ -23,7 +23,7 @@ impl ScalarUDF for ToMapFunction {
                 "Cannot call map with no inputs".to_string(),
             ));
         }
-        if inputs.len() % 2 != 0 {
+        if !inputs.len().is_multiple_of(2) {
             return Err(DaftError::ValueError(
                 "Map constructor requires an even number of key/value inputs".to_string(),
             ));
@@ -93,7 +93,7 @@ impl ScalarUDF for ToMapFunction {
                 "Cannot call map with no inputs".to_string(),
             ));
         }
-        if inputs.len() % 2 != 0 {
+        if !inputs.len().is_multiple_of(2) {
             return Err(DaftError::ValueError(
                 "Map constructor requires an even number of key/value inputs".to_string(),
             ));

--- a/tests/expressions/test_to_map.py
+++ b/tests/expressions/test_to_map.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import pytest
+
+import daft
+from daft import col
+from daft.functions import to_map
+
+
+def test_map_constructor_empty():
+    with pytest.raises(ValueError, match="Map constructor requires at least one key/value pair"):
+        to_map()
+
+
+def test_map_constructor_odd_positional_args():
+    with pytest.raises(ValueError, match="Map constructor requires an even number of positional key/value arguments"):
+        to_map("a", col("x"), "b")
+
+
+def test_map_constructor_positional_pairs():
+    df = daft.from_pydict({"k1": ["a", "b"], "v1": [1, 2], "k2": ["c", "d"], "v2": [3, 4]})
+
+    result = df.select(to_map(col("k1"), col("v1"), col("k2"), col("v2")).alias("m")).to_pydict(
+        maps_as_pydicts="lossy"
+    )
+
+    assert result == {"m": [{"a": 1, "c": 3}, {"b": 2, "d": 4}]}
+
+
+def test_map_constructor_keyword_pairs():
+    df = daft.from_pydict({"x": [1, 2], "y": [3, 4]})
+
+    result = df.select(to_map(a=col("x"), b=col("y")).alias("m")).to_pydict(maps_as_pydicts="lossy")
+
+    assert result == {"m": [{"a": 1, "b": 3}, {"a": 2, "b": 4}]}
+
+
+def test_map_constructor_mixed_pairs_and_map_get():
+    df = daft.from_pydict({"k": ["a", "b"], "v": [1, 2], "lookup": ["c", "static"]})
+    map_expr = to_map(col("k"), col("v"), c=col("v") * 10, static=5)
+
+    result = df.select(map_expr.map_get(col("lookup")).alias("value")).to_pydict()
+
+    assert result == {"value": [10, 5]}
+
+
+def test_map_constructor_value_coercion():
+    df = daft.from_pydict({"k": ["a", "b"], "x": [1, 2], "y": [1.5, 2.5]})
+
+    result = df.select(to_map(col("k"), col("x"), "other", col("y")).alias("m")).to_pydict(
+        maps_as_pydicts="lossy"
+    )
+
+    assert result == {"m": [{"a": 1.0, "other": 1.5}, {"b": 2.0, "other": 2.5}]}

--- a/tests/expressions/test_to_map.py
+++ b/tests/expressions/test_to_map.py
@@ -52,3 +52,11 @@ def test_map_constructor_value_coercion():
     )
 
     assert result == {"m": [{"a": 1.0, "other": 1.5}, {"b": 2.0, "other": 2.5}]}
+
+
+def test_map_constructor_literal_entries_empty_input():
+    df = daft.from_pydict({"x": []})
+
+    result = df.select(to_map("key", 1).alias("m")).to_pydict(maps_as_pydicts="lossy")
+
+    assert result == {"m": []}

--- a/tests/expressions/test_to_map.py
+++ b/tests/expressions/test_to_map.py
@@ -20,9 +20,7 @@ def test_map_constructor_odd_positional_args():
 def test_map_constructor_positional_pairs():
     df = daft.from_pydict({"k1": ["a", "b"], "v1": [1, 2], "k2": ["c", "d"], "v2": [3, 4]})
 
-    result = df.select(to_map(col("k1"), col("v1"), col("k2"), col("v2")).alias("m")).to_pydict(
-        maps_as_pydicts="lossy"
-    )
+    result = df.select(to_map(col("k1"), col("v1"), col("k2"), col("v2")).alias("m")).to_pydict(maps_as_pydicts="lossy")
 
     assert result == {"m": [{"a": 1, "c": 3}, {"b": 2, "d": 4}]}
 
@@ -47,9 +45,7 @@ def test_map_constructor_mixed_pairs_and_map_get():
 def test_map_constructor_value_coercion():
     df = daft.from_pydict({"k": ["a", "b"], "x": [1, 2], "y": [1.5, 2.5]})
 
-    result = df.select(to_map(col("k"), col("x"), "other", col("y")).alias("m")).to_pydict(
-        maps_as_pydicts="lossy"
-    )
+    result = df.select(to_map(col("k"), col("x"), "other", col("y")).alias("m")).to_pydict(maps_as_pydicts="lossy")
 
     assert result == {"m": [{"a": 1.0, "other": 1.5}, {"b": 2.0, "other": 2.5}]}
 


### PR DESCRIPTION
First time looking/working with Daft code...any process errors are strictly mine. 

## Changes Made

Fixes #6885

## Summary
- Add a `daft.functions.to_map` constructor for key/value expression pairs.
- Support keyword arguments as string keys.
- Add expression tests for positional pairs, keyword pairs, mixed use, map_get, coercion, and invalid inputs.

## Tests
- `make build`
- `DAFT_RUNNER=native pytest -q tests/expressions/test_to_map.py`
- `DAFT_RUNNER=native pytest -q tests/expressions/test_to_list.py tests/recordbatch/struct/test_to_struct.py tests/expressions/test_to_map.py`
- `DAFT_RUNNER=native pytest -q tests/recordbatch/test_from_py.py tests/expressions/test_to_map.py`



## AI usage
Used AI assistance to draft the implementation and tests; verified locally with the commands above.
## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
