### PR TITLE
feat(file): trace media file reads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2866,6 +2866,7 @@ dependencies = [
  "mime_guess",
  "pyo3",
  "serde",
+ "tracing",
  "typetag",
  "url",
 ]

--- a/src/daft-file/Cargo.toml
+++ b/src/daft-file/Cargo.toml
@@ -12,6 +12,7 @@ common-runtime.workspace = true
 serde.workspace = true
 typetag.workspace = true
 url.workspace = true
+tracing.workspace = true
 
 [features]
 python = [

--- a/src/daft-file/src/file.rs
+++ b/src/daft-file/src/file.rs
@@ -8,6 +8,7 @@ use common_error::{DaftError, DaftResult};
 use daft_core::file::FileReference;
 use daft_io::{GetRange, IOConfig, IOStatsRef, ObjectSource};
 use daft_schema::media_type::MediaType;
+use tracing::{Instrument, Span};
 use url::Url;
 
 pub struct DaftFile {
@@ -185,18 +186,21 @@ impl ObjectSourceReader {
         let uri = self.uri.clone();
         let io_stats = self.io_stats.clone();
 
-        rt.block_within_async_context(async move {
-            let result = source
-                .get(&uri, None, io_stats)
-                .await
-                .map_err(map_get_error)?;
+        rt.block_within_async_context(
+            async move {
+                let result = source
+                    .get(&uri, None, io_stats)
+                    .await
+                    .map_err(map_get_error)?;
 
-            result
-                .bytes()
-                .await
-                .map(|b| b.to_vec())
-                .map_err(map_bytes_error)
-        })
+                result
+                    .bytes()
+                    .await
+                    .map(|b| b.to_vec())
+                    .map_err(map_bytes_error)
+            }
+            .instrument(Span::current()),
+        )
         .map_err(map_async_error)
         .flatten()
     }
@@ -233,32 +237,35 @@ impl Read for ObjectSourceReader {
         let uri = self.uri.clone();
         let io_stats = self.io_stats.clone();
         let bytes = rt
-            .block_within_async_context(async move {
-                match source.get(&uri, range, io_stats.clone()).await {
-                    Ok(result) => {
-                        let bytes = result.bytes().await.map_err(map_bytes_error)?;
-                        Ok(bytes.to_vec())
-                    }
-                    Err(e) => {
-                        let error_str = e.to_string();
-                        // Check if error suggests range requests aren't supported
-                        if error_str.contains("Requested Range Not Satisfiable")
-                            || error_str.contains("416")
-                        {
-                            // Fall back to reading the entire file
-                            let result = source
-                                .get(&uri, None, io_stats)
-                                .await
-                                .map_err(map_get_error)?;
-
+            .block_within_async_context(
+                async move {
+                    match source.get(&uri, range, io_stats.clone()).await {
+                        Ok(result) => {
                             let bytes = result.bytes().await.map_err(map_bytes_error)?;
                             Ok(bytes.to_vec())
-                        } else {
-                            Err(map_get_error(e))
+                        }
+                        Err(e) => {
+                            let error_str = e.to_string();
+                            // Check if error suggests range requests aren't supported
+                            if error_str.contains("Requested Range Not Satisfiable")
+                                || error_str.contains("416")
+                            {
+                                // Fall back to reading the entire file
+                                let result = source
+                                    .get(&uri, None, io_stats)
+                                    .await
+                                    .map_err(map_get_error)?;
+
+                                let bytes = result.bytes().await.map_err(map_bytes_error)?;
+                                Ok(bytes.to_vec())
+                            } else {
+                                Err(map_get_error(e))
+                            }
                         }
                     }
                 }
-            })
+                .instrument(Span::current()),
+            )
             .map_err(map_async_error)??;
 
         if bytes.is_empty() {

--- a/src/daft-file/src/python.rs
+++ b/src/daft-file/src/python.rs
@@ -9,10 +9,12 @@ use std::{
 
 use common_error::DaftError;
 use daft_core::file::FileReference;
+use daft_schema::media_type::MediaType;
 use pyo3::{
     exceptions::{PyIOError, PyRuntimeError, PyValueError},
     prelude::*,
 };
+use tracing::instrument;
 
 use crate::file::{DaftFile, FileCursor};
 
@@ -145,23 +147,33 @@ impl PyDaftFile {
             "File not opened inside a context manager. use `with file.open() as f:`",
         ))
     }
-}
 
-#[pymethods]
-impl PyDaftFile {
-    #[staticmethod]
-    #[pyo3(signature=(f, buffer_size=None))]
-    fn _from_file_reference(
-        py: Python<'_>,
-        f: PyFileReference,
-        buffer_size: Option<usize>,
-    ) -> PyResult<Self> {
-        let file_ref = f.inner.as_ref().clone();
-        py.detach(move || Ok(DaftFile::load_blocking(file_ref, false, buffer_size)?.into()))
+    #[instrument(skip_all, name = "File::read")]
+    fn read_file(&mut self, py: Python<'_>, size: isize) -> PyResult<Vec<u8>> {
+        self.read_impl(py, size)
     }
 
-    #[pyo3(signature=(size=-1))]
-    fn read(&mut self, py: Python<'_>, size: isize) -> PyResult<Vec<u8>> {
+    #[instrument(skip_all, name = "VideoFile::read")]
+    fn read_video(&mut self, py: Python<'_>, size: isize) -> PyResult<Vec<u8>> {
+        self.read_impl(py, size)
+    }
+
+    #[instrument(skip_all, name = "AudioFile::read")]
+    fn read_audio(&mut self, py: Python<'_>, size: isize) -> PyResult<Vec<u8>> {
+        self.read_impl(py, size)
+    }
+
+    #[instrument(skip_all, name = "ImageFile::read")]
+    fn read_image(&mut self, py: Python<'_>, size: isize) -> PyResult<Vec<u8>> {
+        self.read_impl(py, size)
+    }
+
+    #[instrument(skip_all, name = "Hdf5File::read")]
+    fn read_hdf5(&mut self, py: Python<'_>, size: isize) -> PyResult<Vec<u8>> {
+        self.read_impl(py, size)
+    }
+
+    fn read_impl(&mut self, py: Python<'_>, size: isize) -> PyResult<Vec<u8>> {
         self.check_context()?;
         let mut cursor = self
             .inner
@@ -210,6 +222,31 @@ impl PyDaftFile {
                 self.inner.cursor = Some(cursor_back);
                 Err(e)
             }
+        }
+    }
+}
+
+#[pymethods]
+impl PyDaftFile {
+    #[staticmethod]
+    #[pyo3(signature=(f, buffer_size=None))]
+    fn _from_file_reference(
+        py: Python<'_>,
+        f: PyFileReference,
+        buffer_size: Option<usize>,
+    ) -> PyResult<Self> {
+        let file_ref = f.inner.as_ref().clone();
+        py.detach(move || Ok(DaftFile::load_blocking(file_ref, false, buffer_size)?.into()))
+    }
+
+    #[pyo3(signature=(size=-1))]
+    fn read(&mut self, py: Python<'_>, size: isize) -> PyResult<Vec<u8>> {
+        match self.inner.media_type {
+            MediaType::Unknown => self.read_file(py, size),
+            MediaType::Video => self.read_video(py, size),
+            MediaType::Audio => self.read_audio(py, size),
+            MediaType::Image => self.read_image(py, size),
+            MediaType::Hdf5 => self.read_hdf5(py, size),
         }
     }
 

--- a/tests/test_trace_to_speedscope.py
+++ b/tests/test_trace_to_speedscope.py
@@ -8,22 +8,55 @@ import pytest
 from tools.trace_to_speedscope import SPEEDSCOPE_SCHEMA, TraceConversionError, convert_file, convert_records, main
 
 
-def span_event(timestamp: str, message: str, name: str, ancestors: list[str] | None = None) -> dict:
+def span_event(
+    timestamp: str,
+    message: str,
+    name: str,
+    ancestors: list[str] | None = None,
+    *,
+    include_current_span: bool = False,
+) -> dict:
+    spans = [*ancestors] if ancestors is not None else []
+    if include_current_span:
+        spans.append(name)
     return {
         "timestamp": timestamp,
         "fields": {"message": message},
         "span": {"name": name},
-        "spans": [{"name": ancestor} for ancestor in ancestors or []],
+        "spans": [{"name": ancestor} for ancestor in spans],
     }
 
 
-def test_convert_nested_span_events():
+@pytest.mark.parametrize("include_current_span", [False, True])
+def test_convert_nested_span_events(include_current_span: bool):
     records = [
         {"timestamp": "2026-01-01T00:00:00Z", "fields": {"message": "ordinary log"}},
-        span_event("2026-01-01T00:00:01.000000Z", "new", "VideoFile::frames"),
-        span_event("2026-01-01T00:00:01.000250Z", "new", "VideoFile::read", ["VideoFile::frames"]),
-        span_event("2026-01-01T00:00:01.000750Z", "close", "VideoFile::read", ["VideoFile::frames"]),
-        span_event("2026-01-01T00:00:01.001000Z", "close", "VideoFile::frames"),
+        span_event(
+            "2026-01-01T00:00:01.000000Z",
+            "new",
+            "VideoFile::frames",
+            include_current_span=include_current_span,
+        ),
+        span_event(
+            "2026-01-01T00:00:01.000250Z",
+            "new",
+            "VideoFile::read",
+            ["VideoFile::frames"],
+            include_current_span=include_current_span,
+        ),
+        span_event(
+            "2026-01-01T00:00:01.000750Z",
+            "close",
+            "VideoFile::read",
+            ["VideoFile::frames"],
+            include_current_span=include_current_span,
+        ),
+        span_event(
+            "2026-01-01T00:00:01.001000Z",
+            "close",
+            "VideoFile::frames",
+            include_current_span=include_current_span,
+        ),
     ]
 
     output = convert_records(records, "video trace")

--- a/tests/test_trace_to_speedscope.py
+++ b/tests/test_trace_to_speedscope.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.trace_to_speedscope import SPEEDSCOPE_SCHEMA, TraceConversionError, convert_file, convert_records, main
+
+
+def span_event(timestamp: str, message: str, name: str, ancestors: list[str] | None = None) -> dict:
+    return {
+        "timestamp": timestamp,
+        "fields": {"message": message},
+        "span": {"name": name},
+        "spans": [{"name": ancestor} for ancestor in ancestors or []],
+    }
+
+
+def test_convert_nested_span_events():
+    records = [
+        {"timestamp": "2026-01-01T00:00:00Z", "fields": {"message": "ordinary log"}},
+        span_event("2026-01-01T00:00:01.000000Z", "new", "VideoFile::frames"),
+        span_event("2026-01-01T00:00:01.000250Z", "new", "VideoFile::read", ["VideoFile::frames"]),
+        span_event("2026-01-01T00:00:01.000750Z", "close", "VideoFile::read", ["VideoFile::frames"]),
+        span_event("2026-01-01T00:00:01.001000Z", "close", "VideoFile::frames"),
+    ]
+
+    output = convert_records(records, "video trace")
+
+    assert output["$schema"] == SPEEDSCOPE_SCHEMA
+    assert output["shared"]["frames"] == [{"name": "VideoFile::frames"}, {"name": "VideoFile::read"}]
+    profile = output["profiles"][0]
+    assert profile["name"] == "video trace"
+    assert profile["unit"] == "microseconds"
+    assert profile["startValue"] == 0
+    assert profile["endValue"] == 1000
+    assert profile["events"] == [
+        {"type": "O", "at": 0, "frame": 0},
+        {"type": "O", "at": 250, "frame": 1},
+        {"type": "C", "at": 750, "frame": 1},
+        {"type": "C", "at": 1000, "frame": 0},
+    ]
+
+
+def test_rejects_non_nested_span_events():
+    records = [
+        span_event("2026-01-01T00:00:00Z", "new", "outer"),
+        span_event("2026-01-01T00:00:00.001000Z", "new", "concurrent"),
+    ]
+
+    with pytest.raises(TraceConversionError, match="may contain concurrent spans"):
+        convert_records(records, "invalid")
+
+
+def test_rejects_unclosed_spans():
+    records = [span_event("2026-01-01T00:00:00Z", "new", "File::read")]
+
+    with pytest.raises(TraceConversionError, match="unclosed spans"):
+        convert_records(records, "invalid")
+
+
+def test_convert_file_and_cli_default_output(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+    source = tmp_path / "file-read.trace.jsonl"
+    source.write_text(
+        "\n".join(
+            json.dumps(record)
+            for record in [
+                span_event("2026-01-01T00:00:00Z", "new", "File::read"),
+                span_event("2026-01-01T00:00:00.001000Z", "close", "File::read"),
+            ]
+        )
+    )
+
+    destination = tmp_path / "explicit.speedscope.json"
+    convert_file(source, destination, "explicit")
+    assert json.loads(destination.read_text())["name"] == "explicit"
+
+    assert main([str(source), "--name", "CLI profile"]) == 0
+    default_output = source.with_suffix(".speedscope.json")
+    assert capsys.readouterr().out.strip() == str(default_output)
+    assert json.loads(default_output.read_text())["name"] == "CLI profile"

--- a/tools/trace_to_speedscope.py
+++ b/tools/trace_to_speedscope.py
@@ -109,6 +109,8 @@ def convert_records(records: list[dict[str, Any]], profile_name: str) -> dict[st
             start = timestamp
 
         if message == "new":
+            if ancestors != stack and ancestors == [*stack, name]:
+                ancestors.pop()
             if ancestors != stack:
                 raise TraceConversionError(
                     f"Span event {span_event_number} opens {name!r} beneath {ancestors!r}, "
@@ -117,6 +119,9 @@ def convert_records(records: list[dict[str, Any]], profile_name: str) -> dict[st
             stack.append(name)
             event_type = "O"
         else:
+            expected_ancestors = stack[:-1]
+            if ancestors != expected_ancestors and ancestors == [*expected_ancestors, name]:
+                ancestors.pop()
             if not stack or stack[-1] != name or ancestors != stack[:-1]:
                 raise TraceConversionError(
                     f"Span event {span_event_number} closes {name!r} beneath {ancestors!r}, "

--- a/tools/trace_to_speedscope.py
+++ b/tools/trace_to_speedscope.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Convert Daft JSON tracing span events into a SpeedScope evented profile.
+
+Capture a trace with Daft's JSON formatter, then run this utility:
+
+    DAFT_TRACE=info DAFT_TRACE_FORMAT=json python workload.py 2> trace.jsonl
+    python tools/trace_to_speedscope.py trace.jsonl
+
+The output can be opened at https://www.speedscope.app. The converter ignores
+ordinary JSON log records, but requires span ``new`` and ``close`` events to be
+properly nested. A trace containing interleaved concurrent spans cannot be
+converted because Daft's JSON formatter does not currently include span IDs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+SPEEDSCOPE_SCHEMA = "https://www.speedscope.app/file-format-schema.json"
+
+
+class TraceConversionError(ValueError):
+    """Raised when tracing records cannot form a valid SpeedScope profile."""
+
+
+def _parse_timestamp(value: Any, event_number: int) -> datetime:
+    if not isinstance(value, str):
+        raise TraceConversionError(f"Span event {event_number} has no string timestamp")
+
+    try:
+        timestamp = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise TraceConversionError(f"Span event {event_number} has invalid timestamp {value!r}") from error
+
+    if timestamp.tzinfo is None:
+        raise TraceConversionError(f"Span event {event_number} has a timestamp without a UTC offset")
+    return timestamp
+
+
+def _extract_span_event(record: dict[str, Any]) -> tuple[str, str, list[str]] | None:
+    fields = record.get("fields")
+    span = record.get("span")
+    if not isinstance(fields, dict) or not isinstance(span, dict):
+        return None
+
+    message = fields.get("message")
+    name = span.get("name")
+    if message not in {"new", "close"} or not isinstance(name, str):
+        return None
+
+    raw_ancestors = record.get("spans", [])
+    if not isinstance(raw_ancestors, list):
+        raise TraceConversionError(f"Span {name!r} has a non-list ancestor field")
+
+    ancestors: list[str] = []
+    for ancestor in raw_ancestors:
+        if not isinstance(ancestor, dict) or not isinstance(ancestor.get("name"), str):
+            raise TraceConversionError(f"Span {name!r} has an invalid ancestor entry")
+        ancestors.append(ancestor["name"])
+
+    return message, name, ancestors
+
+
+def load_json_lines(path: Path) -> list[dict[str, Any]]:
+    """Load JSON objects from a newline-delimited trace file."""
+    records: list[dict[str, Any]] = []
+    with path.open() as trace_file:
+        for line_number, line in enumerate(trace_file, 1):
+            if not line.strip():
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError as error:
+                raise TraceConversionError(f"{path}:{line_number}: invalid JSON: {error.msg}") from error
+            if not isinstance(record, dict):
+                raise TraceConversionError(f"{path}:{line_number}: expected a JSON object")
+            records.append(record)
+    return records
+
+
+def convert_records(records: list[dict[str, Any]], profile_name: str) -> dict[str, Any]:
+    """Convert Daft tracing records into a SpeedScope file-format object."""
+    frame_names: list[str] = []
+    frame_indexes: dict[str, int] = {}
+    events: list[dict[str, int | float | str]] = []
+    stack: list[str] = []
+    start: datetime | None = None
+    previous_timestamp: datetime | None = None
+    span_event_number = 0
+
+    for record in records:
+        extracted = _extract_span_event(record)
+        if extracted is None:
+            continue
+
+        span_event_number += 1
+        message, name, ancestors = extracted
+        timestamp = _parse_timestamp(record.get("timestamp"), span_event_number)
+
+        if previous_timestamp is not None and timestamp < previous_timestamp:
+            raise TraceConversionError(f"Span event {span_event_number} is earlier than the preceding event")
+        previous_timestamp = timestamp
+        if start is None:
+            start = timestamp
+
+        if message == "new":
+            if ancestors != stack:
+                raise TraceConversionError(
+                    f"Span event {span_event_number} opens {name!r} beneath {ancestors!r}, "
+                    f"but the active stack is {stack!r}. The trace may contain concurrent spans."
+                )
+            stack.append(name)
+            event_type = "O"
+        else:
+            if not stack or stack[-1] != name or ancestors != stack[:-1]:
+                raise TraceConversionError(
+                    f"Span event {span_event_number} closes {name!r} beneath {ancestors!r}, "
+                    f"but the active stack is {stack!r}. The trace may contain concurrent spans."
+                )
+            stack.pop()
+            event_type = "C"
+
+        if name not in frame_indexes:
+            frame_indexes[name] = len(frame_names)
+            frame_names.append(name)
+
+        events.append(
+            {
+                "type": event_type,
+                "at": (timestamp - start).total_seconds() * 1_000_000,
+                "frame": frame_indexes[name],
+            }
+        )
+
+    if not events:
+        raise TraceConversionError("Trace contains no span lifecycle events")
+    if stack:
+        raise TraceConversionError(f"Trace ended with unclosed spans: {stack!r}")
+
+    end_value = float(events[-1]["at"])
+    return {
+        "$schema": SPEEDSCOPE_SCHEMA,
+        "name": profile_name,
+        "activeProfileIndex": 0,
+        "exporter": "Daft JSON tracing to SpeedScope",
+        "shared": {"frames": [{"name": name} for name in frame_names]},
+        "profiles": [
+            {
+                "type": "evented",
+                "name": profile_name,
+                "unit": "microseconds",
+                "startValue": 0,
+                "endValue": end_value,
+                "events": events,
+            }
+        ],
+    }
+
+
+def convert_file(source: Path, destination: Path, profile_name: str) -> None:
+    """Convert a Daft JSONL trace file and write a SpeedScope JSON file."""
+    profile = convert_records(load_json_lines(source), profile_name)
+    destination.write_text(json.dumps(profile, indent=2) + "\n")
+
+
+def _default_output_path(source: Path) -> Path:
+    return source.with_suffix(".speedscope.json")
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Convert TRACE.jsonl to TRACE.speedscope.json from the command line."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("trace", type=Path, help="Daft newline-delimited JSON trace")
+    parser.add_argument("-o", "--output", type=Path, help="Output path (default: TRACE.speedscope.json)")
+    parser.add_argument("--name", help="Profile name shown in SpeedScope")
+    args = parser.parse_args(argv)
+
+    output = args.output or _default_output_path(args.trace)
+    profile_name = args.name or args.trace.stem
+    try:
+        convert_file(args.trace, output, profile_name)
+    except (OSError, TraceConversionError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+
+    print(output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Changes Made

- Add stable `File::read`, `VideoFile::read`, `AudioFile::read`, `ImageFile::read`, and `Hdf5File::read` tracing spans at the shared Python file-read boundary.
- Propagate the current tracing span into blocking object-store I/O futures so context survives runtime boundaries and reaches Daft's existing OpenTelemetry integration.
- Add `tools/trace_to_speedscope.py` to convert `DAFT_TRACE_FORMAT=json` span lifecycle logs into validated SpeedScope evented profiles, with a short command-line usage docstring.
- Add focused converter tests.

This makes media and file I/O visible in Daft traces and OTLP exports while providing a local visualization workflow.

Validation:

- `cargo fmt --check`
- `cargo check -p daft-file --features python`
- `make build`
- Ruff lint and formatting checks
- 151 focused file and converter tests

## Related Issues

N/A