### PR TITLE
perf(sql): cache SQLAlchemy engine with thread-safe double-checked locking

### DIFF
--- a/daft/sql/sql_connection.py
+++ b/daft/sql/sql_connection.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import threading
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
@@ -22,6 +23,22 @@ class SQLConnection:
         self.dialect = dialect
         self.driver = driver
         self.url = url
+        self._engine = None
+        self._engine_lock = threading.Lock()
+
+    def __getstate__(self) -> dict:
+        state = self.__dict__.copy()
+        # SQLAlchemy Engine contains connection pools and thread locks
+        # that are not picklable. The engine will be lazily recreated
+        # via _get_or_create_engine() after deserialization.
+        state["_engine"] = None
+        state["_engine_lock"] = None
+        return state
+
+    def __setstate__(self, state: dict) -> None:
+        self.__dict__.update(state)
+        if self._engine_lock is None:
+            self._engine_lock = threading.Lock()
 
     def __repr__(self) -> str:
         # Deliberately omit the URL: secrets can appear anywhere in a
@@ -45,7 +62,7 @@ class SQLConnection:
         try:
             with conn_factory() as connection:
                 if not isinstance(connection, Connection):
-                    raise ValueError(
+                    raise TypeError(
                         f"Connection factory must return a SQLAlchemy connection object, got: {type(connection)}"
                     )
                 dialect = connection.engine.dialect.name
@@ -126,10 +143,7 @@ class SQLConnection:
             "redshift",
         }
 
-        if isinstance(self.conn, str):
-            if self.dialect in connectorx_supported_dbs and self.driver == "":
-                return True
-        return False
+        return isinstance(self.conn, str) and self.dialect in connectorx_supported_dbs and self.driver == ""
 
     def execute_sql_query(self, sql: str, schema: pa.Schema | None = None) -> pa.Table:
         if schema is None and self._should_use_connectorx():
@@ -153,13 +167,49 @@ class SQLConnection:
             # so the URL is redundant here.
             raise RuntimeError(f"Failed to execute sql: {sql}, error: {e}") from e
 
+    def _get_or_create_engine(self):
+        """Get or create a cached SQLAlchemy engine for string connection URLs."""
+        # Fast path: engine already created (no lock needed for the read).
+        if self._engine is not None:
+            return self._engine
+        # Slow path: serialize creation to avoid duplicate connection pools.
+        with self._engine_lock:
+            # Double-check after acquiring the lock.
+            if self._engine is not None:
+                return self._engine
+            if not isinstance(self.conn, str):
+                return None
+            from sqlalchemy import create_engine
+
+            url = self.conn
+            # Auto-rewrite mysql:// to mysql+pymysql:// when pymysql is available
+            # but mysqlclient is not. This avoids ModuleNotFoundError: No module named 'MySQLdb'
+            if url.startswith("mysql://"):
+                try:
+                    import MySQLdb  # noqa: F401
+                except ImportError:
+                    try:
+                        import pymysql  # noqa: F401
+
+                        url = url.replace("mysql://", "mysql+pymysql://", 1)
+                        logger.info("Rewrote mysql:// to mysql+pymysql:// (MySQLdb not available)")
+                    except ImportError:
+                        logger.warning(
+                            "mysql:// URL detected but neither MySQLdb nor pymysql is installed. "
+                            "Install pymysql to avoid ModuleNotFoundError: No module named 'MySQLdb'."
+                        )
+
+            self._engine = create_engine(url)
+        return self._engine
+
     def _execute_sql_query_with_sqlalchemy(self, sql: str, schema: pa.Schema | None = None) -> pa.Table:
-        from sqlalchemy import create_engine, text
+        from sqlalchemy import text
 
         logger.info("Using sqlalchemy to execute sql: %s", sql)
         try:
             if isinstance(self.conn, str):
-                with create_engine(self.conn).connect() as connection:
+                engine = self._get_or_create_engine()
+                with engine.connect() as connection:
                     result = connection.execute(text(sql))
                     rows = result.fetchall()
             else:

--- a/daft/sql/sql_connection.py
+++ b/daft/sql/sql_connection.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import threading
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
 from daft.dependencies import pa
@@ -11,7 +11,7 @@ from daft.logical.schema import Schema
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from sqlalchemy.engine import Connection
+    from sqlalchemy.engine import Connection, Engine
 
 
 logger = logging.getLogger(__name__)
@@ -26,7 +26,7 @@ class SQLConnection:
         self._engine = None
         self._engine_lock = threading.Lock()
 
-    def __getstate__(self) -> dict:
+    def __getstate__(self) -> dict[str, Any]:
         state = self.__dict__.copy()
         # SQLAlchemy Engine contains connection pools and thread locks
         # that are not picklable. The engine will be lazily recreated
@@ -35,7 +35,7 @@ class SQLConnection:
         state["_engine_lock"] = None
         return state
 
-    def __setstate__(self, state: dict) -> None:
+    def __setstate__(self, state: dict[str, Any]) -> None:
         self.__dict__.update(state)
         if self._engine_lock is None:
             self._engine_lock = threading.Lock()
@@ -167,7 +167,7 @@ class SQLConnection:
             # so the URL is redundant here.
             raise RuntimeError(f"Failed to execute sql: {sql}, error: {e}") from e
 
-    def _get_or_create_engine(self):
+    def _get_or_create_engine(self) -> Engine | None:
         """Get or create a cached SQLAlchemy engine for string connection URLs."""
         # Fast path: engine already created (no lock needed for the read).
         if self._engine is not None:
@@ -189,7 +189,7 @@ class SQLConnection:
                     import MySQLdb  # noqa: F401
                 except ImportError:
                     try:
-                        import pymysql  # noqa: F401
+                        import pymysql  # type: ignore[import-untyped]  # noqa: F401
 
                         url = url.replace("mysql://", "mysql+pymysql://", 1)
                         logger.info("Rewrote mysql:// to mysql+pymysql:// (MySQLdb not available)")
@@ -209,6 +209,7 @@ class SQLConnection:
         try:
             if isinstance(self.conn, str):
                 engine = self._get_or_create_engine()
+                assert engine is not None  # guaranteed by isinstance(self.conn, str) guard
                 with engine.connect() as connection:
                     result = connection.execute(text(sql))
                     rows = result.fetchall()

--- a/daft/sql/sql_connection.py
+++ b/daft/sql/sql_connection.py
@@ -37,8 +37,11 @@ class SQLConnection:
 
     def __setstate__(self, state: dict[str, Any]) -> None:
         self.__dict__.update(state)
-        if self._engine_lock is None:
-            self._engine_lock = threading.Lock()
+        # Always restore these fields from a clean state. This handles both
+        # objects serialized before the fields were introduced and objects
+        # serialized by __getstate__, which deliberately stores None here.
+        self._engine = None
+        self._engine_lock = threading.Lock()
 
     def __repr__(self) -> str:
         # Deliberately omit the URL: secrets can appear anywhere in a

--- a/tests/sql/test_sql_connection.py
+++ b/tests/sql/test_sql_connection.py
@@ -1,0 +1,109 @@
+"""Tests for SQLConnection engine caching and mysql:// rewrite."""
+
+from __future__ import annotations
+
+import builtins
+import pickle
+import threading
+from unittest.mock import MagicMock, patch
+
+from daft.sql.sql_connection import SQLConnection
+
+
+class TestSQLConnectionEngineCaching:
+    """Test that SQLAlchemy Engine is cached."""
+
+    def test_engine_cached_on_first_call(self):
+        """Engine should be created once and reused."""
+        conn = SQLConnection("sqlite:///test.db", "", "sqlite", "sqlite:///test.db")
+        assert conn._engine is None
+
+        with patch("sqlalchemy.create_engine") as mock_create:
+            mock_engine = MagicMock()
+            mock_create.return_value = mock_engine
+
+            engine1 = conn._get_or_create_engine()
+            engine2 = conn._get_or_create_engine()
+
+            assert engine1 is mock_engine
+            assert engine2 is mock_engine
+            mock_create.assert_called_once()
+
+    def test_engine_not_created_for_callable(self):
+        """Engine should not be created when conn is a callable."""
+        conn_factory = MagicMock()
+        conn = SQLConnection(conn_factory, "", "sqlite", "sqlite:///test.db")
+        assert conn._get_or_create_engine() is None
+
+    def test_engine_excluded_from_pickle(self):
+        """Engine must be dropped during pickle to avoid serialization failures on distributed runners."""
+        conn = SQLConnection("sqlite://", "", "sqlite", "sqlite://")
+        conn._get_or_create_engine()  # populate live engine
+        assert conn._engine is not None
+
+        restored = pickle.loads(pickle.dumps(conn))
+        assert restored._engine is None  # dropped, will be lazily recreated
+        assert restored.conn == "sqlite://"
+        assert restored.dialect == "sqlite"
+        assert restored.driver == ""
+        assert restored.url == "sqlite://"
+
+    def test_engine_thread_safety(self):
+        """Concurrent calls should not create multiple engines."""
+        conn = SQLConnection("sqlite://", "", "sqlite", "sqlite://")
+        engines = []
+
+        def get_engine():
+            engines.append(conn._get_or_create_engine())
+
+        threads = [threading.Thread(target=get_engine) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert all(e is engines[0] for e in engines), "Thread safety failed: different engines returned"
+
+
+class TestMySQLPyMySQLRewrite:
+    """Test mysql:// to mysql+pymysql:// rewrite."""
+
+    def test_no_rewrite_when_not_mysql(self):
+        """Non-mysql URLs should not be rewritten."""
+        conn = SQLConnection("postgresql://user:pass@host/db", "", "postgres", "postgresql://user:pass@host/db")
+
+        with patch("sqlalchemy.create_engine") as mock_create:
+            mock_create.return_value = MagicMock()
+            conn._get_or_create_engine()
+            call_args = mock_create.call_args[0][0]
+            assert call_args == "postgresql://user:pass@host/db"
+
+    def test_no_rewrite_when_mysql_with_driver(self):
+        """mysql+pymysql:// should not be rewritten again."""
+        conn = SQLConnection("mysql+pymysql://user:pass@host/db", "", "mysql", "mysql+pymysql://user:pass@host/db")
+
+        with patch("sqlalchemy.create_engine") as mock_create:
+            mock_create.return_value = MagicMock()
+            conn._get_or_create_engine()
+            call_args = mock_create.call_args[0][0]
+            assert call_args == "mysql+pymysql://user:pass@host/db"
+
+    def test_mysql_rewritten_when_mysqldb_absent(self):
+        """mysql:// should be rewritten to mysql+pymysql:// when MySQLdb is not available."""
+        conn = SQLConnection("mysql://user:pass@host/db", "", "mysql", "mysql://user:pass@host/db")
+
+        real_import = builtins.__import__
+
+        def mock_import(name, *args, **kwargs):
+            if name == "MySQLdb":
+                raise ImportError("No module named 'MySQLdb'")
+            return real_import(name, *args, **kwargs)
+
+        with (
+            patch("sqlalchemy.create_engine") as mock_create,
+            patch.object(builtins, "__import__", side_effect=mock_import),
+        ):
+            mock_create.return_value = MagicMock()
+            conn._get_or_create_engine()
+            call_args = mock_create.call_args[0][0]
+            assert call_args == "mysql+pymysql://user:pass@host/db"

--- a/tests/sql/test_sql_connection.py
+++ b/tests/sql/test_sql_connection.py
@@ -48,6 +48,26 @@ class TestSQLConnectionEngineCaching:
         assert restored.driver == ""
         assert restored.url == "sqlite://"
 
+    def test_legacy_pickle_state_restores_missing_fields(self):
+        """State serialized before engine caching should still be loadable."""
+        restored = SQLConnection.__new__(SQLConnection)
+        restored.__setstate__(
+            {
+                "conn": "sqlite://",
+                "driver": "",
+                "dialect": "sqlite",
+                "url": "sqlite://",
+            }
+        )
+
+        assert restored._engine is None
+        assert restored._engine_lock is not None
+
+        with patch("sqlalchemy.create_engine") as mock_create:
+            mock_create.return_value = MagicMock()
+            assert restored._get_or_create_engine() is not None
+        mock_create.assert_called_once()
+
     def test_engine_thread_safety(self):
         """Concurrent calls should not create multiple engines."""
         conn = SQLConnection("sqlite://", "", "sqlite", "sqlite://")


### PR DESCRIPTION
## Changes Made

For string connection URLs, every call to `_execute_sql_query_with_sqlalchemy()` previously created a new SQLAlchemy connection pool via `create_engine()`. This PR caches the `Engine` instance and reuses it across queries on the same `SQLConnection`.

Key details:

- **Double-checked locking**: a fast path without lock acquisition when the engine is already cached, and a slow path with `threading.Lock` for serialised creation. The lock is per-instance (not class-level), so independent connections do not contend.
- **Pickle support**: `__getstate__` excludes `_engine` and `_engine_lock`; `__setstate__` recreates the lock after deserialisation.
- **Driver rewrite for mysql://**: when `mysqldb` is unavailable but PyMySQL is installed, bare `mysql://` URLs are automatically rewritten to `mysql+pymysql://` during engine creation, avoiding `ModuleNotFoundError: No module named 'MySQLdb'`.

## Testing

Added `tests/sql/test_sql_connection.py`:
- Engine caching (create_engine called once, reused on second call)
- Thread safety (concurrent calls return the same engine instance)
- Pickle round-trip drops the cached engine
- `mysql://` → `mysql+pymysql://` rewrite when MySQLdb absent

## Related Issues

Relates #7198
