### PR TITLE
fix: IsIn/Decimal/UnresolvedColumn expressions fail to translate to SQL

### DIFF
--- a/src/daft-core/src/lit/mod.rs
+++ b/src/daft-core/src/lit/mod.rs
@@ -438,9 +438,20 @@ impl Literal {
                 "TIMESTAMP '{}'",
                 display_timestamp(*val, tu, tz).replace('T', " ")
             ),
-            Self::Decimal(..)
-            | Self::Uuid(..)
-            | Self::List(..)
+            Self::Decimal(val, precision, scale) => {
+                if *scale < 0 {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        format!(
+                            "Cannot display Decimal({}, {}) as SQL: negative scale not supported",
+                            precision, scale
+                        ),
+                    ));
+                }
+                write!(buffer, "{}", display_decimal128(*val, *precision, *scale))
+            }
+            Self::Uuid(val) => write!(buffer, "'{}'", val),
+            Self::List(..)
             | Self::Time(..)
             | Self::Binary(..)
             | Self::Duration(..)
@@ -709,4 +720,49 @@ mod test {
 
         Ok(())
     }
+
+    #[test]
+    fn test_display_sql_uuid() {
+        use uuid::Uuid;
+        let uuid = Uuid::parse_str("12345678-1234-5678-1234-567812345678").unwrap();
+        let lit = Literal::Uuid(uuid);
+        let mut buf = Vec::<u8>::new();
+        lit.display_sql(&mut buf).unwrap();
+        assert_eq!(
+            String::from_utf8(buf).unwrap(),
+            "'12345678-1234-5678-1234-567812345678'"
+        );
+    }
+
+    #[test]
+    fn test_display_sql_decimal_positive_scale() {
+        // 123.45 with precision=5, scale=2
+        let lit = Literal::Decimal(12345, 5, 2);
+        let mut buf = Vec::<u8>::new();
+        lit.display_sql(&mut buf).unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "123.45");
+    }
+
+    #[test]
+    fn test_display_sql_decimal_zero_scale() {
+        let lit = Literal::Decimal(1500, 4, 0);
+        let mut buf = Vec::<u8>::new();
+        lit.display_sql(&mut buf).unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "1500");
+    }
+
+    #[test]
+    fn test_display_sql_decimal_negative_scale_returns_error() {
+        let lit = Literal::Decimal(1500, 4, -2);
+        let mut buf = Vec::<u8>::new();
+        let result = lit.display_sql(&mut buf);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string().contains("negative scale"),
+            "Expected negative scale error, got: {}",
+            err
+        );
+    }
+
 }

--- a/src/daft-core/src/lit/mod.rs
+++ b/src/daft-core/src/lit/mod.rs
@@ -764,5 +764,4 @@ mod test {
             err
         );
     }
-
 }

--- a/src/daft-dsl/src/expr/mod.rs
+++ b/src/daft-dsl/src/expr/mod.rs
@@ -2393,12 +2393,21 @@ impl Expr {
         }
     }
 
-    /// Returns the expression as SQL using PostgreSQL's dialect.
+    /// Returns the expression as a SQL string using PostgreSQL's dialect.
+    ///
+    /// The caller (`sql_connection.py`) passes this through `sqlglot` which
+    /// re-renders it in the target dialect (MySQL, Trino, etc.).
     pub fn to_sql(&self) -> Option<String> {
         fn to_sql_inner<W: Write>(expr: &Expr, buffer: &mut W) -> io::Result<()> {
             match expr {
-                Expr::Column(Column::Resolved(ResolvedColumn::Basic(name))) => {
-                    write!(buffer, "{}", name)
+                Expr::Column(Column::Resolved(ResolvedColumn::Basic(name)))
+                | Expr::Column(Column::Unresolved(UnresolvedColumn { name, .. })) => {
+                    // Always quote identifiers with SQL-standard double quotes.
+                    // This handles spaces, reserved words, and special characters
+                    // uniformly.  sqlglot re-renders in the target dialect's quoting
+                    // style (backticks for MySQL, etc.) during the parse->render
+                    // round-trip.
+                    write!(buffer, "\"{}\"", name.replace('"', "\"\""))
                 }
                 Expr::Literal(lit) => lit.display_sql(buffer),
                 Expr::Alias(expr, ..) => to_sql_inner(expr, buffer),
@@ -2440,11 +2449,27 @@ impl Expr {
                     to_sql_inner(inner, buffer)?;
                     write!(buffer, ") IS NOT NULL")
                 }
+                Expr::IsIn(expr, items) => {
+                    if items.is_empty() {
+                        // Empty IN () is a syntax error in most SQL engines;
+                        // emit a constant-false predicate instead.
+                        return write!(buffer, "(1 = 0)");
+                    }
+                    write!(buffer, "(")?;
+                    to_sql_inner(expr, buffer)?;
+                    write!(buffer, ") IN (")?;
+                    for (i, item) in items.iter().enumerate() {
+                        if i > 0 {
+                            write!(buffer, ", ")?;
+                        }
+                        to_sql_inner(item, buffer)?;
+                    }
+                    write!(buffer, ")")
+                }
                 // TODO: Implement SQL translations for these expressions if possible
                 Expr::IfElse { .. }
                 | Expr::Agg(..)
                 | Expr::Cast(..)
-                | Expr::IsIn(..)
                 | Expr::List(..)
                 | Expr::Between(..)
                 | Expr::Function { .. }

--- a/tests/io/test_sql_translation.py
+++ b/tests/io/test_sql_translation.py
@@ -1,0 +1,200 @@
+"""Tests for expression SQL translation (Expr.to_sql / Literal.display_sql)."""
+
+from __future__ import annotations
+
+import datetime
+import uuid
+from decimal import Decimal
+
+from daft.expressions import col, lit
+
+
+class TestLiteralSqlTranslation:
+    """Test Literal.display_sql for various types."""
+
+    def test_int_types(self):
+        assert lit(42)._to_sql() == "42"
+        assert lit(-1)._to_sql() == "-1"
+        assert lit(0)._to_sql() == "0"
+
+    def test_float_types(self):
+        assert lit(3.14)._to_sql() == "3.14"
+        assert lit(-0.5)._to_sql() == "-0.5"
+
+    def test_boolean(self):
+        assert lit(True)._to_sql() == "true"
+        assert lit(False)._to_sql() == "false"
+
+    def test_null(self):
+        assert lit(None)._to_sql() == "NULL"
+
+    def test_date(self):
+        assert lit(datetime.date(2024, 1, 15))._to_sql() is not None
+
+    def test_decimal(self):
+        """B6: Decimal literals should produce valid SQL."""
+        result = lit(Decimal("123.45"))._to_sql()
+        assert result is not None
+        assert "123.45" in result
+
+    def test_decimal_integer(self):
+        result = lit(Decimal(100))._to_sql()
+        assert result is not None
+        assert "100" in result
+
+    def test_decimal_scientific_notation_does_not_panic(self):
+        """Decimal with scientific notation should not panic.
+
+        Python Decimal('1.5E+3') normalizes to exponent=2, so Daft
+        sets scale=0 (via the from_pyobj normalizer in lit/python.rs).
+        This test verifies
+        the conversion doesn't panic, even though it doesn't exercise
+        the negative-scale guard (that path is only reachable from
+        Arrow data with negative-scale Decimal128 schema).
+        """
+        result = lit(Decimal("1.5E+3"))._to_sql()
+        assert result is not None
+        assert isinstance(result, str)
+
+    def test_uuid_python_lit_returns_none(self):
+        """Python uuid.UUID does not map to Lit::Uuid in from_pyobj.
+
+        Python uuid.UUID objects fall through the generic branch of
+        Literal::from_pyobj (lit/python.rs) and become a Python-typed
+        literal, not Lit::Uuid. The Lit::Uuid display_sql arm added in
+        lit/mod.rs serves the Arrow→Lit path (get_lit.rs) for UUID
+        columns read from Parquet/Iceberg files, not Python lit().
+        """
+        val = uuid.UUID("12345678-1234-5678-1234-567812345678")
+        result = lit(val)._to_sql()
+        assert result is None  # current limitation — Python UUID → Lit::Uuid not wired
+
+
+class TestIsInSqlTranslation:
+    """Test Expr.is_in SQL generation."""
+
+    def test_is_in_integers(self):
+        """B2: is_in should generate col IN (v1, v2, v3)."""
+        expr = col("x").is_in([lit(1), lit(2), lit(3)])
+        sql = expr._to_sql()
+        assert sql is not None
+        assert "IN" in sql
+        assert "1" in sql
+        assert "2" in sql
+        assert "3" in sql
+
+    def test_is_in_strings(self):
+        expr = col("name").is_in([lit("alice"), lit("bob")])
+        sql = expr._to_sql()
+        assert sql is not None
+        assert "IN" in sql
+        assert "'alice'" in sql
+        assert "'bob'" in sql
+
+    def test_is_in_single_item(self):
+        expr = col("x").is_in([lit(42)])
+        sql = expr._to_sql()
+        assert sql is not None
+        assert "IN" in sql
+        assert "42" in sql
+
+    def test_is_in_empty(self):
+        """Empty is_in([]) should emit constant-false, not invalid IN ()."""
+        expr = col("x").is_in([])
+        sql = expr._to_sql()
+        assert sql is not None
+        assert sql == "(1 = 0)"
+        assert "IN ()" not in sql  # must not generate invalid SQL
+
+
+class TestBinaryOpSqlTranslation:
+    """Test BinaryOp SQL generation (existing functionality)."""
+
+    def test_eq(self):
+        assert (col("x") == lit(1))._to_sql() == '"x" = 1'
+
+    def test_neq(self):
+        assert (col("x") != lit(1))._to_sql() == '"x" != 1'
+
+    def test_lt(self):
+        assert (col("x") < lit(1))._to_sql() == '"x" < 1'
+
+    def test_lte(self):
+        assert (col("x") <= lit(1))._to_sql() == '"x" <= 1'
+
+    def test_gt(self):
+        assert (col("x") > lit(1))._to_sql() == '"x" > 1'
+
+    def test_gte(self):
+        assert (col("x") >= lit(1))._to_sql() == '"x" >= 1'
+
+    def test_and(self):
+        expr = (col("x") > lit(1)) & (col("y") < lit(10))
+        sql = expr._to_sql()
+        assert sql is not None
+        assert "AND" in sql
+
+    def test_or(self):
+        expr = (col("x") > lit(1)) | (col("y") < lit(10))
+        sql = expr._to_sql()
+        assert sql is not None
+        assert "OR" in sql
+
+
+class TestIdentifierQuoting:
+    """Verify column identifiers are properly quoted for SQL safety."""
+
+    def test_space_in_name(self):
+        sql = (col("full name") == lit(1))._to_sql()
+        assert sql is not None
+        assert '"full name"' in sql
+
+    def test_embedded_double_quote(self):
+        sql = (col('x"y') == lit(1))._to_sql()
+        assert sql is not None
+        # SQL-standard escaping: embedded " becomes ""
+        assert '"x""y"' in sql
+
+    def test_hyphen_in_name(self):
+        sql = (col("my-col") == lit(1))._to_sql()
+        assert sql is not None
+        assert '"my-col"' in sql
+
+    def test_reserved_word_column(self):
+        sql = (col("SELECT") == lit(1))._to_sql()
+        assert sql is not None
+        assert '"SELECT"' in sql
+
+    def test_special_names_survive_construct_sql_query(self):
+        """Quoted identifiers must survive sqlglot parse→render round-trip."""
+        from daft.sql.sql_connection import SQLConnection
+
+        conn = SQLConnection.from_url("mysql://u:p@h/db")
+        # "full name" should become `full name` in MySQL dialect
+        predicate = (col("full name") == lit(1))._to_sql()
+        assert predicate is not None
+        query = conn.construct_sql_query("SELECT * FROM t", predicate=predicate)
+        # sqlglot renders MySQL identifiers with backticks
+        assert "full name" in query
+
+
+class TestUnarySqlTranslation:
+    """Test unary expression SQL generation."""
+
+    def test_not(self):
+        expr = ~(col("x") == lit(1))
+        sql = expr._to_sql()
+        assert sql is not None
+        assert "NOT" in sql
+
+    def test_is_null(self):
+        expr = col("x").is_null()
+        sql = expr._to_sql()
+        assert sql is not None
+        assert "IS NULL" in sql
+
+    def test_not_null(self):
+        expr = col("x").not_null()
+        sql = expr._to_sql()
+        assert sql is not None
+        assert "IS NOT NULL" in sql


### PR DESCRIPTION
## Changes Made

This fixes two gaps in the SQL expression translation layer (`Expr::to_sql` / `Literal::display_sql`) and extends column support, each of which silently degrades filter pushdown or causes SQL syntax errors when using `read_sql()` with partition bounds or filtered reads.

**IsIn expression translation** (`src/daft-dsl/src/expr/mod.rs`): `Expr::IsIn` was in the "unsupported" catch-all branch and returned `None`, so filters like `col("x").is_in([1, 2, 3])` could never be pushed down — every `read_sql` call with such a filter fell back to a full table scan with in-memory filtering. Implemented standard `col IN (v1, v2, v3)` generation. Empty `is_in([])` emits `(1 = 0)` (constant-false) rather than invalid `IN ()`.

**Decimal literal translation** (`src/daft-core/src/lit/mod.rs`): Decimal literals were in the unsupported branch. Now use the existing `display_decimal128` helper. Negative scale values return an explicit error rather than panicking.

**Unresolved column support** (`src/daft-dsl/src/expr/mod.rs`): `Column::Unresolved` was previously skipped. Real-world column references are often unresolved at the point `to_sql()` is called, so `to_sql()` now handles both `Resolved` and `Unresolved` columns. All column identifiers are quoted with SQL-standard double quotes to handle spaces, reserved words, and special characters; `sqlglot` re-renders in the target dialect during the parse→render round-trip.

**Note on Utf8 single-quote escaping**: Handled separately by PR #7269.

## Testing

Added `tests/io/test_sql_translation.py` covering:

- **Decimal literals**: simple, integer, scientific notation
- **Uuid limitation**: documents that Python `uuid.UUID` does not map to `Lit::Uuid` (Arrow/Iceberg path only)
- **IsIn**: integers, strings, single item, empty list `(1 = 0)`
- **Identifier quoting**: spaces (`full name`), embedded double quotes (`x"y` → `"x""y"`), hyphens (`my-col`), reserved words (`SELECT`), and a `construct_sql_query()` round-trip through sqlglot MySQL dialect
- **Binary/unary operators**: `=`, `!=`, `<`, `<=`, `>`, `>=`, `AND`, `OR`, `NOT`, `IS NULL`, `IS NOT NULL`

Rust unit tests in `lit/mod.rs` cover Decimal (positive/zero/negative scale) and Uuid display. All existing tests pass.

## Related Issues

Closes #7197