### PR TITLE
feat(parquet): unify row group reader lifecycle

### DIFF
--- a/src/daft-parquet/src/reader/budget.rs
+++ b/src/daft-parquet/src/reader/budget.rs
@@ -112,6 +112,7 @@ impl std::fmt::Debug for ByteBudget {
             .field("in_use", &s.in_use)
             .field("exclusive", &s.exclusive)
             .field("waiters", &s.waiters.len())
+            .field("metrics", &self.metrics)
             .finish()
     }
 }
@@ -139,7 +140,7 @@ impl ByteBudget {
         if s.exclusive {
             return to_notify;
         }
-        for w in s.waiters.iter_mut() {
+        for w in &mut s.waiters {
             if w.granted {
                 continue;
             }
@@ -306,6 +307,7 @@ pub(crate) struct BudgetPermit {
 }
 
 impl BudgetPermit {
+    #[cfg(test)]
     pub(crate) fn bytes(&self) -> usize {
         self.bytes
     }
@@ -343,11 +345,6 @@ mod tests {
     use std::time::Duration;
 
     use super::*;
-
-    fn granted_now(b: &Arc<ByteBudget>, bytes: usize) -> Option<BudgetReservation> {
-        let r = b.reserve(bytes);
-        if b.is_granted(r.id) { Some(r) } else { None }
-    }
 
     #[tokio::test]
     async fn sequential_acquire_release() {

--- a/src/daft-parquet/src/reader/budget.rs
+++ b/src/daft-parquet/src/reader/budget.rs
@@ -1,0 +1,540 @@
+//! Process-wide resident-byte budget for the owned parquet reader.
+//!
+//! Bounds the compressed bytes concurrently resident across every parquet
+//! reader in this process (one Ray Swordfish actor == one process, so this
+//! is the actor-wide admission control).
+//!
+//! Design (see the OOM analysis docs for rationale):
+//! - `reserve(bytes)` registers a waiter in strict FIFO order
+//!   **synchronously** and returns a cancellation-safe future. The caller
+//!   (the RG driver) must never await admission itself — it registers in RG
+//!   order, hands the reservation to the RG task, and keeps draining output.
+//!   Awaiting in the driver while the front RG is blocked on a full channel
+//!   deadlocks (front can't finish → can't release → next permit never
+//!   granted).
+//! - Strict FIFO: a small request behind a blocked large request must NOT
+//!   overtake it. Fairness over utilization — overtaking starves the front
+//!   RG, whose output the ordered consumer is waiting on.
+//! - Oversized requests (`bytes > total`): granted only when `in_use == 0`,
+//!   and mark the budget `exclusive` while running. No Polars-style
+//!   truncation — the ledger stays accurate; "at most one oversized RG" is
+//!   the explainable bound.
+//! - All bookkeeping happens inside a `std::sync::Mutex` (no await inside
+//!   the critical section), so `Drop` impls can clean up synchronously.
+//!   Every waiter has its own `Notify` — no lost wakeups, no thundering
+//!   herd.
+
+use std::{
+    collections::VecDeque,
+    sync::{
+        Arc, Mutex, OnceLock,
+        atomic::{AtomicI64, AtomicU64, Ordering},
+    },
+};
+
+use tokio::sync::Notify;
+
+/// Live metrics, exported for logging/tests. Planned (reserved) bytes and
+/// actually-downloaded resident bytes are tracked separately: a permit is
+/// granted before the GETs run, so `reserved` leads `resident`.
+#[derive(Debug, Default)]
+pub(crate) struct BudgetMetrics {
+    pub reserved_bytes: AtomicI64,
+    pub resident_bytes: AtomicI64,
+    pub resident_bytes_peak: AtomicI64,
+    pub active_resident_row_groups: AtomicI64,
+    pub oversized_row_groups: AtomicU64,
+}
+
+/// `DAFT_PARQUET_MEM_VERBOSE=1` → eprintln lifecycle events with live
+/// totals. Test/diagnostic hook, mirrors the methodology used throughout
+/// the OOM investigation.
+pub(crate) fn mem_verbose() -> bool {
+    static V: OnceLock<bool> = OnceLock::new();
+    *V.get_or_init(|| std::env::var("DAFT_PARQUET_MEM_VERBOSE").as_deref() == Ok("1"))
+}
+
+impl BudgetMetrics {
+    pub(crate) fn snapshot_line(&self) -> String {
+        format!(
+            "reserved={} resident={} peak={} active_rgs={}",
+            self.reserved_bytes.load(Ordering::Relaxed),
+            self.resident_bytes.load(Ordering::Relaxed),
+            self.resident_bytes_peak.load(Ordering::Relaxed),
+            self.active_resident_row_groups.load(Ordering::Relaxed),
+        )
+    }
+
+    pub(crate) fn record_resident(&self, actual: usize) {
+        let now = self
+            .resident_bytes
+            .fetch_add(actual as i64, Ordering::Relaxed)
+            + actual as i64;
+        self.resident_bytes_peak.fetch_max(now, Ordering::Relaxed);
+        self.active_resident_row_groups
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(crate) fn release_resident(&self, actual: usize) {
+        self.resident_bytes
+            .fetch_sub(actual as i64, Ordering::Relaxed);
+        self.active_resident_row_groups
+            .fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
+struct Waiter {
+    id: u64,
+    bytes: usize,
+    notify: Arc<Notify>,
+    granted: bool,
+}
+
+struct State {
+    in_use: usize,
+    exclusive: bool,
+    next_id: u64,
+    waiters: VecDeque<Waiter>,
+}
+
+pub(crate) struct ByteBudget {
+    /// `None` = unlimited (admission never blocks, ledger still tracked).
+    total: Option<usize>,
+    state: Mutex<State>,
+    pub(crate) metrics: BudgetMetrics,
+}
+
+impl std::fmt::Debug for ByteBudget {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = self.state.lock().unwrap();
+        f.debug_struct("ByteBudget")
+            .field("total", &self.total)
+            .field("in_use", &s.in_use)
+            .field("exclusive", &s.exclusive)
+            .field("waiters", &s.waiters.len())
+            .finish()
+    }
+}
+
+impl ByteBudget {
+    pub(crate) fn new(total: Option<usize>) -> Arc<Self> {
+        Arc::new(Self {
+            total,
+            state: Mutex::new(State {
+                in_use: 0,
+                exclusive: false,
+                next_id: 0,
+                waiters: VecDeque::new(),
+            }),
+            metrics: BudgetMetrics::default(),
+        })
+    }
+
+    /// Grant as many queue-front waiters as fit. Strict FIFO: stop at the
+    /// first ungranted waiter that does not fit — a smaller request behind
+    /// it must not overtake. Collect the notifies and fire them after the
+    /// lock is released.
+    fn pump(total: Option<usize>, s: &mut State, metrics: &BudgetMetrics) -> Vec<Arc<Notify>> {
+        let mut to_notify = Vec::new();
+        if s.exclusive {
+            return to_notify;
+        }
+        for w in s.waiters.iter_mut() {
+            if w.granted {
+                continue;
+            }
+            let oversized = total.is_some_and(|t| w.bytes > t);
+            let admissible = match total {
+                None => true,
+                Some(_) if oversized => s.in_use == 0,
+                Some(t) => s.in_use.saturating_add(w.bytes) <= t,
+            };
+            if !admissible {
+                break;
+            }
+            w.granted = true;
+            s.in_use += w.bytes;
+            metrics
+                .reserved_bytes
+                .fetch_add(w.bytes as i64, Ordering::Relaxed);
+            to_notify.push(w.notify.clone());
+            if oversized {
+                s.exclusive = true;
+                metrics.oversized_row_groups.fetch_add(1, Ordering::Relaxed);
+                break; // exclusive holder admitted; nothing else may enter
+            }
+        }
+        to_notify
+    }
+
+    /// Synchronously register a FIFO reservation. Never blocks. The returned
+    /// reservation must be awaited (usually inside the RG task) to obtain
+    /// the permit; dropping it at any point deregisters cleanly.
+    pub(crate) fn reserve(self: &Arc<Self>, bytes: usize) -> BudgetReservation {
+        let notify = Arc::new(Notify::new());
+        let id = {
+            let mut s = self.state.lock().unwrap();
+            let id = s.next_id;
+            s.next_id = s.next_id.checked_add(1).expect("reservation id overflow");
+            s.waiters.push_back(Waiter {
+                id,
+                bytes,
+                notify: notify.clone(),
+                granted: false,
+            });
+            let to_notify = Self::pump(self.total, &mut s, &self.metrics);
+            drop(s);
+            for n in to_notify {
+                n.notify_one();
+            }
+            id
+        };
+        BudgetReservation {
+            budget: self.clone(),
+            id,
+            bytes,
+            notify,
+            resolved: false,
+        }
+    }
+
+    /// Remove a waiter (cancelled reservation). If it was already granted,
+    /// roll the grant back. Either way, re-pump the queue.
+    fn deregister(&self, id: u64) {
+        let mut s = self.state.lock().unwrap();
+        if let Some(pos) = s.waiters.iter().position(|w| w.id == id) {
+            let w = s.waiters.remove(pos).unwrap();
+            if w.granted {
+                s.in_use -= w.bytes;
+                if self.total.is_some_and(|t| w.bytes > t) {
+                    s.exclusive = false;
+                }
+                self.metrics
+                    .reserved_bytes
+                    .fetch_sub(w.bytes as i64, Ordering::Relaxed);
+            }
+        }
+        let to_notify = Self::pump(self.total, &mut s, &self.metrics);
+        drop(s);
+        for n in to_notify {
+            n.notify_one();
+        }
+    }
+
+    fn is_granted(&self, id: u64) -> bool {
+        let s = self.state.lock().unwrap();
+        s.waiters.iter().any(|w| w.id == id && w.granted)
+    }
+
+    /// Convert a granted reservation into a held permit: the waiter entry
+    /// leaves the queue but its bytes stay accounted until `release`.
+    fn commit(&self, id: u64) {
+        let mut s = self.state.lock().unwrap();
+        if let Some(pos) = s.waiters.iter().position(|w| w.id == id) {
+            debug_assert!(s.waiters[pos].granted);
+            s.waiters.remove(pos);
+        }
+    }
+
+    fn release(&self, bytes: usize) {
+        let mut s = self.state.lock().unwrap();
+        s.in_use -= bytes;
+        if self.total.is_some_and(|t| bytes > t) {
+            s.exclusive = false;
+        }
+        self.metrics
+            .reserved_bytes
+            .fetch_sub(bytes as i64, Ordering::Relaxed);
+        let to_notify = Self::pump(self.total, &mut s, &self.metrics);
+        drop(s);
+        for n in to_notify {
+            n.notify_one();
+        }
+    }
+
+    #[cfg(test)]
+    fn in_use(&self) -> usize {
+        self.state.lock().unwrap().in_use
+    }
+
+    #[cfg(test)]
+    fn waiter_count(&self) -> usize {
+        self.state.lock().unwrap().waiters.len()
+    }
+}
+
+/// A queued admission request. Await it to obtain the [`BudgetPermit`].
+/// Dropping it — before or after grant, awaited or not — deregisters and
+/// rolls back cleanly (cancellation safety).
+pub(crate) struct BudgetReservation {
+    budget: Arc<ByteBudget>,
+    id: u64,
+    bytes: usize,
+    notify: Arc<Notify>,
+    resolved: bool,
+}
+
+impl BudgetReservation {
+    pub(crate) async fn acquire(mut self) -> BudgetPermit {
+        loop {
+            if self.budget.is_granted(self.id) {
+                self.budget.commit(self.id);
+                self.resolved = true;
+                return BudgetPermit {
+                    budget: self.budget.clone(),
+                    bytes: self.bytes,
+                };
+            }
+            self.notify.notified().await;
+        }
+    }
+}
+
+impl Drop for BudgetReservation {
+    fn drop(&mut self) {
+        if !self.resolved {
+            self.budget.deregister(self.id);
+        }
+    }
+}
+
+/// Held admission for one row group's planned compressed bytes. Dropping it
+/// returns the bytes to the budget and wakes the queue front.
+pub(crate) struct BudgetPermit {
+    budget: Arc<ByteBudget>,
+    bytes: usize,
+}
+
+impl BudgetPermit {
+    pub(crate) fn bytes(&self) -> usize {
+        self.bytes
+    }
+
+    pub(crate) fn metrics(&self) -> &BudgetMetrics {
+        &self.budget.metrics
+    }
+}
+
+impl Drop for BudgetPermit {
+    fn drop(&mut self) {
+        self.budget.release(self.bytes);
+    }
+}
+
+/// The process-wide budget used by all owned-mode parquet readers.
+/// `DAFT_PARQUET_RESIDENT_BUDGET_MB`: unset → 256MB default; `0` → unlimited.
+pub(crate) fn process_budget() -> &'static Arc<ByteBudget> {
+    static BUDGET: OnceLock<Arc<ByteBudget>> = OnceLock::new();
+    BUDGET.get_or_init(|| {
+        let total = match std::env::var("DAFT_PARQUET_RESIDENT_BUDGET_MB")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+        {
+            Some(0) => None,
+            Some(mb) => Some(mb.saturating_mul(1024 * 1024)),
+            None => Some(256 * 1024 * 1024),
+        };
+        ByteBudget::new(total)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    fn granted_now(b: &Arc<ByteBudget>, bytes: usize) -> Option<BudgetReservation> {
+        let r = b.reserve(bytes);
+        if b.is_granted(r.id) { Some(r) } else { None }
+    }
+
+    #[tokio::test]
+    async fn sequential_acquire_release() {
+        let b = ByteBudget::new(Some(100));
+        for _ in 0..5 {
+            let p = b.reserve(60).acquire().await;
+            assert_eq!(b.in_use(), 60);
+            drop(p);
+            assert_eq!(b.in_use(), 0);
+        }
+        assert_eq!(b.waiter_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn concurrent_fit_together() {
+        let b = ByteBudget::new(Some(100));
+        let p1 = b.reserve(40).acquire().await;
+        let p2 = b.reserve(40).acquire().await;
+        assert_eq!(b.in_use(), 80);
+        drop((p1, p2));
+        assert_eq!(b.in_use(), 0);
+    }
+
+    #[tokio::test]
+    async fn fifo_no_overtake() {
+        let b = ByteBudget::new(Some(100));
+        let p1 = b.reserve(80).acquire().await;
+        // Large request that doesn't fit heads the queue...
+        let r_big = b.reserve(50);
+        // ...a small request that WOULD fit must not overtake it.
+        let r_small = b.reserve(10);
+        assert!(!b.is_granted(r_big.id));
+        assert!(!b.is_granted(r_small.id));
+        drop(p1);
+        // Now the big one is granted; small fits alongside it.
+        assert!(b.is_granted(r_big.id));
+        assert!(b.is_granted(r_small.id));
+        let _pb = r_big.acquire().await;
+        let _ps = r_small.acquire().await;
+        assert_eq!(b.in_use(), 60);
+    }
+
+    #[tokio::test]
+    async fn waiter_cancellation_unblocks_queue() {
+        let b = ByteBudget::new(Some(100));
+        let p1 = b.reserve(80).acquire().await;
+        let r_blocked = b.reserve(90); // can't fit while p1 held
+        let r_next = b.reserve(20); // fits, but FIFO-blocked behind r_blocked
+        assert!(!b.is_granted(r_next.id));
+        drop(r_blocked); // cancel the blocker
+        assert!(b.is_granted(r_next.id)); // next must be pumped immediately
+        let _p = r_next.acquire().await;
+        drop(p1);
+    }
+
+    #[tokio::test]
+    async fn granted_but_unconsumed_cancellation_rolls_back() {
+        let b = ByteBudget::new(Some(100));
+        let r = b.reserve(70);
+        assert!(b.is_granted(r.id));
+        assert_eq!(b.in_use(), 70);
+        drop(r); // never awaited
+        assert_eq!(b.in_use(), 0);
+        assert_eq!(b.metrics.reserved_bytes.load(Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test]
+    async fn oversized_exclusive_singleton() {
+        let b = ByteBudget::new(Some(100));
+        let p_small = b.reserve(30).acquire().await;
+        let r_big = b.reserve(500); // oversized: needs in_use == 0
+        assert!(!b.is_granted(r_big.id));
+        drop(p_small);
+        assert!(b.is_granted(r_big.id));
+        // While oversized runs, nothing else enters — not even tiny requests.
+        let r_tiny = b.reserve(1);
+        assert!(!b.is_granted(r_tiny.id));
+        let p_big = r_big.acquire().await;
+        assert!(!b.is_granted(r_tiny.id));
+        drop(p_big);
+        assert!(b.is_granted(r_tiny.id));
+        let _pt = r_tiny.acquire().await;
+    }
+
+    #[tokio::test]
+    async fn oversized_waiter_cancellation_unblocks() {
+        let b = ByteBudget::new(Some(100));
+        let p1 = b.reserve(10).acquire().await;
+        let r_big = b.reserve(500); // waits for idle
+        let r_after = b.reserve(10);
+        assert!(!b.is_granted(r_after.id));
+        drop(r_big);
+        assert!(b.is_granted(r_after.id));
+        drop(p1);
+    }
+
+    #[tokio::test]
+    async fn unlimited_never_blocks() {
+        let b = ByteBudget::new(None);
+        let p1 = b.reserve(usize::MAX / 4).acquire().await;
+        let p2 = b.reserve(usize::MAX / 4).acquire().await;
+        drop((p1, p2));
+        assert_eq!(b.in_use(), 0);
+    }
+
+    #[tokio::test]
+    async fn zero_bytes_immediate() {
+        let b = ByteBudget::new(Some(1));
+        let _p1 = b.reserve(1).acquire().await;
+        let p2 = b.reserve(0).acquire().await;
+        assert_eq!(p2.bytes(), 0);
+    }
+
+    /// Regression for the v1 driver deadlock: budget=256, RG0=RG1=200,
+    /// lookahead=2, channel capacity 1. The driver registers both
+    /// reservations synchronously (never blocking), RG0's task acquires and
+    /// streams into a full channel; RG1's task waits on its reservation.
+    /// The driver keeps draining RG0, RG0 completes, drops its permit, and
+    /// RG1 proceeds. With driver-side `acquire().await` this hangs forever.
+    #[tokio::test]
+    async fn deadlock_regression_reserve_then_await_in_task() {
+        let b = ByteBudget::new(Some(256));
+        let r0 = b.reserve(200); // driver: sync registration, RG order
+        let r1 = b.reserve(200);
+
+        let (tx0, mut rx0) = tokio::sync::mpsc::channel::<u32>(1);
+        let t0 = tokio::spawn(async move {
+            let _p = r0.acquire().await;
+            for i in 0..3 {
+                tx0.send(i).await.unwrap(); // blocks on full channel until drained
+            }
+            // permit dropped here
+        });
+        let t1 = tokio::spawn(async move {
+            let _p = r1.acquire().await; // must eventually be granted
+            true
+        });
+
+        // Driver drains RG0 while RG1 waits for budget.
+        let drained = async {
+            let mut got = Vec::new();
+            while let Some(v) = rx0.recv().await {
+                got.push(v);
+            }
+            got
+        };
+        let (got, r0_join, r1_ok) = tokio::time::timeout(Duration::from_secs(5), async {
+            tokio::join!(drained, t0, t1)
+        })
+        .await
+        .expect("deadlock: RG1 never admitted");
+        assert_eq!(got, vec![0, 1, 2]);
+        r0_join.unwrap();
+        assert!(r1_ok.unwrap());
+        assert_eq!(b.in_use(), 0);
+    }
+
+    #[tokio::test]
+    async fn multi_reader_fairness_fifo_order() {
+        let b = ByteBudget::new(Some(100));
+        let p_hold = b.reserve(100).acquire().await;
+        // Two "readers" queue interleaved requests; grant order must be FIFO.
+        let ra1 = b.reserve(50);
+        let rb1 = b.reserve(50);
+        let ra2 = b.reserve(50);
+        drop(p_hold);
+        assert!(b.is_granted(ra1.id));
+        assert!(b.is_granted(rb1.id));
+        assert!(!b.is_granted(ra2.id));
+        let pa1 = ra1.acquire().await;
+        drop(pa1);
+        assert!(b.is_granted(ra2.id));
+        let _ = (rb1, ra2);
+    }
+
+    #[tokio::test]
+    async fn permit_drop_on_panic_returns_budget() {
+        let b = ByteBudget::new(Some(100));
+        let r = b.reserve(100);
+        let b2 = b.clone();
+        let t = tokio::spawn(async move {
+            let _p = r.acquire().await;
+            assert_eq!(b2.in_use(), 100);
+            panic!("boom");
+        });
+        assert!(t.await.is_err());
+        assert_eq!(b.in_use(), 0);
+        let _p = b.reserve(100).acquire().await; // budget still usable
+    }
+}

--- a/src/daft-parquet/src/reader/chunk_source.rs
+++ b/src/daft-parquet/src/reader/chunk_source.rs
@@ -274,6 +274,26 @@ impl ChunkSourceBuilder {
         }
     }
 
+    /// Owned-mode counterpart of [`Self::build`]: produce an immutable range
+    /// *plan* (no GETs spawned, no `Bytes` held) for the remote source.
+    /// Returns `Err(self)` for local sources — the caller falls back to the
+    /// legacy path (local reads are per-call `pread`s with no resident
+    /// cache, so the ownership model buys nothing there this round).
+    pub(super) fn build_plan(
+        self,
+        parquet_metadata: &Arc<ParquetMetaData>,
+        rg_indices: &[usize],
+    ) -> Result<RemoteChunkSourcePlan, Box<Self>> {
+        match self {
+            Self::Local(_) => Err(Box::new(self)),
+            Self::Remote(prep) => Ok(RemoteChunkSourcePlan::from_metadata(
+                prep,
+                parquet_metadata,
+                rg_indices,
+            )),
+        }
+    }
+
     /// Finalize the chunk source. For `Remote`, this is when byte-range fetches
     /// for `rg_indices` are spawned — call only after predicate-based pruning.
     pub(super) fn build(
@@ -359,6 +379,11 @@ pub(crate) enum RgReader {
         chunk_source: Arc<ChunkSource>,
         rg_idx: usize,
     },
+    /// Owned mode: cloning this clones the `Arc<ResidentRowGroup>` — every
+    /// column decoder task keeps the resident owner (bytes + budget permit)
+    /// alive for its entire lifetime. Type-level lifetime binding: the
+    /// permit cannot be returned while any decoder still reads the bytes.
+    Resident(Arc<ResidentRowGroup>),
 }
 
 impl RgReader {
@@ -374,6 +399,7 @@ impl RgReader {
             } => Ok(Arc::new(
                 chunk_source.read_rg_chunks(*rg_idx, col_leaves).await?,
             )),
+            Self::Resident(resident) => Ok(resident.leaves.clone()),
         }
     }
 }
@@ -544,17 +570,7 @@ impl RemoteChunkSource {
         let mut rgs = HashMap::with_capacity(active_rg_indices.len());
 
         for &rg_idx in active_rg_indices {
-            let rg = parquet_metadata.row_group(rg_idx);
-            let mut leaf_ranges: Vec<LeafRange> = Vec::with_capacity(active_col_indices.len());
-            for &col_idx in active_col_indices {
-                let (start, len) = rg.column(col_idx).byte_range();
-                leaf_ranges.push(LeafRange {
-                    leaf: col_idx,
-                    start,
-                    len,
-                });
-            }
-            let groups = Self::coalesce_and_split(leaf_ranges);
+            let groups = rg_coalesced_layout(&parquet_metadata, rg_idx, active_col_indices);
 
             let mut group_slots: Vec<GroupSlot> = Vec::with_capacity(groups.len());
             let mut leaves: HashMap<usize, LeafLoc> =
@@ -729,5 +745,244 @@ impl RemoteChunkSource {
             );
         }
         Ok(out)
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Owned-mode types: immutable range plan + RAII resident row group.
+//
+// The legacy path above instantiates the whole-file range plan as whole-file
+// resident work (every GET spawned at build, bytes cached until the reader
+// drops). The owned path keeps the same coalesced layout (preserving the
+// cross-column IO merging that motivated the custom reader, see PR #6952)
+// but binds download and residency to a per-row-group owner admitted through
+// the process-wide byte budget.
+// ─────────────────────────────────────────────────────────────────────────────
+
+use super::budget::BudgetPermit;
+
+/// Shared between the legacy eager source and the owned plan so the IO
+/// layout (coalesce ≤1MiB gaps, split >24MiB at chunk boundaries) can never
+/// diverge between the two modes.
+fn rg_coalesced_layout(
+    metadata: &ParquetMetaData,
+    rg_idx: usize,
+    active_col_indices: &[usize],
+) -> Vec<RangeGroup> {
+    let rg = metadata.row_group(rg_idx);
+    let mut leaf_ranges: Vec<LeafRange> = Vec::with_capacity(active_col_indices.len());
+    for &col_idx in active_col_indices {
+        let (start, len) = rg.column(col_idx).byte_range();
+        leaf_ranges.push(LeafRange {
+            leaf: col_idx,
+            start,
+            len,
+        });
+    }
+    RemoteChunkSource::coalesce_and_split(leaf_ranges)
+}
+
+/// Immutable per-RG download plan: coalesced byte ranges and the leaf → range
+/// mapping. Holds no `Bytes` and spawns nothing.
+pub(crate) struct RgRangePlan {
+    groups: Vec<RangeGroup>,
+    /// Checked sum of group byte lengths — the budget weight for this RG.
+    total_bytes: usize,
+}
+
+/// Owned-mode replacement for `RemoteChunkSource`: the fetch context plus one
+/// [`RgRangePlan`] per active row group *occurrence position*. Keyed by
+/// position in the pruned `rg_indices` list (NOT by `rg_idx`) so duplicate
+/// row groups (`row_groups=[0, 0]`, supported since PR #6952) get fully
+/// independent plans/permits/residents.
+pub(crate) struct RemoteChunkSourcePlan {
+    pub(super) path: Arc<str>,
+    file_len: u64,
+    uri: String,
+    io_client: Arc<daft_io::IOClient>,
+    io_stats: Option<daft_io::IOStatsRef>,
+    /// Indexed by occurrence position, parallel to the pruned rg_indices.
+    per_occurrence: Vec<RgRangePlan>,
+}
+
+impl RemoteChunkSourcePlan {
+    pub(super) fn from_metadata(
+        prep: RemoteChunkSourcePrep,
+        parquet_metadata: &Arc<ParquetMetaData>,
+        rg_indices: &[usize],
+    ) -> Self {
+        let per_occurrence = rg_indices
+            .iter()
+            .map(|&rg_idx| {
+                let groups =
+                    rg_coalesced_layout(parquet_metadata, rg_idx, &prep.active_col_indices);
+                let total_bytes = groups
+                    .iter()
+                    .map(|g| usize::try_from(g.end - g.start).expect("range length exceeds usize"))
+                    .try_fold(0usize, |acc, len| acc.checked_add(len))
+                    .expect("row-group byte ranges overflow usize");
+                RgRangePlan {
+                    groups,
+                    total_bytes,
+                }
+            })
+            .collect();
+        Self {
+            path: prep.path,
+            file_len: prep.file_size as u64,
+            uri: prep.uri,
+            io_client: prep.io_client,
+            io_stats: prep.io_stats,
+            per_occurrence,
+        }
+    }
+
+    /// Budget weight of one RG occurrence: planned compressed bytes.
+    pub(super) fn occurrence_bytes(&self, occurrence: usize) -> usize {
+        self.per_occurrence[occurrence].total_bytes
+    }
+
+    /// Download every coalesced range of one RG occurrence and assemble the
+    /// RAII owner. Concurrency: all GETs of this RG run together via
+    /// `try_join_all` — actual connection concurrency is bounded by the IO
+    /// client's own pool semaphore (`max_connections_per_io_thread`, see
+    /// `s3_like.rs`), so no extra limiter here. Any failed GET cancels the
+    /// remaining futures; the permit is released by the caller dropping it.
+    pub(super) async fn download_occurrence(
+        &self,
+        occurrence: usize,
+        permit: BudgetPermit,
+    ) -> crate::Result<ResidentRowGroup> {
+        let plan = &self.per_occurrence[occurrence];
+        let fetches = plan.groups.iter().map(|g| {
+            let range = g.start as usize..g.end as usize;
+            let uri = self.uri.clone();
+            let io_client = self.io_client.clone();
+            let io_stats = self.io_stats.clone();
+            async move {
+                let expected = range.end - range.start;
+                let get_result = io_client
+                    .single_url_get(
+                        uri,
+                        Some(daft_io::range::GetRange::Bounded(range)),
+                        io_stats,
+                    )
+                    .await?;
+                let bytes = get_result.bytes().await?;
+                Ok::<_, crate::Error>((bytes, expected))
+            }
+        });
+        let results = futures::future::try_join_all(fetches).await?;
+
+        let mut group_bytes = Vec::with_capacity(results.len());
+        let mut actual_bytes = 0usize;
+        for (i, (bytes, expected)) in results.into_iter().enumerate() {
+            // A short/long body would silently corrupt slicing offsets AND
+            // the budget ledger — fail with a diagnosable error instead.
+            if bytes.len() != expected {
+                return Err(ReaderInternalSnafu {
+                    path: self.path.to_string(),
+                    message: format!(
+                        "range GET length mismatch for group {i}: expected {expected} bytes, got {}",
+                        bytes.len()
+                    ),
+                }
+                .build());
+            }
+            actual_bytes = actual_bytes
+                .checked_add(bytes.len())
+                .expect("resident byte total overflows usize");
+            group_bytes.push(bytes);
+        }
+
+        let mut leaves = HashMap::new();
+        for (group, bytes) in plan.groups.iter().zip(&group_bytes) {
+            for &LeafRange { leaf, start, len } in &group.members {
+                let local_start = (start - group.start) as usize;
+                let slice = bytes.slice(local_start..local_start + len as usize);
+                leaves.insert(
+                    leaf,
+                    OffsetBytes {
+                        base: start,
+                        file_len: self.file_len,
+                        bytes: slice,
+                    },
+                );
+            }
+        }
+
+        permit.metrics().record_resident(actual_bytes);
+        log::debug!(
+            "resident rg occurrence={} bytes={} path={}",
+            occurrence,
+            actual_bytes,
+            self.path
+        );
+        if super::budget::mem_verbose() {
+            eprintln!(
+                "[parquet-mem] +resident occurrence={} bytes={} {}",
+                occurrence,
+                actual_bytes,
+                permit.metrics().snapshot_line()
+            );
+        }
+        Ok(ResidentRowGroup {
+            group_bytes,
+            leaves: Arc::new(leaves),
+            actual_bytes,
+            permit,
+        })
+    }
+}
+
+/// RAII owner of one downloaded row group occurrence. Every decoder holds
+/// this via `RgReader::Resident(Arc<..>)`, so the compressed bytes AND the
+/// budget permit are released exactly when the last reference disappears —
+/// on success, error, panic, or abort alike. No release state machine.
+pub(crate) struct ResidentRowGroup {
+    /// Master references to the downloaded coalesced ranges. `leaves` holds
+    /// refcounted slices of these same allocations — metrics must count
+    /// `group_bytes` lengths only (leaf slices would double-count shared
+    /// coalesced regions).
+    #[allow(dead_code)]
+    group_bytes: Vec<Bytes>,
+    pub(super) leaves: Arc<HashMap<usize, OffsetBytes>>,
+    actual_bytes: usize,
+    permit: BudgetPermit,
+}
+
+impl Drop for ResidentRowGroup {
+    fn drop(&mut self) {
+        self.permit.metrics().release_resident(self.actual_bytes);
+        log::debug!("released resident rg bytes={}", self.actual_bytes);
+        if super::budget::mem_verbose() {
+            eprintln!(
+                "[parquet-mem] -resident bytes={} {}",
+                self.actual_bytes,
+                self.permit.metrics().snapshot_line()
+            );
+        }
+        // `permit` field drops after this, returning the planned bytes to
+        // the budget and waking the queue front.
+    }
+}
+
+/// Per-RG chunk access handed to the decoders: either the legacy shared
+/// source (lazy per-column reads) or an owned resident row group.
+pub(crate) enum RgAccess {
+    Source(Arc<ChunkSource>),
+    Resident(Arc<ResidentRowGroup>),
+}
+
+impl RgAccess {
+    pub(super) async fn open_rg(
+        &self,
+        rg_idx: usize,
+        all_leaves: Arc<[usize]>,
+    ) -> crate::Result<RgReader> {
+        match self {
+            Self::Source(cs) => cs.clone().open_rg(rg_idx, all_leaves).await,
+            Self::Resident(r) => Ok(RgReader::Resident(r.clone())),
+        }
     }
 }

--- a/src/daft-parquet/src/reader/mod.rs
+++ b/src/daft-parquet/src/reader/mod.rs
@@ -1,3 +1,4 @@
+mod budget;
 mod chunk_source;
 mod field_reader;
 mod rg_processor;
@@ -10,7 +11,8 @@ use std::{
 
 use arrow::{array::ArrayRef, datatypes::Schema as ArrowSchema};
 use chunk_source::{
-    ChunkSource, ChunkSourceBuilder, LocalChunkSource, open_local_file, prepare_remote_chunk_source,
+    ChunkSource, ChunkSourceBuilder, LocalChunkSource, RgAccess, open_local_file,
+    prepare_remote_chunk_source,
 };
 use common_error::DaftResult;
 use common_runtime::{JoinSet, get_compute_runtime};
@@ -348,119 +350,183 @@ async fn build_rg_inputs(
             .collect());
     };
 
-    // Limit set → chunked streaming for early termination. Unbounded → one
-    // chunk per col so per-chunk arrow setup costs collapse to per-RG.
-    let chunk_size = match opts.num_rows {
-        Some(_) => opts.batch_size.unwrap_or(DEFAULT_BATCH_SIZE).max(1),
-        None => usize::MAX,
-    };
-    let pred_arrow_schema = schema_from_indices(arrow_schema, &plan.pred_col_indices);
-    // Bind predicate once across all RGs — same chunk schema everywhere.
-    let chunk_daft_schema = Arc::new(Schema::try_from(pred_arrow_schema.as_ref())?);
-    let bound_pred = BoundExpr::try_new(
-        substitute_missing_cols(prefilter_predicate, &chunk_daft_schema)?,
-        &chunk_daft_schema,
-    )?;
+    let setup = PredPrefilter::try_new(arrow_schema, plan, prefilter_predicate, opts)?;
 
     let mut selected_rows_remaining = opts.num_rows.unwrap_or(usize::MAX);
     let mut out: Vec<RgInputs> = Vec::with_capacity(rg_indices.len());
 
+    let access = RgAccess::Source(chunk_source.clone());
     for (&rg_idx, base_sel) in rg_indices.iter().zip(base_selections) {
         if selected_rows_remaining == 0 {
             break;
         }
-        let total_selected = base_sel
-            .as_ref()
-            .map(|s| s.row_count())
-            .unwrap_or_else(|| metadata.row_group(rg_idx).num_rows() as usize);
-
-        let (mut col_receivers, _col_handles) = spawn_col_decoders(
-            &plan.pred_col_indices,
-            chunk_source,
-            metadata,
-            arrow_schema,
-            base_sel.as_ref(),
-            rg_idx,
-            chunk_size,
-            path,
-        )
-        .await?;
-
-        let mut predicate_selectors: Vec<RowSelector> = Vec::new();
-        let mut filtered_pred_by_col: Vec<Vec<ArrayRef>> = (0..plan.pred_col_indices.len())
-            .map(|_| Vec::new())
-            .collect();
-        let mut processed_rows = 0usize;
-
-        loop {
-            let Some(chunks) = recv_one_chunk(&mut col_receivers).await? else {
-                break;
-            };
-            let chunk_rows = chunks[0].len();
-            let daft_pred =
-                record_batch_from_arrow(pred_arrow_schema.clone(), chunks.clone(), path.as_ref())?;
-            let mask = eval_predicate_mask(&daft_pred, &bound_pred)?;
-
-            let selected_rows = mask.true_count();
-            let (mask, selected_rows) = if selected_rows > selected_rows_remaining {
-                (
-                    truncate_mask_to_n_trues(&mask, selected_rows_remaining),
-                    selected_rows_remaining,
-                )
-            } else {
-                (mask, selected_rows)
-            };
-
-            let filtered = filter_arrays_by_mask(&chunks, &mask, path.as_ref())?;
-            for (col_pos, filtered) in filtered.into_iter().enumerate() {
-                filtered_pred_by_col[col_pos].push(filtered);
-            }
-            predicate_selectors.extend(bool_array_to_row_selection(&mask).iter().copied());
-            processed_rows += chunk_rows;
-            selected_rows_remaining -= selected_rows;
-            if selected_rows_remaining == 0 {
-                break;
-            }
-        }
-        // Dropping receivers closes the channels → spawned decoders abort.
-        drop(col_receivers);
-
-        // Concat per-col filtered chunks into one ArrayRef per col. Zero rows
-        // processed (e.g. base_sel selected 0 rows) → empty array of the col's
-        // data type.
-        let pred_arrays: Vec<ArrayRef> = plan
-            .pred_col_indices
-            .iter()
-            .enumerate()
-            .map(|(col_pos, &col_idx)| {
-                let chunks = &filtered_pred_by_col[col_pos];
-                if chunks.is_empty() {
-                    arrow::array::new_empty_array(arrow_schema.field(col_idx).data_type())
-                } else {
-                    let refs: Vec<&dyn arrow::array::Array> =
-                        chunks.iter().map(|a| a.as_ref()).collect();
-                    arrow::compute::concat(&refs).expect("concat per-col chunks")
-                }
-            })
-            .collect();
-
-        let unprocessed = total_selected - processed_rows;
-        if unprocessed > 0 {
-            predicate_selectors.push(RowSelector::skip(unprocessed));
-        }
-        let pred_sel = RowSelection::from(predicate_selectors);
-        let selection = Some(match &base_sel {
-            Some(base) => refine_selection(base, &pred_sel),
-            None => pred_sel,
-        });
-
-        out.push(RgInputs {
-            selection,
-            pred_arrays,
-        });
+        out.push(
+            prefilter_one_rg(
+                &access,
+                metadata,
+                arrow_schema,
+                plan,
+                path,
+                &setup,
+                rg_idx,
+                base_sel,
+                Some(&mut selected_rows_remaining),
+            )
+            .await?,
+        );
     }
 
     Ok(out)
+}
+
+/// Per-file setup for the predicate prefilter pass, shared across RGs.
+struct PredPrefilter {
+    pred_arrow_schema: Arc<ArrowSchema>,
+    bound_pred: BoundExpr,
+    chunk_size: usize,
+}
+
+impl PredPrefilter {
+    fn try_new(
+        arrow_schema: &Arc<ArrowSchema>,
+        plan: &ColumnPlan,
+        prefilter_predicate: &ExprRef,
+        opts: &ParquetReadOptions,
+    ) -> DaftResult<Self> {
+        // Limit set → chunked streaming for early termination. Unbounded → one
+        // chunk per col so per-chunk arrow setup costs collapse to per-RG.
+        let chunk_size = match opts.num_rows {
+            Some(_) => opts.batch_size.unwrap_or(DEFAULT_BATCH_SIZE).max(1),
+            None => usize::MAX,
+        };
+        let pred_arrow_schema = schema_from_indices(arrow_schema, &plan.pred_col_indices);
+        // Bind predicate once across all RGs — same chunk schema everywhere.
+        let chunk_daft_schema = Arc::new(Schema::try_from(pred_arrow_schema.as_ref())?);
+        let bound_pred = BoundExpr::try_new(
+            substitute_missing_cols(prefilter_predicate, &chunk_daft_schema)?,
+            &chunk_daft_schema,
+        )?;
+        Ok(Self {
+            pred_arrow_schema,
+            bound_pred,
+            chunk_size,
+        })
+    }
+}
+
+/// Run the predicate prefilter for ONE row group: decode predicate columns,
+/// evaluate the mask, and produce the refined `RowSelection` + filtered
+/// predicate arrays.
+///
+/// `cross_rg_remaining`: the legacy sequential pass threads the global
+/// `num_rows` limit through here (truncate the mask, stop early). The owned
+/// pipeline passes `None` — RG tasks run concurrently, so cross-RG limit
+/// state must not enter them; the outer `apply_cross_rg_limit` is the single
+/// point of truncation (lookahead RGs may do some extra work — accepted).
+#[allow(clippy::too_many_arguments)]
+async fn prefilter_one_rg(
+    access: &RgAccess,
+    metadata: &Arc<ParquetMetaData>,
+    arrow_schema: &Arc<ArrowSchema>,
+    plan: &ColumnPlan,
+    path: &Arc<str>,
+    setup: &PredPrefilter,
+    rg_idx: usize,
+    base_sel: Option<RowSelection>,
+    mut cross_rg_remaining: Option<&mut usize>,
+) -> DaftResult<RgInputs> {
+    let total_selected = base_sel
+        .as_ref()
+        .map(|s| s.row_count())
+        .unwrap_or_else(|| metadata.row_group(rg_idx).num_rows() as usize);
+
+    let (mut col_receivers, _col_handles) = spawn_col_decoders(
+        &plan.pred_col_indices,
+        access,
+        metadata,
+        arrow_schema,
+        base_sel.as_ref(),
+        rg_idx,
+        setup.chunk_size,
+        path,
+    )
+    .await?;
+
+    let mut predicate_selectors: Vec<RowSelector> = Vec::new();
+    let mut filtered_pred_by_col: Vec<Vec<ArrayRef>> = (0..plan.pred_col_indices.len())
+        .map(|_| Vec::new())
+        .collect();
+    let mut processed_rows = 0usize;
+
+    loop {
+        let Some(chunks) = recv_one_chunk(&mut col_receivers).await? else {
+            break;
+        };
+        let chunk_rows = chunks[0].len();
+        let daft_pred = record_batch_from_arrow(
+            setup.pred_arrow_schema.clone(),
+            chunks.clone(),
+            path.as_ref(),
+        )?;
+        let mut mask = eval_predicate_mask(&daft_pred, &setup.bound_pred)?;
+
+        let mut selected_rows = mask.true_count();
+        if let Some(remaining) = cross_rg_remaining.as_deref_mut()
+            && selected_rows > *remaining
+        {
+            mask = truncate_mask_to_n_trues(&mask, *remaining);
+            selected_rows = *remaining;
+        }
+
+        let filtered = filter_arrays_by_mask(&chunks, &mask, path.as_ref())?;
+        for (col_pos, filtered) in filtered.into_iter().enumerate() {
+            filtered_pred_by_col[col_pos].push(filtered);
+        }
+        predicate_selectors.extend(bool_array_to_row_selection(&mask).iter().copied());
+        processed_rows += chunk_rows;
+        if let Some(remaining) = cross_rg_remaining.as_deref_mut() {
+            *remaining -= selected_rows;
+            if *remaining == 0 {
+                break;
+            }
+        }
+    }
+    // Dropping receivers closes the channels → spawned decoders abort.
+    drop(col_receivers);
+
+    // Concat per-col filtered chunks into one ArrayRef per col. Zero rows
+    // processed (e.g. base_sel selected 0 rows) → empty array of the col's
+    // data type.
+    let pred_arrays: Vec<ArrayRef> = plan
+        .pred_col_indices
+        .iter()
+        .enumerate()
+        .map(|(col_pos, &col_idx)| {
+            let chunks = &filtered_pred_by_col[col_pos];
+            if chunks.is_empty() {
+                arrow::array::new_empty_array(arrow_schema.field(col_idx).data_type())
+            } else {
+                let refs: Vec<&dyn arrow::array::Array> =
+                    chunks.iter().map(|a| a.as_ref()).collect();
+                arrow::compute::concat(&refs).expect("concat per-col chunks")
+            }
+        })
+        .collect();
+
+    let unprocessed = total_selected - processed_rows;
+    if unprocessed > 0 {
+        predicate_selectors.push(RowSelector::skip(unprocessed));
+    }
+    let pred_sel = RowSelection::from(predicate_selectors);
+    let selection = Some(match &base_sel {
+        Some(base) => refine_selection(base, &pred_sel),
+        None => pred_sel,
+    });
+
+    Ok(RgInputs {
+        selection,
+        pred_arrays,
+    })
 }
 
 /// Shared per-file state for an RG-decoding task. One `Arc<RgTaskCtx>` is
@@ -471,7 +537,6 @@ async fn build_rg_inputs(
 /// Default path.
 pub(super) struct RgTaskCtx {
     pub(super) path: Arc<str>,
-    pub(super) chunk_source: Arc<ChunkSource>,
     pub(super) metadata: Arc<ParquetMetaData>,
     pub(super) arrow_schema: Arc<ArrowSchema>,
     pub(super) plan: ColumnPlan,
@@ -485,6 +550,7 @@ pub(super) struct RgTaskCtx {
 /// a single file.
 fn build_rg_stream(
     ctx: Arc<RgTaskCtx>,
+    chunk_source: Arc<ChunkSource>,
     rg_indices: Vec<usize>,
     rg_inputs: Vec<RgInputs>,
 ) -> BoxStream<'static, DaftResult<RecordBatch>> {
@@ -499,14 +565,21 @@ fn build_rg_stream(
     let mut joinset: JoinSet<DaftResult<()>> = JoinSet::new();
     for (rg_pos, (sender, inputs)) in senders.into_iter().zip(rg_inputs).enumerate() {
         let ctx = ctx.clone();
+        let access = RgAccess::Source(chunk_source.clone());
         let rg_idx = rg_indices[rg_pos];
         joinset.spawn_on(
             async move {
                 let mut sub_stream = if ctx.plan.data_col_indices.is_empty() {
-                    process_rg_predicate_only(ctx.clone(), rg_idx, inputs.selection).await
+                    process_rg_predicate_only(ctx.clone(), access, rg_idx, inputs.selection).await
                 } else {
-                    process_rg_with_data_cols(ctx, rg_idx, inputs.selection, inputs.pred_arrays)
-                        .await
+                    process_rg_with_data_cols(
+                        ctx,
+                        access,
+                        rg_idx,
+                        inputs.selection,
+                        inputs.pred_arrays,
+                    )
+                    .await
                 };
                 while let Some(item) = sub_stream.next().await {
                     if sender.send(item).await.is_err() {
@@ -618,7 +691,52 @@ pub async fn stream_parquet(
         );
     }
 
-    // Now spawn the byte-range fetches (remote) — pruned set only.
+    let return_schema = plan.return_daft_schema.clone();
+    let ctx = Arc::new(RgTaskCtx {
+        path: path.clone(),
+        metadata: prepared.parquet_metadata.clone(),
+        arrow_schema: prepared.arrow_schema.clone(),
+        plan,
+        predicate: opts.predicate.clone(),
+        chunk_size,
+    });
+
+    // Owned mode (default): per-RG lifecycle admitted through the
+    // process-wide byte budget. Local sources fall back to legacy this
+    // round (per-call preads, nothing resident to bound).
+    let cs_builder = if reader_mode_owned() {
+        match cs_builder.build_plan(&prepared.parquet_metadata, &rg_indices) {
+            Ok(remote_plan) => {
+                let base_selections =
+                    build_base_selections(&prepared.parquet_metadata, &rg_indices, opts);
+                let pred_setup =
+                    match ctx.predicate.as_ref().filter(|_| {
+                        ctx.plan.predicate_pushed && !ctx.plan.data_col_indices.is_empty()
+                    }) {
+                        Some(pred) => Some(Arc::new(PredPrefilter::try_new(
+                            &prepared.arrow_schema,
+                            &ctx.plan,
+                            pred,
+                            opts,
+                        )?)),
+                        None => None,
+                    };
+                let stream = stream_parquet_owned(
+                    Arc::new(remote_plan),
+                    ctx,
+                    rg_indices,
+                    base_selections,
+                    pred_setup,
+                );
+                return Ok((return_schema, apply_cross_rg_limit(stream, opts.num_rows)));
+            }
+            Err(local_builder) => *local_builder,
+        }
+    } else {
+        cs_builder
+    };
+
+    // Legacy path: spawn every byte-range fetch now (remote) — pruned set only.
     let chunk_source = Arc::new(cs_builder.build(prepared.parquet_metadata.clone(), &rg_indices));
 
     let rg_inputs = build_rg_inputs(
@@ -626,23 +744,168 @@ pub async fn stream_parquet(
         &prepared.parquet_metadata,
         &prepared.arrow_schema,
         &rg_indices,
-        &plan,
+        &ctx.plan,
         opts,
         &path,
     )
     .await?;
 
-    let return_schema = plan.return_daft_schema.clone();
-    let ctx = Arc::new(RgTaskCtx {
-        path,
-        chunk_source,
-        metadata: prepared.parquet_metadata,
-        arrow_schema: prepared.arrow_schema,
-        plan,
-        predicate: opts.predicate.clone(),
-        chunk_size,
-    });
-    let stream = build_rg_stream(ctx, rg_indices, rg_inputs);
+    let stream = build_rg_stream(ctx, chunk_source, rg_indices, rg_inputs);
 
     Ok((return_schema, apply_cross_rg_limit(stream, opts.num_rows)))
+}
+
+/// `DAFT_PARQUET_READER_MODE`: `legacy` → eager whole-file path; anything
+/// else (default) → owned per-RG lifecycle. Same-binary A/B toggle for the
+/// prototype; the legacy path is slated for removal in the upstream PR.
+fn reader_mode_owned() -> bool {
+    static MODE: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *MODE.get_or_init(|| {
+        !matches!(
+            std::env::var("DAFT_PARQUET_READER_MODE").as_deref(),
+            Ok("legacy")
+        )
+    })
+}
+
+/// Decode lookahead: how many RG tasks may exist concurrently (download of
+/// RG i+1 overlaps decode of RG i). Bounds TASK COUNT only — resident memory
+/// is bounded by the byte budget, network in-flight by the IO client pool.
+fn rg_lookahead() -> usize {
+    static L: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *L.get_or_init(|| {
+        std::env::var("DAFT_PARQUET_RG_LOOKAHEAD")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .unwrap_or(2)
+            .max(1)
+    })
+}
+
+/// Owned-mode pipeline. Structure (each piece is load-bearing):
+///
+/// - The coordinator registers budget reservations **synchronously** in RG
+///   occurrence order and never awaits admission itself — awaiting here
+///   while the front RG blocks on a full output channel is the v1 deadlock
+///   (front can't finish → can't release budget → next permit never comes).
+///   Each RG task awaits its own reservation.
+/// - Per-RG tasks are `RuntimeTask`s (abort-on-drop) owned by the
+///   coordinator, which is itself a `RuntimeTask` owned by the returned
+///   stream: dropping the stream (limit hit, consumer cancelled) cascades
+///   into aborting every task, whose `ResidentRowGroup`/reservation Drops
+///   release bytes and budget.
+/// - After a RG's channel closes the coordinator explicitly awaits its task
+///   handle, so an Err or panic surfaces instead of hanging the pipeline.
+/// - No cross-RG limit state enters the tasks; `apply_cross_rg_limit`
+///   truncates at the single ordered exit.
+fn stream_parquet_owned(
+    remote_plan: Arc<chunk_source::RemoteChunkSourcePlan>,
+    ctx: Arc<RgTaskCtx>,
+    rg_indices: Vec<usize>,
+    base_selections: Vec<Option<RowSelection>>,
+    pred_setup: Option<Arc<PredPrefilter>>,
+) -> BoxStream<'static, DaftResult<RecordBatch>> {
+    use tokio_stream::wrappers::ReceiverStream;
+
+    let budget = budget::process_budget().clone();
+    let lookahead = rg_lookahead();
+    let compute = get_compute_runtime();
+
+    let (out_tx, out_rx) = tokio::sync::mpsc::channel::<DaftResult<RecordBatch>>(1);
+
+    let coordinator: common_runtime::RuntimeTask<DaftResult<()>> = compute.spawn(async move {
+        let compute = get_compute_runtime();
+        let mut inflight: std::collections::VecDeque<(
+            common_runtime::RuntimeTask<DaftResult<()>>,
+            tokio::sync::mpsc::Receiver<DaftResult<RecordBatch>>,
+        )> = std::collections::VecDeque::new();
+        let mut pending = rg_indices
+            .into_iter()
+            .zip(base_selections)
+            .enumerate()
+            .collect::<std::collections::VecDeque<_>>();
+
+        loop {
+            while inflight.len() < lookahead {
+                let Some((occurrence, (rg_idx, base_sel))) = pending.pop_front() else {
+                    break;
+                };
+                // Synchronous FIFO registration — the admission ORDER is
+                // fixed here; the WAIT happens inside the task.
+                let reservation = budget.reserve(remote_plan.occurrence_bytes(occurrence));
+                let (tx, rx) = tokio::sync::mpsc::channel::<DaftResult<RecordBatch>>(1);
+                let remote_plan = remote_plan.clone();
+                let ctx = ctx.clone();
+                let pred_setup = pred_setup.clone();
+                let task = compute.spawn(async move {
+                    let permit = reservation.acquire().await;
+                    let resident =
+                        Arc::new(remote_plan.download_occurrence(occurrence, permit).await?);
+                    let access = RgAccess::Resident(resident.clone());
+
+                    let inputs = match &pred_setup {
+                        Some(setup) => {
+                            prefilter_one_rg(
+                                &access,
+                                &ctx.metadata,
+                                &ctx.arrow_schema,
+                                &ctx.plan,
+                                &ctx.path,
+                                setup,
+                                rg_idx,
+                                base_sel,
+                                None, // no cross-RG limit state in concurrent tasks
+                            )
+                            .await?
+                        }
+                        None => RgInputs {
+                            selection: base_sel,
+                            pred_arrays: Vec::new(),
+                        },
+                    };
+
+                    let mut sub_stream = if ctx.plan.data_col_indices.is_empty() {
+                        process_rg_predicate_only(ctx.clone(), access, rg_idx, inputs.selection)
+                            .await
+                    } else {
+                        process_rg_with_data_cols(
+                            ctx.clone(),
+                            access,
+                            rg_idx,
+                            inputs.selection,
+                            inputs.pred_arrays,
+                        )
+                        .await
+                    };
+                    while let Some(item) = sub_stream.next().await {
+                        if tx.send(item).await.is_err() {
+                            break;
+                        }
+                    }
+                    // sub_stream (and its decoders) dropped here; `resident`
+                    // follows — bytes and permit release together.
+                    DaftResult::Ok(())
+                });
+                inflight.push_back((task, rx));
+            }
+
+            let Some((task, mut rx)) = inflight.pop_front() else {
+                break; // nothing pending, nothing inflight — done
+            };
+            while let Some(item) = rx.recv().await {
+                if out_tx.send(item).await.is_err() {
+                    // Consumer went away; dropping `inflight`/`task` aborts
+                    // everything and releases budget via Drop.
+                    return Ok(());
+                }
+            }
+            // Channel closed: harvest the task so errors and panics surface
+            // (a panic here is a JoinError, mapped into DaftError::External).
+            task.await??;
+        }
+        Ok(())
+    });
+
+    let merged: BoxStream<'static, DaftResult<RecordBatch>> = Box::pin(ReceiverStream::new(out_rx));
+    common_runtime::combine_stream(merged, async move { coordinator.await? }).boxed()
 }

--- a/src/daft-parquet/src/reader/mod.rs
+++ b/src/daft-parquet/src/reader/mod.rs
@@ -782,6 +782,14 @@ fn rg_lookahead() -> usize {
     })
 }
 
+/// One in-flight RG: its task handle paired with the channel its batches
+/// arrive on. The coordinator drains the front receiver and then awaits the
+/// matching task to surface Err/panic.
+type InflightRg = (
+    common_runtime::RuntimeTask<DaftResult<()>>,
+    tokio::sync::mpsc::Receiver<DaftResult<RecordBatch>>,
+);
+
 /// Owned-mode pipeline. Structure (each piece is load-bearing):
 ///
 /// - The coordinator registers budget reservations **synchronously** in RG
@@ -815,10 +823,8 @@ fn stream_parquet_owned(
 
     let coordinator: common_runtime::RuntimeTask<DaftResult<()>> = compute.spawn(async move {
         let compute = get_compute_runtime();
-        let mut inflight: std::collections::VecDeque<(
-            common_runtime::RuntimeTask<DaftResult<()>>,
-            tokio::sync::mpsc::Receiver<DaftResult<RecordBatch>>,
-        )> = std::collections::VecDeque::new();
+        let mut inflight: std::collections::VecDeque<InflightRg> =
+            std::collections::VecDeque::new();
         let mut pending = rg_indices
             .into_iter()
             .zip(base_selections)

--- a/src/daft-parquet/src/reader/rg_processor.rs
+++ b/src/daft-parquet/src/reader/rg_processor.rs
@@ -15,7 +15,7 @@ use tokio::sync::mpsc;
 
 use super::{
     RgTaskCtx,
-    chunk_source::ChunkSource,
+    chunk_source::RgAccess,
     field_reader::{decode_one_streaming, leaves_for_top_fields},
     util::{
         eval_predicate_mask, filter_arrays_by_mask, project_to_schema, record_batch_from_arrow,
@@ -49,7 +49,7 @@ pub(super) async fn recv_one_chunk(receivers: &mut [ColRx]) -> DaftResult<Option
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn spawn_col_decoders(
     col_indices: &[usize],
-    chunk_source: &Arc<ChunkSource>,
+    access: &RgAccess,
     metadata: &Arc<ParquetMetaData>,
     arrow_schema: &Arc<ArrowSchema>,
     selection: Option<&RowSelection>,
@@ -58,9 +58,11 @@ pub(super) async fn spawn_col_decoders(
     path: &Arc<str>,
 ) -> DaftResult<(Vec<ColRx>, JoinSet<DaftResult<()>>)> {
     // The reader picks its own per-RG access pattern (batched pre-fetch for
-    // local, lazy per-column for remote). See `ChunkSource::open_rg`.
+    // local, lazy per-column for remote, owned resident RG). Each column
+    // task clones `rg_reader`, so a `Resident` reader keeps the RG owner
+    // (bytes + budget permit) alive until every decoder exits.
     let all_leaves: Arc<[usize]> = leaves_for_top_fields(metadata.as_ref(), col_indices).into();
-    let rg_reader = chunk_source.clone().open_rg(rg_idx, all_leaves).await?;
+    let rg_reader = access.open_rg(rg_idx, all_leaves).await?;
 
     let compute = get_compute_runtime();
     let mut rxs = Vec::with_capacity(col_indices.len());
@@ -114,6 +116,7 @@ struct StreamingState {
 
 pub(super) async fn process_rg_with_data_cols(
     ctx: Arc<RgTaskCtx>,
+    access: RgAccess,
     rg_idx: usize,
     selection: Option<RowSelection>,
     filtered_pred: Vec<ArrayRef>,
@@ -124,7 +127,7 @@ pub(super) async fn process_rg_with_data_cols(
 
     let (col_receivers, mut col_decoders) = match spawn_col_decoders(
         &ctx.plan.data_col_indices,
-        &ctx.chunk_source,
+        &access,
         &ctx.metadata,
         &ctx.arrow_schema,
         selection.as_ref(),
@@ -215,6 +218,7 @@ struct PredicateOnlyState {
 
 pub(super) async fn process_rg_predicate_only(
     ctx: Arc<RgTaskCtx>,
+    access: RgAccess,
     rg_idx: usize,
     selection: Option<RowSelection>,
 ) -> BoxStream<'static, DaftResult<RecordBatch>> {
@@ -226,7 +230,7 @@ pub(super) async fn process_rg_predicate_only(
 
     let (col_receivers, mut col_decoders) = match spawn_col_decoders(
         &plan.pred_col_indices,
-        &ctx.chunk_source,
+        &access,
         &ctx.metadata,
         &ctx.arrow_schema,
         selection.as_ref(),


### PR DESCRIPTION
## Changes Made

- Replace the eager remote reader and local fallback with one ordered, bounded row-group coordinator for both source types. Local `pread` and remote range GET remain source-specific, but planning, predicate handling, cancellation, ordering, and error propagation are shared.
- Build occurrence plans only after the final `ColumnPlan` has expanded top-level fields to physical Parquet leaves. Duplicate and out-of-order row-group requests retain occurrence order.
- Split pushed predicates into predicate and data range phases. A rejected row group never reads its data-only ranges; filtered predicate arrays remain available for the data decode phase.
- Bind each resident phase's compressed bytes and FIFO admission permit to `ResidentRowGroup` RAII ownership. Reservations are registered synchronously by the coordinator; cancellation, errors, and consumer drop return reservations/permits.
- Apply the shared admission path to local and remote reads. `DAFT_PARQUET_READER_MEMORY_BUDGET_BYTES` is process-scoped: unset or `0` is unlimited; a positive value enables FIFO byte admission; an invalid value fails reader initialization.
- Remove the prototype reader-mode switch and old eager source. Local range reads now reject short reads instead of decoding zero-filled buffers.

## Behavior and Limits

- The budget bounds admitted application-owned compressed ranges, not total RSS. Decode/output buffers, downstream operators, allocator retention, and Ray object-store memory remain outside it.
- Lookahead remains two row groups per reader. It bounds task depth; the shared budget governs compressed-byte admission.
- Predicate/data ranges are fetched per phase. This deliberately avoids data-only reads for rejected predicates; real-S3 throughput and first-batch benchmarks remain required before removing draft status.

## Validation

- `cargo fmt --all`
- `cargo test -p daft-parquet` — 27 passed, including S3 reader tests
- `git diff --check`

A focused Python integration test was attempted with the local Ray environment, but the checkout's Python source and installed Rust extension disagree on the pre-existing `min_cpu_per_task` config field before the Parquet read starts.

## Related Issues

Related to #7290