### PR TITLE
fix: fd and thread leak from tqdm progress bar in Jupyter

### DIFF
--- a/daft/runners/progress_bar.py
+++ b/daft/runners/progress_bar.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
 
@@ -103,11 +104,22 @@ class ProgressBar:
             del p
 
 
+# All tqdm writes happen on this single long-lived thread. Progress updates arrive from
+# native (Rust) threads, which can get a fresh Python thread identity on every call into
+# Python (always on 3.13+), and ipykernel allocates a zmq pipe (~2 fds) per writing
+# thread identity that it only reclaims when that thread dies - so writing directly from
+# native threads leaks fds without bound in Jupyter. See issue #7253.
+_writer = ThreadPoolExecutor(max_workers=1, thread_name_prefix="daft-progress-bar-writer")
+
+
 # Progress Bar for local execution, should only be used in the native executor
 class SwordfishProgressBar:
     def __init__(self) -> None:
         self._maxinterval = 5.0
         self.tqdm_mod = get_tqdm(False)
+        # tqdm spawns one monitor thread per class that never exits, and get_tqdm may
+        # return a fresh class per call - disable it to avoid leaking a thread per query.
+        self.tqdm_mod.monitor_interval = 0
         self.pbar: Any = None  # Single combined progress bar
         self.pbars: dict[int, str] = dict()  # pbar_id -> latest message
         self.bar_configs: dict[int, str] = dict()  # pbar_id -> name
@@ -121,6 +133,9 @@ class SwordfishProgressBar:
         return pbar_id
 
     def update_bar(self, pbar_id: int, message: str) -> None:
+        _writer.submit(self._update_bar, pbar_id, message)
+
+    def _update_bar(self, pbar_id: int, message: str) -> None:
         self.pbars[pbar_id] = message
 
         # Create combined bar on first update
@@ -144,6 +159,11 @@ class SwordfishProgressBar:
         pass
 
     def close(self) -> None:
+        # Wait for the close (and any queued updates before it) to be written, so the
+        # bar is fully drawn before query results are displayed.
+        _writer.submit(self._close).result()
+
+    def _close(self) -> None:
         if self.pbar is not None:
             self.pbar.close()
             self.pbar = None

--- a/daft/runners/progress_bar.py
+++ b/daft/runners/progress_bar.py
@@ -104,11 +104,8 @@ class ProgressBar:
             del p
 
 
-# All tqdm writes happen on this single long-lived thread. Progress updates arrive from
-# native (Rust) threads, which can get a fresh Python thread identity on every call into
-# Python (always on 3.13+), and ipykernel allocates a zmq pipe (~2 fds) per writing
-# thread identity that it only reclaims when that thread dies - so writing directly from
-# native threads leaks fds without bound in Jupyter. See issue #7253.
+# All tqdm writes happen on this single long-lived thread; writing from the native (Rust)
+# threads leaks fds in Jupyter. See issue #7253 for details.
 _writer = ThreadPoolExecutor(max_workers=1, thread_name_prefix="daft-progress-bar-writer")
 
 

--- a/daft/runners/progress_bar.py
+++ b/daft/runners/progress_bar.py
@@ -117,9 +117,6 @@ class SwordfishProgressBar:
     def __init__(self) -> None:
         self._maxinterval = 5.0
         self.tqdm_mod = get_tqdm(False)
-        # tqdm spawns one monitor thread per class that never exits, and get_tqdm may
-        # return a fresh class per call - disable it to avoid leaking a thread per query.
-        self.tqdm_mod.monitor_interval = 0
         self.pbar: Any = None  # Single combined progress bar
         self.pbars: dict[int, str] = dict()  # pbar_id -> latest message
         self.bar_configs: dict[int, str] = dict()  # pbar_id -> name

--- a/tests/observability/test_progress_bar.py
+++ b/tests/observability/test_progress_bar.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import threading
+
 import pytest
 
 import daft
+from daft.runners.progress_bar import SwordfishProgressBar
 
 
 # Non-regression test for progress bar truncating UTF-8 pipeline names correctly.
@@ -25,3 +28,39 @@ def test_progress_bar_truncates_multibyte_utf8_pipeline_names(col_name):
     df = df.with_column(col_name, daft.col(col_name) + daft.col(col_name))
     result = df.collect()
     assert result.to_pydict()[col_name] == [2.0, 4.0, 6.0]
+
+
+# Non-regression test for fd leaks in Jupyter: writing to stdout from native threads
+# leaks an ipykernel zmq pipe (~2 fds) per write on Python 3.13+, because each call
+# into Python from a native thread can get a fresh thread identity. All tqdm writes
+# must therefore happen on a single long-lived Python thread, never the caller's.
+# See: https://github.com/Eventual-Inc/Daft/issues/7253
+def test_swordfish_progress_bar_writes_from_single_stable_thread():
+    write_threads = set()
+
+    class RecordingTqdm:
+        def __init__(self, *args, **kwargs):
+            write_threads.add(threading.get_ident())
+
+        def set_description_str(self, desc):
+            write_threads.add(threading.get_ident())
+
+        def close(self):
+            write_threads.add(threading.get_ident())
+
+    bar = SwordfishProgressBar()
+    bar.tqdm_mod = RecordingTqdm
+    pb_id = bar.make_new_bar("🗡️ 🐟 test: {elapsed} {desc}")
+
+    # Simulate updates arriving from short-lived foreign threads, each with a
+    # distinct Python thread identity, as happens with native threads on 3.13+.
+    caller_threads = []
+    for i in range(5):
+        t = threading.Thread(target=bar.update_bar, args=(pb_id, f"message {i}"))
+        t.start()
+        t.join()
+        caller_threads.append(t.ident)
+    bar.close()
+
+    assert len(write_threads) == 1
+    assert write_threads.isdisjoint(caller_threads)


### PR DESCRIPTION
## Changes Made

In Jupyter on Python 3.13+, each progress bar write from Daft's Rust threads appears as a new Python thread, and ipykernel opens a ~2-fd zmq pipe per writing thread, freed only when that thread dies. The pooled Rust threads never die, so each query leaks ~10 fds until the kernel crashes (`Too many open files`) or hangs.

Fix: `SwordfishProgressBar` no longer writes from the calling (Rust) thread - updates are queued to a single long-lived Python writer thread, so ipykernel only ever creates one pipe. `close()` drains the queue so the bar finishes drawing before results display.

Verified with the issue's repro (30 queries, `ulimit -n 256`): fds stay flat at ~110 on Python 3.13 and 3.11; before, the kernel died around iteration 14.

Includes a regression test asserting all tqdm writes happen on a single stable thread, never the caller's - it fails on the previous code.

## Related Issues

Closes #7253