### PR TITLE
fix(io): support writing to hdfs:// URLs that include a port

### DIFF
--- a/src/daft-io/src/utils.rs
+++ b/src/daft-io/src/utils.rs
@@ -25,7 +25,7 @@ pub fn parse_object_url(uri: &str) -> super::Result<ObjectPath> {
         source,
     })?;
 
-    let bucket = match parsed.host_str() {
+    let host = match parsed.host_str() {
         Some(s) => Ok(s),
         None => Err(Error::InvalidUrl {
             path: uri.into(),
@@ -33,13 +33,21 @@ pub fn parse_object_url(uri: &str) -> super::Result<ObjectPath> {
         }),
     }?;
 
+    // The authority (e.g. a HDFS name node) may include a port, which is part of
+    // the bucket rather than the key. Preserve it so the URL can be reconstructed.
+    let bucket = match parsed.port() {
+        Some(port) => format!("{host}:{port}"),
+        None => host.to_string(),
+    };
+
     // Use raw `uri` for object key: URI special character escaping might mangle key.
-    let bucket_scheme_prefix_len = parsed[..Position::AfterHost].len();
+    // Split after the authority (including any port) so the port never leaks into the key.
+    let bucket_scheme_prefix_len = parsed[..Position::BeforePath].len();
     let key = uri[bucket_scheme_prefix_len..].trim_start_matches(GLOB_DELIMITER);
 
     Ok(ObjectPath {
         scheme: parsed.scheme().to_string(),
-        bucket: bucket.to_string(),
+        bucket,
         key: key.to_string(),
     })
 }
@@ -171,7 +179,23 @@ pub(crate) fn verify_glob(glob: &str) -> super::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use crate::utils::{group_glob_paths, verify_glob};
+    use crate::utils::{group_glob_paths, parse_object_url, verify_glob};
+
+    #[test]
+    fn test_parse_object_url() {
+        // No port (e.g. S3): host is the bucket, key is the remainder.
+        let parsed = parse_object_url("s3://bucket/path/to/file.parquet").unwrap();
+        assert_eq!(parsed.scheme, "s3");
+        assert_eq!(parsed.bucket, "bucket");
+        assert_eq!(parsed.key, "path/to/file.parquet");
+
+        // With port (e.g. HDFS name node): the port stays with the bucket and must
+        // not leak into the key.
+        let parsed = parse_object_url("hdfs://localhost:9000/tmp/out/file.parquet").unwrap();
+        assert_eq!(parsed.scheme, "hdfs");
+        assert_eq!(parsed.bucket, "localhost:9000");
+        assert_eq!(parsed.key, "tmp/out/file.parquet");
+    }
 
     #[test]
     fn test_verify_glob() {

--- a/src/daft-writers/src/utils.rs
+++ b/src/daft-writers/src/utils.rs
@@ -145,7 +145,7 @@ mod tests {
     };
     use daft_recordbatch::RecordBatch;
 
-    use crate::utils::record_batch_to_partition_path;
+    use crate::utils::{build_object_path, record_batch_to_partition_path};
 
     #[test]
     fn test_record_batch_to_partition_string() -> DaftResult<()> {
@@ -216,6 +216,42 @@ mod tests {
             result.as_ref().unwrap_err().to_string(),
             "DaftError::InternalError Only single row RecordBatches can be converted to partition strings"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn test_build_object_path_preserves_port() -> DaftResult<()> {
+        use std::path::PathBuf;
+
+        // Regression guard: a port-bearing authority (e.g. an HDFS name node)
+        // must keep its port with the bucket and never leak it into the key,
+        // which previously produced an invalid path like `localhost/:9000/...`.
+        let path = build_object_path(
+            "hdfs://localhost:9000/tmp/out",
+            PathBuf::new(),
+            "file.parquet".to_string(),
+        )?;
+        assert_eq!(path, PathBuf::from("localhost:9000/tmp/out/file.parquet"));
+
+        // With a partition path.
+        let path = build_object_path(
+            "hdfs://localhost:9000/tmp/out",
+            PathBuf::from("year=2023"),
+            "file.parquet".to_string(),
+        )?;
+        assert_eq!(
+            path,
+            PathBuf::from("localhost:9000/tmp/out/year=2023/file.parquet")
+        );
+
+        // Port-less authority (e.g. S3) is unaffected.
+        let path = build_object_path(
+            "s3://bucket/prefix",
+            PathBuf::new(),
+            "file.parquet".to_string(),
+        )?;
+        assert_eq!(path, PathBuf::from("bucket/prefix/file.parquet"));
+
         Ok(())
     }
 }


### PR DESCRIPTION
Sorry about this one. The port-bearing write path was working locally when I did #7202, but I lost some local changes and that commit never made it into the branch I pushed — so the merged code was missing the fix.

## Changes Made

`parse_object_url` split the object key at `Position::AfterHost`, which is before the port. For a URL like `hdfs://namenode:9000/...` the port leaked into the key, producing an invalid path (`:9000/tmp/...`) that HDFS rejects.

- Split the key at `Position::BeforePath` and keep the port with the bucket. Port-less URLs (S3/GCS/Azure/OSS) are unaffected — with no port, `AfterHost` and `BeforePath` resolve to the same offset.
- Add Rust unit tests for `parse_object_url` and `build_object_path` covering port-less (S3) and port-bearing (HDFS) authorities. Both run on CI without HDFS or a JVM.

## Related Issues

Follow-up to #7202. 