### PR TITLE
refactor(io): migrate Delta Lake scans to DataSource

### DIFF
--- a/daft/daft/__init__.pyi
+++ b/daft/daft/__init__.pyi
@@ -1255,6 +1255,7 @@ class PyDataSourceTask:
         path: str,
         schema: PySchema,
         *,
+        parquet_config: ParquetSourceConfig | None = None,
         pushdowns: PyPushdowns | None = None,
         num_rows: int | None = None,
         size_bytes: int | None = None,

--- a/daft/io/delta_lake/_deltalake.py
+++ b/daft/io/delta_lake/_deltalake.py
@@ -5,10 +5,9 @@ from typing import TYPE_CHECKING, Union
 
 from daft import context, runners
 from daft.api_annotations import PublicAPI
-from daft.daft import IOConfig, ScanOperatorHandle, StorageConfig
+from daft.daft import IOConfig, StorageConfig
 from daft.dataframe import DataFrame
 from daft.dependencies import unity_catalog
-from daft.logical.builder import LogicalPlanBuilder
 
 if TYPE_CHECKING:
     from datetime import datetime
@@ -61,7 +60,7 @@ def read_deltalake(
         >>> df = daft.read_deltalake("s3://daft-oss-public-data/test_fixtures/delta_table/", io_config=io_config)
         >>> df.show()
     """
-    from daft.io.delta_lake.delta_lake_scan import DeltaLakeScanOperator
+    from daft.io.delta_lake.delta_lake_scan import DeltaLakeDataSource
 
     # If running on Ray, we want to limit the amount of concurrency and requests being made.
     # This is because each Ray worker process receives its own pool of thread workers and connections
@@ -85,13 +84,10 @@ def read_deltalake(
         raise ValueError(
             f"table argument must be a table URI string or UnityCatalogTable instance, but got: {type(table)}, {table}"
         )
-    delta_lake_operator = DeltaLakeScanOperator(
+    delta_lake_source = DeltaLakeDataSource(
         table_uri, storage_config=storage_config, version=version, ignore_deletion_vectors=ignore_deletion_vectors
     )
-
-    handle = ScanOperatorHandle.from_python_scan_operator(delta_lake_operator)
-    builder = LogicalPlanBuilder.from_tabular_scan(scan_operator=handle)
-    return DataFrame(builder)
+    return delta_lake_source.read()
 
 
 def delta_schema_to_pyarrow(schema: "deltalake.Schema") -> "pa.Schema":

--- a/daft/io/delta_lake/delta_lake_scan.py
+++ b/daft/io/delta_lake/delta_lake_scan.py
@@ -18,24 +18,24 @@ import daft
 import daft.exceptions
 from daft import DataType
 from daft.daft import (
-    FileFormatConfig,
     ParquetSourceConfig,
     PyField,
-    PyPartitionField,
-    PyPushdowns,
     S3Config,
-    ScanTask,
     StorageConfig,
 )
+from daft.expressions import ExpressionsProjection
 from daft.io.delta_lake._deltalake import delta_schema_to_pyarrow
 from daft.io.delta_lake.utils import construct_delta_file_path
 from daft.io.object_store_options import io_config_to_storage_options
-from daft.io.scan import ScanOperator
+from daft.io.partitioning import PartitionField
+from daft.io.source import DataSource, DataSourceTask
 from daft.logical.schema import Schema
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import AsyncIterator, Iterator
     from datetime import datetime
+
+    from daft.io.pushdowns import Pushdowns
 
 logger = logging.getLogger(__name__)
 
@@ -123,7 +123,7 @@ def get_s3_bucket_region(bucket_name: str) -> str | None:
         return None
 
 
-class DeltaLakeScanOperator(ScanOperator):
+class DeltaLakeDataSource(DataSource):
     def __init__(
         self,
         table_uri: str,
@@ -131,8 +131,6 @@ class DeltaLakeScanOperator(ScanOperator):
         version: int | str | datetime | None = None,
         ignore_deletion_vectors: bool = False,
     ) -> None:
-        super().__init__()
-
         # Unfortunately delta-rs doesn't do very good inference of credentials for S3. Thus the current Daft behavior of passing
         # in `None` for credentials will cause issues when instantiating the DeltaTable without credentials.
         #
@@ -221,38 +219,26 @@ class DeltaLakeScanOperator(ScanOperator):
             self._stats_physical_to_logical: dict[str, str] = {}
         else:
             field_id_mapping, self._stats_physical_to_logical = _column_mapping_maps(delta_schema)
-        self._file_format_config = FileFormatConfig.from_parquet_config(
-            ParquetSourceConfig(field_id_mapping=field_id_mapping)
-        )
+        self._parquet_config = ParquetSourceConfig(field_id_mapping=field_id_mapping)
 
         partition_columns = set(self._table.metadata().partition_columns)
-        self._partition_keys = [
-            PyPartitionField(field._field) for field in self._schema if field.name in partition_columns
+        self._partition_fields = [
+            PartitionField.create(field) for field in self._schema if field.name in partition_columns
         ]
         self._ignore_deletion_vectors = ignore_deletion_vectors
 
+    @property
     def schema(self) -> Schema:
         return self._schema
 
+    @property
     def name(self) -> str:
-        return "DeltaLakeScanOperator"
+        return f"DeltaLakeDataSource({self._table.metadata().name})"
 
-    def display_name(self) -> str:
-        return f"DeltaLakeScanOperator({self._table.metadata().name})"
+    def get_partition_fields(self) -> list[PartitionField]:
+        return self._partition_fields
 
-    def partitioning_keys(self) -> list[PyPartitionField]:
-        return self._partition_keys
-
-    def multiline_display(self) -> list[str]:
-        return [
-            self.display_name(),
-            f"Schema = {self._schema}",
-            f"Partitioning keys = {self.partitioning_keys()}",
-            # TODO(Clark): Improve repr of storage config here.
-            f"Storage config = {self._storage_config}",
-        ]
-
-    def to_scan_tasks(self, pushdowns: PyPushdowns) -> Iterator[ScanTask]:
+    async def get_tasks(self, pushdowns: Pushdowns) -> AsyncIterator[DataSourceTask]:
         import pyarrow as pa
 
         metadata = self._table.metadata()
@@ -271,11 +257,11 @@ class DeltaLakeScanOperator(ScanOperator):
         # TODO(Clark): Push limit and filter expressions into deltalake action fetch, to prune the files returned.
         # Issue: https://github.com/Eventual-Inc/Daft/issues/1953
         add_actions = pa.table(self._table.get_add_actions())
-        if len(self.partitioning_keys()) > 0 and pushdowns.partition_filters is None:
+        if self._partition_fields and pushdowns.partition_filters is None:
             logger.warning(
                 "%s has partitioning keys = %s, but no partition filter was specified. This will result in a full table scan.",
-                self.display_name(),
-                self.partitioning_keys(),
+                self.name,
+                self._partition_fields,
             )
 
         # TODO(Clark): Add support for deletion vectors.
@@ -289,7 +275,6 @@ class DeltaLakeScanOperator(ScanOperator):
 
         limit_files = pushdowns.limit is not None and pushdowns.filters is None and pushdowns.partition_filters is None
         rows_left = pushdowns.limit if pushdowns.limit is not None else 0
-        scan_tasks = []
 
         # Determine which partition field name is used in the schema
         # Deltalake versions <1.2.0 use "partition_values", >=1.2.0 use "partition"
@@ -346,9 +331,14 @@ class DeltaLakeScanOperator(ScanOperator):
                             type=dtype.field(field_idx).type,
                         )
                     arrays[field_name] = daft.Series.from_arrow(arrow_arr, field_name)
-                partition_values = daft.recordbatch.RecordBatch.from_pydict(arrays)._recordbatch
+                partition_values = daft.recordbatch.RecordBatch.from_pydict(arrays)
             else:
                 partition_values = None
+
+            if partition_values is not None and pushdowns.partition_filters is not None:
+                filtered = partition_values.filter(ExpressionsProjection([pushdowns.partition_filters]))
+                if len(filtered) == 0:
+                    continue
 
             # Populate scan task with column-wise stats.
             schema_names = add_actions.schema.names
@@ -385,33 +375,20 @@ class DeltaLakeScanOperator(ScanOperator):
                 stats = daft.recordbatch.RecordBatch.from_pydict(arrays)
             else:
                 stats = None
-            st = ScanTask.catalog_scan_task(
-                file=path,
-                file_format=self._file_format_config,
-                schema=self._schema._schema,
+            task = DataSourceTask.parquet(
+                path=path,
+                schema=self._schema,
+                parquet_config=self._parquet_config,
                 num_rows=record_count,
                 storage_config=self._storage_config,
                 size_bytes=size_bytes,
-                iceberg_delete_files=None,
                 pushdowns=pushdowns,
                 partition_values=partition_values,
-                stats=stats._recordbatch if stats is not None else None,
+                stats=stats,
             )
-            if st is None:
-                continue
             if record_count is not None:
                 rows_left -= record_count
-            scan_tasks.append(st)
-        return iter(scan_tasks)
-
-    def can_absorb_filter(self) -> bool:
-        return False
-
-    def can_absorb_limit(self) -> bool:
-        return False
-
-    def can_absorb_select(self) -> bool:
-        return True
+            yield task
 
 
 # Returns True if the Delta Lake library does not return the deletion vectors in the add_actions.

--- a/daft/io/source.py
+++ b/daft/io/source.py
@@ -4,7 +4,7 @@ import warnings
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
-from daft.daft import PyDataSourceTask, StorageConfig
+from daft.daft import ParquetSourceConfig, PyDataSourceTask, StorageConfig
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Iterator
@@ -139,6 +139,7 @@ class DataSourceTask(ABC):
         path: str,
         schema: Schema,
         *,
+        parquet_config: ParquetSourceConfig | None = None,
         pushdowns: Pushdowns | None = None,
         num_rows: int | None = None,
         size_bytes: int | None = None,
@@ -159,6 +160,8 @@ class DataSourceTask(ABC):
         Args:
             path: Path or URI of the Parquet file (e.g., ``"s3://bucket/file.parquet"``).
             schema: Schema to read the file with.
+            parquet_config: Optional Parquet reader configuration. Defaults to
+                :class:`~daft.daft.ParquetSourceConfig` defaults.
             pushdowns: Query pushdowns (filters, column projection, limit). Pass
                 through the pushdowns received by DataSource.get_tasks.
             num_rows: Exact row count, if known. Enables metadata-only optimizations.
@@ -186,6 +189,7 @@ class DataSourceTask(ABC):
         inner = PyDataSourceTask.parquet(
             path=path,
             schema=schema._schema,
+            parquet_config=parquet_config,
             pushdowns=pushdowns._to_pypushdowns() if pushdowns is not None else None,
             num_rows=num_rows,
             size_bytes=size_bytes,

--- a/src/daft-logical-plan/src/scan_builder.rs
+++ b/src/daft-logical-plan/src/scan_builder.rs
@@ -374,15 +374,11 @@ pub fn delta_scan<T: AsRef<str>>(
         };
 
         let delta_lake_scan = PyModule::import(py, "daft.io.delta_lake.delta_lake_scan")?;
-        let delta_lake_scan_operator =
-            delta_lake_scan.getattr(pyo3::intern!(py, "DeltaLakeScanOperator"))?;
-        let delta_lake_operator = delta_lake_scan_operator
-            .call1((glob_path.as_ref(), storage_config))?
-            .into_pyobject(py)
-            .unwrap()
-            .into();
-        let scan_operator_handle =
-            ScanOperatorHandle::from_python_scan_operator(delta_lake_operator, py)?;
+        let delta_lake_data_source =
+            delta_lake_scan.getattr(pyo3::intern!(py, "DeltaLakeDataSource"))?;
+        let delta_lake_source =
+            delta_lake_data_source.call1((glob_path.as_ref(), storage_config))?;
+        let scan_operator_handle = ScanOperatorHandle::from_data_source(delta_lake_source);
         LogicalPlanBuilder::table_scan(scan_operator_handle.into(), None)
     })
 }

--- a/src/daft-scan/src/python.rs
+++ b/src/daft-scan/src/python.rs
@@ -78,6 +78,7 @@ impl PyDataSourceTask {
         path,
         schema,
         *,
+        parquet_config = None,
         pushdowns = None,
         num_rows = None,
         size_bytes = None,
@@ -88,6 +89,7 @@ impl PyDataSourceTask {
     fn parquet(
         path: String,
         schema: PySchema,
+        parquet_config: Option<ParquetSourceConfig>,
         pushdowns: Option<pylib_scan_info::PyPushdowns>,
         num_rows: Option<i64>,
         size_bytes: Option<u64>,
@@ -133,7 +135,7 @@ impl PyDataSourceTask {
         let scan_task = Arc::new(ScanTask::new(
             vec![source],
             Arc::new(SourceConfig::File(FileFormatConfig::Parquet(
-                ParquetSourceConfig::default(),
+                parquet_config.unwrap_or_default(),
             ))),
             schema.schema,
             storage_config,


### PR DESCRIPTION
## Changes Made

* Replace `DeltaLakeScanOperator` with `DeltaLakeDataSource` and route Python and SQL reads through the DataSource bridge.
* Preserve partition pruning, file statistics, limit handling, storage configuration, and deletion-vector checks.
* Allow `DataSourceTask.parquet` to accept a `ParquetSourceConfig` so Delta column-mapping field IDs continue to reach the native Parquet reader.

Validation:

* `uvx ruff@0.14.10 check daft/daft/__init__.pyi daft/io/source.py daft/io/delta_lake/_deltalake.py daft/io/delta_lake/delta_lake_scan.py`
* `uvx ruff@0.14.10 format --check daft/daft/__init__.pyi daft/io/source.py daft/io/delta_lake/_deltalake.py daft/io/delta_lake/delta_lake_scan.py`
* `cargo fmt --all -- --check`
* `PYO3_PYTHON=python3 CARGO_TARGET_DIR=/tmp/daft-target-7294 cargo check -p daft-scan -p daft-logical-plan --features daft-scan/python,daft-logical-plan/python`

No new tests were added because this is a behavior-preserving migration and the existing Delta Lake integration suite covers basic Python/SQL reads, pushdowns, limits, and column mapping. A local `maturin develop` build did not complete within the available WSL1 execution window, so runtime integration tests were not run locally; this draft PR will use the repository CI for that coverage before review.

AI disclosure: This change was produced with material AI assistance. I reviewed the complete diff and verified the Rust/Python boundary with the checks listed above.

## Related Issues

Fixes Eventual-Inc/Daft#7294