### PR TITLE
fix: add cffi dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ requires = ["maturin>=1.5.0,<2.0.0"]
 [project]
 authors = [{name = "Eventual Inc", email = "daft@eventualcomputing.com"}]
 dependencies = [
+  "cffi",
   "pyarrow >= 16.0.0,<25.0.0",
   "fsspec<2026.5.0",
   "tqdm<4.68.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1489,6 +1489,7 @@ nvtx = [
 name = "daft"
 source = { editable = "." }
 dependencies = [
+    { name = "cffi" },
     { name = "fsspec" },
     { name = "packaging" },
     { name = "pyarrow" },
@@ -1716,6 +1717,7 @@ docs = [
 requires-dist = [
     { name = "av", marker = "extra == 'video'", specifier = ">=15.0.0,<17.1.0" },
     { name = "boto3", marker = "extra == 'aws'", specifier = "<1.44.0" },
+    { name = "cffi" },
     { name = "clickhouse-connect", marker = "extra == 'clickhouse'", specifier = "<1.1.0" },
     { name = "connectorx", marker = "extra == 'postgres'", specifier = ">=0.4.4,<0.5.0" },
     { name = "connectorx", marker = "extra == 'sql'", specifier = ">=0.4.4,<0.5.0" },


### PR DESCRIPTION
## Summary

- Add `cffi` to Daft's core Python package dependencies.
- Update `uv.lock` so the editable `daft` package metadata lists `cffi` as a direct dependency.

## Why

Build tooling now warns that `cffi` is an undeclared package dependency and notes this will become an error. Declaring it directly keeps package metadata accurate and avoids the future failure.

## Validation

- `uv lock --check`
- `uv run --no-sync python -c 'import tomllib; data=tomllib.load(open("pyproject.toml", "rb")); assert "cffi" in data["project"]["dependencies"]; print("cffi dependency present")'`