### PR TITLE
fix: predicate prefilter drops rows silently when a column decoder panics

### DIFF
--- a/src/daft-parquet/src/read.rs
+++ b/src/daft-parquet/src/read.rs
@@ -639,6 +639,82 @@ mod tests {
         d.to_str().unwrap().to_string()
     }
 
+    /// Copy the local fixture to a temp path containing the test-only panic
+    /// marker (see `spawn_col_decoders`), so the decoder for column `col`
+    /// panics while other columns decode normally.
+    fn make_decoder_panic_fixture(tag: &str, col: &str) -> std::path::PathBuf {
+        // `--` terminates the column name so e.g. col `a` can't be matched
+        // by a marker targeting a hypothetical col `ab`.
+        let dst = std::env::temp_dir().join(format!(
+            "daft-{}-{tag}-inject-decoder-panic-{col}--.parquet",
+            std::process::id()
+        ));
+        std::fs::copy(get_local_parquet_path(), &dst).unwrap();
+        dst
+    }
+
+    /// A predicate-column decoder panic must fail the query. Before the
+    /// prefilter harvested its decoder tasks, the closed channel looked like
+    /// a normal stream end and the unprocessed rows were silently skipped.
+    #[test]
+    fn test_predicate_prefilter_decoder_panic_fails_query() -> DaftResult<()> {
+        use daft_dsl::{lit, resolved_col};
+
+        let io_client = Arc::new(IOClient::new(IOConfig::default().into())?);
+        let runtime = get_io_runtime(true);
+        // `resolved_col`: predicate pushdown (and thus the prefilter) only
+        // engages when `get_required_columns` sees resolved column refs.
+        let opts = ParquetReadOptions {
+            predicate: Some(resolved_col("a").gt(lit(2i64))),
+            ..Default::default()
+        };
+
+        // Panic only column `a`'s decoder — the predicate column. The data
+        // column `b` decodes normally, so an error can only come from the
+        // prefilter harvesting its decoders (pre-fix: 0-row success).
+        let marked = make_decoder_panic_fixture("prefilter", "a");
+        let result = runtime.block_on_current_thread(read_parquet_into_recordbatch(
+            marked.to_str().unwrap(),
+            io_client.clone(),
+            None,
+            opts.clone(),
+        ));
+        std::fs::remove_file(&marked).ok();
+        assert!(
+            result.is_err(),
+            "decoder panic must fail the query, not return fewer rows"
+        );
+
+        // Control: the same predicate on the unmarked fixture succeeds.
+        let table = runtime.block_on_current_thread(read_parquet_into_recordbatch(
+            &get_local_parquet_path(),
+            io_client,
+            None,
+            opts,
+        ))?;
+        assert_eq!(table.len(), 88);
+        Ok(())
+    }
+
+    /// Contrast case: a data-column decoder panic (no predicate) must also
+    /// fail the query — that path was already harvested via `combine_stream`.
+    #[test]
+    fn test_data_decoder_panic_fails_query() -> DaftResult<()> {
+        let io_client = Arc::new(IOClient::new(IOConfig::default().into())?);
+        let runtime = get_io_runtime(true);
+
+        let marked = make_decoder_panic_fixture("datacol", "b");
+        let result = runtime.block_on_current_thread(read_parquet_into_recordbatch(
+            marked.to_str().unwrap(),
+            io_client,
+            None,
+            ParquetReadOptions::default(),
+        ));
+        std::fs::remove_file(&marked).ok();
+        assert!(result.is_err(), "decoder panic must fail the query");
+        Ok(())
+    }
+
     #[test]
     fn test_parquet_read_from_s3() -> DaftResult<()> {
         let mut io_config = IOConfig::default();

--- a/src/daft-parquet/src/reader/mod.rs
+++ b/src/daft-parquet/src/reader/mod.rs
@@ -12,7 +12,7 @@ use arrow::{array::ArrayRef, datatypes::Schema as ArrowSchema};
 use chunk_source::{
     ChunkSource, ChunkSourceBuilder, LocalChunkSource, open_local_file, prepare_remote_chunk_source,
 };
-use common_error::DaftResult;
+use common_error::{DaftError, DaftResult};
 use common_runtime::{JoinSet, get_compute_runtime};
 use daft_core::prelude::*;
 use daft_dsl::{ExprRef, expr::bound_expr::BoundExpr, optimization::get_required_columns};
@@ -314,6 +314,52 @@ struct RgInputs {
     pred_arrays: Vec<ArrayRef>,
 }
 
+/// How the prefilter recv loop exited (its `?` error paths return instead,
+/// relying on abort-on-drop to cancel the decoders).
+enum PrefilterExit {
+    /// Every decoder channel closed — must harvest before reporting success.
+    DecoderEof,
+    /// The row limit was hit mid-stream — remaining decoder output is unused.
+    LimitReached,
+}
+
+/// Finish the per-RG predicate-column decoders after the prefilter recv loop.
+///
+/// EOF is the only loop exit that reports success without having seen every
+/// decoder finish: a panicked decoder drops its channel sender, which
+/// `recv_one_chunk` cannot distinguish from a normal stream end. Reporting
+/// success there without harvesting would let the skip-padding in
+/// `build_rg_inputs` silently drop the unprocessed rows. So on EOF, join every
+/// decoder (panics surface as `Err`) and require that every selected row was
+/// processed. Early exits (limit reached, error) keep abort-on-drop instead:
+/// decoders may still be blocked in column I/O, their remaining output cannot
+/// affect the query, and waiting on them would only delay cancellation.
+///
+/// Callers must drop the column receivers first: decoders block on `tx.send`
+/// (capacity-1 channels), so joining with receivers alive deadlocks.
+async fn harvest_prefilter_decoders(
+    exit: PrefilterExit,
+    mut col_handles: JoinSet<DaftResult<()>>,
+    processed_rows: usize,
+    total_selected: usize,
+    path: &str,
+) -> DaftResult<()> {
+    match exit {
+        // Dropping the JoinSet aborts the remaining decoders.
+        PrefilterExit::LimitReached => return Ok(()),
+        // A new exit reason must explicitly choose: cancel or harvest.
+        PrefilterExit::DecoderEof => {}
+    }
+    col_handles.join_all().await?;
+    if processed_rows != total_selected {
+        return Err(DaftError::InternalError(format!(
+            "Parquet predicate prefilter on {path} ended early: processed {processed_rows} of \
+             {total_selected} selected rows"
+        )));
+    }
+    Ok(())
+}
+
 /// Build the per-RG input bundles for the streaming decoder.
 ///
 /// Without a pushed predicate prefilter, this just forwards offset/delete/limit
@@ -374,7 +420,7 @@ async fn build_rg_inputs(
             .map(|s| s.row_count())
             .unwrap_or_else(|| metadata.row_group(rg_idx).num_rows() as usize);
 
-        let (mut col_receivers, _col_handles) = spawn_col_decoders(
+        let (mut col_receivers, col_handles) = spawn_col_decoders(
             &plan.pred_col_indices,
             chunk_source,
             metadata,
@@ -392,9 +438,9 @@ async fn build_rg_inputs(
             .collect();
         let mut processed_rows = 0usize;
 
-        loop {
+        let exit = loop {
             let Some(chunks) = recv_one_chunk(&mut col_receivers).await? else {
-                break;
+                break PrefilterExit::DecoderEof;
             };
             let chunk_rows = chunks[0].len();
             let daft_pred =
@@ -419,11 +465,13 @@ async fn build_rg_inputs(
             processed_rows += chunk_rows;
             selected_rows_remaining -= selected_rows;
             if selected_rows_remaining == 0 {
-                break;
+                break PrefilterExit::LimitReached;
             }
-        }
-        // Dropping receivers closes the channels → spawned decoders abort.
+        };
+        // Receivers must close before harvesting: decoders block on `tx.send`
+        // (capacity-1 channels), so joining with receivers alive deadlocks.
         drop(col_receivers);
+        harvest_prefilter_decoders(exit, col_handles, processed_rows, total_selected, path).await?;
 
         // Concat per-col filtered chunks into one ArrayRef per col. Zero rows
         // processed (e.g. base_sel selected 0 rows) → empty array of the col's
@@ -645,4 +693,83 @@ pub async fn stream_parquet(
     let stream = build_rg_stream(ctx, rg_indices, rg_inputs);
 
     Ok((return_schema, apply_cross_rg_limit(stream, opts.num_rows)))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use common_error::{DaftError, DaftResult};
+    use common_runtime::JoinSet;
+    use tokio::time::timeout;
+
+    use super::{PrefilterExit, harvest_prefilter_decoders};
+
+    #[tokio::test]
+    async fn harvest_surfaces_decoder_panic_on_eof() {
+        let mut handles: JoinSet<DaftResult<()>> = JoinSet::new();
+        handles.spawn(async { panic!("injected decoder panic") });
+        let res =
+            harvest_prefilter_decoders(PrefilterExit::DecoderEof, handles, 10, 10, "test.parquet")
+                .await;
+        assert!(res.is_err(), "decoder panic must fail the prefilter");
+    }
+
+    #[tokio::test]
+    async fn harvest_rejects_missing_rows_on_eof() {
+        let mut handles: JoinSet<DaftResult<()>> = JoinSet::new();
+        handles.spawn(async { Ok(()) });
+        let res =
+            harvest_prefilter_decoders(PrefilterExit::DecoderEof, handles, 7, 10, "test.parquet")
+                .await;
+        assert!(matches!(res, Err(DaftError::InternalError(_))));
+    }
+
+    #[tokio::test]
+    async fn harvest_accepts_clean_eof() {
+        let mut handles: JoinSet<DaftResult<()>> = JoinSet::new();
+        handles.spawn(async { Ok(()) });
+        harvest_prefilter_decoders(PrefilterExit::DecoderEof, handles, 10, 10, "test.parquet")
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn harvest_joins_decoders_that_exit_on_closed_channel() {
+        // Guards the helper's contract for any caller: a decoder blocked on
+        // `tx.send` must exit Ok once the receiver drops, so harvesting after
+        // `drop(col_receivers)` cannot hang. (At the current EOF call site all
+        // senders are provably closed already; this is defense-in-depth.)
+        let (tx, rx) = tokio::sync::mpsc::channel::<DaftResult<()>>(1);
+        let mut handles: JoinSet<DaftResult<()>> = JoinSet::new();
+        handles.spawn(async move {
+            let _ = tx.send(Ok(())).await;
+            let _ = tx.send(Ok(())).await;
+            Ok(())
+        });
+        drop(rx);
+        timeout(
+            Duration::from_secs(5),
+            harvest_prefilter_decoders(PrefilterExit::DecoderEof, handles, 5, 5, "test.parquet"),
+        )
+        .await
+        .expect("harvest must not hang once receivers are dropped")
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn harvest_aborts_decoders_after_limit_early_stop() {
+        let mut handles: JoinSet<DaftResult<()>> = JoinSet::new();
+        handles.spawn(async {
+            futures::future::pending::<()>().await;
+            Ok(())
+        });
+        timeout(
+            Duration::from_secs(5),
+            harvest_prefilter_decoders(PrefilterExit::LimitReached, handles, 3, 10, "test.parquet"),
+        )
+        .await
+        .expect("limit early-stop must not wait for decoders")
+        .unwrap();
+    }
 }

--- a/src/daft-parquet/src/reader/rg_processor.rs
+++ b/src/daft-parquet/src/reader/rg_processor.rs
@@ -4,7 +4,7 @@ use arrow::{
     array::{Array, ArrayRef},
     datatypes::Schema as ArrowSchema,
 };
-use common_error::DaftResult;
+use common_error::{DaftError, DaftResult};
 use common_runtime::{JoinSet, get_compute_runtime};
 use daft_core::prelude::*;
 use daft_dsl::expr::bound_expr::BoundExpr;
@@ -33,17 +33,33 @@ fn err_stream<T: Send + 'static>(e: common_error::DaftError) -> BoxStream<'stati
 /// Recv one chunk from each column receiver in lockstep.
 ///
 /// - `Ok(Some(v))` — every receiver yielded; `v` is the per-col array slice for this chunk.
-/// - `Err(e)` — a receiver propagated a decode error.
-/// - `Ok(None)` — at least one receiver closed (stream end). Decoders close their
-///   channel after the final chunk, so the first `None` we see ends the RG.
+/// - `Err(e)` — a receiver propagated a decode error, or the receivers went out
+///   of lockstep (some closed while others yielded — a decoder exited early).
+/// - `Ok(None)` — every receiver closed (stream end). A closed channel alone
+///   does not prove a clean finish — a panicked decoder also drops its sender —
+///   so callers that report success on EOF must also harvest the decoder tasks.
 pub(super) async fn recv_one_chunk(receivers: &mut [ColRx]) -> DaftResult<Option<Vec<ArrayRef>>> {
-    try_join_all(
+    // Zero receivers would return `Ok(Some(vec![]))` forever; every caller
+    // spawns at least one decoder column.
+    debug_assert!(!receivers.is_empty());
+    let chunks = try_join_all(
         receivers
             .iter_mut()
             .map(|r| async { r.recv().await.transpose() }),
     )
-    .await
-    .map(|chunks| chunks.into_iter().collect())
+    .await?;
+    let closed = chunks.iter().filter(|c| c.is_none()).count();
+    if closed == 0 {
+        Ok(Some(chunks.into_iter().flatten().collect()))
+    } else if closed == chunks.len() {
+        Ok(None)
+    } else {
+        Err(DaftError::InternalError(
+            "Parquet column decoders went out of lockstep: some columns ended while others still \
+             had chunks (a column decoder may have exited early)"
+                .to_string(),
+        ))
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -75,6 +91,17 @@ pub(super) async fn spawn_col_decoders(
         let col_leaves: Arc<[usize]> = leaves_for_top_fields(metadata.as_ref(), &[col_idx]).into();
         joinset.spawn_on(
             async move {
+                // Test-only injection: a file path containing this marker
+                // panics the decoder task for the named column, simulating a
+                // decoder bug. Keyed off the path so parallel tests don't
+                // interfere, and off the column so a test can target the
+                // predicate-prefilter decoders without also tripping the
+                // data-column ones.
+                #[cfg(test)]
+                assert!(
+                    !path.contains(&format!("inject-decoder-panic-{}--", arrow_field.name())),
+                    "injected decoder panic"
+                );
                 let chunks = match rg_reader.read_col(col_leaves).await {
                     Ok(c) => c,
                     Err(e) => {
@@ -309,4 +336,52 @@ pub(super) async fn process_rg_predicate_only(
     .boxed();
 
     common_runtime::combine_stream(stream, async move { col_decoders.join_all().await }).boxed()
+}
+
+#[cfg(test)]
+mod tests {
+    use arrow::array::Int64Array;
+
+    use super::*;
+
+    fn arr() -> ArrayRef {
+        Arc::new(Int64Array::from(vec![1, 2, 3]))
+    }
+
+    #[tokio::test]
+    async fn recv_one_chunk_lockstep_then_eof() {
+        let (tx1, rx1) = mpsc::channel(1);
+        let (tx2, rx2) = mpsc::channel(1);
+        tx1.send(Ok(arr())).await.unwrap();
+        tx2.send(Ok(arr())).await.unwrap();
+        drop(tx1);
+        drop(tx2);
+        let mut rxs = vec![rx1, rx2];
+        let chunk = recv_one_chunk(&mut rxs).await.unwrap();
+        assert_eq!(chunk.map(|c| c.len()), Some(2));
+        assert!(recv_one_chunk(&mut rxs).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn recv_one_chunk_mixed_closure_is_error() {
+        // One column still has a chunk while the other already closed — a
+        // decoder exited early (e.g. panicked); must not look like clean EOF.
+        let (tx1, rx1) = mpsc::channel(1);
+        let (tx2, rx2) = mpsc::channel::<DaftResult<ArrayRef>>(1);
+        tx1.send(Ok(arr())).await.unwrap();
+        drop(tx1);
+        drop(tx2);
+        let mut rxs = vec![rx1, rx2];
+        assert!(recv_one_chunk(&mut rxs).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn recv_one_chunk_propagates_decode_error() {
+        let (tx1, rx1) = mpsc::channel::<DaftResult<ArrayRef>>(1);
+        tx1.send(Err(DaftError::InternalError("decode failed".to_string())))
+            .await
+            .unwrap();
+        let mut rxs = vec![rx1];
+        assert!(recv_one_chunk(&mut rxs).await.is_err());
+    }
 }


### PR DESCRIPTION
## Changes Made

The two-phase Parquet predicate prefilter (`build_rg_inputs`) spawned per-column decoder tasks but discarded the returned `JoinSet`. When a decoder task **panicked**, its channel sender was dropped during unwind, which `recv_one_chunk` reported as a normal stream end (`Ok(None)`). The prefilter loop then broke, appended `total_selected - processed_rows` as a `RowSelector::skip(...)`, and the query **returned successfully with silently missing rows**. (Ordinary decode failures return `Err` through the channel and already propagated correctly; the gap was panics only. The data-column paths were already safe via `combine_stream(..., col_decoders.join_all())` — this closes the same gap in the prefilter phase.)

### Fix: EOF success barrier + fast cancel

- **Decoder EOF** is the only loop exit that reports success without having seen every decoder finish, so it must prove a clean finish before the skip-padding can be trusted:
  1. `drop(col_receivers)` — must precede joining: decoders block on `tx.send` (capacity-1 channels), so the order is deadlock-critical (documented at the call site);
  2. `col_handles.join_all()` — a panic surfaces as `JoinError` → query error;
  3. row-count invariant `processed_rows == total_selected` — also catches a decoder that exits early *without* panicking, and prevents the skip-padding from legalizing it.
- **Limit early-stop and `?` error paths keep abort-on-drop** (unchanged cancellation semantics): decoders may still be blocked in whole-column I/O, and their remaining output cannot affect the query, so waiting on them would only delay cancellation — no performance regression on these paths.
- **`recv_one_chunk` lockstep protocol strengthened**: all-`Some` = chunk, all-`None` = EOF, and a `Some`/`None` mix (a decoder exited early while sibling columns still stream) is now an error instead of a silent EOF. Healthy decoders always close in lockstep since chunk boundaries are driven by the same `chunk_size` and selection. Its doc comment — which previously *defined* a closed channel as stream end, the semantic root of this bug — is rewritten accordingly.
- Exit reasons use a `PrefilterExit` enum with exhaustive matching, so a future third exit reason must explicitly choose between cancel and harvest.

### Tests

- Unit tests for the harvest helper (panic surfaces on EOF, row-count invariant, clean EOF, no hang once receivers drop, limit early-stop does not wait — timeout-guarded) and for the lockstep protocol (chunk/EOF/mixed/error propagation).
- End-to-end regression tests via a test-only (`#[cfg(test)]`), path-keyed and column-targeted panic injection in `spawn_col_decoders` (marker `inject-decoder-panic-{col}--` in the file path; no global state, parallel-test safe):
  - predicate-column decoder panic with a pushed-down predicate → query must error, not return fewer rows;
  - data-column decoder panic (no predicate) → query errors (regression guard for the already-correct `combine_stream` path).
- The prefilter E2E test was verified to be discriminating: with the harvest step disabled (simulating pre-fix behavior) the query returned **`Ok` with 0 rows** — exactly the silent row loss — and the test failed; with the fix it errors with the decoder's `JoinError`.

Known coverage note: the harvest helper and the protocol are unit-tested and the E2E tests cover the full chain; there is no unit test asserting the internal wiring of `build_rg_inputs` in isolation (the E2E tests are what guard it).

## Related Issues

Closes #7285

https://claude.ai/code/session_01H3HGmK8s37SmtzZDNBdSH7