### PR TITLE
feat(io): support hdfs via opendal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if 1.0.4",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1504,6 +1515,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "blocking"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1643,6 +1663,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1732,6 +1761,16 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.7",
+ "inout",
 ]
 
 [[package]]
@@ -2430,6 +2469,15 @@ name = "ctor-proc-macro"
 version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "daft"
@@ -3749,6 +3797,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "des"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdd80ce8ce993de27e9f063a444a4d53ce8e8db4c1f00cc03af5ad5a9867a1e"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3816,6 +3873,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
 dependencies = [
  "const-random",
+]
+
+[[package]]
+name = "dns-lookup"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e39034cee21a2f5bbb66ba0e3689819c4bb5d00382a282006e802a7ffa6c41d"
+dependencies = [
+ "cfg-if 1.0.4",
+ "libc",
+ "socket2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4289,6 +4358,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "g2gen"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a7e0eb46f83a20260b850117d204366674e85d3a908d90865c78df9a6b1dfc"
+dependencies = [
+ "g2poly",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "g2p"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "539e2644c030d3bf4cd208cb842d2ce2f80e82e6e8472390bcef83ceba0d80ad"
+dependencies = [
+ "g2gen",
+ "g2poly",
+]
+
+[[package]]
+name = "g2poly"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "312d2295c7302019c395cfb90dacd00a82a2eabd700429bba9c7a3f38dbbe11b"
+
+[[package]]
 name = "gearhash"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4615,6 +4712,47 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "hdfs-native"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51610510377a0847d53b78b53f9c6c9b7df3ffb300d1181b2e04f68bba363734"
+dependencies = [
+ "aes",
+ "base64 0.22.1",
+ "bitflags 2.11.0",
+ "bumpalo",
+ "bytes",
+ "cbc",
+ "chrono",
+ "cipher",
+ "crc",
+ "ctr",
+ "des",
+ "dns-lookup",
+ "futures",
+ "g2p",
+ "hex",
+ "hmac",
+ "libc",
+ "libloading 0.9.0",
+ "log",
+ "md-5 0.10.6",
+ "num-traits",
+ "once_cell",
+ "prost",
+ "prost-types",
+ "rand 0.9.2",
+ "regex",
+ "roxmltree",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "url",
+ "uuid",
+ "whoami 1.6.1",
+]
 
 [[package]]
 name = "heapify"
@@ -5118,6 +5256,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac"
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5482,7 +5630,10 @@ version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
+ "bitflags 2.11.0",
  "libc",
+ "plain",
+ "redox_syscall 0.8.1",
 ]
 
 [[package]]
@@ -5944,6 +6095,7 @@ dependencies = [
  "opendal-service-fs",
  "opendal-service-github",
  "opendal-service-goosefs",
+ "opendal-service-hdfs-native",
  "opendal-service-obs",
  "opendal-service-oss",
  "opendal-service-tos",
@@ -6035,6 +6187,20 @@ dependencies = [
  "opendal-core",
  "serde",
  "tokio",
+]
+
+[[package]]
+name = "opendal-service-hdfs-native"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d967da0d0c6996d570feabaa9198303d78600feca98853eb7bf50e136f1f128b"
+dependencies = [
+ "bytes",
+ "futures",
+ "hdfs-native",
+ "log",
+ "opendal-core",
+ "serde",
 ]
 
 [[package]]
@@ -7120,6 +7286,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b44b894f2a6e36457d665d1e08c3866add6ed5e70050c1b4ba8a8ddedb02ce7"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7450,6 +7625,15 @@ dependencies = [
  "libc",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "roxmltree"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1964b10c76125c36f8afe190065a4bf9a87bf324842c05701330bba9f1cacbb"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -9138,6 +9322,12 @@ dependencies = [
 
 [[package]]
 name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
+name = "wasite"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
@@ -9325,6 +9515,17 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite 0.1.0",
+ "web-sys",
+]
+
+[[package]]
+name = "whoami"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6a5b12f9df4f978d2cfdb1bd3bac52433f44393342d7ee9c25f5a1c14c0f45d"
@@ -9332,7 +9533,7 @@ dependencies = [
  "libc",
  "libredox",
  "objc2-system-configuration",
- "wasite",
+ "wasite 1.0.2",
  "web-sys",
 ]
 
@@ -9485,7 +9686,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -9494,7 +9695,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -9512,14 +9722,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -9538,10 +9765,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -9550,10 +9789,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -9562,10 +9813,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -9574,10 +9837,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -9835,7 +10110,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
- "whoami",
+ "whoami 2.1.1",
  "winapi",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6730,7 +6730,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,17 +15,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "aes"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
-dependencies = [
- "cfg-if 1.0.4",
- "cipher",
- "cpufeatures 0.2.17",
-]
-
-[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1515,15 +1504,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-padding"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "blocking"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1663,15 +1643,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
-name = "cbc"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
-dependencies = [
- "cipher",
-]
-
-[[package]]
 name = "cc"
 version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1761,16 +1732,6 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
-]
-
-[[package]]
-name = "cipher"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
-dependencies = [
- "crypto-common 0.1.7",
- "inout",
 ]
 
 [[package]]
@@ -2469,15 +2430,6 @@ name = "ctor-proc-macro"
 version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
-
-[[package]]
-name = "ctr"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
-dependencies = [
- "cipher",
-]
 
 [[package]]
 name = "daft"
@@ -3797,15 +3749,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "des"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdd80ce8ce993de27e9f063a444a4d53ce8e8db4c1f00cc03af5ad5a9867a1e"
-dependencies = [
- "cipher",
-]
-
-[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3873,18 +3816,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
 dependencies = [
  "const-random",
-]
-
-[[package]]
-name = "dns-lookup"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e39034cee21a2f5bbb66ba0e3689819c4bb5d00382a282006e802a7ffa6c41d"
-dependencies = [
- "cfg-if 1.0.4",
- "libc",
- "socket2",
- "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4358,34 +4289,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "g2gen"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5a7e0eb46f83a20260b850117d204366674e85d3a908d90865c78df9a6b1dfc"
-dependencies = [
- "g2poly",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "g2p"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "539e2644c030d3bf4cd208cb842d2ce2f80e82e6e8472390bcef83ceba0d80ad"
-dependencies = [
- "g2gen",
- "g2poly",
-]
-
-[[package]]
-name = "g2poly"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312d2295c7302019c395cfb90dacd00a82a2eabd700429bba9c7a3f38dbbe11b"
-
-[[package]]
 name = "gearhash"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4714,44 +4617,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
-name = "hdfs-native"
-version = "0.13.5"
+name = "hdfs-sys"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51610510377a0847d53b78b53f9c6c9b7df3ffb300d1181b2e04f68bba363734"
+checksum = "33e2d5cefba2d51a26b44d2a493f963a32725a0f6593c91be4a610ad449c49cb"
 dependencies = [
- "aes",
- "base64 0.22.1",
- "bitflags 2.11.0",
- "bumpalo",
- "bytes",
- "cbc",
- "chrono",
- "cipher",
- "crc",
- "ctr",
- "des",
- "dns-lookup",
+ "cc",
+ "java-locator",
+]
+
+[[package]]
+name = "hdrs"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c42a693bfe5dc8fcad1f24044c5ec355c5f157b8ce63c7d62f51cecbc7878d"
+dependencies = [
+ "blocking",
+ "errno",
  "futures",
- "g2p",
- "hex",
- "hmac",
+ "hdfs-sys",
  "libc",
- "libloading 0.9.0",
  "log",
- "md-5 0.10.6",
- "num-traits",
- "once_cell",
- "prost",
- "prost-types",
- "rand 0.9.2",
- "regex",
- "roxmltree",
- "socket2",
- "thiserror 2.0.18",
- "tokio",
- "url",
- "uuid",
- "whoami 1.6.1",
 ]
 
 [[package]]
@@ -5256,16 +5142,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac"
 
 [[package]]
-name = "inout"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
-dependencies = [
- "block-padding",
- "generic-array",
-]
-
-[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5377,6 +5253,15 @@ dependencies = [
  "log",
  "regex-lite",
  "urlencoding",
+]
+
+[[package]]
+name = "java-locator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09c46c1fe465c59b1474e665e85e1256c3893dd00927b8d55f63b09044c1e64f"
+dependencies = [
+ "glob",
 ]
 
 [[package]]
@@ -5630,10 +5515,7 @@ version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
- "bitflags 2.11.0",
  "libc",
- "plain",
- "redox_syscall 0.8.1",
 ]
 
 [[package]]
@@ -6095,7 +5977,7 @@ dependencies = [
  "opendal-service-fs",
  "opendal-service-github",
  "opendal-service-goosefs",
- "opendal-service-hdfs-native",
+ "opendal-service-hdfs",
  "opendal-service-obs",
  "opendal-service-oss",
  "opendal-service-tos",
@@ -6190,17 +6072,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "opendal-service-hdfs-native"
+name = "opendal-service-hdfs"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d967da0d0c6996d570feabaa9198303d78600feca98853eb7bf50e136f1f128b"
+checksum = "fb51ce674ce98b8b7d9ac7d2dfc9d7fc8f1bbd1da1a5fb928ecc5f13ba7dc88a"
 dependencies = [
  "bytes",
  "futures",
- "hdfs-native",
+ "hdrs",
  "log",
  "opendal-core",
  "serde",
+ "tokio",
 ]
 
 [[package]]
@@ -7286,15 +7169,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b44b894f2a6e36457d665d1e08c3866add6ed5e70050c1b4ba8a8ddedb02ce7"
-dependencies = [
- "bitflags 2.11.0",
-]
-
-[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7625,15 +7499,6 @@ dependencies = [
  "libc",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "roxmltree"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1964b10c76125c36f8afe190065a4bf9a87bf324842c05701330bba9f1cacbb"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -9322,12 +9187,6 @@ dependencies = [
 
 [[package]]
 name = "wasite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
-
-[[package]]
-name = "wasite"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
@@ -9515,17 +9374,6 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "whoami"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
-dependencies = [
- "libredox",
- "wasite 0.1.0",
- "web-sys",
-]
-
-[[package]]
-name = "whoami"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6a5b12f9df4f978d2cfdb1bd3bac52433f44393342d7ee9c25f5a1c14c0f45d"
@@ -9533,7 +9381,7 @@ dependencies = [
  "libc",
  "libredox",
  "objc2-system-configuration",
- "wasite 1.0.2",
+ "wasite",
  "web-sys",
 ]
 
@@ -9686,7 +9534,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -9695,16 +9543,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -9722,31 +9561,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -9765,22 +9587,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -9789,22 +9599,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -9813,22 +9611,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -9837,22 +9623,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -10110,7 +9884,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
- "whoami 2.1.1",
+ "whoami",
  "winapi",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ pyo3-log = {workspace = true, optional = true}
 sysinfo = {workspace = true}
 
 [features]
+hdfs = ["daft-io/hdfs"]
 # maturin will turn this on
 python = [
   "dep:pyo3",

--- a/src/common/io-config/Cargo.toml
+++ b/src/common/io-config/Cargo.toml
@@ -12,6 +12,7 @@ serde = {workspace = true}
 typetag = {workspace = true}
 
 [features]
+hdfs = []
 python = ["dep:pyo3", "common-error/python", "common-py-serde/python"]
 
 [lints]

--- a/src/common/io-config/src/config.rs
+++ b/src/common/io-config/src/config.rs
@@ -98,8 +98,27 @@ impl IOConfig {
     /// Validates that no protocol alias key shadows a built-in scheme.
     pub fn validate_protocol_aliases(&self) -> std::result::Result<(), String> {
         const BUILTIN_SCHEMES: &[&str] = &[
-            "file", "http", "https", "s3", "s3a", "s3n", "az", "abfs", "abfss", "gcs", "gs", "hf",
-            "tos", "cos", "cosn", "goosefs", "hdfs", "vol+dbfs", "dbfs", "gvfs",
+            "file",
+            "http",
+            "https",
+            "s3",
+            "s3a",
+            "s3n",
+            "az",
+            "abfs",
+            "abfss",
+            "gcs",
+            "gs",
+            "hf",
+            "tos",
+            "cos",
+            "cosn",
+            "goosefs",
+            "vol+dbfs",
+            "dbfs",
+            "gvfs",
+            #[cfg(feature = "hdfs")]
+            "hdfs",
         ];
         for key in self.protocol_aliases.keys() {
             if BUILTIN_SCHEMES.contains(&key.as_str()) {

--- a/src/common/io-config/src/config.rs
+++ b/src/common/io-config/src/config.rs
@@ -99,7 +99,7 @@ impl IOConfig {
     pub fn validate_protocol_aliases(&self) -> std::result::Result<(), String> {
         const BUILTIN_SCHEMES: &[&str] = &[
             "file", "http", "https", "s3", "s3a", "s3n", "az", "abfs", "abfss", "gcs", "gs", "hf",
-            "tos", "cos", "cosn", "goosefs", "vol+dbfs", "dbfs", "gvfs",
+            "tos", "cos", "cosn", "goosefs", "hdfs", "vol+dbfs", "dbfs", "gvfs",
         ];
         for key in self.protocol_aliases.keys() {
             if BUILTIN_SCHEMES.contains(&key.as_str()) {

--- a/src/daft-io/Cargo.toml
+++ b/src/daft-io/Cargo.toml
@@ -31,6 +31,7 @@ opendal = {version = "0.57", default-features = false, features = [
   "services-obs",  # Huawei Cloud Object Storage
   "services-tos",  # Volcengine TOS (Torch Object Storage)
   "services-goosefs",  # Tencent Cloud GooseFS distributed cache
+  "services-hdfs-native",  # Hadoop Distributed File System
   "services-memory",  # In-memory backend (used for testing)
   "services-fs",  # Local filesystem (used for integration testing)
   "services-github"  # GitHub repository contents

--- a/src/daft-io/Cargo.toml
+++ b/src/daft-io/Cargo.toml
@@ -31,7 +31,7 @@ opendal = {version = "0.57", default-features = false, features = [
   "services-obs",  # Huawei Cloud Object Storage
   "services-tos",  # Volcengine TOS (Torch Object Storage)
   "services-goosefs",  # Tencent Cloud GooseFS distributed cache
-  "services-hdfs-native",  # Hadoop Distributed File System
+  "services-hdfs",  # Hadoop Distributed File System
   "services-memory",  # In-memory backend (used for testing)
   "services-fs",  # Local filesystem (used for integration testing)
   "services-github"  # GitHub repository contents

--- a/src/daft-io/Cargo.toml
+++ b/src/daft-io/Cargo.toml
@@ -31,7 +31,6 @@ opendal = {version = "0.57", default-features = false, features = [
   "services-obs",  # Huawei Cloud Object Storage
   "services-tos",  # Volcengine TOS (Torch Object Storage)
   "services-goosefs",  # Tencent Cloud GooseFS distributed cache
-  "services-hdfs",  # Hadoop Distributed File System
   "services-memory",  # In-memory backend (used for testing)
   "services-fs",  # Local filesystem (used for integration testing)
   "services-github"  # GitHub repository contents
@@ -60,6 +59,7 @@ md5 = "0.8.0"
 tempfile = "3.23.0"
 
 [features]
+hdfs = ["common-io-config/hdfs", "opendal/services-hdfs"]
 python = [
   "dep:pyo3",
   "common-error/python",

--- a/src/daft-io/src/lib.rs
+++ b/src/daft-io/src/lib.rs
@@ -291,41 +291,7 @@ impl IOClient {
                 }
             }
             SourceType::OpenDAL { scheme } => {
-                let empty_config = std::collections::BTreeMap::new();
-                let mut backend_config = match scheme.as_str() {
-                    "cos" | "tos" => {
-                        let parsed_url =
-                            url::Url::parse(&path).context(InvalidUrlSnafu { path: input })?;
-                        let bucket = parsed_url.host_str().unwrap_or_default();
-                        match scheme.as_str() {
-                            "cos" => self.config.cos.to_opendal_config(bucket),
-                            _ => self.config.tos.to_opendal_config(bucket),
-                        }
-                    }
-                    "goosefs" => {
-                        // Extract authority (host:port) from URL as default master_addr.
-                        let parsed_url =
-                            url::Url::parse(&path).context(InvalidUrlSnafu { path: input })?;
-                        let authority = match parsed_url.port() {
-                            Some(port) => {
-                                format!("{}:{}", parsed_url.host_str().unwrap_or(""), port)
-                            }
-                            None => parsed_url.host_str().unwrap_or("").to_string(),
-                        };
-                        self.config.goosefs.to_opendal_config(&authority)
-                    }
-                    _ => self
-                        .config
-                        .opendal_backends
-                        .get(scheme)
-                        .unwrap_or(&empty_config)
-                        .clone(),
-                };
-                if let Some(extra) = self.config.opendal_backends.get(scheme) {
-                    for (k, v) in extra {
-                        backend_config.insert(k.clone(), v.clone());
-                    }
-                }
+                let backend_config = opendal_backend_config(scheme, &path, &self.config)?;
                 OpenDALSource::get_client(scheme, &backend_config).await? as Arc<dyn ObjectSource>
             }
         };
@@ -578,6 +544,59 @@ pub fn local_path_to_file_uri(local_path: &str) -> String {
     }
 }
 
+fn url_authority(path: &str, input: &str) -> Result<String> {
+    let parsed_url = url::Url::parse(path).context(InvalidUrlSnafu { path: input })?;
+    Ok(match parsed_url.port() {
+        Some(port) => format!("{}:{}", parsed_url.host_str().unwrap_or(""), port),
+        None => parsed_url.host_str().unwrap_or("").to_string(),
+    })
+}
+
+fn opendal_backend_config(
+    scheme: &str,
+    path: &str,
+    config: &IOConfig,
+) -> Result<std::collections::BTreeMap<String, String>> {
+    let empty_config = std::collections::BTreeMap::new();
+    let mut backend_config = match scheme {
+        "cos" | "tos" => {
+            let parsed_url = url::Url::parse(path).context(InvalidUrlSnafu { path })?;
+            let bucket = parsed_url.host_str().unwrap_or_default();
+            match scheme {
+                "cos" => config.cos.to_opendal_config(bucket),
+                _ => config.tos.to_opendal_config(bucket),
+            }
+        }
+        "goosefs" => {
+            // Extract authority (host:port) from URL as default master_addr.
+            let authority = url_authority(path, path)?;
+            config.goosefs.to_opendal_config(&authority)
+        }
+        "hdfs" => {
+            let authority = url_authority(path, path)?;
+            if authority.is_empty() {
+                std::collections::BTreeMap::new()
+            } else {
+                std::collections::BTreeMap::from([(
+                    "name_node".to_string(),
+                    format!("hdfs://{authority}"),
+                )])
+            }
+        }
+        _ => config
+            .opendal_backends
+            .get(scheme)
+            .unwrap_or(&empty_config)
+            .clone(),
+    };
+    if let Some(extra) = config.opendal_backends.get(scheme) {
+        for (k, v) in extra {
+            backend_config.insert(k.clone(), v.clone());
+        }
+    }
+    Ok(backend_config)
+}
+
 pub fn parse_url(input: &str) -> Result<(SourceType, Cow<'_, str>)> {
     let mut fixed_input = Cow::Borrowed(input);
     // handle tilde `~` expansion
@@ -639,6 +658,12 @@ pub fn parse_url(input: &str) -> Result<(SourceType, Cow<'_, str>)> {
         "goosefs" => Ok((
             SourceType::OpenDAL {
                 scheme: "goosefs".to_string(),
+            },
+            fixed_input,
+        )),
+        "hdfs" => Ok((
+            SourceType::OpenDAL {
+                scheme: "hdfs".to_string(),
             },
             fixed_input,
         )),
@@ -766,5 +791,54 @@ mod resolve_alias_tests {
         let config = config_with_aliases(&[("custom", "s3")]);
         let result = resolve_url_alias("custom://my-bucket/some/deep/path?query=1", &config);
         assert_eq!(result.as_ref(), "s3://my-bucket/some/deep/path?query=1");
+    }
+}
+
+#[cfg(test)]
+mod opendal_config_tests {
+    use std::collections::BTreeMap;
+
+    use super::*;
+
+    #[test]
+    fn test_hdfs_opendal_config_uses_uri_authority_as_name_node() {
+        let config = IOConfig::default();
+
+        let result = opendal_backend_config(
+            "hdfs",
+            "hdfs://namenode.example.com:8020/user/warehouse/data.parquet",
+            &config,
+        )
+        .unwrap();
+
+        assert_eq!(
+            result.get("name_node"),
+            Some(&"hdfs://namenode.example.com:8020".to_string())
+        );
+    }
+
+    #[test]
+    fn test_hdfs_opendal_config_allows_ioconfig_override() {
+        let mut hdfs_config = BTreeMap::new();
+        hdfs_config.insert("name_node".to_string(), "default".to_string());
+        hdfs_config.insert("root".to_string(), "/warehouse".to_string());
+
+        let mut opendal_backends = BTreeMap::new();
+        opendal_backends.insert("hdfs".to_string(), hdfs_config);
+
+        let config = IOConfig {
+            opendal_backends,
+            ..Default::default()
+        };
+
+        let result = opendal_backend_config(
+            "hdfs",
+            "hdfs://namenode.example.com:8020/user/warehouse/data.parquet",
+            &config,
+        )
+        .unwrap();
+
+        assert_eq!(result.get("name_node"), Some(&"default".to_string()));
+        assert_eq!(result.get("root"), Some(&"/warehouse".to_string()));
     }
 }

--- a/src/daft-io/src/lib.rs
+++ b/src/daft-io/src/lib.rs
@@ -572,6 +572,7 @@ fn opendal_backend_config(
             let authority = url_authority(path, path)?;
             config.goosefs.to_opendal_config(&authority)
         }
+        #[cfg(feature = "hdfs")]
         "hdfs" => {
             let authority = url_authority(path, path)?;
             if authority.is_empty() {
@@ -661,6 +662,7 @@ pub fn parse_url(input: &str) -> Result<(SourceType, Cow<'_, str>)> {
             },
             fixed_input,
         )),
+        #[cfg(feature = "hdfs")]
         "hdfs" => Ok((
             SourceType::OpenDAL {
                 scheme: "hdfs".to_string(),
@@ -794,7 +796,7 @@ mod resolve_alias_tests {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "hdfs"))]
 mod opendal_config_tests {
     use std::collections::BTreeMap;
 

--- a/src/daft-io/src/opendal_source.rs
+++ b/src/daft-io/src/opendal_source.rs
@@ -36,13 +36,8 @@ impl OpenDALSource {
         // OperatorRegistry. This is a no-op after the first call.
         opendal::init_default_registry();
 
-        let opendal_scheme = match scheme {
-            "hdfs" => "hdfs-native",
-            _ => scheme,
-        };
-
         let operator =
-            Operator::via_iter(opendal_scheme, config.clone()).map_err(|e: opendal::Error| {
+            Operator::via_iter(scheme, config.clone()).map_err(|e: opendal::Error| {
                 super::Error::UnableToCreateClient {
                     store: super::SourceType::OpenDAL {
                         scheme: scheme.to_string(),
@@ -492,15 +487,8 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn test_opendal_hdfs_scheme_uses_configured_backend() {
-        let config = BTreeMap::from([(
-            "name_node".to_string(),
-            "hdfs://namenode.example.com:8020".to_string(),
-        )]);
-
-        OpenDALSource::get_client("hdfs", &config)
-            .await
-            .expect("Failed to create hdfs client");
+    #[test]
+    fn test_available_schemes_includes_hdfs() {
+        assert!(OpenDALSource::available_schemes().contains(&"hdfs"));
     }
 }

--- a/src/daft-io/src/opendal_source.rs
+++ b/src/daft-io/src/opendal_source.rs
@@ -24,7 +24,16 @@ impl OpenDALSource {
     /// List the OpenDAL service schemes that are compiled into this build.
     fn available_schemes() -> &'static [&'static str] {
         &[
-            "oss", "cos", "obs", "tos", "goosefs", "hdfs", "memory", "fs", "github",
+            "oss",
+            "cos",
+            "obs",
+            "tos",
+            "goosefs",
+            #[cfg(feature = "hdfs")]
+            "hdfs",
+            "memory",
+            "fs",
+            "github",
         ]
     }
 
@@ -487,8 +496,15 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "hdfs")]
     #[test]
     fn test_available_schemes_includes_hdfs() {
         assert!(OpenDALSource::available_schemes().contains(&"hdfs"));
+    }
+
+    #[cfg(not(feature = "hdfs"))]
+    #[test]
+    fn test_available_schemes_excludes_hdfs_by_default() {
+        assert!(!OpenDALSource::available_schemes().contains(&"hdfs"));
     }
 }

--- a/src/daft-io/src/opendal_source.rs
+++ b/src/daft-io/src/opendal_source.rs
@@ -24,7 +24,7 @@ impl OpenDALSource {
     /// List the OpenDAL service schemes that are compiled into this build.
     fn available_schemes() -> &'static [&'static str] {
         &[
-            "oss", "cos", "obs", "tos", "goosefs", "memory", "fs", "github",
+            "oss", "cos", "obs", "tos", "goosefs", "hdfs", "memory", "fs", "github",
         ]
     }
 
@@ -36,8 +36,13 @@ impl OpenDALSource {
         // OperatorRegistry. This is a no-op after the first call.
         opendal::init_default_registry();
 
+        let opendal_scheme = match scheme {
+            "hdfs" => "hdfs-native",
+            _ => scheme,
+        };
+
         let operator =
-            Operator::via_iter(scheme, config.clone()).map_err(|e: opendal::Error| {
+            Operator::via_iter(opendal_scheme, config.clone()).map_err(|e: opendal::Error| {
                 super::Error::UnableToCreateClient {
                     store: super::SourceType::OpenDAL {
                         scheme: scheme.to_string(),
@@ -485,5 +490,17 @@ mod tests {
             url_to_opendal_path("memory://test/hello.txt").unwrap(),
             "hello.txt"
         );
+    }
+
+    #[tokio::test]
+    async fn test_opendal_hdfs_scheme_uses_configured_backend() {
+        let config = BTreeMap::from([(
+            "name_node".to_string(),
+            "hdfs://namenode.example.com:8020".to_string(),
+        )]);
+
+        OpenDALSource::get_client("hdfs", &config)
+            .await
+            .expect("Failed to create hdfs client");
     }
 }


### PR DESCRIPTION
## Summary

Adds HDFS support to Daft's generic OpenDAL I/O path. Unknown `hdfs://` URLs are routed through `SourceType::OpenDAL`, and users can configure the backend with `IOConfig(opendal_backends={"hdfs": {...}})`.

## Details

- Enables OpenDAL `services-hdfs` for `daft-io`.
- Adds `hdfs` to OpenDAL scheme reporting and protocol alias validation.
- Derives `name_node` from `hdfs://host:port/path` when not explicitly provided.
- Preserves `opendal_backends["hdfs"]` overrides for values such as `name_node` and `root`.
- Adds unit tests for HDFS config derivation and scheme availability.

## Validation

- `cargo fmt --check`
- `cargo test -p common-io-config --lib`
- `JAVA_HOME=$(/usr/libexec/java_home) DYLD_LIBRARY_PATH=$(/usr/libexec/java_home)/lib/server cargo test -p daft-io --lib`
