### PR TITLE
refactor(io): migrate Hudi scans to DataSource

### DIFF
--- a/daft/io/hudi/_hudi.py
+++ b/daft/io/hudi/_hudi.py
@@ -47,16 +47,16 @@ def read_hudi(
         >>> df = daft.read_hudi("s3://bucket/path/to/hudi_table/", io_config=io_config)
         >>> df.show()
     """
-    from daft.io.hudi.hudi_scan import HudiScanOperator
+    from daft.io.hudi.hudi_scan import HudiDataSource
 
     io_config = context.get_context().daft_planning_config.default_io_config if io_config is None else io_config
 
     multithreaded_io = runners.get_or_create_runner().name != "ray"
     storage_config = StorageConfig(multithreaded_io, io_config)
 
-    hudi_operator = HudiScanOperator(table_uri, storage_config=storage_config)
+    hudi_source = HudiDataSource(table_uri, storage_config=storage_config)
 
-    handle = ScanOperatorHandle.from_python_scan_operator(hudi_operator)
+    handle = ScanOperatorHandle.from_data_source(hudi_source)
     builder = LogicalPlanBuilder.from_tabular_scan(scan_operator=handle)
     builder = attach_checkpoint(builder, checkpoint)
     return DataFrame(builder)

--- a/daft/io/hudi/hudi_scan.py
+++ b/daft/io/hudi/hudi_scan.py
@@ -4,66 +4,59 @@ import logging
 from typing import TYPE_CHECKING
 
 import daft
-from daft.daft import FileFormatConfig, ParquetSourceConfig, PyPartitionField, PyPushdowns, ScanTask, StorageConfig
+from daft.expressions import ExpressionsProjection
 from daft.filesystem import _resolve_paths_and_filesystem, join_path
 from daft.io.hudi.pyhudi.table import HUDI_METAFIELD_PARTITION_PATH, HudiTable, HudiTableMetadata
-from daft.io.scan import ScanOperator
+from daft.io.partitioning import PartitionField
+from daft.io.source import DataSource, DataSourceTask
 from daft.logical.schema import Schema
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import AsyncIterator
+
+    from daft.daft import StorageConfig
+    from daft.io.pushdowns import Pushdowns
 
 logger = logging.getLogger(__name__)
 
 
-class HudiScanOperator(ScanOperator):
+class HudiDataSource(DataSource):
     def __init__(self, table_uri: str, storage_config: StorageConfig) -> None:
-        super().__init__()
         resolved_path, self._resolved_fs = _resolve_paths_and_filesystem(table_uri, storage_config.io_config)
         self._table = HudiTable(table_uri, self._resolved_fs, resolved_path[0])
         self._storage_config = storage_config
         self._schema = Schema.from_pyarrow_schema(self._table.schema)
         partition_fields = set(self._table.props.partition_fields)
-        self._partition_keys = [
-            PyPartitionField(field._field) for field in self._schema if field.name in partition_fields
+        self._partition_fields = [
+            PartitionField.create(field) for field in self._schema if field.name in partition_fields
         ]
 
+    @property
+    def name(self) -> str:
+        return f"HudiDataSource({self._table.props.name})"
+
+    @property
     def schema(self) -> Schema:
         return self._schema
 
-    def name(self) -> str:
-        return "HudiScanOperator"
+    def get_partition_fields(self) -> list[PartitionField]:
+        return self._partition_fields
 
-    def display_name(self) -> str:
-        return f"HudiScanOperator({self._table.props.name})"
-
-    def partitioning_keys(self) -> list[PyPartitionField]:
-        return self._partition_keys
-
-    def multiline_display(self) -> list[str]:
-        return [
-            self.display_name(),
-            f"Schema = {self._schema}",
-            f"Partitioning keys = {self.partitioning_keys()}",
-            f"Storage config = {self._storage_config}",
-        ]
-
-    def to_scan_tasks(self, pushdowns: PyPushdowns) -> Iterator[ScanTask]:
+    async def get_tasks(self, pushdowns: Pushdowns) -> AsyncIterator[DataSourceTask]:
         import pyarrow as pa
 
         hudi_table_metadata: HudiTableMetadata = self._table.latest_table_metadata()
         files_metadata = hudi_table_metadata.files_metadata
 
-        if len(self.partitioning_keys()) > 0 and pushdowns.partition_filters is None:
+        if self._partition_fields and pushdowns.partition_filters is None:
             logger.warning(
                 "%s has partitioning keys = %s, but no partition filter was specified. This will result in a full table scan.",
-                self.display_name(),
-                self.partitioning_keys(),
+                self.name,
+                self._partition_fields,
             )
 
         limit_files = pushdowns.limit is not None and pushdowns.filters is None and pushdowns.partition_filters is None
         rows_left = pushdowns.limit if pushdowns.limit is not None else 0
-        scan_tasks = []
         for task_idx in range(files_metadata.num_rows):
             if limit_files and rows_left <= 0:
                 break
@@ -74,7 +67,6 @@ class HudiScanOperator(ScanOperator):
                 size_bytes = files_metadata["size_bytes"][task_idx].as_py()
             except KeyError:
                 size_bytes = None
-            file_format_config = FileFormatConfig.from_parquet_config(ParquetSourceConfig())
 
             if self._table.supports_partition_values:
                 try:
@@ -85,9 +77,16 @@ class HudiScanOperator(ScanOperator):
                 partition_paths = {
                     HUDI_METAFIELD_PARTITION_PATH: daft.Series.from_arrow(arrow_arr, HUDI_METAFIELD_PARTITION_PATH),
                 }
-                partition_values = daft.recordbatch.RecordBatch.from_pydict(partition_paths)._recordbatch
+                partition_values = daft.recordbatch.RecordBatch.from_pydict(partition_paths)
             else:
                 partition_values = None
+
+            # Partition pruning is the DataSource's responsibility: skip files whose
+            # partition values do not match the pushed-down partition filters.
+            if partition_values is not None and pushdowns.partition_filters is not None:
+                filtered = partition_values.filter(ExpressionsProjection([pushdowns.partition_filters]))
+                if len(filtered) == 0:
+                    continue
 
             # Populate scan task with column-wise stats.
             # TODO: nested fields are skipped
@@ -109,31 +108,17 @@ class HudiScanOperator(ScanOperator):
                         type=field_type,
                     )
                 arrays[field_name] = daft.Series.from_arrow(arrow_arr, field_name)
-            stats = daft.recordbatch.RecordBatch.from_pydict(arrays)._recordbatch
+            stats = daft.recordbatch.RecordBatch.from_pydict(arrays)
 
-            st = ScanTask.catalog_scan_task(
-                file=path,
-                file_format=file_format_config,
-                schema=self._schema._schema,
-                storage_config=self._storage_config,
+            task = DataSourceTask.parquet(
+                path=path,
+                schema=self._schema,
+                pushdowns=pushdowns,
                 num_rows=record_count,
                 size_bytes=size_bytes,
-                iceberg_delete_files=None,
-                pushdowns=pushdowns,
                 partition_values=partition_values,
                 stats=stats,
+                storage_config=self._storage_config,
             )
-            if st is None:
-                continue
             rows_left -= record_count
-            scan_tasks.append(st)
-        return iter(scan_tasks)
-
-    def can_absorb_filter(self) -> bool:
-        return False
-
-    def can_absorb_limit(self) -> bool:
-        return False
-
-    def can_absorb_select(self) -> bool:
-        return True
+            yield task


### PR DESCRIPTION
## Changes Made

- Replace `HudiScanOperator` with `HudiDataSource`, migrating the Hudi reader from the older `ScanOperator` interface to the `DataSource` interface.
- Route `read_hudi` through the DataSource bridge via `ScanOperatorHandle.from_data_source`, keeping the manual builder path so the `checkpoint` parameter continues to work.
- Move partition pruning from the Rust-side `catalog_scan_task` into `HudiDataSource.get_tasks`, following the DataSource model where pruning is the source's responsibility.
- Preserve existing behavior 1-to-1: full-scan warning, limit-based file pruning, per-file column min/max statistics, and partition values keyed by `_hoodie_partition_path`.

### Validation

- `DAFT_RUNNER=native pytest tests/io/hudi/` passes, and `count_rows`/limit/select/filter give identical results to the previous implementation on the same test tables.

## Related Issues

Closes #7295