### PR TITLE
fix(asof): make join_asof output partition-invariant on (by, on) ties

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -3976,6 +3976,9 @@ class DataFrame:
             left_by: Equality keys on the left when names differ; use with ``right_by``.
             right_by: Equality keys on the right when names differ; use with ``left_by``.
             strategy: Match strategy. ``"backward"`` finds the latest right row at or before the left timestamp. ``"forward"`` finds the earliest right row at or after the left timestamp. ``"nearest"`` finds the right row with the minimum absolute difference in on_key; For tie-breaking, prefer the larger/forward value.
+                Ties on ``(by, on)`` are broken deterministically (greatest right row for
+                ``"backward"``/``"nearest"``, least for ``"forward"``, over the output columns);
+                rows differing only in non-orderable columns remain an arbitrary pick.
             _assume_sorted_and_aligned: Asserts that both inputs have the same number of
                 partitions with identical boundaries, and that rows within each partition are
                 sorted ascending by the on-key. Also requires

--- a/src/daft-core/src/array/ops/mod.rs
+++ b/src/daft-core/src/array/ops/mod.rs
@@ -70,7 +70,7 @@ mod variance;
 use std::hash::BuildHasher;
 
 pub use hll_sketch::HLL_SKETCH_DTYPE;
-pub use sort::{build_multi_array_bicompare, build_multi_array_compare};
+pub use sort::{DynComparator, build_multi_array_bicompare, build_multi_array_compare};
 
 use crate::count_mode::CountMode;
 

--- a/src/daft-distributed/src/pipeline_node/join/asof_join.rs
+++ b/src/daft-distributed/src/pipeline_node/join/asof_join.rs
@@ -8,10 +8,12 @@ use common_metrics::{
 use daft_dsl::{
     AggExpr, bound_col,
     expr::bound_expr::{BoundAggExpr, BoundExpr},
+    lit,
 };
 use daft_local_plan::{LocalNodeContext, LocalPhysicalPlan, ShuffleReadBackend};
 use daft_logical_plan::{AsofJoinStrategy, stats::StatsState};
 use daft_schema::{
+    dtype::DataType,
     field::Field,
     schema::{Schema, SchemaRef},
 };
@@ -450,10 +452,11 @@ impl AsofJoinNode {
             .collect()
     }
 
-    /// Builds and submits a task reducing `inputs` to the extreme right row(s) for carryover.
-    /// Without by-keys this is a single top_n(limit=1) row; with by-keys it is the extreme
-    /// row(s) *per group* (window max/min of the on-key over the by-keys, keeping matching rows).
-    /// `descending=true` picks the max (backward carryover); `false` picks the min (forward carryover).
+    /// Builds and submits a task reducing `inputs` to the carryover rows: every right row whose
+    /// on-key equals the partition extreme (per by-key group, or over the whole frame when there are
+    /// no by-keys). `descending=true` keeps the max on-key (backward carryover), `false` the min
+    /// (forward). Keeping *all* rows tied at the extreme rather than one means the local operator
+    /// stays the single place tie-breaks happen; the carryover only promises not to drop a candidate.
     fn submit_carryover_task(
         &self,
         inputs: Vec<MaterializedOutput>,
@@ -474,77 +477,94 @@ impl AsofJoinNode {
             phase,
         );
 
-        let plan = if self.right_by.is_empty() {
-            let composite_keys = self.right_composite_key();
-            let n_keys = composite_keys.len();
-            LocalPhysicalPlan::top_n(
-                in_memory_scan,
-                composite_keys,
-                vec![descending; n_keys],
-                vec![false; n_keys],
-                1,
-                None,
-                StatsState::NotMaterialized,
-                context,
-            )
+        const EXTREME_COL: &str = "__asof_carryover_extreme";
+        const PART_COL: &str = "__asof_carryover_part";
+        let on_expr = self.right_on.inner().clone();
+        let on_field = on_expr.to_field(&right_schema)?;
+        let agg = if descending {
+            AggExpr::Max(on_expr.clone())
         } else {
-            const EXTREME_COL: &str = "__asof_carryover_extreme";
-            let on_expr = self.right_on.inner().clone();
-            let on_field = on_expr.to_field(&right_schema)?;
-            let agg = if descending {
-                AggExpr::Max(on_expr.clone())
-            } else {
-                AggExpr::Min(on_expr.clone())
-            };
+            AggExpr::Min(on_expr.clone())
+        };
 
-            let extreme_field = Field::new(EXTREME_COL, on_field.dtype);
-            let window_schema = Arc::new(Schema::new(
+        // Partition by the by-keys, or by an injected constant column when there are none (the whole
+        // frame is one partition; window_partition_only requires a non-empty partition_by).
+        let (windowed_input, partition_by, base_schema) = if self.right_by.is_empty() {
+            let part_field = Field::new(PART_COL, DataType::Boolean);
+            let base_schema = Arc::new(Schema::new(
                 right_schema
                     .fields()
                     .iter()
                     .cloned()
-                    .chain(std::iter::once(extreme_field.clone())),
+                    .chain(std::iter::once(part_field.clone())),
             ));
-            let window = LocalPhysicalPlan::window_partition_only(
-                in_memory_scan,
-                self.right_by.clone(),
-                window_schema,
-                StatsState::NotMaterialized,
-                vec![BoundAggExpr::new_unchecked(agg)],
-                vec![EXTREME_COL.to_string()],
-                context.clone(),
-            );
-
-            // Rows with a null on-key compare to null and are filtered out, which is correct:
-            // they can never be an asof match.
-            let predicate =
-                BoundExpr::new_unchecked(on_expr.eq(bound_col(right_schema.len(), extreme_field)));
-            let filtered = LocalPhysicalPlan::filter(
-                window,
-                predicate,
-                StatsState::NotMaterialized,
-                context.clone(),
-            );
-
-            let projection = right_schema
+            let mut projection: Vec<BoundExpr> = right_schema
                 .fields()
                 .iter()
                 .enumerate()
                 .map(|(i, f)| BoundExpr::new_unchecked(bound_col(i, f.clone())))
                 .collect();
-            LocalPhysicalPlan::project(
-                filtered,
+            projection.push(BoundExpr::new_unchecked(lit(true).alias(PART_COL)));
+            let scan = LocalPhysicalPlan::project(
+                in_memory_scan,
                 projection,
-                right_schema,
+                base_schema.clone(),
                 StatsState::NotMaterialized,
-                context,
-            )
+                context.clone(),
+            );
+            let part_col = BoundExpr::new_unchecked(bound_col(right_schema.len(), part_field));
+            (scan, vec![part_col], base_schema)
+        } else {
+            (in_memory_scan, self.right_by.clone(), right_schema.clone())
         };
 
+        let extreme_field = Field::new(EXTREME_COL, on_field.dtype);
+        let window_schema = Arc::new(Schema::new(
+            base_schema
+                .fields()
+                .iter()
+                .cloned()
+                .chain(std::iter::once(extreme_field.clone())),
+        ));
+        let window = LocalPhysicalPlan::window_partition_only(
+            windowed_input,
+            partition_by,
+            window_schema,
+            StatsState::NotMaterialized,
+            vec![BoundAggExpr::new_unchecked(agg)],
+            vec![EXTREME_COL.to_string()],
+            context.clone(),
+        );
+
+        // Keep every row whose on-key equals the partition extreme. Null on-keys compare to null and
+        // drop out, which is correct: they can never be an asof match.
+        let predicate =
+            BoundExpr::new_unchecked(on_expr.eq(bound_col(base_schema.len(), extreme_field)));
+        let filtered = LocalPhysicalPlan::filter(
+            window,
+            predicate,
+            StatsState::NotMaterialized,
+            context.clone(),
+        );
+
+        // Project back to the right schema, dropping the extreme and any injected partition column.
+        let projection = right_schema
+            .fields()
+            .iter()
+            .enumerate()
+            .map(|(i, f)| BoundExpr::new_unchecked(bound_col(i, f.clone())))
+            .collect();
+        let plan = LocalPhysicalPlan::project(
+            filtered,
+            projection,
+            right_schema.clone(),
+            StatsState::NotMaterialized,
+            context,
+        );
+
         SwordfishTaskBuilder::new(plan, self, node_id)
-            // Forward (min) and backward (max) carryover tasks have identical top_n plans but
-            // compute different results, so give them distinct fingerprints to avoid
-            // sharing a worker pipeline and producing incorrect outputs.
+            // Backward (max) and forward (min) carryover tasks differ only in the window agg, so
+            // give them distinct fingerprints to avoid sharing a worker pipeline.
             .extend_fingerprint(u32::from(descending))
             .with_psets(node_id, psets)
             .with_strategy(strategy)

--- a/src/daft-local-execution/src/join/asof_join.rs
+++ b/src/daft-local-execution/src/join/asof_join.rs
@@ -10,7 +10,8 @@ use common_metrics::ops::NodeType;
 use common_runtime::{get_compute_pool_num_threads, get_compute_runtime};
 use daft_core::{
     array::ops::{
-        GroupIndices, VecIndices, arrow::comparison::build_multi_array_is_equal_from_arrays,
+        DynComparator, GroupIndices, VecIndices,
+        arrow::comparison::build_multi_array_is_equal_from_arrays, build_multi_array_bicompare,
     },
     join::AsofJoinStrategy,
     kernels::cmp::{DynPartialComparator, build_partial_compare_with_nulls, is_nearer},
@@ -78,6 +79,11 @@ use crate::{
 //      2  |   A    |   5    | 2     <- forward-filled from idx=1
 //      3  |   B    |   2    | null  <- no right event at or before on_key=2 in group B
 //      4  |   B    |   7    | 4
+//
+// DETERMINISM: among right rows sharing a (by, on) key, the match is a per-key max/min over a
+// total order of the output columns (`build_tie_cols`), not probe/merge order -- backward/nearest
+// keep the greatest such row, forward the least -- so it is independent of batch splitting, worker,
+// and shuffle order.
 
 pub(crate) struct AsofJoinBuildState {
     record_batches: Vec<RecordBatch>,
@@ -315,6 +321,9 @@ pub(crate) struct AsofJoinProbeState {
     best_match: Vec<Option<(u32, u32)>>,
     // Each entry pairs a pruned RecordBatch with its on_key Arrow array for cross-batch comparisons.
     right_rbs_and_on_keys: Vec<(RecordBatch, Arc<dyn Array>)>,
+    // Parallel to `right_rbs_and_on_keys`: each batch's tie-break columns (see `build_tie_cols`),
+    // used to break equal-on-key ties deterministically. `Arc` keeps the per-probe snapshot cheap.
+    right_tie_cols: Vec<Arc<Vec<Series>>>,
 }
 
 impl AsofJoinProbeState {
@@ -329,11 +338,15 @@ impl AsofJoinProbeState {
         let rb_idx = self.right_rbs_and_on_keys.len();
         let build_state = self.build_contents.clone();
 
-        let right_on_arr: Arc<dyn Array> = right_rb.eval_expression(right_on)?.to_arrow()?;
-        self.right_rbs_and_on_keys.push((
-            prune_right_batch(right_rb, right_cols_to_keep),
-            right_on_arr.clone(),
-        ));
+        let right_on_series = right_rb.eval_expression(right_on)?;
+        let right_on_arr: Arc<dyn Array> = right_on_series.to_arrow()?;
+        let pruned_rb = prune_right_batch(right_rb, right_cols_to_keep);
+        // Tie-break over the pruned (output) columns, which are already retained for the join
+        // output, so no extra buffers are pinned (see `build_tie_cols`).
+        self.right_tie_cols
+            .push(Arc::new(build_tie_cols(&right_on_series, &pruned_rb)));
+        self.right_rbs_and_on_keys
+            .push((pruned_rb, right_on_arr.clone()));
         // Build one comparator per by_key group: compares that group's sorted left on_key array
         // against the current right batch's on_key array, used for binary search.
         let grouped_on_key_cmps: Vec<DynPartialComparator> = build_state
@@ -373,13 +386,16 @@ impl AsofJoinProbeState {
             .as_ref()
             .map(|(h, eq)| (h, eq.as_ref()));
 
-        let right_on_key_arrs: Vec<Arc<dyn Array>> = self
-            .right_rbs_and_on_keys
-            .iter()
-            .map(|(_, on_key_arr)| on_key_arr.clone())
-            .collect();
+        // Owned snapshot (cheap Arc clones) so the per-row loop can hold `&mut self.best_match`.
+        let tie_cols: Vec<Arc<Vec<Series>>> = self.right_tie_cols.clone();
+        let mut cmp_cache: HashMap<(usize, usize), DynComparator> = HashMap::new();
 
         if dir == AsofJoinStrategy::Nearest {
+            let right_on_key_arrs: Vec<Arc<dyn Array>> = self
+                .right_rbs_and_on_keys
+                .iter()
+                .map(|(_, on_key_arr)| on_key_arr.clone())
+                .collect();
             let left_self_cmps: Vec<DynPartialComparator> = build_state
                 .grouped_sorted_materialized_on_keys
                 .iter()
@@ -411,23 +427,15 @@ impl AsofJoinProbeState {
                     update_nearest_match(
                         &mut self.best_match[bucket[pos] as usize],
                         &right_on_key_arrs,
+                        &tie_cols,
                         candidate,
+                        &mut cmp_cache,
                         sorted_on_key_arr.as_ref(),
                         pos,
                     )?;
                 }
             }
         } else {
-            let mut cmp_cache: HashMap<(usize, usize), DynPartialComparator> = HashMap::new();
-            cmp_cache.insert(
-                (rb_idx, rb_idx),
-                build_partial_compare_with_nulls(
-                    right_on_arr.as_ref(),
-                    right_on_arr.as_ref(),
-                    false,
-                )?,
-            );
-
             for right_idx in 0..right_rb.len() {
                 if !right_on_arr.is_valid(right_idx) {
                     continue;
@@ -451,7 +459,7 @@ impl AsofJoinProbeState {
                 };
                 update_best_match(
                     &mut self.best_match[matched_left_idx],
-                    &right_on_key_arrs,
+                    &tie_cols,
                     MatchCandidate {
                         rb_idx,
                         row_idx: right_idx,
@@ -472,11 +480,47 @@ struct MatchCandidate {
     row_idx: usize,
 }
 
+/// Columns for the equal-on-key tie-break: the on-key, then every totally-orderable column of the
+/// *pruned* (output) right batch in schema order. Only output columns matter -- two rows equal on
+/// them are interchangeable in the result -- and reusing the pruned batch pins no extra buffers.
+/// Non-orderable columns (nested, Python) are skipped, so candidates differing only in those keep
+/// an arbitrary pick, and the winner can change if the output columns change (not a cross-schema
+/// contract).
+fn build_tie_cols(on_key_series: &Series, pruned_rb: &RecordBatch) -> Vec<Series> {
+    let mut cols = vec![on_key_series.clone()];
+    for s in pruned_rb.as_materialized_series() {
+        if is_totally_ordered_scalar(s.data_type()) {
+            cols.push(s.clone());
+        }
+    }
+    cols
+}
+
+/// Whether a dtype has a total order the comparison kernels support (`make_daft_comparator`): the
+/// scalar, unambiguously-orderable types. Nested and Python types are excluded.
+fn is_totally_ordered_scalar(dtype: &DaftDataType) -> bool {
+    if let DaftDataType::Extension(_, inner, _) = dtype {
+        return is_totally_ordered_scalar(inner);
+    }
+    dtype.is_numeric()
+        || dtype.is_temporal()
+        || matches!(
+            dtype,
+            DaftDataType::Boolean
+                | DaftDataType::Utf8
+                | DaftDataType::Binary
+                | DaftDataType::FixedSizeBinary(_)
+                | DaftDataType::Decimal128(..)
+                | DaftDataType::Time(..)
+                | DaftDataType::Duration(..)
+        )
+}
+
 fn update_best_match(
     slot: &mut Option<(u32, u32)>,
-    on_key_arrs: &[Arc<dyn Array>],
+    tie_cols: &[Arc<Vec<Series>>],
     candidate: MatchCandidate,
-    cmp_cache: &mut HashMap<(usize, usize), DynPartialComparator>,
+    cmp_cache: &mut HashMap<(usize, usize), DynComparator>,
     dir: AsofJoinStrategy,
 ) -> DaftResult<()> {
     let preferred_ordering = match dir {
@@ -492,7 +536,7 @@ fn update_best_match(
                 rb_idx: existing_rb_idx as usize,
                 row_idx: existing_right_idx as usize,
             },
-            on_key_arrs,
+            tie_cols,
             cmp_cache,
             preferred_ordering,
         )?,
@@ -506,22 +550,42 @@ fn update_best_match(
 fn update_nearest_match(
     slot: &mut Option<(u32, u32)>,
     on_key_arrs: &[Arc<dyn Array>],
+    tie_cols: &[Arc<Vec<Series>>],
     candidate: MatchCandidate,
+    cmp_cache: &mut HashMap<(usize, usize), DynComparator>,
     left_on_arr: &dyn Array,
     left_on_idx: usize,
 ) -> DaftResult<()> {
-    let nearer = match *slot {
+    let take = match *slot {
         None => true,
-        Some((existing_rb_idx, existing_right_idx)) => is_nearer(
-            on_key_arrs[candidate.rb_idx].as_ref(),
-            candidate.row_idx,
-            on_key_arrs[existing_rb_idx as usize].as_ref(),
-            existing_right_idx as usize,
-            left_on_arr,
-            left_on_idx,
-        ),
+        Some((existing_rb_idx, existing_right_idx)) => {
+            let existing = MatchCandidate {
+                rb_idx: existing_rb_idx as usize,
+                row_idx: existing_right_idx as usize,
+            };
+            let is_nearer_arg = |a: MatchCandidate, b: MatchCandidate| {
+                is_nearer(
+                    on_key_arrs[a.rb_idx].as_ref(),
+                    a.row_idx,
+                    on_key_arrs[b.rb_idx].as_ref(),
+                    b.row_idx,
+                    left_on_arr,
+                    left_on_idx,
+                )
+            };
+            if is_nearer_arg(candidate, existing) {
+                true
+            } else if is_nearer_arg(existing, candidate) {
+                false
+            } else {
+                // Neither is nearer: identical distance and on-key. Break the tie deterministically
+                // by keeping the greater tie-break row (consistent with the forward/larger-wins
+                // convention `is_nearer` already applies to equal-distance, unequal-on-key pairs).
+                is_candidate_better(candidate, existing, tie_cols, cmp_cache, Ordering::Greater)?
+            }
+        }
     };
-    if nearer {
+    if take {
         *slot = Some((candidate.rb_idx as u32, candidate.row_idx as u32));
     }
     Ok(())
@@ -530,19 +594,26 @@ fn update_nearest_match(
 fn is_candidate_better(
     candidate: MatchCandidate,
     existing: MatchCandidate,
-    on_key_arrs: &[Arc<dyn Array>],
-    cmp_cache: &mut HashMap<(usize, usize), DynPartialComparator>,
+    tie_cols: &[Arc<Vec<Series>>],
+    cmp_cache: &mut HashMap<(usize, usize), DynComparator>,
     preferred_ordering: Ordering,
 ) -> DaftResult<bool> {
     let cmp = match cmp_cache.entry((candidate.rb_idx, existing.rb_idx)) {
         Entry::Occupied(e) => e.into_mut(),
-        Entry::Vacant(e) => e.insert(build_partial_compare_with_nulls(
-            on_key_arrs[candidate.rb_idx].as_ref(),
-            on_key_arrs[existing.rb_idx].as_ref(),
-            false,
-        )?),
+        Entry::Vacant(e) => {
+            let cand_cols = tie_cols[candidate.rb_idx].as_slice();
+            // Ascending, nulls-last on every column; the winner direction comes from
+            // `preferred_ordering` at the comparison below.
+            let descending = vec![false; cand_cols.len()];
+            e.insert(build_multi_array_bicompare(
+                cand_cols,
+                tie_cols[existing.rb_idx].as_slice(),
+                &descending,
+                &descending,
+            )?)
+        }
     };
-    Ok(cmp(candidate.row_idx, existing.row_idx) == Some(preferred_ordering))
+    Ok(cmp(candidate.row_idx, existing.row_idx) == preferred_ordering)
 }
 
 fn forward_fill(global_best: &mut [Option<(u32, u32)>], grouped_sorted_indices: &GroupIndices) {
@@ -796,6 +867,7 @@ impl JoinOperator for AsofJoinOperator {
             build_contents: finalized_build_state,
             best_match: vec![None::<(u32, u32)>; n],
             right_rbs_and_on_keys: Vec::new(),
+            right_tie_cols: Vec::new(),
         }
     }
 
@@ -878,6 +950,7 @@ impl JoinOperator for AsofJoinOperator {
 
                     let mut global_rb_offsets: Vec<usize> = Vec::with_capacity(states.len());
                     let mut global_right_on_key_arrs: Vec<Arc<dyn Array>> = Vec::new();
+                    let mut global_right_tie_cols: Vec<Arc<Vec<Series>>> = Vec::new();
                     let mut state_best_matches: Vec<Vec<Option<(u32, u32)>>> =
                         Vec::with_capacity(states.len());
                     let mut global_right_rbs: Vec<RecordBatch> = Vec::new();
@@ -890,10 +963,12 @@ impl JoinOperator for AsofJoinOperator {
                             global_right_on_key_arrs.push(on_key_arr);
                             global_right_rbs.push(rb);
                         }
+                        global_right_tie_cols.extend(state.right_tie_cols);
                         state_best_matches.push(state.best_match);
                     }
 
                     let global_right_on_key_arrs = Arc::new(global_right_on_key_arrs);
+                    let global_right_tie_cols = Arc::new(global_right_tie_cols);
                     let global_rb_offsets = Arc::new(global_rb_offsets);
                     let state_best_matches = Arc::new(state_best_matches);
 
@@ -907,12 +982,13 @@ impl JoinOperator for AsofJoinOperator {
                             let end = (start + rows_per_chunk).min(total_left_rows);
                             let mut chunk: Vec<Option<(u32, u32)>> = vec![None; end - start];
                             let global_right_on_key_arrs = global_right_on_key_arrs.clone();
+                            let global_right_tie_cols = global_right_tie_cols.clone();
                             let global_rb_offsets = global_rb_offsets.clone();
                             let state_best_matches = state_best_matches.clone();
                             let left_on_arr = left_on_arr.clone();
 
                             get_compute_runtime().spawn(async move {
-                                let mut cmp_cache: HashMap<(usize, usize), DynPartialComparator> =
+                                let mut cmp_cache: HashMap<(usize, usize), DynComparator> =
                                     HashMap::new();
 
                                 for (chunk_row_idx, curr_best_match) in chunk.iter_mut().enumerate()
@@ -938,7 +1014,9 @@ impl JoinOperator for AsofJoinOperator {
                                                 update_nearest_match(
                                                     curr_best_match,
                                                     &global_right_on_key_arrs,
+                                                    &global_right_tie_cols,
                                                     candidate,
+                                                    &mut cmp_cache,
                                                     left_on_arr
                                                         .as_deref()
                                                         .expect("left_on_arr required for Nearest"),
@@ -948,7 +1026,7 @@ impl JoinOperator for AsofJoinOperator {
                                             _ => {
                                                 update_best_match(
                                                     curr_best_match,
-                                                    &global_right_on_key_arrs,
+                                                    &global_right_tie_cols,
                                                     candidate,
                                                     &mut cmp_cache,
                                                     strategy,

--- a/tests/dataframe/test_asof_join.py
+++ b/tests/dataframe/test_asof_join.py
@@ -282,13 +282,11 @@ class TestAsofJoinBackwardMatchCorrectness:
         assert result.to_pydict() == {"ts": [6, 6, 11], "v": [1, 2, 3], "w": [40, 40, 80]}
 
     def test_duplicate_right_timestamps(self):
-        """Multiple right rows at same timestamp -- one is picked."""
+        """Multiple right rows at the same timestamp -- backward deterministically keeps the greatest."""
         left = daft.from_pydict({"ts": [7], "v": [1]})
         right = daft.from_pydict({"ts": [7, 7], "w": [70, 77]})
         result = left.join_asof(right, on="ts")
-        assert result.to_pydict()["ts"] == [7]
-        assert result.to_pydict()["v"] == [1]
-        assert result.to_pydict()["w"][0] in [70, 77]
+        assert result.to_pydict() == {"ts": [7], "v": [1], "w": [77]}
 
     @pytest.mark.parametrize("n_partitions", get_n_partitions())
     def test_trades_quotes_with_by(self, make_df, n_partitions, with_default_morsel_size):
@@ -955,3 +953,74 @@ class TestAsofJoinDistributed:
             # GOOG@10: right GOOG@7=70; GOOG@20: right GOOG@18=180
             "w": [80, 150, 70, 180],
         }
+
+
+# ---------------------------------------------------------------------------
+# 12. Deterministic tie-break on equal (by, on) right rows
+# ---------------------------------------------------------------------------
+
+
+class TestAsofJoinDeterministicTieBreak:
+    """Equal (by, on) right rows resolve deterministically regardless of partitioning.
+
+    Backward/nearest keep the greatest right row, forward the least.
+    """
+
+    @pytest.mark.parametrize("n_partitions", get_n_partitions())
+    def test_backward_keeps_greatest_with_by(self, make_df, n_partitions, with_default_morsel_size):
+        left = make_df({"ticker": ["A", "A", "B"], "ts": [10, 20, 10]}, repartition=n_partitions)
+        right = make_df(
+            {
+                "ticker": ["A", "A", "A", "B", "B"],
+                "ts": [5, 5, 15, 5, 5],
+                "w": [1, 3, 99, 7, 4],
+            },
+            repartition=n_partitions,
+        )
+        result = left.join_asof(right, on="ts", by="ticker").sort(["ticker", "ts"])
+        # A@10: right A ts<=10 is ts=5 (w in {1,3}) -> greatest 3; A@20: max ts=15 -> 99.
+        # B@10: right B ts<=10 is ts=5 (w in {7,4}) -> greatest 7.
+        assert result.to_pydict() == {"ticker": ["A", "A", "B"], "ts": [10, 20, 10], "w": [3, 99, 7]}
+
+    @pytest.mark.parametrize("n_partitions", get_n_partitions())
+    def test_forward_keeps_least_with_by(self, make_df, n_partitions, with_default_morsel_size):
+        left = make_df({"ticker": ["A", "B"], "ts": [10, 10]}, repartition=n_partitions)
+        right = make_df(
+            {"ticker": ["A", "A", "B", "B"], "ts": [15, 15, 12, 12], "w": [8, 2, 6, 4]},
+            repartition=n_partitions,
+        )
+        result = left.join_asof(right, on="ts", by="ticker", strategy="forward").sort(["ticker", "ts"])
+        # forward from @10: A -> ts=15 (w in {8,2}) least 2; B -> ts=12 (w in {6,4}) least 4.
+        assert result.to_pydict() == {"ticker": ["A", "B"], "ts": [10, 10], "w": [2, 4]}
+
+    @pytest.mark.parametrize("n_partitions", get_n_partitions())
+    def test_nearest_exact_key_tie_keeps_greatest(self, make_df, n_partitions, with_default_morsel_size):
+        left = make_df({"ticker": ["A", "B"], "ts": [10, 10]}, repartition=n_partitions)
+        right = make_df(
+            {"ticker": ["A", "A", "B", "B"], "ts": [10, 10, 10, 10], "w": [5, 9, 1, 3]},
+            repartition=n_partitions,
+        )
+        result = left.join_asof(right, on="ts", by="ticker", strategy="nearest").sort(["ticker", "ts"])
+        # exact-key tie (distance 0, same on-key) -> greatest w: A -> 9, B -> 3.
+        assert result.to_pydict() == {"ticker": ["A", "B"], "ts": [10, 10], "w": [9, 3]}
+
+    @pytest.mark.parametrize("strategy", ["backward", "forward", "nearest"])
+    @pytest.mark.parametrize("n_partitions", get_n_partitions())
+    def test_no_by_duplicate_keys_partition_invariant(self, make_df, strategy, n_partitions, with_default_morsel_size):
+        # Duplicate right on-keys with distinct payloads; some fall on partition boundaries, so this
+        # also exercises the no-by carryover tie-break. Result must match the single-partition run.
+        left_data = {"ts": list(range(0, 40, 2)), "v": list(range(20))}
+        right_data = {"ts": [5, 5, 15, 15, 25, 25, 35, 35], "w": [1, 2, 3, 4, 5, 6, 7, 8]}
+        result = (
+            make_df(left_data, repartition=n_partitions)
+            .join_asof(make_df(right_data, repartition=n_partitions), on="ts", strategy=strategy)
+            .sort("ts")
+            .to_pydict()
+        )
+        expected = (
+            daft.from_pydict(left_data)
+            .join_asof(daft.from_pydict(right_data), on="ts", strategy=strategy)
+            .sort("ts")
+            .to_pydict()
+        )
+        assert result == expected

--- a/tests/dataframe/test_asof_join_forward.py
+++ b/tests/dataframe/test_asof_join_forward.py
@@ -58,13 +58,11 @@ class TestAsofJoinForwardMatchCorrectness:
         assert result.to_pydict() == {"ts": [6, 6, 11], "v": [1, 2, 3], "w": [80, 80, 150]}
 
     def test_duplicate_right_timestamps(self):
-        """Multiple right rows at the same timestamp -- one is picked (either is valid)."""
+        """Multiple right rows at the same timestamp -- forward deterministically keeps the least."""
         left = daft.from_pydict({"ts": [7], "v": [1]})
         right = daft.from_pydict({"ts": [7, 7], "w": [70, 77]})
         result = left.join_asof(right, on="ts", strategy="forward")
-        assert result.to_pydict()["ts"] == [7]
-        assert result.to_pydict()["v"] == [1]
-        assert result.to_pydict()["w"][0] in [70, 77]
+        assert result.to_pydict() == {"ts": [7], "v": [1], "w": [70]}
 
     @pytest.mark.parametrize("n_partitions", get_n_partitions())
     def test_trades_quotes_with_by(self, make_df, n_partitions, with_default_morsel_size):


### PR DESCRIPTION
## Changes Made

**Bug:** `join_asof` output depends on partition count when several right rows share the same `(by, on)` key.

Among right rows tied on the `(by, on)` key, the operator kept whichever it saw first during the concurrent probe/cross-worker merge. That "first-seen" choice varies with how right batches split across workers and with the range-shuffle order, so the same query returns different right-side values at different partition counts. The old `test_duplicate_right_timestamps` even encoded this with `assert w[0] in [70, 77]`.

**Fix:** resolve equal-on-key ties by value instead of arrival order. Among equal-on-key candidates, keep the greatest right row for `backward`/`nearest` and the least for `forward`, compared lexicographically over the on-key and the right output columns. A per-key max/min over a total order is independent of execution order, so the result is partition-invariant. This matches pandas `merge_asof` (backward keeps the last matching row, forward the first).

Implementation:

- **`daft-local-execution`** (`join/asof_join.rs`): the tie-break folds into the existing per-batch-pair comparator — a single lexicographic compare over `[on_key] ++ right output columns` replaces the on-key-only compare in `is_candidate_better` (the `Option`/null handling drops out, since match candidates never have a null on-key). `nearest` keeps `is_nearer` for distance and only breaks exact `(distance, on-key)` ties by value. It compares the **pruned output** columns, which are already retained to build the join output, so the tie-break pins no additional memory. The fill passes are unchanged.
- **`daft-distributed`** (`pipeline_node/join/asof_join.rs`): a partition boundary can split rows tied on the boundary on-key across partitions, so the carryover must not drop any of them. The no-`by` carryover now keeps **every** row tied at the extreme on-key (whole-frame window + `filter(on == extreme)`), mirroring what the with-`by` carryover already did; both share one code path. The carryover therefore makes no tie-break decision of its own — the local operator stays the single source of truth — which removes the need to reproduce the tie-break order in the distributed layer.
- **`daft-core`**: exports `DynComparator` (already the return type of the public `build_multi_array_bicompare`).

**Behavior change:** duplicate-`(by, on)` results are now deterministic. Backward keeps the greatest row ("keep last"), so a pipeline that previously deduplicated the right side to one row per `(by, on)` before an asof join can drop that step and its shuffle.

Notes on the guarantee: two right rows equal on all orderable output columns but differing only in a non-orderable column (nested, Python) still get an arbitrary pick, and the chosen row can change if the right output columns change — it is "deterministic within a query," not a stable contract across schema changes. The docstring says as much.

## Testing

`TestAsofJoinDeterministicTieBreak` is the headline coverage. `test_no_by_duplicate_keys_partition_invariant` runs each strategy at 1/2/4/8 partitions and asserts the result matches the single-partition run (the property the bug violated, and the one that exercises the carryover). The class also pins the concrete winner per strategy with and without `by`, and the two tests that asserted "one is picked" now assert the deterministic winner.

Verified locally on both runners: full `tests/dataframe/test_asof_join*.py` under `DAFT_RUNNER=native` (977 passed) and `DAFT_RUNNER=ray` (1066 passed).

## Related Issues

None.
