### PR TITLE
fix(sql): fall back to SQLAlchemy on ConnectorX COM_STMT_PREPARE failure

### DIFF
--- a/daft/sql/sql_connection.py
+++ b/daft/sql/sql_connection.py
@@ -184,7 +184,7 @@ class SQLConnection:
             fallback_conn = self._sa_ready_url()
             try:
                 return self._execute_sql_query_with_sqlalchemy(sql, _conn=fallback_conn)
-            except Exception as sqlalchemy_error:  # noqa: BLE001
+            except Exception as sqlalchemy_error:
                 # Sanitize exception messages: strip the connection URL to
                 # prevent credential leakage (secrets can appear anywhere in a
                 # URL – userinfo, query params, driver extras).  We still expose

--- a/daft/sql/sql_connection.py
+++ b/daft/sql/sql_connection.py
@@ -45,7 +45,7 @@ class SQLConnection:
         try:
             with conn_factory() as connection:
                 if not isinstance(connection, Connection):
-                    raise ValueError(
+                    raise TypeError(
                         f"Connection factory must return a SQLAlchemy connection object, got: {type(connection)}"
                     )
                 dialect = connection.engine.dialect.name
@@ -57,10 +57,20 @@ class SQLConnection:
 
     def read_schema(self, sql: str, infer_schema_length: int) -> Schema:
         if self._should_use_connectorx():
-            sql = self.construct_sql_query(sql, limit=0)
+            # ConnectorX can infer column types from LIMIT 0 metadata
+            # without transferring data.
+            schema_sql = self.construct_sql_query(sql, limit=0)
+            table = self.execute_sql_query(schema_sql)
+            # When ConnectorX fails and falls back to SQLAlchemy, LIMIT 0
+            # produces null column types because there is no data to infer
+            # from.  Retry with a proper row count, skipping ConnectorX to
+            # avoid a second COM_STMT_PREPARE failure + warning log.
+            if any(dt == pa.null() for dt in table.schema.types):
+                schema_sql = self.construct_sql_query(sql, limit=infer_schema_length)
+                table = self._execute_sql_query_with_sqlalchemy(schema_sql, _conn=self._sa_ready_url())
         else:
-            sql = self.construct_sql_query(sql, limit=infer_schema_length)
-        table = self.execute_sql_query(sql)
+            schema_sql = self.construct_sql_query(sql, limit=infer_schema_length)
+            table = self.execute_sql_query(schema_sql)
         schema = Schema.from_pyarrow_schema(table.schema)
         return schema
 
@@ -126,16 +136,29 @@ class SQLConnection:
             "redshift",
         }
 
-        if isinstance(self.conn, str):
-            if self.dialect in connectorx_supported_dbs and self.driver == "":
-                return True
-        return False
+        return isinstance(self.conn, str) and self.dialect in connectorx_supported_dbs and self.driver == ""
 
     def execute_sql_query(self, sql: str, schema: pa.Schema | None = None) -> pa.Table:
         if schema is None and self._should_use_connectorx():
             return self._execute_sql_query_with_connectorx(sql)
         else:
             return self._execute_sql_query_with_sqlalchemy(sql, schema=schema)
+
+    def _sa_ready_url(self) -> str:
+        """Return a SQLAlchemy-ready URL string.
+
+        Bare ``mysql://`` URLs default to the mysqldb driver which requires
+        ``mysqlclient`` (not included in Daft's sql extra).  Rewrite them to
+        ``mysql+pymysql://`` so PyMySQL (already a dev dependency and widely
+        available) is used instead.
+
+        Must only be called when ``self.conn`` is a string (i.e., when the
+        ConnectorX path or its fallback is relevant).
+        """
+        assert isinstance(self.conn, str), "_sa_ready_url() requires a string connection"
+        if self.conn.startswith("mysql://"):
+            return self.conn.replace("mysql://", "mysql+pymysql://", 1)
+        return self.conn
 
     def _execute_sql_query_with_connectorx(self, sql: str) -> pa.Table:
         import connectorx as cx
@@ -146,20 +169,51 @@ class SQLConnection:
             table = cx.read_sql(conn=self.conn, query=sql, return_type="arrow")
             return table
         except Exception as e:
-            # The connection URL is deliberately omitted from the error message:
-            # secrets can appear anywhere in it (userinfo, query params,
-            # driver-specific extras), so dropping the URL is the only robust
-            # mitigation. The caller knows which connection they passed in,
-            # so the URL is redundant here.
-            raise RuntimeError(f"Failed to execute sql: {sql}, error: {e}") from e
+            # Fallback to SQLAlchemy only for COM_STMT_PREPARE failures.
+            # MySQL-compatible databases like Doris and StarRocks do not support
+            # the binary prepared-statement protocol that ConnectorX uses.
+            # Connection-level errors (auth, network, DNS) should surface immediately.
+            if "COM_STMT_PREPARE" not in str(e):
+                raise RuntimeError(f"Failed to execute sql: {sql}, error: {type(e).__name__}") from e
+            # COM_STMT_PREPARE failures may include the connection URL
+            # in their error message — sanitize before logging.
+            logger.warning(
+                "ConnectorX COM_STMT_PREPARE failed, falling back to SQLAlchemy: %s",
+                str(e).replace(self.conn, "<redacted>") if isinstance(self.conn, str) else e,
+            )
+            fallback_conn = self._sa_ready_url()
+            try:
+                return self._execute_sql_query_with_sqlalchemy(sql, _conn=fallback_conn)
+            except Exception as sqlalchemy_error:  # noqa: BLE001
+                # Sanitize exception messages: strip the connection URL to
+                # prevent credential leakage (secrets can appear anywhere in a
+                # URL – userinfo, query params, driver extras).  We still expose
+                # the exception type and the sanitised message so callers can
+                # diagnose which backend failed and why.
+                if isinstance(self.conn, str):
+                    cx_msg = str(e).replace(self.conn, "<redacted>")
+                    sa_msg = str(sqlalchemy_error).replace(self.conn, "<redacted>")
+                    # Also sanitize the rewritten URL if it differs.
+                    if fallback_conn != self.conn:
+                        sa_msg = sa_msg.replace(fallback_conn, "<redacted>")
+                else:
+                    cx_msg = str(e)
+                    sa_msg = str(sqlalchemy_error)
+                raise RuntimeError(
+                    f"Failed to execute sql with both ConnectorX ({type(e).__name__}: {cx_msg}) "
+                    f"and SQLAlchemy ({type(sqlalchemy_error).__name__}: {sa_msg})"
+                ) from e
 
-    def _execute_sql_query_with_sqlalchemy(self, sql: str, schema: pa.Schema | None = None) -> pa.Table:
+    def _execute_sql_query_with_sqlalchemy(
+        self, sql: str, schema: pa.Schema | None = None, *, _conn: str | None = None
+    ) -> pa.Table:
         from sqlalchemy import create_engine, text
 
         logger.info("Using sqlalchemy to execute sql: %s", sql)
         try:
-            if isinstance(self.conn, str):
-                with create_engine(self.conn).connect() as connection:
+            if _conn is not None or isinstance(self.conn, str):
+                conn_url = _conn if _conn is not None else self.conn
+                with create_engine(conn_url).connect() as connection:
                     result = connection.execute(text(sql))
                     rows = result.fetchall()
             else:

--- a/daft/sql/sql_connection.py
+++ b/daft/sql/sql_connection.py
@@ -184,7 +184,7 @@ class SQLConnection:
             fallback_conn = self._sa_ready_url()
             try:
                 return self._execute_sql_query_with_sqlalchemy(sql, _conn=fallback_conn)
-            except Exception as sqlalchemy_error:
+            except RuntimeError as sqlalchemy_error:
                 # Sanitize exception messages: strip the connection URL to
                 # prevent credential leakage (secrets can appear anywhere in a
                 # URL – userinfo, query params, driver extras).  We still expose

--- a/daft/sql/sql_connection.py
+++ b/daft/sql/sql_connection.py
@@ -67,7 +67,7 @@ class SQLConnection:
             # avoid a second COM_STMT_PREPARE failure + warning log.
             if any(dt == pa.null() for dt in table.schema.types):
                 schema_sql = self.construct_sql_query(sql, limit=infer_schema_length)
-                table = self._execute_sql_query_with_sqlalchemy(schema_sql, _conn=self._sa_ready_url())
+                table = self._execute_sql_query_with_sqlalchemy_fallback(schema_sql)
         else:
             schema_sql = self.construct_sql_query(sql, limit=infer_schema_length)
             table = self.execute_sql_query(schema_sql)
@@ -149,8 +149,8 @@ class SQLConnection:
 
         Bare ``mysql://`` URLs default to the mysqldb driver which requires
         ``mysqlclient`` (not included in Daft's sql extra).  Rewrite them to
-        ``mysql+pymysql://`` so PyMySQL (already a dev dependency and widely
-        available) is used instead.
+        ``mysql+pymysql://`` so PyMySQL (included in Daft's sql extra) is used
+        instead.
 
         Must only be called when ``self.conn`` is a string (i.e., when the
         ConnectorX path or its fallback is relevant).
@@ -159,6 +159,24 @@ class SQLConnection:
         if self.conn.startswith("mysql://"):
             return self.conn.replace("mysql://", "mysql+pymysql://", 1)
         return self.conn
+
+    def _redact_connection_urls(self, message: str) -> str:
+        """Redact both ConnectorX and SQLAlchemy forms of the connection URL."""
+        assert isinstance(self.conn, str), "URL redaction requires a string connection"
+        redacted = message.replace(self.conn, "<redacted>")
+        sqlalchemy_url = self._sa_ready_url()
+        if sqlalchemy_url != self.conn:
+            redacted = redacted.replace(sqlalchemy_url, "<redacted>")
+        return redacted
+
+    def _execute_sql_query_with_sqlalchemy_fallback(self, sql: str) -> pa.Table:
+        """Execute a ConnectorX fallback without exposing its connection URL."""
+        try:
+            return self._execute_sql_query_with_sqlalchemy(sql, _conn=self._sa_ready_url())
+        except RuntimeError as e:
+            # Do not chain the original error: it may contain the unredacted URL,
+            # which Python would display even when this message is sanitized.
+            raise RuntimeError(self._redact_connection_urls(str(e))) from None
 
     def _execute_sql_query_with_connectorx(self, sql: str) -> pa.Table:
         import connectorx as cx
@@ -170,8 +188,8 @@ class SQLConnection:
             return table
         except Exception as e:
             # Fallback to SQLAlchemy only for COM_STMT_PREPARE failures.
-            # MySQL-compatible databases like Doris and StarRocks do not support
-            # the binary prepared-statement protocol that ConnectorX uses.
+            # Some MySQL-compatible endpoints reject the prepared-statement
+            # protocol that ConnectorX uses for metadata queries.
             # Connection-level errors (auth, network, DNS) should surface immediately.
             if "COM_STMT_PREPARE" not in str(e):
                 raise RuntimeError(f"Failed to execute sql: {sql}, error: {type(e).__name__}") from e
@@ -179,30 +197,22 @@ class SQLConnection:
             # in their error message — sanitize before logging.
             logger.warning(
                 "ConnectorX COM_STMT_PREPARE failed, falling back to SQLAlchemy: %s",
-                str(e).replace(self.conn, "<redacted>") if isinstance(self.conn, str) else e,
+                self._redact_connection_urls(str(e)),
             )
-            fallback_conn = self._sa_ready_url()
             try:
-                return self._execute_sql_query_with_sqlalchemy(sql, _conn=fallback_conn)
+                return self._execute_sql_query_with_sqlalchemy_fallback(sql)
             except RuntimeError as sqlalchemy_error:
                 # Sanitize exception messages: strip the connection URL to
                 # prevent credential leakage (secrets can appear anywhere in a
                 # URL – userinfo, query params, driver extras).  We still expose
                 # the exception type and the sanitised message so callers can
                 # diagnose which backend failed and why.
-                if isinstance(self.conn, str):
-                    cx_msg = str(e).replace(self.conn, "<redacted>")
-                    sa_msg = str(sqlalchemy_error).replace(self.conn, "<redacted>")
-                    # Also sanitize the rewritten URL if it differs.
-                    if fallback_conn != self.conn:
-                        sa_msg = sa_msg.replace(fallback_conn, "<redacted>")
-                else:
-                    cx_msg = str(e)
-                    sa_msg = str(sqlalchemy_error)
+                cx_msg = self._redact_connection_urls(str(e))
+                sa_msg = self._redact_connection_urls(str(sqlalchemy_error))
                 raise RuntimeError(
                     f"Failed to execute sql with both ConnectorX ({type(e).__name__}: {cx_msg}) "
                     f"and SQLAlchemy ({type(sqlalchemy_error).__name__}: {sa_msg})"
-                ) from e
+                ) from None
 
     def _execute_sql_query_with_sqlalchemy(
         self, sql: str, schema: pa.Schema | None = None, *, _conn: str | None = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ ray = [
 ]
 transformers = ["transformers<5.10.0", "sentence-transformers<5.6.0", "torch<2.13.0", "torchvision<0.28.0", "pillow==12.2.0"]
 # connectorx 0.4.4 is needed for pgvector support.
-sql = ["connectorx>=0.4.4,<0.5.0", "sqlalchemy<2.1.0", "sqlglot<30.9.0"]
+sql = ["connectorx>=0.4.4,<0.5.0", "pymysql>=1.0.0", "sqlalchemy<2.1.0", "sqlglot<30.9.0"]
 turbopuffer = ["turbopuffer<2.2.0"]
 unity = ["httpx<=0.28.1", "unitycatalog<0.2.0", "deltalake>=1.5.0,<1.7.0"]
 video = ["av >= 15.0.0,< 17.1.0", "pillow==12.2.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ ray = [
 ]
 transformers = ["transformers<5.10.0", "sentence-transformers<5.6.0", "torch<2.13.0", "torchvision<0.28.0", "pillow==12.2.0"]
 # connectorx 0.4.4 is needed for pgvector support.
-sql = ["connectorx>=0.4.4,<0.5.0", "sqlalchemy<2.1.0", "sqlglot<30.9.0"]
+sql = ["connectorx>=0.4.4,<0.5.0", "pymysql>=1.0.0", "sqlalchemy<2.1.0", "sqlglot<30.9.0"]
 turbopuffer = ["turbopuffer<2.2.0"]
 unity = ["httpx<=0.28.1", "unitycatalog<0.2.0", "deltalake>=1.6.0,<1.7.0"]
 video = ["av >= 15.0.0,< 17.1.0", "pillow==12.2.0"]

--- a/tests/sql/test_doris_fallback.py
+++ b/tests/sql/test_doris_fallback.py
@@ -1,0 +1,259 @@
+"""Tests for Doris ConnectorX fallback (Issue #7199).
+
+Covers three paths:
+1. ConnectorX succeeds → SQLAlchemy not called
+2. ConnectorX fails → fallback to SQLAlchemy succeeds
+3. Both ConnectorX and SQLAlchemy fail → error preserves both causes
+"""
+
+from __future__ import annotations
+
+import socket
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from daft.sql.sql_connection import SQLConnection
+
+# ── shared helpers ──────────────────────────────────────────────────────────
+
+
+def _make_conn(url: str | None = None) -> SQLConnection:
+    """Create a SQLConnection for a mysql:// URL (no driver → triggers ConnectorX)."""
+    url = url or "mysql://user:pass@host:9030/db"
+    return SQLConnection(url, "", "mysql", url)
+
+
+# ── unit tests (mock) ───────────────────────────────────────────────────────
+
+
+class TestConnectorXFallbackUnit:
+    """Verify fallback logic without real database dependencies."""
+
+    def test_connectorx_success_no_fallback(self):
+        """When ConnectorX succeeds, SQLAlchemy should not be called."""
+        conn = _make_conn()
+        mock_cx = MagicMock()
+        mock_cx.read_sql.return_value = MagicMock()
+
+        with (
+            patch.dict("sys.modules", {"connectorx": mock_cx}),
+            patch.object(conn, "_execute_sql_query_with_sqlalchemy") as mock_sa,
+        ):
+            conn._execute_sql_query_with_connectorx("SELECT 1")
+
+            mock_cx.read_sql.assert_called_once()
+            mock_sa.assert_not_called()
+
+    def test_connectorx_failure_fallback_to_sqlalchemy(self):
+        """When ConnectorX fails, should fall back to SQLAlchemy."""
+        conn = _make_conn()
+        mock_cx = MagicMock()
+        mock_cx.read_sql.side_effect = RuntimeError("COM_STMT_PREPARE not supported")
+
+        with (
+            patch.dict("sys.modules", {"connectorx": mock_cx}),
+            patch.object(conn, "_execute_sql_query_with_sqlalchemy") as mock_sa,
+        ):
+            mock_sa.return_value = MagicMock()
+            conn._execute_sql_query_with_connectorx("SELECT 1")
+
+            mock_cx.read_sql.assert_called_once()
+            mock_sa.assert_called_once_with("SELECT 1", _conn="mysql+pymysql://user:pass@host:9030/db")
+
+    def test_both_fail_preserves_both_causes(self):
+        """When both backends fail, the error must include both exception types and messages."""
+        conn = _make_conn()
+        mock_cx = MagicMock()
+        mock_cx.read_sql.side_effect = RuntimeError("COM_STMT_PREPARE not supported")
+
+        with (
+            patch.dict("sys.modules", {"connectorx": mock_cx}),
+            patch.object(conn, "_execute_sql_query_with_sqlalchemy") as mock_sa,
+        ):
+            mock_sa.side_effect = RuntimeError("SQLAlchemy connection failed")
+
+            with pytest.raises(
+                RuntimeError,
+                match=r"ConnectorX.*COM_STMT_PREPARE.*SQLAlchemy.*SQLAlchemy connection failed",
+            ):
+                conn._execute_sql_query_with_connectorx("SELECT 1")
+
+    def test_dual_failure_does_not_leak_credentials(self):
+        """The raised RuntimeError must not echo the connection URL.
+
+        Secrets can appear anywhere in a URL (userinfo, query params, driver
+        extras), so the error message must strip the connection string.
+        """
+        secret = "super-secret-pw"
+        url = f"mysql://alice:{secret}@doris.example.com:9030/db"
+        conn = _make_conn(url)
+
+        mock_cx = MagicMock()
+        # Make the exception message include the full URL so that the
+        # str.replace sanitization is actually exercised.
+        mock_cx.read_sql.side_effect = RuntimeError(f"COM_STMT_PREPARE not supported for {url}")
+
+        with (
+            patch.dict("sys.modules", {"connectorx": mock_cx}),
+            patch.object(conn, "_execute_sql_query_with_sqlalchemy") as mock_sa,
+        ):
+            mock_sa.side_effect = RuntimeError(f"SQLAlchemy connection failed to {url}")
+
+            with pytest.raises(RuntimeError) as exc_info:
+                conn._execute_sql_query_with_connectorx("SELECT 1")
+
+            # The secret must not appear in the error message
+            assert secret not in str(exc_info.value)
+            # The host should also be redacted
+            assert "doris.example.com" not in str(exc_info.value)
+
+    def test_non_com_stmt_prepare_error_propagates(self):
+        """Connection-level errors (auth, network) should NOT trigger fallback."""
+        conn = _make_conn()
+        mock_cx = MagicMock()
+        mock_cx.read_sql.side_effect = RuntimeError("Access denied for user 'root'@'localhost'")
+
+        with (
+            patch.dict("sys.modules", {"connectorx": mock_cx}),
+            patch.object(conn, "_execute_sql_query_with_sqlalchemy") as mock_sa,
+        ):
+            with pytest.raises(RuntimeError, match=r"Failed to execute sql: SELECT 1, error: RuntimeError"):
+                conn._execute_sql_query_with_connectorx("SELECT 1")
+
+            mock_sa.assert_not_called()
+
+    def test_fallback_passes_rewritten_url(self):
+        """Fallback passes mysql+pymysql:// as _conn to SQLAlchemy, self.conn unchanged."""
+        url = "mysql://user:pass@host:9030/db"
+        conn = _make_conn(url)
+        mock_cx = MagicMock()
+        mock_cx.read_sql.side_effect = RuntimeError("COM_STMT_PREPARE not supported")
+
+        with (
+            patch.dict("sys.modules", {"connectorx": mock_cx}),
+            patch.object(conn, "_execute_sql_query_with_sqlalchemy") as mock_sa,
+        ):
+            mock_sa.return_value = MagicMock()
+            conn._execute_sql_query_with_connectorx("SELECT 1")
+
+            # self.conn must NOT be mutated.
+            assert conn.conn == url
+            # _conn override must be the rewritten mysql+pymysql:// URL.
+            mock_sa.assert_called_once()
+            assert mock_sa.call_args.kwargs["_conn"] == "mysql+pymysql://user:pass@host:9030/db"
+
+    def test_read_schema_retries_after_null_types(self):
+        """When LIMIT 0 produces null types after fallback, retries via SQLAlchemy directly."""
+        import pyarrow as pa
+
+        conn = _make_conn()
+        mock_cx = MagicMock()
+        mock_cx.read_sql.side_effect = RuntimeError("COM_STMT_PREPARE not supported")
+
+        # First call (LIMIT 0 via fallback): returns null-typed schema.
+        null_table = pa.table({"x": pa.array([], type=pa.null())})
+        # Retry goes directly to _execute_sql_query_with_sqlalchemy → proper types.
+        typed_table = pa.table({"x": pa.array([1, 2, 3], type=pa.int64())})
+
+        with (
+            patch.dict("sys.modules", {"connectorx": mock_cx}),
+            patch.object(conn, "execute_sql_query") as mock_exec,
+            patch.object(conn, "_execute_sql_query_with_sqlalchemy") as mock_sa,
+        ):
+            mock_exec.return_value = null_table
+            mock_sa.return_value = typed_table
+
+            schema = conn.read_schema("SELECT x FROM t", infer_schema_length=100)
+
+        # First call: execute_sql_query (ConnectorX → fallback → LIMIT 0 → null).
+        # Second call: _execute_sql_query_with_sqlalchemy directly (skips ConnectorX).
+        assert mock_exec.call_count == 1
+        mock_sa.assert_called_once()
+        assert schema.to_pyarrow_schema().field("x").type == pa.int64()
+
+
+# ── Docker integration test ─────────────────────────────────────────────────
+
+_DORIS_HOST = "127.0.0.40"
+_DORIS_PORT = 9032
+_TEST_DB = "test_fallback"
+_TEST_TABLE = "fallback_test"
+
+
+def _doris_reachable() -> bool:
+    try:
+        s = socket.create_connection((_DORIS_HOST, _DORIS_PORT), timeout=2)
+        s.close()
+        return True
+    except OSError:
+        return False
+
+
+@pytest.mark.integration
+class TestDorisFallbackIntegration:
+    """End-to-end test against a real Doris instance.
+
+    Requires:
+    - Doris Docker container reachable at 127.0.0.40:9032
+    - PyMySQL installed (for SQLAlchemy fallback)
+    """
+
+    @pytest.fixture(scope="class")
+    def doris_setup(self):
+        """Create a test table in Doris and tear it down after the test."""
+        if not _doris_reachable():
+            pytest.skip("Doris Docker container not reachable at 127.0.0.40:9032")
+
+        pytest.importorskip("pymysql")
+        pytest.importorskip("sqlalchemy")
+
+        import pymysql
+
+        conn = pymysql.connect(host=_DORIS_HOST, port=_DORIS_PORT, user="root")
+        cursor = conn.cursor()
+        cursor.execute(f"CREATE DATABASE IF NOT EXISTS {_TEST_DB}")
+        cursor.execute(f"DROP TABLE IF EXISTS {_TEST_DB}.{_TEST_TABLE}")
+        cursor.execute(
+            f"CREATE TABLE {_TEST_DB}.{_TEST_TABLE} "
+            "(id INT, value DOUBLE, label VARCHAR(50)) "
+            "ENGINE=OLAP DUPLICATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 1 "
+            "PROPERTIES('replication_num' = '1')"
+        )
+        for i in range(20):
+            cursor.execute(f"INSERT INTO {_TEST_DB}.{_TEST_TABLE} VALUES ({i}, {float(i)}, 'row_{i}')")
+        conn.commit()
+        conn.close()
+
+        yield
+
+        # Teardown
+        conn = pymysql.connect(host=_DORIS_HOST, port=_DORIS_PORT, user="root")
+        cursor = conn.cursor()
+        cursor.execute(f"DROP TABLE IF EXISTS {_TEST_DB}.{_TEST_TABLE}")
+        conn.commit()
+        conn.close()
+
+    def test_connectorx_failure_falls_back_to_sqlalchemy_doris(self, doris_setup):
+        """ConnectorX fails on Doris (COM_STMT_PREPARE), SQLAlchemy fallback reads data.
+
+        This is the critical end-to-end path: we mock ConnectorX to simulate
+        the COM_STMT_PREPARE failure, then verify that data is correctly read
+        through the SQLAlchemy fallback.
+        """
+        import daft
+
+        url = f"mysql://root:@127.0.0.40:9032/{_TEST_DB}"
+        mock_cx = MagicMock()
+        mock_cx.read_sql.side_effect = RuntimeError(
+            "MySqlError { ERROR 1064 (HY000): Unsupported command(COM_STMT_PREPARE) }"
+        )
+
+        with patch.dict("sys.modules", {"connectorx": mock_cx}):
+            df = daft.read_sql(f"SELECT * FROM {_TEST_TABLE}", url)
+            result = df.sort("id").to_pydict()
+
+        assert result["id"] == list(range(20))
+        assert result["value"] == [float(i) for i in range(20)]
+        assert result["label"] == [f"row_{i}" for i in range(20)]
+        mock_cx.read_sql.assert_called_once()

--- a/tests/sql/test_doris_fallback.py
+++ b/tests/sql/test_doris_fallback.py
@@ -1,14 +1,13 @@
 """Tests for Doris ConnectorX fallback (Issue #7199).
 
-Covers three paths:
-1. ConnectorX succeeds → SQLAlchemy not called
-2. ConnectorX fails → fallback to SQLAlchemy succeeds
-3. Both ConnectorX and SQLAlchemy fail → error preserves both causes
+Covers ConnectorX success, targeted SQLAlchemy fallback, dual-failure
+reporting, credential redaction, and schema-inference retry behavior.
 """
 
 from __future__ import annotations
 
 import socket
+import traceback
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -61,7 +60,7 @@ class TestConnectorXFallbackUnit:
             mock_cx.read_sql.assert_called_once()
             mock_sa.assert_called_once_with("SELECT 1", _conn="mysql+pymysql://user:pass@host:9030/db")
 
-    def test_both_fail_preserves_both_causes(self):
+    def test_both_fail_reports_both_backends(self):
         """When both backends fail, the error must include both exception types and messages."""
         conn = _make_conn()
         mock_cx = MagicMock()
@@ -107,6 +106,11 @@ class TestConnectorXFallbackUnit:
             assert secret not in str(exc_info.value)
             # The host should also be redacted
             assert "doris.example.com" not in str(exc_info.value)
+            # The traceback must not recover an unredacted chained exception.
+            rendered_traceback = "".join(traceback.format_exception(exc_info.type, exc_info.value, exc_info.tb))
+            assert secret not in rendered_traceback
+            assert "doris.example.com" not in rendered_traceback
+            assert exc_info.value.__cause__ is None
 
     def test_non_com_stmt_prepare_error_propagates(self):
         """Connection-level errors (auth, network) should NOT trigger fallback."""
@@ -153,7 +157,7 @@ class TestConnectorXFallbackUnit:
 
         # First call (LIMIT 0 via fallback): returns null-typed schema.
         null_table = pa.table({"x": pa.array([], type=pa.null())})
-        # Retry goes directly to _execute_sql_query_with_sqlalchemy → proper types.
+        # Retry uses the SQLAlchemy fallback wrapper → proper types.
         typed_table = pa.table({"x": pa.array([1, 2, 3], type=pa.int64())})
 
         with (
@@ -167,10 +171,36 @@ class TestConnectorXFallbackUnit:
             schema = conn.read_schema("SELECT x FROM t", infer_schema_length=100)
 
         # First call: execute_sql_query (ConnectorX → fallback → LIMIT 0 → null).
-        # Second call: _execute_sql_query_with_sqlalchemy directly (skips ConnectorX).
+        # Second call: SQLAlchemy fallback wrapper (skips ConnectorX).
         assert mock_exec.call_count == 1
         mock_sa.assert_called_once()
         assert schema.to_pyarrow_schema().field("x").type == pa.int64()
+
+    def test_read_schema_retry_failure_does_not_leak_credentials(self):
+        """The sampled SQLAlchemy retry must redact its URL and exception chain."""
+        import pyarrow as pa
+
+        secret = "super-secret-pw"
+        url = f"mysql://alice:{secret}@doris.example.com:9030/db"
+        sqlalchemy_url = f"mysql+pymysql://alice:{secret}@doris.example.com:9030/db"
+        conn = _make_conn(url)
+        null_table = pa.table({"x": pa.array([], type=pa.null())})
+
+        with (
+            patch.object(conn, "execute_sql_query", return_value=null_table),
+            patch.object(
+                conn,
+                "_execute_sql_query_with_sqlalchemy",
+                side_effect=RuntimeError(f"SQLAlchemy connection failed to {sqlalchemy_url}"),
+            ),
+            pytest.raises(RuntimeError) as exc_info,
+        ):
+            conn.read_schema("SELECT x FROM t", infer_schema_length=100)
+
+        rendered_traceback = "".join(traceback.format_exception(exc_info.type, exc_info.value, exc_info.tb))
+        assert secret not in rendered_traceback
+        assert "doris.example.com" not in rendered_traceback
+        assert exc_info.value.__cause__ is None
 
 
 # ── Docker integration test ─────────────────────────────────────────────────
@@ -192,7 +222,7 @@ def _doris_reachable() -> bool:
 
 @pytest.mark.integration
 class TestDorisFallbackIntegration:
-    """End-to-end test against a real Doris instance.
+    """Exercise the SQLAlchemy fallback against a real Doris instance.
 
     Requires:
     - Doris Docker container reachable at 127.0.0.40:9032
@@ -237,9 +267,8 @@ class TestDorisFallbackIntegration:
     def test_connectorx_failure_falls_back_to_sqlalchemy_doris(self, doris_setup):
         """ConnectorX fails on Doris (COM_STMT_PREPARE), SQLAlchemy fallback reads data.
 
-        This is the critical end-to-end path: we mock ConnectorX to simulate
-        the COM_STMT_PREPARE failure, then verify that data is correctly read
-        through the SQLAlchemy fallback.
+        ConnectorX is mocked to simulate the COM_STMT_PREPARE failure while the
+        fallback executes real queries against Doris.
         """
         import daft
 
@@ -256,4 +285,4 @@ class TestDorisFallbackIntegration:
         assert result["id"] == list(range(20))
         assert result["value"] == [float(i) for i in range(20)]
         assert result["label"] == [f"row_{i}" for i in range(20)]
-        mock_cx.read_sql.assert_called_once()
+        assert mock_cx.read_sql.called

--- a/uv.lock
+++ b/uv.lock
@@ -1520,6 +1520,7 @@ all = [
     { name = "psycopg", extra = ["binary"] },
     { name = "pyarrow" },
     { name = "pyiceberg" },
+    { name = "pymysql" },
     { name = "ray", extra = ["client", "data"] },
     { name = "requests" },
     { name = "sentence-transformers" },
@@ -1596,6 +1597,7 @@ ray = [
 ]
 sql = [
     { name = "connectorx" },
+    { name = "pymysql" },
     { name = "sqlalchemy" },
     { name = "sqlglot" },
 ]
@@ -1748,6 +1750,7 @@ requires-dist = [
     { name = "pyarrow", specifier = ">=16.0.0,<25.0.0" },
     { name = "pyarrow", marker = "extra == 'hudi'", specifier = ">=16.0.0,<25.0.0" },
     { name = "pyiceberg", marker = "extra == 'iceberg'", specifier = ">=0.7.0,!=0.9.1,!=0.10.0,<=0.11.1" },
+    { name = "pymysql", marker = "extra == 'sql'", specifier = ">=1.0.0" },
     { name = "ray", extras = ["data", "client"], marker = "extra == 'ray'", specifier = ">=2.11.0,<2.56.0" },
     { name = "requests", marker = "extra == 'gravitino'", specifier = ">=2.28.0,<3.0.0" },
     { name = "sentence-transformers", marker = "extra == 'transformers'", specifier = "<5.6.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -1520,6 +1520,7 @@ all = [
     { name = "pillow" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pyiceberg" },
+    { name = "pymysql" },
     { name = "ray", extra = ["client", "data"] },
     { name = "requests" },
     { name = "sentence-transformers" },
@@ -1594,6 +1595,7 @@ ray = [
 ]
 sql = [
     { name = "connectorx" },
+    { name = "pymysql" },
     { name = "sqlalchemy" },
     { name = "sqlglot" },
 ]
@@ -1745,6 +1747,7 @@ requires-dist = [
     { name = "psycopg", extras = ["binary"], marker = "extra == 'postgres'", specifier = "<3.4.0" },
     { name = "pyarrow", specifier = ">=16.0.0,<26.0.0" },
     { name = "pyiceberg", marker = "extra == 'iceberg'", specifier = ">=0.7.0,!=0.9.1,!=0.10.0,<=0.11.1" },
+    { name = "pymysql", marker = "extra == 'sql'", specifier = ">=1.0.0" },
     { name = "ray", extras = ["data", "client"], marker = "extra == 'ray'", specifier = ">=2.11.0,<2.58.0" },
     { name = "requests", marker = "extra == 'gravitino'", specifier = ">=2.28.0,<3.0.0" },
     { name = "sentence-transformers", marker = "extra == 'transformers'", specifier = "<5.6.0" },


### PR DESCRIPTION
## Changes Made

When `read_sql()` connects to MySQL-compatible databases that do not support the binary prepared-statement protocol (e.g., Apache Doris, StarRocks), ConnectorX raises a `COM_STMT_PREPARE` error. Previously this was re-raised as `RuntimeError` with no recovery path.

This PR adds a targeted fallback: when ConnectorX fails specifically with `COM_STMT_PREPARE`, the query is retried through SQLAlchemy instead. Unrelated ConnectorX errors (authentication, network) do not trigger fallback and surface as `RuntimeError`.

Key details:

- **`_execute_sql_query_with_connectorx`**: catch `COM_STMT_PREPARE`, log with sanitised URL, retry via `_execute_sql_query_with_sqlalchemy`.
- **Driver rewrite**: bare `mysql://` URLs default to the `mysqldb` driver in SQLAlchemy, which requires `mysqlclient` (not included in Daft's `sql` extra). The fallback rewrites to `mysql+pymysql://` so PyMySQL (added to the `sql` extra) is used instead.
- **Credential protection**: connection URLs are stripped from logger output and `RuntimeError` messages via `str.replace(self.conn, "<redacted>")`.
- **Schema inference**: when ConnectorX-fallback returns null column types from a `LIMIT 0` query, `read_schema()` retries with `infer_schema_length`, skipping ConnectorX to avoid a second failure.
- **Dual-failure**: when both ConnectorX and SQLAlchemy fail, the `RuntimeError` preserves both exception types and sanitised messages.

## Testing

Added `tests/sql/test_doris_fallback.py`:
- 7 mock unit tests covering: ConnectorX success, COM_STMT_PREPARE fallback, dual-failure error message, credential leak prevention, non-COM_STMT_PREPARE propagation, `_conn` rewrite, schema null-type retry.
- 1 optional Docker integration test (marked `@pytest.mark.integration`) against a real Doris instance at `127.0.0.40:9032`; skipped automatically when Doris is not reachable.

## Related Issues

Closes #7199
