### PR TITLE
refactor(shuffle): migrate repartition onto shared backend and unify pipeline dispatch

### DIFF
--- a/src/daft-local-execution/src/pipeline.rs
+++ b/src/daft-local-execution/src/pipeline.rs
@@ -20,10 +20,9 @@ use daft_local_plan::{
     AsofJoin, CommitWrite, Concat, CrossJoin, Dedup, Explode, Filter, FlightShuffleReadInput,
     GatherWrite, GlobScan, HashAggregate, HashJoin, InMemoryScan, IntoBatches, Limit,
     LocalNodeContext, LocalPhysicalPlan, MonotonicallyIncreasingId, PhysicalScan, PhysicalWrite,
-    Pivot, Project, RepartitionWrite, Sample, ShuffleBackend, ShuffleReadBackend, Sort,
-    SortMergeJoin, SourceId, TopN, UDFProject, UnGroupedAggregate, Unpivot, VLLMProject,
-    WindowOrderByOnly, WindowPartitionAndDynamicFrame, WindowPartitionAndOrderBy,
-    WindowPartitionOnly,
+    Pivot, Project, RepartitionWrite, Sample, ShuffleReadBackend, Sort, SortMergeJoin, SourceId,
+    TopN, UDFProject, UnGroupedAggregate, Unpivot, VLLMProject, WindowOrderByOnly,
+    WindowPartitionAndDynamicFrame, WindowPartitionAndOrderBy, WindowPartitionOnly,
 };
 use daft_logical_plan::{JoinType, stats::StatsState};
 use daft_micropartition::{MicroPartition, MicroPartitionRef};
@@ -59,6 +58,7 @@ use crate::{
         into_partitions::IntoPartitionsSink,
         pivot::PivotSink,
         repartition::RepartitionSink,
+        shuffle_backend::LocalShuffleBackend,
         sort::SortSink,
         top_n::TopNSink,
         window_order_by_only::WindowOrderByOnlySink,
@@ -1590,45 +1590,20 @@ fn physical_plan_to_pipeline(
             backend,
         }) => {
             let child_node = physical_plan_to_pipeline(input, cfg, ctx, input_senders)?;
-            match backend {
-                daft_local_plan::ShuffleBackend::Ray => BlockingSinkNode::new(
-                    Arc::new(IntoPartitionsSink::new_ray(*num_partitions, schema.clone())),
-                    child_node,
-                    stats_state.clone(),
-                    ctx,
-                    context,
-                )
-                .boxed(),
-                daft_local_plan::ShuffleBackend::Flight {
-                    shuffle_id,
-                    shuffle_dirs,
-                    compression,
-                } => {
-                    let (shuffle_server, shuffle_address) = ctx
-                        .shuffle_server()
-                        .expect("Flight shuffle server must be initialized for Flight into_partitions plans when using flight_shuffle algorithm");
-                    let into_partitions_sink = IntoPartitionsSink::try_new_flight(
-                        *num_partitions,
-                        schema.clone(),
-                        *shuffle_id,
-                        shuffle_dirs.clone(),
-                        compression.clone(),
-                        shuffle_server,
-                        shuffle_address,
-                    )
-                    .with_context(|_| PipelineCreationSnafu {
-                        plan_name: physical_plan.name(),
-                    })?;
-                    BlockingSinkNode::new(
-                        Arc::new(into_partitions_sink),
-                        child_node,
-                        stats_state.clone(),
-                        ctx,
-                        context,
-                    )
-                    .boxed()
-                }
-            }
+            let backend =
+                LocalShuffleBackend::from_plan(backend, ctx.shuffle_server(), schema.clone());
+            BlockingSinkNode::new(
+                Arc::new(IntoPartitionsSink::new(
+                    *num_partitions,
+                    schema.clone(),
+                    backend,
+                )),
+                child_node,
+                stats_state.clone(),
+                ctx,
+                context,
+            )
+            .boxed()
         }
         LocalPhysicalPlan::RepartitionWrite(RepartitionWrite {
             input,
@@ -1640,58 +1615,26 @@ fn physical_plan_to_pipeline(
             context,
         }) => {
             let child_node = physical_plan_to_pipeline(input, cfg, ctx, input_senders)?;
-            match backend {
-                ShuffleBackend::Ray => {
-                    let repartition_sink = RepartitionSink::new_ray(
-                        schema.clone(),
-                        repartition_spec.clone(),
-                        *num_partitions,
-                    )
-                    .with_context(|_| PipelineCreationSnafu {
-                        plan_name: physical_plan.name(),
-                    })?;
+            let backend =
+                LocalShuffleBackend::from_plan(backend, ctx.shuffle_server(), schema.clone());
+            let repartition_sink = RepartitionSink::new(
+                schema.clone(),
+                repartition_spec.clone(),
+                *num_partitions,
+                backend,
+            )
+            .with_context(|_| PipelineCreationSnafu {
+                plan_name: physical_plan.name(),
+            })?;
 
-                    BlockingSinkNode::new(
-                        Arc::new(repartition_sink),
-                        child_node,
-                        stats_state.clone(),
-                        ctx,
-                        context,
-                    )
-                    .boxed()
-                }
-                ShuffleBackend::Flight {
-                    shuffle_id,
-                    shuffle_dirs,
-                    compression,
-                } => {
-                    let (shuffle_server, shuffle_address) = ctx
-                        .shuffle_server()
-                        .expect("Flight shuffle server must be initialized for Flight repartition plans when using flight_shuffle algorithm");
-                    let repartition_sink = RepartitionSink::try_new_flight(
-                        *num_partitions,
-                        schema.clone(),
-                        *shuffle_id,
-                        repartition_spec.clone(),
-                        shuffle_dirs.clone(),
-                        compression.clone(),
-                        shuffle_server,
-                        shuffle_address,
-                    )
-                    .with_context(|_| PipelineCreationSnafu {
-                        plan_name: physical_plan.name(),
-                    })?;
-
-                    BlockingSinkNode::new(
-                        Arc::new(repartition_sink),
-                        child_node,
-                        stats_state.clone(),
-                        ctx,
-                        context,
-                    )
-                    .boxed()
-                }
-            }
+            BlockingSinkNode::new(
+                Arc::new(repartition_sink),
+                child_node,
+                stats_state.clone(),
+                ctx,
+                context,
+            )
+            .boxed()
         }
         LocalPhysicalPlan::GatherWrite(GatherWrite {
             input,
@@ -1701,45 +1644,16 @@ fn physical_plan_to_pipeline(
             context,
         }) => {
             let child_node = physical_plan_to_pipeline(input, cfg, ctx, input_senders)?;
-            match backend {
-                ShuffleBackend::Ray => BlockingSinkNode::new(
-                    Arc::new(GatherSink::new_ray()),
-                    child_node,
-                    stats_state.clone(),
-                    ctx,
-                    context,
-                )
-                .boxed(),
-                ShuffleBackend::Flight {
-                    shuffle_id,
-                    shuffle_dirs,
-                    compression,
-                } => {
-                    let (shuffle_server, shuffle_address) = ctx
-                        .shuffle_server()
-                        .expect("Flight shuffle server must be initialized for Flight gather plans when using flight_shuffle algorithm");
-                    let gather_sink = GatherSink::try_new_flight(
-                        schema.clone(),
-                        *shuffle_id,
-                        shuffle_dirs.clone(),
-                        compression.clone(),
-                        shuffle_server,
-                        shuffle_address,
-                    )
-                    .with_context(|_| PipelineCreationSnafu {
-                        plan_name: physical_plan.name(),
-                    })?;
-
-                    BlockingSinkNode::new(
-                        Arc::new(gather_sink),
-                        child_node,
-                        stats_state.clone(),
-                        ctx,
-                        context,
-                    )
-                    .boxed()
-                }
-            }
+            let backend =
+                LocalShuffleBackend::from_plan(backend, ctx.shuffle_server(), schema.clone());
+            BlockingSinkNode::new(
+                Arc::new(GatherSink::new(backend)),
+                child_node,
+                stats_state.clone(),
+                ctx,
+                context,
+            )
+            .boxed()
         }
         LocalPhysicalPlan::ShuffleRead(daft_local_plan::ShuffleRead {
             source_id,

--- a/src/daft-local-execution/src/pipeline.rs
+++ b/src/daft-local-execution/src/pipeline.rs
@@ -1590,8 +1590,7 @@ fn physical_plan_to_pipeline(
             backend,
         }) => {
             let child_node = physical_plan_to_pipeline(input, cfg, ctx, input_senders)?;
-            let backend =
-                LocalShuffleBackend::from_plan(backend, ctx.shuffle_server(), schema.clone());
+            let backend = LocalShuffleBackend::from_plan(backend, ctx.shuffle_server());
             BlockingSinkNode::new(
                 Arc::new(IntoPartitionsSink::new(
                     *num_partitions,
@@ -1615,8 +1614,7 @@ fn physical_plan_to_pipeline(
             context,
         }) => {
             let child_node = physical_plan_to_pipeline(input, cfg, ctx, input_senders)?;
-            let backend =
-                LocalShuffleBackend::from_plan(backend, ctx.shuffle_server(), schema.clone());
+            let backend = LocalShuffleBackend::from_plan(backend, ctx.shuffle_server());
             let repartition_sink = RepartitionSink::new(
                 schema.clone(),
                 repartition_spec.clone(),
@@ -1644,10 +1642,9 @@ fn physical_plan_to_pipeline(
             context,
         }) => {
             let child_node = physical_plan_to_pipeline(input, cfg, ctx, input_senders)?;
-            let backend =
-                LocalShuffleBackend::from_plan(backend, ctx.shuffle_server(), schema.clone());
+            let backend = LocalShuffleBackend::from_plan(backend, ctx.shuffle_server());
             BlockingSinkNode::new(
-                Arc::new(GatherSink::new(backend)),
+                Arc::new(GatherSink::new(schema.clone(), backend)),
                 child_node,
                 stats_state.clone(),
                 ctx,

--- a/src/daft-local-execution/src/sinks/gather.rs
+++ b/src/daft-local-execution/src/sinks/gather.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use common_error::DaftResult;
 use common_metrics::ops::NodeType;
+use daft_core::prelude::SchemaRef;
 use daft_micropartition::MicroPartition;
 use daft_partition_refs::FlightPartitionRef;
 use daft_shuffles::shuffle_cache::{InProgressShuffleCache, partition_ref_id};
@@ -35,6 +36,7 @@ impl RayGatherState {
 
 pub(crate) struct FlightGatherState {
     shared: Arc<FlightShuffleContext>,
+    schema: SchemaRef,
     input_id: InputId,
     refs: Vec<FlightPartitionRef>,
 }
@@ -45,7 +47,7 @@ impl FlightGatherState {
         let partition_ref_id = partition_ref_id(self.input_id, self.refs.len());
         let cache = InProgressShuffleCache::try_new(
             partition_ref_id,
-            shared.schema.clone(),
+            self.schema.clone(),
             &shared.shuffle_dirs,
             shared.shuffle_id,
             TARGET_IN_MEMORY_SIZE_BYTES,
@@ -113,12 +115,13 @@ fn collect_output(backend: &LocalShuffleBackend, states: Vec<GatherState>) -> Bl
 }
 
 pub struct GatherSink {
+    schema: SchemaRef,
     backend: LocalShuffleBackend,
 }
 
 impl GatherSink {
-    pub fn new(backend: LocalShuffleBackend) -> Self {
-        Self { backend }
+    pub fn new(schema: SchemaRef, backend: LocalShuffleBackend) -> Self {
+        Self { schema, backend }
     }
 }
 
@@ -178,6 +181,7 @@ impl BlockingSink for GatherSink {
             })),
             LocalShuffleBackend::Flight(shared) => Ok(GatherState::Flight(FlightGatherState {
                 shared: shared.clone(),
+                schema: self.schema.clone(),
                 input_id,
                 refs: Vec::new(),
             })),

--- a/src/daft-local-execution/src/sinks/gather.rs
+++ b/src/daft-local-execution/src/sinks/gather.rs
@@ -2,13 +2,9 @@ use std::sync::Arc;
 
 use common_error::DaftResult;
 use common_metrics::ops::NodeType;
-use daft_core::prelude::SchemaRef;
 use daft_micropartition::MicroPartition;
 use daft_partition_refs::FlightPartitionRef;
-use daft_shuffles::{
-    server::flight_server::ShuffleFlightServer,
-    shuffle_cache::{InProgressShuffleCache, partition_ref_id},
-};
+use daft_shuffles::shuffle_cache::{InProgressShuffleCache, partition_ref_id};
 use tracing::{Span, instrument};
 
 use super::{
@@ -21,6 +17,11 @@ use crate::{
     ExecutionTaskSpawner,
     pipeline::{InputId, NodeName},
 };
+
+// Each input MP gets its own cache (unlike repartition, which keeps N open caches per
+// input and divides a global budget by `num_partitions`). Matches the upper end of
+// `RepartitionSink`'s per-partition clamp so the two sinks spill at similar sizes.
+const TARGET_IN_MEMORY_SIZE_BYTES: usize = 1024 * 1024 * 128;
 
 pub(crate) struct RayGatherState {
     partitions: Vec<MicroPartition>,
@@ -47,7 +48,7 @@ impl FlightGatherState {
             shared.schema.clone(),
             &shared.shuffle_dirs,
             shared.shuffle_id,
-            shared.target_in_memory_size_per_partition,
+            TARGET_IN_MEMORY_SIZE_BYTES,
             shared.compression.as_deref(),
         )?;
         cache.push_partition_data(input).await?;
@@ -116,35 +117,8 @@ pub struct GatherSink {
 }
 
 impl GatherSink {
-    pub fn new_ray() -> Self {
-        Self {
-            backend: LocalShuffleBackend::Ray,
-        }
-    }
-
-    pub fn try_new_flight(
-        schema: SchemaRef,
-        shuffle_id: u64,
-        shuffle_dirs: Vec<String>,
-        compression: Option<String>,
-        local_server: Arc<ShuffleFlightServer>,
-        shuffle_address: String,
-    ) -> DaftResult<Self> {
-        // Each input MP gets its own cache (unlike repartition, which keeps N open caches per
-        // input and divides a global budget by `num_partitions`). Matches the upper end of
-        // `RepartitionSink`'s per-partition clamp so the two sinks spill at similar sizes.
-        const TARGET_IN_MEMORY_SIZE_BYTES: usize = 1024 * 1024 * 128;
-        Ok(Self {
-            backend: LocalShuffleBackend::Flight(Arc::new(FlightShuffleContext {
-                shuffle_id,
-                shuffle_dirs,
-                compression,
-                local_server,
-                shuffle_address,
-                target_in_memory_size_per_partition: TARGET_IN_MEMORY_SIZE_BYTES,
-                schema,
-            })),
-        })
+    pub fn new(backend: LocalShuffleBackend) -> Self {
+        Self { backend }
     }
 }
 

--- a/src/daft-local-execution/src/sinks/into_partitions.rs
+++ b/src/daft-local-execution/src/sinks/into_partitions.rs
@@ -63,6 +63,7 @@ pub(crate) struct FlightIntoPartitionsState {
 impl FlightIntoPartitionsState {
     fn try_new(
         shared: Arc<FlightShuffleContext>,
+        schema: SchemaRef,
         input_id: InputId,
         num_partitions: usize,
     ) -> DaftResult<Self> {
@@ -79,7 +80,7 @@ impl FlightIntoPartitionsState {
             let partition_ref_id = partition_ref_id(input_id, partition_idx);
             let cache = InProgressShuffleCache::try_new(
                 partition_ref_id,
-                shared.schema.clone(),
+                schema.clone(),
                 &shared.shuffle_dirs,
                 shared.shuffle_id,
                 target_in_memory_size_per_partition,
@@ -277,7 +278,12 @@ impl BlockingSink for IntoPartitionsSink {
                 partitions: Vec::new(),
             })),
             LocalShuffleBackend::Flight(shared) => Ok(IntoPartitionsState::Flight(
-                FlightIntoPartitionsState::try_new(shared.clone(), input_id, self.num_partitions)?,
+                FlightIntoPartitionsState::try_new(
+                    shared.clone(),
+                    self.schema.clone(),
+                    input_id,
+                    self.num_partitions,
+                )?,
             )),
         }
     }

--- a/src/daft-local-execution/src/sinks/into_partitions.rs
+++ b/src/daft-local-execution/src/sinks/into_partitions.rs
@@ -5,10 +5,7 @@ use common_metrics::ops::NodeType;
 use daft_core::prelude::SchemaRef;
 use daft_micropartition::MicroPartition;
 use daft_partition_refs::FlightPartitionRef;
-use daft_shuffles::{
-    server::flight_server::ShuffleFlightServer,
-    shuffle_cache::{InProgressShuffleCache, partition_ref_id},
-};
+use daft_shuffles::shuffle_cache::{InProgressShuffleCache, partition_ref_id};
 use tracing::{Span, instrument};
 
 use super::{
@@ -69,6 +66,14 @@ impl FlightIntoPartitionsState {
         input_id: InputId,
         num_partitions: usize,
     ) -> DaftResult<Self> {
+        // Divide a global 2000 MiB budget evenly across the output partitions,
+        // clamped to [8 MiB, 128 MiB] per cache so we spill at roughly the same
+        // rate regardless of N.
+        const TARGET_TOTAL_IN_MEMORY_SIZE_BYTES: usize = 1024 * 1024 * 2000;
+        let target_in_memory_size_per_partition = (TARGET_TOTAL_IN_MEMORY_SIZE_BYTES
+            / num_partitions.max(1))
+        .clamp(1024 * 1024 * 8, 1024 * 1024 * 128);
+
         let mut caches = Vec::with_capacity(num_partitions);
         for partition_idx in 0..num_partitions {
             let partition_ref_id = partition_ref_id(input_id, partition_idx);
@@ -77,7 +82,7 @@ impl FlightIntoPartitionsState {
                 shared.schema.clone(),
                 &shared.shuffle_dirs,
                 shared.shuffle_id,
-                shared.target_in_memory_size_per_partition,
+                target_in_memory_size_per_partition,
                 shared.compression.as_deref(),
             )?;
             caches.push(cache);
@@ -166,43 +171,12 @@ pub struct IntoPartitionsSink {
 }
 
 impl IntoPartitionsSink {
-    pub fn new_ray(num_partitions: usize, schema: SchemaRef) -> Self {
+    pub fn new(num_partitions: usize, schema: SchemaRef, backend: LocalShuffleBackend) -> Self {
         Self {
             num_partitions,
             schema,
-            backend: LocalShuffleBackend::Ray,
+            backend,
         }
-    }
-
-    pub fn try_new_flight(
-        num_partitions: usize,
-        schema: SchemaRef,
-        shuffle_id: u64,
-        shuffle_dirs: Vec<String>,
-        compression: Option<String>,
-        local_server: Arc<ShuffleFlightServer>,
-        shuffle_address: String,
-    ) -> DaftResult<Self> {
-        // Mirror `RepartitionSink::try_new_flight`: divide a global 2000 MiB budget
-        // evenly across the output partitions, clamped to [8 MiB, 128 MiB] per
-        // cache so we spill at roughly the same rate regardless of N.
-        const TARGET_TOTAL_IN_MEMORY_SIZE_BYTES: usize = 1024 * 1024 * 2000;
-        let target_in_memory_size_per_partition = (TARGET_TOTAL_IN_MEMORY_SIZE_BYTES
-            / num_partitions.max(1))
-        .clamp(1024 * 1024 * 8, 1024 * 1024 * 128);
-        Ok(Self {
-            num_partitions,
-            schema: schema.clone(),
-            backend: LocalShuffleBackend::Flight(Arc::new(FlightShuffleContext {
-                shuffle_id,
-                shuffle_dirs,
-                compression,
-                local_server,
-                shuffle_address,
-                target_in_memory_size_per_partition,
-                schema,
-            })),
-        })
     }
 }
 

--- a/src/daft-local-execution/src/sinks/repartition.rs
+++ b/src/daft-local-execution/src/sinks/repartition.rs
@@ -9,15 +9,15 @@ use daft_logical_plan::partitioning::RepartitionSpec;
 use daft_micropartition::MicroPartition;
 use daft_partition_refs::FlightPartitionRef;
 use daft_recordbatch::RecordBatch;
-use daft_shuffles::{
-    oneshot_writer::write_partitions_one_shot, server::flight_server::ShuffleFlightServer,
-    shuffle_cache::CHUNK_TARGET_BYTES,
-};
+use daft_shuffles::{oneshot_writer::write_partitions_one_shot, shuffle_cache::CHUNK_TARGET_BYTES};
 use itertools::Itertools;
 use tracing::{Span, instrument};
 
-use super::blocking_sink::{
-    BlockingSink, BlockingSinkFinalizeResult, BlockingSinkOutput, BlockingSinkSinkResult,
+use super::{
+    blocking_sink::{
+        BlockingSink, BlockingSinkFinalizeResult, BlockingSinkOutput, BlockingSinkSinkResult,
+    },
+    shuffle_backend::LocalShuffleBackend,
 };
 use crate::{
     ExecutionTaskSpawner,
@@ -91,35 +91,13 @@ impl RepartitionAccState {
     }
 }
 
-// TODO: unify shuffle backends in all local operations
-#[derive(Clone)]
-enum RepartitionBackend {
-    Ray,
-    Flight {
-        shuffle_id: u64,
-        shuffle_dirs: Vec<String>,
-        local_server: Arc<ShuffleFlightServer>,
-        shuffle_address: String,
-        compression: Option<arrow_ipc::CompressionType>,
-    },
-}
-
-impl RepartitionBackend {
-    fn name(&self) -> &'static str {
-        match &self {
-            Self::Ray => "Ray",
-            Self::Flight { .. } => "Flight",
-        }
-    }
-}
-
 fn repartition_buffer_threshold_bytes(
-    backend: &RepartitionBackend,
+    backend: &LocalShuffleBackend,
     num_partitions: usize,
 ) -> usize {
     match backend {
-        RepartitionBackend::Ray => REPARTITION_MAX_BUFFER_THRESHOLD_BYTES,
-        RepartitionBackend::Flight { .. } => CHUNK_TARGET_BYTES
+        LocalShuffleBackend::Ray => REPARTITION_MAX_BUFFER_THRESHOLD_BYTES,
+        LocalShuffleBackend::Flight(_) => CHUNK_TARGET_BYTES
             .saturating_mul(num_partitions.max(1))
             .clamp(
                 REPARTITION_MIN_BUFFER_THRESHOLD_BYTES,
@@ -129,7 +107,7 @@ fn repartition_buffer_threshold_bytes(
 }
 
 pub struct RepartitionSink {
-    backend: RepartitionBackend,
+    backend: LocalShuffleBackend,
     schema: SchemaRef,
     repartition_spec: RepartitionSpec,
     bound_keys: Vec<BoundExpr>,
@@ -137,47 +115,18 @@ pub struct RepartitionSink {
 }
 
 impl RepartitionSink {
-    pub fn new_ray(
+    pub fn new(
         schema: SchemaRef,
         repartition_spec: RepartitionSpec,
         num_partitions: usize,
+        backend: LocalShuffleBackend,
     ) -> DaftResult<Self> {
         let bound_keys = match &repartition_spec {
             RepartitionSpec::Hash(config) => BoundExpr::bind_all(&config.by, &schema)?,
             RepartitionSpec::Random(_) | RepartitionSpec::Range(_) => Vec::new(),
         };
         Ok(Self {
-            backend: RepartitionBackend::Ray,
-            schema,
-            repartition_spec,
-            bound_keys,
-            num_partitions,
-        })
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    pub fn try_new_flight(
-        num_partitions: usize,
-        schema: SchemaRef,
-        shuffle_id: u64,
-        repartition_spec: RepartitionSpec,
-        shuffle_dirs: Vec<String>,
-        compression: Option<String>,
-        local_server: Arc<ShuffleFlightServer>,
-        shuffle_address: String,
-    ) -> DaftResult<Self> {
-        let bound_keys = match &repartition_spec {
-            RepartitionSpec::Hash(config) => BoundExpr::bind_all(&config.by, &schema)?,
-            RepartitionSpec::Random(_) | RepartitionSpec::Range(_) => Vec::new(),
-        };
-        Ok(Self {
-            backend: RepartitionBackend::Flight {
-                shuffle_id,
-                shuffle_dirs,
-                local_server,
-                shuffle_address,
-                compression: parse_compression(compression.as_deref())?,
-            },
+            backend,
             schema,
             repartition_spec,
             bound_keys,
@@ -240,7 +189,7 @@ impl BlockingSink for RepartitionSink {
                         flatten_per_partition(states, num_partitions, schema.clone())?;
 
                     match backend {
-                        RepartitionBackend::Ray => {
+                        LocalShuffleBackend::Ray => {
                             let mut joinset = OrderedJoinSet::new();
                             for data in per_partition {
                                 joinset.spawn(async move {
@@ -259,32 +208,30 @@ impl BlockingSink for RepartitionSink {
                             }
                             Ok(BlockingSinkOutput::Partitions(partitions))
                         }
-                        RepartitionBackend::Flight {
-                            shuffle_id,
-                            shuffle_dirs,
-                            local_server,
-                            shuffle_address,
-                            compression,
-                        } => {
+                        LocalShuffleBackend::Flight(ctx) => {
+                            let compression = parse_compression(ctx.compression.as_deref())?;
                             let partition_caches = write_partitions_one_shot(
                                 input_id,
-                                shuffle_id,
-                                &shuffle_dirs,
+                                ctx.shuffle_id,
+                                &ctx.shuffle_dirs,
                                 schema,
                                 compression,
                                 per_partition,
                             )
                             .await?;
 
-                            local_server
-                                .register_shuffle_partitions(shuffle_id, partition_caches.clone())
+                            ctx.local_server
+                                .register_shuffle_partitions(
+                                    ctx.shuffle_id,
+                                    partition_caches.clone(),
+                                )
                                 .await?;
                             Ok(BlockingSinkOutput::FlightPartitionRefs(
                                 partition_caches
                                     .into_iter()
                                     .map(|partition| FlightPartitionRef {
-                                        shuffle_id,
-                                        server_address: shuffle_address.clone(),
+                                        shuffle_id: ctx.shuffle_id,
+                                        server_address: ctx.shuffle_address.clone(),
                                         partition_ref_id: partition.partition_ref_id,
                                         num_rows: partition.num_rows,
                                         size_bytes: partition.size_bytes,

--- a/src/daft-local-execution/src/sinks/shuffle_backend.rs
+++ b/src/daft-local-execution/src/sinks/shuffle_backend.rs
@@ -1,20 +1,19 @@
 use std::sync::Arc;
 
-use daft_core::prelude::SchemaRef;
 use daft_shuffles::server::flight_server::ShuffleFlightServer;
 
 /// Transport handles shared by all Flight-backed states of a single shuffle sink.
 ///
-/// Per-partition sizing (e.g. cache spill targets) is intentionally not stored
-/// here: it is specific to the streaming cache writer used by gather and
-/// into_partitions, and has no analogue in repartition's one-shot writer.
+/// Sink-specific inputs (the schema, per-partition cache spill targets) are
+/// intentionally not stored here: they are owned by each sink, since not every
+/// sink reads them from a shared context (e.g. repartition uses its own schema
+/// and one-shot writer with no per-partition spill knob).
 pub(crate) struct FlightShuffleContext {
     pub(crate) shuffle_id: u64,
     pub(crate) shuffle_dirs: Vec<String>,
     pub(crate) compression: Option<String>,
     pub(crate) local_server: Arc<ShuffleFlightServer>,
     pub(crate) shuffle_address: String,
-    pub(crate) schema: SchemaRef,
 }
 
 /// Picks between the Ray path and the Flight path for local shuffle operators
@@ -33,7 +32,6 @@ impl LocalShuffleBackend {
     pub(crate) fn from_plan(
         backend: &daft_local_plan::ShuffleBackend,
         shuffle_server: Option<(Arc<ShuffleFlightServer>, String)>,
-        schema: SchemaRef,
     ) -> Self {
         match backend {
             daft_local_plan::ShuffleBackend::Ray => Self::Ray,
@@ -51,7 +49,6 @@ impl LocalShuffleBackend {
                     compression: compression.clone(),
                     local_server,
                     shuffle_address,
-                    schema,
                 }))
             }
         }

--- a/src/daft-local-execution/src/sinks/shuffle_backend.rs
+++ b/src/daft-local-execution/src/sinks/shuffle_backend.rs
@@ -3,21 +3,22 @@ use std::sync::Arc;
 use daft_core::prelude::SchemaRef;
 use daft_shuffles::server::flight_server::ShuffleFlightServer;
 
-/// Runtime config shared by all Flight-backed states of a single shuffle sink.
+/// Transport handles shared by all Flight-backed states of a single shuffle sink.
+///
+/// Per-partition sizing (e.g. cache spill targets) is intentionally not stored
+/// here: it is specific to the streaming cache writer used by gather and
+/// into_partitions, and has no analogue in repartition's one-shot writer.
 pub(crate) struct FlightShuffleContext {
     pub(crate) shuffle_id: u64,
     pub(crate) shuffle_dirs: Vec<String>,
     pub(crate) compression: Option<String>,
     pub(crate) local_server: Arc<ShuffleFlightServer>,
     pub(crate) shuffle_address: String,
-    pub(crate) target_in_memory_size_per_partition: usize,
     pub(crate) schema: SchemaRef,
 }
 
 /// Picks between the Ray path and the Flight path for local shuffle operators
 /// and carries Flight's runtime handles.
-// TODO: unify shuffle backends in all local operations. Remaining:
-// `sinks/repartition.rs` and the dispatch blocks in `pipeline.rs`.
 #[derive(Clone)]
 pub(crate) enum LocalShuffleBackend {
     Ray,
@@ -25,6 +26,37 @@ pub(crate) enum LocalShuffleBackend {
 }
 
 impl LocalShuffleBackend {
+    /// Resolve a plan-level [`daft_local_plan::ShuffleBackend`] into the runtime
+    /// backend, threading in the worker's Flight server for the Flight path.
+    /// This is the single point where the shuffle server is resolved for all
+    /// local shuffle sinks.
+    pub(crate) fn from_plan(
+        backend: &daft_local_plan::ShuffleBackend,
+        shuffle_server: Option<(Arc<ShuffleFlightServer>, String)>,
+        schema: SchemaRef,
+    ) -> Self {
+        match backend {
+            daft_local_plan::ShuffleBackend::Ray => Self::Ray,
+            daft_local_plan::ShuffleBackend::Flight {
+                shuffle_id,
+                shuffle_dirs,
+                compression,
+            } => {
+                let (local_server, shuffle_address) = shuffle_server.expect(
+                    "Flight shuffle server must be initialized for Flight shuffle plans when using flight_shuffle algorithm",
+                );
+                Self::Flight(Arc::new(FlightShuffleContext {
+                    shuffle_id: *shuffle_id,
+                    shuffle_dirs: shuffle_dirs.clone(),
+                    compression: compression.clone(),
+                    local_server,
+                    shuffle_address,
+                    schema,
+                }))
+            }
+        }
+    }
+
     pub(crate) fn name(&self) -> &'static str {
         match self {
             Self::Ray => "Ray",


### PR DESCRIPTION
## Summary

Follows #7221 (merged). Completes the local shuffle backend unification (#7212) by migrating `RepartitionSink` onto the shared `LocalShuffleBackend` and collapsing the three per-operator Ray/Flight dispatch blocks in `pipeline.rs` into a single resolution point. Removes the last `// TODO: unify shuffle backends in all local operations` markers.

## Why

After #7221, gather and into_partitions share `LocalShuffleBackend`, but `repartition.rs` still carried its own `RepartitionBackend` enum, and `physical_plan_to_pipeline` repeated the same Ray/Flight match (including an identical `ctx.shuffle_server().expect(...)`) three times. This is the remaining phase 2 cleanup from #6472.

## Changes Made

- `sinks/shuffle_backend.rs`: make `FlightShuffleContext` transport-only (`shuffle_id`, `shuffle_dirs`, `compression`, `local_server`, `shuffle_address`); sink-specific inputs (schema, per-partition spill target) are owned by each sink. Add `LocalShuffleBackend::from_plan` as the single place that resolves a plan-level `ShuffleBackend` and the worker'''s Flight server
- `sinks/repartition.rs`: replace `RepartitionBackend` with `LocalShuffleBackend`; parse compression lazily at `finalize` instead of eagerly at construction; collapse `new_ray` / `try_new_flight` into one `new(..., backend)`
- `sinks/gather.rs`, `sinks/into_partitions.rs`: each cache sink derives its own per-partition spill target locally (a module const for gather, a `num_partitions`-derived value for into_partitions) and sources its schema from its own field instead of the shared context; collapse constructors to take the resolved backend
- `pipeline.rs`: the three shuffle-sink arms now call `LocalShuffleBackend::from_plan(...)` and the unified constructors; the duplicated shuffle-server `expect` lives once in `from_plan`

## Behavior

Functionally equivalent for all inputs. Spill thresholds, state machines, output types, and node display names are unchanged. Repartition no longer parses the compression string eagerly at pipeline construction; it parses at `finalize` like the write step of the other sinks. This is unobservable in practice: `flight_shuffle_compression` is validated at config-set time (`set_execution_config` accepts only `lz4`, `zstd`, or `none`), so no invalid value reaches any sink.

## Test Plan

- `cargo check` / `cargo fmt` / `cargo clippy -p daft-local-execution --lib --no-deps` clean for the touched files
- `DAFT_RUNNER=ray pytest tests/dataframe/test_shuffles.py`: 39 passed (gather / into_partitions / repartition under Ray and Flight backends)
- `DAFT_RUNNER=ray pytest tests/dataframe/test_sort.py`: 188 passed, 8 skipped (repartition `Range` spec via sort)
- `DAFT_RUNNER=native pytest tests/dataframe/test_sort.py tests/dataframe/test_into_partitions.py tests/dataframe/test_sort_shuffle_elision.py`: 316 passed, 58 skipped

## Related Issues

Second of two PRs for #7212. Part of #6472.