### PR TITLE
feat(iceberg): inject DataFile column stats into DataSourceTask for predicate short-circuit

### DIFF
--- a/daft/io/iceberg/iceberg_scan.py
+++ b/daft/io/iceberg/iceberg_scan.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
 import logging
+import struct
 import warnings
 from typing import TYPE_CHECKING
 
+from pyiceberg.conversions import from_bytes
+from pyiceberg.io.pyarrow import schema_to_pyarrow
 from pyiceberg.schema import visit
+from pyiceberg.types import PrimitiveType
 
 import daft
 from daft.daft import (
@@ -29,6 +33,7 @@ from daft.recordbatch import RecordBatch
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Iterator
 
+    from pyiceberg.manifest import DataFile
     from pyiceberg.partitioning import PartitionField as IcebergPartitionField
     from pyiceberg.partitioning import PartitionSpec as IcebergPartitionSpec
     from pyiceberg.schema import Schema as IcebergSchema
@@ -38,6 +43,18 @@ if TYPE_CHECKING:
     from daft.io.pushdowns import Pushdowns
 
 logger = logging.getLogger(__name__)
+
+# Errors that can occur during Iceberg stats decoding and are safe to treat
+# as "stats unavailable for this field" rather than fatal errors.
+_EXPECTED_STATS_DECODE_ERRORS = (
+    pa.ArrowInvalid,
+    pa.ArrowTypeError,
+    pa.ArrowNotImplementedError,
+    TypeError,
+    ValueError,
+    NotImplementedError,
+    struct.error,
+)
 
 
 def _iceberg_count_result_function(total_count: int, field_name: str) -> Iterator[RecordBatch]:
@@ -94,6 +111,78 @@ def iceberg_partition_spec_to_fields(iceberg_schema: IcebergSchema, spec: Iceber
     return [_iceberg_partition_field_to_daft_partition_field(iceberg_schema, field) for field in spec.fields]
 
 
+def _build_iceberg_data_source_task_stats(
+    file: DataFile,
+    top_level_fields: list[tuple[int, str, object, bool, pa.DataType]],
+    task_schema: Schema,
+) -> RecordBatch | None:
+    """Decode Iceberg DataFile column bounds into a 2-row stats RecordBatch.
+
+    Returns a RecordBatch with row 0 = min values, row 1 = max values,
+    matching the column names, order, and dtypes of ``task_schema`` exactly.
+
+    Columns whose bounds are missing or fail to decode are filled with typed
+    nulls. If no column produces usable bounds, returns ``None``.
+
+    Args:
+        file: PyIceberg DataFile with optional ``lower_bounds`` / ``upper_bounds`` dicts.
+        top_level_fields: Precomputed list of ``(field_id, name, iceberg_type,
+            is_primitive, arrow_type)`` in schema order.
+        task_schema: Daft Schema the returned RecordBatch must match.
+    """
+    lower = file.lower_bounds or {}
+    upper = file.upper_bounds or {}
+
+    if not lower and not upper:
+        return None
+
+    arrays: dict[str, daft.Series] = {}
+    has_decoded_bounds = False
+
+    for field_id, field_name, field_type, is_primitive, arrow_type in top_level_fields:
+        # Require both lower and upper bounds. Single-sided bounds
+        # (e.g. key-only metrics with only one direction populated)
+        # cannot be expressed by ColumnRangeStatistics — it requires
+        # paired min/max — so the field is conservatively treated as
+        # unknown rather than partially used.
+        if is_primitive and field_id in lower and field_id in upper:
+            assert isinstance(field_type, PrimitiveType)  # narrow object→PrimitiveType for mypy
+            try:
+                values = [
+                    from_bytes(field_type, lower[field_id]),
+                    from_bytes(field_type, upper[field_id]),
+                ]
+                arrays[field_name] = daft.Series.from_arrow(
+                    pa.array(values, type=arrow_type),
+                    name=field_name,
+                    dtype=task_schema[field_name].dtype,
+                )
+                has_decoded_bounds = True
+                continue
+            except _EXPECTED_STATS_DECODE_ERRORS:
+                logger.debug(
+                    "Failed to decode stats for field %s (id=%d, type=%s)",
+                    field_name,
+                    field_id,
+                    field_type,
+                )
+
+        arrays[field_name] = daft.Series.from_arrow(
+            pa.array([None, None], type=arrow_type),
+            name=field_name,
+            dtype=task_schema[field_name].dtype,
+        )
+
+    if not has_decoded_bounds:
+        return None
+
+    stats = RecordBatch.from_pydict(arrays)
+    assert stats.schema() == task_schema, (
+        f"stats schema {stats.schema().column_names()} != task schema {task_schema.column_names()}"
+    )
+    return stats
+
+
 class IcebergDataSource(DataSource):
     """DataSource for Apache Iceberg tables.
 
@@ -129,6 +218,20 @@ class IcebergDataSource(DataSource):
 
         self._schema = convert_iceberg_schema(iceberg_schema)
         self._partition_fields = iceberg_partition_spec_to_fields(iceberg_schema, self._iceberg_table.spec())
+
+        # Precompute ordered field metadata for per-file stats decoding.  The
+        # order must match self._schema — downstream consumers (TableStatistics,
+        # MicroPartition) index columns by position and require exact equality.
+        self._top_level_fields: list[tuple[int, str, object, bool, pa.DataType]] = [
+            (
+                field.field_id,
+                field.name,
+                field.field_type,
+                isinstance(field.field_type, PrimitiveType),
+                schema_to_pyarrow(field.field_type),
+            )
+            for field in iceberg_schema.fields
+        ]
 
     @property
     def name(self) -> str:
@@ -226,7 +329,6 @@ class IcebergDataSource(DataSource):
 
             iceberg_delete_files = [f.file_path for f in task.delete_files]
 
-            # TODO: Thread in Statistics to each task: P2
             pspec = self._iceberg_record_to_partition_spec(self._iceberg_table.specs()[file.spec_id], file.partition)
 
             # Partition pruning is the DataSource's responsibility in the DataSource model.
@@ -234,6 +336,12 @@ class IcebergDataSource(DataSource):
                 filtered = pspec.filter(ExpressionsProjection([pushdowns.partition_filters]))
                 if len(filtered) == 0:
                     continue
+
+            stats = _build_iceberg_data_source_task_stats(
+                file=file,
+                top_level_fields=self._top_level_fields,
+                task_schema=self._schema,
+            )
 
             yield DataSourceTask.parquet(
                 path=path,
@@ -243,6 +351,7 @@ class IcebergDataSource(DataSource):
                 num_rows=record_count,
                 size_bytes=file.file_size_in_bytes,
                 partition_values=pspec,
+                stats=stats,
                 storage_config=self._storage_config,
                 iceberg_delete_files=iceberg_delete_files if iceberg_delete_files else None,
             )

--- a/src/daft-micropartition/src/ops/filter.rs
+++ b/src/daft-micropartition/src/ops/filter.rs
@@ -41,3 +41,97 @@ impl MicroPartition {
         ))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use daft_core::{
+        datatypes::{DataType, Field, Int64Array},
+        prelude::Schema,
+        series::IntoSeries,
+    };
+    use daft_dsl::{expr::bound_expr::BoundExpr, lit, resolved_col};
+    use daft_recordbatch::RecordBatch;
+    use daft_stats::TableStatistics;
+
+    use crate::MicroPartition;
+
+    #[test]
+    fn test_filter_short_circuits_on_false_stats() {
+        // Stats: min=10, max=20. Predicate: col < 5 → TruthValue::False.
+        // MicroPartition.filter() should return empty WITHOUT scanning data.
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int64)]));
+
+        // Create data that would NOT satisfy the predicate if scanned normally
+        let data = RecordBatch::from_nonempty_columns(vec![
+            Int64Array::from_slice("a", &[1, 2, 3]).into_series(),
+        ])
+        .unwrap();
+
+        // Create stats with min=10, max=20 (different from actual data)
+        let stats_table = RecordBatch::from_nonempty_columns(vec![
+            Int64Array::from_slice("a", &[10, 20]).into_series(),
+        ])
+        .unwrap();
+        let stats = TableStatistics::from_stats_table(&stats_table).unwrap();
+
+        let mp = MicroPartition::new_loaded(schema.clone(), Arc::new(vec![data]), Some(stats));
+
+        // Predicate: col < 5 → should be False based on stats (min=10 > 5)
+        let pred = BoundExpr::try_new(resolved_col("a").lt(lit(5i64)), &schema).unwrap();
+        let result = mp.filter(&[pred]).unwrap();
+
+        // Should return empty MicroPartition (short-circuit, not scan)
+        assert_eq!(result.len(), 0);
+        assert_eq!(result.schema, schema);
+    }
+
+    #[test]
+    fn test_filter_does_not_short_circuit_on_maybe_stats() {
+        // Stats: min=10, max=20. Predicate: col >= 10 → TruthValue::Maybe.
+        // MicroPartition.filter() should actually scan the data.
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int64)]));
+
+        // Data: [1, 12, 3] — only 12 satisfies col >= 10
+        let data = RecordBatch::from_nonempty_columns(vec![
+            Int64Array::from_slice("a", &[1, 12, 3]).into_series(),
+        ])
+        .unwrap();
+
+        let stats_table = RecordBatch::from_nonempty_columns(vec![
+            Int64Array::from_slice("a", &[10, 20]).into_series(),
+        ])
+        .unwrap();
+        let stats = TableStatistics::from_stats_table(&stats_table).unwrap();
+
+        let mp = MicroPartition::new_loaded(schema.clone(), Arc::new(vec![data]), Some(stats));
+
+        // Predicate: col >= 10 → Maybe (some values in [10,20] satisfy, some don't)
+        let pred = BoundExpr::try_new(resolved_col("a").gt_eq(lit(10i64)), &schema).unwrap();
+        let result = mp.filter(&[pred]).unwrap();
+
+        // Should NOT be empty — data was actually scanned
+        // Only row with a=12 satisfies a >= 10
+        assert_eq!(result.len(), 1);
+    }
+
+    #[test]
+    fn test_filter_without_stats_scans_data() {
+        // No stats → filter must scan data normally.
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int64)]));
+
+        let data = RecordBatch::from_nonempty_columns(vec![
+            Int64Array::from_slice("a", &[1, 2, 3]).into_series(),
+        ])
+        .unwrap();
+
+        let mp = MicroPartition::new_loaded(schema.clone(), Arc::new(vec![data]), None);
+
+        let pred = BoundExpr::try_new(resolved_col("a").lt(lit(3i64)), &schema).unwrap();
+        let result = mp.filter(&[pred]).unwrap();
+
+        // Rows 1 and 2 satisfy a < 3
+        assert_eq!(result.len(), 2);
+    }
+}

--- a/src/daft-stats/src/table_stats.rs
+++ b/src/daft-stats/src/table_stats.rs
@@ -347,4 +347,54 @@ mod test {
 
         Ok(())
     }
+
+    #[test]
+    fn test_range_stats_false_when_predicate_outside_range() -> crate::Result<()> {
+        // Stats: min=10, max=20. Predicate: col < 5 → must be False.
+        // This verifies that injected stats can trigger the MicroPartition.filter
+        // short-circuit (TruthValue::False → return empty without scanning data).
+        let table = RecordBatch::from_nonempty_columns(vec![
+            Int64Array::from_slice("a", &[10, 20]).into_series(),
+        ])
+        .unwrap();
+        let table_stats = TableStatistics::from_table(&table);
+
+        // col < 5 → False (5 < min=10)
+        let expr = BoundExpr::try_new(resolved_col("a").lt(lit(5i64)), &table.schema)
+            .context(DaftCoreComputeSnafu)?;
+        let result = table_stats.eval_expression(&expr)?;
+        assert_eq!(result.to_truth_value(), TruthValue::False);
+
+        // col > 25 → False (25 > max=20)
+        let expr = BoundExpr::try_new(resolved_col("a").gt(lit(25i64)), &table.schema)
+            .context(DaftCoreComputeSnafu)?;
+        let result = table_stats.eval_expression(&expr)?;
+        assert_eq!(result.to_truth_value(), TruthValue::False);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_range_stats_maybe_when_predicate_overlaps_range() -> crate::Result<()> {
+        // Stats: min=10, max=20. Predicate: col < 15 → must be Maybe.
+        let table = RecordBatch::from_nonempty_columns(vec![
+            Int64Array::from_slice("a", &[10, 20]).into_series(),
+        ])
+        .unwrap();
+        let table_stats = TableStatistics::from_table(&table);
+
+        // col < 15 → Maybe (15 is within [10, 20], some values satisfy, some don't)
+        let expr = BoundExpr::try_new(resolved_col("a").lt(lit(15i64)), &table.schema)
+            .context(DaftCoreComputeSnafu)?;
+        let result = table_stats.eval_expression(&expr)?;
+        assert_eq!(result.to_truth_value(), TruthValue::Maybe);
+
+        // col > 12 → Maybe (12 is within [10, 20], some values satisfy, some don't)
+        let expr = BoundExpr::try_new(resolved_col("a").gt(lit(12i64)), &table.schema)
+            .context(DaftCoreComputeSnafu)?;
+        let result = table_stats.eval_expression(&expr)?;
+        assert_eq!(result.to_truth_value(), TruthValue::Maybe);
+
+        Ok(())
+    }
 }

--- a/tests/integration/iceberg/test_iceberg_count_pushdown_coverage.py
+++ b/tests/integration/iceberg/test_iceberg_count_pushdown_coverage.py
@@ -92,6 +92,7 @@ class TestIcebergDataSourceUnit:
 
         # Mock schema
         mock_schema = Mock()
+        mock_schema.fields = []  # Required by IcebergDataSource.__init__
         mock_table.schema.return_value = mock_schema
 
         # Mock spec
@@ -281,7 +282,9 @@ class TestIcebergDataSourceUnit:
         # Create table that will fail on scan
         mock_table = Mock()
         mock_table.name.return_value = ["test", "table"]
-        mock_table.schema.return_value = Mock()
+        mock_schema_exc = Mock()
+        mock_schema_exc.fields = []
+        mock_table.schema.return_value = mock_schema_exc
         mock_spec = Mock()
         mock_spec.fields = []
         mock_table.spec.return_value = mock_spec
@@ -312,7 +315,9 @@ class TestIcebergDataSourceUnit:
         # Create table that will fail on scan
         mock_table = Mock()
         mock_table.name.return_value = ["test", "table"]
-        mock_table.schema.return_value = Mock()
+        mock_schema_exc2 = Mock()
+        mock_schema_exc2.fields = []
+        mock_table.schema.return_value = mock_schema_exc2
         mock_spec = Mock()
         mock_spec.fields = []
         mock_table.spec.return_value = mock_spec

--- a/tests/io/iceberg/test_iceberg_stats.py
+++ b/tests/io/iceberg/test_iceberg_stats.py
@@ -1,0 +1,752 @@
+"""Tests for Iceberg scan task statistics injection."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pyarrow as pa
+import pytest
+
+pyiceberg = pytest.importorskip("pyiceberg")
+
+from pyiceberg.conversions import to_bytes
+from pyiceberg.io.pyarrow import schema_to_pyarrow
+from pyiceberg.schema import Schema as IcebergSchema
+from pyiceberg.types import (
+    BinaryType,
+    DateType,
+    DecimalType,
+    DoubleType,
+    FloatType,
+    IntegerType,
+    LongType,
+    NestedField,
+    PrimitiveType,
+    StringType,
+    StructType,
+    TimestampType,
+    TimestamptzType,
+    UUIDType,
+)
+
+from daft.io.iceberg.iceberg_scan import _build_iceberg_data_source_task_stats
+
+
+def _make_data_file(lower_bounds=None, upper_bounds=None):
+    """Create a mock DataFile with given bounds."""
+    file = Mock()
+    file.lower_bounds = lower_bounds
+    file.upper_bounds = upper_bounds
+    return file
+
+
+def _make_top_level_fields(schema: IcebergSchema) -> list[tuple[int, str, object, bool, pa.DataType]]:
+    """Build the precomputed top-level field list matching IcebergDataSource.__init__."""
+    return [
+        (
+            field.field_id,
+            field.name,
+            field.field_type,
+            isinstance(field.field_type, PrimitiveType),
+            schema_to_pyarrow(field.field_type),
+        )
+        for field in schema.fields
+    ]
+
+
+def _make_task_schema(iceberg_schema: IcebergSchema):
+    """Build a minimal Daft Schema for assertions."""
+    from daft.logical.schema import Schema
+
+    pyarrow_schema = pa.schema(
+        [
+            pa.field(
+                field.name,
+                schema_to_pyarrow(field.field_type),
+                nullable=not field.required,
+            )
+            for field in iceberg_schema.fields
+        ]
+    )
+    return Schema.from_pyarrow_schema(pyarrow_schema)
+
+
+class TestBuildIcebergDataSourceTaskStats:
+    """Test suite for _build_iceberg_data_source_task_stats."""
+
+    def test_none_stats(self):
+        """Returns None when both bounds are None."""
+        schema = IcebergSchema(
+            NestedField(field_id=1, name="id", field_type=LongType(), required=True),
+        )
+        file = _make_data_file(lower_bounds=None, upper_bounds=None)
+        result = _build_iceberg_data_source_task_stats(
+            file,
+            _make_top_level_fields(schema),
+            _make_task_schema(schema),
+        )
+        assert result is None
+
+    def test_empty_stats(self):
+        """Returns None when both bounds are empty dicts."""
+        schema = IcebergSchema(
+            NestedField(field_id=1, name="id", field_type=LongType(), required=True),
+        )
+        file = _make_data_file(lower_bounds={}, upper_bounds={})
+        result = _build_iceberg_data_source_task_stats(
+            file,
+            _make_top_level_fields(schema),
+            _make_task_schema(schema),
+        )
+        assert result is None
+
+    def test_long_type(self):
+        """Long type min/max decoded correctly."""
+        schema = IcebergSchema(
+            NestedField(field_id=1, name="id", field_type=LongType(), required=True),
+        )
+        lower = {1: to_bytes(LongType(), 10)}
+        upper = {1: to_bytes(LongType(), 20)}
+        file = _make_data_file(lower_bounds=lower, upper_bounds=upper)
+
+        result = _build_iceberg_data_source_task_stats(
+            file,
+            _make_top_level_fields(schema),
+            _make_task_schema(schema),
+        )
+        assert result is not None
+        arrow_table = result.to_arrow_table()
+        assert arrow_table.num_rows == 2
+        assert arrow_table.column("id")[0].as_py() == 10
+        assert arrow_table.column("id")[1].as_py() == 20
+
+    def test_integer_type(self):
+        """Integer type min/max decoded correctly."""
+        schema = IcebergSchema(
+            NestedField(field_id=1, name="val", field_type=IntegerType(), required=True),
+        )
+        lower = {1: to_bytes(IntegerType(), 5)}
+        upper = {1: to_bytes(IntegerType(), 100)}
+        file = _make_data_file(lower_bounds=lower, upper_bounds=upper)
+
+        result = _build_iceberg_data_source_task_stats(
+            file,
+            _make_top_level_fields(schema),
+            _make_task_schema(schema),
+        )
+        assert result is not None
+        arrow_table = result.to_arrow_table()
+        assert arrow_table.column("val")[0].as_py() == 5
+        assert arrow_table.column("val")[1].as_py() == 100
+
+    def test_string_type(self):
+        """String type min/max decoded correctly."""
+        schema = IcebergSchema(
+            NestedField(field_id=1, name="name", field_type=StringType(), required=True),
+        )
+        lower = {1: to_bytes(StringType(), "aaa")}
+        upper = {1: to_bytes(StringType(), "zzz")}
+        file = _make_data_file(lower_bounds=lower, upper_bounds=upper)
+
+        result = _build_iceberg_data_source_task_stats(
+            file,
+            _make_top_level_fields(schema),
+            _make_task_schema(schema),
+        )
+        assert result is not None
+        arrow_table = result.to_arrow_table()
+        assert arrow_table.column("name")[0].as_py() == "aaa"
+        assert arrow_table.column("name")[1].as_py() == "zzz"
+
+    def test_truncated_string_type(self):
+        """Truncated string bounds (from Iceberg truncate(N) metrics) decode without error.
+
+        When Iceberg's MetricsMode is truncate(N), bounds are shorter than the
+        actual column values. The decoder must handle these partial UTF-8 sequences
+        gracefully.
+        """
+        schema = IcebergSchema(
+            NestedField(field_id=1, name="name", field_type=StringType(), required=True),
+        )
+        # Simulate a truncated bound: actual value might be "abcdefghij" but
+        # the bound is truncated to "abcde". The raw bytes are still valid UTF-8.
+        truncated_lower = to_bytes(StringType(), "abcde")  # truncated from "abcdefghij"
+        truncated_upper = to_bytes(StringType(), "uvwxy")  # truncated from "uvwxyz1234"
+        lower = {1: truncated_lower}
+        upper = {1: truncated_upper}
+        file = _make_data_file(lower_bounds=lower, upper_bounds=upper)
+
+        result = _build_iceberg_data_source_task_stats(
+            file,
+            _make_top_level_fields(schema),
+            _make_task_schema(schema),
+        )
+        assert result is not None
+        arrow_table = result.to_arrow_table()
+        # Truncated bounds decode to the truncated prefix, not the original value
+        assert arrow_table.column("name")[0].as_py() == "abcde"
+        assert arrow_table.column("name")[1].as_py() == "uvwxy"
+
+    def test_date_type(self):
+        """Date type min/max decoded correctly."""
+        import datetime
+
+        schema = IcebergSchema(
+            NestedField(field_id=1, name="dt", field_type=DateType(), required=True),
+        )
+        # 2020-01-01 = day 18262, 2020-12-31 = day 18627
+        lower = {1: to_bytes(DateType(), 18262)}
+        upper = {1: to_bytes(DateType(), 18627)}
+        file = _make_data_file(lower_bounds=lower, upper_bounds=upper)
+
+        result = _build_iceberg_data_source_task_stats(
+            file,
+            _make_top_level_fields(schema),
+            _make_task_schema(schema),
+        )
+        assert result is not None
+        arrow_table = result.to_arrow_table()
+        assert arrow_table.column("dt")[0].as_py() == datetime.date(2020, 1, 1)
+        assert arrow_table.column("dt")[1].as_py() == datetime.date(2020, 12, 31)
+
+    def test_timestamp_type(self):
+        """TimestampType (no timezone) min/max decoded correctly."""
+        schema = IcebergSchema(
+            NestedField(field_id=1, name="ts", field_type=TimestampType(), required=True),
+        )
+        # microseconds since epoch
+        min_us = 1577836800000000  # 2020-01-01 00:00:00 UTC
+        max_us = 1609459200000000  # 2021-01-01 00:00:00 UTC
+        lower = {1: to_bytes(TimestampType(), min_us)}
+        upper = {1: to_bytes(TimestampType(), max_us)}
+        file = _make_data_file(lower_bounds=lower, upper_bounds=upper)
+
+        result = _build_iceberg_data_source_task_stats(
+            file,
+            _make_top_level_fields(schema),
+            _make_task_schema(schema),
+        )
+        assert result is not None
+        arrow_table = result.to_arrow_table()
+        # Compare underlying microsecond values to avoid datetime-timezone lint
+        assert arrow_table.column("ts")[0].cast(pa.int64()).as_py() == min_us
+        assert arrow_table.column("ts")[1].cast(pa.int64()).as_py() == max_us
+
+    def test_timestamptz_type(self):
+        """TimestamptzType (with timezone) min/max decoded correctly."""
+        import datetime
+
+        schema = IcebergSchema(
+            NestedField(field_id=1, name="ts_tz", field_type=TimestamptzType(), required=True),
+        )
+        min_us = 1577836800000000
+        max_us = 1609459200000000
+        lower = {1: to_bytes(TimestamptzType(), min_us)}
+        upper = {1: to_bytes(TimestamptzType(), max_us)}
+        file = _make_data_file(lower_bounds=lower, upper_bounds=upper)
+
+        result = _build_iceberg_data_source_task_stats(
+            file,
+            _make_top_level_fields(schema),
+            _make_task_schema(schema),
+        )
+        assert result is not None
+        arrow_table = result.to_arrow_table()
+        # Arrow returns datetime objects for timestamps with timezone
+        assert arrow_table.column("ts_tz")[0].as_py() == datetime.datetime(
+            2020, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc
+        )
+        assert arrow_table.column("ts_tz")[1].as_py() == datetime.datetime(
+            2021, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc
+        )
+
+    def test_decimal_type(self):
+        """Decimal type min/max decoded with correct scale/precision."""
+        schema = IcebergSchema(
+            NestedField(field_id=1, name="amount", field_type=DecimalType(10, 2), required=True),
+        )
+        from decimal import Decimal
+
+        lower = {1: to_bytes(DecimalType(10, 2), Decimal("10.50"))}
+        upper = {1: to_bytes(DecimalType(10, 2), Decimal("999.99"))}
+        file = _make_data_file(lower_bounds=lower, upper_bounds=upper)
+
+        result = _build_iceberg_data_source_task_stats(
+            file,
+            _make_top_level_fields(schema),
+            _make_task_schema(schema),
+        )
+        assert result is not None
+        arrow_table = result.to_arrow_table()
+        assert arrow_table.column("amount")[0].as_py() == Decimal("10.50")
+        assert arrow_table.column("amount")[1].as_py() == Decimal("999.99")
+
+    def test_binary_type(self):
+        """Binary type min/max decoded correctly (logical value consistency)."""
+        schema = IcebergSchema(
+            NestedField(field_id=1, name="data", field_type=BinaryType(), required=True),
+        )
+        min_bytes = b"\x00\x01\x02"
+        max_bytes = b"\xff\xfe\xfd"
+        lower = {1: to_bytes(BinaryType(), min_bytes)}
+        upper = {1: to_bytes(BinaryType(), max_bytes)}
+        file = _make_data_file(lower_bounds=lower, upper_bounds=upper)
+
+        result = _build_iceberg_data_source_task_stats(
+            file,
+            _make_top_level_fields(schema),
+            _make_task_schema(schema),
+        )
+        assert result is not None
+        arrow_table = result.to_arrow_table()
+        assert arrow_table.column("data")[0].as_py() == min_bytes
+        assert arrow_table.column("data")[1].as_py() == max_bytes
+
+    def test_uuid_type(self):
+        """UUID type min/max decoded correctly (logical value consistency)."""
+        import uuid
+
+        schema = IcebergSchema(
+            NestedField(field_id=1, name="uid", field_type=UUIDType(), required=True),
+        )
+
+        min_uuid = uuid.UUID("00000000-0000-0000-0000-000000000000")
+        max_uuid = uuid.UUID("ffffffff-ffff-ffff-ffff-ffffffffffff")
+        lower = {1: to_bytes(UUIDType(), min_uuid)}
+        upper = {1: to_bytes(UUIDType(), max_uuid)}
+        file = _make_data_file(lower_bounds=lower, upper_bounds=upper)
+
+        result = _build_iceberg_data_source_task_stats(
+            file,
+            _make_top_level_fields(schema),
+            _make_task_schema(schema),
+        )
+        assert result is not None
+        arrow_table = result.to_arrow_table()
+        assert arrow_table.column("uid")[0].as_py() == min_uuid
+        assert arrow_table.column("uid")[1].as_py() == max_uuid
+        assert result.schema() == _make_task_schema(schema)
+
+    def test_missing_upper_bound(self):
+        """Returns None when upper bound is missing for all valid fields."""
+        schema = IcebergSchema(
+            NestedField(field_id=1, name="id", field_type=LongType(), required=True),
+        )
+        lower = {1: to_bytes(LongType(), 10)}
+        upper = {}  # missing upper
+        file = _make_data_file(lower_bounds=lower, upper_bounds=upper)
+
+        result = _build_iceberg_data_source_task_stats(
+            file,
+            _make_top_level_fields(schema),
+            _make_task_schema(schema),
+        )
+        # The function now checks field_id in lower AND field_id in upper, so
+        # a field with only one side produces no decoded bounds, and the
+        # full-schema batch is non-empty but has no decoded values → None.
+        assert result is None
+
+    def test_unknown_field_id(self):
+        """Returns None when no field ids match the schema."""
+        schema = IcebergSchema(
+            NestedField(field_id=1, name="id", field_type=LongType(), required=True),
+        )
+        # field_id=999 doesn't exist in schema
+        lower = {999: to_bytes(LongType(), 10)}
+        upper = {999: to_bytes(LongType(), 20)}
+        file = _make_data_file(lower_bounds=lower, upper_bounds=upper)
+
+        result = _build_iceberg_data_source_task_stats(
+            file,
+            _make_top_level_fields(schema),
+            _make_task_schema(schema),
+        )
+        assert result is None
+
+    def test_nested_field_skipped(self):
+        """Skips nested fields (struct), only processes top-level primitives."""
+        schema = IcebergSchema(
+            NestedField(field_id=1, name="id", field_type=LongType(), required=True),
+            NestedField(
+                field_id=2,
+                name="address",
+                field_type=StructType(
+                    NestedField(field_id=3, name="city", field_type=StringType(), required=True),
+                ),
+                required=False,
+            ),
+        )
+        # Only provide stats for nested leaf (should be skipped — is_primitive=False)
+        lower = {3: to_bytes(StringType(), "a")}
+        upper = {3: to_bytes(StringType(), "z")}
+        file = _make_data_file(lower_bounds=lower, upper_bounds=upper)
+
+        result = _build_iceberg_data_source_task_stats(
+            file,
+            _make_top_level_fields(schema),
+            _make_task_schema(schema),
+        )
+        assert result is None
+
+    def test_multiple_columns(self):
+        """Correctly handles multiple columns with stats."""
+        schema = IcebergSchema(
+            NestedField(field_id=1, name="id", field_type=LongType(), required=True),
+            NestedField(field_id=2, name="name", field_type=StringType(), required=True),
+        )
+        lower = {1: to_bytes(LongType(), 1), 2: to_bytes(StringType(), "alice")}
+        upper = {1: to_bytes(LongType(), 100), 2: to_bytes(StringType(), "zack")}
+        file = _make_data_file(lower_bounds=lower, upper_bounds=upper)
+
+        result = _build_iceberg_data_source_task_stats(
+            file,
+            _make_top_level_fields(schema),
+            _make_task_schema(schema),
+        )
+        assert result is not None
+        arrow_table = result.to_arrow_table()
+        assert arrow_table.num_rows == 2
+        assert arrow_table.column("id")[0].as_py() == 1
+        assert arrow_table.column("id")[1].as_py() == 100
+        assert arrow_table.column("name")[0].as_py() == "alice"
+        assert arrow_table.column("name")[1].as_py() == "zack"
+        assert result.schema().column_names() == ["id", "name"]
+
+    def test_float_type(self):
+        """Float type min/max decoded correctly."""
+        schema = IcebergSchema(
+            NestedField(field_id=1, name="score", field_type=FloatType(), required=True),
+        )
+        lower = {1: to_bytes(FloatType(), 1.5)}
+        upper = {1: to_bytes(FloatType(), 9.9)}
+        file = _make_data_file(lower_bounds=lower, upper_bounds=upper)
+
+        result = _build_iceberg_data_source_task_stats(
+            file,
+            _make_top_level_fields(schema),
+            _make_task_schema(schema),
+        )
+        assert result is not None
+        arrow_table = result.to_arrow_table()
+        assert abs(arrow_table.column("score")[0].as_py() - 1.5) < 0.01
+        assert abs(arrow_table.column("score")[1].as_py() - 9.9) < 0.01
+
+    def test_double_type(self):
+        """Double type min/max decoded correctly."""
+        schema = IcebergSchema(
+            NestedField(field_id=1, name="price", field_type=DoubleType(), required=True),
+        )
+        lower = {1: to_bytes(DoubleType(), 0.01)}
+        upper = {1: to_bytes(DoubleType(), 99999.99)}
+        file = _make_data_file(lower_bounds=lower, upper_bounds=upper)
+
+        result = _build_iceberg_data_source_task_stats(
+            file,
+            _make_top_level_fields(schema),
+            _make_task_schema(schema),
+        )
+        assert result is not None
+        arrow_table = result.to_arrow_table()
+        assert abs(arrow_table.column("price")[0].as_py() - 0.01) < 0.001
+        assert abs(arrow_table.column("price")[1].as_py() - 99999.99) < 0.01
+
+    def test_mixed_valid_and_invalid_fields(self):
+        """When some fields fail to decode, others still succeed."""
+        schema = IcebergSchema(
+            NestedField(field_id=1, name="id", field_type=LongType(), required=True),
+            NestedField(field_id=2, name="bad", field_type=IntegerType(), required=True),
+        )
+        lower = {1: to_bytes(LongType(), 1), 2: b"\xff\xff"}  # invalid bytes for IntegerType
+        upper = {1: to_bytes(LongType(), 100), 2: b"\xff\xff"}
+        file = _make_data_file(lower_bounds=lower, upper_bounds=upper)
+
+        result = _build_iceberg_data_source_task_stats(
+            file,
+            _make_top_level_fields(schema),
+            _make_task_schema(schema),
+        )
+        assert result is not None
+        arrow_table = result.to_arrow_table()
+        # Both columns present with full schema
+        assert set(arrow_table.column_names) == {"id", "bad"}
+        # id was valid
+        assert arrow_table.column("id")[0].as_py() == 1
+        assert arrow_table.column("id")[1].as_py() == 100
+        # bad was invalid → typed null
+        assert arrow_table.column("bad")[0].as_py() is None
+        assert arrow_table.column("bad")[1].as_py() is None
+        # Schema order preserved (id before bad as per schema definition)
+        assert result.schema().column_names() == ["id", "bad"]
+
+    def test_reversed_field_order(self):
+        """Stats output follows schema order, not bounds dict iteration order."""
+        schema = IcebergSchema(
+            NestedField(field_id=1, name="a", field_type=LongType(), required=True),
+            NestedField(field_id=2, name="b", field_type=StringType(), required=True),
+            NestedField(field_id=3, name="c", field_type=FloatType(), required=True),
+        )
+        # Provide bounds in reverse order of schema
+        lower = {
+            3: to_bytes(FloatType(), 3.0),
+            2: to_bytes(StringType(), "b_val"),
+            1: to_bytes(LongType(), 1),
+        }
+        upper = {
+            3: to_bytes(FloatType(), 30.0),
+            2: to_bytes(StringType(), "b_upper"),
+            1: to_bytes(LongType(), 10),
+        }
+        file = _make_data_file(lower_bounds=lower, upper_bounds=upper)
+
+        result = _build_iceberg_data_source_task_stats(
+            file,
+            _make_top_level_fields(schema),
+            _make_task_schema(schema),
+        )
+        assert result is not None
+        # Column order must be [a, b, c] as per schema, not [c, b, a]
+        assert result.schema().column_names() == ["a", "b", "c"]
+
+    def test_partial_bounds_full_schema(self):
+        """Return full-schema batch with typed nulls for columns missing bounds."""
+        schema = IcebergSchema(
+            NestedField(field_id=1, name="x", field_type=LongType(), required=True),
+            NestedField(field_id=2, name="y", field_type=DoubleType(), required=True),
+        )
+        lower = {1: to_bytes(LongType(), 100)}
+        upper = {1: to_bytes(LongType(), 200)}
+        # y has no bounds at all
+        file = _make_data_file(lower_bounds=lower, upper_bounds=upper)
+
+        result = _build_iceberg_data_source_task_stats(
+            file,
+            _make_top_level_fields(schema),
+            _make_task_schema(schema),
+        )
+        assert result is not None
+        assert result.schema().column_names() == ["x", "y"]
+        assert result.to_arrow_table().column("y")[0].as_py() is None
+        assert result.to_arrow_table().column("y")[1].as_py() is None
+
+    def test_complex_top_level_field_is_typed_null(self):
+        """Struct/map/list top-level fields receive typed nulls, not skipped."""
+        schema = IcebergSchema(
+            NestedField(field_id=1, name="id", field_type=LongType(), required=True),
+            NestedField(
+                field_id=2,
+                name="meta",
+                field_type=StructType(
+                    NestedField(field_id=3, name="key", field_type=StringType()),
+                ),
+                required=False,
+            ),
+        )
+        lower = {1: to_bytes(LongType(), 1)}
+        upper = {1: to_bytes(LongType(), 10)}
+        file = _make_data_file(lower_bounds=lower, upper_bounds=upper)
+
+        result = _build_iceberg_data_source_task_stats(
+            file,
+            _make_top_level_fields(schema),
+            _make_task_schema(schema),
+        )
+        assert result is not None
+        assert result.schema().column_names() == ["id", "meta"]
+        # meta is complex → typed null
+        assert result.to_arrow_table().column("meta")[0].as_py() is None
+        assert result.to_arrow_table().column("meta")[1].as_py() is None
+
+
+class TestBuildIcebergDataSourceTaskStatsSchemaContract:
+    """Tests that verify the schema contract: output matches task schema exactly."""
+
+    def test_stats_schema_equals_task_schema(self):
+        """Stats RecordBatch schema columns, names, and order match task_schema."""
+        schema = IcebergSchema(
+            NestedField(field_id=1, name="id", field_type=LongType(), required=True),
+            NestedField(field_id=2, name="name", field_type=StringType(), required=True),
+            NestedField(field_id=3, name="score", field_type=FloatType(), required=True),
+        )
+        task_schema = _make_task_schema(schema)
+        lower = {
+            1: to_bytes(LongType(), 1),
+            2: to_bytes(StringType(), "a"),
+            3: to_bytes(FloatType(), 1.0),
+        }
+        upper = {
+            1: to_bytes(LongType(), 100),
+            2: to_bytes(StringType(), "z"),
+            3: to_bytes(FloatType(), 10.0),
+        }
+        file = _make_data_file(lower_bounds=lower, upper_bounds=upper)
+
+        result = _build_iceberg_data_source_task_stats(
+            file,
+            _make_top_level_fields(schema),
+            task_schema,
+        )
+        assert result is not None
+        assert result.schema() == task_schema
+
+    def test_stats_schema_matches_column_order(self):
+        """Output column order matches schema, even with shuffled bounds keys."""
+        schema = IcebergSchema(
+            NestedField(field_id=3, name="c", field_type=LongType(), required=True),
+            NestedField(field_id=1, name="a", field_type=LongType(), required=True),
+            NestedField(field_id=2, name="b", field_type=StringType(), required=True),
+        )
+        task_schema = _make_task_schema(schema)
+        # bounds keys are in natural id order, which is NOT schema order
+        lower = {
+            1: to_bytes(LongType(), 1),
+            2: to_bytes(StringType(), "b"),
+            3: to_bytes(LongType(), 3),
+        }
+        upper = {
+            1: to_bytes(LongType(), 10),
+            2: to_bytes(StringType(), "B"),
+            3: to_bytes(LongType(), 30),
+        }
+        file = _make_data_file(lower_bounds=lower, upper_bounds=upper)
+
+        result = _build_iceberg_data_source_task_stats(
+            file,
+            _make_top_level_fields(schema),
+            task_schema,
+        )
+        assert result is not None
+        # Must be [c, a, b] as per schema, not [1, 2, 3]
+        assert result.schema().column_names() == ["c", "a", "b"]
+
+
+class TestBuildIcebergDataSourceTaskStatsEdgeCases:
+    """Edge-case coverage required by the test plan but not covered above."""
+
+    def test_boolean_type(self):
+        """Boolean type min/max decoded correctly."""
+        from pyiceberg.types import BooleanType
+
+        schema = IcebergSchema(
+            NestedField(field_id=1, name="flag", field_type=BooleanType(), required=True),
+        )
+        lower = {1: to_bytes(BooleanType(), False)}
+        upper = {1: to_bytes(BooleanType(), True)}
+        file = _make_data_file(lower_bounds=lower, upper_bounds=upper)
+
+        result = _build_iceberg_data_source_task_stats(
+            file,
+            _make_top_level_fields(schema),
+            _make_task_schema(schema),
+        )
+        assert result is not None
+        arrow_table = result.to_arrow_table()
+        assert arrow_table.column("flag")[0].as_py() is False
+        assert arrow_table.column("flag")[1].as_py() is True
+
+    def test_time_type(self):
+        """TimeType min/max decoded correctly."""
+        import datetime
+
+        from pyiceberg.types import TimeType
+
+        schema = IcebergSchema(
+            NestedField(field_id=1, name="t", field_type=TimeType(), required=True),
+        )
+        # microseconds since midnight → datetime.time objects via Arrow
+        lower = {1: to_bytes(TimeType(), 0)}
+        upper = {1: to_bytes(TimeType(), 86_400_000_000 - 1)}  # 23:59:59.999999
+        file = _make_data_file(lower_bounds=lower, upper_bounds=upper)
+
+        result = _build_iceberg_data_source_task_stats(
+            file,
+            _make_top_level_fields(schema),
+            _make_task_schema(schema),
+        )
+        assert result is not None
+        arrow_table = result.to_arrow_table()
+        assert arrow_table.column("t")[0].as_py() == datetime.time(0, 0)
+        assert arrow_table.column("t")[1].as_py() == datetime.time(23, 59, 59, 999999)
+
+    def test_missing_lower_bound(self):
+        """Returns None when lower bound is missing for all valid fields."""
+        schema = IcebergSchema(
+            NestedField(field_id=1, name="id", field_type=LongType(), required=True),
+        )
+        lower = {}  # missing lower
+        upper = {1: to_bytes(LongType(), 100)}  # only upper
+        file = _make_data_file(lower_bounds=lower, upper_bounds=upper)
+
+        result = _build_iceberg_data_source_task_stats(
+            file,
+            _make_top_level_fields(schema),
+            _make_task_schema(schema),
+        )
+        assert result is None
+
+    def test_type_promotion_int_to_long(self):
+        """Old file bounds encoded as int, but current schema has long — decode fails."""
+        # This simulates an Iceberg type promotion: the file was written with
+        # IntegerType bounds but the schema now has LongType. The bounds bytes
+        # are 4 bytes (int) but from_bytes expects 8 bytes (long) → ValueError.
+        schema = IcebergSchema(
+            NestedField(field_id=1, name="id", field_type=LongType(), required=True),
+        )
+        # Encode as IntegerType (4 bytes), but schema says LongType (8 bytes)
+        import struct as _struct
+
+        lower = {1: _struct.pack("<i", 42)}
+        upper = {1: _struct.pack("<i", 999)}
+        file = _make_data_file(lower_bounds=lower, upper_bounds=upper)
+
+        result = _build_iceberg_data_source_task_stats(
+            file,
+            _make_top_level_fields(schema),
+            _make_task_schema(schema),
+        )
+        # Decode fails → returned batch is all typed nulls → None
+        assert result is None
+
+    def test_type_promotion_float_to_double(self):
+        """Old file bounds encoded as float, current schema has double — decode fails."""
+        # 4-byte float bytes cannot be decoded by from_bytes(DoubleType, ...)
+        # (struct.error). The conservative contract: decode failure → None.
+        schema = IcebergSchema(
+            NestedField(field_id=1, name="val", field_type=DoubleType(), required=True),
+        )
+        lower = {1: to_bytes(FloatType(), 1.5)}
+        upper = {1: to_bytes(FloatType(), 9.9)}
+        file = _make_data_file(lower_bounds=lower, upper_bounds=upper)
+
+        result = _build_iceberg_data_source_task_stats(
+            file,
+            _make_top_level_fields(schema),
+            _make_task_schema(schema),
+        )
+        # Decode fails → no usable bounds → None (never crashes)
+        assert result is None
+
+    def test_schema_evolution_added_column(self):
+        """New column added by schema evolution — old file has no bounds for it."""
+        schema = IcebergSchema(
+            NestedField(field_id=1, name="id", field_type=LongType(), required=True),
+            NestedField(field_id=2, name="new_col", field_type=StringType(), required=False),
+        )
+        # Only field_id=1 has bounds; new_col has none
+        lower = {1: to_bytes(LongType(), 1)}
+        upper = {1: to_bytes(LongType(), 100)}
+        file = _make_data_file(lower_bounds=lower, upper_bounds=upper)
+
+        result = _build_iceberg_data_source_task_stats(
+            file,
+            _make_top_level_fields(schema),
+            _make_task_schema(schema),
+        )
+        assert result is not None
+        assert result.schema().column_names() == ["id", "new_col"]
+        arrow_table = result.to_arrow_table()
+        # id has values
+        assert arrow_table.column("id")[0].as_py() == 1
+        assert arrow_table.column("id")[1].as_py() == 100
+        # new_col is typed null
+        assert arrow_table.column("new_col")[0].as_py() is None
+        assert arrow_table.column("new_col")[1].as_py() is None

--- a/tests/io/iceberg/test_iceberg_stats_integration.py
+++ b/tests/io/iceberg/test_iceberg_stats_integration.py
@@ -1,0 +1,422 @@
+"""Integration tests for Iceberg DataSource task statistics injection."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pyiceberg = pytest.importorskip("pyiceberg")
+
+import pyarrow as pa
+from pyiceberg.catalog.sql import SqlCatalog
+from pyiceberg.schema import Schema as IcebergSchema
+from pyiceberg.transforms import IdentityTransform
+from pyiceberg.types import (
+    DoubleType,
+    LongType,
+    NestedField,
+    StringType,
+)
+
+import daft
+from daft.daft import StorageConfig
+from daft.io.iceberg.iceberg_scan import IcebergDataSource
+from daft.io.pushdowns import Pushdowns
+from daft.io.source import DataSourceTask
+
+
+@pytest.fixture(scope="function")
+def local_catalog(tmpdir):
+    catalog = SqlCatalog(
+        "default",
+        uri=f"sqlite:///{tmpdir}/pyiceberg_catalog.db",
+        warehouse=f"file://{tmpdir}",
+    )
+    catalog.create_namespace("default")
+    yield catalog
+    catalog.engine.dispose()
+
+
+@pytest.fixture(scope="function")
+def multi_file_table(local_catalog, tmpdir):
+    """Create a table with multiple data files for stats testing."""
+    schema = IcebergSchema(
+        NestedField(field_id=1, name="id", field_type=LongType(), required=True),
+        NestedField(field_id=2, name="name", field_type=StringType(), required=False),
+        NestedField(field_id=3, name="value", field_type=DoubleType(), required=False),
+    )
+
+    table = local_catalog.create_table(
+        identifier="default.test_stats",
+        schema=schema,
+    )
+
+    # Write multiple files with different data
+    # File 1: ids 1-100
+    data1 = pa.table(
+        {
+            "id": pa.array(range(1, 101), type=pa.int64()),
+            "name": pa.array([f"row_{i}" for i in range(1, 101)]),
+            "value": pa.array([float(i) * 1.5 for i in range(1, 101)]),
+        },
+        schema=pa.schema(
+            [
+                pa.field("id", pa.int64(), nullable=False),
+                pa.field("name", pa.string(), nullable=True),
+                pa.field("value", pa.float64(), nullable=True),
+            ]
+        ),
+    )
+    table.append(data1)
+
+    # File 2: ids 101-200
+    data2 = pa.table(
+        {
+            "id": pa.array(range(101, 201), type=pa.int64()),
+            "name": pa.array([f"row_{i}" for i in range(101, 201)]),
+            "value": pa.array([float(i) * 1.5 for i in range(101, 201)]),
+        },
+        schema=pa.schema(
+            [
+                pa.field("id", pa.int64(), nullable=False),
+                pa.field("name", pa.string(), nullable=True),
+                pa.field("value", pa.float64(), nullable=True),
+            ]
+        ),
+    )
+    table.append(data2)
+
+    # File 3: ids 201-300
+    data3 = pa.table(
+        {
+            "id": pa.array(range(201, 301), type=pa.int64()),
+            "name": pa.array([f"row_{i}" for i in range(201, 301)]),
+            "value": pa.array([float(i) * 1.5 for i in range(201, 301)]),
+        },
+        schema=pa.schema(
+            [
+                pa.field("id", pa.int64(), nullable=False),
+                pa.field("name", pa.string(), nullable=True),
+                pa.field("value", pa.float64(), nullable=True),
+            ]
+        ),
+    )
+    table.append(data3)
+
+    return table
+
+
+class TestIcebergStatsIntegration:
+    """Integration tests for Iceberg stats injection via DataSource."""
+
+    def test_tasks_have_stats_injected(self, multi_file_table):
+        """Verify each DataSourceTask receives stats with expected columns."""
+        storage_config = StorageConfig(multithreaded_io=False, io_config=daft.io.IOConfig())
+        source = IcebergDataSource(multi_file_table, None, storage_config)
+
+        pushdowns = Pushdowns()
+
+        captured_stats = []
+
+        def capturing_parquet(**kwargs):
+            captured_stats.append(kwargs.get("stats"))
+            return MagicMock()
+
+        with patch.object(DataSourceTask, "parquet", side_effect=capturing_parquet):
+            tasks = list(source._create_regular_tasks(pushdowns))
+
+        assert len(tasks) == 3
+
+        # Each scan task should have received non-None stats
+        for i, stats_rb in enumerate(captured_stats):
+            assert stats_rb is not None, f"task {i} received stats=None"
+
+        # Stats should contain the primitive columns (id, value)
+        first_stats = captured_stats[0]
+        col_names = list(first_stats.to_arrow_record_batch().schema.names)
+        assert "id" in col_names, f"Expected 'id' in stats columns, got {col_names}"
+        assert "value" in col_names, f"Expected 'value' in stats columns, got {col_names}"
+
+    def test_stats_values_are_correct(self, multi_file_table):
+        """Verify stats values match the actual data ranges."""
+        storage_config = StorageConfig(multithreaded_io=False, io_config=daft.io.IOConfig())
+        source = IcebergDataSource(multi_file_table, None, storage_config)
+
+        pushdowns = Pushdowns()
+
+        captured_stats = []
+
+        def capturing_parquet(**kwargs):
+            captured_stats.append(kwargs.get("stats"))
+            return MagicMock()
+
+        with patch.object(DataSourceTask, "parquet", side_effect=capturing_parquet):
+            list(source._create_regular_tasks(pushdowns))
+
+        # Collect all id min/max pairs
+        id_ranges = []
+        for stats_rb in captured_stats:
+            arrow_rb = stats_rb.to_arrow_record_batch()
+            id_min = arrow_rb.column("id")[0].as_py()
+            id_max = arrow_rb.column("id")[1].as_py()
+            id_ranges.append((id_min, id_max))
+
+        # Sort by min value for deterministic comparison
+        id_ranges.sort()
+
+        # File 1: ids 1-100
+        assert id_ranges[0] == (1, 100)
+        # File 2: ids 101-200
+        assert id_ranges[1] == (101, 200)
+        # File 3: ids 201-300
+        assert id_ranges[2] == (201, 300)
+
+    def test_stats_schema_equals_datasource_schema(self, multi_file_table):
+        """Verify stats schema matches IcebergDataSource.schema exactly."""
+        storage_config = StorageConfig(multithreaded_io=False, io_config=daft.io.IOConfig())
+        source = IcebergDataSource(multi_file_table, None, storage_config)
+
+        pushdowns = Pushdowns()
+
+        captured_stats = []
+
+        def capturing_parquet(**kwargs):
+            captured_stats.append(kwargs.get("stats"))
+            return MagicMock()
+
+        with patch.object(DataSourceTask, "parquet", side_effect=capturing_parquet):
+            list(source._create_regular_tasks(pushdowns))
+
+        for stats_rb in captured_stats:
+            assert stats_rb is not None
+            assert stats_rb.schema() == source.schema
+
+    def test_query_results_unchanged(self, multi_file_table):
+        """Verify query results are correct with stats injection."""
+        df = daft.read_iceberg(multi_file_table)
+        result = df.to_pydict()
+
+        assert len(result["id"]) == 300
+        assert sorted(result["id"]) == list(range(1, 301))
+
+    def test_query_with_filter(self, multi_file_table):
+        """Verify filtered query results are correct with stats injection."""
+        df = daft.read_iceberg(multi_file_table)
+        filtered = df.where(daft.col("id") > 200)
+        result = filtered.to_pydict()
+
+        assert len(result["id"]) == 100
+        assert sorted(result["id"]) == list(range(201, 301))
+
+    def test_query_with_complex_filter(self, multi_file_table):
+        """Verify complex filtered query results are correct."""
+        df = daft.read_iceberg(multi_file_table)
+        filtered = df.where((daft.col("id") >= 50) & (daft.col("id") <= 150))
+        result = filtered.to_pydict()
+
+        assert len(result["id"]) == 101
+        assert sorted(result["id"]) == list(range(50, 151))
+
+    def test_tasks_with_partitioned_table(self, local_catalog, tmpdir):
+        """Verify stats injection works with partitioned tables."""
+        schema = IcebergSchema(
+            NestedField(field_id=1, name="id", field_type=LongType(), required=True),
+            NestedField(field_id=2, name="category", field_type=StringType(), required=False),
+            NestedField(field_id=3, name="value", field_type=DoubleType(), required=False),
+        )
+
+        from pyiceberg.partitioning import PartitionField, PartitionSpec
+
+        table = local_catalog.create_table(
+            identifier="default.test_stats_partitioned",
+            schema=schema,
+            partition_spec=PartitionSpec(
+                PartitionField(
+                    source_id=2,
+                    field_id=1000,
+                    transform=IdentityTransform(),
+                    name="category",
+                )
+            ),
+        )
+
+        data1 = pa.table(
+            {
+                "id": pa.array([1, 2, 3], type=pa.int64()),
+                "category": pa.array(["A", "A", "A"]),
+                "value": pa.array([1.0, 2.0, 3.0]),
+            },
+            schema=pa.schema(
+                [
+                    pa.field("id", pa.int64(), nullable=False),
+                    pa.field("category", pa.string(), nullable=True),
+                    pa.field("value", pa.float64(), nullable=True),
+                ]
+            ),
+        )
+        table.append(data1)
+
+        data2 = pa.table(
+            {
+                "id": pa.array([4, 5, 6], type=pa.int64()),
+                "category": pa.array(["B", "B", "B"]),
+                "value": pa.array([4.0, 5.0, 6.0]),
+            },
+            schema=pa.schema(
+                [
+                    pa.field("id", pa.int64(), nullable=False),
+                    pa.field("category", pa.string(), nullable=True),
+                    pa.field("value", pa.float64(), nullable=True),
+                ]
+            ),
+        )
+        table.append(data2)
+
+        storage_config = StorageConfig(multithreaded_io=False, io_config=daft.io.IOConfig())
+        source = IcebergDataSource(table, None, storage_config)
+        pushdowns = Pushdowns()
+
+        captured_stats = []
+
+        def capturing_parquet(**kwargs):
+            captured_stats.append(kwargs.get("stats"))
+            return MagicMock()
+
+        with patch.object(DataSourceTask, "parquet", side_effect=capturing_parquet):
+            tasks = list(source._create_regular_tasks(pushdowns))
+
+        assert len(tasks) == 2
+        for i, stats_rb in enumerate(captured_stats):
+            assert stats_rb is not None, f"Partitioned task {i} should have stats"
+
+    def test_tasks_with_table_without_stats(self, local_catalog, tmpdir):
+        """Verify degradation when PyIceberg DataFile has no bounds.
+
+        Uses a mock DataFile with lower_bounds/upper_bounds=None to simulate
+        old Iceberg metadata or stats-stripped files.
+        """
+        from unittest.mock import Mock
+
+        schema = IcebergSchema(
+            NestedField(field_id=1, name="id", field_type=LongType(), required=True),
+        )
+
+        table = local_catalog.create_table(
+            identifier="default.test_no_stats",
+            schema=schema,
+        )
+
+        data = pa.table(
+            {"id": pa.array([1, 2, 3], type=pa.int64())},
+            schema=pa.schema([pa.field("id", pa.int64(), nullable=False)]),
+        )
+        table.append(data)
+
+        # Patch _build_iceberg_data_source_task_stats to simulate missing bounds
+        from daft.io.iceberg import iceberg_scan
+
+        original_build = iceberg_scan._build_iceberg_data_source_task_stats
+
+        def mock_build_no_stats(**kwargs):
+            # Simulate DataFile with no bounds
+            mock_file = Mock()
+            mock_file.lower_bounds = None
+            mock_file.upper_bounds = None
+            return original_build(mock_file, kwargs["top_level_fields"], kwargs["task_schema"])
+
+        storage_config = StorageConfig(multithreaded_io=False, io_config=daft.io.IOConfig())
+        source = IcebergDataSource(table, None, storage_config)
+        pushdowns = Pushdowns()
+
+        captured_stats = []
+
+        def capturing_parquet(**kwargs):
+            captured_stats.append(kwargs.get("stats"))
+            return MagicMock()
+
+        with (
+            patch.object(iceberg_scan, "_build_iceberg_data_source_task_stats", side_effect=mock_build_no_stats),
+            patch.object(DataSourceTask, "parquet", side_effect=capturing_parquet),
+        ):
+            tasks = list(source._create_regular_tasks(pushdowns))
+
+            assert len(tasks) == 1
+            # Stats should be None when bounds are missing
+            assert captured_stats[0] is None, "Expected stats=None when bounds are missing"
+
+    def test_partial_bounds_end_to_end(self, local_catalog, tmpdir):
+        """Schema-evolution: new column has no bounds in old files.
+
+        Exercises the full pipeline — DataSourceTask.parquet → TableStatistics
+        → native scan → MicroPartition.filter — with partial stats where
+        one column has typed nulls.  Must not panic, must not incorrectly
+        prune data, and must return correct results.
+        """
+        from pyiceberg.types import DoubleType
+
+        schema_v1 = IcebergSchema(
+            NestedField(field_id=1, name="id", field_type=LongType(), required=True),
+        )
+        table = local_catalog.create_table(
+            identifier="default.test_schema_evolution",
+            schema=schema_v1,
+        )
+
+        # Write data with only id column (v1 schema)
+        data_v1 = pa.table(
+            {"id": pa.array(range(1, 101), type=pa.int64())},
+            schema=pa.schema([pa.field("id", pa.int64(), nullable=False)]),
+        )
+        table.append(data_v1)
+
+        # Evolve schema: add a value column
+        with table.update_schema() as update:
+            update.add_column("value", DoubleType())
+
+        # Write more data with both columns
+        data_v2 = pa.table(
+            {
+                "id": pa.array(range(101, 201), type=pa.int64()),
+                "value": pa.array([float(i) * 1.5 for i in range(101, 201)]),
+            },
+            schema=pa.schema(
+                [
+                    pa.field("id", pa.int64(), nullable=False),
+                    pa.field("value", pa.float64(), nullable=True),
+                ]
+            ),
+        )
+        table.append(data_v2)
+
+        # Full-table query — must return all 200 rows, no panic
+        df = daft.read_iceberg(table)
+        result = df.collect().to_pydict()
+        assert len(result["id"]) == 200
+        assert sorted(result["id"]) == list(range(1, 201))
+        # Old-file rows have None for value; new-file rows have actual values.
+        # Row order is not guaranteed, so count by null/non-null.
+        null_count = sum(1 for v in result["value"] if v is None)
+        assert null_count == 100  # v1 rows without value column
+        non_null = [(i, v) for i, v in zip(result["id"], result["value"]) if v is not None]
+        assert len(non_null) == 100
+        for i, v in non_null:
+            assert v == pytest.approx(float(i) * 1.5)
+
+        # Filter query on the column present in both schemas (id) —
+        # stats for v1 files have id range + typed-null value;
+        # must not incorrectly prune files.
+        filtered = df.where(daft.col("id") < 50)
+        filtered_result = filtered.collect().to_pydict()
+        assert len(filtered_result["id"]) == 49
+        assert sorted(filtered_result["id"]) == list(range(1, 50))
+
+        # Filter on the evolved column — v1 files have no value stats,
+        # so stats are typed null for those files. Must still return
+        # correct results (all v2 rows matching the predicate, no
+        # false pruning of v1 files).
+        filtered2 = df.where(daft.col("value") > 200.0)
+        filtered2_result = filtered2.collect().to_pydict()
+        # v1 files have value=None → skipped by filter; v2 files have values
+        expected_ids = [i for i in range(101, 201) if float(i) * 1.5 > 200.0]
+        assert sorted(filtered2_result["id"]) == expected_ids


### PR DESCRIPTION
## Changes Made

**TL;DR**: Inject Iceberg `DataFile.lower_bounds`/`upper_bounds` into `DataSourceTask.parquet(stats=...)` so `MicroPartition.filter()` can short-circuit on file-level column ranges already present in the manifest.

Daft's Iceberg scan currently passes no column statistics to `DataSourceTask.parquet()`, so `MicroPartition.filter()` can never short-circuit on file-level column ranges — even though the Iceberg manifest already contains `lower_bounds`/`upper_bounds` for every data file. The TODO (`# TODO: Thread in Statistics to each task: P2`) is now resolved.

This PR decodes those bounds and injects them via `DataSourceTask.parquet(stats=...)` as a 2-row RecordBatch (row 0 = min, row 1 = max), following the same pattern used by Delta Lake (`delta_lake_scan.py`). The downstream Rust path — `TableStatistics.eval_expression()` returning `TruthValue::False` when bounds disprove a predicate, causing `MicroPartition.filter()` to short-circuit — already exists; this PR provides the data it was waiting for.

### Core change (`daft/io/iceberg/iceberg_scan.py`)

- `IcebergDataSource.__init__` precomputes `_top_level_fields`: ordered list of `(field_id, name, iceberg_type, is_primitive, arrow_type)` for every top-level field, avoiding per-file schema traversal.
- `_build_iceberg_data_source_task_stats()` decodes paired `lower_bounds`/`upper_bounds` from each `DataFile` and builds a RecordBatch strictly matching `task_schema` — column names, order, and **Daft logical dtype** (via `Series.from_arrow(..., dtype=task_schema[name].dtype)`).
  - Missing or undecodable fields are filled with typed nulls (not omitted).
  - If no field produces usable bounds, returns `None`.
  - `pa.array()` construction is inside the same `try` block as `from_bytes()` — a decode or Arrow error on one field never crashes the scan.
- Stats are built **after** partition pruning (not before), so pruned files incur no stats cost.
- `assert stats.schema() == task_schema` validates the exact-schema contract at runtime.

### Tests (64 total: 59 Python + 5 Rust)

- **Unit tests** (`test_iceberg_stats.py`, 30 tests): int, long, float, double, boolean, string, truncated-string, binary, date, time, timestamp, timestamptz, decimal, UUID; partial/missing bounds, reversed field order, unknown field IDs, nested-field skipping, complex typed-null, mixed valid/invalid, schema evolution, type promotion — all with unconditional `assert result.schema() == task_schema`.
- **Integration tests** (`test_iceberg_stats_integration.py`, 9 tests): stats injection verification, value correctness, full-schema equality, query correctness (full scan, filter, complex filter), partitioned tables, missing-bounds degradation, and **schema-evolution partial-bounds end-to-end** (creates table, adds column via `update_schema`, verifies filter on evolved column with partial stats does not panic or incorrectly prune).
- **Rust tests** (`filter.rs` 3 tests, `table_stats.rs` 2 tests): False/Maybe/no-stats short-circuit regression.
- **Existing regression** (`test_iceberg_count_pushdown_coverage.py`, 20 tests): all pass.

### Scope and limitations

- **Only min/max bounds**: null counts are not injected — `TableStatistics.eval_expression()` currently only consumes range stats.
- **Only top-level primitive fields**: nested types (struct, list, map) are skipped.
- **Minimal regression risk**: stats are purely additive. If stats are absent or malformed, the scan degrades gracefully to a full data read — identical to current behavior.

## Related Issues

Closes #7299

## Testing

```bash
# Unit tests (30)
DAFT_RUNNER=native .venv/bin/pytest -q tests/io/iceberg/test_iceberg_stats.py

# Integration tests (9)
DAFT_RUNNER=native .venv/bin/pytest -q tests/io/iceberg/test_iceberg_stats_integration.py

# Existing Iceberg regression (20)
DAFT_RUNNER=native .venv/bin/pytest -q tests/integration/iceberg/test_iceberg_count_pushdown_coverage.py

# Rust tests (5)
cargo test -p daft-stats --lib -- test_range_stats
cargo test -p daft-micropartition --lib -- test_filter

# Format
make check-format
```
