### PR TITLE
fix(parquet): honor row-group constraints in count_rows() count pushdown

### DIFF
--- a/src/daft-local-execution/src/sources/scan_task_reader.rs
+++ b/src/daft-local-execution/src/sources/scan_task_reader.rs
@@ -114,16 +114,10 @@ async fn read_parquet(
     if let Some(aggregation) = &scan_task.pushdowns.aggregation
         && let Expr::Agg(AggExpr::Count(_, count_mode)) = aggregation.as_ref()
     {
-        // The metadata count shortcut derives a total row count from parquet
-        // metadata; it cannot apply any row-level processing (non-`All` count
-        // modes, filters, limits, delete rows). The optimizer
-        // (`PushDownAggregation::can_pushdown`) and scan materialization
-        // guarantee none of these reach here for built-in sources. If a custom
-        // ScanOperator ever breaks that invariant, error loudly rather than
-        // silently returning a wrong count. Falling back to the normal read path
-        // is not safe: after aggregation pushdown the schema is a single count
-        // field, so a zero-column batch would be filled with nulls and `SUM`
-        // would yield null instead of a count.
+        // The optimizer guarantees built-in sources never reach here with row-level
+        // processing. Error loudly if a custom ScanOperator breaks that: falling back
+        // isn't safe, since the post-pushdown schema is a single count field and
+        // `SUM` over a null-filled batch yields null instead of a count.
         let has_deletes = delete_map
             .as_ref()
             .and_then(|m| m.get(url))
@@ -172,18 +166,9 @@ async fn read_parquet(
     .await
 }
 
-/// Returns `Some(reason)` if the given count aggregation cannot be served by the
-/// parquet metadata count shortcut and must error instead of silently returning
-/// a wrong count. The shortcut only produces a total row count from metadata, so
-/// any row-level processing is unsupported:
-/// - a count mode other than `CountMode::All` (needs per-value null info),
-/// - a pushed-down filter (rows must be counted after filtering),
-/// - a limit (a global, cross-task semantic the shortcut can't honor),
-/// - delete rows (rows must be excluded before counting).
-///
-/// Built-in sources never reach the shortcut with any of these (the optimizer
-/// and scan materialization prevent it); this guards against custom
-/// ScanOperators that bypass those invariants.
+/// Returns `Some(reason)` if the count can't be served from parquet metadata alone.
+/// A non-`All` count mode, filter, limit, or delete rows all require row-level
+/// processing the metadata shortcut can't do.
 fn parquet_count_pushdown_unsupported_reason(
     count_mode: &daft_core::count_mode::CountMode,
     pushdowns: &daft_scan::Pushdowns,

--- a/src/daft-local-execution/src/sources/scan_task_reader.rs
+++ b/src/daft-local-execution/src/sources/scan_task_reader.rs
@@ -106,23 +106,45 @@ async fn read_parquet(
 ) -> DaftResult<BoxStream<'static, DaftResult<RecordBatch>>> {
     let source = scan_task.sources.first().unwrap();
 
+    let row_groups = match source.get_chunk_spec() {
+        Some(ChunkSpec::Parquet(rgs)) => Some(rgs.clone()),
+        _ => None,
+    };
+
     if let Some(aggregation) = &scan_task.pushdowns.aggregation
-        && let Expr::Agg(AggExpr::Count(_, _)) = aggregation.as_ref()
+        && let Expr::Agg(AggExpr::Count(_, count_mode)) = aggregation.as_ref()
     {
+        // The metadata count shortcut derives a total row count from parquet
+        // metadata; it cannot apply any row-level processing (non-`All` count
+        // modes, filters, limits, delete rows). The optimizer
+        // (`PushDownAggregation::can_pushdown`) and scan materialization
+        // guarantee none of these reach here for built-in sources. If a custom
+        // ScanOperator ever breaks that invariant, error loudly rather than
+        // silently returning a wrong count. Falling back to the normal read path
+        // is not safe: after aggregation pushdown the schema is a single count
+        // field, so a zero-column batch would be filled with nulls and `SUM`
+        // would yield null instead of a count.
+        let has_deletes = delete_map
+            .as_ref()
+            .and_then(|m| m.get(url))
+            .is_some_and(|d| !d.is_empty());
+        if let Some(reason) =
+            parquet_count_pushdown_unsupported_reason(count_mode, &scan_task.pushdowns, has_deletes)
+        {
+            return Err(common_error::DaftError::InternalError(reason));
+        }
+
         return count_pushdown_stream(
             url,
             io_client,
             io_stats,
             cfg.field_id_mapping.clone(),
             aggregation,
+            row_groups,
         )
         .await;
     }
 
-    let row_groups = match source.get_chunk_spec() {
-        Some(ChunkSpec::Parquet(rgs)) => Some(rgs.clone()),
-        _ => None,
-    };
     let opts = ParquetReadOptions {
         columns: file_column_names,
         num_rows: scan_task.pushdowns.limit,
@@ -150,12 +172,47 @@ async fn read_parquet(
     .await
 }
 
+/// Returns `Some(reason)` if the given count aggregation cannot be served by the
+/// parquet metadata count shortcut and must error instead of silently returning
+/// a wrong count. The shortcut only produces a total row count from metadata, so
+/// any row-level processing is unsupported:
+/// - a count mode other than `CountMode::All` (needs per-value null info),
+/// - a pushed-down filter (rows must be counted after filtering),
+/// - a limit (a global, cross-task semantic the shortcut can't honor),
+/// - delete rows (rows must be excluded before counting).
+///
+/// Built-in sources never reach the shortcut with any of these (the optimizer
+/// and scan materialization prevent it); this guards against custom
+/// ScanOperators that bypass those invariants.
+fn parquet_count_pushdown_unsupported_reason(
+    count_mode: &daft_core::count_mode::CountMode,
+    pushdowns: &daft_scan::Pushdowns,
+    has_deletes: bool,
+) -> Option<String> {
+    if !matches!(count_mode, daft_core::count_mode::CountMode::All) {
+        return Some(format!(
+            "unsupported count mode for parquet count pushdown: {count_mode:?}"
+        ));
+    }
+    if pushdowns.filters.is_some() {
+        return Some("parquet metadata count pushdown cannot apply row-level filters".to_string());
+    }
+    if pushdowns.limit.is_some() {
+        return Some("parquet metadata count pushdown cannot apply a limit".to_string());
+    }
+    if has_deletes {
+        return Some("parquet metadata count pushdown cannot apply delete rows".to_string());
+    }
+    None
+}
+
 async fn count_pushdown_stream(
     url: &str,
     io_client: Arc<daft_io::IOClient>,
     io_stats: IOStatsRef,
     field_id_mapping: Option<Arc<std::collections::BTreeMap<i32, daft_core::prelude::Field>>>,
     aggregation: &daft_dsl::ExprRef,
+    row_groups: Option<Vec<i64>>,
 ) -> DaftResult<BoxStream<'static, DaftResult<RecordBatch>>> {
     daft_parquet::read::stream_parquet_count_pushdown(
         url,
@@ -163,6 +220,7 @@ async fn count_pushdown_stream(
         Some(io_stats),
         field_id_mapping,
         aggregation,
+        row_groups.as_deref(),
     )
     .await
 }
@@ -345,4 +403,55 @@ async fn read_python_function(
     let iter = daft_micropartition::python::read_pyfunc_into_table_iter(scan_task.clone())?;
     let stream = futures::stream::iter(iter.map(|r| r.map_err(|e| e.into())));
     Ok(Box::pin(stream))
+}
+
+#[cfg(test)]
+mod tests {
+    use daft_core::count_mode::CountMode;
+    use daft_scan::Pushdowns;
+
+    use super::parquet_count_pushdown_unsupported_reason;
+
+    #[test]
+    fn count_all_no_pushdowns_is_supported() {
+        let reason = parquet_count_pushdown_unsupported_reason(
+            &CountMode::All,
+            &Pushdowns::default(),
+            false,
+        );
+        assert_eq!(reason, None);
+    }
+
+    #[test]
+    fn non_all_count_mode_errors() {
+        for mode in [CountMode::Valid, CountMode::Null] {
+            let reason =
+                parquet_count_pushdown_unsupported_reason(&mode, &Pushdowns::default(), false);
+            assert!(
+                reason.is_some_and(|r| r.contains("count mode")),
+                "expected count-mode error for {mode:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn filter_errors() {
+        let pushdowns = Pushdowns::default().with_filters(Some(daft_dsl::lit(true)));
+        let reason = parquet_count_pushdown_unsupported_reason(&CountMode::All, &pushdowns, false);
+        assert!(reason.is_some_and(|r| r.contains("filter")));
+    }
+
+    #[test]
+    fn limit_errors() {
+        let pushdowns = Pushdowns::default().with_limit(Some(10));
+        let reason = parquet_count_pushdown_unsupported_reason(&CountMode::All, &pushdowns, false);
+        assert!(reason.is_some_and(|r| r.contains("limit")));
+    }
+
+    #[test]
+    fn delete_rows_error() {
+        let reason =
+            parquet_count_pushdown_unsupported_reason(&CountMode::All, &Pushdowns::default(), true);
+        assert!(reason.is_some_and(|r| r.contains("delete rows")));
+    }
 }

--- a/src/daft-logical-plan/src/optimization/rules/push_down_aggregation.rs
+++ b/src/daft-logical-plan/src/optimization/rules/push_down_aggregation.rs
@@ -60,10 +60,8 @@ impl OptimizerRule for PushDownAggregation {
                                     } else {
                                         external_info.pushdowns.filters.is_none()
                                     };
-                                    // A limit is a global, cross-task semantic; the count
-                                    // shortcut counts each scan task's row groups independently,
-                                    // so pushing count down under a limit could overcount. Leave
-                                    // these to the normal aggregation path.
+                                    // A limit is global, but each scan task counts its own row
+                                    // groups independently — pushing down under a limit overcounts.
                                     let can_pushdown = scan_op.supports_count_pushdown()
                                         && is_count_mode_supported(count_mode)
                                         && is_remaining_filters

--- a/src/daft-logical-plan/src/optimization/rules/push_down_aggregation.rs
+++ b/src/daft-logical-plan/src/optimization/rules/push_down_aggregation.rs
@@ -60,8 +60,6 @@ impl OptimizerRule for PushDownAggregation {
                                     } else {
                                         external_info.pushdowns.filters.is_none()
                                     };
-                                    // A limit is global, but each scan task counts its own row
-                                    // groups independently — pushing down under a limit overcounts.
                                     let can_pushdown = scan_op.supports_count_pushdown()
                                         && is_count_mode_supported(count_mode)
                                         && is_remaining_filters

--- a/src/daft-logical-plan/src/optimization/rules/push_down_aggregation.rs
+++ b/src/daft-logical-plan/src/optimization/rules/push_down_aggregation.rs
@@ -60,9 +60,14 @@ impl OptimizerRule for PushDownAggregation {
                                     } else {
                                         external_info.pushdowns.filters.is_none()
                                     };
+                                    // A limit is a global, cross-task semantic; the count
+                                    // shortcut counts each scan task's row groups independently,
+                                    // so pushing count down under a limit could overcount. Leave
+                                    // these to the normal aggregation path.
                                     let can_pushdown = scan_op.supports_count_pushdown()
                                         && is_count_mode_supported(count_mode)
-                                        && is_remaining_filters;
+                                        && is_remaining_filters
+                                        && external_info.pushdowns.limit.is_none();
 
                                     if can_pushdown {
                                         // Create new pushdown info with count aggregation
@@ -369,6 +374,22 @@ mod tests {
                 RuleExecutionStrategy::Once,
             )],
         )?;
+        Ok(())
+    }
+
+    #[test]
+    fn agg_count_all_with_limit_should_not_pushdown() -> DaftResult<()> {
+        // A limit is global; the count shortcut counts each scan task's row groups
+        // independently, so count pushdown must not happen under a limit.
+        let scan_op =
+            dummy_scan_operator_for_aggregation(vec![Field::new("a", DataType::UInt64)], true);
+        let plan =
+            dummy_scan_node_with_pushdowns(scan_op, Pushdowns::default().with_limit(Some(10)))
+                .aggregate(vec![unresolved_col("a").count(CountMode::All)], vec![])?
+                .build();
+
+        let expected = plan.clone();
+        assert_optimized_plan_eq(plan, expected)?;
         Ok(())
     }
 

--- a/src/daft-parquet/src/helpers.rs
+++ b/src/daft-parquet/src/helpers.rs
@@ -199,6 +199,36 @@ pub fn refine_selection(base: &RowSelection, predicate_sel: &RowSelection) -> Ro
     result.into()
 }
 
+/// Validate & resolve user/ChunkSpec-requested row group indices to positional
+/// indices into `metadata`. Preserves order and duplicates (`[1, 1, 1]` → three
+/// entries), empty input → empty output, out-of-bounds/negative index → error.
+///
+/// Single source of truth shared by the normal read path ([`prune_row_groups`])
+/// and the count-pushdown shortcut, so both validate row groups identically.
+pub fn validate_requested_row_groups(
+    metadata: &ParquetMetaData,
+    requested_row_groups: &[i64],
+    uri: &str,
+) -> DaftResult<Vec<usize>> {
+    let num_row_groups = metadata.num_row_groups();
+    requested_row_groups
+        .iter()
+        .map(|&i| {
+            // A negative `i` wraps to a large `usize` and is caught by the
+            // bounds check below, matching the prior behavior of this path.
+            let idx = i as usize;
+            if idx >= num_row_groups {
+                Err(common_error::DaftError::ValueError(format!(
+                    "Row group index {} out of bounds for '{}' (has {} row groups)",
+                    i, uri, num_row_groups
+                )))
+            } else {
+                Ok(idx)
+            }
+        })
+        .collect()
+}
+
 /// Single-source-of-truth RG-level pruning. Applies, in order:
 /// - user-supplied `requested_row_groups` (validated against metadata)
 /// - positional `start_offset`: drop RGs whose last row is at/before the offset
@@ -218,22 +248,9 @@ pub fn prune_row_groups(
     uri: &str,
 ) -> DaftResult<Vec<usize>> {
     let num_row_groups = metadata.num_row_groups();
-    let candidates: Vec<usize> = if let Some(rgs) = requested_row_groups {
-        rgs.iter()
-            .map(|&i| {
-                let idx = i as usize;
-                if idx >= num_row_groups {
-                    Err(common_error::DaftError::ValueError(format!(
-                        "Row group index {} out of bounds for '{}' (has {} row groups)",
-                        i, uri, num_row_groups
-                    )))
-                } else {
-                    Ok(idx)
-                }
-            })
-            .collect::<DaftResult<Vec<_>>>()?
-    } else {
-        (0..num_row_groups).collect()
+    let candidates: Vec<usize> = match requested_row_groups {
+        Some(rgs) => validate_requested_row_groups(metadata, rgs, uri)?,
+        None => (0..num_row_groups).collect(),
     };
 
     // File-relative row starts for ALL RGs — start_offset is a file-level
@@ -294,4 +311,113 @@ pub fn prune_row_groups(
         rows_remaining = rows_remaining.saturating_sub(contrib as i64);
     }
     Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use parquet::{
+        basic::Type as PhysicalType,
+        file::metadata::{ColumnChunkMetaData, FileMetaData, ParquetMetaData, RowGroupMetaData},
+        schema::types::{SchemaDescriptor, Type as SchemaType},
+    };
+
+    use super::validate_requested_row_groups;
+
+    /// Build metadata with one row group per entry in `row_group_sizes`.
+    fn make_metadata(row_group_sizes: &[i64]) -> ParquetMetaData {
+        let schema = SchemaType::group_type_builder("schema")
+            .with_fields(vec![Arc::new(
+                SchemaType::primitive_type_builder("x", PhysicalType::INT64)
+                    .build()
+                    .unwrap(),
+            )])
+            .build()
+            .unwrap();
+        let descr = Arc::new(SchemaDescriptor::new(Arc::new(schema)));
+        let row_groups: Vec<RowGroupMetaData> = row_group_sizes
+            .iter()
+            .map(|&n| {
+                RowGroupMetaData::builder(descr.clone())
+                    .set_num_rows(n)
+                    .set_column_metadata(vec![
+                        ColumnChunkMetaData::builder(descr.column(0))
+                            .set_num_values(n)
+                            .build()
+                            .unwrap(),
+                    ])
+                    .build()
+                    .unwrap()
+            })
+            .collect();
+        let total: i64 = row_group_sizes.iter().sum();
+        let file_metadata = FileMetaData::new(1, total, None, None, descr, None);
+        ParquetMetaData::new(file_metadata, row_groups)
+    }
+
+    /// Sum row counts for the positional indices returned by validation — mirrors
+    /// what the count-pushdown shortcut does.
+    fn count(md: &ParquetMetaData, requested: &[i64]) -> usize {
+        let indices = validate_requested_row_groups(md, requested, "test").unwrap();
+        indices
+            .iter()
+            .map(|&i| md.row_group(i).num_rows() as usize)
+            .sum()
+    }
+
+    #[test]
+    fn single_index() {
+        let md = make_metadata(&[10, 20, 30]);
+        assert_eq!(
+            validate_requested_row_groups(&md, &[0], "test").unwrap(),
+            vec![0]
+        );
+        assert_eq!(count(&md, &[0]), 10);
+        assert_eq!(count(&md, &[2]), 30);
+    }
+
+    #[test]
+    fn non_monotonic_preserves_order() {
+        let md = make_metadata(&[10, 20, 30]);
+        assert_eq!(
+            validate_requested_row_groups(&md, &[1, 0], "test").unwrap(),
+            vec![1, 0]
+        );
+        assert_eq!(count(&md, &[1, 0]), 30);
+    }
+
+    #[test]
+    fn duplicates_counted_per_occurrence() {
+        let md = make_metadata(&[10, 20, 30]);
+        assert_eq!(
+            validate_requested_row_groups(&md, &[1, 1, 1], "test").unwrap(),
+            vec![1, 1, 1]
+        );
+        assert_eq!(count(&md, &[1, 1, 1]), 60);
+    }
+
+    #[test]
+    fn empty_is_zero() {
+        let md = make_metadata(&[10, 20, 30]);
+        assert_eq!(
+            validate_requested_row_groups(&md, &[], "test").unwrap(),
+            Vec::<usize>::new()
+        );
+        assert_eq!(count(&md, &[]), 0);
+    }
+
+    #[test]
+    fn out_of_bounds_errors() {
+        let md = make_metadata(&[10, 20, 30]);
+        let err = validate_requested_row_groups(&md, &[3], "test").unwrap_err();
+        assert!(err.to_string().contains("out of bounds"), "{err}");
+    }
+
+    #[test]
+    fn negative_index_errors() {
+        let md = make_metadata(&[10, 20, 30]);
+        let err = validate_requested_row_groups(&md, &[-1], "test").unwrap_err();
+        assert!(err.to_string().contains("out of bounds"), "{err}");
+    }
 }

--- a/src/daft-parquet/src/helpers.rs
+++ b/src/daft-parquet/src/helpers.rs
@@ -203,8 +203,8 @@ pub fn refine_selection(base: &RowSelection, predicate_sel: &RowSelection) -> Ro
 /// indices into `metadata`. Preserves order and duplicates (`[1, 1, 1]` → three
 /// entries), empty input → empty output, out-of-bounds/negative index → error.
 ///
-/// Single source of truth shared by the normal read path ([`prune_row_groups`])
-/// and the count-pushdown shortcut, so both validate row groups identically.
+/// Shared by the normal read path ([`prune_row_groups`]) and the count-pushdown
+/// shortcut so both validate identically.
 pub fn validate_requested_row_groups(
     metadata: &ParquetMetaData,
     requested_row_groups: &[i64],
@@ -311,113 +311,4 @@ pub fn prune_row_groups(
         rows_remaining = rows_remaining.saturating_sub(contrib as i64);
     }
     Ok(result)
-}
-
-#[cfg(test)]
-mod tests {
-    use std::sync::Arc;
-
-    use parquet::{
-        basic::Type as PhysicalType,
-        file::metadata::{ColumnChunkMetaData, FileMetaData, ParquetMetaData, RowGroupMetaData},
-        schema::types::{SchemaDescriptor, Type as SchemaType},
-    };
-
-    use super::validate_requested_row_groups;
-
-    /// Build metadata with one row group per entry in `row_group_sizes`.
-    fn make_metadata(row_group_sizes: &[i64]) -> ParquetMetaData {
-        let schema = SchemaType::group_type_builder("schema")
-            .with_fields(vec![Arc::new(
-                SchemaType::primitive_type_builder("x", PhysicalType::INT64)
-                    .build()
-                    .unwrap(),
-            )])
-            .build()
-            .unwrap();
-        let descr = Arc::new(SchemaDescriptor::new(Arc::new(schema)));
-        let row_groups: Vec<RowGroupMetaData> = row_group_sizes
-            .iter()
-            .map(|&n| {
-                RowGroupMetaData::builder(descr.clone())
-                    .set_num_rows(n)
-                    .set_column_metadata(vec![
-                        ColumnChunkMetaData::builder(descr.column(0))
-                            .set_num_values(n)
-                            .build()
-                            .unwrap(),
-                    ])
-                    .build()
-                    .unwrap()
-            })
-            .collect();
-        let total: i64 = row_group_sizes.iter().sum();
-        let file_metadata = FileMetaData::new(1, total, None, None, descr, None);
-        ParquetMetaData::new(file_metadata, row_groups)
-    }
-
-    /// Sum row counts for the positional indices returned by validation — mirrors
-    /// what the count-pushdown shortcut does.
-    fn count(md: &ParquetMetaData, requested: &[i64]) -> usize {
-        let indices = validate_requested_row_groups(md, requested, "test").unwrap();
-        indices
-            .iter()
-            .map(|&i| md.row_group(i).num_rows() as usize)
-            .sum()
-    }
-
-    #[test]
-    fn single_index() {
-        let md = make_metadata(&[10, 20, 30]);
-        assert_eq!(
-            validate_requested_row_groups(&md, &[0], "test").unwrap(),
-            vec![0]
-        );
-        assert_eq!(count(&md, &[0]), 10);
-        assert_eq!(count(&md, &[2]), 30);
-    }
-
-    #[test]
-    fn non_monotonic_preserves_order() {
-        let md = make_metadata(&[10, 20, 30]);
-        assert_eq!(
-            validate_requested_row_groups(&md, &[1, 0], "test").unwrap(),
-            vec![1, 0]
-        );
-        assert_eq!(count(&md, &[1, 0]), 30);
-    }
-
-    #[test]
-    fn duplicates_counted_per_occurrence() {
-        let md = make_metadata(&[10, 20, 30]);
-        assert_eq!(
-            validate_requested_row_groups(&md, &[1, 1, 1], "test").unwrap(),
-            vec![1, 1, 1]
-        );
-        assert_eq!(count(&md, &[1, 1, 1]), 60);
-    }
-
-    #[test]
-    fn empty_is_zero() {
-        let md = make_metadata(&[10, 20, 30]);
-        assert_eq!(
-            validate_requested_row_groups(&md, &[], "test").unwrap(),
-            Vec::<usize>::new()
-        );
-        assert_eq!(count(&md, &[]), 0);
-    }
-
-    #[test]
-    fn out_of_bounds_errors() {
-        let md = make_metadata(&[10, 20, 30]);
-        let err = validate_requested_row_groups(&md, &[3], "test").unwrap_err();
-        assert!(err.to_string().contains("out of bounds"), "{err}");
-    }
-
-    #[test]
-    fn negative_index_errors() {
-        let md = make_metadata(&[10, 20, 30]);
-        let err = validate_requested_row_groups(&md, &[-1], "test").unwrap_err();
-        assert!(err.to_string().contains("out of bounds"), "{err}");
-    }
 }

--- a/src/daft-parquet/src/read.rs
+++ b/src/daft-parquet/src/read.rs
@@ -530,13 +530,8 @@ pub async fn stream_parquet_count_pushdown(
 
     // Currently only CountMode::All is supported for count pushdown.
     //
-    // When the ScanTask constrains the read to specific row groups (user-supplied
-    // `row_groups`, or a split subtask's `ChunkSpec::Parquet`), count only those
-    // groups instead of the whole file. This mirrors the normal read path, which
-    // re-reads the full footer and treats these indices as positional into it
-    // (see `prune_row_groups` / `count_only_stream`). Without this, count pushdown
-    // ignores the constraint and returns the whole-file row count — inflating
-    // `count_rows()` by N× once a file is split into N subtasks.
+    // When the ScanTask constrains the read to specific row groups, count only those.
+    // Indices are positional into the full footer, mirroring `prune_row_groups`.
     let count = match row_groups {
         None => parquet_metadata.num_rows(),
         Some(rgs) => {

--- a/src/daft-parquet/src/read.rs
+++ b/src/daft-parquet/src/read.rs
@@ -523,12 +523,31 @@ pub async fn stream_parquet_count_pushdown(
     io_stats: Option<IOStatsRef>,
     field_id_mapping: Option<Arc<BTreeMap<i32, Field>>>,
     aggregation: &ExprRef,
+    row_groups: Option<&[i64]>,
 ) -> DaftResult<BoxStream<'static, DaftResult<RecordBatch>>> {
     let parquet_metadata =
         read_parquet_metadata(url, io_client, io_stats, field_id_mapping.clone()).await?;
 
     // Currently only CountMode::All is supported for count pushdown.
-    let count = parquet_metadata.num_rows();
+    //
+    // When the ScanTask constrains the read to specific row groups (user-supplied
+    // `row_groups`, or a split subtask's `ChunkSpec::Parquet`), count only those
+    // groups instead of the whole file. This mirrors the normal read path, which
+    // re-reads the full footer and treats these indices as positional into it
+    // (see `prune_row_groups` / `count_only_stream`). Without this, count pushdown
+    // ignores the constraint and returns the whole-file row count — inflating
+    // `count_rows()` by N× once a file is split into N subtasks.
+    let count = match row_groups {
+        None => parquet_metadata.num_rows(),
+        Some(rgs) => {
+            let arrow_md = parquet_metadata.as_arrowrs();
+            let indices = crate::helpers::validate_requested_row_groups(arrow_md, rgs, url)?;
+            indices
+                .iter()
+                .map(|&i| arrow_md.row_group(i).num_rows() as usize)
+                .sum()
+        }
+    };
     let count_field = daft_core::datatypes::Field::new(
         aggregation.name(),
         daft_core::datatypes::DataType::UInt64,

--- a/tests/io/test_parquet.py
+++ b/tests/io/test_parquet.py
@@ -184,14 +184,9 @@ def test_read_parquet_row_group_edges(tmp_path):
 
 
 def test_count_rows_respects_row_groups(tmp_path):
-    # Regression: count_rows() count-pushdown used to ignore the row group
-    # constraint (ChunkSpec::Parquet) and return the whole-file row count. This
-    # is the same path a split subtask takes on the Ray runner, where the bug
-    # manifested as an N-times-inflated silent overcount.
-    #
-    # Use unequal row groups (sizes 4, 4, 2; 10 total) so subset/duplicate sums
-    # are distinct from the whole-file count — otherwise the assertions would
-    # pass even without the fix.
+    # Regression: count_rows() count-pushdown ignored the row group constraint and
+    # returned the whole-file count. Row groups are unequal (4, 4, 2) so subset and
+    # duplicate sums differ from the whole-file count.
     path = tmp_path / "row_groups.parquet"
     papq.write_table(pa.table({"x": list(range(10))}), path, row_group_size=4)
 
@@ -213,9 +208,8 @@ def test_count_rows_respects_row_groups(tmp_path):
     df = daft.read_parquet([str(path)], row_groups=[[2, 0]])
     assert df.count_rows() == df.agg(daft.col("x").count()).to_pydict()["x"][0]
 
-    # Guard that count_rows() actually goes through the count-pushdown shortcut
-    # (the path this fix touches). `count_rows()` runs eagerly, so build its
-    # underlying plan the same way it does and inspect the optimized plan.
+    # Guard that count_rows() actually takes the pushdown path. It runs eagerly, so
+    # rebuild its plan the same way to inspect it.
     plan = io.StringIO()
     type(df)(df._builder.count()).explain(show_all=True, file=plan)
     assert "Aggregation pushdown = count" in plan.getvalue()

--- a/tests/io/test_parquet.py
+++ b/tests/io/test_parquet.py
@@ -183,6 +183,44 @@ def test_read_parquet_row_group_edges(tmp_path):
         daft.read_parquet([str(path)], row_groups=[[2]]).to_pydict()
 
 
+def test_count_rows_respects_row_groups(tmp_path):
+    # Regression: count_rows() count-pushdown used to ignore the row group
+    # constraint (ChunkSpec::Parquet) and return the whole-file row count. This
+    # is the same path a split subtask takes on the Ray runner, where the bug
+    # manifested as an N-times-inflated silent overcount.
+    #
+    # Use unequal row groups (sizes 4, 4, 2; 10 total) so subset/duplicate sums
+    # are distinct from the whole-file count — otherwise the assertions would
+    # pass even without the fix.
+    path = tmp_path / "row_groups.parquet"
+    papq.write_table(pa.table({"x": list(range(10))}), path, row_group_size=4)
+
+    assert daft.read_parquet([str(path)]).count_rows() == 10  # whole file
+    assert daft.read_parquet([str(path)], row_groups=[[2]]).count_rows() == 2  # last (partial) group
+    assert daft.read_parquet([str(path)], row_groups=[[0]]).count_rows() == 4
+    assert daft.read_parquet([str(path)], row_groups=[[]]).count_rows() == 0
+    # Non-monotonic indices — sums both selected groups (4 + 2), not the file.
+    assert daft.read_parquet([str(path)], row_groups=[[2, 0]]).count_rows() == 6
+    # Duplicate indices are counted once per occurrence (4 * 3 = 12 > whole file,
+    # impossible to produce without honoring the row-group selection).
+    assert daft.read_parquet([str(path)], row_groups=[[0, 0, 0]]).count_rows() == 12
+
+    with pytest.raises(DaftCoreException, match="Row group index 3 out of bounds"):
+        daft.read_parquet([str(path)], row_groups=[[3]]).count_rows()
+
+    # count_rows() must agree with an explicit count aggregation (which never
+    # takes the count-pushdown shortcut).
+    df = daft.read_parquet([str(path)], row_groups=[[2, 0]])
+    assert df.count_rows() == df.agg(daft.col("x").count()).to_pydict()["x"][0]
+
+    # Guard that count_rows() actually goes through the count-pushdown shortcut
+    # (the path this fix touches). `count_rows()` runs eagerly, so build its
+    # underlying plan the same way it does and inspect the optimized plan.
+    plan = io.StringIO()
+    type(df)(df._builder.count()).explain(show_all=True, file=plan)
+    assert "Aggregation pushdown = count" in plan.getvalue()
+
+
 def test_read_parquet_casts_map_values_to_explicit_schema(tmp_path):
     int32_path = tmp_path / "map_i32.parquet"
     int64_path = tmp_path / "map_i64.parquet"

--- a/tests/io/test_split_scan_tasks.py
+++ b/tests/io/test_split_scan_tasks.py
@@ -36,6 +36,27 @@ def test_split_parquet_read(parquet_files):
         assert df.to_pydict() == {"data": ["aaa"] * 100}
 
 
+def test_split_parquet_count_rows(parquet_files):
+    """Regression: count_rows() must not N-times overcount a split file.
+
+    When a file is split into N subtasks, each subtask's count-pushdown shortcut
+    used to ignore its row-group constraint (ChunkSpec) and return the WHOLE-file
+    row count, so the sum over subtasks was N x the true count — a silent
+    data-correctness error on the officially recommended split configuration.
+    """
+    with daft.execution_config_ctx(
+        enable_scan_task_split_and_merge=True,
+        scan_tasks_min_size_bytes=1,
+        scan_tasks_max_size_bytes=10,
+    ):
+        df = daft.read_parquet(str(parquet_files))
+        assert df.num_partitions() == 10, "file should split into 10 subtasks"
+        # Fixture is 100 rows; before the fix this returned 100 * 10 = 1000.
+        assert df.count_rows() == 100
+        # Agrees with an explicit count aggregation (which never takes the shortcut).
+        assert df.agg(daft.col("data").count()).to_pydict()["data"][0] == 100
+
+
 def test_split_parquet_estimate_uses_materialized_size(tmpdir):
     """The scan size estimate must reflect the materialized buffer size, not encoded size.
 


### PR DESCRIPTION
## Changes Made

`count_rows()`'s count-pushdown shortcut returned the whole-file row count from parquet footer metadata and **ignored the ScanTask's row-group constraint** (`ChunkSpec::Parquet`). This caused:

- **Explicit `row_groups=`**: `count_rows()` returned the whole-file count instead of the selected groups' count (any runner).
- **Scan-task splitting on Ray** (`enable_scan_task_split_and_merge`, the recommended large-file config): a file split into N subtasks had each subtask return the whole-file count, so the sum was **N× the true count** — a silent data-correctness error.

### Main fix
- `stream_parquet_count_pushdown` now takes the requested row groups and sums only those. It reads the full footer and treats the `ChunkSpec` indices as **positional** indices into it — mirroring the normal read path, which also re-reads the full footer and ignores the embedded (pruned) metadata, so original index == positional index in every case.
- `scan_task_reader.rs` extracts `ChunkSpec::Parquet` before entering the shortcut and threads it through.
- Row-group validation is now shared with the normal read path via a new `validate_requested_row_groups` helper in `helpers.rs` (order- and duplicate-preserving: `[1,1,1]` counts three times; `[]` → 0; out-of-bounds/negative → error), so both paths stay consistent.

### Defense in depth
The metadata-only count path cannot apply row-level processing. Built-in sources never reach it with such pushdowns, but to protect against custom `ScanOperator`s that bypass the optimizer's invariants:
- `PushDownAggregation::can_pushdown` now also requires `pushdowns.limit.is_none()` (a limit is a global semantic; per-subtask `min` then sum could overcount).
- The parquet count shortcut errors loudly — never silently miscounts, never falls back (fallback would yield `SUM(null)` = null after aggregation rewriting) — on a non-`All` count mode, a filter, a limit, or delete rows. These four guards are consolidated in a small pure, unit-tested helper.

### Tests
- Rust: `validate_requested_row_groups` (single/non-monotonic/duplicate/empty/out-of-bounds/negative); the execution-layer invariant guard (all four unsupported inputs); a new optimizer test that a limit prevents count pushdown.
- Python (native): `count_rows()` over explicit `row_groups=` using unequal row groups so subset/duplicate sums differ from the whole-file count, plus agreement with `agg(col.count())` and an assertion that the pushdown is actually taken.
- Python (Ray): a 10-way split regression asserting `count_rows()` is not N× inflated.

## Related Issues

Closes #7287
