### PR TITLE
feat(iceberg): push down starts_with and is_nan/not_nan filters

### DIFF
--- a/daft/io/iceberg/_visitors.py
+++ b/daft/io/iceberg/_visitors.py
@@ -11,14 +11,17 @@ from pyiceberg.expressions import (
     GreaterThan,
     GreaterThanOrEqual,
     In,
+    IsNaN,
     IsNull,
     LessThan,
     LessThanOrEqual,
     Not,
     NotEqualTo,
+    NotNaN,
     NotNull,
     Or,
     Reference,
+    StartsWith,
 )
 from pyiceberg.expressions.literals import DateLiteral, Literal, StringLiteral, TimestampLiteral, literal
 from pyiceberg.types import TimestampType, TimestamptzType
@@ -73,6 +76,11 @@ class IcebergPredicateVisitor(PredicateVisitor[BooleanExpression]):
         return self.visit(expr)
 
     def visit_function(self, name: str, args: list[Expression]) -> BooleanExpression:
+        # `is_nan`/`not_nan` have no dedicated `visit_*` hook on the base visitor,
+        # so they arrive here as generic function calls with a single argument.
+        if name in ("is_nan", "not_nan") and len(args) == 1:
+            ref = self.visit_as_ref(args[0])
+            return IsNaN(term=ref) if name == "is_nan" else NotNaN(term=ref)
         raise ValueError(f"Iceberg does not support function '{name}' in filter expressions")
 
     def visit_coalesce(self, args: list[Expression]) -> BooleanExpression:
@@ -142,6 +150,11 @@ class IcebergPredicateVisitor(PredicateVisitor[BooleanExpression]):
 
     def visit_not_null(self, expr: Expression) -> BooleanExpression:
         return NotNull(term=self.visit_as_ref(expr))
+
+    def visit_starts_with(self, input: Expression, prefix: Expression) -> BooleanExpression:
+        ref = self.visit_as_ref(input)
+        lit = self.visit_as_lit(prefix)
+        return StartsWith(term=ref, literal=lit)
 
     ##
     # Helpers

--- a/tests/io/iceberg/test_iceberg_expressions.py
+++ b/tests/io/iceberg/test_iceberg_expressions.py
@@ -13,13 +13,16 @@ from pyiceberg.expressions import (
     GreaterThan,
     GreaterThanOrEqual,
     In,
+    IsNaN,
     IsNull,
     LessThan,
     LessThanOrEqual,
     Not,
     NotEqualTo,
+    NotNaN,
     NotNull,
     Or,
+    StartsWith,
 )
 from pyiceberg.expressions.literals import DateLiteral, StringLiteral
 from pyiceberg.schema import Schema
@@ -146,6 +149,32 @@ def test_not_null() -> None:
 def test_is_in() -> None:
     result = convert_expression_to_iceberg(daft.col("x").is_in([1, 2, 3]))
     assert isinstance(result, In)
+    assert result.term.name == "x"
+
+
+def test_starts_with() -> None:
+    result = convert_expression_to_iceberg(daft.col("name").startswith("foo"))
+    assert isinstance(result, StartsWith)
+    assert result.term.name == "name"
+    assert result.literal.value == "foo"
+
+
+def test_not_starts_with() -> None:
+    result = convert_expression_to_iceberg(~daft.col("name").startswith("foo"))
+    assert isinstance(result, Not)
+    assert isinstance(result.child, StartsWith)
+    assert result.child.term.name == "name"
+
+
+def test_is_nan() -> None:
+    result = convert_expression_to_iceberg(daft.col("x").is_nan())
+    assert isinstance(result, IsNaN)
+    assert result.term.name == "x"
+
+
+def test_not_nan() -> None:
+    result = convert_expression_to_iceberg(daft.col("x").not_nan())
+    assert isinstance(result, NotNaN)
     assert result.term.name == "x"
 
 


### PR DESCRIPTION
## Changes Made

Extends `IcebergPredicateVisitor` so three more predicates are forwarded to PyIceberg for manifest- and file-level pruning, instead of silently falling back to a full scan + post-filter.

- `col.startswith(prefix)` → pyiceberg `StartsWith`
- `col.is_nan()` → pyiceberg `IsNaN`
- `col.not_nan()` → pyiceberg `NotNaN`

Previously these expressions reached `visit_function`, which raises `ValueError`; `convert_filter` swallows that and drops the predicate from pushdown, so Iceberg scanned every file and Daft filtered afterwards. PyIceberg natively supports all three (`StartsWith`/`IsNaN`/`NotNaN`).

Implementation notes:
- `starts_with` is dispatched through the visitor's `visit_starts_with` hook (mirrors the existing Paimon predicate visitor).
- `is_nan`/`not_nan` have no dedicated `visit_*` hook on the base `PredicateVisitor`, so they are handled inside `visit_function` by name.
- Negation composes for free via the existing `visit_not` (e.g. `~col.startswith(...)` → `Not(StartsWith(...))`).

## Testing

- Added `test_starts_with`, `test_not_starts_with`, `test_is_nan`, `test_not_nan` in `tests/io/iceberg/test_iceberg_expressions.py`.
- Full `tests/io/iceberg/` suite passes (179 passed, 21 skipped); pre-commit (ruff, mypy, format) clean.

## Related Issues

None.