### PR TITLE
refactor: migrate IcebergScanOperator to DataSource

### DIFF
--- a/daft/daft/__init__.pyi
+++ b/daft/daft/__init__.pyi
@@ -1293,6 +1293,7 @@ class PyDataSourceTask:
         partition_values: PyRecordBatch | None = None,
         stats: PyRecordBatch | None = None,
         storage_config: StorageConfig | None = None,
+        iceberg_delete_files: list[str] | None = None,
     ) -> PyDataSourceTask: ...
 
 class ScanOperatorHandle:

--- a/daft/io/iceberg/_iceberg.py
+++ b/daft/io/iceberg/_iceberg.py
@@ -162,7 +162,7 @@ def read_iceberg(
     """
     from pyiceberg.table import StaticTable
 
-    from daft.io.iceberg.iceberg_scan import IcebergScanOperator
+    from daft.io.iceberg.iceberg_scan import IcebergDataSource
 
     # support for read_iceberg('path/to/metadata.json')
     if isinstance(table, (str, os.PathLike)):
@@ -180,11 +180,11 @@ def read_iceberg(
     multithreaded_io = runners.get_or_create_runner().name != "ray"
     storage_config = StorageConfig(multithreaded_io, io_config)
 
-    iceberg_operator = IcebergScanOperator(
+    iceberg_source = IcebergDataSource(
         table, snapshot_id=snapshot_id, storage_config=storage_config, ignore_corrupt_files=ignore_corrupt_files
     )
 
-    handle = ScanOperatorHandle.from_python_scan_operator(iceberg_operator)
+    handle = ScanOperatorHandle.from_data_source(iceberg_source)
     builder = LogicalPlanBuilder.from_tabular_scan(scan_operator=handle)
     builder = attach_checkpoint(builder, checkpoint)
     return DataFrame(builder)

--- a/daft/io/iceberg/iceberg_scan.py
+++ b/daft/io/iceberg/iceberg_scan.py
@@ -9,15 +9,11 @@ from pyiceberg.schema import visit
 import daft
 from daft.daft import (
     CountMode,
-    FileFormatConfig,
     ParquetSourceConfig,
-    PyPartitionField,
-    PyPushdowns,
-    PyRecordBatch,
-    ScanTask,
     StorageConfig,
 )
 from daft.dependencies import pa
+from daft.expressions import ExpressionsProjection
 from daft.io.iceberg._expressions import convert_row_filter
 from daft.io.iceberg._metadata import (
     convert_iceberg_data_type,
@@ -25,12 +21,13 @@ from daft.io.iceberg._metadata import (
     convert_iceberg_transform,
 )
 from daft.io.iceberg.schema_field_id_mapping_visitor import SchemaFieldIdMappingVisitor
-from daft.io.scan import ScanOperator, make_partition_field
+from daft.io.partitioning import PartitionField
+from daft.io.source import DataSource, DataSourceTask
 from daft.logical.schema import Field, Schema
 from daft.recordbatch import RecordBatch
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import AsyncIterator, Iterator
 
     from pyiceberg.partitioning import PartitionField as IcebergPartitionField
     from pyiceberg.partitioning import PartitionSpec as IcebergPartitionSpec
@@ -38,10 +35,12 @@ if TYPE_CHECKING:
     from pyiceberg.table import Table
     from pyiceberg.typedef import Record
 
+    from daft.io.pushdowns import Pushdowns
+
 logger = logging.getLogger(__name__)
 
 
-def _iceberg_count_result_function(total_count: int, field_name: str) -> Iterator[PyRecordBatch]:
+def _iceberg_count_result_function(total_count: int, field_name: str) -> Iterator[RecordBatch]:
     """Construct Iceberg count query result."""
     try:
         arrow_schema = pa.schema([pa.field(field_name, pa.uint64())])
@@ -50,15 +49,32 @@ def _iceberg_count_result_function(total_count: int, field_name: str) -> Iterato
 
         logger.debug("Generated Iceberg count result: %s=%d", field_name, total_count)
 
-        yield RecordBatch.from_arrow_record_batches([arrow_batch], arrow_schema)._recordbatch
+        yield RecordBatch.from_arrow_record_batches([arrow_batch], arrow_schema)
     except Exception as e:
         logger.error("Failed to construct Iceberg count result: %s", e)
         raise
 
 
+class _IcebergCountTask(DataSourceTask):
+    """Metadata-only count result task produced for count pushdown."""
+
+    def __init__(self, total_count: int, field_name: str, schema: Schema) -> None:
+        self._total_count = total_count
+        self._field_name = field_name
+        self._schema = schema
+
+    @property
+    def schema(self) -> Schema:
+        return self._schema
+
+    async def read(self) -> AsyncIterator[RecordBatch]:
+        for batch in _iceberg_count_result_function(self._total_count, self._field_name):
+            yield batch
+
+
 def _iceberg_partition_field_to_daft_partition_field(
     iceberg_schema: IcebergSchema, pfield: IcebergPartitionField
-) -> PyPartitionField:
+) -> PartitionField:
     source_id = pfield.source_id
     source_field = iceberg_schema.find_field(source_id)
     source_name = source_field.name
@@ -66,22 +82,30 @@ def _iceberg_partition_field_to_daft_partition_field(
     daft_field = Field.create(source_name, source_type)
     try:
         partition_transform, result_type = convert_iceberg_transform(pfield.transform, source_type)
-        tfm = partition_transform._partition_transform if partition_transform is not None else None
     except NotImplementedError:
         warnings.warn(f"{pfield.transform} not implemented, Please make an issue!")
-        tfm = None
+        partition_transform = None
         result_type = source_type
     result_field = Field.create(pfield.name, result_type)
-    return make_partition_field(result_field, daft_field, transform=tfm)
+    return PartitionField.create(result_field, daft_field, transform=partition_transform)
 
 
-def iceberg_partition_spec_to_fields(
-    iceberg_schema: IcebergSchema, spec: IcebergPartitionSpec
-) -> list[PyPartitionField]:
+def iceberg_partition_spec_to_fields(iceberg_schema: IcebergSchema, spec: IcebergPartitionSpec) -> list[PartitionField]:
     return [_iceberg_partition_field_to_daft_partition_field(iceberg_schema, field) for field in spec.fields]
 
 
-class IcebergScanOperator(ScanOperator):
+class IcebergDataSource(DataSource):
+    """DataSource for Apache Iceberg tables.
+
+    Uses pyiceberg for catalog metadata and scan planning (file listing,
+    partition pruning, statistics-based file skipping), then yields
+    DataSourceTask objects executed by Daft's native Parquet reader.
+    Positional delete files are passed through to the native reader.
+
+    For count aggregation pushdowns on tables without delete files, a
+    metadata-only _IcebergCountTask is yielded instead of scanning data files.
+    """
+
     def __init__(
         self,
         iceberg_table: Table,
@@ -89,7 +113,6 @@ class IcebergScanOperator(ScanOperator):
         storage_config: StorageConfig,
         ignore_corrupt_files: bool = False,
     ) -> None:
-        super().__init__()
         iceberg_schema = (
             iceberg_table.schema() if snapshot_id is None else iceberg_table.scan(snapshot_id=snapshot_id).projection()
         )
@@ -99,27 +122,24 @@ class IcebergScanOperator(ScanOperator):
         self._storage_config = storage_config
 
         field_id_mapping = visit(iceberg_schema, SchemaFieldIdMappingVisitor())
-        self._file_format_config = FileFormatConfig.from_parquet_config(
-            ParquetSourceConfig(
-                field_id_mapping=field_id_mapping,
-                ignore_corrupt_files=ignore_corrupt_files,
-            )
+        self._parquet_config = ParquetSourceConfig(
+            field_id_mapping=field_id_mapping,
+            ignore_corrupt_files=ignore_corrupt_files,
         )
 
         self._schema = convert_iceberg_schema(iceberg_schema)
-        self._partition_keys = iceberg_partition_spec_to_fields(iceberg_schema, self._iceberg_table.spec())
+        self._partition_fields = iceberg_partition_spec_to_fields(iceberg_schema, self._iceberg_table.spec())
 
+    @property
+    def name(self) -> str:
+        return f"IcebergDataSource({'.'.join(self._iceberg_table.name())})"
+
+    @property
     def schema(self) -> Schema:
         return self._schema
 
-    def name(self) -> str:
-        return "IcebergScanOperator"
-
-    def display_name(self) -> str:
-        return f"IcebergScanOperator({'.'.join(self._iceberg_table.name())})"
-
-    def partitioning_keys(self) -> list[PyPartitionField]:
-        return self._partition_keys
+    def get_partition_fields(self) -> list[PartitionField]:
+        return self._partition_fields
 
     def _iceberg_record_to_partition_spec(
         self, spec: IcebergPartitionSpec, record: Record
@@ -128,7 +148,7 @@ class IcebergScanOperator(ScanOperator):
         arrays = dict()
         assert len(record) == len(partition_fields)
         for idx, pfield in enumerate(partition_fields):
-            field = Field._from_pyfield(pfield.field)
+            field = pfield.field
             field_name = field.name
             field_dtype = field.dtype
             arrow_type = field_dtype.to_arrow_dtype()
@@ -140,31 +160,24 @@ class IcebergScanOperator(ScanOperator):
         else:
             return None
 
-    def multiline_display(self) -> list[str]:
-        return [
-            self.display_name(),
-            f"Schema = {self._schema}",
-            f"Partitioning keys = {self.partitioning_keys}",
-            # TODO(Clark): Improve repr of storage config here.
-            f"Storage config = {self._storage_config}",
-        ]
-
-    def to_scan_tasks(self, pushdowns: PyPushdowns) -> Iterator[ScanTask]:
+    async def get_tasks(self, pushdowns: Pushdowns) -> AsyncIterator[DataSourceTask]:
         # Check if there is a count aggregation pushdown
+        py_pushdowns = pushdowns._to_pypushdowns()
         if (
-            pushdowns.aggregation is not None
-            and pushdowns.aggregation_count_mode() is not None
-            and pushdowns.aggregation_required_column_names()
+            py_pushdowns.aggregation is not None
+            and py_pushdowns.aggregation_count_mode() is not None
+            and py_pushdowns.aggregation_required_column_names()
         ):
-            count_mode = pushdowns.aggregation_count_mode()
-            fields = pushdowns.aggregation_required_column_names()
+            count_mode = py_pushdowns.aggregation_count_mode()
+            fields = py_pushdowns.aggregation_required_column_names()
 
             if count_mode in self.supported_count_modes():
                 logger.info(
                     "Using Iceberg count pushdown optimization for count mode: %s",
                     count_mode,
                 )
-                yield from self._create_count_scan_task(pushdowns, fields[0])
+                for task in self._create_count_tasks(pushdowns, fields[0]):
+                    yield task
                 return
             else:
                 logger.warning(
@@ -173,12 +186,13 @@ class IcebergScanOperator(ScanOperator):
                 )
 
         # Regular scan without count pushdown
-        yield from self._create_regular_scan_tasks(pushdowns)
+        for task in self._create_regular_tasks(pushdowns):
+            yield task
 
-    def _create_regular_scan_tasks(self, pushdowns: PyPushdowns) -> Iterator[ScanTask]:
-        """Create regular scan tasks without count pushdown."""
+    def _create_regular_tasks(self, pushdowns: Pushdowns) -> Iterator[DataSourceTask]:
+        """Create regular tasks without count pushdown."""
         limit = pushdowns.limit
-        row_filter = convert_row_filter(pushdowns, self._iceberg_schema)
+        row_filter = convert_row_filter(pushdowns._to_pypushdowns(), self._iceberg_schema)
 
         iceberg_tasks = self._iceberg_table.scan(
             row_filter=row_filter,
@@ -188,13 +202,12 @@ class IcebergScanOperator(ScanOperator):
 
         should_limit_files = limit is not None and pushdowns.filters is None and pushdowns.partition_filters is None
 
-        if len(self.partitioning_keys()) > 0 and pushdowns.partition_filters is None:
+        if len(self._partition_fields) > 0 and pushdowns.partition_filters is None:
             logger.warning(
                 "%s has Partitioning Keys: %s but no partition filter was specified. This will result in a full table scan.",
-                self.display_name(),
-                self.partitioning_keys(),
+                self.name,
+                self._partition_fields,
             )
-        scan_tasks = []
 
         if limit is not None:
             rows_left = limit
@@ -213,28 +226,30 @@ class IcebergScanOperator(ScanOperator):
 
             iceberg_delete_files = [f.file_path for f in task.delete_files]
 
-            # TODO: Thread in Statistics to each ScanTask: P2
+            # TODO: Thread in Statistics to each task: P2
             pspec = self._iceberg_record_to_partition_spec(self._iceberg_table.specs()[file.spec_id], file.partition)
-            st = ScanTask.catalog_scan_task(
-                file=path,
-                file_format=self._file_format_config,
-                schema=self._schema._schema,
-                num_rows=record_count,
-                storage_config=self._storage_config,
-                size_bytes=file.file_size_in_bytes,
-                iceberg_delete_files=iceberg_delete_files,
-                pushdowns=pushdowns,
-                partition_values=pspec._recordbatch if pspec is not None else None,
-                stats=None,
-            )
-            if st is None:
-                continue
-            rows_left -= record_count
-            scan_tasks.append(st)
-        return iter(scan_tasks)
 
-    def _create_count_scan_task(self, pushdowns: PyPushdowns, field_name: str) -> Iterator[ScanTask]:
-        """Create count pushdown scan task using Iceberg metadata."""
+            # Partition pruning is the DataSource's responsibility in the DataSource model.
+            if pspec is not None and pushdowns.partition_filters is not None:
+                filtered = pspec.filter(ExpressionsProjection([pushdowns.partition_filters]))
+                if len(filtered) == 0:
+                    continue
+
+            yield DataSourceTask.parquet(
+                path=path,
+                schema=self._schema,
+                parquet_config=self._parquet_config,
+                pushdowns=pushdowns,
+                num_rows=record_count,
+                size_bytes=file.file_size_in_bytes,
+                partition_values=pspec,
+                storage_config=self._storage_config,
+                iceberg_delete_files=iceberg_delete_files if iceberg_delete_files else None,
+            )
+            rows_left -= record_count
+
+    def _create_count_tasks(self, pushdowns: Pushdowns, field_name: str) -> Iterator[DataSourceTask]:
+        """Create count pushdown task using Iceberg metadata."""
         try:
             iceberg_tasks = self._iceberg_table.scan(limit=None, snapshot_id=self._snapshot_id).plan_files()
             total_count = 0
@@ -251,23 +266,13 @@ class IcebergScanOperator(ScanOperator):
                 total_count,
                 field_name,
             )
-            yield ScanTask.python_factory_func_scan_task(
-                module=_iceberg_count_result_function.__module__,
-                func_name=_iceberg_count_result_function.__name__,
-                func_args=(total_count, field_name),
-                schema=result_schema._schema,
-                num_rows=1,
-                size_bytes=8,
-                pushdowns=pushdowns,
-                stats=None,
-                source_name=self.display_name(),
-            )
+            yield _IcebergCountTask(total_count, field_name, result_schema)
         except Exception as e:
             logger.error(
                 "Failed to create Iceberg count pushdown task: %s, now falling back to regular scan",
                 e,
             )
-            yield from self._create_regular_scan_tasks(pushdowns)
+            yield from self._create_regular_tasks(pushdowns)
 
     def _has_delete_files(self) -> bool:
         """Check if the table has any delete files.
@@ -299,15 +304,6 @@ class IcebergScanOperator(ScanOperator):
                 e,
             )
             return True
-
-    def can_absorb_filter(self) -> bool:
-        return False
-
-    def can_absorb_limit(self) -> bool:
-        return False
-
-    def can_absorb_select(self) -> bool:
-        return True
 
     def supports_count_pushdown(self) -> bool:
         return not self._has_delete_files()

--- a/daft/io/source.py
+++ b/daft/io/source.py
@@ -76,6 +76,16 @@ class DataSource(ABC):
         """
         return None
 
+    def supports_count_pushdown(self) -> bool:
+        """Returns true if this source can absorb a count aggregation pushdown.
+
+        When true, the optimizer may replace a full scan + count with a single
+        task whose pushdowns carry the count aggregation; get_tasks is
+        then responsible for producing the count result (e.g. from catalog
+        metadata) instead of scanning data files.
+        """
+        return False
+
     @abstractmethod
     async def get_tasks(self, pushdowns: Pushdowns) -> AsyncIterator[DataSourceTask]:
         """Yields tasks as they are discovered. Called during execution, not planning."""
@@ -146,6 +156,7 @@ class DataSourceTask(ABC):
         partition_values: RecordBatch | None = None,
         stats: RecordBatch | None = None,
         storage_config: StorageConfig | None = None,
+        iceberg_delete_files: list[str] | None = None,
     ) -> DataSourceTask:
         """Create a task that reads a Parquet file using the native reader.
 
@@ -170,6 +181,9 @@ class DataSourceTask(ABC):
             stats: Column statistics as a RecordBatch for predicate pushdown evaluation.
             storage_config: Optional StorageConfig for IO credentials/settings.
                 Defaults to ``StorageConfig(multithreaded_io=True)``.
+            iceberg_delete_files: Optional list of Iceberg positional delete file paths
+                to apply to this file, per the Iceberg spec
+                (https://iceberg.apache.org/spec/#position-delete-files).
 
         Example:
             class MyCatalogSource(DataSource):
@@ -196,6 +210,7 @@ class DataSourceTask(ABC):
             partition_values=partition_values._recordbatch if partition_values is not None else None,
             stats=stats._recordbatch if stats is not None else None,
             storage_config=storage_config,
+            iceberg_delete_files=iceberg_delete_files,
         )
 
         return _RustDataSourceTask(inner)

--- a/docs/connectors/iceberg.md
+++ b/docs/connectors/iceberg.md
@@ -219,13 +219,13 @@ algebraic operator is called a *scan*.
 Daft's [`daft.read_iceberg`][daft.read_iceberg] method creates a DataFrame from the given PyIceberg
 table. It produces rows by traversing the table's metadata tree to locate all
 the data files for the given snapshot which is handled by our
-`IcebergScanOperator`.
+`IcebergDataSource`.
 
-Daft's `IcebergScanOperator` initializes itself by fetching the latest schema,
+Daft's `IcebergDataSource` initializes itself by fetching the latest schema,
 or the schema of the given snapshot, along with setting up the partition key
-metadata. The scan operator's primary method, `to_scan_tasks`, accepts pushdowns
-(projections, predicates, partition filters) and returns an iterator of
-`ScanTasks`. Each `ScanTask` object holds a data file, optional delete files,
+metadata. The data source's primary method, `get_tasks`, accepts pushdowns
+(projections, predicates, partition filters) and yields an iterator of
+tasks. Each task holds a data file, optional delete files,
 and the associated pushdowns. Finally, we read each data file's parquet to
 produce a stream of record batches which later operators consume and transform.
 

--- a/src/daft-logical-plan/src/scan_builder.rs
+++ b/src/daft-logical-plan/src/scan_builder.rs
@@ -392,7 +392,7 @@ pub fn delta_scan<T: IntoGlobPath>(
     panic!("Delta Lake scan requires the 'python' feature to be enabled.")
 }
 
-/// Creates a logical scan operator from a Python IcebergScanOperator.
+/// Creates a logical scan operator from a Python IcebergDataSource.
 #[cfg(feature = "python")]
 pub fn iceberg_scan<T: AsRef<str>>(
     metadata_location: T,
@@ -402,9 +402,8 @@ pub fn iceberg_scan<T: AsRef<str>>(
     io_config: Option<IOConfig>,
     ignore_corrupt_files: bool,
 ) -> DaftResult<LogicalPlanBuilder> {
-    use pyo3::IntoPyObjectExt;
     let storage_config: StorageConfig = io_config.unwrap_or_default().into();
-    let scan_operator = Python::attach(|py| -> DaftResult<ScanOperatorHandle> {
+    Python::attach(|py| {
         let iceberg_table_module = PyModule::import(py, "pyiceberg.table")?;
         let iceberg_static_table = iceberg_table_module.getattr("StaticTable")?;
         let iceberg_table =
@@ -414,21 +413,16 @@ pub fn iceberg_scan<T: AsRef<str>>(
             .getattr("resolve_snapshot_id")?
             .call1((&iceberg_table, snapshot_id, branch, tag))?;
         let iceberg_scan_module = PyModule::import(py, "daft.io.iceberg.iceberg_scan")?;
-        let iceberg_scan_class = iceberg_scan_module.getattr("IcebergScanOperator")?;
-        let iceberg_scan = iceberg_scan_class
-            .call1((
-                iceberg_table,
-                snapshot_id,
-                storage_config,
-                ignore_corrupt_files,
-            ))?
-            .into_py_any(py)?;
-        Ok(ScanOperatorHandle::from_python_scan_operator(
-            iceberg_scan,
-            py,
-        )?)
-    })?;
-    LogicalPlanBuilder::table_scan(scan_operator.into(), None)
+        let iceberg_data_source = iceberg_scan_module.getattr("IcebergDataSource")?;
+        let iceberg_source = iceberg_data_source.call1((
+            iceberg_table,
+            snapshot_id,
+            storage_config,
+            ignore_corrupt_files,
+        ))?;
+        let scan_operator_handle = ScanOperatorHandle::from_data_source(iceberg_source);
+        LogicalPlanBuilder::table_scan(scan_operator_handle.into(), None)
+    })
 }
 
 #[cfg(not(feature = "python"))]

--- a/src/daft-scan/src/python.rs
+++ b/src/daft-scan/src/python.rs
@@ -85,6 +85,7 @@ impl PyDataSourceTask {
         partition_values = None,
         stats = None,
         storage_config = None,
+        iceberg_delete_files = None,
     ))]
     fn parquet(
         path: String,
@@ -96,6 +97,7 @@ impl PyDataSourceTask {
         partition_values: Option<PyRecordBatch>,
         stats: Option<PyRecordBatch>,
         storage_config: Option<StorageConfig>,
+        iceberg_delete_files: Option<Vec<String>>,
     ) -> PyResult<Self> {
         let storage_config = storage_config.unwrap_or_default().into();
 
@@ -127,7 +129,7 @@ impl PyDataSourceTask {
             kind: ScanSourceKind::File {
                 path,
                 chunk_spec: None,
-                iceberg_delete_files: None,
+                iceberg_delete_files,
                 parquet_metadata: None,
             },
         };

--- a/src/daft-scan/src/python/wrappers.rs
+++ b/src/daft-scan/src/python/wrappers.rs
@@ -53,6 +53,7 @@ pub struct PyDataSourceWrapper {
     schema: SchemaRef,
     partition_fields: Vec<PartitionField>,
     clustering_keys: Option<ClusteringKeys>,
+    supports_count_pushdown: bool,
 }
 
 impl PyDataSourceWrapper {
@@ -98,12 +99,21 @@ impl PyDataSourceWrapper {
             .and_then(|keys| keys.extract::<PyClusteringKeys>().ok())
             .map(ClusteringKeys::from);
 
+        // A source may opt into count pushdown via `supports_count_pushdown()`. Any
+        // failure degrades gracefully to false so the optimizer stays conservative,
+        // mirroring the `get_clustering_keys` handling above.
+        let supports_count_pushdown: bool = source
+            .call_method0(intern!(source.py(), "supports_count_pushdown"))
+            .and_then(|v| v.extract())
+            .unwrap_or(false);
+
         Self {
             source: source.unbind(),
             name,
             schema,
             partition_fields,
             clustering_keys,
+            supports_count_pushdown,
         }
     }
 
@@ -273,6 +283,10 @@ impl ScanOperator for PyDataSourceWrapper {
 
     fn can_absorb_shard(&self) -> bool {
         false
+    }
+
+    fn supports_count_pushdown(&self) -> bool {
+        self.supports_count_pushdown
     }
 
     fn multiline_display(&self) -> Vec<String> {

--- a/tests/integration/iceberg/test_iceberg_count_pushdown_coverage.py
+++ b/tests/integration/iceberg/test_iceberg_count_pushdown_coverage.py
@@ -7,11 +7,13 @@ import pytest
 
 pyiceberg = pytest.importorskip("pyiceberg")
 
-from daft.daft import CountMode, PyPushdowns
+from daft.daft import CountMode
 from daft.io.iceberg.iceberg_scan import (
-    IcebergScanOperator,
+    IcebergDataSource,
     _iceberg_count_result_function,
+    _IcebergCountTask,
 )
+from daft.io.pushdowns import Pushdowns
 from daft.logical.schema import Schema
 
 
@@ -77,8 +79,8 @@ class TestIcebergCountResultFunction:
         assert results[0] is not None
 
 
-class TestIcebergScanOperatorUnit:
-    """Unit tests for IcebergScanOperator methods."""
+class TestIcebergDataSourceUnit:
+    """Unit tests for IcebergDataSource methods."""
 
     def create_mock_iceberg_table(self, has_delete_files=False, record_counts=None):
         """Create a mock Iceberg table for testing."""
@@ -129,195 +131,100 @@ class TestIcebergScanOperatorUnit:
 
         return mock_table
 
-    @patch("daft.io.iceberg.iceberg_scan.schema_to_pyarrow")
-    @patch("daft.io.iceberg.iceberg_scan.visit")
-    @patch("daft.io.iceberg.iceberg_scan.Schema.from_pyarrow_schema")
-    def test_has_delete_files_no_delete_files(self, mock_from_pyarrow, mock_visit, mock_schema_to_pyarrow):
+    def create_source(self, mock_table):
+        """Create an IcebergDataSource with schema conversion mocked out."""
+        with (
+            patch("daft.io.iceberg.iceberg_scan.visit") as mock_visit,
+            patch("daft.io.iceberg.iceberg_scan.convert_iceberg_schema") as mock_convert_schema,
+        ):
+            mock_visit.return_value = {}
+            mock_convert_schema.return_value = Schema.from_pyarrow_schema(pa.schema([pa.field("id", pa.int64())]))
+            return IcebergDataSource(mock_table, None, Mock())
+
+    def test_has_delete_files_no_delete_files(self):
         """Test _has_delete_files when there are no delete files."""
-        # Setup mocks
-        mock_schema_to_pyarrow.return_value = pa.schema([pa.field("id", pa.int64())])
-        mock_visit.return_value = {}
-        mock_from_pyarrow.return_value = Schema.from_pyarrow_schema(pa.schema([pa.field("id", pa.int64())]))
-
         mock_table = self.create_mock_iceberg_table(has_delete_files=False)
-        mock_storage_config = Mock()
+        source = self.create_source(mock_table)
 
-        operator = IcebergScanOperator(mock_table, None, mock_storage_config)
-
-        # Test the method
-        result = operator._has_delete_files()
+        result = source._has_delete_files()
         assert result is False
 
-    @patch("daft.io.iceberg.iceberg_scan.schema_to_pyarrow")
-    @patch("daft.io.iceberg.iceberg_scan.visit")
-    @patch("daft.io.iceberg.iceberg_scan.Schema.from_pyarrow_schema")
-    def test_has_delete_files_with_delete_files(self, mock_from_pyarrow, mock_visit, mock_schema_to_pyarrow):
+    def test_has_delete_files_with_delete_files(self):
         """Test _has_delete_files when there are delete files."""
-        # Setup mocks
-        mock_schema_to_pyarrow.return_value = pa.schema([pa.field("id", pa.int64())])
-        mock_visit.return_value = {}
-        mock_from_pyarrow.return_value = Schema.from_pyarrow_schema(pa.schema([pa.field("id", pa.int64())]))
-
         mock_table = self.create_mock_iceberg_table(has_delete_files=True)
-        mock_storage_config = Mock()
+        source = self.create_source(mock_table)
 
-        operator = IcebergScanOperator(mock_table, None, mock_storage_config)
-
-        # Test the method
-        result = operator._has_delete_files()
+        result = source._has_delete_files()
         assert result is True
 
-    @patch("daft.io.iceberg.iceberg_scan.schema_to_pyarrow")
-    @patch("daft.io.iceberg.iceberg_scan.visit")
-    @patch("daft.io.iceberg.iceberg_scan.Schema.from_pyarrow_schema")
-    def test_supports_count_pushdown_no_delete_files(self, mock_from_pyarrow, mock_visit, mock_schema_to_pyarrow):
+    def test_supports_count_pushdown_no_delete_files(self):
         """Test supports_count_pushdown when there are no delete files."""
-        # Setup mocks
-        mock_schema_to_pyarrow.return_value = pa.schema([pa.field("id", pa.int64())])
-        mock_visit.return_value = {}
-        mock_from_pyarrow.return_value = Schema.from_pyarrow_schema(pa.schema([pa.field("id", pa.int64())]))
-
         mock_table = self.create_mock_iceberg_table(has_delete_files=False)
-        mock_storage_config = Mock()
+        source = self.create_source(mock_table)
 
-        operator = IcebergScanOperator(mock_table, None, mock_storage_config)
-
-        # Test the method
-        result = operator.supports_count_pushdown()
+        result = source.supports_count_pushdown()
         assert result is True
 
-    @patch("daft.io.iceberg.iceberg_scan.schema_to_pyarrow")
-    @patch("daft.io.iceberg.iceberg_scan.visit")
-    @patch("daft.io.iceberg.iceberg_scan.Schema.from_pyarrow_schema")
-    def test_supports_count_pushdown_with_delete_files(self, mock_from_pyarrow, mock_visit, mock_schema_to_pyarrow):
+    def test_supports_count_pushdown_with_delete_files(self):
         """Test supports_count_pushdown when there are delete files."""
-        # Setup mocks
-        mock_schema_to_pyarrow.return_value = pa.schema([pa.field("id", pa.int64())])
-        mock_visit.return_value = {}
-        mock_from_pyarrow.return_value = Schema.from_pyarrow_schema(pa.schema([pa.field("id", pa.int64())]))
-
         mock_table = self.create_mock_iceberg_table(has_delete_files=True)
-        mock_storage_config = Mock()
+        source = self.create_source(mock_table)
 
-        operator = IcebergScanOperator(mock_table, None, mock_storage_config)
-
-        # Test the method
-        result = operator.supports_count_pushdown()
+        result = source.supports_count_pushdown()
         assert result is False
 
-    @patch("daft.io.iceberg.iceberg_scan.schema_to_pyarrow")
-    @patch("daft.io.iceberg.iceberg_scan.visit")
-    @patch("daft.io.iceberg.iceberg_scan.Schema.from_pyarrow_schema")
-    def test_supported_count_modes(self, mock_from_pyarrow, mock_visit, mock_schema_to_pyarrow):
+    def test_supported_count_modes(self):
         """Test supported_count_modes returns correct modes."""
-        # Setup mocks
-        mock_schema_to_pyarrow.return_value = pa.schema([pa.field("id", pa.int64())])
-        mock_visit.return_value = {}
-        mock_from_pyarrow.return_value = Schema.from_pyarrow_schema(pa.schema([pa.field("id", pa.int64())]))
-
         mock_table = self.create_mock_iceberg_table()
-        mock_storage_config = Mock()
+        source = self.create_source(mock_table)
 
-        operator = IcebergScanOperator(mock_table, None, mock_storage_config)
-
-        # Test the method
-        result = operator.supported_count_modes()
+        result = source.supported_count_modes()
         assert result == [CountMode.All]
 
-    @patch("daft.io.iceberg.iceberg_scan.schema_to_pyarrow")
-    @patch("daft.io.iceberg.iceberg_scan.visit")
-    @patch("daft.io.iceberg.iceberg_scan.Schema.from_pyarrow_schema")
-    def test_create_count_scan_task_basic(self, mock_from_pyarrow, mock_visit, mock_schema_to_pyarrow):
-        """Test _create_count_scan_task basic functionality."""
-        # Setup mocks
-        mock_schema_to_pyarrow.return_value = pa.schema([pa.field("id", pa.int64())])
-        mock_visit.return_value = {}
-        mock_from_pyarrow.return_value = Schema.from_pyarrow_schema(pa.schema([pa.field("id", pa.int64())]))
-
+    def test_create_count_tasks_basic(self):
+        """Test _create_count_tasks basic functionality."""
         mock_table = self.create_mock_iceberg_table()
-        mock_storage_config = Mock()
+        source = self.create_source(mock_table)
 
-        operator = IcebergScanOperator(mock_table, None, mock_storage_config)
+        mock_pushdowns = Mock(spec=Pushdowns)
 
-        # Create mock pushdowns
-        mock_pushdowns = Mock(spec=PyPushdowns)
+        results = list(source._create_count_tasks(mock_pushdowns, "count"))
 
-        # Test the method
-        with patch("daft.io.iceberg.iceberg_scan.ScanTask.python_factory_func_scan_task") as mock_scan_task:
-            mock_scan_task.return_value = Mock()
+        # Should return one count task with the total from the mock record_count
+        assert len(results) == 1
+        task = results[0]
+        assert isinstance(task, _IcebergCountTask)
+        assert task._total_count == 100
+        assert task._field_name == "count"
 
-            results = list(operator._create_count_scan_task(mock_pushdowns, "count"))
-
-            # Should return one scan task
-            assert len(results) == 1
-
-            # Verify ScanTask.python_factory_func_scan_task was called
-            mock_scan_task.assert_called_once()
-            call_args = mock_scan_task.call_args
-            assert call_args[1]["func_args"] == (100, "count")  # 100 from mock record_count
-
-    @patch("daft.io.iceberg.iceberg_scan.schema_to_pyarrow")
-    @patch("daft.io.iceberg.iceberg_scan.visit")
-    @patch("daft.io.iceberg.iceberg_scan.Schema.from_pyarrow_schema")
-    def test_create_count_scan_task_multiple_files(self, mock_from_pyarrow, mock_visit, mock_schema_to_pyarrow):
-        """Test _create_count_scan_task with multiple data files."""
-        # Setup mocks
-        mock_schema_to_pyarrow.return_value = pa.schema([pa.field("id", pa.int64())])
-        mock_visit.return_value = {}
-        mock_from_pyarrow.return_value = Schema.from_pyarrow_schema(pa.schema([pa.field("id", pa.int64())]))
-
+    def test_create_count_tasks_multiple_files(self):
+        """Test _create_count_tasks with multiple data files."""
         # Create table with multiple files having different counts
         mock_table = self.create_mock_iceberg_table(record_counts=[50, 60, 70])
-        mock_storage_config = Mock()
+        source = self.create_source(mock_table)
 
-        operator = IcebergScanOperator(mock_table, None, mock_storage_config)
+        mock_pushdowns = Mock(spec=Pushdowns)
 
-        # Create mock pushdowns
-        mock_pushdowns = Mock(spec=PyPushdowns)
+        results = list(source._create_count_tasks(mock_pushdowns, "count"))
 
-        # Test the method
-        with patch("daft.io.iceberg.iceberg_scan.ScanTask.python_factory_func_scan_task") as mock_scan_task:
-            mock_scan_task.return_value = Mock()
+        # Should return one count task whose total is the sum of all files: 50 + 60 + 70 = 180
+        assert len(results) == 1
+        assert isinstance(results[0], _IcebergCountTask)
+        assert results[0]._total_count == 180
 
-            results = list(operator._create_count_scan_task(mock_pushdowns, "count"))
-
-            # Should return one scan task
-            assert len(results) == 1
-
-            # Verify total count is sum of all files: 50 + 60 + 70 = 180
-            call_args = mock_scan_task.call_args
-            assert call_args[1]["func_args"] == (180, "count")
-
-    @patch("daft.io.iceberg.iceberg_scan.schema_to_pyarrow")
-    @patch("daft.io.iceberg.iceberg_scan.visit")
-    @patch("daft.io.iceberg.iceberg_scan.Schema.from_pyarrow_schema")
-    def test_empty_table_count_pushdown(self, mock_from_pyarrow, mock_visit, mock_schema_to_pyarrow):
+    def test_empty_table_count_pushdown(self):
         """Test count pushdown on empty table."""
-        # Setup mocks
-        mock_schema_to_pyarrow.return_value = pa.schema([pa.field("id", pa.int64())])
-        mock_visit.return_value = {}
-        mock_from_pyarrow.return_value = Schema.from_pyarrow_schema(pa.schema([pa.field("id", pa.int64())]))
-
-        # Create empty table
         mock_table = self.create_mock_iceberg_table(record_counts=[])
-        mock_storage_config = Mock()
+        source = self.create_source(mock_table)
 
-        operator = IcebergScanOperator(mock_table, None, mock_storage_config)
+        mock_pushdowns = Mock(spec=Pushdowns)
 
-        # Create mock pushdowns
-        mock_pushdowns = Mock(spec=PyPushdowns)
+        results = list(source._create_count_tasks(mock_pushdowns, "count"))
 
-        # Test the method
-        with patch("daft.io.iceberg.iceberg_scan.ScanTask.python_factory_func_scan_task") as mock_scan_task:
-            mock_scan_task.return_value = Mock()
-
-            results = list(operator._create_count_scan_task(mock_pushdowns, "count"))
-
-            # Should return one scan task with count 0
-            assert len(results) == 1
-
-            call_args = mock_scan_task.call_args
-            assert call_args[1]["func_args"] == (0, "count")  # Empty table should have count 0
+        # Should return one count task with count 0
+        assert len(results) == 1
+        assert isinstance(results[0], _IcebergCountTask)
+        assert results[0]._total_count == 0
 
     def test_iceberg_count_result_function_negative_count(self):
         """Test _iceberg_count_result_function with negative count (edge case)."""
@@ -353,70 +260,24 @@ class TestIcebergScanOperatorUnit:
         with pytest.raises(pa.ArrowTypeError, match="Invalid field definition"):
             list(_iceberg_count_result_function(total_count, field_name))
 
-    @patch("daft.io.iceberg.iceberg_scan.schema_to_pyarrow")
-    @patch("daft.io.iceberg.iceberg_scan.visit")
-    @patch("daft.io.iceberg.iceberg_scan.Schema.from_pyarrow_schema")
-    def test_large_file_count_aggregation(self, mock_from_pyarrow, mock_visit, mock_schema_to_pyarrow):
+    def test_large_file_count_aggregation(self):
         """Test count pushdown with many files having large record counts."""
-        # Setup mocks
-        mock_schema_to_pyarrow.return_value = pa.schema([pa.field("id", pa.int64())])
-        mock_visit.return_value = {}
-        mock_from_pyarrow.return_value = Schema.from_pyarrow_schema(pa.schema([pa.field("id", pa.int64())]))
-
         # Create table with many files having large counts
         large_counts = [1000000, 2000000, 3000000, 4000000, 5000000]  # 15M total
-        mock_table = Mock()
-        mock_table.name.return_value = ["test", "large_table"]
-        mock_table.schema.return_value = Mock()
-        mock_spec = Mock()
-        mock_spec.fields = []
-        mock_table.spec.return_value = mock_spec
+        mock_table = self.create_mock_iceberg_table(record_counts=large_counts)
+        source = self.create_source(mock_table)
 
-        # Create multiple mock tasks with large counts
-        mock_tasks = []
-        for i, count in enumerate(large_counts):
-            mock_task = Mock()
-            mock_file = Mock()
-            mock_file.record_count = count
-            mock_task.file = mock_file
-            mock_task.delete_files = []
-            mock_tasks.append(mock_task)
+        mock_pushdowns = Mock(spec=Pushdowns)
 
-        mock_scan = Mock()
-        mock_scan.plan_files.return_value = mock_tasks
-        mock_table.scan.return_value = mock_scan
+        results = list(source._create_count_tasks(mock_pushdowns, "count"))
 
-        mock_storage_config = Mock()
+        # Should return one count task whose total is the sum of all files: 15,000,000
+        assert len(results) == 1
+        assert isinstance(results[0], _IcebergCountTask)
+        assert results[0]._total_count == sum(large_counts)
 
-        operator = IcebergScanOperator(mock_table, None, mock_storage_config)
-
-        # Create mock pushdowns
-        mock_pushdowns = Mock(spec=PyPushdowns)
-
-        # Test the method
-        with patch("daft.io.iceberg.iceberg_scan.ScanTask.python_factory_func_scan_task") as mock_scan_task:
-            mock_scan_task.return_value = Mock()
-
-            results = list(operator._create_count_scan_task(mock_pushdowns, "count"))
-
-            # Should return one scan task
-            assert len(results) == 1
-
-            # Verify total count is sum of all files: 15,000,000
-            call_args = mock_scan_task.call_args
-            expected_total = sum(large_counts)
-            assert call_args[1]["func_args"] == (expected_total, "count")
-
-    @patch("daft.io.iceberg.iceberg_scan.schema_to_pyarrow")
-    @patch("daft.io.iceberg.iceberg_scan.visit")
-    @patch("daft.io.iceberg.iceberg_scan.Schema.from_pyarrow_schema")
-    def test_create_count_scan_task_exception_fallback(self, mock_from_pyarrow, mock_visit, mock_schema_to_pyarrow):
-        """Test _create_count_scan_task exception handling and fallback."""
-        # Setup mocks
-        mock_schema_to_pyarrow.return_value = pa.schema([pa.field("id", pa.int64())])
-        mock_visit.return_value = {}
-        mock_from_pyarrow.return_value = Schema.from_pyarrow_schema(pa.schema([pa.field("id", pa.int64())]))
-
+    def test_create_count_tasks_exception_fallback(self):
+        """Test _create_count_tasks exception handling and fallback."""
         # Create table that will fail on scan
         mock_table = Mock()
         mock_table.name.return_value = ["test", "table"]
@@ -431,32 +292,23 @@ class TestIcebergScanOperatorUnit:
         mock_table.scan.return_value = mock_scan
         mock_scan.projection.return_value = Mock()
 
-        mock_storage_config = Mock()
-        operator = IcebergScanOperator(mock_table, None, mock_storage_config)
+        source = self.create_source(mock_table)
 
         # Mock the fallback method
-        with patch.object(operator, "_create_regular_scan_tasks") as mock_fallback:
+        with patch.object(source, "_create_regular_tasks") as mock_fallback:
             mock_fallback.return_value = iter([Mock()])
 
-            mock_pushdowns = Mock(spec=PyPushdowns)
+            mock_pushdowns = Mock(spec=Pushdowns)
 
             # Test the method - should catch exception and fallback
-            results = list(operator._create_count_scan_task(mock_pushdowns, "count"))
+            results = list(source._create_count_tasks(mock_pushdowns, "count"))
 
             # Should have fallen back to regular scan
             mock_fallback.assert_called_once_with(mock_pushdowns)
             assert len(results) == 1
 
-    @patch("daft.io.iceberg.iceberg_scan.schema_to_pyarrow")
-    @patch("daft.io.iceberg.iceberg_scan.visit")
-    @patch("daft.io.iceberg.iceberg_scan.Schema.from_pyarrow_schema")
-    def test_has_delete_files_exception_handling(self, mock_from_pyarrow, mock_visit, mock_schema_to_pyarrow):
+    def test_has_delete_files_exception_handling(self):
         """Test _has_delete_files exception handling."""
-        # Setup mocks
-        mock_schema_to_pyarrow.return_value = pa.schema([pa.field("id", pa.int64())])
-        mock_visit.return_value = {}
-        mock_from_pyarrow.return_value = Schema.from_pyarrow_schema(pa.schema([pa.field("id", pa.int64())]))
-
         # Create table that will fail on scan
         mock_table = Mock()
         mock_table.name.return_value = ["test", "table"]
@@ -465,9 +317,8 @@ class TestIcebergScanOperatorUnit:
         mock_spec.fields = []
         mock_table.spec.return_value = mock_spec
 
-        mock_storage_config = Mock()
-        operator = IcebergScanOperator(mock_table, None, mock_storage_config)
+        source = self.create_source(mock_table)
 
-        result = operator._has_delete_files()
+        result = source._has_delete_files()
 
         assert result is True

--- a/tests/integration/iceberg/test_iceberg_reads.py
+++ b/tests/integration/iceberg/test_iceberg_reads.py
@@ -293,7 +293,7 @@ class TestIcebergCountPushdown:
         _ = capsys.readouterr()
         df.explain(True)
         actual = capsys.readouterr()
-        assert "daft.io.iceberg.iceberg_scan:_iceberg_count_result_function" in actual.out
+        assert "Aggregation pushdown = count(" in actual.out
 
         daft_count = df.collect().to_pydict()["count"][0]
 
@@ -322,7 +322,7 @@ class TestIcebergCountPushdown:
         _ = capsys.readouterr()
         df.explain(True)
         actual = capsys.readouterr()
-        assert "daft.io.iceberg.iceberg_scan:_iceberg_count_result_function" not in actual.out
+        assert "Aggregation pushdown" not in actual.out
 
         daft_count = df.collect().to_pydict()["count"][0]
 
@@ -344,7 +344,7 @@ class TestIcebergCountPushdown:
         _ = capsys.readouterr()
         df.explain(True)
         actual = capsys.readouterr()
-        assert "daft.io.iceberg.iceberg_scan:_iceberg_count_result_function" not in actual.out
+        assert "Aggregation pushdown" not in actual.out
 
         daft_count = df.collect().to_pydict()["count"][0]
 
@@ -367,7 +367,7 @@ class TestIcebergCountPushdown:
         _ = capsys.readouterr()
         df.explain(True)
         actual = capsys.readouterr()
-        assert "daft.io.iceberg.iceberg_scan:_iceberg_count_result_function" in actual.out
+        assert "Aggregation pushdown = count(" in actual.out
 
         daft_count = df.collect().to_pydict()["count"][0]
 
@@ -389,7 +389,7 @@ class TestIcebergCountPushdown:
         _ = capsys.readouterr()
         df.explain(True)
         actual = capsys.readouterr()
-        assert "daft.io.iceberg.iceberg_scan:_iceberg_count_result_function" not in actual.out
+        assert "Aggregation pushdown" not in actual.out
 
         # Count after limit should be at most the limit value
         assert daft_count <= 5
@@ -413,7 +413,7 @@ class TestIcebergCountPushdown:
                     _ = capsys.readouterr()
                     df.explain(True)
                     actual = capsys.readouterr()
-                    assert "daft.io.iceberg.iceberg_scan:_iceberg_count_result_function" not in actual.out
+                    assert "Aggregation pushdown" not in actual.out
 
                     daft_count = df.collect().to_pydict()["count"][0]
 


### PR DESCRIPTION
## Changes Made

* Migrated `IcebergScanOperator(ScanOperator)` to `IcebergDataSource(DataSource)`: `to_scan_tasks()` (sync iterator of `ScanTask`) becomes `async def get_tasks()` (async generator of `DataSourceTask`); `display_name()` / `schema()` / `partitioning_keys()` map to the corresponding `DataSource` interface
* Data files are read via `DataSourceTask.parquet()`, extended with an optional `iceberg_delete_files` parameter (default `None`) so positional delete files still reach the native Parquet reader for merge-on-read tables
* Kept the metadata-based count pushdown: added an optional `DataSource.supports_count_pushdown()` (default `False`, so other sources are unaffected) and forwarded it in `PyDataSourceWrapper` so the existing optimizer rule still applies; count results are produced by a small `_IcebergCountTask`
* Partition pruning now happens inside `get_tasks` using `pushdowns.partition_filters`, since the DataSource path no longer goes through `ScanTask.catalog_scan_task`
* Updated the SQL scan path (`scan_builder.rs`) to construct `IcebergDataSource` via `ScanOperatorHandle::from_data_source`, same pattern as `delta_scan`
* Updated existing unit/integration tests and connector docs to the new API; behavior is intended to be a 1-to-1 migration with no user-facing changes

Tested locally: Iceberg unit tests, and end-to-end reads against a local catalog (regular reads, partition-pruned reads, count pushdown, and the positional delete file path via a hand-built delete file, since PyIceberg 0.11.1 falls back to copy-on-write for deletes).

## Related Issues

Closes Eventual-Inc/Daft#7296