### PR TITLE
feat: prototype retained native context sessions

### DIFF
--- a/daft/execution/context_protocol.py
+++ b/daft/execution/context_protocol.py
@@ -1,0 +1,755 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import threading
+import time
+from collections.abc import Callable, Hashable, Mapping, Sequence
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Generic, Self, TypeVar, cast
+
+from daft.dependencies import pa, torch
+
+T = TypeVar("T")
+_UNSET = object()
+
+
+class ColumnRepresentation(StrEnum):
+    DENSE_TENSOR = "dense_tensor"
+    DENSE_TENSOR_WITH_VALIDITY = "dense_tensor_with_validity"
+    DICTIONARY_CODES = "dictionary_codes"
+    ARROW_ONLY = "arrow_only"
+
+
+@dataclass(frozen=True)
+class ModelColumn:
+    """One borrowed Arrow column and its trusted read-only model view.
+
+    PyTorch cannot enforce read-only storage for ``frombuffer`` tensors.
+    Model adapters must not use in-place operations on this borrowed view.
+    Callers that require mutable input must allocate and report a private copy.
+    """
+
+    representation: ColumnRepresentation
+    arrow: pa.Array
+    tensor: object | None = None
+    validity: pa.Buffer | None = None
+    dictionary: pa.Array | None = None
+    reason: str | None = None
+    borrowed_read_only: bool = True
+
+
+_TORCH_DTYPES: dict[pa.DataType, str] = {
+    pa.int8(): "int8",
+    pa.int16(): "int16",
+    pa.int32(): "int32",
+    pa.int64(): "int64",
+    pa.uint8(): "uint8",
+    pa.float16(): "float16",
+    pa.float32(): "float32",
+    pa.float64(): "float64",
+}
+
+
+def _one_array(column: pa.Array | pa.ChunkedArray) -> pa.Array:
+    if isinstance(column, pa.Array):
+        return column
+    if column.num_chunks != 1:
+        raise ValueError("Model-column conversion requires one Arrow chunk; rechunking would copy data")
+    return column.chunk(0)
+
+
+def _primitive_tensor(array: pa.Array) -> object:
+    dtype_name = _TORCH_DTYPES[array.type]
+    dtype = getattr(torch, dtype_name)
+    value_buffer = array.buffers()[1]
+    if value_buffer is None:
+        return torch.empty(0, dtype=dtype)
+    byte_width = array.type.bit_width // 8
+    byte_offset = array.offset * byte_width
+    return torch.frombuffer(
+        memoryview(value_buffer)[byte_offset:],
+        dtype=dtype,
+        count=len(array),
+    )
+
+
+def model_column(column: pa.Array | pa.ChunkedArray) -> ModelColumn:
+    """Expose compatible Arrow values as tensor views without broad conversion.
+
+    Primitive numeric values become dense tensor views. Their optional Arrow
+    validity bitmap stays separate because it is bit-packed. Dictionary
+    indices become a tensor view while dictionary values remain Arrow. Strings,
+    lists, Boolean values, and other layouts remain Arrow until an explicit
+    model adapter encodes them.
+    """
+    array = _one_array(column)
+    validity = array.buffers()[0]
+
+    if array.type in _TORCH_DTYPES:
+        representation = (
+            ColumnRepresentation.DENSE_TENSOR_WITH_VALIDITY if array.null_count else ColumnRepresentation.DENSE_TENSOR
+        )
+        return ModelColumn(
+            representation=representation,
+            arrow=array,
+            tensor=_primitive_tensor(array),
+            validity=validity,
+        )
+
+    if pa.types.is_dictionary(array.type):
+        indices = array.indices
+        if indices.type not in _TORCH_DTYPES:
+            return ModelColumn(
+                representation=ColumnRepresentation.ARROW_ONLY,
+                arrow=array,
+                validity=validity,
+                reason=f"unsupported dictionary index type: {indices.type}",
+            )
+        return ModelColumn(
+            representation=ColumnRepresentation.DICTIONARY_CODES,
+            arrow=array,
+            tensor=_primitive_tensor(indices),
+            validity=validity,
+            dictionary=array.dictionary,
+        )
+
+    return ModelColumn(
+        representation=ColumnRepresentation.ARROW_ONLY,
+        arrow=array,
+        validity=validity,
+        reason=f"{array.type} requires explicit model encoding",
+    )
+
+
+@dataclass(frozen=True)
+class LeaseSnapshot:
+    live_count: int
+    live_bytes: int
+    peak_count: int
+    peak_bytes: int
+    acquired: int
+    released: int
+    wait_count: int
+    wait_seconds: float
+
+
+class BatchLease(Generic[T]):
+    """Explicit ownership of one model-facing batch."""
+
+    def __init__(
+        self,
+        ledger: LeaseLedger,
+        lease_id: int,
+        value: T | object,
+        byte_count: int,
+        device: str,
+        release_callback: Callable[[], None] | None,
+    ) -> None:
+        self._ledger = ledger
+        self._lease_id = lease_id
+        self._value = value
+        self._byte_count = byte_count
+        self._device = device
+        self._release_callback = release_callback
+        self._released = False
+
+    @property
+    def value(self) -> T:
+        if self._released:
+            raise RuntimeError("Batch lease has been released")
+        if self._value is _UNSET:
+            raise RuntimeError("Batch lease is reserved but has no result yet")
+        return cast("T", self._value)
+
+    @property
+    def byte_count(self) -> int:
+        return self._byte_count
+
+    @property
+    def device(self) -> str:
+        return self._device
+
+    @property
+    def released(self) -> bool:
+        return self._released
+
+    def release(self) -> None:
+        if self._released:
+            return
+        self._released = True
+        self._ledger._release(self._lease_id, self._byte_count, self._release_callback)
+
+    def _fill(
+        self,
+        value: T,
+        *,
+        byte_count: int,
+        device: str,
+        release_callback: Callable[[], None] | None = None,
+    ) -> None:
+        self._ledger._fill(self, value, byte_count, device, release_callback)
+
+    def __enter__(self) -> BatchLease[T]:
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
+        self.release()
+
+
+class LeaseLedger:
+    """Counts live batch ownership and calls each release callback once."""
+
+    def __init__(self, max_live_count: int | None = None) -> None:
+        if max_live_count is not None and max_live_count <= 0:
+            raise ValueError("max_live_count must be positive")
+        self._condition = threading.Condition()
+        self._max_live_count = max_live_count
+        self._next_id = 0
+        self._live_ids: set[int] = set()
+        self._live_leases: dict[int, BatchLease[object]] = {}
+        self._live_bytes = 0
+        self._peak_count = 0
+        self._peak_bytes = 0
+        self._acquired = 0
+        self._released = 0
+        self._wait_count = 0
+        self._wait_seconds = 0.0
+        self._cancelled = False
+
+    def acquire(
+        self,
+        value: T,
+        *,
+        byte_count: int,
+        device: str,
+        release_callback: Callable[[], None] | None = None,
+        timeout: float | None = None,
+    ) -> BatchLease[T]:
+        if byte_count < 0:
+            raise ValueError("byte_count must be non-negative")
+        return self._acquire(value, byte_count, device, release_callback, timeout)
+
+    def reserve(self, *, timeout: float | None = None) -> BatchLease[T]:
+        """Reserve one live-batch slot before producer execution begins."""
+        return self._acquire(_UNSET, 0, "pending", None, timeout)
+
+    def _acquire(
+        self,
+        value: T | object,
+        byte_count: int,
+        device: str,
+        release_callback: Callable[[], None] | None,
+        timeout: float | None,
+    ) -> BatchLease[T]:
+        with self._condition:
+            started_waiting: float | None = None
+            while self._max_live_count is not None and len(self._live_ids) >= self._max_live_count:
+                if self._cancelled:
+                    raise RuntimeError("Batch lease acquisition was cancelled")
+                if started_waiting is None:
+                    started_waiting = time.perf_counter()
+                    self._wait_count += 1
+                remaining = None
+                if timeout is not None:
+                    remaining = timeout - (time.perf_counter() - started_waiting)
+                    if remaining <= 0:
+                        self._wait_seconds += time.perf_counter() - started_waiting
+                        raise TimeoutError("Timed out waiting for batch lease credit")
+                self._condition.wait(remaining)
+            if started_waiting is not None:
+                self._wait_seconds += time.perf_counter() - started_waiting
+            if self._cancelled:
+                raise RuntimeError("Batch lease acquisition was cancelled")
+            lease_id = self._next_id
+            self._next_id += 1
+            self._live_ids.add(lease_id)
+            self._live_bytes += byte_count
+            self._acquired += 1
+            self._peak_count = max(self._peak_count, len(self._live_ids))
+            self._peak_bytes = max(self._peak_bytes, self._live_bytes)
+            lease = BatchLease(self, lease_id, value, byte_count, device, release_callback)
+            self._live_leases[lease_id] = lease
+        return lease
+
+    def snapshot(self) -> LeaseSnapshot:
+        with self._condition:
+            return LeaseSnapshot(
+                live_count=len(self._live_ids),
+                live_bytes=self._live_bytes,
+                peak_count=self._peak_count,
+                peak_bytes=self._peak_bytes,
+                acquired=self._acquired,
+                released=self._released,
+                wait_count=self._wait_count,
+                wait_seconds=self._wait_seconds,
+            )
+
+    def cancel_waiters(self) -> None:
+        with self._condition:
+            self._cancelled = True
+            self._condition.notify_all()
+
+    def release_all(self) -> None:
+        with self._condition:
+            leases = list(self._live_leases.values())
+        for lease in leases:
+            lease.release()
+
+    def assert_clear(self) -> None:
+        snapshot = self.snapshot()
+        if snapshot.live_count or snapshot.live_bytes:
+            raise RuntimeError(f"{snapshot.live_count} batch leases still own {snapshot.live_bytes} bytes")
+
+    def _release(
+        self,
+        lease_id: int,
+        byte_count: int,
+        release_callback: Callable[[], None] | None,
+    ) -> None:
+        with self._condition:
+            if lease_id not in self._live_ids:
+                return
+            self._live_ids.remove(lease_id)
+            self._live_leases.pop(lease_id, None)
+            self._live_bytes -= byte_count
+            self._released += 1
+            self._condition.notify()
+        if release_callback is not None:
+            release_callback()
+
+    def _fill(
+        self,
+        lease: BatchLease[T],
+        value: T,
+        byte_count: int,
+        device: str,
+        release_callback: Callable[[], None] | None,
+    ) -> None:
+        if byte_count < 0:
+            raise ValueError("byte_count must be non-negative")
+        with self._condition:
+            if lease._lease_id not in self._live_ids or lease._released:
+                raise RuntimeError("Reserved batch lease was released before the result arrived")
+            if lease._value is not _UNSET:
+                raise RuntimeError("Reserved batch lease already has a result")
+            lease._value = value
+            lease._byte_count = byte_count
+            lease._device = device
+            lease._release_callback = release_callback
+            self._live_bytes += byte_count
+            self._peak_bytes = max(self._peak_bytes, self._live_bytes)
+
+
+class ContextChangeKind(StrEnum):
+    ADD = "ADD"
+    REMOVE = "REMOVE"
+    UPDATE = "UPDATE"
+    REORDER = "REORDER"
+
+
+@dataclass(frozen=True)
+class ContextChange:
+    kind: ContextChangeKind
+    seed_key: Hashable
+    row_key: Hashable
+    old_rank: int | None
+    new_rank: int | None
+    old_version: Hashable | None
+    new_version: Hashable | None
+
+
+@dataclass(frozen=True)
+class _ContextMember:
+    version: Hashable
+    rank: int
+
+
+class ContextStateTracker:
+    """Turns complete context selections into row-keyed change records."""
+
+    def __init__(self) -> None:
+        self._members: dict[tuple[Hashable, Hashable], _ContextMember] = {}
+
+    def update(
+        self,
+        table: pa.Table,
+        *,
+        seed_column: str,
+        key_column: str,
+        version_column: str,
+        replace_seeds: Sequence[Hashable] | None = None,
+    ) -> list[ContextChange]:
+        seeds = table[seed_column].to_pylist()
+        keys = table[key_column].to_pylist()
+        versions = table[version_column].to_pylist()
+        current: dict[tuple[Hashable, Hashable], _ContextMember] = {}
+        ranks: dict[Hashable, int] = {}
+        for seed, key, version in zip(seeds, keys, versions, strict=True):
+            rank = ranks.get(seed, 0)
+            ranks[seed] = rank + 1
+            identity = (seed, key)
+            if identity in current:
+                raise ValueError(f"Duplicate context row key for seed: {identity!r}")
+            current[identity] = _ContextMember(version=version, rank=rank)
+
+        if replace_seeds is None:
+            previous = self._members
+            next_members = current
+        else:
+            scope = set(replace_seeds)
+            unexpected = {seed for seed, _ in current} - scope
+            if unexpected:
+                raise ValueError(f"Context update contains seeds outside its replacement scope: {unexpected!r}")
+            previous = {identity: member for identity, member in self._members.items() if identity[0] in scope}
+            next_members = {identity: member for identity, member in self._members.items() if identity[0] not in scope}
+            next_members.update(current)
+
+        changes: list[ContextChange] = []
+        for (seed, key), previous_member in previous.items():
+            if (seed, key) not in current:
+                changes.append(
+                    ContextChange(
+                        ContextChangeKind.REMOVE,
+                        seed,
+                        key,
+                        previous_member.rank,
+                        None,
+                        previous_member.version,
+                        None,
+                    )
+                )
+
+        for (seed, key), member in current.items():
+            previous_member = previous.get((seed, key))
+            if previous_member is None:
+                changes.append(
+                    ContextChange(
+                        ContextChangeKind.ADD,
+                        seed,
+                        key,
+                        None,
+                        member.rank,
+                        None,
+                        member.version,
+                    )
+                )
+                continue
+            if previous_member.version != member.version:
+                changes.append(
+                    ContextChange(
+                        ContextChangeKind.UPDATE,
+                        seed,
+                        key,
+                        previous_member.rank,
+                        member.rank,
+                        previous_member.version,
+                        member.version,
+                    )
+                )
+            if previous_member.rank != member.rank:
+                changes.append(
+                    ContextChange(
+                        ContextChangeKind.REORDER,
+                        seed,
+                        key,
+                        previous_member.rank,
+                        member.rank,
+                        previous_member.version,
+                        member.version,
+                    )
+                )
+
+        self._members = next_members
+        return changes
+
+
+@dataclass(frozen=True)
+class RowTransformKey:
+    table: str
+    row_key: Hashable
+    row_version: Hashable
+    columns: tuple[str, ...]
+    transform_version: str
+    dtype: str
+    layout: str
+    device: str
+
+
+@dataclass(frozen=True)
+class CacheSnapshot:
+    hits: int
+    misses: int
+    invalidated: int
+    reused_bytes: int
+    entries: int
+
+
+class RowTransformCache(Generic[T]):
+    """Row/version-scoped model transform reuse with targeted invalidation."""
+
+    def __init__(self) -> None:
+        self._entries: dict[RowTransformKey, tuple[T, int]] = {}
+        self._hits = 0
+        self._misses = 0
+        self._invalidated = 0
+        self._reused_bytes = 0
+
+    def get_or_compute(
+        self,
+        key: RowTransformKey,
+        compute: Callable[[], tuple[T, int]],
+    ) -> T:
+        cached = self._entries.get(key)
+        if cached is not None:
+            value, byte_count = cached
+            self._hits += 1
+            self._reused_bytes += byte_count
+            return value
+        value, byte_count = compute()
+        if byte_count < 0:
+            raise ValueError("cache byte_count must be non-negative")
+        self._entries[key] = (value, byte_count)
+        self._misses += 1
+        return value
+
+    def invalidate_rows(self, table: str, row_keys: Sequence[Hashable]) -> int:
+        targets = set(row_keys)
+        matching = [key for key in self._entries if key.table == table and key.row_key in targets]
+        for key in matching:
+            del self._entries[key]
+        self._invalidated += len(matching)
+        return len(matching)
+
+    def snapshot(self) -> CacheSnapshot:
+        return CacheSnapshot(
+            hits=self._hits,
+            misses=self._misses,
+            invalidated=self._invalidated,
+            reused_bytes=self._reused_bytes,
+            entries=len(self._entries),
+        )
+
+
+@dataclass(frozen=True)
+class SourceSnapshot:
+    connector: str
+    source: str
+    version: str
+    method: str
+
+    @classmethod
+    def transactional(cls, connector: str, source: str, version: str) -> SourceSnapshot:
+        if not version:
+            raise ValueError("transactional source version must not be empty")
+        return cls(connector, source, version, "connector-version")
+
+    @classmethod
+    def observed_facts(
+        cls,
+        connector: str,
+        source: str,
+        facts: Mapping[str, str | int],
+    ) -> SourceSnapshot:
+        if not facts:
+            raise ValueError("non-transactional snapshot requires observed source facts")
+        payload = json.dumps(
+            {"connector": connector, "source": source, "facts": dict(facts)},
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode()
+        return cls(connector, source, hashlib.sha256(payload).hexdigest(), "observed-facts")
+
+
+@dataclass(frozen=True)
+class ContextProtocolConfig:
+    seed_column: str
+    key_column: str
+    version_column: str
+    source_snapshot: SourceSnapshot
+    max_live_batches: int = 3
+
+
+@dataclass(frozen=True)
+class RowTransformRequest:
+    table: str
+    columns: tuple[str, ...]
+    transform_version: str
+    dtype: str
+    layout: str
+    device: str
+    transform: Callable[[Hashable, Hashable], tuple[object, int]]
+
+
+@dataclass(frozen=True)
+class ContextBatch:
+    session_id: str
+    plan_fingerprint: int
+    input_id: int
+    revision: int
+    query_plan: str
+    rows: BatchLease[pa.Table]
+    row_transforms: tuple[object, ...]
+    changes: tuple[ContextChange, ...]
+    source_snapshot: SourceSnapshot
+    lease_snapshot: LeaseSnapshot
+    cache_snapshot: CacheSnapshot
+
+    @property
+    def table(self) -> pa.Table:
+        return self.rows.value
+
+    def release(self) -> None:
+        self.rows.release()
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
+        self.release()
+
+
+class ContextProtocol:
+    """Session-owned context rows, changes, leases, and row-transform reuse."""
+
+    def __init__(self, session_id: str, config: ContextProtocolConfig) -> None:
+        self.session_id = session_id
+        self.config = config
+        self._source_snapshot = config.source_snapshot
+        self._revision = 0
+        self._tracker = ContextStateTracker()
+        self._leases = LeaseLedger(max_live_count=config.max_live_batches)
+        self._row_cache: RowTransformCache[object] = RowTransformCache()
+
+    @property
+    def source_snapshot(self) -> SourceSnapshot:
+        return self._source_snapshot
+
+    @property
+    def lease_snapshot(self) -> LeaseSnapshot:
+        return self._leases.snapshot()
+
+    @property
+    def cache_snapshot(self) -> CacheSnapshot:
+        return self._row_cache.snapshot()
+
+    def lease_feedback(
+        self,
+        table: pa.Table,
+        *,
+        timeout: float | None = None,
+    ) -> BatchLease[pa.Table]:
+        """Keep row-keyed feedback owned by this session until plan submission."""
+        return self._leases.acquire(
+            table,
+            byte_count=table.nbytes,
+            device="cpu",
+            timeout=timeout,
+        )
+
+    def reserve_result(self, *, timeout: float | None = None) -> BatchLease[pa.Table]:
+        """Reserve flow credit before a context round starts producing rows."""
+        return self._leases.reserve(timeout=timeout)
+
+    def accept(
+        self,
+        table: pa.Table,
+        *,
+        plan_fingerprint: int,
+        input_id: int,
+        query_plan: str,
+        replace_seeds: Sequence[Hashable] | None = None,
+        row_transform: RowTransformRequest | None = None,
+        lease_timeout: float | None = None,
+        reserved_lease: BatchLease[pa.Table] | None = None,
+    ) -> ContextBatch:
+        if reserved_lease is None:
+            lease = self._leases.acquire(
+                table,
+                byte_count=table.nbytes,
+                device="cpu",
+                timeout=lease_timeout,
+            )
+        else:
+            lease = reserved_lease
+            lease._fill(table, byte_count=table.nbytes, device="cpu")
+        try:
+            row_transforms = () if row_transform is None else self._cache_rows(table, row_transform)
+            changes = self._tracker.update(
+                table,
+                seed_column=self.config.seed_column,
+                key_column=self.config.key_column,
+                version_column=self.config.version_column,
+                replace_seeds=replace_seeds,
+            )
+        except BaseException:
+            lease.release()
+            raise
+
+        self._revision += 1
+        return ContextBatch(
+            session_id=self.session_id,
+            plan_fingerprint=plan_fingerprint,
+            input_id=input_id,
+            revision=self._revision,
+            query_plan=query_plan,
+            rows=lease,
+            row_transforms=row_transforms,
+            changes=tuple(changes),
+            source_snapshot=self._source_snapshot,
+            lease_snapshot=self._leases.snapshot(),
+            cache_snapshot=self._row_cache.snapshot(),
+        )
+
+    def update_source(
+        self,
+        source_snapshot: SourceSnapshot,
+        changed_rows: Mapping[str, Sequence[Hashable]],
+    ) -> int:
+        if (
+            source_snapshot.connector != self._source_snapshot.connector
+            or source_snapshot.source != self._source_snapshot.source
+        ):
+            raise ValueError("Updated source identity does not match the context session")
+        removed = sum(self._row_cache.invalidate_rows(table, row_keys) for table, row_keys in changed_rows.items())
+        self._source_snapshot = source_snapshot
+        return removed
+
+    def close(self) -> None:
+        self._leases.assert_clear()
+
+    def cancel(self) -> None:
+        self._leases.cancel_waiters()
+        self._leases.release_all()
+
+    def _cache_rows(self, table: pa.Table, request: RowTransformRequest) -> tuple[object, ...]:
+        row_keys = table[self.config.key_column].to_pylist()
+        versions = table[self.config.version_column].to_pylist()
+        values: list[object] = []
+        for row_key, version in zip(row_keys, versions, strict=True):
+            cache_key = RowTransformKey(
+                table=request.table,
+                row_key=row_key,
+                row_version=version,
+                columns=request.columns,
+                transform_version=request.transform_version,
+                dtype=request.dtype,
+                layout=request.layout,
+                device=request.device,
+            )
+            values.append(
+                self._row_cache.get_or_compute(
+                    cache_key,
+                    lambda row_key=row_key, version=version: request.transform(row_key, version),
+                )
+            )
+        return tuple(values)
+
+
+def retrieval_recall(selected_keys: Sequence[Hashable], relevant_keys: Sequence[Hashable]) -> float:
+    """Measure how much known-relevant context a fixed row budget retrieves."""
+    relevant = set(relevant_keys)
+    if not relevant:
+        raise ValueError("retrieval recall requires at least one relevant row")
+    return len(set(selected_keys) & relevant) / len(relevant)

--- a/daft/execution/native_executor.py
+++ b/daft/execution/native_executor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import secrets
 from typing import TYPE_CHECKING
 
 from daft.daft import (
@@ -19,10 +20,51 @@ from daft.recordbatch import MicroPartition
 from daft.runners.partitioning import LocalMaterializedResult
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator, Generator, Mapping
+    from collections.abc import AsyncGenerator, Generator, Hashable, Iterator, Mapping, Sequence
+
+    from typing_extensions import Self
 
     from daft.context import DaftContext
+    from daft.execution.context_protocol import (
+        BatchLease,
+        ContextBatch,
+        ContextProtocol,
+        ContextProtocolConfig,
+        RowTransformRequest,
+        SourceSnapshot,
+    )
     from daft.logical.builder import LogicalPlanBuilder
+
+
+async def _next_context_result(result_handle: object) -> object:
+    return await result_handle.__anext__()
+
+
+async def _finish_context_result(result_handle: object) -> PyExecutionStats:
+    return await result_handle.try_finish()
+
+
+async def _submit_context_round(
+    executor: object,
+    local_physical_plan: LocalPhysicalPlan,
+    ctx: DaftContext,
+    input_id: int,
+    inputs: Mapping[int, Input | list[PyMicroPartition]],
+    context: Mapping[str, str],
+    maintain_order: bool,
+) -> object:
+    return await executor.run_retained(
+        local_physical_plan,
+        ctx._ctx,
+        input_id,
+        dict(inputs),
+        dict(context),
+        maintain_order,
+    )
+
+
+async def _close_context_plan(executor: object, fingerprint: int) -> None:
+    await executor.close_plan(fingerprint)
 
 
 class NativeExecutor:
@@ -91,3 +133,315 @@ class NativeExecutor:
             return _NativeExecutor.repr_mermaid(builder._builder, daft_execution_config, MermaidOptions(simple))
         else:
             raise ValueError(f"Unknown format: {format}")
+
+
+class NativeContextRound:
+    """One submitted input round in an experimental native context session."""
+
+    def __init__(
+        self,
+        session: NativeContextSession,
+        input_id: int,
+        result_handle: object,
+    ) -> None:
+        self._session = session
+        self._input_id = input_id
+        self._result_handle = result_handle
+        self._finished = False
+        self._saw_eof = False
+        self._stats: PyExecutionStats | None = None
+
+    @property
+    def input_id(self) -> int:
+        return self._input_id
+
+    @property
+    def stats(self) -> PyExecutionStats | None:
+        return self._stats
+
+    def __iter__(self) -> Iterator[LocalMaterializedResult]:
+        return self
+
+    def __next__(self) -> LocalMaterializedResult:
+        if self._finished:
+            raise StopIteration
+
+        event_loop = get_or_init_event_loop()
+        try:
+            part = event_loop.run(_next_context_result(self._result_handle))
+        except BaseException:
+            self._finished = True
+            self._session._round_failed(self)
+            raise
+
+        if part is None:
+            self._saw_eof = True
+            try:
+                self._stats = event_loop.run(_finish_context_result(self._result_handle))
+            except BaseException:
+                self._finished = True
+                self._session._round_failed(self)
+                raise
+            self._finished = True
+            self._session._round_finished(self)
+            raise StopIteration
+
+        return LocalMaterializedResult(MicroPartition._from_pymicropartition(part))
+
+    def close(self) -> None:
+        """Stop this round.
+
+        A round closed before end-of-stream cancels the whole session because
+        the retained pipeline may still be processing that input.
+        """
+        if self._finished:
+            return
+
+        self._finished = True
+        if not self._saw_eof:
+            self._session._round_failed(self)
+
+
+class NativePendingContextRound:
+    """A context round with output credit reserved before plan submission."""
+
+    def __init__(
+        self,
+        session: NativeContextSession,
+        result_round: NativeContextRound,
+        reservation: BatchLease[object],
+        replace_seeds: Sequence[Hashable] | None,
+        row_transform: RowTransformRequest | None,
+    ) -> None:
+        self._session = session
+        self._result_round = result_round
+        self._reservation = reservation
+        self._replace_seeds = replace_seeds
+        self._row_transform = row_transform
+        self._collected = False
+
+    def collect(self) -> ContextBatch:
+        if self._collected:
+            raise RuntimeError("Context round has already been collected")
+        self._collected = True
+        try:
+            parts = [result.partition() for result in self._result_round]
+            if not parts:
+                self._session.cancel()
+                raise RuntimeError("Context round produced no output partition")
+            table = MicroPartition.concat(parts).to_arrow()
+            stats = self._result_round.stats
+            query_plan = "" if stats is None else (stats.query_plan or "")
+            return self._session.protocol.accept(
+                table,
+                plan_fingerprint=self._session.fingerprint,
+                input_id=self._result_round.input_id,
+                query_plan=query_plan,
+                replace_seeds=self._replace_seeds,
+                row_transform=self._row_transform,
+                reserved_lease=self._reservation,
+            )
+        except BaseException:
+            self._reservation.release()
+            raise
+
+    def cancel(self) -> None:
+        self._reservation.release()
+        self._result_round.close()
+
+
+class NativeContextSession:
+    """Experimental retained native executor session.
+
+    One local physical plan is translated once. Each call to ``run_round``
+    supplies a new input mapping and receives a new input ID while reusing the
+    same pipeline and class-UDF worker state.
+    """
+
+    def __init__(
+        self,
+        local_physical_plan: LocalPhysicalPlan,
+        ctx: DaftContext,
+        context: Mapping[str, str] | None = None,
+        *,
+        maintain_order: bool = True,
+        protocol_config: ContextProtocolConfig | None = None,
+    ) -> None:
+        from daft.runners import get_or_infer_runner_type
+
+        runner_type = get_or_infer_runner_type()
+        if runner_type != "native":
+            raise RuntimeError(
+                f"NativeContextSession requires the native runner, but the configured runner is {runner_type!r}"
+            )
+        self._executor = _NativeExecutor(False, "")
+        self._local_physical_plan = local_physical_plan
+        self._ctx = ctx
+        self._context = dict(context or {})
+        self._fingerprint = secrets.randbits(63) or 1
+        self._session_id = f"native-context-{self._fingerprint:016x}"
+        self._context["plan_fingerprint"] = str(self._fingerprint)
+        self._context["context_session_id"] = self._session_id
+        self._maintain_order = maintain_order
+        self._next_input_id = 0
+        self._active_round: NativeContextRound | None = None
+        self._closed = False
+        if protocol_config is None:
+            self._protocol: ContextProtocol | None = None
+        else:
+            from daft.execution.context_protocol import ContextProtocol
+
+            self._protocol = ContextProtocol(self._session_id, protocol_config)
+
+    @property
+    def fingerprint(self) -> int:
+        return self._fingerprint
+
+    @property
+    def session_id(self) -> str:
+        return self._session_id
+
+    @property
+    def protocol(self) -> ContextProtocol:
+        if self._protocol is None:
+            raise RuntimeError("Native context session was created without a context protocol")
+        return self._protocol
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    @property
+    def active_plan_count(self) -> int:
+        return self._executor.active_plan_count()
+
+    def run_round(
+        self,
+        inputs: Mapping[int, Input | list[PyMicroPartition]],
+    ) -> NativeContextRound:
+        """Submit one bounded input round.
+
+        The experimental wrapper permits one submitted round at a time. Consume
+        or close the returned iterator before submitting the next round.
+        """
+        if self._closed:
+            raise RuntimeError("Native context session is closed")
+        if self._active_round is not None:
+            raise RuntimeError("Native context session already has an active input round")
+
+        input_id = self._next_input_id
+        self._next_input_id += 1
+        event_loop = get_or_init_event_loop()
+        try:
+            result_handle = event_loop.run(
+                _submit_context_round(
+                    self._executor,
+                    self._local_physical_plan,
+                    self._ctx,
+                    input_id,
+                    dict(inputs),
+                    self._context,
+                    self._maintain_order,
+                )
+            )
+        except BaseException:
+            self.cancel()
+            raise
+
+        result_round = NativeContextRound(self, input_id, result_handle)
+        self._active_round = result_round
+        return result_round
+
+    def run_context_round(
+        self,
+        inputs: Mapping[int, Input | list[PyMicroPartition]],
+        *,
+        replace_seeds: Sequence[Hashable] | None = None,
+        row_transform: RowTransformRequest | None = None,
+        lease_timeout: float | None = None,
+    ) -> ContextBatch:
+        """Run one retained round and return leased rows plus row-keyed changes."""
+        return self.start_context_round(
+            inputs,
+            replace_seeds=replace_seeds,
+            row_transform=row_transform,
+            lease_timeout=lease_timeout,
+        ).collect()
+
+    def start_context_round(
+        self,
+        inputs: Mapping[int, Input | list[PyMicroPartition]],
+        *,
+        replace_seeds: Sequence[Hashable] | None = None,
+        row_transform: RowTransformRequest | None = None,
+        lease_timeout: float | None = None,
+    ) -> NativePendingContextRound:
+        """Reserve output credit, then submit one retained context round."""
+        if self._closed:
+            raise RuntimeError("Native context session is closed")
+        if self._active_round is not None:
+            raise RuntimeError("Native context session already has an active input round")
+
+        reservation = self.protocol.reserve_result(timeout=lease_timeout)
+        try:
+            result_round = self.run_round(inputs)
+        except BaseException:
+            reservation.release()
+            raise
+        return NativePendingContextRound(
+            self,
+            result_round,
+            reservation,
+            replace_seeds,
+            row_transform,
+        )
+
+    def update_source(
+        self,
+        source_snapshot: SourceSnapshot,
+        changed_rows: Mapping[str, Sequence[Hashable]],
+    ) -> int:
+        """Advance the source token and invalidate only named cached rows."""
+        return self.protocol.update_source(source_snapshot, changed_rows)
+
+    def close(self) -> None:
+        """Cleanly close an idle session and wait for the retained pipeline."""
+        if self._closed:
+            return
+        if self._active_round is not None:
+            raise RuntimeError("Consume or close the active input round before closing the session")
+        if self._protocol is not None:
+            self._protocol.close()
+
+        try:
+            get_or_init_event_loop().run(_close_context_plan(self._executor, self._fingerprint))
+        finally:
+            self._closed = True
+
+    def cancel(self) -> None:
+        """Cancel the retained pipeline and discard cached plan state."""
+        if self._closed:
+            return
+        if self._protocol is not None:
+            self._protocol.cancel()
+        self._executor.cancel_plan(self._fingerprint)
+        self._active_round = None
+        self._closed = True
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
+        if exc_type is None:
+            self.close()
+        else:
+            self.cancel()
+
+    def _round_finished(self, result_round: NativeContextRound) -> None:
+        if self._active_round is result_round:
+            self._active_round = None
+
+    def _round_failed(self, result_round: NativeContextRound) -> None:
+        if self._active_round is result_round:
+            self._active_round = None
+        self.cancel()

--- a/src/daft-local-execution/src/run.rs
+++ b/src/daft-local-execution/src/run.rs
@@ -219,31 +219,55 @@ impl PyNativeExecutor {
         context: Option<HashMap<String, String>>,
         maintain_order: bool,
     ) -> PyResult<Bound<'py, pyo3::PyAny>> {
-        let daft_ctx: &DaftContext = daft_ctx.into();
-        let plan = local_physical_plan.plan.clone();
-        let exec_cfg = daft_ctx.execution_config();
-        let subscribers = daft_ctx.subscribers();
-        let (fingerprint, enqueue_future) = {
-            self.executor.lock_py_attached(py).unwrap().run(
-                &plan,
-                exec_cfg,
-                subscribers,
-                context,
-                inputs,
-                input_id,
-                maintain_order,
-            )?
-        };
+        self.run_with_retention(
+            py,
+            local_physical_plan,
+            daft_ctx,
+            input_id,
+            inputs,
+            context,
+            maintain_order,
+            false,
+        )
+    }
 
-        let executor = self.executor.clone();
+    #[allow(clippy::too_many_arguments)]
+    #[pyo3(signature = (local_physical_plan, daft_ctx, input_id, inputs, context=None, maintain_order=true))]
+    pub fn run_retained<'py>(
+        &self,
+        py: Python<'py>,
+        local_physical_plan: &daft_local_plan::PyLocalPhysicalPlan,
+        daft_ctx: &PyDaftContext,
+        input_id: InputId,
+        inputs: HashMap<SourceId, Input>,
+        context: Option<HashMap<String, String>>,
+        maintain_order: bool,
+    ) -> PyResult<Bound<'py, pyo3::PyAny>> {
+        self.run_with_retention(
+            py,
+            local_physical_plan,
+            daft_ctx,
+            input_id,
+            inputs,
+            context,
+            maintain_order,
+            true,
+        )
+    }
+
+    pub fn close_plan<'py>(
+        &self,
+        py: Python<'py>,
+        fingerprint: u64,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let close_future = self
+            .executor
+            .lock_py_attached(py)
+            .unwrap()
+            .close_plan(fingerprint)?;
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            let result = enqueue_future.await?;
-            Ok(PyResultReceiver {
-                result: Arc::new(tokio::sync::Mutex::new(Some(result))),
-                fingerprint,
-                input_id,
-                executor,
-            })
+            close_future.await?;
+            Ok(())
         })
     }
 
@@ -283,6 +307,50 @@ impl PyNativeExecutor {
             cfg.config,
             options,
         ))
+    }
+}
+
+#[cfg(feature = "python")]
+impl PyNativeExecutor {
+    #[allow(clippy::too_many_arguments)]
+    fn run_with_retention<'py>(
+        &self,
+        py: Python<'py>,
+        local_physical_plan: &daft_local_plan::PyLocalPhysicalPlan,
+        daft_ctx: &PyDaftContext,
+        input_id: InputId,
+        inputs: HashMap<SourceId, Input>,
+        context: Option<HashMap<String, String>>,
+        maintain_order: bool,
+        retain_plan: bool,
+    ) -> PyResult<Bound<'py, pyo3::PyAny>> {
+        let daft_ctx: &DaftContext = daft_ctx.into();
+        let plan = local_physical_plan.plan.clone();
+        let exec_cfg = daft_ctx.execution_config();
+        let subscribers = daft_ctx.subscribers();
+        let (fingerprint, enqueue_future) = {
+            self.executor.lock_py_attached(py).unwrap().run(
+                &plan,
+                exec_cfg,
+                subscribers,
+                context,
+                inputs,
+                input_id,
+                maintain_order,
+            )?
+        };
+
+        let executor = self.executor.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let result = enqueue_future.await?;
+            Ok(PyResultReceiver {
+                result: Arc::new(tokio::sync::Mutex::new(Some(result))),
+                fingerprint,
+                input_id,
+                executor,
+                retain_plan,
+            })
+        })
     }
 }
 
@@ -575,6 +643,24 @@ impl NativeExecutor {
         fingerprint: u64,
         input_id: InputId,
     ) -> DaftResult<BoxFuture<'static, DaftResult<ExecutionStats>>> {
+        self.try_finish_input(fingerprint, input_id, false)
+    }
+
+    /// Finish one retained input round without removing a healthy idle plan.
+    pub fn try_finish_retained(
+        &mut self,
+        fingerprint: u64,
+        input_id: InputId,
+    ) -> DaftResult<BoxFuture<'static, DaftResult<ExecutionStats>>> {
+        self.try_finish_input(fingerprint, input_id, true)
+    }
+
+    fn try_finish_input(
+        &mut self,
+        fingerprint: u64,
+        input_id: InputId,
+        retain_plan: bool,
+    ) -> DaftResult<BoxFuture<'static, DaftResult<ExecutionStats>>> {
         let Some(plan_state) = self.plans.get_mut(&fingerprint) else {
             // Plan already removed (pipeline died and another input_id cleaned it up).
             // Return empty stats; the actual error was already surfaced by the first caller.
@@ -584,7 +670,8 @@ impl NativeExecutor {
 
         plan_state.active_input_ids.remove(&input_id);
         let pipeline_dead = plan_state.enqueue_input_sender.is_closed();
-        let should_remove = plan_state.active_input_ids.is_empty() || pipeline_dead;
+        let should_remove =
+            pipeline_dead || (!retain_plan && plan_state.active_input_ids.is_empty());
 
         if should_remove {
             let plan_state = self.plans.remove(&fingerprint).unwrap();
@@ -621,6 +708,29 @@ impl NativeExecutor {
             }
             .boxed())
         }
+    }
+
+    /// Close an idle retained plan and wait for its pipeline task to stop.
+    pub fn close_plan(
+        &mut self,
+        fingerprint: u64,
+    ) -> DaftResult<BoxFuture<'static, DaftResult<()>>> {
+        let Some(plan_state) = self.plans.get(&fingerprint) else {
+            return Ok(async move { Ok(()) }.boxed());
+        };
+        if !plan_state.active_input_ids.is_empty() {
+            return Err(common_error::DaftError::ValueError(format!(
+                "Cannot close plan {fingerprint} while input rounds are active"
+            )));
+        }
+
+        let plan_state = self.plans.remove(&fingerprint).unwrap();
+        Ok(async move {
+            drop(plan_state.enqueue_input_sender);
+            plan_state.task_handle.await??;
+            Ok(())
+        }
+        .boxed())
     }
 
     pub fn cancel_plan(&mut self, fingerprint: u64) {
@@ -711,6 +821,7 @@ pub struct PyResultReceiver {
     fingerprint: u64,
     input_id: InputId,
     executor: Arc<Mutex<NativeExecutor>>,
+    retain_plan: bool,
 }
 
 #[cfg(feature = "python")]
@@ -754,6 +865,7 @@ impl PyResultReceiver {
         let executor = self.executor.clone();
         let fingerprint = self.fingerprint;
         let input_id = self.input_id;
+        let retain_plan = self.retain_plan;
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             // Take the result to drop the receiver
             let mut result = result.lock().await;
@@ -763,7 +875,14 @@ impl PyResultReceiver {
             drop(result);
 
             // Delegate to NativeExecutor::try_finish
-            let finish_future = executor.lock().unwrap().try_finish(fingerprint, input_id)?;
+            let finish_future = if retain_plan {
+                executor
+                    .lock()
+                    .unwrap()
+                    .try_finish_retained(fingerprint, input_id)?
+            } else {
+                executor.lock().unwrap().try_finish(fingerprint, input_id)?
+            };
             let stats = finish_future.await?;
             Ok(PyExecutionStats::from(stats))
         })

--- a/tests/execution/test_context_protocol.py
+++ b/tests/execution/test_context_protocol.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+import pyarrow as pa
+import pytest
+
+from daft.execution.context_protocol import (
+    BatchLease,
+    ColumnRepresentation,
+    ContextChangeKind,
+    ContextStateTracker,
+    LeaseLedger,
+    RowTransformCache,
+    RowTransformKey,
+    SourceSnapshot,
+    model_column,
+    retrieval_recall,
+)
+
+
+def test_model_column_keeps_complex_layouts_explicit() -> None:
+    nullable = pa.array([10, None, 30], type=pa.int64())
+    nullable_model = model_column(nullable)
+    value_buffer = nullable.buffers()[1]
+    assert value_buffer is not None
+    assert nullable_model.representation == ColumnRepresentation.DENSE_TENSOR_WITH_VALIDITY
+    assert nullable_model.borrowed_read_only
+    assert nullable_model.tensor is not None
+    assert nullable_model.tensor.data_ptr() == value_buffer.address
+    validity_buffer = nullable.buffers()[0]
+    assert validity_buffer is not None
+    assert nullable_model.validity is not None
+    assert nullable_model.validity.address == validity_buffer.address
+    adjusted = nullable_model.tensor + 1
+    assert [adjusted[0].item(), adjusted[2].item()] == [11, 31]
+    assert nullable.to_pylist() == [10, None, 30]
+
+    dictionary = pa.array(["gold", "silver", "gold"]).dictionary_encode()
+    dictionary_model = model_column(dictionary)
+    index_buffer = dictionary.indices.buffers()[1]
+    assert index_buffer is not None
+    assert dictionary_model.representation == ColumnRepresentation.DICTIONARY_CODES
+    assert dictionary_model.tensor is not None
+    assert dictionary_model.tensor.data_ptr() == index_buffer.address
+    assert dictionary_model.dictionary.equals(dictionary.dictionary)
+
+    for arrow_only in (
+        pa.array(["alpha", "beta"]),
+        pa.array([[1, 2], [3]]),
+        pa.array([True, False]),
+    ):
+        converted = model_column(arrow_only)
+        assert converted.representation == ColumnRepresentation.ARROW_ONLY
+        assert converted.tensor is None
+        assert converted.reason is not None
+
+    with pytest.raises(ValueError, match="one Arrow chunk"):
+        model_column(pa.chunked_array([[1, 2], [3, 4]]))
+
+
+def test_batch_leases_release_once_on_success_error_and_cancel() -> None:
+    ledger = LeaseLedger()
+    released: list[str] = []
+
+    with ledger.acquire(
+        "success",
+        byte_count=10,
+        device="cpu",
+        release_callback=lambda: released.append("success"),
+    ) as success:
+        assert success.value == "success"
+    success.release()
+
+    with (
+        pytest.raises(RuntimeError, match="model failed"),
+        ledger.acquire(
+            "error",
+            byte_count=20,
+            device="cpu",
+            release_callback=lambda: released.append("error"),
+        ),
+    ):
+        raise RuntimeError("model failed")
+
+    cancelled: BatchLease[str] = ledger.acquire(
+        "cancelled",
+        byte_count=30,
+        device="cuda:0",
+        release_callback=lambda: released.append("cancelled"),
+    )
+    cancelled.release()
+    cancelled.release()
+
+    assert released == ["success", "error", "cancelled"]
+    assert ledger.snapshot().acquired == 3
+    assert ledger.snapshot().released == 3
+    ledger.assert_clear()
+
+
+def test_batch_lease_credit_bounds_live_batches_and_records_wait() -> None:
+    ledger = LeaseLedger(max_live_count=3)
+    leases = [ledger.acquire(value, byte_count=10, device="cpu") for value in ("queued-1", "queued-2", "executing")]
+    assert ledger.snapshot().peak_count == 3
+
+    with pytest.raises(TimeoutError, match="batch lease credit"):
+        ledger.acquire("blocked", byte_count=10, device="cpu", timeout=0.01)
+    assert ledger.snapshot().wait_count == 1
+    assert ledger.snapshot().wait_seconds >= 0.01
+    assert ledger.snapshot().peak_count == 3
+
+    leases.pop().release()
+    resumed = ledger.acquire("resumed", byte_count=10, device="cpu")
+    for lease in leases:
+        lease.release()
+    resumed.release()
+    ledger.assert_clear()
+
+
+def test_context_state_emits_add_remove_update_and_reorder() -> None:
+    tracker = ContextStateTracker()
+    first = pa.table(
+        {
+            "seed": ["A", "A", "B"],
+            "row_id": [101, 102, 201],
+            "row_version": [1, 1, 1],
+        }
+    )
+    assert [
+        change.kind
+        for change in tracker.update(
+            first,
+            seed_column="seed",
+            key_column="row_id",
+            version_column="row_version",
+        )
+    ] == [ContextChangeKind.ADD, ContextChangeKind.ADD, ContextChangeKind.ADD]
+
+    changed = pa.table(
+        {
+            "seed": ["A", "A", "A"],
+            "row_id": [102, 101, 103],
+            "row_version": [1, 2, 1],
+        }
+    )
+    changes = tracker.update(
+        changed,
+        seed_column="seed",
+        key_column="row_id",
+        version_column="row_version",
+    )
+    observed = {(change.kind, change.seed_key, change.row_key) for change in changes}
+    assert observed == {
+        (ContextChangeKind.REMOVE, "B", 201),
+        (ContextChangeKind.REORDER, "A", 101),
+        (ContextChangeKind.UPDATE, "A", 101),
+        (ContextChangeKind.REORDER, "A", 102),
+        (ContextChangeKind.ADD, "A", 103),
+    }
+
+
+def test_context_state_fetch_more_changes_only_requested_seeds() -> None:
+    tracker = ContextStateTracker()
+    initial = pa.table(
+        {
+            "seed": ["A", "B"],
+            "row_id": [101, 201],
+            "row_version": [1, 1],
+        }
+    )
+    tracker.update(
+        initial,
+        seed_column="seed",
+        key_column="row_id",
+        version_column="row_version",
+    )
+
+    fetch_more = pa.table(
+        {
+            "seed": ["A", "A"],
+            "row_id": [101, 103],
+            "row_version": [1, 1],
+        }
+    )
+    changes = tracker.update(
+        fetch_more,
+        seed_column="seed",
+        key_column="row_id",
+        version_column="row_version",
+        replace_seeds=["A"],
+    )
+    assert [(change.kind, change.seed_key, change.row_key) for change in changes] == [(ContextChangeKind.ADD, "A", 103)]
+
+    with pytest.raises(ValueError, match="outside its replacement scope"):
+        tracker.update(
+            fetch_more,
+            seed_column="seed",
+            key_column="row_id",
+            version_column="row_version",
+            replace_seeds=["B"],
+        )
+
+
+def test_row_transform_cache_reuses_overlap_and_invalidates_one_row() -> None:
+    cache: RowTransformCache[str] = RowTransformCache()
+
+    def key(row_id: int, version: int = 1) -> RowTransformKey:
+        return RowTransformKey(
+            table="orders",
+            row_key=row_id,
+            row_version=version,
+            columns=("amount", "product_id"),
+            transform_version="model-v1",
+            dtype="float32",
+            layout="contiguous",
+            device="cuda:0",
+        )
+
+    computed: list[int] = []
+
+    def transform(row_id: int) -> tuple[str, int]:
+        computed.append(row_id)
+        return f"encoded-{row_id}", 16
+
+    for row_id in range(10):
+        assert cache.get_or_compute(key(row_id), lambda row_id=row_id: transform(row_id)) == f"encoded-{row_id}"
+    for row_id in [*range(8), 10, 11]:
+        assert cache.get_or_compute(key(row_id), lambda row_id=row_id: transform(row_id)) == f"encoded-{row_id}"
+
+    overlap_snapshot = cache.snapshot()
+    assert overlap_snapshot.hits == 8
+    assert overlap_snapshot.misses == 12
+    assert overlap_snapshot.reused_bytes == 8 * 16
+
+    assert cache.invalidate_rows("orders", [3]) == 1
+    assert cache.get_or_compute(key(3, 2), lambda: transform(3)) == "encoded-3"
+    assert cache.get_or_compute(key(4), lambda: transform(4)) == "encoded-4"
+    final = cache.snapshot()
+    assert final.hits == 9
+    assert final.misses == 13
+    assert final.invalidated == 1
+    assert final.entries == 12
+
+
+def test_source_snapshot_and_first_quality_metric() -> None:
+    first = SourceSnapshot.observed_facts(
+        "parquet",
+        "orders/",
+        {"file_count": 2, "total_bytes": 4096, "max_mtime_ns": 100, "schema": "v1"},
+    )
+    same = SourceSnapshot.observed_facts(
+        "parquet",
+        "orders/",
+        {"schema": "v1", "max_mtime_ns": 100, "total_bytes": 4096, "file_count": 2},
+    )
+    changed = SourceSnapshot.observed_facts(
+        "parquet",
+        "orders/",
+        {"file_count": 2, "total_bytes": 4104, "max_mtime_ns": 101, "schema": "v1"},
+    )
+    assert first.version == same.version
+    assert first.version != changed.version
+    assert first.method == "observed-facts"
+
+    with pytest.raises(ValueError, match="observed source facts"):
+        SourceSnapshot.observed_facts("parquet", "orders/", {})
+
+    relevant = [101, 103, 107, 109]
+    baseline = retrieval_recall([101, 102, 104, 105], relevant)
+    model_guided = retrieval_recall([101, 103, 107, 108], relevant)
+    assert baseline == 0.25
+    assert model_guided == 0.75

--- a/tests/execution/test_native_context_session.py
+++ b/tests/execution/test_native_context_session.py
@@ -1,0 +1,567 @@
+from __future__ import annotations
+
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pyarrow as pa
+import pyarrow.compute as pc
+import pytest
+import torch
+
+import daft
+from daft import DataType, col
+from daft.context import get_context
+from daft.daft import LocalPhysicalPlan
+from daft.execution.context_protocol import (
+    ContextChangeKind,
+    ContextProtocolConfig,
+    RowTransformRequest,
+    SourceSnapshot,
+)
+from daft.execution.native_executor import NativeContextSession
+from daft.recordbatch import MicroPartition
+from daft.runners import get_or_create_runner
+from tests.conftest import get_tests_daft_runner_name
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from daft.context import DaftContext
+    from daft.daft import Input, PyMicroPartition
+    from daft.dataframe import DataFrame
+
+
+def _partition_sets() -> dict[str, list[PyMicroPartition]]:
+    runner = get_or_create_runner()
+    return {
+        key: [value.micropartition()._micropartition for value in values.values()]
+        for key, values in runner._part_set_cache.get_all_partition_sets().items()
+    }
+
+
+def _compile(df: DataFrame) -> tuple[LocalPhysicalPlan, Mapping[int, Input | list[PyMicroPartition]], DaftContext]:
+    ctx = get_context()
+    builder = df._builder.optimize(ctx.daft_execution_config)
+    plan, inputs = LocalPhysicalPlan.from_logical_plan_builder(builder._builder, _partition_sets())
+    return plan, inputs, ctx
+
+
+def _collect_arrow(result_round: object) -> pa.Table:
+    parts = [result.partition() for result in result_round]
+    assert parts
+    return MicroPartition.concat(parts).to_arrow()
+
+
+def _arrow_values_to_torch(values: daft.Series) -> tuple[torch.Tensor, int]:
+    arrow_values = values.to_arrow()
+    assert isinstance(arrow_values, pa.Array)
+    assert arrow_values.null_count == 0
+    value_buffer = arrow_values.buffers()[1]
+    assert value_buffer is not None
+    byte_offset = arrow_values.offset * 8
+    torch_values = torch.frombuffer(
+        memoryview(value_buffer)[byte_offset:],
+        dtype=torch.float64,
+        count=len(arrow_values),
+    )
+    return torch_values, value_buffer.address + byte_offset
+
+
+def _torch_to_arrow(values: torch.Tensor, dtype: pa.DataType) -> pa.Array:
+    values = values.contiguous()
+    value_buffer = pa.foreign_buffer(values.data_ptr(), values.numel() * values.element_size(), base=values)
+    return pa.Array.from_buffers(dtype, len(values), [None, value_buffer])
+
+
+def _build_scored_candidates(
+    seed_ids: pa.Array,
+    scorer: object,
+    *,
+    feedback: pa.Table | None = None,
+    first_order_amount: float = 50.0,
+    first_order_version: int = 1,
+) -> DataFrame:
+    if feedback is None:
+        feedback = pa.table(
+            {
+                "order_id": pa.array([101, 102, 103, 104, 105], type=pa.int64()),
+                "keep": pa.array([True, True, True, True, True]),
+            }
+        )
+    seeds = daft.from_arrow(
+        pa.table(
+            {
+                "customer_id": seed_ids,
+                "as_of": pa.array([20, 20], type=pa.int64()),
+            }
+        )
+    )
+    customers = daft.from_arrow(
+        pa.table(
+            {
+                "customer_id": pa.array([1, 2, 3], type=pa.int64()),
+                "tier": pa.array([1.0, 2.0, 0.5], type=pa.float64()),
+            }
+        )
+    )
+    orders = daft.from_arrow(
+        pa.table(
+            {
+                "order_id": pa.array([101, 102, 103, 104, 105], type=pa.int64()),
+                "customer_id": pa.array([1, 1, 2, 2, 3], type=pa.int64()),
+                "product_id": pa.array([10, 11, 10, 12, 11], type=pa.int64()),
+                "order_ts": pa.array([5, 21, 15, 18, 9], type=pa.int64()),
+                "amount": pa.array(
+                    [first_order_amount, 90.0, 80.0, 70.0, 20.0],
+                    type=pa.float64(),
+                ),
+                "row_version": pa.array(
+                    [first_order_version, 1, 1, 1, 1],
+                    type=pa.int64(),
+                ),
+            }
+        )
+    )
+    products = daft.from_arrow(
+        pa.table(
+            {
+                "product_id": pa.array([10, 11, 12], type=pa.int64()),
+                "valid_from": pa.array([0, 0, 19], type=pa.int64()),
+                "valid_to": pa.array([100, 20, 100], type=pa.int64()),
+                "product_bias": pa.array([0.5, 0.2, 0.1], type=pa.float64()),
+            }
+        )
+    )
+
+    candidates = (
+        seeds.join(customers, on="customer_id")
+        .join(orders, on="customer_id")
+        .join(products, on="product_id")
+        .where(
+            (col("order_ts") <= col("as_of"))
+            & (col("valid_from") <= col("order_ts"))
+            & (col("order_ts") < col("valid_to"))
+        )
+    )
+    scored = candidates.select(
+        "order_id",
+        "customer_id",
+        "product_id",
+        "order_ts",
+        "amount",
+        "row_version",
+        scorer.score(candidates["amount"], candidates["tier"], candidates["product_bias"]),
+    )
+    return (
+        scored.join(daft.from_arrow(feedback), on="order_id")
+        .where(col("keep"))
+        .sort("order_id")
+        .select(
+            "order_id",
+            "customer_id",
+            "product_id",
+            "order_ts",
+            "amount",
+            "row_version",
+            "score",
+            "model_call",
+            "model_instance",
+            "arrow_value_ptr",
+            "tensor_value_ptr",
+            "score_tensor_ptr",
+            "score_arrow_ptr",
+        )
+    )
+
+
+def _make_scorer() -> object:
+    output_type = DataType.struct(
+        {
+            "score": DataType.float64(),
+            "model_call": DataType.int64(),
+            "model_instance": DataType.int64(),
+            "arrow_value_ptr": DataType.int64(),
+            "tensor_value_ptr": DataType.int64(),
+            "score_tensor_ptr": DataType.int64(),
+            "score_arrow_ptr": DataType.int64(),
+        }
+    )
+
+    @daft.cls(use_process=False)
+    class DeterministicTorchScorer:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        @daft.method.batch(return_dtype=output_type, unnest=True)
+        def score(self, amount: daft.Series, tier: daft.Series, product_bias: daft.Series) -> daft.Series:
+            amount_tensor, amount_arrow_ptr = _arrow_values_to_torch(amount)
+            tier_tensor, _ = _arrow_values_to_torch(tier)
+            bias_tensor, _ = _arrow_values_to_torch(product_bias)
+
+            self.calls += 1
+            scores = amount_tensor * 0.01 + tier_tensor + bias_tensor
+            score_ptr = scores.data_ptr()
+            score_array = _torch_to_arrow(scores, pa.float64())
+            score_buffer = score_array.buffers()[1]
+            assert score_buffer is not None
+            row_count = len(scores)
+            result = pa.StructArray.from_arrays(
+                [
+                    score_array,
+                    _torch_to_arrow(torch.full((row_count,), self.calls, dtype=torch.int64), pa.int64()),
+                    _torch_to_arrow(torch.full((row_count,), id(self), dtype=torch.int64), pa.int64()),
+                    _torch_to_arrow(torch.full((row_count,), amount_arrow_ptr, dtype=torch.int64), pa.int64()),
+                    _torch_to_arrow(torch.full((row_count,), amount_tensor.data_ptr(), dtype=torch.int64), pa.int64()),
+                    _torch_to_arrow(torch.full((row_count,), score_ptr, dtype=torch.int64), pa.int64()),
+                    _torch_to_arrow(torch.full((row_count,), score_buffer.address, dtype=torch.int64), pa.int64()),
+                ],
+                names=[
+                    "score",
+                    "model_call",
+                    "model_instance",
+                    "arrow_value_ptr",
+                    "tensor_value_ptr",
+                    "score_tensor_ptr",
+                    "score_arrow_ptr",
+                ],
+            )
+            return daft.Series.from_arrow(result)
+
+    return DeterministicTorchScorer()
+
+
+@pytest.mark.skipif(get_tests_daft_runner_name() != "native", reason="requires the native runner")
+def test_retained_context_rounds_feedback_and_fetch_more() -> None:
+    scorer = _make_scorer()
+    first_df = _build_scored_candidates(pa.array([1, 3], type=pa.int64()), scorer)
+    baseline = _build_scored_candidates(
+        pa.array([1, 3], type=pa.int64()),
+        _make_scorer(),
+    ).to_arrow()
+    plan, first_inputs, ctx = _compile(first_df)
+    initial_snapshot = SourceSnapshot.observed_facts(
+        "generated",
+        "customer-order-product",
+        {"dataset_version": 1, "schema": "v1"},
+    )
+    session = NativeContextSession(
+        plan,
+        ctx,
+        {"query_id": "host-context-session"},
+        protocol_config=ContextProtocolConfig(
+            seed_column="customer_id",
+            key_column="order_id",
+            version_column="row_version",
+            source_snapshot=initial_snapshot,
+        ),
+    )
+    transformed: list[tuple[int, int]] = []
+    row_transform = RowTransformRequest(
+        table="orders",
+        columns=("amount", "product_id"),
+        transform_version="model-v1",
+        dtype="float64",
+        layout="contiguous",
+        device="cpu",
+        transform=lambda row_key, version: (
+            transformed.append((int(row_key), int(version))) or {"encoding": f"encoded-{row_key}-v{version}"},
+            16,
+        ),
+    )
+
+    with session.run_context_round(
+        first_inputs,
+        replace_seeds=[1, 3],
+        row_transform=row_transform,
+    ) as first_batch:
+        first = first_batch.table
+        assert first_batch.session_id == session.session_id
+        assert first_batch.plan_fingerprint == session.fingerprint
+        assert first_batch.revision == 1
+        assert first_batch.query_plan
+        retained_query_plan = first_batch.query_plan
+        assert {change.kind for change in first_batch.changes} == {ContextChangeKind.ADD}
+        assert {change.row_key for change in first_batch.changes} == {101, 105}
+        assert first_batch.cache_snapshot.misses == 2
+        first_transform_101 = first_batch.row_transforms[0]
+        assert first_transform_101 == {"encoding": "encoded-101-v1"}
+        assert first_batch.lease_snapshot.live_count == 1
+        assert baseline["order_id"].to_pylist() == [101, 105]
+        assert first["order_id"].to_pylist() == baseline["order_id"].to_pylist()
+        assert first["model_call"].to_pylist() == [1, 1]
+        assert first["arrow_value_ptr"].to_pylist() == first["tensor_value_ptr"].to_pylist()
+        assert first["score_arrow_ptr"].to_pylist() == first["score_tensor_ptr"].to_pylist()
+        first_model_instance = first["model_instance"].to_pylist()[0]
+
+        keep = pc.greater_equal(first["score"], 1.5)
+        guided_feedback = pa.table({"order_id": first["order_id"], "keep": keep})
+        feedback_lease = session.protocol.lease_feedback(guided_feedback)
+
+    with feedback_lease:
+        guided_df = _build_scored_candidates(
+            pa.array([1, 3], type=pa.int64()),
+            scorer,
+            feedback=feedback_lease.value,
+        )
+        _, guided_inputs, _ = _compile(guided_df)
+        assert set(first_inputs) == set(guided_inputs)
+        with session.run_context_round(
+            guided_inputs,
+            replace_seeds=[1, 3],
+            row_transform=row_transform,
+        ) as guided_batch:
+            guided = guided_batch.table
+            assert guided["order_id"].to_pylist() == [101]
+            assert guided["model_call"].to_pylist() == [2]
+            assert guided["model_instance"].to_pylist()[0] == first_model_instance
+            assert guided_batch.query_plan == retained_query_plan
+            assert guided_batch.lease_snapshot.live_count == 2
+            assert [(change.kind, change.row_key) for change in guided_batch.changes] == [
+                (ContextChangeKind.REMOVE, 105)
+            ]
+            assert guided_batch.cache_snapshot.hits == 1
+            assert guided_batch.row_transforms[0] is first_transform_101
+
+    fetch_more_df = _build_scored_candidates(
+        pa.array([2, 999], type=pa.int64()),
+        scorer,
+        feedback=pa.table(
+            {
+                "order_id": pa.array([103], type=pa.int64()),
+                "keep": pa.array([True]),
+            }
+        ),
+    )
+    _, fetch_more_inputs, _ = _compile(fetch_more_df)
+    assert set(first_inputs) == set(fetch_more_inputs)
+    with session.run_context_round(
+        fetch_more_inputs,
+        replace_seeds=[2, 999],
+        row_transform=row_transform,
+    ) as fetched_batch:
+        fetched = fetched_batch.table
+        assert fetched["order_id"].to_pylist() == [103]
+        assert fetched["model_call"].to_pylist() == [3]
+        assert fetched["model_instance"].to_pylist()[0] == first_model_instance
+        assert fetched_batch.query_plan == retained_query_plan
+        assert [(change.kind, change.row_key) for change in fetched_batch.changes] == [(ContextChangeKind.ADD, 103)]
+        assert fetched_batch.cache_snapshot.misses == 3
+        assert fetched_batch.row_transforms == ({"encoding": "encoded-103-v1"},)
+
+    updated_snapshot = SourceSnapshot.observed_facts(
+        "generated",
+        "customer-order-product",
+        {"dataset_version": 2, "schema": "v1"},
+    )
+    assert session.update_source(updated_snapshot, {"orders": [101]}) == 1
+    updated_df = _build_scored_candidates(
+        pa.array([1, 999], type=pa.int64()),
+        scorer,
+        feedback=pa.table(
+            {
+                "order_id": pa.array([101], type=pa.int64()),
+                "keep": pa.array([True]),
+            }
+        ),
+        first_order_amount=60.0,
+        first_order_version=2,
+    )
+    _, updated_inputs, _ = _compile(updated_df)
+    with session.run_context_round(
+        updated_inputs,
+        replace_seeds=[1, 999],
+        row_transform=row_transform,
+    ) as updated_batch:
+        assert updated_batch.table["order_id"].to_pylist() == [101]
+        assert updated_batch.table["model_call"].to_pylist() == [4]
+        assert updated_batch.table["model_instance"].to_pylist()[0] == first_model_instance
+        assert updated_batch.query_plan == retained_query_plan
+        assert updated_batch.source_snapshot == updated_snapshot
+        assert [(change.kind, change.row_key) for change in updated_batch.changes] == [(ContextChangeKind.UPDATE, 101)]
+        assert updated_batch.cache_snapshot.invalidated == 1
+        assert updated_batch.cache_snapshot.misses == 4
+        assert updated_batch.row_transforms[0] == {"encoding": "encoded-101-v2"}
+        assert updated_batch.row_transforms[0] is not first_transform_101
+
+    assert transformed == [(101, 1), (105, 1), (103, 1), (101, 2)]
+    assert session.protocol.lease_snapshot.live_count == 0
+    assert session.protocol.lease_snapshot.acquired == 5
+    assert session.protocol.lease_snapshot.released == 5
+
+    session.close()
+    assert session.closed
+    assert session.active_plan_count == 0
+
+
+@pytest.mark.skipif(get_tests_daft_runner_name() != "native", reason="requires the native runner")
+def test_context_session_bounds_submission_and_cancels() -> None:
+    scorer = _make_scorer()
+    df = _build_scored_candidates(pa.array([1, 3], type=pa.int64()), scorer)
+    plan, inputs, ctx = _compile(df)
+    session = NativeContextSession(plan, ctx)
+
+    result_round = session.run_round(inputs)
+    with pytest.raises(RuntimeError, match="active input round"):
+        session.run_round(inputs)
+    assert session.active_plan_count == 1
+
+    result_round.close()
+    assert session.closed
+    assert session.active_plan_count == 0
+
+
+@pytest.mark.skipif(get_tests_daft_runner_name() != "native", reason="requires the native runner")
+def test_context_session_cancel_releases_protocol_batch() -> None:
+    scorer = _make_scorer()
+    df = _build_scored_candidates(pa.array([1, 3], type=pa.int64()), scorer)
+    plan, inputs, ctx = _compile(df)
+    session = NativeContextSession(
+        plan,
+        ctx,
+        protocol_config=ContextProtocolConfig(
+            seed_column="customer_id",
+            key_column="order_id",
+            version_column="row_version",
+            source_snapshot=SourceSnapshot.transactional("generated", "context", "v1"),
+        ),
+    )
+
+    batch = session.run_context_round(inputs, replace_seeds=[1, 3])
+    assert not batch.rows.released
+    started = time.perf_counter()
+    session.cancel()
+    assert time.perf_counter() - started < 0.5
+    assert batch.rows.released
+    assert session.protocol.lease_snapshot.live_count == 0
+    assert session.active_plan_count == 0
+
+
+@pytest.mark.skipif(get_tests_daft_runner_name() != "native", reason="requires the native runner")
+def test_context_session_reserves_credit_before_model_work() -> None:
+    scorer = _make_scorer()
+    df = _build_scored_candidates(pa.array([1, 3], type=pa.int64()), scorer)
+    plan, inputs, ctx = _compile(df)
+    session = NativeContextSession(
+        plan,
+        ctx,
+        protocol_config=ContextProtocolConfig(
+            seed_column="customer_id",
+            key_column="order_id",
+            version_column="row_version",
+            source_snapshot=SourceSnapshot.transactional("generated", "context", "v1"),
+            max_live_batches=1,
+        ),
+    )
+
+    first_batch = session.run_context_round(inputs, replace_seeds=[1, 3])
+    assert first_batch.table["model_call"].to_pylist() == [1, 1]
+
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        blocked_round = pool.submit(
+            session.run_context_round,
+            inputs,
+            replace_seeds=[1, 3],
+            lease_timeout=2.0,
+        )
+        deadline = time.perf_counter() + 1.0
+        while session.protocol.lease_snapshot.wait_count == 0 and time.perf_counter() < deadline:
+            time.sleep(0.001)
+        assert session.protocol.lease_snapshot.wait_count == 1
+        assert not blocked_round.done()
+        assert first_batch.table["model_call"].to_pylist() == [1, 1]
+
+        first_batch.release()
+        second_batch = blocked_round.result(timeout=2.0)
+
+    assert second_batch.table["model_call"].to_pylist() == [2, 2]
+    second_batch.release()
+    session.close()
+
+
+@pytest.mark.skipif(get_tests_daft_runner_name() != "native", reason="requires the native runner")
+def test_context_session_cancels_during_active_model_work(tmp_path: Path) -> None:
+    started_path = str(tmp_path / "worker-started")
+    exit_path = str(tmp_path / "allow-worker-exit")
+
+    @daft.func.batch(return_dtype=DataType.int64(), use_process=False)
+    def wait_for_cancel(values: daft.Series) -> daft.Series:
+        import time as wait_time
+        from pathlib import Path
+
+        Path(started_path).touch()
+        deadline = wait_time.perf_counter() + 5.0
+        while not Path(exit_path).exists() and wait_time.perf_counter() < deadline:
+            wait_time.sleep(0.001)
+        return values
+
+    source = daft.from_arrow(
+        pa.table(
+            {
+                "customer_id": pa.array([1], type=pa.int64()),
+                "order_id": pa.array([101], type=pa.int64()),
+                "row_version": pa.array([1], type=pa.int64()),
+                "amount": pa.array([50], type=pa.int64()),
+            }
+        )
+    )
+    df = source.select(
+        "customer_id",
+        "order_id",
+        "row_version",
+        wait_for_cancel(source["amount"]).alias("amount"),
+    )
+    plan, inputs, ctx = _compile(df)
+    session = NativeContextSession(
+        plan,
+        ctx,
+        protocol_config=ContextProtocolConfig(
+            seed_column="customer_id",
+            key_column="order_id",
+            version_column="row_version",
+            source_snapshot=SourceSnapshot.transactional("generated", "context", "v1"),
+            max_live_batches=1,
+        ),
+    )
+    pending = session.start_context_round(inputs, replace_seeds=[1])
+
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        collecting = pool.submit(pending.collect)
+        deadline = time.perf_counter() + 2.0
+        while not Path(started_path).exists() and time.perf_counter() < deadline:
+            time.sleep(0.001)
+        assert Path(started_path).exists()
+        started = time.perf_counter()
+        session.cancel()
+        elapsed = time.perf_counter() - started
+        Path(exit_path).touch()
+        assert collecting.exception(timeout=2.0) is not None
+
+    assert elapsed < 0.5
+    assert session.protocol.lease_snapshot.live_count == 0
+    assert session.protocol.lease_snapshot.acquired == 1
+    assert session.protocol.lease_snapshot.released == 1
+    assert session.active_plan_count == 0
+
+
+@pytest.mark.skipif(get_tests_daft_runner_name() != "native", reason="requires the native runner")
+def test_context_session_error_removes_cached_plan() -> None:
+    @daft.func.batch(return_dtype=DataType.int64(), use_process=False)
+    def fail(values: daft.Series) -> daft.Series:
+        raise RuntimeError("expected retained-round failure")
+
+    df = daft.from_arrow(pa.table({"value": pa.array([1, 2], type=pa.int64())})).select(fail(col("value")))
+    plan, inputs, ctx = _compile(df)
+    session = NativeContextSession(plan, ctx)
+
+    with pytest.raises(Exception, match="expected retained-round failure"):
+        list(session.run_round(inputs))
+    assert session.closed
+    assert session.active_plan_count == 0
+
+
+def test_context_session_rejects_non_native_runner(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("daft.runners.get_or_infer_runner_type", lambda: "ray")
+    with pytest.raises(RuntimeError, match="requires the native runner"):
+        NativeContextSession(object(), get_context())  # type: ignore[arg-type]

--- a/tests/udf/test_torch_device_value.py
+++ b/tests/udf/test_torch_device_value.py
@@ -1,0 +1,460 @@
+from __future__ import annotations
+
+import gc
+import json
+import weakref
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+import pytest
+
+import daft
+from daft import DataType, Series, col
+from tests.conftest import get_tests_daft_runner_name
+
+
+@dataclass
+class _DataMovement:
+    phase: str
+    source: str
+    destination: str
+    byte_count: int
+    reason: str
+    measurement: str
+
+
+@dataclass
+class _CudaBatchOwner:
+    tensor: Any
+    created_pointers: tuple[int, ...]
+    created_owner_id: int = 0
+    observed_pointers: tuple[int, ...] = ()
+    observed_devices: tuple[str, ...] = ()
+    observed_owner_ids: tuple[int, ...] = ()
+    sync_guard_error: str | None = None
+    ingress_arrow_ptr: int = 0
+    ingress_torch_ptr: int = 0
+    mask_torch_ptr: int = 0
+    mask_arrow_ptr: int = 0
+    movements: list[_DataMovement] = field(default_factory=list)
+
+
+@dataclass
+class _CudaRowValue:
+    owner: _CudaBatchOwner
+    index: int
+
+
+def _declared_device_transfer(
+    torch: Any,
+    tensor: Any,
+    destination: str,
+    *,
+    phase: str,
+    reason: str,
+    movements: list[_DataMovement],
+) -> Any:
+    previous_mode = torch.cuda.get_sync_debug_mode()
+    assert previous_mode == 2, "all CUDA work outside declared transfers must run with sync debugging set to error"
+
+    torch.cuda.set_sync_debug_mode("default")
+    try:
+        transferred = tensor.to(destination)
+    finally:
+        torch.cuda.set_sync_debug_mode(previous_mode)
+
+    movements.append(
+        _DataMovement(
+            phase=phase,
+            source=str(tensor.device),
+            destination=str(transferred.device),
+            byte_count=tensor.numel() * tensor.element_size(),
+            reason=reason,
+            measurement="physical_buffer_bytes",
+        )
+    )
+    return transferred
+
+
+_DECLARED_SERIES_ITERATIONS: set[int] = set()
+_DECLARED_TENSOR_LISTS: set[int] = set()
+
+
+def _declared_series_list(
+    values: Series,
+    *,
+    phase: str,
+    source: str,
+    destination: str,
+    byte_count: int,
+    reason: str,
+    measurement: str,
+    movements: list[_DataMovement],
+) -> list[Any]:
+    _DECLARED_SERIES_ITERATIONS.add(id(values))
+    try:
+        result = list(values)
+    finally:
+        _DECLARED_SERIES_ITERATIONS.remove(id(values))
+    movements.append(
+        _DataMovement(
+            phase=phase,
+            source=source,
+            destination=destination,
+            byte_count=byte_count,
+            reason=reason,
+            measurement=measurement,
+        )
+    )
+    return result
+
+
+def _declared_tensor_list(
+    tensor: Any,
+    *,
+    phase: str,
+    source: str,
+    destination: str,
+    byte_count: int,
+    reason: str,
+    movements: list[_DataMovement],
+) -> list[Any]:
+    _DECLARED_TENSOR_LISTS.add(id(tensor))
+    try:
+        result = tensor.tolist()
+    finally:
+        _DECLARED_TENSOR_LISTS.remove(id(tensor))
+    movements.append(
+        _DataMovement(
+            phase=phase,
+            source=source,
+            destination=destination,
+            byte_count=byte_count,
+            reason=reason,
+            measurement="logical_payload_bytes",
+        )
+    )
+    return result
+
+
+def _reject_materialization(route: str) -> Any:
+    def reject(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError(f"undeclared materialization through {route}")
+
+    return reject
+
+
+def _install_deep_path_guards(monkeypatch: pytest.MonkeyPatch, torch: Any) -> tuple[str, ...]:
+    from daft.daft import PySeries
+    from daft.dataframe import DataFrame
+    from daft.recordbatch import MicroPartition, RecordBatch
+
+    guarded_routes: list[tuple[type[Any], str]] = [
+        (torch.Tensor, "cpu"),
+        (torch.Tensor, "numpy"),
+        (Series, "to_pylist"),
+        (PySeries, "to_pylist"),
+        (DataFrame, "to_pylist"),
+        (DataFrame, "to_pydict"),
+        (MicroPartition, "to_pylist"),
+        (MicroPartition, "to_pydict"),
+        (RecordBatch, "to_pylist"),
+        (RecordBatch, "to_pydict"),
+    ]
+    original_series_iter = Series.__iter__
+    original_tensor_tolist = torch.Tensor.tolist
+
+    def guarded_series_iter(values: Series) -> Any:
+        if id(values) not in _DECLARED_SERIES_ITERATIONS:
+            raise AssertionError("undeclared materialization through daft.Series.__iter__")
+        return original_series_iter(values)
+
+    def guarded_tensor_tolist(tensor: Any) -> Any:
+        if id(tensor) not in _DECLARED_TENSOR_LISTS:
+            raise AssertionError("undeclared materialization through torch.Tensor.tolist")
+        return original_tensor_tolist(tensor)
+
+    monkeypatch.setattr(Series, "__iter__", guarded_series_iter)
+    monkeypatch.setattr(torch.Tensor, "tolist", guarded_tensor_tolist)
+
+    try:
+        import cupy
+    except ImportError:
+        pass
+    else:
+        guarded_routes.append((cupy.ndarray, "get"))
+
+    installed: list[str] = []
+    for owner, method_name in guarded_routes:
+        route = f"{owner.__module__}.{owner.__name__}.{method_name}"
+        monkeypatch.setattr(owner, method_name, _reject_materialization(route))
+        installed.append(route)
+    installed.extend(("daft.Series.__iter__", "torch.Tensor.tolist"))
+    return tuple(installed)
+
+
+def _run_device_value_spike(
+    monkeypatch: pytest.MonkeyPatch, torch: Any
+) -> tuple[dict[str, Any], weakref.ReferenceType[Any], weakref.ReferenceType[Any]]:
+    @daft.func.batch(return_dtype=DataType.python())
+    def place_on_cuda(values: Series) -> Series:
+        movements: list[_DataMovement] = []
+        arrow_values = values.to_arrow()
+        arrow_buffer = arrow_values.buffers()[1]
+        assert arrow_buffer is not None
+        python_values = _declared_series_list(
+            values,
+            phase="host_ingress_list",
+            source="daft_arrow_values",
+            destination="python_list",
+            byte_count=len(values) * 8,
+            reason="extract numeric values from the Daft batch",
+            measurement="logical_payload_bytes",
+            movements=movements,
+        )
+        host_values = torch.tensor(python_values, dtype=torch.float32)
+        movements.append(
+            _DataMovement(
+                phase="host_ingress_tensor",
+                source="python_list",
+                destination="torch_cpu",
+                byte_count=host_values.numel() * host_values.element_size(),
+                reason="construct the dense CPU tensor used for CUDA ingress",
+                measurement="physical_buffer_bytes",
+            )
+        )
+        cuda_values = _declared_device_transfer(
+            torch,
+            host_values,
+            "cuda",
+            phase="device_ingress",
+            reason="create the CUDA values requested by this feasibility spike",
+            movements=movements,
+        )
+        owner = _CudaBatchOwner(
+            tensor=cuda_values,
+            created_pointers=tuple(cuda_values[index].data_ptr() for index in range(len(cuda_values))),
+            ingress_arrow_ptr=arrow_buffer.address + arrow_values.offset * 8,
+            ingress_torch_ptr=host_values.data_ptr(),
+            movements=movements,
+        )
+        owner.created_owner_id = id(owner)
+        wrapper_values = [_CudaRowValue(owner=owner, index=index) for index in range(len(cuda_values))]
+        result = Series.from_pylist(
+            wrapper_values,
+            dtype=DataType.python(),
+        )
+        movements.append(
+            _DataMovement(
+                phase="device_wrapper_series",
+                source="python_cuda_row_wrappers",
+                destination="daft_python_series",
+                byte_count=0,
+                reason="store references to CUDA rows without moving tensor payload",
+                measurement="zero_copy_tensor_payload",
+            )
+        )
+        return result
+
+    @daft.func.batch(return_dtype=DataType.bool())
+    def create_host_filter_mask(device_values: Series) -> Series:
+        wrapper_movements: list[_DataMovement] = []
+        rows = _declared_series_list(
+            device_values,
+            phase="device_wrapper_list",
+            source="daft_python_series",
+            destination="python_cuda_row_wrappers",
+            byte_count=0,
+            reason="inspect CUDA row references in the second UDF",
+            measurement="zero_copy_tensor_payload",
+            movements=wrapper_movements,
+        )
+        assert rows
+
+        owner = rows[0].owner
+        owner.movements.extend(wrapper_movements)
+        assert all(row.owner is owner for row in rows)
+        owner.observed_owner_ids = tuple(id(row.owner) for row in rows)
+        owner.observed_pointers = tuple(row.owner.tensor[row.index].data_ptr() for row in rows)
+        owner.observed_devices = tuple(str(row.owner.tensor[row.index].device) for row in rows)
+
+        cuda_mask = owner.tensor > 2
+        try:
+            cuda_mask.sum().item()
+        except RuntimeError as error:
+            owner.sync_guard_error = str(error)
+        else:
+            raise AssertionError("sync debugging did not reject an undeclared CUDA synchronization")
+
+        host_mask = _declared_device_transfer(
+            torch,
+            cuda_mask,
+            "cpu",
+            phase="selection_boundary",
+            reason="Daft's native filter requires a host Boolean Series",
+            movements=owner.movements,
+        )
+        owner.mask_torch_ptr = host_mask.data_ptr()
+        mask_values = _declared_tensor_list(
+            host_mask,
+            phase="host_mask_list",
+            source="torch_cpu",
+            destination="python_list",
+            byte_count=host_mask.numel() * host_mask.element_size(),
+            reason="convert the host mask into values accepted by Daft's Boolean constructor",
+            movements=owner.movements,
+        )
+        result = Series.from_pylist(mask_values, dtype=DataType.bool())
+        result_arrow = result.to_arrow()
+        result_buffer = result_arrow.buffers()[1]
+        assert result_buffer is not None
+        owner.mask_arrow_ptr = result_buffer.address
+        owner.movements.append(
+            _DataMovement(
+                phase="host_mask_series",
+                source="python_list",
+                destination="daft_boolean_buffer",
+                byte_count=result_buffer.size,
+                reason="construct the host Boolean Series consumed by Daft's native filter",
+                measurement="physical_buffer_bytes",
+            )
+        )
+        return result
+
+    source = daft.from_pydict({"row_id": [101, 102, 103, 104], "value": [1, 2, 3, 4]})
+    query = (
+        source.with_column("device_value", place_on_cuda(col("value")))
+        .with_column("keep", create_host_filter_mask(col("device_value")))
+        .filter(col("keep"))
+        .select("row_id", "value", "device_value")
+    )
+
+    with monkeypatch.context() as deep_path_guards:
+        guarded_routes = _install_deep_path_guards(deep_path_guards, torch)
+        collected = query.collect()
+
+    result = collected.to_pydict()
+    assert result["row_id"] == [103, 104]
+    assert result["value"] == [3, 4]
+
+    retained_rows = result["device_value"]
+    assert [row.index for row in retained_rows] == [2, 3]
+    owner = retained_rows[0].owner
+    assert all(row.owner is owner for row in retained_rows)
+    assert owner.created_pointers == owner.observed_pointers
+    assert owner.observed_owner_ids == (owner.created_owner_id,) * 4
+    assert owner.observed_devices == ("cuda:0",) * 4
+    assert owner.sync_guard_error is not None
+    assert "synchronizing CUDA operation" in owner.sync_guard_error
+
+    assert owner.ingress_arrow_ptr != owner.ingress_torch_ptr
+    assert owner.mask_torch_ptr != owner.mask_arrow_ptr
+    movements = [asdict(movement) for movement in owner.movements]
+    assert movements == [
+        {
+            "phase": "host_ingress_list",
+            "source": "daft_arrow_values",
+            "destination": "python_list",
+            "byte_count": 32,
+            "reason": "extract numeric values from the Daft batch",
+            "measurement": "logical_payload_bytes",
+        },
+        {
+            "phase": "host_ingress_tensor",
+            "source": "python_list",
+            "destination": "torch_cpu",
+            "byte_count": 16,
+            "reason": "construct the dense CPU tensor used for CUDA ingress",
+            "measurement": "physical_buffer_bytes",
+        },
+        {
+            "phase": "device_ingress",
+            "source": "cpu",
+            "destination": "cuda:0",
+            "byte_count": 16,
+            "reason": "create the CUDA values requested by this feasibility spike",
+            "measurement": "physical_buffer_bytes",
+        },
+        {
+            "phase": "device_wrapper_series",
+            "source": "python_cuda_row_wrappers",
+            "destination": "daft_python_series",
+            "byte_count": 0,
+            "reason": "store references to CUDA rows without moving tensor payload",
+            "measurement": "zero_copy_tensor_payload",
+        },
+        {
+            "phase": "device_wrapper_list",
+            "source": "daft_python_series",
+            "destination": "python_cuda_row_wrappers",
+            "byte_count": 0,
+            "reason": "inspect CUDA row references in the second UDF",
+            "measurement": "zero_copy_tensor_payload",
+        },
+        {
+            "phase": "selection_boundary",
+            "source": "cuda:0",
+            "destination": "cpu",
+            "byte_count": 4,
+            "reason": "Daft's native filter requires a host Boolean Series",
+            "measurement": "physical_buffer_bytes",
+        },
+        {
+            "phase": "host_mask_list",
+            "source": "torch_cpu",
+            "destination": "python_list",
+            "byte_count": 4,
+            "reason": "convert the host mask into values accepted by Daft's Boolean constructor",
+            "measurement": "logical_payload_bytes",
+        },
+        {
+            "phase": "host_mask_series",
+            "source": "python_list",
+            "destination": "daft_boolean_buffer",
+            "byte_count": 1,
+            "reason": "construct the host Boolean Series consumed by Daft's native filter",
+            "measurement": "physical_buffer_bytes",
+        },
+    ]
+    assert not any(movement["phase"] == "between_udfs" for movement in movements)
+
+    summary = {
+        "created_pointers": owner.created_pointers,
+        "observed_pointers": owner.observed_pointers,
+        "device": owner.observed_devices[0],
+        "selected_row_ids": result["row_id"],
+        "ingress_arrow_ptr": owner.ingress_arrow_ptr,
+        "ingress_torch_ptr": owner.ingress_torch_ptr,
+        "mask_torch_ptr": owner.mask_torch_ptr,
+        "mask_arrow_ptr": owner.mask_arrow_ptr,
+        "movements": movements,
+        "guarded_routes": guarded_routes,
+        "sync_guard_error": owner.sync_guard_error,
+    }
+    owner_reference = weakref.ref(owner)
+    tensor_reference = weakref.ref(owner.tensor)
+    return summary, owner_reference, tensor_reference
+
+
+@pytest.mark.skipif(get_tests_daft_runner_name() != "native", reason="requires the native runner")
+def test_cuda_python_value_preserves_pointer_until_native_filter_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    torch = pytest.importorskip("torch")
+    if not torch.cuda.is_available():
+        pytest.skip("requires a CUDA device")
+
+    previous_sync_debug_mode = torch.cuda.get_sync_debug_mode()
+    try:
+        torch.cuda.set_sync_debug_mode("error")
+        summary, owner_reference, tensor_reference = _run_device_value_spike(monkeypatch, torch)
+    finally:
+        torch.cuda.set_sync_debug_mode(previous_sync_debug_mode)
+
+    gc.collect()
+    torch.cuda.empty_cache()
+    assert owner_reference() is None
+    assert tensor_reference() is None
+    assert torch.cuda.get_sync_debug_mode() == previous_sync_debug_mode
+
+    print(f"DEVICE_SPIKE_RESULT={json.dumps(summary, sort_keys=True)}")


### PR DESCRIPTION
## Changes Made

This draft explores whether Daft's native executor can support a context-curation session that repeatedly combines relational operators and model execution without translating and starting a new physical plan for every bounded input round.

The prototype adds:

- a retained native execution path that accepts repeated input rounds while keeping one physical plan and class UDF worker state, with explicit close, cancellation, and failure cleanup;
- a session-level context batch contract with pre-execution output credit, bounded live batches, explicit leases, exactly-once release, and cancellation of waiting or active work;
- row-keyed `ADD`, `REMOVE`, `UPDATE`, and `REORDER` records so a neural consumer can update only the affected context rows;
- row/version-scoped transform reuse keyed by source table, projected columns, transform version, dtype, layout, and device, plus targeted invalidation after a source update;
- source snapshots and leased feedback tables so later bounded rounds can use model feedback while the same retained plan stays active;
- an end-to-end customer/order/product scenario covering initial selection, model-guided feedback, partial fetch-more, and a changed source row;
- CUDA feasibility coverage that records each observed host/device movement and verifies that a CUDA tensor pointer is preserved across adjacent Python UDFs.

Known limits of this prototype:

- native relational values remain host Arrow data; the CUDA experiment carries tensor ownership through Daft Python values rather than introducing a native device-buffer type;
- Daft's native filter still requires a host Boolean Series, so the selection mask returns from CUDA to the host;
- Python controls transitions between bounded rounds. The relational and model work inside each round uses the retained native plan, but the prototype does not add an executor-owned feedback loop.

Validation completed before publishing this branch:

- native focused suite: 125 passed;
- Ray compatibility gate: 1 passed, 6 skipped as native-only;
- Rust formatting check passed;
- Ruff lint and formatting checks passed;
- `daft-local-execution` Clippy check with Python support and warnings denied passed;
- final strict review found no remaining correctness gaps in the tested prototype contract.

Material AI assistance was used to implement and review this research prototype. The validation above was run against the committed implementation, and the draft status is intentional while maintainers assess the design and contribution scope.

## Related Issues

No maintainer-approved issue is linked yet. This is a draft feasibility PR and does not yet satisfy the repository requirement for a non-trivial contribution to reference an approved issue.
