### PR TITLE
feat(file): trace video frame decoding

### DIFF
--- a/daft/daft/__init__.pyi
+++ b/daft/daft/__init__.pyi
@@ -2,6 +2,7 @@ import builtins
 import datetime
 from collections.abc import AsyncIterator, Callable
 from enum import Enum
+from types import TracebackType
 from typing import TYPE_CHECKING, Any, Concatenate, Literal, TypeVar
 
 from daft.dataframe.display import MermaidOptions
@@ -2940,6 +2941,27 @@ class PyScalarFunction:
 
 def get_function_from_registry(name: str) -> PyScalarFunction: ...
 def to_from_proto(builder: LogicalPlanBuilder) -> LogicalPlanBuilder: ...
+
+class _PyFileTracingSpan:
+    @staticmethod
+    def is_enabled() -> bool: ...
+    @staticmethod
+    def video_frames() -> _PyFileTracingSpan: ...
+    @staticmethod
+    def video_open() -> _PyFileTracingSpan: ...
+    @staticmethod
+    def video_seek() -> _PyFileTracingSpan: ...
+    @staticmethod
+    def video_decode() -> _PyFileTracingSpan: ...
+    @staticmethod
+    def video_to_image() -> _PyFileTracingSpan: ...
+    def __enter__(self) -> None: ...
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None: ...
 
 class PyFileReference:
     @staticmethod

--- a/daft/file/video.py
+++ b/daft/file/video.py
@@ -139,17 +139,34 @@ class VideoFile(File):
             VideoFrameData dicts with keys: frame_index, frame_time, frame_time_base,
             frame_pts, frame_dts, frame_duration, is_key_frame, data (PIL Image).
         """
-        tracing_span = _PyFileTracingSpan.video_frames() if _FILE_TRACING_ENABLED else nullcontext()
-        with tracing_span:
-            yield from self._frames(
-                start_time=start_time,
-                end_time=end_time,
-                width=width,
-                height=height,
-                is_key_frame=is_key_frame,
-                sample_interval_seconds=sample_interval_seconds,
-                buffer_size=buffer_size,
-            )
+        frames = self._frames(
+            start_time=start_time,
+            end_time=end_time,
+            width=width,
+            height=height,
+            is_key_frame=is_key_frame,
+            sample_interval_seconds=sample_interval_seconds,
+            buffer_size=buffer_size,
+        )
+        if not _FILE_TRACING_ENABLED:
+            yield from frames
+            return
+
+        try:
+            while True:
+                try:
+                    # A generator must not retain an entered tracing span while it
+                    # is suspended in caller code. Enter a short-lived span only
+                    # while advancing the underlying iterator.
+                    with _PyFileTracingSpan.video_frames():
+                        frame = next(frames)
+                except StopIteration:
+                    return
+                yield frame
+        finally:
+            close = getattr(frames, "close", None)
+            if close is not None:
+                close()
 
     def _frames(
         self,
@@ -171,8 +188,7 @@ class VideoFile(File):
             raise ValueError("sample_interval_seconds must be positive if provided")
 
         with ExitStack() as stack:
-            tracing_span = _PyFileTracingSpan.video_open() if _FILE_TRACING_ENABLED else nullcontext()
-            with tracing_span:
+            with _PyFileTracingSpan.video_open() if _FILE_TRACING_ENABLED else nullcontext():
                 f = stack.enter_context(self.open(buffer_size=buffer_size))
                 container = stack.enter_context(av.open(f))
 
@@ -189,8 +205,7 @@ class VideoFile(File):
             # Seek to start time
             if start_time > 0 and video.time_base:
                 seek_timestamp = int(start_time / float(video.time_base))
-                tracing_span = _PyFileTracingSpan.video_seek() if _FILE_TRACING_ENABLED else nullcontext()
-                with tracing_span:
+                with _PyFileTracingSpan.video_seek() if _FILE_TRACING_ENABLED else nullcontext():
                     container.seek(seek_timestamp, stream=video)
 
             time_base = float(video.time_base) if video.time_base else None

--- a/daft/file/video.py
+++ b/daft/file/video.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
+from contextlib import ExitStack, nullcontext
 from typing import TYPE_CHECKING
 
+from daft.daft import _PyFileTracingSpan
 from daft.datatype import MediaType
 from daft.dependencies import av, pil_image
 from daft.file import File
 from daft.file.file import BUFFER_COPY, BUFFER_METADATA
 from daft.file.typing import VideoFrameData, VideoMetadata
+
+_FILE_TRACING_ENABLED = _PyFileTracingSpan.is_enabled()
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -135,6 +139,28 @@ class VideoFile(File):
             VideoFrameData dicts with keys: frame_index, frame_time, frame_time_base,
             frame_pts, frame_dts, frame_duration, is_key_frame, data (PIL Image).
         """
+        tracing_span = _PyFileTracingSpan.video_frames() if _FILE_TRACING_ENABLED else nullcontext()
+        with tracing_span:
+            yield from self._frames(
+                start_time=start_time,
+                end_time=end_time,
+                width=width,
+                height=height,
+                is_key_frame=is_key_frame,
+                sample_interval_seconds=sample_interval_seconds,
+                buffer_size=buffer_size,
+            )
+
+    def _frames(
+        self,
+        start_time: float,
+        end_time: float | None,
+        width: int | None,
+        height: int | None,
+        is_key_frame: bool | None,
+        sample_interval_seconds: float | None,
+        buffer_size: int,
+    ) -> Iterator[VideoFrameData]:
         if not pil_image.module_available():
             raise ImportError(
                 "The 'pillow' module is required for frame decoding. Install it with `pip install daft[video]`."
@@ -143,7 +169,13 @@ class VideoFile(File):
             raise ValueError("Both width and height must be specified together for resizing.")
         if sample_interval_seconds is not None and sample_interval_seconds <= 0:
             raise ValueError("sample_interval_seconds must be positive if provided")
-        with self.open(buffer_size=buffer_size) as f, av.open(f) as container:
+
+        with ExitStack() as stack:
+            tracing_span = _PyFileTracingSpan.video_open() if _FILE_TRACING_ENABLED else nullcontext()
+            with tracing_span:
+                f = stack.enter_context(self.open(buffer_size=buffer_size))
+                container = stack.enter_context(av.open(f))
+
             video = next(
                 (stream for stream in container.streams if stream.type == "video"),
                 None,
@@ -157,7 +189,9 @@ class VideoFile(File):
             # Seek to start time
             if start_time > 0 and video.time_base:
                 seek_timestamp = int(start_time / float(video.time_base))
-                container.seek(seek_timestamp, stream=video)
+                tracing_span = _PyFileTracingSpan.video_seek() if _FILE_TRACING_ENABLED else nullcontext()
+                with tracing_span:
+                    container.seek(seek_timestamp, stream=video)
 
             time_base = float(video.time_base) if video.time_base else None
             fps = float(video.average_rate) if video.average_rate else None
@@ -172,7 +206,17 @@ class VideoFile(File):
             epsilon: float = 1e-9 if sample_interval_seconds is None else max(1e-9, sample_interval_seconds * 1e-6)
 
             frame_index: int = 0
-            for frame in container.decode(video):
+            decoded_frames = iter(container.decode(video))
+            while True:
+                try:
+                    if _FILE_TRACING_ENABLED:
+                        with _PyFileTracingSpan.video_decode():
+                            frame = next(decoded_frames)
+                    else:
+                        frame = next(decoded_frames)
+                except StopIteration:
+                    break
+
                 # Skip frames before start_time (seek may land earlier)
                 if frame.time is not None and frame.time < start_time:
                     frame_index += 1
@@ -210,6 +254,12 @@ class VideoFile(File):
                 if frame.pts is not None and time_base is not None and fps is not None:
                     current_frame_index = int(round((frame.pts - start_pts) * time_base * fps))
 
+                if _FILE_TRACING_ENABLED:
+                    with _PyFileTracingSpan.video_to_image():
+                        image = output_frame.to_image()
+                else:
+                    image = output_frame.to_image()
+
                 yield VideoFrameData(
                     frame_index=current_frame_index,
                     frame_time=frame.time,
@@ -218,7 +268,7 @@ class VideoFile(File):
                     frame_dts=frame.dts,
                     frame_duration=frame.duration,
                     is_key_frame=frame.key_frame,
-                    data=output_frame.to_image(),
+                    data=image,
                 )
 
                 frame_index += 1

--- a/src/daft-file/src/python.rs
+++ b/src/daft-file/src/python.rs
@@ -14,12 +14,77 @@ use pyo3::{
     exceptions::{PyIOError, PyRuntimeError, PyValueError},
     prelude::*,
 };
-use tracing::instrument;
+use tracing::{Span, instrument};
 
 use crate::file::{DaftFile, FileCursor};
 
 type ReadResult = Result<(Vec<u8>, usize, bool, FileCursor), (PyErr, FileCursor)>;
 type SeekResult = Result<(u64, FileCursor), (PyErr, FileCursor)>;
+
+#[pyclass(name = "_PyFileTracingSpan", unsendable)]
+struct PyFileTracingSpan {
+    span: Option<Span>,
+    entered: Option<tracing::span::EnteredSpan>,
+}
+
+impl PyFileTracingSpan {
+    fn new(span: Span) -> Self {
+        Self {
+            span: Some(span),
+            entered: None,
+        }
+    }
+}
+
+#[pymethods]
+impl PyFileTracingSpan {
+    #[staticmethod]
+    fn is_enabled() -> bool {
+        tracing::enabled!(tracing::Level::INFO)
+    }
+
+    #[staticmethod]
+    fn video_frames() -> Self {
+        Self::new(tracing::info_span!("VideoFile::frames"))
+    }
+
+    #[staticmethod]
+    fn video_open() -> Self {
+        Self::new(tracing::info_span!("VideoFile::open"))
+    }
+
+    #[staticmethod]
+    fn video_seek() -> Self {
+        Self::new(tracing::info_span!("VideoFile::seek"))
+    }
+
+    #[staticmethod]
+    fn video_decode() -> Self {
+        Self::new(tracing::info_span!("VideoFile::decode"))
+    }
+
+    #[staticmethod]
+    fn video_to_image() -> Self {
+        Self::new(tracing::info_span!("VideoFile::to_image"))
+    }
+
+    fn __enter__(&mut self) -> PyResult<()> {
+        let span = self.span.take().ok_or_else(|| {
+            PyRuntimeError::new_err("Tracing span cannot be entered more than once")
+        })?;
+        self.entered = Some(span.entered());
+        Ok(())
+    }
+
+    fn __exit__(
+        &mut self,
+        _exc_type: Option<Py<PyAny>>,
+        _exc_value: Option<Py<PyAny>>,
+        _traceback: Option<Py<PyAny>>,
+    ) {
+        self.entered.take();
+    }
+}
 
 #[pyclass(from_py_object)]
 #[derive(Clone)]
@@ -372,6 +437,7 @@ fn guess_mimetype_from_content(mut bytes: Vec<u8>) -> PyResult<Option<String>> {
 pub fn register_modules(parent: &Bound<PyModule>) -> PyResult<()> {
     parent.add_class::<PyDaftFile>()?;
     parent.add_class::<PyFileReference>()?;
+    parent.add_class::<PyFileTracingSpan>()?;
     parent.add_function(wrap_pyfunction!(guess_mimetype_from_content, parent)?)?;
 
     Ok(())

--- a/tests/file/test_video.py
+++ b/tests/file/test_video.py
@@ -181,6 +181,47 @@ def test_frames_standalone(sample_video_path):
     assert first["data"].size == (192, 144)
 
 
+def test_frames_exits_tracing_span_before_yield(sample_video_path, monkeypatch):
+    """Caller work between frames must not inherit the VideoFile::frames span."""
+    import daft.file.video as video_module
+
+    events: list[str] = []
+
+    class FakeTracingSpan:
+        def __enter__(self):
+            events.append("enter")
+
+        def __exit__(self, _exc_type, _exc_value, _traceback):
+            events.append("exit")
+
+    class FakeFileTracing:
+        @staticmethod
+        def video_frames():
+            return FakeTracingSpan()
+
+    def fake_frames(*_args, **_kwargs):
+        try:
+            yield {"frame_index": 0}
+            yield {"frame_index": 1}
+        finally:
+            events.append("inner_close")
+
+    monkeypatch.setattr(video_module, "_FILE_TRACING_ENABLED", True)
+    monkeypatch.setattr(video_module, "_PyFileTracingSpan", FakeFileTracing)
+    monkeypatch.setattr(video_module.VideoFile, "_frames", fake_frames)
+
+    frames = daft.VideoFile(sample_video_path).frames()
+    assert next(frames)["frame_index"] == 0
+    assert events == ["enter", "exit"]
+
+    events.append("caller")
+    assert next(frames)["frame_index"] == 1
+    assert events == ["enter", "exit", "caller", "enter", "exit"]
+
+    frames.close()
+    assert events == ["enter", "exit", "caller", "enter", "exit", "inner_close"]
+
+
 def test_frames_with_resize(sample_video_path):
     """VideoFile.frames() resizes frames when width/height are given."""
     file = daft.VideoFile(sample_video_path)


### PR DESCRIPTION
## Changes Made

- Add a private Rust-backed Python tracing context manager so Python/PyAV operations emit spans through Daft's existing tracing subscriber and OpenTelemetry exporter.
- Add `VideoFile::frames`, `VideoFile::open`, `VideoFile::seek`, `VideoFile::decode`, and `VideoFile::to_image` spans around the corresponding work.
- Avoid Python-to-Rust tracing context allocation when INFO tracing is disabled.
- Stack this follow-up on #7312, which provides the per-type read spans and SpeedScope conversion utility.

Together with #7312, this exposes the full VideoFile read, demux, decode, and image-conversion path. The generated SpeedScope profile contains all six expected VideoFile operations across 626 events.

Validation:

- `cargo fmt --check`
- `cargo check -p daft-file --features python`
- `make build`
- `DAFT_RUNNER=native .venv/bin/pytest -q tests/file/test_video.py` (33 passed)
- Converted the detailed JSON trace with `tools/trace_to_speedscope.py`

## Related Issues

N/A