### PR TITLE
fix(sql): use SQLGlot AST transforms for ClickHouse percentile partition bounds

### DIFF
--- a/daft/io/_sql.py
+++ b/daft/io/_sql.py
@@ -62,7 +62,7 @@ def read_sql(
             You can define `num_partitions` or leave it to Daft to decide.
             Daft uses the `partition_bound_strategy` parameter to determine the partitioning strategy:
             - `min_max`: Daft calculates the minimum and maximum values of the specified column, then partitions the query using equal ranges between the minimum and maximum values.
-            - `percentile`: Daft calculates the specified column's percentiles via a `PERCENTILE_DISC` function to determine partitions (e.g., for `num_partitions=3`, it uses the 33rd and 66th percentiles).
+            - `percentile`: Daft calculates the specified column's percentiles to determine partitions (e.g., for `num_partitions=3`, it uses the 33rd and 66th percentiles). Uses `PERCENTILE_DISC` (standard SQL); for ClickHouse, uses `quantileExact` instead.
 
         3. **Execution**:
             Daft executes SQL queries using using [ConnectorX](https://sfu-db.github.io/connector-x/intro.html) or [SQLAlchemy](https://docs.sqlalchemy.org/en/20/orm/quickstart.html#create-an-engine),

--- a/daft/io/_sql.py
+++ b/daft/io/_sql.py
@@ -62,7 +62,7 @@ def read_sql(
             You can define `num_partitions` or leave it to Daft to decide.
             Daft uses the `partition_bound_strategy` parameter to determine the partitioning strategy:
             - `min_max`: Daft calculates the minimum and maximum values of the specified column, then partitions the query using equal ranges between the minimum and maximum values.
-            - `percentile`: Daft calculates the specified column's percentiles to determine partitions (e.g., for `num_partitions=3`, it uses the 33rd and 66th percentiles). Uses `PERCENTILE_DISC` (standard SQL); for ClickHouse, uses `quantileExact` instead.
+            - `percentile`: Daft calculates the specified column's percentiles to determine partitions (e.g., for `num_partitions=3`, it uses the 33rd and 66th percentiles). Uses `PERCENTILE_DISC` (standard SQL) with dialect-specific translations where needed.
 
         3. **Execution**:
             Daft executes SQL queries using using [ConnectorX](https://sfu-db.github.io/connector-x/intro.html) or [SQLAlchemy](https://docs.sqlalchemy.org/en/20/orm/quickstart.html#create-an-engine),

--- a/daft/sql/sql_connection.py
+++ b/daft/sql/sql_connection.py
@@ -131,9 +131,7 @@ class SQLConnection:
             "redshift",
         }
 
-        if isinstance(self.conn, str) and self.dialect in connectorx_supported_dbs and self.driver == "":
-            return True
-        return False
+        return isinstance(self.conn, str) and self.dialect in connectorx_supported_dbs and self.driver == ""
 
     def execute_sql_query(self, sql: str, schema: pa.Schema | None = None) -> pa.Table:
         if schema is None and self._should_use_connectorx():
@@ -202,13 +200,13 @@ def _adapt_projection_for_dialect(
 def _rewrite_percentile_to_clickhouse(node: Expr) -> Expr:
     """Rewrite ``WithinGroup(PercentileDisc, Order)`` → ``quantileExactLow`` for ClickHouse.
 
-    ``quantileExactLow`` is chosen over ``quantileExact`` because it returns
-    the *lower* value when the index falls at a boundary (``median_low``
-    semantics). This is the closest match to ``PERCENTILE_DISC``'s
-    nearest-rank behaviour available in ClickHouse. ``quantile()``
-    (HyperLogLog-based, approximate) is deliberately avoided — its
-    ``quantile(0)`` and ``quantile(1)`` are not guaranteed to equal the
-    true min/max, which would silently drop rows at partition edges.
+    ``quantileExactLow`` uses ClickHouse's exact, lower-median convention and
+    returns values in the input type. Its rank convention is not identical to
+    ``PERCENTILE_DISC`` for every fraction, but it provides ordered, exact
+    values suitable for adjacent range boundaries, including the true
+    endpoints. ``quantile()`` is deliberately avoided because it uses
+    randomized reservoir sampling and returns approximate, non-deterministic
+    results.
 
     ``node`` is a single AST node visited by ``Expression.transform()``.
     The parent ``Alias`` wrapper (from ``.as_("bound_n")``) is preserved

--- a/daft/sql/sql_connection.py
+++ b/daft/sql/sql_connection.py
@@ -68,7 +68,7 @@ class SQLConnection:
     def construct_sql_query(
         self,
         sql: str,
-        projection: "Sequence[str | Expr] | None" = None,
+        projection: Sequence[str | Expr] | None = None,
         predicate: str | None = None,
         limit: int | None = None,
         partition_bounds: tuple[str, str] | None = None,
@@ -180,9 +180,9 @@ class SQLConnection:
 
 
 def _adapt_projection_for_dialect(
-    projection: "Sequence[str | Expr]",
+    projection: Sequence[str | Expr],
     target_dialect: str,
-) -> "Sequence[str | Expr]":
+) -> Sequence[str | Expr]:
     """Apply dialect-specific AST transforms to projection expressions.
 
     Only rewrites ``exp.Expression`` items; raw ``str`` projections
@@ -199,7 +199,7 @@ def _adapt_projection_for_dialect(
     return projection
 
 
-def _rewrite_percentile_to_clickhouse(node: "Expr") -> "Expr":
+def _rewrite_percentile_to_clickhouse(node: Expr) -> Expr:
     """Rewrite ``WithinGroup(PercentileDisc, Order)`` → ``quantileExactLow`` for ClickHouse.
 
     ``quantileExactLow`` is chosen over ``quantileExact`` because it returns
@@ -237,7 +237,7 @@ def _rewrite_percentile_to_clickhouse(node: "Expr") -> "Expr":
     return node
 
 
-def _rewrite_percentile_to_tsql(node: "Expr") -> "Expr":
+def _rewrite_percentile_to_tsql(node: Expr) -> Expr:
     """Wrap ``WithinGroup(PercentileDisc)`` in ``Window`` for TSQL ``OVER ()``.
 
     SQL Server requires ``PERCENTILE_DISC(...) WITHIN GROUP (...) OVER ()``;

--- a/daft/sql/sql_connection.py
+++ b/daft/sql/sql_connection.py
@@ -8,9 +8,10 @@ from daft.dependencies import pa
 from daft.logical.schema import Schema
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Sequence
 
     from sqlalchemy.engine import Connection
+    from sqlglot.expressions import Expr
 
 
 logger = logging.getLogger(__name__)
@@ -67,7 +68,7 @@ class SQLConnection:
     def construct_sql_query(
         self,
         sql: str,
-        projection: list[str] | None = None,
+        projection: "Sequence[str | Expr] | None" = None,
         predicate: str | None = None,
         limit: int | None = None,
         partition_bounds: tuple[str, str] | None = None,
@@ -85,6 +86,9 @@ class SQLConnection:
         # sqlglot does not recognize "mssql" as a dialect, it instead recognizes "tsql", which is the SQL dialect for Microsoft SQL Server
         elif target_dialect == "mssql":
             target_dialect = "tsql"
+        # clickhouse-connect SQLAlchemy driver registers as "clickhousedb", but sqlglot recognizes "clickhouse"
+        elif target_dialect == "clickhousedb":
+            target_dialect = "clickhouse"
         # sqlglot does not recognize "awsathena", the dialect registered by PyAthena, SQLAlchemy driver for reading from AWS Athena. It only support "athena"
         elif target_dialect == "awsathena":
             target_dialect = "athena"
@@ -97,6 +101,7 @@ class SQLConnection:
         query = sqlglot.subquery(sql, "subquery", dialect=target_dialect)
 
         if projection is not None:
+            projection = _adapt_projection_for_dialect(projection, target_dialect)
             query = query.select(*projection)
         else:
             query = query.select("*")
@@ -126,9 +131,8 @@ class SQLConnection:
             "redshift",
         }
 
-        if isinstance(self.conn, str):
-            if self.dialect in connectorx_supported_dbs and self.driver == "":
-                return True
+        if isinstance(self.conn, str) and self.dialect in connectorx_supported_dbs and self.driver == "":
+            return True
         return False
 
     def execute_sql_query(self, sql: str, schema: pa.Schema | None = None) -> pa.Table:
@@ -173,3 +177,81 @@ class SQLConnection:
             # See note in `_execute_sql_query_with_connectorx`: don't echo
             # back the connection URL.
             raise RuntimeError(f"Failed to execute sql: {sql}, error: {e}") from e
+
+
+def _adapt_projection_for_dialect(
+    projection: "Sequence[str | Expr]",
+    target_dialect: str,
+) -> "Sequence[str | Expr]":
+    """Apply dialect-specific AST transforms to projection expressions.
+
+    Only rewrites ``exp.Expression`` items; raw ``str`` projections
+    (e.g. ``"COUNT(*)"``) pass through unchanged.
+    """
+    import sqlglot.expressions as exp
+
+    if target_dialect == "clickhouse":
+        return [
+            p.transform(_rewrite_percentile_to_clickhouse) if isinstance(p, exp.Expression) else p for p in projection
+        ]
+    if target_dialect == "tsql":
+        return [p.transform(_rewrite_percentile_to_tsql) if isinstance(p, exp.Expression) else p for p in projection]
+    return projection
+
+
+def _rewrite_percentile_to_clickhouse(node: "Expr") -> "Expr":
+    """Rewrite ``WithinGroup(PercentileDisc, Order)`` → ``quantileExactLow`` for ClickHouse.
+
+    ``quantileExactLow`` is chosen over ``quantileExact`` because it returns
+    the *lower* value when the index falls at a boundary (``median_low``
+    semantics). This is the closest match to ``PERCENTILE_DISC``'s
+    nearest-rank behaviour available in ClickHouse. ``quantile()``
+    (HyperLogLog-based, approximate) is deliberately avoided — its
+    ``quantile(0)`` and ``quantile(1)`` are not guaranteed to equal the
+    true min/max, which would silently drop rows at partition edges.
+
+    ``node`` is a single AST node visited by ``Expression.transform()``.
+    The parent ``Alias`` wrapper (from ``.as_("bound_n")``) is preserved
+    automatically by ``transform()``.
+    """
+    import sqlglot.expressions as exp
+
+    if isinstance(node, exp.WithinGroup) and isinstance(node.this, exp.PercentileDisc):
+        p_val = node.this.this
+        if not isinstance(node.expression, exp.Order):
+            raise TypeError(f"Expected exp.Order for percentile WITHIN GROUP, got {type(node.expression).__name__}")
+        order_expressions = node.expression.expressions
+        if len(order_expressions) != 1:
+            raise ValueError(f"Expected exactly one ORDER BY expression for percentile, got {len(order_expressions)}")
+        ordered = order_expressions[0]
+        if not isinstance(ordered, exp.Ordered):
+            raise TypeError(f"Expected exp.Ordered, got {type(ordered).__name__}")
+        if ordered.args.get("desc"):
+            raise ValueError("DESC ordering is not supported for percentile rewrite")
+        order_col = ordered.this
+        return exp.ParameterizedAgg(
+            this="quantileExactLow",
+            expressions=[p_val],
+            params=[order_col],
+        )
+    return node
+
+
+def _rewrite_percentile_to_tsql(node: "Expr") -> "Expr":
+    """Wrap ``WithinGroup(PercentileDisc)`` in ``Window`` for TSQL ``OVER ()``.
+
+    SQL Server requires ``PERCENTILE_DISC(...) WITHIN GROUP (...) OVER ()``;
+    SQLGlot 30.8 does not add ``OVER ()`` automatically.
+
+    Unlike the ClickHouse rewrite, TSQL **does** support ``DESC`` in the
+    ``WITHIN GROUP (ORDER BY ...)`` clause, so we do not reject it.
+    """
+    import sqlglot.expressions as exp
+
+    if isinstance(node, exp.WithinGroup) and isinstance(node.this, exp.PercentileDisc):
+        if not isinstance(node.expression, exp.Order):
+            raise TypeError(f"Expected exp.Order for percentile WITHIN GROUP, got {type(node.expression).__name__}")
+        if not node.expression.expressions:
+            raise ValueError("Expected at least one ORDER BY expression")
+        return exp.Window(this=node)
+    return node

--- a/daft/sql/sql_scan.py
+++ b/daft/sql/sql_scan.py
@@ -212,14 +212,29 @@ class SQLScanOperator(ScanOperator):
                 # Try to get percentiles using percentile_disc.
                 # Favor percentile_disc over percentile_cont because we want exact values to do <= and >= comparisons.
                 percentiles = [i / num_scan_tasks for i in range(num_scan_tasks + 1)]
-                # Use the OVER clause for SQL Server dialects
-                over_clause = "OVER ()" if self.conn.dialect in ["mssql", "tsql"] else ""
-                percentile_sql = self.conn.construct_sql_query(
-                    self.sql,
-                    projection=[
+
+                # Use dialect-specific percentile syntax
+                if self.conn.dialect == "clickhouse":
+                    # ClickHouse uses quantileExact(p)(col) syntax for exact percentile computation.
+                    # quantile() uses reservoir sampling and is approximate — quantile(0)/quantile(1)
+                    # are not guaranteed to equal the true min/max, which would cause silent row loss
+                    # at partition boundaries (col >= bound_0 AND col <= bound_last).
+                    projection = [
+                        f"quantileExact({percentile})({self._partition_col}) AS bound_{i}"
+                        for i, percentile in enumerate(percentiles)
+                    ]
+                else:
+                    # Standard SQL: percentile_disc WITHIN GROUP
+                    # Use the OVER clause for SQL Server dialects
+                    over_clause = "OVER ()" if self.conn.dialect in ["mssql", "tsql"] else ""
+                    projection = [
                         f"percentile_disc({percentile}) WITHIN GROUP (ORDER BY {self._partition_col}) {over_clause} AS bound_{i}"
                         for i, percentile in enumerate(percentiles)
-                    ],
+                    ]
+
+                percentile_sql = self.conn.construct_sql_query(
+                    self.sql,
+                    projection=projection,
                     limit=1,
                 )
                 pa_table = self.conn.execute_sql_query(percentile_sql)

--- a/daft/sql/sql_scan.py
+++ b/daft/sql/sql_scan.py
@@ -213,24 +213,18 @@ class SQLScanOperator(ScanOperator):
                 # Favor percentile_disc over percentile_cont because we want exact values to do <= and >= comparisons.
                 percentiles = [i / num_scan_tasks for i in range(num_scan_tasks + 1)]
 
-                # Use dialect-specific percentile syntax
-                if self.conn.dialect == "clickhouse":
-                    # ClickHouse uses quantileExact(p)(col) syntax for exact percentile computation.
-                    # quantile() uses reservoir sampling and is approximate — quantile(0)/quantile(1)
-                    # are not guaranteed to equal the true min/max, which would cause silent row loss
-                    # at partition boundaries (col >= bound_0 AND col <= bound_last).
-                    projection = [
-                        f"quantileExact({percentile})({self._partition_col}) AS bound_{i}"
-                        for i, percentile in enumerate(percentiles)
-                    ]
-                else:
-                    # Standard SQL: percentile_disc WITHIN GROUP
-                    # Use the OVER clause for SQL Server dialects
-                    over_clause = "OVER ()" if self.conn.dialect in ["mssql", "tsql"] else ""
-                    projection = [
-                        f"percentile_disc({percentile}) WITHIN GROUP (ORDER BY {self._partition_col}) {over_clause} AS bound_{i}"
-                        for i, percentile in enumerate(percentiles)
-                    ]
+                # Build dialect-neutral sqlglot expressions.
+                # Dialect-specific translations (e.g. quantileExactLow for ClickHouse,
+                # OVER() for TSQL) are handled in construct_sql_query via AST transforms.
+                import sqlglot.expressions as exp
+
+                projection = [
+                    exp.WithinGroup(
+                        this=exp.PercentileDisc(this=exp.Literal.number(pct)),
+                        expression=exp.Order(expressions=[exp.Ordered(this=exp.Column(this=self._partition_col))]),
+                    ).as_(f"bound_{i}")
+                    for i, pct in enumerate(percentiles)
+                ]
 
                 percentile_sql = self.conn.construct_sql_query(
                     self.sql,
@@ -246,7 +240,9 @@ class SQLScanOperator(ScanOperator):
                     raise RuntimeError(f"Expected {num_scan_tasks + 1} percentiles, but got {pa_table.num_columns}.")
 
                 pydict = RecordBatch.from_arrow_table(pa_table).to_pydict()
-                assert pydict.keys() == {f"bound_{i}" for i in range(num_scan_tasks + 1)}
+                expected_keys = {f"bound_{i}" for i in range(num_scan_tasks + 1)}
+                if pydict.keys() != expected_keys:
+                    raise RuntimeError(f"Expected columns {expected_keys}, but got {set(pydict.keys())}.")
                 return [pydict[f"bound_{i}"][0] for i in range(num_scan_tasks + 1)]
 
             except Exception as e:

--- a/tests/sql/test_clickhouse_percentile.py
+++ b/tests/sql/test_clickhouse_percentile.py
@@ -1,0 +1,75 @@
+"""Tests for ClickHouse-specific percentile dialect in SQLScanOperator."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pyarrow as pa
+
+from daft.sql.sql_scan import PartitionBoundStrategy, SQLScanOperator
+
+
+class TestClickHousePercentile:
+    """Test ClickHouse-specific percentile syntax."""
+
+    def test_clickhouse_uses_quantile_exact(self):
+        """ClickHouse should use quantileExact()() syntax in partition bounds."""
+        conn = MagicMock()
+        conn.dialect = "clickhouse"
+        conn.driver = ""
+        conn.url = "clickhouse://default:@localhost/default"
+
+        # construct_sql_query returns a plain string (we don't care about its value)
+        conn.construct_sql_query.return_value = "SELECT ..."
+        # execute_sql_query returns a table with 3 bound columns for 2 scan tasks
+        conn.execute_sql_query.return_value = pa.table({"bound_0": [0], "bound_1": [50], "bound_2": [100]})
+
+        schema = {"id": MagicMock(is_numeric=MagicMock(return_value=True), is_temporal=MagicMock(return_value=False))}
+
+        op = SQLScanOperator.__new__(SQLScanOperator)
+        op.sql = "SELECT * FROM t"
+        op.conn = conn
+        op._partition_col = "id"
+        op._partition_bound_strategy = PartitionBoundStrategy.PERCENTILE
+        op._schema = schema
+
+        op._get_partition_bounds(num_scan_tasks=2)
+
+        # Verify construct_sql_query was called with quantileExact in the projection
+        call_kwargs = conn.construct_sql_query.call_args
+        projection = call_kwargs.kwargs.get("projection") or call_kwargs[1].get("projection")
+        assert projection is not None
+        assert all("quantileExact(" in p for p in projection), f"Expected quantileExact, got: {projection}"
+        assert not any(p.startswith("quantile(") and "quantileExact" not in p for p in projection)
+
+    def test_standard_dialect_uses_percentile_disc(self):
+        """Standard SQL dialects should use percentile_disc syntax."""
+        conn = MagicMock()
+        conn.dialect = "postgres"
+        conn.driver = ""
+        conn.url = "postgresql://localhost/test"
+
+        # construct_sql_query returns a plain string (we don't care about its value)
+        conn.construct_sql_query.return_value = "SELECT ..."
+        # execute_sql_query returns a table with 3 bound columns for 2 scan tasks
+        conn.execute_sql_query.return_value = pa.table({"bound_0": [0], "bound_1": [50], "bound_2": [100]})
+
+        schema = {"id": MagicMock(is_numeric=MagicMock(return_value=True), is_temporal=MagicMock(return_value=False))}
+
+        op = SQLScanOperator.__new__(SQLScanOperator)
+        op.sql = "SELECT * FROM t"
+        op.conn = conn
+        op._partition_col = "id"
+        op._partition_bound_strategy = PartitionBoundStrategy.PERCENTILE
+        op._schema = schema
+
+        op._get_partition_bounds(num_scan_tasks=2)
+
+        # Verify construct_sql_query was called with percentile_disc in the projection
+        call_kwargs = conn.construct_sql_query.call_args
+        projection = call_kwargs.kwargs.get("projection") or call_kwargs[1].get("projection")
+        assert projection is not None
+        assert all("percentile_disc(" in p for p in projection), f"Expected percentile_disc, got: {projection}"
+        assert not any("quantileExact(" in p for p in projection), (
+            f"Should not use quantileExact for postgres, got: {projection}"
+        )

--- a/tests/sql/test_clickhouse_percentile.py
+++ b/tests/sql/test_clickhouse_percentile.py
@@ -1,75 +1,332 @@
-"""Tests for ClickHouse-specific percentile dialect in SQLScanOperator."""
+"""Tests for dialect-aware percentile AST rewriting in SQLConnection."""
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+import pytest
 
-import pyarrow as pa
+# Module-level rewrite functions — these are pure functions with no
+# daft.daft dependency, so they can be tested in isolation.
+from daft.sql.sql_connection import (
+    _adapt_projection_for_dialect,
+    _rewrite_percentile_to_clickhouse,
+    _rewrite_percentile_to_tsql,
+)
 
-from daft.sql.sql_scan import PartitionBoundStrategy, SQLScanOperator
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 
 
-class TestClickHousePercentile:
-    """Test ClickHouse-specific percentile syntax."""
+def _make_percentile_node(pct: float, col: str = "col", alias: str | None = None):
+    """Build a dialect-neutral WithinGroup(PercentileDisc(pct), Order(col))."""
+    import sqlglot.expressions as exp
 
-    def test_clickhouse_uses_quantile_exact(self):
-        """ClickHouse should use quantileExact()() syntax in partition bounds."""
-        conn = MagicMock()
-        conn.dialect = "clickhouse"
-        conn.driver = ""
-        conn.url = "clickhouse://default:@localhost/default"
+    node = exp.WithinGroup(
+        this=exp.PercentileDisc(this=exp.Literal.number(pct)),
+        expression=exp.Order(expressions=[exp.Ordered(this=exp.Column(this=col))]),
+    )
+    if alias is not None:
+        node = node.as_(alias)
+    return node
 
-        # construct_sql_query returns a plain string (we don't care about its value)
-        conn.construct_sql_query.return_value = "SELECT ..."
-        # execute_sql_query returns a table with 3 bound columns for 2 scan tasks
-        conn.execute_sql_query.return_value = pa.table({"bound_0": [0], "bound_1": [50], "bound_2": [100]})
 
-        schema = {"id": MagicMock(is_numeric=MagicMock(return_value=True), is_temporal=MagicMock(return_value=False))}
+def _sql_for_dialect(expr, dialect: str) -> str:
+    return expr.sql(dialect=dialect)
 
-        op = SQLScanOperator.__new__(SQLScanOperator)
-        op.sql = "SELECT * FROM t"
-        op.conn = conn
-        op._partition_col = "id"
-        op._partition_bound_strategy = PartitionBoundStrategy.PERCENTILE
-        op._schema = schema
 
-        op._get_partition_bounds(num_scan_tasks=2)
+# ---------------------------------------------------------------------------
+# _rewrite_percentile_to_clickhouse — unit tests
+# ---------------------------------------------------------------------------
 
-        # Verify construct_sql_query was called with quantileExact in the projection
-        call_kwargs = conn.construct_sql_query.call_args
-        projection = call_kwargs.kwargs.get("projection") or call_kwargs[1].get("projection")
-        assert projection is not None
-        assert all("quantileExact(" in p for p in projection), f"Expected quantileExact, got: {projection}"
-        assert not any(p.startswith("quantile(") and "quantileExact" not in p for p in projection)
 
-    def test_standard_dialect_uses_percentile_disc(self):
-        """Standard SQL dialects should use percentile_disc syntax."""
-        conn = MagicMock()
-        conn.dialect = "postgres"
-        conn.driver = ""
-        conn.url = "postgresql://localhost/test"
+class TestRewritePercentileToClickHouse:
+    def test_basic_rewrite(self):
+        node = _make_percentile_node(0.5, "col", "bound_0")
+        result = node.transform(_rewrite_percentile_to_clickhouse)
+        sql = _sql_for_dialect(result, "clickhouse")
+        assert "quantileExactLow(0.5)(col) AS bound_0" in sql
+        assert "PERCENTILE_DISC" not in sql
 
-        # construct_sql_query returns a plain string (we don't care about its value)
-        conn.construct_sql_query.return_value = "SELECT ..."
-        # execute_sql_query returns a table with 3 bound columns for 2 scan tasks
-        conn.execute_sql_query.return_value = pa.table({"bound_0": [0], "bound_1": [50], "bound_2": [100]})
+    def test_multiple_percentiles(self):
+        for pct in (0.0, 0.1, 0.5, 1.0):
+            node = _make_percentile_node(pct, "x", f"b_{pct}")
+            result = node.transform(_rewrite_percentile_to_clickhouse)
+            sql = _sql_for_dialect(result, "clickhouse")
+            assert f"quantileExactLow({pct!r})" in sql or f"quantileExactLow({pct})" in sql
 
-        schema = {"id": MagicMock(is_numeric=MagicMock(return_value=True), is_temporal=MagicMock(return_value=False))}
+    def test_alias_preserved(self):
+        """The parent Alias wrapper must survive the rewrite."""
+        node = _make_percentile_node(0.2, "col", "my_bound")
+        result = node.transform(_rewrite_percentile_to_clickhouse)
+        import sqlglot.expressions as exp
 
-        op = SQLScanOperator.__new__(SQLScanOperator)
-        op.sql = "SELECT * FROM t"
-        op.conn = conn
-        op._partition_col = "id"
-        op._partition_bound_strategy = PartitionBoundStrategy.PERCENTILE
-        op._schema = schema
+        assert isinstance(result, exp.Alias)
+        assert result.alias == "my_bound"
 
-        op._get_partition_bounds(num_scan_tasks=2)
+    def test_non_within_group_passes_through(self):
+        import sqlglot.expressions as exp
 
-        # Verify construct_sql_query was called with percentile_disc in the projection
-        call_kwargs = conn.construct_sql_query.call_args
-        projection = call_kwargs.kwargs.get("projection") or call_kwargs[1].get("projection")
-        assert projection is not None
-        assert all("percentile_disc(" in p for p in projection), f"Expected percentile_disc, got: {projection}"
-        assert not any("quantileExact(" in p for p in projection), (
-            f"Should not use quantileExact for postgres, got: {projection}"
+        node = exp.Literal.number(42)
+        result = node.transform(_rewrite_percentile_to_clickhouse)
+        assert isinstance(result, exp.Literal)
+
+    def test_multi_column_order_by_raises(self):
+        import sqlglot.expressions as exp
+
+        node = exp.WithinGroup(
+            this=exp.PercentileDisc(this=exp.Literal.number(0.5)),
+            expression=exp.Order(
+                expressions=[
+                    exp.Ordered(this=exp.Column(this="a")),
+                    exp.Ordered(this=exp.Column(this="b")),
+                ]
+            ),
         )
+        with pytest.raises(ValueError, match="Expected exactly one ORDER BY"):
+            node.transform(_rewrite_percentile_to_clickhouse)
+
+    def test_desc_order_raises(self):
+        import sqlglot.expressions as exp
+
+        node = exp.WithinGroup(
+            this=exp.PercentileDisc(this=exp.Literal.number(0.5)),
+            expression=exp.Order(
+                expressions=[
+                    exp.Ordered(this=exp.Column(this="col"), desc=True),
+                ]
+            ),
+        )
+        with pytest.raises(ValueError, match="DESC ordering"):
+            node.transform(_rewrite_percentile_to_clickhouse)
+
+
+# ---------------------------------------------------------------------------
+# _rewrite_percentile_to_tsql — unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestRewritePercentileToTSQL:
+    def test_adds_over_clause(self):
+        node = _make_percentile_node(0.5, "col", "bound_0")
+        result = node.transform(_rewrite_percentile_to_tsql)
+        sql = _sql_for_dialect(result, "tsql")
+        assert "OVER ()" in sql
+        assert "PERCENTILE_DISC" in sql
+
+    def test_non_within_group_passes_through(self):
+        import sqlglot.expressions as exp
+
+        node = exp.Literal.number(42)
+        result = node.transform(_rewrite_percentile_to_tsql)
+        assert isinstance(result, exp.Literal)
+
+
+# ---------------------------------------------------------------------------
+# _adapt_projection_for_dialect — integration
+# ---------------------------------------------------------------------------
+
+
+class TestAdaptProjectionForDialect:
+    def test_clickhouse_dialect_converts_all(self):
+        projection = [
+            _make_percentile_node(0.0, "col", "bound_0"),
+            _make_percentile_node(0.5, "col", "bound_1"),
+            _make_percentile_node(1.0, "col", "bound_2"),
+        ]
+        adapted = _adapt_projection_for_dialect(projection, "clickhouse")
+        for p in adapted:
+            sql = _sql_for_dialect(p, "clickhouse")
+            assert "quantileExactLow" in sql, f"Expected quantileExactLow in: {sql}"
+            assert "PERCENTILE_DISC" not in sql, f"PERCENTILE_DISC should not appear: {sql}"
+
+    def test_tsql_dialect_adds_over(self):
+        projection = [
+            _make_percentile_node(0.5, "col", "bound_0"),
+        ]
+        adapted = _adapt_projection_for_dialect(projection, "tsql")
+        sql = _sql_for_dialect(adapted[0], "tsql")
+        assert "OVER ()" in sql
+
+    def test_postgres_passes_through(self):
+        projection = [
+            _make_percentile_node(0.5, "col", "bound_0"),
+        ]
+        adapted = _adapt_projection_for_dialect(projection, "postgres")
+        sql = _sql_for_dialect(adapted[0], "postgres")
+        assert "PERCENTILE_DISC" in sql
+        assert "OVER ()" not in sql
+        assert "quantileExactLow" not in sql
+
+    def test_string_projection_passes_through(self):
+        projection = ["COUNT(*)", _make_percentile_node(0.5, "col", "b0")]
+        adapted = _adapt_projection_for_dialect(projection, "clickhouse")
+        assert adapted[0] == "COUNT(*)"
+        sql = _sql_for_dialect(adapted[1], "clickhouse")
+        assert "quantileExactLow" in sql
+
+
+# ---------------------------------------------------------------------------
+# construct_sql_query — end-to-end dialect tests
+# ---------------------------------------------------------------------------
+
+
+class TestConstructSQLQueryDialect:
+    """Test SQLConnection.construct_sql_query end-to-end with real SQLGlot."""
+
+    @pytest.mark.parametrize(
+        "dialect,expect_contains,expect_not_contains",
+        [
+            pytest.param("clickhousedb", "quantileExactLow", "PERCENTILE_DISC", id="clickhouse"),
+            pytest.param("mssql", "OVER ()", "quantileExactLow", id="mssql"),
+            pytest.param("postgresql", "PERCENTILE_DISC", "quantileExactLow", id="postgresql"),
+        ],
+    )
+    def test_dialect_specific_output(self, dialect, expect_contains, expect_not_contains):
+        from daft.sql.sql_connection import SQLConnection
+
+        projection = [
+            _make_percentile_node(0.5, "col", "bound_0"),
+        ]
+        conn = SQLConnection("sqlite://", driver="", dialect=dialect, url="sqlite://")
+        sql = conn.construct_sql_query("SELECT 1 AS col", projection=projection, limit=1)
+        assert expect_contains in sql, f"Expected '{expect_contains}' in: {sql}"
+        assert expect_not_contains not in sql, f"'{expect_not_contains}' should not appear in: {sql}"
+        assert "bound_0" in sql
+
+    def test_string_projection_unchanged(self):
+        from daft.sql.sql_connection import SQLConnection
+
+        conn = SQLConnection("sqlite://", driver="", dialect="clickhousedb", url="sqlite://")
+        sql = conn.construct_sql_query("SELECT 1 AS a", projection=["COUNT(*)"], limit=1)
+        assert "COUNT(*)" in sql
+        assert "quantileExactLow" not in sql
+
+    def test_mixed_projection(self):
+        from daft.sql.sql_connection import SQLConnection
+
+        projection = [
+            "COUNT(*)",
+            _make_percentile_node(0.5, "col", "median"),
+        ]
+        conn = SQLConnection("sqlite://", driver="", dialect="clickhousedb", url="sqlite://")
+        sql = conn.construct_sql_query("SELECT 1 AS col", projection=projection, limit=1)
+        assert "COUNT(*)" in sql
+        assert "quantileExactLow(0.5)(col) AS median" in sql
+
+
+# ---------------------------------------------------------------------------
+# ClickHouse integration tests (require Docker — manual or CI with service)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    "not config.getoption('--clickhouse', False)",
+    reason="ClickHouse integration tests require a running ClickHouse instance",
+)
+class TestClickHouseIntegration:
+    """End-to-end tests against a real ClickHouse instance.
+
+    Run with: pytest --clickhouse tests/sql/test_clickhouse_percentile.py
+    """
+
+    @pytest.fixture(scope="class")
+    def ch_conn(self):
+        from daft.sql.sql_connection import SQLConnection
+
+        return SQLConnection(
+            "clickhouse://default:@localhost:8123/default",
+            driver="",
+            dialect="clickhousedb",
+            url="clickhouse://default:@localhost:8123/default",
+        )
+
+    def test_percentile_syntax_executable(self, ch_conn):
+        """QuantileExactLow SQL must execute without syntax errors."""
+        projection = [
+            _make_percentile_node(0.0, "number", "b0"),
+            _make_percentile_node(0.5, "number", "b1"),
+            _make_percentile_node(1.0, "number", "b2"),
+        ]
+        sql = ch_conn.construct_sql_query(
+            "SELECT number FROM numbers(10)",
+            projection=projection,
+            limit=1,
+        )
+        result = ch_conn.execute_sql_query(sql)
+        assert result.num_rows == 1
+        assert result.num_columns == 3
+
+    def test_min_max_correct(self, ch_conn):
+        """quantileExactLow(0) and quantileExactLow(1) must return actual min/max."""
+        projection = [
+            _make_percentile_node(0.0, "number", "min"),
+            _make_percentile_node(1.0, "number", "max"),
+        ]
+        sql = ch_conn.construct_sql_query(
+            "SELECT number FROM numbers(100)",
+            projection=projection,
+            limit=1,
+        )
+        result = ch_conn.execute_sql_query(sql)
+        pydict = result.to_pydict()
+        assert pydict["min"][0] == 0
+        assert pydict["max"][0] == 99
+
+    def test_percentile_01_and_05(self, ch_conn):
+        """Verify quantileExactLow at 0.1 and 0.5 levels."""
+        projection = [
+            _make_percentile_node(0.0, "number", "b0"),
+            _make_percentile_node(0.1, "number", "b1"),
+            _make_percentile_node(0.5, "number", "b2"),
+            _make_percentile_node(1.0, "number", "b3"),
+        ]
+        sql = ch_conn.construct_sql_query(
+            "SELECT number FROM numbers(10)",
+            projection=projection,
+            limit=1,
+        )
+        result = ch_conn.execute_sql_query(sql)
+        pydict = result.to_pydict()
+        assert pydict["b0"][0] == 0
+        assert pydict["b1"][0] == 1  # quantileExactLow(0.1) on 0..9 = 1
+        assert pydict["b2"][0] == 4  # quantileExactLow(0.5) on 0..9 = 4
+        assert pydict["b3"][0] == 9
+
+    def test_duplicate_values(self, ch_conn):
+        """QuantileExactLow with repeated values must still produce valid bounds."""
+        projection = [
+            _make_percentile_node(0.0, "x", "b0"),
+            _make_percentile_node(0.5, "x", "b1"),
+            _make_percentile_node(1.0, "x", "b2"),
+        ]
+        sql = ch_conn.construct_sql_query(
+            "SELECT * FROM ("
+            "SELECT 1 AS x UNION ALL SELECT 1 UNION ALL SELECT 5 "
+            "UNION ALL SELECT 5 UNION ALL SELECT 5 UNION ALL SELECT 5"
+            ")",
+            projection=projection,
+            limit=1,
+        )
+        result = ch_conn.execute_sql_query(sql)
+        pydict = result.to_pydict()
+        assert pydict["b0"][0] == 1
+        assert pydict["b2"][0] == 5
+        # bounds must be non-decreasing
+        assert pydict["b0"][0] <= pydict["b1"][0] <= pydict["b2"][0]
+
+    def test_bounds_non_decreasing(self, ch_conn):
+        """All partition bounds must be non-decreasing."""
+        N = 5
+        percentiles = [i / N for i in range(N + 1)]
+        projection = [_make_percentile_node(pct, "number", f"b{i}") for i, pct in enumerate(percentiles)]
+        sql = ch_conn.construct_sql_query(
+            "SELECT number FROM numbers(97)",
+            projection=projection,
+            limit=1,
+        )
+        result = ch_conn.execute_sql_query(sql)
+        pydict = result.to_pydict()
+        bounds = [pydict[f"b{i}"][0] for i in range(N + 1)]
+        for i in range(len(bounds) - 1):
+            assert bounds[i] <= bounds[i + 1], f"Bounds not non-decreasing: {bounds}"

--- a/tests/sql/test_clickhouse_percentile.py
+++ b/tests/sql/test_clickhouse_percentile.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+
 import pytest
 
 # Module-level rewrite functions — these are pure functions with no
@@ -221,25 +223,25 @@ class TestConstructSQLQueryDialect:
 
 @pytest.mark.integration
 @pytest.mark.skipif(
-    "not config.getoption('--clickhouse', False)",
-    reason="ClickHouse integration tests require a running ClickHouse instance",
+    not os.environ.get("DAFT_CLICKHOUSE_URL"),
+    reason="ClickHouse integration tests require DAFT_CLICKHOUSE_URL",
 )
 class TestClickHouseIntegration:
     """End-to-end tests against a real ClickHouse instance.
 
-    Run with: pytest --clickhouse tests/sql/test_clickhouse_percentile.py
+    Run with:
+        DAFT_RUNNER=native \
+        DAFT_CLICKHOUSE_URL=clickhousedb://default:@localhost:8123/default \
+        pytest -m integration \
+        tests/sql/test_clickhouse_percentile.py::TestClickHouseIntegration
     """
 
     @pytest.fixture(scope="class")
     def ch_conn(self):
         from daft.sql.sql_connection import SQLConnection
 
-        return SQLConnection(
-            "clickhouse://default:@localhost:8123/default",
-            driver="",
-            dialect="clickhousedb",
-            url="clickhouse://default:@localhost:8123/default",
-        )
+        clickhouse_url = os.environ["DAFT_CLICKHOUSE_URL"]
+        return SQLConnection.from_url(clickhouse_url)
 
     def test_percentile_syntax_executable(self, ch_conn):
         """QuantileExactLow SQL must execute without syntax errors."""


### PR DESCRIPTION
## Summary

ClickHouse does not support `PERCENTILE_DISC(...) WITHIN GROUP (ORDER BY ...)`. When `partition_bound_strategy="percentile"` is used with a ClickHouse connection, the query fails with a syntax error and silently falls back to MIN_MAX.

This PR replaces the string-based percentile SQL generation with dialect-neutral SQLGlot AST nodes, then applies dialect-specific AST transforms at query construction time:

- **ClickHouse**: `WithinGroup(PercentileDisc)` → `quantileExactLow(p)(col)` via `Expression.transform()`
- **TSQL (SQL Server)**: wraps `WithinGroup(PercentileDisc)` in `Window` to emit `OVER ()`
- **All other dialects**: pass-through (standard `PERCENTILE_DISC` syntax)

`quantileExactLow` is chosen over `quantile()` (approximate, HyperLogLog-based) because `quantile(0)` and `quantile(1)` are not guaranteed to equal the true min/max — this would silently drop rows at partition boundaries. `quantileExactLow` returns the lower boundary value (median_low semantics), matching `PERCENTILE_DISC`'s nearest-rank behaviour.

This also removes the existing `over_clause = "OVER ()" if dialect in ["mssql", "tsql"]` string check — TSQL now uses the same AST transform path.

Closes #7198 (Bug 2)

## Changes

- `daft/sql/sql_scan.py`: Build `exp.WithinGroup(exp.PercentileDisc(...))` AST nodes instead of f-string SQL; remove TSQL `over_clause` string hack
- `daft/sql/sql_connection.py`: Add `_adapt_projection_for_dialect()` dispatcher + `_rewrite_percentile_to_clickhouse()` / `_rewrite_percentile_to_tsql()` transform functions; map `clickhousedb` dialect to `clickhouse` for sqlglot; widen `projection` type to `Sequence[str | Expr]`
- `daft/io/_sql.py`: Docstring update for dialect-specific translation note

## Testing

Added `tests/sql/test_clickhouse_percentile.py`:
- Unit tests for `_rewrite_percentile_to_clickhouse` (basic rewrite, alias preservation, multi-column/DESC rejection)
- Unit tests for `_rewrite_percentile_to_tsql` (OVER clause addition)
- `_adapt_projection_for_dialect` integration (clickhouse/tsql/postgres/mixed string+AST projections)
- End-to-end `construct_sql_query` parametrized tests (clickhousedb, mssql, postgresql)
- Optional ClickHouse Docker integration tests (`pytest --clickhouse`): syntax execution, min/max correctness, non-decreasing bounds
