### PR TITLE
perf(io): push predicates into native MCAP scans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3353,6 +3353,7 @@ version = "0.3.0-dev0"
 dependencies = [
  "bytes",
  "common-error",
+ "daft-algebra",
  "daft-core",
  "daft-dsl",
  "daft-io",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3363,6 +3363,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-util",
+ "tracing",
 ]
 
 [[package]]

--- a/docs/connectors/mcap.md
+++ b/docs/connectors/mcap.md
@@ -87,6 +87,31 @@ df = daft.read_mcap(
 df.show()
 ```
 
+### Predicate Pushdown
+
+Filters on `topic` and `log_time` are pushed into the reader, where they prune
+chunks through the file's summary index, so queries like this read only the
+relevant byte ranges from storage:
+
+```python
+df = daft.read_mcap("/path/to/recording.mcap").where(
+    (col("topic") == "/camera/image")
+    & (col("log_time") >= 1609459200000000000)
+    & (col("log_time") < 1609545600000000000)
+)
+```
+
+Pushed filters combine with any explicit `topics`/`start_time`/`end_time`
+arguments, and the full predicate is still applied to decoded batches, so
+results are identical either way.
+
+### Ordering
+
+Indexed MCAP files (files with a summary and chunk indexes, the common case)
+are read in `log_time` order within each file, even when messages are
+physically out of order across chunks. Files without an index stream in file
+order, and ordering across multiple files is not guaranteed.
+
 ### Batch Size
 
 Control memory usage by adjusting the batch size:

--- a/src/daft-mcap/Cargo.toml
+++ b/src/daft-mcap/Cargo.toml
@@ -10,6 +10,7 @@ futures = {workspace = true}
 mcap = {workspace = true}
 tokio = {workspace = true}
 tokio-util = {workspace = true}
+tracing = {workspace = true}
 
 [dev-dependencies]
 tempfile = "3.23.0"

--- a/src/daft-mcap/Cargo.toml
+++ b/src/daft-mcap/Cargo.toml
@@ -1,6 +1,7 @@
 [dependencies]
 bytes = {workspace = true}
 common-error = {path = "../common/error", default-features = false}
+daft-algebra = {path = "../daft-algebra", default-features = false}
 daft-core = {path = "../daft-core", default-features = false}
 daft-dsl = {path = "../daft-dsl", default-features = false}
 daft-io = {path = "../daft-io", default-features = false}

--- a/src/daft-mcap/src/lib.rs
+++ b/src/daft-mcap/src/lib.rs
@@ -114,6 +114,12 @@ impl BufferedRange {
 }
 
 /// Reads the optional summary section from the end of an MCAP file.
+#[tracing::instrument(
+    skip_all,
+    name = "McapReader::read_summary",
+    fields(file_size = file_size, is_remote = is_remote),
+    err
+)]
 pub(crate) async fn read_summary(
     uri: &str,
     file_size: usize,

--- a/src/daft-mcap/src/lib.rs
+++ b/src/daft-mcap/src/lib.rs
@@ -21,6 +21,7 @@ use daft_recordbatch::RecordBatch;
 use futures::{StreamExt, stream::BoxStream};
 use mcap::sans_io::{SummaryReadEvent, SummaryReader, SummaryReaderOptions};
 
+mod pushdown;
 mod read;
 #[cfg(test)]
 mod test_utils;
@@ -276,9 +277,10 @@ fn reader_batch_stream(
 
 /// Stream MCAP messages as record batches.
 ///
-/// Topic/time constraints are applied while decoding. Residual predicates run
-/// before projection so filters can reference unprojected columns. The final
-/// batch is truncated to honor the limit exactly.
+/// Topic/time constraints — explicit ones and any recovered from the
+/// predicate — are applied while decoding. Residual predicates run before
+/// projection so filters can reference unprojected columns. The final batch
+/// is truncated to honor the limit exactly.
 pub async fn stream_mcap(
     uri: &str,
     io_client: Arc<IOClient>,
@@ -286,6 +288,8 @@ pub async fn stream_mcap(
     read_options: McapReadOptions,
     convert_options: McapConvertOptions,
 ) -> DaftResult<BoxStream<'static, DaftResult<RecordBatch>>> {
+    let read_options =
+        pushdown::apply_predicate_pushdown(read_options, convert_options.predicate.as_ref());
     let reader = NativeMcapReader::new(uri, io_client, io_stats, read_options).await?;
     let batches = reader_batch_stream(reader, convert_options.limit.is_none());
     let stream = futures::stream::try_unfold(
@@ -407,6 +411,95 @@ mod tests {
 
         assert_eq!(batches.len(), 5);
         assert_eq!(batches.iter().map(|batch| batch.len()).sum::<usize>(), 20);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn stream_pushes_predicate_constraints_into_index() -> DaftResult<()> {
+        use std::sync::Arc;
+
+        // 16 messages x 64 KiB: an index-pruned read of one message must
+        // fetch well under half the file even with no explicit constraints.
+        let file = write_mcap(true, None, 16, 64 * 1024);
+        let file_size = file.as_file().metadata().unwrap().len() as usize;
+        let predicate = resolved_col("topic")
+            .eq(lit("/camera"))
+            .and(resolved_col("log_time").gt_eq(lit(8_u64)))
+            .and(resolved_col("log_time").lt(lit(9_u64)));
+
+        let io_client = daft_io::get_io_client(true, Arc::new(daft_io::IOConfig::default()))?;
+        let io_stats = daft_io::IOStatsContext::new("daft-mcap pushdown test");
+        let uri = file.path().to_string_lossy().into_owned();
+        let batches: Vec<_> = futures::TryStreamExt::try_collect(
+            crate::stream_mcap(
+                &uri,
+                io_client,
+                io_stats.clone(),
+                McapReadOptions::default(),
+                McapConvertOptions {
+                    predicate: Some(predicate),
+                    include_columns: None,
+                    limit: None,
+                },
+            )
+            .await?,
+        )
+        .await?;
+
+        assert_eq!(batches.iter().map(|batch| batch.len()).sum::<usize>(), 1);
+        assert!(
+            io_stats.load_bytes_read() < file_size / 2,
+            "predicate-pruned read fetched {} of {file_size} bytes",
+            io_stats.load_bytes_read()
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn stream_predicate_matches_explicit_kwargs() -> DaftResult<()> {
+        fn log_times(batches: &[daft_recordbatch::RecordBatch]) -> Vec<u64> {
+            batches
+                .iter()
+                .flat_map(|batch| {
+                    let times = batch.get_column(2).u64().unwrap();
+                    (0..batch.len())
+                        .map(|index| times.get(index).unwrap())
+                        .collect::<Vec<_>>()
+                })
+                .collect()
+        }
+
+        let file = write_mcap(true, None, 40, 32);
+        let via_kwargs = collect_stream(
+            &file,
+            McapReadOptions {
+                start_time: Some(4),
+                end_time: Some(20),
+                topics: Some(vec!["/camera".to_string()]),
+                ..Default::default()
+            },
+            McapConvertOptions::default(),
+        )
+        .await?;
+        let via_predicate = collect_stream(
+            &file,
+            McapReadOptions::default(),
+            McapConvertOptions {
+                predicate: Some(
+                    resolved_col("topic")
+                        .eq(lit("/camera"))
+                        .and(resolved_col("log_time").gt_eq(lit(4_u64)))
+                        .and(resolved_col("log_time").lt(lit(20_u64))),
+                ),
+                include_columns: None,
+                limit: None,
+            },
+        )
+        .await?;
+
+        let expected = log_times(&via_kwargs);
+        assert!(!expected.is_empty());
+        assert_eq!(log_times(&via_predicate), expected);
         Ok(())
     }
 

--- a/src/daft-mcap/src/lib.rs
+++ b/src/daft-mcap/src/lib.rs
@@ -176,6 +176,35 @@ pub(crate) async fn read_summary(
     Ok(reader.finish())
 }
 
+/// Parses the optional summary section from a fully buffered MCAP file.
+pub(crate) fn parse_summary_from_bytes(bytes: &Bytes) -> DaftResult<Option<mcap::Summary>> {
+    let file_size = bytes.len() as u64;
+    let mut reader = SummaryReader::new_with_options(
+        SummaryReaderOptions::default()
+            .with_file_size(file_size)
+            .with_record_length_limit(MAX_RECORD_LENGTH),
+    );
+    let mut position = 0_u64;
+    while let Some(event) = reader.next_event() {
+        match event.map_err(mcap_error)? {
+            SummaryReadEvent::SeekRequest(request) => {
+                position = seek_position(request, position, file_size)?;
+                reader.notify_seeked(position);
+            }
+            SummaryReadEvent::ReadRequest(requested) => {
+                let start = usize::try_from(position)
+                    .map_err(|_| mcap_error("summary position does not fit in usize"))?;
+                let available = bytes.len().saturating_sub(start).min(requested);
+                reader.insert(requested)[..available]
+                    .copy_from_slice(&bytes[start..start + available]);
+                reader.notify_read(available);
+                position = position.saturating_add(available as u64);
+            }
+        }
+    }
+    Ok(reader.finish())
+}
+
 #[derive(Clone, Debug)]
 pub struct McapReadOptions {
     pub batch_size: usize,
@@ -315,7 +344,7 @@ mod tests {
     use tempfile::NamedTempFile;
 
     use super::{BufferedRange, McapConvertOptions, McapReadOptions};
-    use crate::test_utils::{collect_stream, write_mcap};
+    use crate::test_utils::{collect_stream, write_corrupt_chunk_mcap, write_mcap};
 
     #[test]
     fn buffered_range_slices_within_bounds() {
@@ -383,6 +412,23 @@ mod tests {
 
     #[tokio::test]
     async fn prefetched_stream_propagates_reader_errors() -> DaftResult<()> {
+        // A corrupt chunk fails mid-stream, after the reader opens cleanly,
+        // so the error must travel through the prefetch channel.
+        let file = write_corrupt_chunk_mcap();
+        let error = collect_stream(
+            &file,
+            McapReadOptions::default(),
+            McapConvertOptions::default(),
+        )
+        .await
+        .expect_err("corrupt MCAP chunk should fail");
+
+        assert!(error.to_string().contains("Failed to read MCAP messages"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn stream_surfaces_open_errors() -> DaftResult<()> {
         let file = NamedTempFile::new().unwrap();
         std::fs::write(file.path(), b"not an mcap file").unwrap();
         let error = collect_stream(

--- a/src/daft-mcap/src/pushdown.rs
+++ b/src/daft-mcap/src/pushdown.rs
@@ -1,0 +1,317 @@
+//! Conservative extraction of MCAP reader constraints from Daft predicates.
+//!
+//! Extraction only tightens the [`McapReadOptions`] used for index-based I/O
+//! pruning; the complete predicate is always re-applied to decoded batches,
+//! so a skipped expression costs performance, never correctness. Only
+//! top-level conjuncts of the forms `topic == <literal>`,
+//! `topic IS IN (<literals>)`, and `log_time <cmp> <integer literal>` are
+//! recognized.
+
+use std::collections::BTreeSet;
+
+use daft_algebra::boolean::split_conjunction;
+use daft_core::{lit::Literal, prelude::Operator};
+use daft_dsl::{Column, Expr, ExprRef, ResolvedColumn};
+
+use crate::McapReadOptions;
+
+const TOPIC_COLUMN: &str = "topic";
+const LOG_TIME_COLUMN: &str = "log_time";
+
+/// Tightens reader constraints with topic/log-time bounds recovered from the
+/// scan predicate. Recovered bounds intersect any explicit constraints.
+pub(crate) fn apply_predicate_pushdown(
+    mut read_options: McapReadOptions,
+    predicate: Option<&ExprRef>,
+) -> McapReadOptions {
+    let Some(predicate) = predicate else {
+        return read_options;
+    };
+    for conjunct in split_conjunction(predicate) {
+        match conjunct.as_ref() {
+            Expr::BinaryOp { op, left, right } => {
+                apply_comparison(&mut read_options, *op, left, right);
+            }
+            Expr::IsIn(expr, items) => {
+                if column_name(expr) == Some(TOPIC_COLUMN)
+                    && let Some(topics) = utf8_literals(items)
+                {
+                    intersect_topics(&mut read_options, topics);
+                }
+            }
+            _ => {}
+        }
+    }
+    read_options
+}
+
+fn apply_comparison(
+    read_options: &mut McapReadOptions,
+    op: Operator,
+    left: &ExprRef,
+    right: &ExprRef,
+) {
+    // Normalize to `column <op> literal`.
+    let (column, op, literal) = if let Some(column) = column_name(left) {
+        (column, op, right)
+    } else if let Some(column) = column_name(right) {
+        let Some(op) = flip_comparison(op) else {
+            return;
+        };
+        (column, op, left)
+    } else {
+        return;
+    };
+
+    match column {
+        TOPIC_COLUMN => {
+            if op == Operator::Eq
+                && let Expr::Literal(Literal::Utf8(topic)) = literal.as_ref()
+            {
+                intersect_topics(read_options, BTreeSet::from([topic.clone()]));
+            }
+        }
+        LOG_TIME_COLUMN => {
+            let Some(value) = u64_literal(literal) else {
+                return;
+            };
+            // The reader's time range is half-open: [start_time, end_time).
+            // Bounds that cannot be represented in u64 are skipped, which
+            // simply leaves them to the residual predicate.
+            match op {
+                Operator::GtEq => raise_start(read_options, value),
+                Operator::Gt => {
+                    if let Some(bound) = value.checked_add(1) {
+                        raise_start(read_options, bound);
+                    }
+                }
+                Operator::Lt => lower_end(read_options, value),
+                Operator::LtEq => {
+                    if let Some(bound) = value.checked_add(1) {
+                        lower_end(read_options, bound);
+                    }
+                }
+                _ => {}
+            }
+        }
+        _ => {}
+    }
+}
+
+fn flip_comparison(op: Operator) -> Option<Operator> {
+    match op {
+        Operator::Eq => Some(Operator::Eq),
+        Operator::Lt => Some(Operator::Gt),
+        Operator::LtEq => Some(Operator::GtEq),
+        Operator::Gt => Some(Operator::Lt),
+        Operator::GtEq => Some(Operator::LtEq),
+        _ => None,
+    }
+}
+
+fn column_name(expr: &ExprRef) -> Option<&str> {
+    match expr.as_ref() {
+        Expr::Column(Column::Resolved(ResolvedColumn::Basic(name))) => Some(name.as_ref()),
+        _ => None,
+    }
+}
+
+fn utf8_literals(items: &[ExprRef]) -> Option<BTreeSet<String>> {
+    items
+        .iter()
+        .map(|item| match item.as_ref() {
+            Expr::Literal(Literal::Utf8(value)) => Some(value.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+fn u64_literal(expr: &ExprRef) -> Option<u64> {
+    let Expr::Literal(literal) = expr.as_ref() else {
+        return None;
+    };
+    match *literal {
+        Literal::UInt8(value) => Some(u64::from(value)),
+        Literal::UInt16(value) => Some(u64::from(value)),
+        Literal::UInt32(value) => Some(u64::from(value)),
+        Literal::UInt64(value) => Some(value),
+        Literal::Int8(value) => u64::try_from(value).ok(),
+        Literal::Int16(value) => u64::try_from(value).ok(),
+        Literal::Int32(value) => u64::try_from(value).ok(),
+        Literal::Int64(value) => u64::try_from(value).ok(),
+        _ => None,
+    }
+}
+
+fn intersect_topics(read_options: &mut McapReadOptions, topics: BTreeSet<String>) {
+    let merged = match read_options.topics.take() {
+        Some(existing) => existing
+            .into_iter()
+            .filter(|topic| topics.contains(topic))
+            .collect(),
+        None => topics.into_iter().collect(),
+    };
+    read_options.topics = Some(merged);
+}
+
+fn raise_start(read_options: &mut McapReadOptions, bound: u64) {
+    read_options.start_time = Some(
+        read_options
+            .start_time
+            .map_or(bound, |start| start.max(bound)),
+    );
+}
+
+fn lower_end(read_options: &mut McapReadOptions, bound: u64) {
+    read_options.end_time = Some(read_options.end_time.map_or(bound, |end| end.min(bound)));
+}
+
+#[cfg(test)]
+mod tests {
+    use daft_dsl::{lit, resolved_col};
+
+    use super::apply_predicate_pushdown;
+    use crate::McapReadOptions;
+
+    fn extract(predicate: daft_dsl::ExprRef) -> McapReadOptions {
+        apply_predicate_pushdown(McapReadOptions::default(), Some(&predicate))
+    }
+
+    #[test]
+    fn no_predicate_is_a_no_op() {
+        let options = apply_predicate_pushdown(McapReadOptions::default(), None);
+        assert_eq!(options.topics, None);
+        assert_eq!(options.start_time, None);
+        assert_eq!(options.end_time, None);
+    }
+
+    #[test]
+    fn topic_equality_becomes_topic_set() {
+        let options = extract(resolved_col("topic").eq(lit("/camera")));
+        assert_eq!(options.topics, Some(vec!["/camera".to_string()]));
+    }
+
+    #[test]
+    fn flipped_topic_equality_becomes_topic_set() {
+        let options = extract(lit("/camera").eq(resolved_col("topic")));
+        assert_eq!(options.topics, Some(vec!["/camera".to_string()]));
+    }
+
+    #[test]
+    fn topic_is_in_becomes_topic_set() {
+        let options = extract(resolved_col("topic").is_in(vec![lit("/camera"), lit("/imu")]));
+        assert_eq!(
+            options.topics,
+            Some(vec!["/camera".to_string(), "/imu".to_string()])
+        );
+    }
+
+    #[test]
+    fn topic_constraints_intersect_explicit_topics() {
+        let explicit = McapReadOptions {
+            topics: Some(vec!["/camera".to_string(), "/imu".to_string()]),
+            ..Default::default()
+        };
+        let predicate = resolved_col("topic").eq(lit("/imu"));
+        let options = apply_predicate_pushdown(explicit, Some(&predicate));
+        assert_eq!(options.topics, Some(vec!["/imu".to_string()]));
+    }
+
+    #[test]
+    fn contradictory_topics_intersect_to_empty() {
+        let predicate = resolved_col("topic")
+            .eq(lit("/camera"))
+            .and(resolved_col("topic").eq(lit("/imu")));
+        let options = extract(predicate);
+        assert_eq!(options.topics, Some(vec![]));
+    }
+
+    #[test]
+    fn log_time_bounds_map_to_half_open_range() {
+        let options = extract(
+            resolved_col("log_time")
+                .gt_eq(lit(4_u64))
+                .and(resolved_col("log_time").lt(lit(10_u64))),
+        );
+        assert_eq!(options.start_time, Some(4));
+        assert_eq!(options.end_time, Some(10));
+
+        let options = extract(
+            resolved_col("log_time")
+                .gt(lit(4_u64))
+                .and(resolved_col("log_time").lt_eq(lit(10_u64))),
+        );
+        assert_eq!(options.start_time, Some(5));
+        assert_eq!(options.end_time, Some(11));
+    }
+
+    #[test]
+    fn flipped_log_time_bounds_are_normalized() {
+        let options = extract(lit(4_u64).lt_eq(resolved_col("log_time")));
+        assert_eq!(options.start_time, Some(4));
+
+        let options = extract(lit(10_u64).gt(resolved_col("log_time")));
+        assert_eq!(options.end_time, Some(10));
+    }
+
+    #[test]
+    fn log_time_bounds_tighten_explicit_range() {
+        let explicit = McapReadOptions {
+            start_time: Some(10),
+            end_time: Some(100),
+            ..Default::default()
+        };
+        let predicate = resolved_col("log_time")
+            .gt_eq(lit(5_u64))
+            .and(resolved_col("log_time").lt(lit(50_u64)));
+        let options = apply_predicate_pushdown(explicit, Some(&predicate));
+        assert_eq!(options.start_time, Some(10));
+        assert_eq!(options.end_time, Some(50));
+    }
+
+    #[test]
+    fn unrepresentable_bounds_are_skipped() {
+        let options = extract(resolved_col("log_time").gt(lit(u64::MAX)));
+        assert_eq!(options.start_time, None);
+
+        let options = extract(resolved_col("log_time").lt_eq(lit(u64::MAX)));
+        assert_eq!(options.end_time, None);
+
+        let options = extract(resolved_col("log_time").gt_eq(lit(-5_i64)));
+        assert_eq!(options.start_time, None);
+    }
+
+    #[test]
+    fn disjunctions_are_not_extracted() {
+        let predicate = resolved_col("topic")
+            .eq(lit("/camera"))
+            .or(resolved_col("topic").eq(lit("/imu")));
+        let options = extract(predicate);
+        assert_eq!(options.topics, None);
+    }
+
+    #[test]
+    fn unrelated_expressions_are_skipped() {
+        let options = extract(resolved_col("publish_time").gt_eq(lit(5_u64)));
+        assert_eq!(options.start_time, None);
+
+        let options = extract(resolved_col("log_time").gt_eq(resolved_col("publish_time")));
+        assert_eq!(options.start_time, None);
+
+        let options = extract(resolved_col("topic").eq(resolved_col("source_path")));
+        assert_eq!(options.topics, None);
+    }
+
+    #[test]
+    fn conjunction_combines_topic_and_time_constraints() {
+        let predicate = resolved_col("topic")
+            .eq(lit("/camera"))
+            .and(resolved_col("log_time").gt_eq(lit(4_u64)))
+            .and(resolved_col("log_time").lt(lit(10_u64)))
+            .and(resolved_col("sequence").gt(lit(1_u32)));
+        let options = extract(predicate);
+        assert_eq!(options.topics, Some(vec!["/camera".to_string()]));
+        assert_eq!(options.start_time, Some(4));
+        assert_eq!(options.end_time, Some(10));
+    }
+}

--- a/src/daft-mcap/src/read.rs
+++ b/src/daft-mcap/src/read.rs
@@ -192,6 +192,17 @@ pub struct NativeMcapReader {
 }
 
 impl NativeMcapReader {
+    #[tracing::instrument(
+        skip_all,
+        name = "NativeMcapReader::new",
+        fields(
+            batch_size = options.batch_size,
+            topic_filter_count = options.topics.as_ref().map_or(0, Vec::len),
+            has_start_time = options.start_time.is_some(),
+            has_end_time = options.end_time.is_some(),
+        ),
+        err
+    )]
     pub async fn new(
         uri: impl Into<String>,
         io_client: Arc<IOClient>,

--- a/src/daft-mcap/src/read.rs
+++ b/src/daft-mcap/src/read.rs
@@ -23,7 +23,8 @@ use tokio::io::AsyncRead;
 use tokio_util::io::StreamReader;
 
 use crate::{
-    BufferedRange, MAX_RECORD_LENGTH, McapReadOptions, fetch_exact_range, mcap_error, read_summary,
+    BufferedRange, MAX_RECORD_LENGTH, McapReadOptions, fetch_exact_range, mcap_error,
+    parse_summary_from_bytes, read_summary,
 };
 
 // Read small remote files in one request.
@@ -211,98 +212,93 @@ impl NativeMcapReader {
                 .start_time
                 .zip(options.end_time)
                 .is_some_and(|(start, end)| start >= end);
-        let unfiltered =
-            topics.is_none() && options.start_time.is_none() && options.end_time.is_none();
-        let is_remote = !matches!(parse_url(&uri)?.0, SourceType::File);
 
         let mut channels = BTreeMap::new();
-        let (mode, indexed, indexed_remote_file_size) = if unfiltered {
-            (
-                ReaderMode::Linear {
-                    reader: open_linear_reader(&uri, &io_client, &io_stats).await?,
-                    record_buffer: Vec::new(),
-                },
-                false,
-                None,
-            )
+        let (mode, indexed, indexed_remote_file_size, indexed_read_buffer) = if empty {
+            // Provably-empty constraints never touch storage.
+            (ReaderMode::Empty, false, None, None)
         } else {
+            let is_remote = !matches!(parse_url(&uri)?.0, SourceType::File);
             let file_size = io_client
                 .single_url_get_size(uri.clone(), Some(io_stats.clone()))
                 .await?;
             if file_size < mcap::MAGIC.len() {
                 return Err(mcap_error("file is shorter than MCAP magic"));
             }
-            let is_small_remote = file_size <= SMALL_REMOTE_FILE_THRESHOLD && is_remote;
-            let buffered = if is_small_remote && !empty {
+
+            // Small remote files: one request buys the whole file; the summary
+            // and any chunk reads are then served from the buffer.
+            let buffer = if is_remote && file_size <= SMALL_REMOTE_FILE_THRESHOLD {
                 Some(fetch_exact_range(&uri, 0, file_size, &io_client, &io_stats).await?)
             } else {
-                let magic =
-                    fetch_exact_range(&uri, 0, mcap::MAGIC.len(), &io_client, &io_stats).await?;
-                if magic.as_ref() != mcap::MAGIC {
-                    return Err(mcap_error("bad leading magic"));
-                }
                 None
             };
-
-            if let Some(bytes) = buffered {
-                if !bytes.starts_with(mcap::MAGIC) {
-                    return Err(mcap_error("bad leading magic"));
+            let magic = match &buffer {
+                Some(bytes) => bytes.slice(0..mcap::MAGIC.len()),
+                None => {
+                    fetch_exact_range(&uri, 0, mcap::MAGIC.len(), &io_client, &io_stats).await?
                 }
+            };
+            if magic.as_ref() != mcap::MAGIC {
+                return Err(mcap_error("bad leading magic"));
+            }
+
+            let summary = match &buffer {
+                Some(bytes) => parse_summary_from_bytes(bytes)?,
+                None => read_summary(&uri, file_size, is_remote, &io_client, &io_stats).await?,
+            };
+            if let Some(summary) = &summary {
+                channels.extend(
+                    summary
+                        .channels
+                        .iter()
+                        .map(|(id, channel)| (*id, channel.topic.clone())),
+                );
+            }
+
+            let usable = summary.filter(|summary| {
+                !summary.chunk_indexes.is_empty() && !summary.channels.is_empty()
+            });
+            if let Some(summary) = usable {
+                // Indexed traversal is the primary path: chunk indexes prune
+                // I/O and ReadOrder::LogTime yields per-file log-time order.
+                let mut reader_options = IndexedReaderOptions::new().with_order(ReadOrder::LogTime);
+                if let Some(start_time) = options.start_time {
+                    reader_options = reader_options.log_time_on_or_after(start_time);
+                }
+                if let Some(end_time) = options.end_time {
+                    reader_options = reader_options.log_time_before(end_time);
+                }
+                if let Some(topics) = &topics {
+                    reader_options = reader_options.include_topics(topics.iter().cloned());
+                }
+                reader_options = reader_options.with_record_length_limit(MAX_RECORD_LENGTH);
+                let read_buffer = buffer.map(|bytes| BufferedRange { start: 0, bytes });
+                let remote_file_size = (is_remote && read_buffer.is_none()).then_some(file_size);
+                (
+                    ReaderMode::Indexed(
+                        IndexedReader::new_with_options(&summary, reader_options)
+                            .map_err(mcap_error)?,
+                    ),
+                    true,
+                    remote_file_size,
+                    read_buffer,
+                )
+            } else {
+                // Unindexed fallback: stream records in file order.
+                let reader = match buffer {
+                    Some(bytes) => open_buffered_linear_reader(bytes),
+                    None => open_linear_reader(&uri, &io_client, &io_stats).await?,
+                };
                 (
                     ReaderMode::Linear {
-                        reader: open_buffered_linear_reader(bytes),
+                        reader,
                         record_buffer: Vec::new(),
                     },
                     false,
                     None,
+                    None,
                 )
-            } else if empty {
-                (ReaderMode::Empty, false, None)
-            } else {
-                let summary =
-                    read_summary(&uri, file_size, is_remote, &io_client, &io_stats).await?;
-                if let Some(summary) = &summary {
-                    channels.extend(
-                        summary
-                            .channels
-                            .iter()
-                            .map(|(id, channel)| (*id, channel.topic.clone())),
-                    );
-                }
-
-                if let Some(summary) = summary.filter(|summary| {
-                    !summary.chunk_indexes.is_empty() && !summary.channels.is_empty()
-                }) {
-                    let mut reader_options =
-                        IndexedReaderOptions::new().with_order(ReadOrder::LogTime);
-                    if let Some(start_time) = options.start_time {
-                        reader_options = reader_options.log_time_on_or_after(start_time);
-                    }
-                    if let Some(end_time) = options.end_time {
-                        reader_options = reader_options.log_time_before(end_time);
-                    }
-                    if let Some(topics) = &topics {
-                        reader_options = reader_options.include_topics(topics.iter().cloned());
-                    }
-                    reader_options = reader_options.with_record_length_limit(MAX_RECORD_LENGTH);
-                    (
-                        ReaderMode::Indexed(
-                            IndexedReader::new_with_options(&summary, reader_options)
-                                .map_err(mcap_error)?,
-                        ),
-                        true,
-                        is_remote.then_some(file_size),
-                    )
-                } else {
-                    (
-                        ReaderMode::Linear {
-                            reader: open_linear_reader(&uri, &io_client, &io_stats).await?,
-                            record_buffer: Vec::new(),
-                        },
-                        false,
-                        None,
-                    )
-                }
             }
         };
 
@@ -319,7 +315,7 @@ impl NativeMcapReader {
             finished: false,
             indexed,
             indexed_remote_file_size,
-            indexed_read_buffer: None,
+            indexed_read_buffer,
         })
     }
 
@@ -530,7 +526,7 @@ mod tests {
     use super::indexed_read_length;
     use crate::{
         McapReadOptions,
-        test_utils::{collect_rows, make_reader, write_mcap},
+        test_utils::{collect_rows, make_reader, write_mcap, write_mcap_out_of_order},
     };
 
     #[test]
@@ -550,15 +546,62 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn unfiltered_reader_streams_file_once() -> DaftResult<()> {
-        let file = write_mcap(true, None, 20, 32);
+    async fn unfiltered_unindexed_reader_streams_file_once() -> DaftResult<()> {
+        let file = write_mcap(false, None, 20, 32);
         let file_size = file.as_file().metadata().unwrap().len() as usize;
         let (mut reader, io_stats) = make_reader(&file, McapReadOptions::default()).await?;
 
         assert!(!reader.indexed());
         assert_eq!(collect_rows(&mut reader).await?.len(), 20);
         drop(reader);
-        assert_eq!(io_stats.load_bytes_read(), file_size);
+        // One magic probe and one summary probe, then a single linear pass.
+        let bytes_read = io_stats.load_bytes_read();
+        assert!(
+            bytes_read >= file_size && bytes_read < 2 * file_size,
+            "unindexed unfiltered read fetched {bytes_read} of {file_size} bytes"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn unfiltered_indexed_read_returns_log_time_order() -> DaftResult<()> {
+        let file = write_mcap_out_of_order(10);
+        // Fixture precondition: chunks must be physically out of log-time order.
+        let contents = bytes::Bytes::from(std::fs::read(file.path()).unwrap());
+        let summary = crate::parse_summary_from_bytes(&contents)?.expect("fixture has a summary");
+        assert!(
+            summary
+                .chunk_indexes
+                .windows(2)
+                .any(|pair| pair[0].message_start_time > pair[1].message_start_time),
+            "fixture chunks are not out of log-time order"
+        );
+
+        let (mut reader, _) = make_reader(&file, McapReadOptions::default()).await?;
+        assert!(reader.indexed());
+        let times = collect_rows(&mut reader)
+            .await?
+            .iter()
+            .map(|(_, time, _)| *time)
+            .collect::<Vec<_>>();
+        assert_eq!(times.len(), 20);
+        assert_eq!(times.first(), Some(&0));
+        let mut sorted = times.clone();
+        sorted.sort_unstable();
+        assert_eq!(times, sorted);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn empty_constraints_skip_io() -> DaftResult<()> {
+        let file = write_mcap(true, None, 4, 8);
+        let options = McapReadOptions {
+            topics: Some(vec![]),
+            ..Default::default()
+        };
+        let (mut reader, io_stats) = make_reader(&file, options).await?;
+        assert!(reader.next_batch().await?.is_none());
+        assert_eq!(io_stats.load_bytes_read(), 0);
         Ok(())
     }
 
@@ -653,11 +696,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn invalid_magic_is_rejected() -> DaftResult<()> {
+    async fn invalid_magic_is_rejected_at_open() -> DaftResult<()> {
         let file = NamedTempFile::new().unwrap();
         std::fs::write(file.path(), b"not an mcap file").unwrap();
-        let (mut reader, _) = make_reader(&file, McapReadOptions::default()).await?;
-        let result = reader.next_batch().await;
+        let result = make_reader(&file, McapReadOptions::default()).await;
         assert!(
             result
                 .err()

--- a/src/daft-mcap/src/test_utils.rs
+++ b/src/daft-mcap/src/test_utils.rs
@@ -62,6 +62,61 @@ pub(crate) fn write_mcap(
     temp
 }
 
+/// Writes an indexed MCAP whose chunks are physically out of log-time order:
+/// a run of log times starting at 100 precedes a run starting at 0, with a
+/// chunk size small enough that the runs never share a chunk.
+pub(crate) fn write_mcap_out_of_order(messages_per_run: usize) -> NamedTempFile {
+    let temp = NamedTempFile::new().unwrap();
+    let output = File::create(temp.path()).unwrap();
+    let mut writer = WriteOptions::new()
+        .use_chunks(true)
+        .chunk_size(Some(64))
+        .create(BufWriter::new(output))
+        .unwrap();
+    let channel = Arc::new(Channel {
+        id: 1,
+        schema: None,
+        topic: "/camera".to_string(),
+        message_encoding: String::new(),
+        metadata: BTreeMap::new(),
+    });
+
+    for run_start in [100_u64, 0_u64] {
+        for offset in 0..messages_per_run as u64 {
+            let time = run_start + offset;
+            writer
+                .write(&Message {
+                    channel: channel.clone(),
+                    sequence: time as u32,
+                    log_time: time,
+                    publish_time: time,
+                    data: Cow::Owned(time.to_le_bytes().to_vec()),
+                })
+                .unwrap();
+        }
+    }
+    writer.finish().unwrap();
+    drop(writer);
+    temp
+}
+
+/// Writes a valid indexed MCAP, then flips the first byte of the first
+/// chunk's compressed data (the zstd frame magic) so that chunk fails to
+/// decompress during streaming while the summary stays intact.
+pub(crate) fn write_corrupt_chunk_mcap() -> NamedTempFile {
+    let temp = write_mcap(true, Some(Compression::Zstd), 64, 512);
+    let mut contents = std::fs::read(temp.path()).unwrap();
+    let summary = crate::parse_summary_from_bytes(&bytes::Bytes::from(contents.clone()))
+        .unwrap()
+        .expect("fixture has a summary");
+    let data_offset = summary.chunk_indexes[0]
+        .compressed_data_offset()
+        .expect("fixture chunk has a data offset");
+    contents[usize::try_from(data_offset).unwrap()] ^= 0xFF;
+    std::fs::write(temp.path(), &contents).unwrap();
+    temp
+}
+
 pub(crate) async fn make_reader(
     file: &NamedTempFile,
     options: McapReadOptions,

--- a/tests/io/mcap/test_mcap.py
+++ b/tests/io/mcap/test_mcap.py
@@ -324,6 +324,87 @@ def test_mcap_small_remote_filter_uses_one_body_request(tmp_path):
     assert CountingRangeHandler.bytes_served == len(contents)
 
 
+def test_mcap_where_pushdown_coalesces_remote_ranges(tmp_path):
+    path = tmp_path / "chunked.mcap"
+    with path.open("wb") as output:
+        writer = MCAPWriter(output, chunk_size=64 * 1024, compression=CompressionType.NONE)
+        writer.start()
+        schema_id = writer.register_schema(name="", encoding="", data=b"")
+        channel_id = writer.register_channel(topic="/camera", message_encoding="", schema_id=schema_id)
+        payload = b"x" * (60 * 1024)
+        for sequence in range(64):
+            writer.add_message(
+                channel_id=channel_id,
+                log_time=sequence,
+                publish_time=sequence,
+                sequence=sequence,
+                data=payload,
+            )
+        writer.finish()
+    contents = path.read_bytes()
+    CountingRangeHandler = _make_counting_range_handler(contents)
+    server = ThreadingHTTPServer(("127.0.0.1", 0), CountingRangeHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        url = f"http://127.0.0.1:{server.server_port}/chunked.mcap"
+        result = (
+            daft.read_mcap(url)
+            .where((daft.col("topic") == "/camera") & (daft.col("log_time") >= 32) & (daft.col("log_time") < 37))
+            .select("log_time")
+            .to_pydict()
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert result == {"log_time": [32, 33, 34, 35, 36]}
+    assert CountingRangeHandler.bytes_served * 2 < len(contents)
+    assert CountingRangeHandler.get_requests <= 6
+
+
+def test_mcap_unfiltered_read_is_log_time_ordered(tmp_path):
+    path = tmp_path / "out_of_order.mcap"
+    with path.open("wb") as output:
+        writer = MCAPWriter(output, chunk_size=64, compression=CompressionType.NONE)
+        writer.start()
+        schema_id = writer.register_schema(name="", encoding="", data=b"")
+        channel_id = writer.register_channel(topic="/camera", message_encoding="", schema_id=schema_id)
+        for log_time in [*range(100, 110), *range(10)]:
+            writer.add_message(
+                channel_id,
+                log_time=log_time,
+                publish_time=log_time,
+                sequence=log_time,
+                data=log_time.to_bytes(8, "little"),
+            )
+        writer.finish()
+
+    result = daft.read_mcap(path).select("log_time").to_pydict()
+    assert result == {"log_time": [*range(10), *range(100, 110)]}
+
+
+def test_mcap_where_matches_kwargs_results(raw_bytes_mcap_dataset_path):
+    topic = "/robot0/sensor/camera0/compressed"
+    start, end = 100_000_000, 110_000_000
+
+    via_kwargs = (
+        daft.read_mcap(raw_bytes_mcap_dataset_path, topics=[topic], start_time=start, end_time=end)
+        .select("log_time", "sequence")
+        .to_pydict()
+    )
+    via_where = (
+        daft.read_mcap(raw_bytes_mcap_dataset_path)
+        .where((daft.col("topic") == topic) & (daft.col("log_time") >= start) & (daft.col("log_time") < end))
+        .select("log_time", "sequence")
+        .to_pydict()
+    )
+
+    assert len(via_kwargs["log_time"]) == 10
+    assert via_where == via_kwargs
+
+
 def test_mcap_batch_size_must_be_positive(raw_bytes_mcap_dataset_path):
     with pytest.raises(ValueError, match="batch_size must be positive"):
         daft.read_mcap(raw_bytes_mcap_dataset_path, batch_size=0)


### PR DESCRIPTION
## Changes Made

This is **3 of 3** in the stack replacing #7319 and is based on #7333.

This PR completes the native MCAP implementation with conservative predicate pushdown, per-file log-time ordering for indexed files, remote-I/O pruning tests, and reader tracing spans.

Simple conjunctive predicates on `topic` and `log_time` are intersected with explicit `read_mcap` constraints and passed into the MCAP indexed reader. Chunk indexes then eliminate irrelevant byte ranges before decompression. The complete predicate is still evaluated residually, so unsupported expressions and conservative extraction cannot change results. Indexed reads use MCAP `ReadOrder::LogTime`, restoring parity with the original reader even when chunks are physically out of order.

Tracing spans cover reader initialization, summary loading, and scan execution, which made it possible to distinguish remote wait, summary probing, decoding, and task-drain overhead in the profile below.

## Performance and correctness

All 16 queries matched the original implementation across four synthetic shapes, including log-time ordering:

| dataset/query | original | stack | improvement |
|---|---:|---:|---:|
| 493 MB camera/full scan | 22.87 s | 4.11 s | 5.6x |
| 493 MB camera/`where` filter | 5.20 s | 0.63 s | 8.2x |
| camera/peak RSS | 3,818 MB | 975 MB | 3.9x lower |
| 1M-row IMU/`where` filter | 9.57 s | 0.58 s | 16.5x |
| 1M-row IMU/`LIMIT 10` | 9.76 s | 0.11 s | 88x |
| unindexed/`LIMIT 10` | 1.00 s | 0.03 s | 33x |

On a gated 458,207,008-byte `XDOF/ABC-130K` MCAP, a release-build topic/time filter with `LIMIT 2000` improved from **506.103 s and 238.5 MB peak RSS** to **8.791 s and 101.4 MB**: **57.6x faster** and **2.35x lower memory**. Both implementations returned exactly the same 2,000 rows, predicates, first/last log times, checksum, and monotonic ordering. The profile used Xcode Time Profiler; complete SpeedScope-compatible traces are retained with the original #7319 artifacts.

These are single profiled runs for ABC-130K and single debug runs for the synthetic table; the broad consistency and exact parity matter more than any one ratio.

## Stack

1. Native reader core — #7332
2. Native scan-task integration — #7333
3. **Predicate pushdown, ordering, and profiling** — this PR

## Validation

- `cargo fmt --all --check`
- `cargo check --locked -p daft-mcap -p daft-scan -p daft-local-execution`
- `cargo test --locked -p daft-mcap` — 30 passed
- MCAP and native-task Python tests — 29 passed, 1 expected S3 skip
- The original monolithic PR completed 41/41 CI checks before being split.

## Related Issues

- Depends on #7332 and #7333.
- Replaces the optimization and correctness portion of #7319.
- #7329 tracks unindexed linear-fallback overhead.
- #7330 tracks fixed overhead on small out-of-order indexed files.
- #7331 tracks projection-aware batch construction.
