### PR TITLE
feat: add lineage section to plan JSON

### DIFF
--- a/src/daft-logical-plan/src/display/json.rs
+++ b/src/daft-logical-plan/src/display/json.rs
@@ -190,15 +190,16 @@ where
             let schema = node.schema();
             object["schema"] = json!(schema.fields());
         }
+
         self.objects.insert(id, object);
         self.parent_ids.push(id);
         Ok(common_treenode::TreeNodeRecursion::Continue)
     }
 
-    fn f_up(&mut self, _node: &Self::Node) -> DaftResult<common_treenode::TreeNodeRecursion> {
+    fn f_up(&mut self, node: &Self::Node) -> DaftResult<common_treenode::TreeNodeRecursion> {
         let id = self.parent_ids.pop().unwrap();
 
-        let current_node = self
+        let mut current_node = self
             .objects
             .remove(&id)
             .ok_or_else(|| DaftError::ValueError("Missing current node!".to_string()))?;
@@ -216,7 +217,9 @@ where
 
             plans.push(current_node);
         } else {
-            // This is the root node
+            // This is the root node; attach plan-level lineage alongside it.
+            current_node["lineage"] =
+                serde_json::to_value(node.lineage()).map_err(DaftError::SerdeJsonError)?;
             let plan = serde_json::json!(&current_node);
             write!(
                 self.f,
@@ -354,6 +357,7 @@ mod tests {
               "type": "Project"
             }
           ],
+          "lineage": { "inputs": [], "outputs": [] },
           "limit": 10,
           "type": "Limit"
         }
@@ -375,6 +379,7 @@ mod tests {
         let expected = r#"
             {
               "children": [],
+              "lineage": { "inputs": [], "outputs": [] },
               "schema": [
                 {
                   "dtype": "Utf8",
@@ -415,6 +420,61 @@ mod tests {
             "Hash (num_partitions=auto, by=[col(id)])",
         );
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_repr_json_lineage() -> DaftResult<()> {
+        use std::sync::Arc;
+
+        use common_file_formats::{FileFormat, WriteMode};
+
+        use crate::{
+            LogicalPlan,
+            ops::Sink,
+            sink_info::{OutputFileInfo, SinkInfo},
+        };
+
+        // A glob scan feeding a file sink exercises both input and output extraction.
+        let input =
+            LogicalPlanBuilder::from_glob_scan(vec!["/data/events/*.parquet".to_string()], None)?
+                .build();
+
+        let sink_info = SinkInfo::OutputFileInfo(OutputFileInfo::new(
+            "/warehouse/out".to_string(),
+            WriteMode::Overwrite,
+            FileFormat::Parquet,
+            None,
+            None,
+            None,
+            None,
+            false,
+            false,
+        ));
+        let plan = LogicalPlan::Sink(
+            Sink::try_new(input, Arc::new(sink_info)).expect("failed to build sink"),
+        )
+        .arced();
+
+        let mut output = String::new();
+        let mut json_vis = super::JsonVisitor::new(&mut output);
+        plan.visit(&mut json_vis).unwrap();
+        let actual: serde_json::Value = serde_json::from_str(&output).unwrap();
+
+        let expected_lineage: serde_json::Value = serde_json::from_str(
+            r#"{
+              "inputs": [
+                { "type": "glob_scan", "glob_paths": ["/data/events/*.parquet"] }
+              ],
+              "outputs": [
+                { "type": "file", "root_dir": "/warehouse/out", "file_format": "Parquet" }
+              ]
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(actual["type"], "Sink");
+        assert_eq!(actual["lineage"], expected_lineage);
         Ok(())
     }
 }

--- a/src/daft-logical-plan/src/lib.rs
+++ b/src/daft-logical-plan/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod builder;
 pub mod display;
+pub mod lineage;
 pub mod logical_plan;
 pub mod ops;
 pub mod optimization;
@@ -21,6 +22,7 @@ use daft_scan::{
     CsvSourceConfig, DatabaseSourceConfig, JsonSourceConfig, ParquetSourceConfig, TextSourceConfig,
     WarcSourceConfig, python::PyFileFormatConfig,
 };
+pub use lineage::{Lineage, LineageInput, LineageOutput};
 pub use logical_plan::{LogicalPlan, LogicalPlanRef};
 pub use ops::join::JoinOptions;
 pub use partitioning::ClusteringSpec;

--- a/src/daft-logical-plan/src/lineage.rs
+++ b/src/daft-logical-plan/src/lineage.rs
@@ -1,0 +1,136 @@
+use common_file_formats::FileFormat;
+use serde::Serialize;
+
+use crate::{
+    LogicalPlan,
+    ops::{Sink, Source},
+    sink_info::SinkInfo,
+    source_info::SourceInfo,
+};
+
+/// Plan-level lineage: the external input and output datasets a logical plan
+/// references.
+///
+/// Derived by walking the plan tree (see [`LogicalPlan::lineage`]) and exposed
+/// through the plan's JSON representation, so subscribers can consume it without
+/// reaching into internal plan structures.
+#[derive(Debug, Default, Serialize)]
+pub struct Lineage {
+    pub inputs: Vec<LineageInput>,
+    pub outputs: Vec<LineageOutput>,
+}
+
+/// An input dataset, extracted from a source node.
+#[derive(Debug, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum LineageInput {
+    /// File paths only materialize into scan tasks after planning, so at the
+    /// logical level the operator name is the best available identifier.
+    PhysicalScan {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        name: Option<String>,
+    },
+    GlobScan {
+        glob_paths: Vec<String>,
+    },
+    InMemory,
+}
+
+/// An output dataset, extracted from a sink node.
+#[derive(Debug, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum LineageOutput {
+    File {
+        root_dir: String,
+        file_format: FileFormat,
+    },
+    #[cfg(feature = "python")]
+    Iceberg { name: String, location: String },
+    #[cfg(feature = "python")]
+    DeltaLake { path: String },
+    #[cfg(feature = "python")]
+    Lance { path: String },
+    #[cfg(feature = "python")]
+    DataSink { name: String },
+}
+
+impl LineageInput {
+    /// Returns `None` for internal placeholder sources, which don't map to a
+    /// real external dataset.
+    fn from_source(source: &Source) -> Option<Self> {
+        match source.source_info.as_ref() {
+            SourceInfo::Physical(info) => {
+                let name = match &info.scan_state {
+                    daft_scan::ScanState::Operator(scan_op) => Some(scan_op.0.name().to_string()),
+                    daft_scan::ScanState::Tasks(_) => None,
+                };
+                Some(Self::PhysicalScan { name })
+            }
+            SourceInfo::GlobScan(info) => Some(Self::GlobScan {
+                glob_paths: info.glob_paths.as_ref().clone(),
+            }),
+            SourceInfo::InMemory(_) => Some(Self::InMemory),
+            SourceInfo::PlaceHolder(_) => None,
+        }
+    }
+}
+
+impl LineageOutput {
+    fn from_sink(sink: &Sink) -> Option<Self> {
+        match sink.sink_info.as_ref() {
+            SinkInfo::OutputFileInfo(info) => Some(Self::File {
+                root_dir: info.root_dir.clone(),
+                file_format: info.file_format,
+            }),
+            #[cfg(feature = "python")]
+            SinkInfo::CatalogInfo(info) => {
+                use crate::sink_info::CatalogType;
+                Some(match &info.catalog {
+                    CatalogType::Iceberg(iceberg) => Self::Iceberg {
+                        name: iceberg.table_name.clone(),
+                        location: iceberg.table_location.clone(),
+                    },
+                    CatalogType::DeltaLake(delta) => Self::DeltaLake {
+                        path: delta.path.clone(),
+                    },
+                    CatalogType::Lance(lance) => Self::Lance {
+                        path: lance.path.clone(),
+                    },
+                })
+            }
+            #[cfg(feature = "python")]
+            SinkInfo::DataSinkInfo(info) => Some(Self::DataSink {
+                name: info.name.clone(),
+            }),
+        }
+    }
+}
+
+impl LogicalPlan {
+    /// Derive plan-level lineage by walking the plan tree, collecting input
+    /// datasets from source nodes and output datasets from sink nodes.
+    pub fn lineage(&self) -> Lineage {
+        let mut lineage = Lineage::default();
+        self.collect_lineage(&mut lineage);
+        lineage
+    }
+
+    fn collect_lineage(&self, lineage: &mut Lineage) {
+        match self {
+            Self::Source(source) => {
+                if let Some(input) = LineageInput::from_source(source) {
+                    lineage.inputs.push(input);
+                }
+            }
+            Self::Sink(sink) => {
+                if let Some(output) = LineageOutput::from_sink(sink) {
+                    lineage.outputs.push(output);
+                }
+            }
+            _ => {}
+        }
+        for child in self.children() {
+            child.collect_lineage(lineage);
+        }
+    }
+}

--- a/src/daft-logical-plan/src/lineage.rs
+++ b/src/daft-logical-plan/src/lineage.rs
@@ -1,8 +1,11 @@
 use common_file_formats::FileFormat;
+use common_treenode::{TreeNode, TreeNodeRecursion};
+use daft_dsl::{Expr, ExprRef};
 use serde::Serialize;
 
 use crate::{
     LogicalPlan,
+    logical_plan::downcast_subquery,
     ops::{Sink, Source},
     sink_info::SinkInfo,
     source_info::SourceInfo,
@@ -127,10 +130,73 @@ impl LogicalPlan {
                     lineage.outputs.push(output);
                 }
             }
+            // Subqueries embedded in expressions aren't returned by `children()`,
+            // so recurse into their plans explicitly to capture their sources.
+            Self::Filter(filter) => collect_subquery_lineage(&filter.predicate, lineage),
+            Self::Project(project) => {
+                for expr in &project.projection {
+                    collect_subquery_lineage(expr, lineage);
+                }
+            }
             _ => {}
         }
         for child in self.children() {
             child.collect_lineage(lineage);
         }
+    }
+}
+
+/// Recurse into subquery plans embedded in an expression — scalar, `IN`, and
+/// `EXISTS` subqueries — which aren't reachable through [`LogicalPlan::children`].
+fn collect_subquery_lineage(expr: &ExprRef, lineage: &mut Lineage) {
+    let _ = expr.apply(|e| {
+        if let Expr::Subquery(subquery) | Expr::Exists(subquery) | Expr::InSubquery(_, subquery) =
+            e.as_ref()
+        {
+            downcast_subquery(subquery).collect_lineage(lineage);
+        }
+        Ok(TreeNodeRecursion::Continue)
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use common_error::DaftResult;
+    use daft_dsl::{Expr, Subquery};
+
+    use super::LineageInput;
+    use crate::{LogicalPlan, builder::LogicalPlanBuilder, ops::Filter};
+
+    #[test]
+    fn test_lineage_includes_subquery_sources() -> DaftResult<()> {
+        // Outer source, reachable through `children()`.
+        let outer =
+            LogicalPlanBuilder::from_glob_scan(vec!["/data/a/*.parquet".to_string()], None)?
+                .build();
+
+        // A source that only appears inside an EXISTS subquery, so it's reachable
+        // through the predicate expression rather than `children()`.
+        let sub = LogicalPlanBuilder::from_glob_scan(vec!["/data/b/*.parquet".to_string()], None)?
+            .build();
+        let predicate = Arc::new(Expr::Exists(Subquery { plan: sub }));
+
+        let plan = LogicalPlan::Filter(Filter::try_new(outer, predicate)?).arced();
+        let lineage = plan.lineage();
+
+        let globs: Vec<Vec<String>> = lineage
+            .inputs
+            .iter()
+            .filter_map(|input| match input {
+                LineageInput::GlobScan { glob_paths } => Some(glob_paths.clone()),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(globs.len(), 2);
+        assert!(globs.contains(&vec!["/data/a/*.parquet".to_string()]));
+        assert!(globs.contains(&vec!["/data/b/*.parquet".to_string()]));
+        Ok(())
     }
 }


### PR DESCRIPTION
## Changes Made

Exposes plan-level lineage so subscribers can consume it without reaching into internal plan structures.

* New `lineage` module with typed `Lineage` / `LineageInput` / `LineageOutput`, and `LogicalPlan::lineage()` that walks the plan tree — inputs from source nodes, outputs from sink nodes.
* `repr_json` serializes it onto the root node as a `lineage` key, sibling to the node's `type` / `children` keys. Additive and non-breaking; Rust consumers (e.g. the Dashboard) can reuse `LogicalPlan::lineage()` directly instead of parsing JSON.

Supported entries:

* **inputs**: `glob_scan` (glob paths), `physical_scan` (operator name), `in_memory`.
* **outputs**: `file` (root dir + format), `iceberg`, `delta_lake`, `lance`, `data_sink`.

```json
"lineage": {
  "inputs": [{ "type": "glob_scan", "glob_paths": ["/data/events/*.parquet"] }],
  "outputs": [{ "type": "file", "root_dir": "/warehouse/out", "file_format": "Parquet" }]
}
```

`Physical_scan` reports the operator name only — concrete file paths materialize into scan tasks after planning and aren't exposed on `ScanOperator`. Left as a follow-up.

## Related Issues

Part of Eventual-Inc/Daft#6496