### PR TITLE
test(ai): mock beta chat completions parse

### DIFF
--- a/tests/ai/openai/test_openai_prompter.py
+++ b/tests/ai/openai/test_openai_prompter.py
@@ -490,7 +490,7 @@ def test_openai_request_does_not_receive_udf_options(use_chat_completions, struc
             message = Mock()
             if structured:
                 message.parsed = SimpleResponse(answer="Yes", confidence=0.95)
-                request = mock_client.chat.completions.parse
+                request = mock_client.beta.chat.completions.parse
             else:
                 message.content = "Yes"
                 request = mock_client.chat.completions.create


### PR DESCRIPTION
## Changes Made

- Update the parametrized OpenAI prompter test to mock the beta namespace used by the structured chat-completions path.
- Restore the unit-test matrix after #6995 changed the production request route.

## Related Issues

- Follow-up to #6995

## Validation

- DAFT_RUNNER=native pytest tests/ai/openai/test_openai_prompter.py::test_openai_request_does_not_receive_udf_options (4 passed)