### PR TITLE
fix(flotilla): enable in-place restarts for RaySwordfishActor to avoi…

### DIFF
--- a/daft/runners/flotilla.py
+++ b/daft/runners/flotilla.py
@@ -407,6 +407,44 @@ class RaySwordfishActorHandle:
 
 DEFAULT_WORKER_STARTUP_TIMEOUT = 120
 
+# Maximum number of times Ray restarts a crashed RaySwordfishActor in place
+# (e.g. after an OOM kill) before declaring it permanently dead. Ray's default
+# is 0 (never restart), which makes every actor crash terminal: all in-flight
+# calls raise `ActorDiedError`, the dispatcher evicts the whole node from the
+# worker pool (upstream PR Eventual-Inc/Daft#4628), and the node's compute is
+# lost until the next worker-refresh cycle re-creates an actor on it. With
+# `max_restarts > 0`, Ray restarts the actor on the same node and in-flight
+# calls surface `ActorUnavailableError` (the reason the ray floor was bumped
+# to >=2.11.0 in upstream PR Eventual-Inc/Daft#7116) instead, which maps to
+# `RayTaskResult.worker_unavailable()` -> the task is requeued *without*
+# evicting the node. `max_task_retries` intentionally stays at Ray's default
+# of 0: task re-execution is owned by Daft's dispatcher, which requeues
+# WorkerDied/WorkerUnavailable tasks itself.
+# Default matches MAX_UDFACTOR_ACTOR_RESTARTS in daft/execution/ray_actor_pool_udf.py.
+DEFAULT_SWORDFISH_ACTOR_MAX_RESTARTS = 4
+SWORDFISH_ACTOR_MAX_RESTARTS_ENV = "DAFT_SWORDFISH_ACTOR_MAX_RESTARTS"
+
+
+def _get_swordfish_actor_max_restarts() -> int:
+    """Resolve `max_restarts` for RaySwordfishActor from the environment.
+
+    Accepts any integer Ray accepts (-1 means infinite restarts, 0 disables
+    restarts). Falls back to the default on unset or unparsable values.
+    """
+    raw = os.environ.get(SWORDFISH_ACTOR_MAX_RESTARTS_ENV)
+    if raw is None:
+        return DEFAULT_SWORDFISH_ACTOR_MAX_RESTARTS
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning(
+            "Invalid value %r for %s; falling back to default %d",
+            raw,
+            SWORDFISH_ACTOR_MAX_RESTARTS_ENV,
+            DEFAULT_SWORDFISH_ACTOR_MAX_RESTARTS,
+        )
+        return DEFAULT_SWORDFISH_ACTOR_MAX_RESTARTS
+
 
 def _attach_remote_event_log_subscriber(component: str, node_role: str) -> None:
     """Attach a RemoteEventLogSubscriber to this process's context.
@@ -470,6 +508,10 @@ def start_ray_workers(
                     node_id=node["NodeID"],
                     soft=False,
                 ),
+                # Restart crashed actors in place so a transient crash (e.g.
+                # OOM kill) doesn't permanently evict the node's compute from
+                # the worker pool. See DEFAULT_SWORDFISH_ACTOR_MAX_RESTARTS.
+                "max_restarts": _get_swordfish_actor_max_restarts(),
             }
             if runtime_env:
                 swordfish_options["runtime_env"] = runtime_env

--- a/tests/ray/test_flotilla_actor_fault_tolerance.py
+++ b/tests/ray/test_flotilla_actor_fault_tolerance.py
@@ -1,0 +1,122 @@
+"""Fault-tolerance tests for RaySwordfishActor.
+
+Covers the fix for node-level compute loss on actor crash: swordfish actors
+are created with ``max_restarts > 0`` so a transient crash (e.g. OOM kill) is
+restarted in place by Ray instead of permanently evicting the node from the
+worker pool.
+
+Context (upstream Eventual-Inc/Daft):
+- PR #4628 (feat(flotilla): Fault tolerance) introduced dispatcher-level
+  rescheduling on WorkerDied/WorkerUnavailable.
+- PR #7116 bumped the ray floor to >=2.11.0 because Daft relies on
+  ``ActorUnavailableError`` to distinguish a restarting actor from a dead one.
+- Without ``max_restarts``, ``ActorUnavailableError`` is never raised for a
+  crashed actor -- only the terminal ``ActorDiedError`` path is reachable.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from daft.runners import flotilla
+
+# ---------------------------------------------------------------------------
+# _get_swordfish_actor_max_restarts env parsing
+# ---------------------------------------------------------------------------
+
+
+def test_max_restarts_default_when_env_unset(monkeypatch):
+    monkeypatch.delenv(flotilla.SWORDFISH_ACTOR_MAX_RESTARTS_ENV, raising=False)
+    assert flotilla._get_swordfish_actor_max_restarts() == flotilla.DEFAULT_SWORDFISH_ACTOR_MAX_RESTARTS
+    # The whole point of the fix: the default must enable in-place restarts.
+    assert flotilla.DEFAULT_SWORDFISH_ACTOR_MAX_RESTARTS > 0
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("0", 0),  # explicit opt-out restores the old behavior
+        ("7", 7),
+        ("-1", -1),  # infinite restarts
+    ],
+)
+def test_max_restarts_env_override(monkeypatch, raw, expected):
+    monkeypatch.setenv(flotilla.SWORDFISH_ACTOR_MAX_RESTARTS_ENV, raw)
+    assert flotilla._get_swordfish_actor_max_restarts() == expected
+
+
+@pytest.mark.parametrize("raw", ["", "abc", "1.5"])
+def test_max_restarts_invalid_env_falls_back_to_default(monkeypatch, raw):
+    monkeypatch.setenv(flotilla.SWORDFISH_ACTOR_MAX_RESTARTS_ENV, raw)
+    assert flotilla._get_swordfish_actor_max_restarts() == flotilla.DEFAULT_SWORDFISH_ACTOR_MAX_RESTARTS
+
+
+# ---------------------------------------------------------------------------
+# RaySwordfishTaskHandle actor-error -> RayTaskResult mapping
+# ---------------------------------------------------------------------------
+#
+# The dispatcher (src/daft-distributed/src/scheduling/dispatcher.rs) treats:
+# - WorkerDied        -> evict the worker + requeue the task (slow path)
+# - WorkerUnavailable -> requeue the task, keep the worker   (fast path)
+# With max_restarts > 0, Ray raises ActorUnavailableError while the actor is
+# restarting, so a crashed-but-restartable actor takes the fast path and the
+# node's compute is not lost. These tests pin that error-mapping contract.
+
+
+def _actor_error(name: str) -> Exception:
+    # Construct without invoking Ray's constructor (signature varies by version).
+    cls = getattr(flotilla.ray.exceptions, name)
+    return cls.__new__(cls)
+
+
+class _FakeResultHandle:
+    """Stand-in for the ObjectRefGenerator returned by ``run_plan.remote()``."""
+
+    def __init__(self, exc: Exception) -> None:
+        self._exc = exc
+
+    async def completed(self) -> None:
+        raise self._exc
+
+
+class _FakeRayTaskResult:
+    @staticmethod
+    def worker_died() -> str:
+        return "worker_died"
+
+    @staticmethod
+    def worker_unavailable() -> str:
+        return "worker_unavailable"
+
+
+@pytest.mark.parametrize(
+    ("error_name", "expected"),
+    [
+        # Permanently dead (max_restarts exhausted, or restarts disabled).
+        ("ActorDiedError", "worker_died"),
+        # Node churned away before the actor could be scheduled.
+        ("ActorUnschedulableError", "worker_died"),
+        # Actor crashed but Ray is restarting it in place (max_restarts > 0):
+        # the task must be requeued WITHOUT evicting the node.
+        ("ActorUnavailableError", "worker_unavailable"),
+    ],
+)
+def test_task_handle_maps_actor_errors(monkeypatch, error_name, expected):
+    monkeypatch.setattr(flotilla, "RayTaskResult", _FakeRayTaskResult)
+
+    handle = flotilla.RaySwordfishTaskHandle(result_handle=_FakeResultHandle(_actor_error(error_name)))
+    result = asyncio.run(handle.get_result())
+
+    assert result == expected
+
+
+def test_task_handle_propagates_non_actor_errors(monkeypatch):
+    """Genuine task failures (e.g. UDF errors) must not be masked as worker churn."""
+    monkeypatch.setattr(flotilla, "RayTaskResult", _FakeRayTaskResult)
+
+    handle = flotilla.RaySwordfishTaskHandle(result_handle=_FakeResultHandle(ValueError("boom")))
+
+    with pytest.raises(ValueError, match="boom"):
+        asyncio.run(handle.get_result())

--- a/tests/ray/test_flotilla_worker_startup.py
+++ b/tests/ray/test_flotilla_worker_startup.py
@@ -69,7 +69,7 @@ def _install_fakes(monkeypatch, nodes, outcomes):
     ``ray.get`` raises), or ``("timeout", None)`` (never resolves -> stays in
     ``ray.wait``'s ``not_ready`` bucket).
     """
-    captured: dict[str, object] = {"killed": []}
+    captured: dict[str, object] = {"killed": [], "options": []}
 
     created = {"i": 0}
 
@@ -82,6 +82,7 @@ def _install_fakes(monkeypatch, nodes, outcomes):
     class _FakeActorClass:
         @staticmethod
         def options(**kwargs):
+            captured["options"].append(kwargs)
             return _Opts()
 
     def _fake_ray_wait(refs, *, num_returns, timeout):
@@ -223,3 +224,46 @@ def test_start_ray_workers_refresh_total_failure_is_non_fatal(monkeypatch):
 
     assert workers == []
     assert captured["killed"] == [0]
+
+
+def test_start_ray_workers_sets_actor_max_restarts_by_default(monkeypatch):
+    """Swordfish actors must be created with max_restarts > 0.
+
+    Ray's default of max_restarts=0 makes any actor crash (e.g. an OOM kill)
+    terminal: in-flight calls raise ActorDiedError, the dispatcher evicts the
+    node from the worker pool, and its compute is lost until the next refresh
+    cycle. With max_restarts > 0 Ray restarts the actor in place and in-flight
+    calls surface ActorUnavailableError, which requeues tasks without evicting
+    the node.
+    """
+    monkeypatch.delenv(flotilla.SWORDFISH_ACTOR_MAX_RESTARTS_ENV, raising=False)
+    captured = _install_fakes(
+        monkeypatch,
+        nodes=[_node(_hex_node_id(0))],
+        outcomes={0: ("ok", "1.2.3.4:5000")},
+    )
+
+    workers = flotilla.start_ray_workers(existing_worker_ids=[])
+
+    assert len(workers) == 1
+    assert len(captured["options"]) == 1
+    options = captured["options"][0]
+    assert options["max_restarts"] == flotilla.DEFAULT_SWORDFISH_ACTOR_MAX_RESTARTS
+    assert options["max_restarts"] > 0
+    # Task retry stays owned by Daft's dispatcher, never delegated to Ray.
+    assert "max_task_retries" not in options
+
+
+def test_start_ray_workers_max_restarts_env_override(monkeypatch):
+    """DAFT_SWORDFISH_ACTOR_MAX_RESTARTS overrides the default (-1 = infinite)."""
+    monkeypatch.setenv(flotilla.SWORDFISH_ACTOR_MAX_RESTARTS_ENV, "-1")
+    captured = _install_fakes(
+        monkeypatch,
+        nodes=[_node(_hex_node_id(0))],
+        outcomes={0: ("ok", "1.2.3.4:5000")},
+    )
+
+    workers = flotilla.start_ray_workers(existing_worker_ids=[])
+
+    assert len(workers) == 1
+    assert captured["options"][0]["max_restarts"] == -1


### PR DESCRIPTION
## Changes Made

### Problem

`RaySwordfishActor` is created with Ray's default `max_restarts=0`, so any actor crash (e.g. the worker process getting OOM-killed, or a segfault in native code) is terminal:

1. All in-flight calls on the actor raise `ActorDiedError`.
2. `RaySwordfishTaskHandle._get_result` maps this to `RayTaskResult.worker_died()`, and the dispatcher (`src/daft-distributed/src/scheduling/dispatcher.rs`) evicts the **entire node** from the worker pool via `mark_worker_died`.
3. The node's compute stays lost until a later worker-refresh cycle (`refresh_workers`, rate-limited to every 5s) re-creates an actor on it, plus actor cold-start time.
4. Meanwhile, all requeued tasks pile onto the remaining workers, increasing memory pressure there and risking cascading OOM kills across the cluster.

The key gap: #4628 (feat(flotilla): Fault tolerance) introduced two recovery paths in the dispatcher —

| Task status         | Dispatcher behavior                           |
| ------------------- | --------------------------------------------- |
| `WorkerDied`        | evict worker + requeue task (slow path)       |
| `WorkerUnavailable` | requeue task, **keep the worker** (fast path) |

— and #7116 / #7104 bumped the ray floor to `>=2.11.0` specifically so Daft can rely on `ActorUnavailableError`. But without `max_restarts`, Ray never puts a crashed actor into the *restarting* state, so `ActorUnavailableError` never fires for a crashed actor and the `WorkerUnavailable` fast path is unreachable. Only the terminal `ActorDiedError` path can ever be taken.

(The actor's own docstring also claims it "is able to retry itself and it's tasks", which was not actually true.)

### Fix

Pass `max_restarts` to the actor options in `start_ray_workers` (`daft/runners/flotilla.py`):

- **Default: `4`**, matching the existing precedent `MAX_UDFACTOR_ACTOR_RESTARTS` in `daft/execution/ray_actor_pool_udf.py`. A finite default avoids infinite restart loops on persistently crashing workloads; once restarts are exhausted, behavior degrades to today's evict-and-refresh path.
- **Overridable via `DAFT_SWORDFISH_ACTOR_MAX_RESTARTS`** (`-1` = infinite restarts, `0` = restore the old behavior; unparsable values fall back to the default with a warning).
- **`max_task_retries` intentionally stays at Ray's default of `0`**: task re-execution is owned by Daft's dispatcher, which already requeues `WorkerDied`/`WorkerUnavailable` tasks itself. Delegating retries to Ray as well would risk double execution and bypass Daft's scheduling decisions.

With `max_restarts > 0`, Ray restarts a crashed actor **on the same node** (the actor uses a hard `NodeAffinitySchedulingStrategy`). While it is restarting, in-flight calls surface `ActorUnavailableError`, which already maps to `RayTaskResult.worker_unavailable()` → the task is requeued **without** evicting the node. No changes to the Rust scheduling layer are needed; this un-blocks the recovery path that #4628 and #7116 already built.

### Behavior before / after

| Scenario                              | Before (`max_restarts=0`)                                        | After (`max_restarts=4`)                                          |
| ------------------------------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------ |
| Actor OOM-killed, node healthy        | `ActorDiedError` → node evicted → wait for refresh (≥5s + cold start); tasks pile onto other nodes | `ActorUnavailableError` → task requeued, node kept; Ray restarts the actor in place |
| Crash loop (restarts exhausted)       | n/a                                                               | `ActorDiedError` → falls back to today's evict-and-refresh path    |
| Node actually gone                    | `ActorDiedError`/`ActorUnschedulableError` → evict (correct)      | unchanged                                                           |
| Opt-out                               | n/a                                                               | `DAFT_SWORDFISH_ACTOR_MAX_RESTARTS=0`                               |

### Notes on flight shuffle

No regression: when the actor process dies, its Flight shuffle server dies with it either way. Previously-completed flight partitions served from that process become unreachable regardless of whether we restart the actor in place or create a fresh one via refresh — both paths rely on task re-execution to recompute, exactly as before.

### Tests

- `tests/ray/test_flotilla_worker_startup.py`
  - `test_start_ray_workers_sets_actor_max_restarts_by_default`: actor options carry `max_restarts > 0` by default, and `max_task_retries` is **not** set.
  - `test_start_ray_workers_max_restarts_env_override`: env override (`-1`) is honored.
- `tests/ray/test_flotilla_actor_fault_tolerance.py` (new)
  - Env parsing: default when unset, overrides (`0`/`7`/`-1`), fallback on invalid values (`""`, `"abc"`, `"1.5"`).
  - Pins the error-mapping contract of `RaySwordfishTaskHandle`:
    - `ActorDiedError` → `worker_died` (evict, slow path)
    - `ActorUnschedulableError` → `worker_died`
    - `ActorUnavailableError` → `worker_unavailable` (keep node, fast path)
    - non-actor exceptions (e.g. UDF errors) propagate unchanged and are never masked as worker churn.

All 23 tests in `tests/ray/test_flotilla_worker_startup.py` + `tests/ray/test_flotilla_actor_fault_tolerance.py` pass locally.

## Related Issues

- Builds on #4628 (feat(flotilla): Fault tolerance) — makes its `WorkerUnavailable` fast path reachable for crashed actors.
- Builds on #7116 / closes the remaining gap from #7104 (ray floor `>=2.11.0` for `ActorUnavailableError`) — that error can now actually fire for crashed-but-restartable actors.
- Related: #5169 (memory in ray execution explodes vs local) — cascading pressure after a node eviction is one aggravating factor this PR mitigates.
