### PR TITLE
feat(mcap): add native MCAP reader core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,6 +166,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "array-init"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1410,6 +1416,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bimap"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
+
+[[package]]
 name = "bincode"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1427,6 +1439,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
 dependencies = [
  "virtue",
+]
+
+[[package]]
+name = "binrw"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ad120d555272286c1017d25165ab8bd74806f13fc85b258484ec7e4ce75458f"
+dependencies = [
+ "array-init",
+ "binrw_derive",
+ "bytemuck",
+]
+
+[[package]]
+name = "binrw_derive"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6df92e0e9baae4dc82c7bad7715ca40c0a5c71539057bf2ea04a5c29c980410b"
+dependencies = [
+ "either",
+ "owo-colors",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1594,6 +1630,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "byteorder-lite"
@@ -3305,6 +3347,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "daft-mcap"
+version = "0.3.0-dev0"
+dependencies = [
+ "bytes",
+ "common-error",
+ "daft-core",
+ "daft-io",
+ "daft-recordbatch",
+ "futures",
+ "mcap",
+ "tempfile",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "daft-micropartition"
 version = "0.3.0-dev0"
 dependencies = [
@@ -3669,6 +3727,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3946,6 +4038,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
 dependencies = [
  "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "enumset"
+version = "1.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccc5801fd11762e24d1e420d01d2ac518f2a2ca4329d4fbb6639f2412b6204e0"
+dependencies = [
+ "enumset_derive",
+]
+
+[[package]]
+name = "enumset_derive"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd536557b58c682b217b8fb199afdff47cd3eff260623f19e77074eb073d63a"
+dependencies = [
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5033,6 +5146,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5567,6 +5686,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "lz4"
+version = "1.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a20b523e860d03443e98350ceaac5e71c6ba89aea7d960769ec3ce37f4de5af4"
+dependencies = [
+ "lz4-sys",
+]
+
+[[package]]
+name = "lz4-sys"
+version = "1.11.1+lz4-1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "lz4_flex"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5624,6 +5762,27 @@ checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
 dependencies = [
  "autocfg",
  "rawpointer",
+]
+
+[[package]]
+name = "mcap"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b215e79631de2a19ed76fda13cd52950c3057b487a2f41d9dc85c4079b969c40"
+dependencies = [
+ "bimap",
+ "binrw",
+ "byteorder",
+ "crc32fast",
+ "enumset",
+ "log",
+ "lz4",
+ "num_cpus",
+ "paste",
+ "static_assertions",
+ "thiserror 2.0.18",
+ "tokio",
+ "zstd",
 ]
 
 [[package]]
@@ -5867,6 +6026,16 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -6249,6 +6418,12 @@ name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
+name = "owo-colors"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "p256"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3360,6 +3360,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-util",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -225,6 +225,7 @@ members = [
   "src/daft-local-execution",
   "src/daft-local-plan",
   "src/daft-logical-plan",
+  "src/daft-mcap",
   "src/daft-micropartition",
   "src/daft-parquet",
   "src/daft-partition-refs",
@@ -305,6 +306,7 @@ daft-hash = {path = "src/daft-hash"}
 daft-io = {path = "src/daft-io"}
 daft-local-execution = {path = "src/daft-local-execution"}
 daft-logical-plan = {path = "src/daft-logical-plan"}
+daft-mcap = {path = "src/daft-mcap"}
 daft-micropartition = {path = "src/daft-micropartition"}
 daft-runners = {path = "src/daft-runners"}
 daft-recordbatch = {path = "src/daft-recordbatch"}
@@ -327,6 +329,7 @@ jaq-core = "2.2.1"
 jaq-json = {version = "1.1.3", features = ["serde_json"]}
 jaq-std = "2.1.2"
 libloading = "0.9"
+mcap = {version = "0.25.0", default-features = false, features = ["lz4", "tokio", "zstd"]}
 mur3 = "0.1.0"
 ndarray = "0.17"
 num-derive = "0.4.2"

--- a/src/daft-mcap/Cargo.toml
+++ b/src/daft-mcap/Cargo.toml
@@ -1,0 +1,21 @@
+[dependencies]
+bytes = {workspace = true}
+common-error = {path = "../common/error", default-features = false}
+daft-core = {path = "../daft-core", default-features = false}
+daft-io = {path = "../daft-io", default-features = false}
+daft-recordbatch = {path = "../daft-recordbatch", default-features = false}
+futures = {workspace = true}
+mcap = {workspace = true}
+tokio = {workspace = true}
+tokio-util = {workspace = true}
+
+[dev-dependencies]
+tempfile = "3.23.0"
+
+[lints]
+workspace = true
+
+[package]
+edition = {workspace = true}
+name = "daft-mcap"
+version = {workspace = true}

--- a/src/daft-mcap/Cargo.toml
+++ b/src/daft-mcap/Cargo.toml
@@ -8,6 +8,7 @@ futures = {workspace = true}
 mcap = {workspace = true}
 tokio = {workspace = true}
 tokio-util = {workspace = true}
+tracing = {workspace = true}
 
 [dev-dependencies]
 tempfile = "3.23.0"

--- a/src/daft-mcap/README.md
+++ b/src/daft-mcap/README.md
@@ -1,0 +1,82 @@
+# MCAP I/O profiling
+
+Native scan tasks pass their `IOStatsContext` into the MCAP reader. The backend
+records GET/HEAD/LIST operations and bytes; `NativeMcapReader::read_stats()` adds
+logical summary seeks/reads, summary size, indexed chunk reads/fetches, and buffer
+hits. The logical counters are also emitted at debug level when a reader drops.
+Seeks update offsets without issuing I/O. These counters are not OS syscall
+counts. Backend GET counts are not exact wire-request counts: redirects, retries,
+and Xet reconstruction can perform additional network requests.
+
+The footer contains `summary_start`. After fetching the footer, the reader knows
+the distance from that offset to EOF (`summary_tail_bytes`, including footer and
+trailing magic). Its existing 8 MiB summary read-ahead fetches that whole tail in
+one GET when it fits. Larger summaries can require more fetches; inspect the
+counters before increasing the buffer budget. A normal ranged open costs one
+HEAD plus three GETs: leading magic, footer, summary. Remote files at most 64 KiB
+are fetched in one GET and parsed from memory.
+
+## Opt-in ABC-130k integration test
+
+Accept access at <https://huggingface.co/datasets/XDOF/ABC-130k> and export an
+authorized `HF_TOKEN` through your normal credential setup. The test reads that
+environment variable; it does not print the token. It defaults to a pinned
+602 MB validation episode, but reads only the first batch (1,000 messages).
+Read-ahead/overlapping chunks can fetch more than that batch's payload.
+
+```sh
+cargo test --locked -p daft-mcap --test remote_profile -- --ignored --nocapture
+```
+
+If the token is in a gitignored `.env` instead of the shell environment:
+
+```sh
+uv tool run --from 'python-dotenv[cli]' dotenv -f .env run -- cargo test --locked -p daft-mcap --test remote_profile -- --ignored --nocapture
+```
+
+Each file reports cumulative counters after `open` and after `batch_cap` or
+`eof`, followed by dataset totals. Subtract open counters from final counters to
+isolate message reads. A capped sample is not a full-dataset throughput estimate.
+This profiles the native reader directly, not Python discovery/plan construction.
+
+Optional environment variables:
+
+| Variable | Meaning |
+| --- | --- |
+| `MCAP_PROFILE_URIS` | Whitespace-separated remote MCAP URIs; overrides the sample |
+| `MCAP_PROFILE_MAX_BATCHES` | Per-file batch cap; default `1`, `0` scans to EOF |
+| `MCAP_PROFILE_TOPIC` | One topic to select |
+| `MCAP_PROFILE_START_TIME` / `MCAP_PROFILE_END_TIME` | Nanoseconds, inclusive start / exclusive end |
+| `MCAP_PROFILE_XET` | `1` enables Xet; default HTTP ranges give a simpler baseline |
+
+The default test suite includes a local HTTP range server regression that checks
+GETs, HEADs, and bytes against server-observed counts, and verifies that many
+logical reads are satisfied from each buffer. No external access is needed:
+
+```sh
+cargo test --locked -p daft-mcap remote_requests_match_io_stats_and_logical_reads
+```
+
+## Measured baseline (2026-09-09)
+
+Default pinned ABC-130k episode, HTTP mode, 602,196,185-byte file. Counts below
+are cumulative, from separate first-batch and full-scan runs; times depend on
+the network and machine. These are one-episode measurements, not a dataset-wide
+estimate or exact wire-request counts.
+
+| Phase | Messages | GETs | HEADs | Bytes read | Elapsed |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Open (full-scan run) | 0 | 3 | 1 | 125,563 | 1.71 s |
+| First batch | 1,000 | 4 | 1 | 8,322,227 | 3.18 s |
+| Full episode | 288,765 | 82 | 1 | 652,128,552 | 84.18 s |
+
+The summary tail is **125,518 bytes**. Its 2 seeks and 1,246 logical reads
+require just **2 fetches** (footer, then complete summary tail); 1,244 reads hit
+the summary buffer. The 8-byte leading magic probe is the third startup GET.
+
+The full scan requests **579 chunks**: **500 buffer hits, 79 fetches**. Together
+with startup, that is 82 GETs. Total bytes exceed file size by about **8.3%**
+because read-ahead ranges can overlap and the summary/footer are read separately.
+For this episode, chunk read-ahead is the larger optimization opportunity; the
+summary is already fetched in one piece after the footer. Read-ahead policy is
+unchanged by this profiling instrumentation.

--- a/src/daft-mcap/src/indexed.rs
+++ b/src/daft-mcap/src/indexed.rs
@@ -1,0 +1,140 @@
+//! Index-pruned, log-time ordered traversal using the CRC-validating decoder.
+
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+
+use bytes::Bytes;
+use common_error::DaftResult;
+use mcap::records::{ChunkIndex, MessageHeader, Record};
+
+use crate::{MAX_RECORD_LENGTH, McapReadOptions, mcap_error};
+
+pub(crate) enum IndexedAction {
+    ReadChunk {
+        offset: u64,
+        length: usize,
+    },
+    Message {
+        header: MessageHeader,
+        data: Vec<u8>,
+    },
+    End,
+}
+
+pub(crate) struct IndexedReader {
+    chunks: VecDeque<ChunkIndex>,
+    // File position breaks ties between equal timestamps deterministically.
+    messages: BTreeMap<(u64, u64, usize), (MessageHeader, Vec<u8>)>,
+    channels: Option<BTreeSet<u16>>,
+    start_time: Option<u64>,
+    end_time: Option<u64>,
+}
+
+impl IndexedReader {
+    pub(crate) fn new(summary: &mcap::Summary, options: &McapReadOptions) -> DaftResult<Self> {
+        let channels: Option<BTreeSet<_>> = options.topics.as_ref().map(|topics| {
+            summary
+                .channels
+                .iter()
+                .filter_map(|(id, channel)| topics.contains(&channel.topic).then_some(*id))
+                .collect()
+        });
+        let mut chunks: Vec<_> = summary
+            .chunk_indexes
+            .iter()
+            .filter(|chunk| {
+                !options
+                    .start_time
+                    .is_some_and(|start| chunk.message_end_time < start)
+                    && !options
+                        .end_time
+                        .is_some_and(|end| chunk.message_start_time >= end)
+                    && channels.as_ref().is_none_or(|channels| {
+                        !channels.is_empty()
+                            && (chunk.message_index_offsets.is_empty()
+                                || chunk
+                                    .message_index_offsets
+                                    .keys()
+                                    .any(|id| channels.contains(id)))
+                    })
+            })
+            .cloned()
+            .collect();
+        for chunk in &chunks {
+            if chunk.compressed_size > MAX_RECORD_LENGTH as u64
+                || chunk.uncompressed_size > MAX_RECORD_LENGTH as u64
+            {
+                return Err(mcap_error("indexed chunk exceeds record length limit"));
+            }
+            // Validate before using an index-provided length for allocation/I/O.
+            let data_offset = chunk.compressed_data_offset().map_err(mcap_error)?;
+            let expected_length = (data_offset - chunk.chunk_start_offset)
+                .checked_add(chunk.compressed_size)
+                .ok_or_else(|| mcap_error("chunk length overflow"))?;
+            if chunk.chunk_length != expected_length {
+                return Err(mcap_error(
+                    "chunk index length does not match compressed size",
+                ));
+            }
+        }
+        chunks.sort_by_key(|chunk| (chunk.message_start_time, chunk.chunk_start_offset));
+        Ok(Self {
+            chunks: chunks.into(),
+            messages: BTreeMap::new(),
+            channels,
+            start_time: options.start_time,
+            end_time: options.end_time,
+        })
+    }
+
+    pub(crate) fn next_action(&mut self) -> DaftResult<IndexedAction> {
+        // Load all overlapping chunks before emitting a message, including ties.
+        if self.chunks.front().is_some_and(|chunk| {
+            self.messages
+                .first_key_value()
+                .is_none_or(|(key, _)| chunk.message_start_time <= key.0)
+        }) {
+            let chunk = self.chunks.pop_front().unwrap();
+            return Ok(IndexedAction::ReadChunk {
+                offset: chunk.chunk_start_offset,
+                length: usize::try_from(chunk.chunk_length).map_err(mcap_error)?,
+            });
+        }
+        Ok(match self.messages.pop_first() {
+            Some((_, (header, data))) => IndexedAction::Message { header, data },
+            None => IndexedAction::End,
+        })
+    }
+
+    pub(crate) async fn insert_chunk(&mut self, offset: u64, bytes: Bytes) -> DaftResult<()> {
+        if bytes.first() != Some(&mcap::records::op::CHUNK) {
+            return Err(mcap_error("chunk index does not point to a chunk record"));
+        }
+        let options = mcap::tokio::LinearReaderOptions::default()
+            .with_skip_start_magic(true)
+            .with_skip_end_magic(true)
+            .with_prevalidate_chunk_crcs(true)
+            .with_record_length_limit(MAX_RECORD_LENGTH);
+        let mut reader =
+            mcap::tokio::LinearReader::new_with_options(std::io::Cursor::new(bytes), &options);
+        let mut buffer = Vec::new();
+        let mut position = 0;
+        while let Some(opcode) = reader.next_record(&mut buffer).await {
+            if let Record::Message { header, data } =
+                mcap::parse_record(opcode.map_err(mcap_error)?, &buffer).map_err(mcap_error)?
+                && !self.start_time.is_some_and(|start| header.log_time < start)
+                && !self.end_time.is_some_and(|end| header.log_time >= end)
+                && self
+                    .channels
+                    .as_ref()
+                    .is_none_or(|channels| channels.contains(&header.channel_id))
+            {
+                self.messages.insert(
+                    (header.log_time, offset, position),
+                    (header, data.into_owned()),
+                );
+            }
+            position += 1;
+        }
+        Ok(())
+    }
+}

--- a/src/daft-mcap/src/lib.rs
+++ b/src/daft-mcap/src/lib.rs
@@ -1,0 +1,205 @@
+//! Native MCAP reader core.
+//!
+//! [`NativeMcapReader`] decodes one MCAP file into Daft record batches using
+//! indexed chunk traversal when a usable summary is present and a linear
+//! fallback otherwise.
+//!
+//! Peak memory scales with chunk size and batch payload size, not total file
+//! size.
+
+use std::{io::SeekFrom, sync::Arc};
+
+use bytes::Bytes;
+use common_error::{DaftError, DaftResult};
+use daft_io::{GetRange, GetResult, IOClient, IOStatsRef};
+use mcap::sans_io::{SummaryReadEvent, SummaryReader, SummaryReaderOptions};
+
+mod read;
+#[cfg(test)]
+mod test_utils;
+
+pub use read::NativeMcapReader;
+
+pub(crate) const MAX_RECORD_LENGTH: usize = 1024 * 1024 * 1024;
+const SUMMARY_READ_AHEAD_BYTES: usize = 8 * 1024 * 1024;
+
+pub(crate) fn mcap_error(error: impl std::fmt::Display) -> DaftError {
+    DaftError::ComputeError(format!("Failed to read MCAP messages: {error}"))
+}
+
+fn invalid_seek_error(position: SeekFrom, file_size: u64) -> DaftError {
+    mcap_error(format!(
+        "invalid summary seek {position:?} for file of {file_size} bytes"
+    ))
+}
+
+fn seek_position(position: SeekFrom, current: u64, file_size: u64) -> DaftResult<u64> {
+    let value = match position {
+        SeekFrom::Start(offset) => i128::from(offset),
+        SeekFrom::Current(offset) => i128::from(current) + i128::from(offset),
+        SeekFrom::End(offset) => i128::from(file_size) + i128::from(offset),
+    };
+    if !(0..=i128::from(u64::MAX)).contains(&value) {
+        return Err(invalid_seek_error(position, file_size));
+    }
+    Ok(value as u64)
+}
+
+async fn fetch_range(
+    uri: &str,
+    start: u64,
+    length: usize,
+    io_client: &Arc<IOClient>,
+    io_stats: &IOStatsRef,
+) -> DaftResult<Bytes> {
+    if length == 0 {
+        return Ok(Bytes::new());
+    }
+    let start =
+        usize::try_from(start).map_err(|_| mcap_error("range offset does not fit in usize"))?;
+    let end = start
+        .checked_add(length)
+        .ok_or_else(|| mcap_error("range end overflow"))?;
+    let result = io_client
+        .single_url_get(
+            uri.to_string(),
+            Some(GetRange::Bounded(start..end)),
+            Some(io_stats.clone()),
+        )
+        .await?;
+    let local = matches!(&result, GetResult::File(_));
+    let bytes = result.bytes().await?;
+    if local {
+        io_stats.mark_bytes_read(bytes.len());
+    }
+    Ok(bytes)
+}
+
+pub(crate) async fn fetch_exact_range(
+    uri: &str,
+    start: u64,
+    length: usize,
+    io_client: &Arc<IOClient>,
+    io_stats: &IOStatsRef,
+) -> DaftResult<Bytes> {
+    let bytes = fetch_range(uri, start, length, io_client, io_stats).await?;
+    if bytes.len() != length {
+        return Err(mcap_error(format!(
+            "unexpected EOF reading range at {start}: requested {length} bytes, received {}",
+            bytes.len()
+        )));
+    }
+    Ok(bytes)
+}
+
+pub(crate) struct BufferedRange {
+    pub(crate) start: u64,
+    pub(crate) bytes: Bytes,
+}
+
+impl BufferedRange {
+    pub(crate) fn slice(&self, start: u64, length: usize) -> Option<Bytes> {
+        let relative_start = usize::try_from(start.checked_sub(self.start)?).ok()?;
+        let relative_end = relative_start.checked_add(length)?;
+        (relative_end <= self.bytes.len()).then(|| self.bytes.slice(relative_start..relative_end))
+    }
+}
+
+/// Reads the optional summary section from the end of an MCAP file.
+pub(crate) async fn read_summary(
+    uri: &str,
+    file_size: usize,
+    is_remote: bool,
+    io_client: &Arc<IOClient>,
+    io_stats: &IOStatsRef,
+) -> DaftResult<Option<mcap::Summary>> {
+    let file_size_u64 =
+        u64::try_from(file_size).map_err(|_| mcap_error("file size does not fit in u64"))?;
+    let mut reader = SummaryReader::new_with_options(
+        SummaryReaderOptions::default()
+            .with_file_size(file_size_u64)
+            .with_record_length_limit(MAX_RECORD_LENGTH),
+    );
+    let mut position = 0_u64;
+    let mut read_buffer: Option<BufferedRange> = None;
+
+    while let Some(event) = reader.next_event() {
+        match event.map_err(mcap_error)? {
+            SummaryReadEvent::SeekRequest(request) => {
+                position = seek_position(request, position, file_size_u64)?;
+                reader.notify_seeked(position);
+            }
+            SummaryReadEvent::ReadRequest(requested) => {
+                let remaining = file_size_u64.saturating_sub(position);
+                let available = requested.min(usize::try_from(remaining).unwrap_or(usize::MAX));
+                let bytes = if available == 0 {
+                    Bytes::new()
+                } else if !is_remote {
+                    fetch_range(uri, position, available, io_client, io_stats).await?
+                } else if let Some(bytes) = read_buffer
+                    .as_ref()
+                    .and_then(|buffer| buffer.slice(position, available))
+                {
+                    bytes
+                } else {
+                    let read_length = available
+                        .max(SUMMARY_READ_AHEAD_BYTES)
+                        .min(usize::try_from(remaining).unwrap_or(usize::MAX));
+                    let buffer = BufferedRange {
+                        start: position,
+                        bytes: fetch_exact_range(uri, position, read_length, io_client, io_stats)
+                            .await?,
+                    };
+                    let bytes = buffer.slice(position, available).ok_or_else(|| {
+                        DaftError::InternalError(
+                            "MCAP summary read-ahead did not contain requested bytes".to_string(),
+                        )
+                    })?;
+                    read_buffer = Some(buffer);
+                    bytes
+                };
+                let read = bytes.len().min(requested);
+                reader.insert(requested)[..read].copy_from_slice(&bytes[..read]);
+                reader.notify_read(read);
+                position = position.saturating_add(read as u64);
+            }
+        }
+    }
+
+    Ok(reader.finish())
+}
+
+#[derive(Clone, Debug)]
+pub struct McapReadOptions {
+    pub batch_size: usize,
+    pub start_time: Option<u64>,
+    pub end_time: Option<u64>,
+    pub topics: Option<Vec<String>>,
+}
+
+impl Default for McapReadOptions {
+    fn default() -> Self {
+        Self {
+            batch_size: 1000,
+            start_time: None,
+            end_time: None,
+            topics: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::BufferedRange;
+
+    #[test]
+    fn buffered_range_slices_within_bounds() {
+        let buffer = BufferedRange {
+            start: 100,
+            bytes: bytes::Bytes::from_static(b"abcdefgh"),
+        };
+        assert_eq!(buffer.slice(102, 3).as_deref(), Some(&b"cde"[..]));
+        assert!(buffer.slice(99, 1).is_none());
+        assert!(buffer.slice(107, 2).is_none());
+    }
+}

--- a/src/daft-mcap/src/lib.rs
+++ b/src/daft-mcap/src/lib.rs
@@ -4,8 +4,8 @@
 //! indexed chunk traversal when a usable summary is present and a linear
 //! fallback otherwise.
 //!
-//! Peak memory scales with chunk size and batch payload size, not total file
-//! size.
+//! Indexed traversal buffers overlapping chunks for log-time ordering. HTTP
+//! servers without range support require a full-file buffer.
 
 use std::{io::SeekFrom, sync::Arc};
 
@@ -14,11 +14,14 @@ use common_error::{DaftError, DaftResult};
 use daft_io::{GetRange, GetResult, IOClient, IOStatsRef};
 use mcap::sans_io::{SummaryReadEvent, SummaryReader, SummaryReaderOptions};
 
+mod indexed;
 mod read;
+mod stats;
 #[cfg(test)]
 mod test_utils;
 
 pub use read::NativeMcapReader;
+pub use stats::McapReadStats;
 
 pub(crate) const MAX_RECORD_LENGTH: usize = 1024 * 1024 * 1024;
 const SUMMARY_READ_AHEAD_BYTES: usize = 8 * 1024 * 1024;
@@ -45,9 +48,9 @@ fn seek_position(position: SeekFrom, current: u64, file_size: u64) -> DaftResult
     Ok(value as u64)
 }
 
-async fn fetch_range(
+pub(crate) async fn fetch_range(
     uri: &str,
-    start: u64,
+    start: usize,
     length: usize,
     io_client: &Arc<IOClient>,
     io_stats: &IOStatsRef,
@@ -55,8 +58,6 @@ async fn fetch_range(
     if length == 0 {
         return Ok(Bytes::new());
     }
-    let start =
-        usize::try_from(start).map_err(|_| mcap_error("range offset does not fit in usize"))?;
     let end = start
         .checked_add(length)
         .ok_or_else(|| mcap_error("range end overflow"))?;
@@ -75,9 +76,13 @@ async fn fetch_range(
     Ok(bytes)
 }
 
+/// Require the range contract when callers rely on the requested interval.
+/// An oversized response is not necessarily extra bytes at the
+/// requested offset: a server ignoring Range can return the file from byte zero.
+/// Without a verified response offset, truncating that body would be unsafe.
 pub(crate) async fn fetch_exact_range(
     uri: &str,
-    start: u64,
+    start: usize,
     length: usize,
     io_client: &Arc<IOClient>,
     io_stats: &IOStatsRef,
@@ -85,7 +90,7 @@ pub(crate) async fn fetch_exact_range(
     let bytes = fetch_range(uri, start, length, io_client, io_stats).await?;
     if bytes.len() != length {
         return Err(mcap_error(format!(
-            "unexpected EOF reading range at {start}: requested {length} bytes, received {}",
+            "unexpected range length at {start}: requested {length} bytes, received {}",
             bytes.len()
         )));
     }
@@ -106,18 +111,23 @@ impl BufferedRange {
 }
 
 /// Reads the optional summary section from the end of an MCAP file.
+#[tracing::instrument(
+    skip_all,
+    name = "McapReader::read_summary",
+    fields(file_size = file_size, is_remote = is_remote),
+    err
+)]
 pub(crate) async fn read_summary(
     uri: &str,
-    file_size: usize,
+    file_size: u64,
     is_remote: bool,
     io_client: &Arc<IOClient>,
     io_stats: &IOStatsRef,
+    stats: &mut McapReadStats,
 ) -> DaftResult<Option<mcap::Summary>> {
-    let file_size_u64 =
-        u64::try_from(file_size).map_err(|_| mcap_error("file size does not fit in u64"))?;
     let mut reader = SummaryReader::new_with_options(
         SummaryReaderOptions::default()
-            .with_file_size(file_size_u64)
+            .with_file_size(file_size)
             .with_record_length_limit(MAX_RECORD_LENGTH),
     );
     let mut position = 0_u64;
@@ -126,31 +136,43 @@ pub(crate) async fn read_summary(
     while let Some(event) = reader.next_event() {
         match event.map_err(mcap_error)? {
             SummaryReadEvent::SeekRequest(request) => {
-                position = seek_position(request, position, file_size_u64)?;
+                stats.summary_seeks += 1;
+                position = seek_position(request, position, file_size)?;
+                if stats.summary_seeks == 2 {
+                    stats.summary_tail_bytes = file_size.checked_sub(position);
+                }
                 reader.notify_seeked(position);
             }
             SummaryReadEvent::ReadRequest(requested) => {
-                let remaining = file_size_u64.saturating_sub(position);
-                let available = requested.min(usize::try_from(remaining).unwrap_or(usize::MAX));
-                let bytes = if available == 0 {
+                stats.summary_reads += 1;
+                let remaining =
+                    usize::try_from(file_size.saturating_sub(position)).unwrap_or(usize::MAX);
+                let read_length = requested.min(remaining);
+                let start = usize::try_from(position)
+                    .map_err(|_| mcap_error("range offset does not fit in usize"))?;
+                let bytes = if read_length == 0 {
                     Bytes::new()
                 } else if !is_remote {
-                    fetch_range(uri, position, available, io_client, io_stats).await?
+                    stats.summary_fetches += 1;
+                    fetch_range(uri, start, read_length, io_client, io_stats).await?
                 } else if let Some(bytes) = read_buffer
                     .as_ref()
-                    .and_then(|buffer| buffer.slice(position, available))
+                    .and_then(|buffer| buffer.slice(position, read_length))
                 {
+                    stats.summary_buffer_hits += 1;
                     bytes
                 } else {
-                    let read_length = available
-                        .max(SUMMARY_READ_AHEAD_BYTES)
-                        .min(usize::try_from(remaining).unwrap_or(usize::MAX));
+                    stats.summary_fetches += 1;
+                    // The footer seek gives us summary_start, so remaining is
+                    // the exact tail size. Fetch it in one piece when it fits
+                    // the read-ahead budget; bound memory for larger summaries.
+                    let fetch_length = read_length.max(SUMMARY_READ_AHEAD_BYTES).min(remaining);
                     let buffer = BufferedRange {
                         start: position,
-                        bytes: fetch_exact_range(uri, position, read_length, io_client, io_stats)
+                        bytes: fetch_exact_range(uri, start, fetch_length, io_client, io_stats)
                             .await?,
                     };
-                    let bytes = buffer.slice(position, available).ok_or_else(|| {
+                    let bytes = buffer.slice(position, read_length).ok_or_else(|| {
                         DaftError::InternalError(
                             "MCAP summary read-ahead did not contain requested bytes".to_string(),
                         )
@@ -166,6 +188,54 @@ pub(crate) async fn read_summary(
         }
     }
 
+    Ok(reader.finish())
+}
+
+/// Parses the optional summary section from a fully buffered MCAP file.
+#[cfg(test)]
+pub(crate) fn parse_summary_from_bytes(bytes: &Bytes) -> DaftResult<Option<mcap::Summary>> {
+    parse_summary_from_bytes_with_stats(bytes, &mut McapReadStats::default())
+}
+
+pub(crate) fn parse_summary_from_bytes_with_stats(
+    bytes: &Bytes,
+    stats: &mut McapReadStats,
+) -> DaftResult<Option<mcap::Summary>> {
+    let file_size = bytes.len() as u64;
+    let mut reader = SummaryReader::new_with_options(
+        SummaryReaderOptions::default()
+            .with_file_size(file_size)
+            .with_record_length_limit(MAX_RECORD_LENGTH),
+    );
+    let mut position = 0_u64;
+    while let Some(event) = reader.next_event() {
+        match event.map_err(mcap_error)? {
+            SummaryReadEvent::SeekRequest(request) => {
+                stats.summary_seeks += 1;
+                position = seek_position(request, position, file_size)?;
+                if stats.summary_seeks == 2 {
+                    stats.summary_tail_bytes = file_size.checked_sub(position);
+                }
+                reader.notify_seeked(position);
+            }
+            SummaryReadEvent::ReadRequest(requested) => {
+                stats.summary_reads += 1;
+                let start = usize::try_from(position)
+                    .map_err(|_| mcap_error("summary position does not fit in usize"))?;
+                if start > bytes.len() {
+                    return Err(mcap_error("summary offset exceeds file size"));
+                }
+                let read_length = bytes.len().saturating_sub(start).min(requested);
+                if read_length > 0 {
+                    stats.summary_buffer_hits += 1;
+                }
+                reader.insert(requested)[..read_length]
+                    .copy_from_slice(&bytes[start..start + read_length]);
+                reader.notify_read(read_length);
+                position = position.saturating_add(read_length as u64);
+            }
+        }
+    }
     Ok(reader.finish())
 }
 

--- a/src/daft-mcap/src/read.rs
+++ b/src/daft-mcap/src/read.rs
@@ -1,0 +1,668 @@
+//! The MCAP reader: indexed chunk traversal with a linear fallback.
+//!
+//! [`NativeMcapReader`] decodes one MCAP file into record batches. Indexed
+//! files are read through the summary's chunk indexes in log-time order;
+//! files without a usable index stream linearly in file order.
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
+};
+
+use bytes::Bytes;
+use common_error::{DaftError, DaftResult};
+use daft_core::prelude::{BinaryArray, IntoSeries, Series, UInt32Array, UInt64Array, Utf8Array};
+use daft_io::{CountingReader, GetResult, IOClient, IOStatsRef, SourceType, parse_url};
+use daft_recordbatch::RecordBatch;
+use futures::StreamExt;
+use mcap::{
+    records::{MessageHeader, Record},
+    sans_io::{IndexedReadEvent, IndexedReader, IndexedReaderOptions, indexed_reader::ReadOrder},
+};
+use tokio::io::AsyncRead;
+use tokio_util::io::StreamReader;
+
+use crate::{
+    BufferedRange, MAX_RECORD_LENGTH, McapReadOptions, fetch_exact_range, mcap_error, read_summary,
+};
+
+// Read small remote files in one request.
+const SMALL_REMOTE_FILE_THRESHOLD: usize = 64 * 1024;
+// Coalesce nearby indexed reads without unbounded overfetch.
+const INDEXED_READ_AHEAD_MULTIPLIER: usize = 8;
+const MAX_INDEXED_READ_AHEAD_BYTES: usize = 8 * 1024 * 1024;
+
+type AsyncInput = Box<dyn AsyncRead + Send + Unpin>;
+type LinearReader = mcap::tokio::LinearReader<AsyncInput>;
+
+fn linear_reader(input: AsyncInput) -> LinearReader {
+    let options = mcap::tokio::LinearReaderOptions::default()
+        .with_prevalidate_chunk_crcs(true)
+        .with_record_length_limit(MAX_RECORD_LENGTH);
+    LinearReader::new_with_options(input, &options)
+}
+
+fn open_buffered_linear_reader(bytes: Bytes) -> LinearReader {
+    linear_reader(Box::new(std::io::Cursor::new(bytes)))
+}
+
+fn indexed_read_length(requested: usize, available: usize) -> usize {
+    requested
+        .saturating_mul(INDEXED_READ_AHEAD_MULTIPLIER)
+        .min(MAX_INDEXED_READ_AHEAD_BYTES)
+        .max(requested)
+        .min(available)
+}
+
+async fn open_linear_reader(
+    uri: &str,
+    io_client: &Arc<IOClient>,
+    io_stats: &IOStatsRef,
+) -> DaftResult<LinearReader> {
+    let result = io_client
+        .single_url_get(uri.to_string(), None, Some(io_stats.clone()))
+        .await?;
+    let input: AsyncInput = match result {
+        GetResult::File(file) => {
+            if file.range.is_some() {
+                return Err(DaftError::InternalError(
+                    "full MCAP read unexpectedly returned a ranged local file".to_string(),
+                ));
+            }
+            let source = tokio::fs::File::open(&file.path).await.map_err(|error| {
+                DaftError::External(
+                    std::io::Error::new(
+                        error.kind(),
+                        format!("failed to open {}: {error}", file.path.display()),
+                    )
+                    .into(),
+                )
+            })?;
+            Box::new(CountingReader::new(source, Some(io_stats.clone())))
+        }
+        GetResult::Stream(stream, ..) => Box::new(StreamReader::new(
+            stream.map(|result| result.map_err(std::io::Error::from)),
+        )),
+    };
+    Ok(linear_reader(input))
+}
+
+struct OwnedMessage {
+    topic: String,
+    header: MessageHeader,
+    data: Vec<u8>,
+}
+
+struct McapBatchBuilder {
+    source_paths: Vec<String>,
+    topics: Vec<String>,
+    log_times: Vec<u64>,
+    publish_times: Vec<u64>,
+    sequences: Vec<u32>,
+    data: Vec<Vec<u8>>,
+}
+
+impl McapBatchBuilder {
+    fn new(capacity: usize) -> Self {
+        Self {
+            source_paths: Vec::with_capacity(capacity),
+            topics: Vec::with_capacity(capacity),
+            log_times: Vec::with_capacity(capacity),
+            publish_times: Vec::with_capacity(capacity),
+            sequences: Vec::with_capacity(capacity),
+            data: Vec::with_capacity(capacity),
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.topics.len()
+    }
+
+    fn push(&mut self, source_path: &str, message: OwnedMessage) {
+        self.source_paths.push(source_path.to_string());
+        self.topics.push(message.topic);
+        self.log_times.push(message.header.log_time);
+        self.publish_times.push(message.header.publish_time);
+        self.sequences.push(message.header.sequence);
+        self.data.push(message.data);
+    }
+
+    fn finish(self) -> DaftResult<RecordBatch> {
+        let columns: Vec<Series> = vec![
+            Utf8Array::from_values("source_path", self.source_paths).into_series(),
+            Utf8Array::from_values("topic", self.topics).into_series(),
+            UInt64Array::from_vec("log_time", self.log_times).into_series(),
+            UInt64Array::from_vec("publish_time", self.publish_times).into_series(),
+            UInt32Array::from_vec("sequence", self.sequences).into_series(),
+            BinaryArray::from_values("data", self.data).into_series(),
+        ];
+        RecordBatch::from_nonempty_columns(columns)
+    }
+}
+
+enum ReaderMode {
+    Indexed(IndexedReader),
+    Linear {
+        reader: LinearReader,
+        record_buffer: Vec<u8>,
+    },
+    Empty,
+}
+
+enum IndexedAction {
+    ReadChunk {
+        offset: u64,
+        length: usize,
+    },
+    Message {
+        header: MessageHeader,
+        data: Vec<u8>,
+    },
+    End,
+}
+
+enum LinearAction {
+    Channel {
+        id: u16,
+        topic: String,
+    },
+    Message {
+        header: MessageHeader,
+        data: Vec<u8>,
+    },
+    Ignore,
+    End,
+}
+
+pub struct NativeMcapReader {
+    uri: String,
+    io_client: Arc<IOClient>,
+    io_stats: IOStatsRef,
+    mode: ReaderMode,
+    channels: BTreeMap<u16, String>,
+    topics: Option<BTreeSet<String>>,
+    start_time: Option<u64>,
+    end_time: Option<u64>,
+    batch_size: usize,
+    finished: bool,
+    indexed: bool,
+    indexed_remote_file_size: Option<usize>,
+    indexed_read_buffer: Option<BufferedRange>,
+}
+
+impl NativeMcapReader {
+    pub async fn new(
+        uri: impl Into<String>,
+        io_client: Arc<IOClient>,
+        io_stats: IOStatsRef,
+        options: McapReadOptions,
+    ) -> DaftResult<Self> {
+        if options.batch_size == 0 {
+            return Err(DaftError::ValueError(
+                "MCAP batch_size must be positive".to_string(),
+            ));
+        }
+        let uri = uri.into();
+        let topics = options
+            .topics
+            .map(|topics| topics.into_iter().collect::<BTreeSet<_>>());
+        let empty = topics.as_ref().is_some_and(BTreeSet::is_empty)
+            || options
+                .start_time
+                .zip(options.end_time)
+                .is_some_and(|(start, end)| start >= end);
+        let unfiltered =
+            topics.is_none() && options.start_time.is_none() && options.end_time.is_none();
+        let is_remote = !matches!(parse_url(&uri)?.0, SourceType::File);
+
+        let mut channels = BTreeMap::new();
+        let (mode, indexed, indexed_remote_file_size) = if unfiltered {
+            (
+                ReaderMode::Linear {
+                    reader: open_linear_reader(&uri, &io_client, &io_stats).await?,
+                    record_buffer: Vec::new(),
+                },
+                false,
+                None,
+            )
+        } else {
+            let file_size = io_client
+                .single_url_get_size(uri.clone(), Some(io_stats.clone()))
+                .await?;
+            if file_size < mcap::MAGIC.len() {
+                return Err(mcap_error("file is shorter than MCAP magic"));
+            }
+            let is_small_remote = file_size <= SMALL_REMOTE_FILE_THRESHOLD && is_remote;
+            let buffered = if is_small_remote && !empty {
+                Some(fetch_exact_range(&uri, 0, file_size, &io_client, &io_stats).await?)
+            } else {
+                let magic =
+                    fetch_exact_range(&uri, 0, mcap::MAGIC.len(), &io_client, &io_stats).await?;
+                if magic.as_ref() != mcap::MAGIC {
+                    return Err(mcap_error("bad leading magic"));
+                }
+                None
+            };
+
+            if let Some(bytes) = buffered {
+                if !bytes.starts_with(mcap::MAGIC) {
+                    return Err(mcap_error("bad leading magic"));
+                }
+                (
+                    ReaderMode::Linear {
+                        reader: open_buffered_linear_reader(bytes),
+                        record_buffer: Vec::new(),
+                    },
+                    false,
+                    None,
+                )
+            } else if empty {
+                (ReaderMode::Empty, false, None)
+            } else {
+                let summary =
+                    read_summary(&uri, file_size, is_remote, &io_client, &io_stats).await?;
+                if let Some(summary) = &summary {
+                    channels.extend(
+                        summary
+                            .channels
+                            .iter()
+                            .map(|(id, channel)| (*id, channel.topic.clone())),
+                    );
+                }
+
+                if let Some(summary) = summary.filter(|summary| {
+                    !summary.chunk_indexes.is_empty() && !summary.channels.is_empty()
+                }) {
+                    let mut reader_options =
+                        IndexedReaderOptions::new().with_order(ReadOrder::LogTime);
+                    if let Some(start_time) = options.start_time {
+                        reader_options = reader_options.log_time_on_or_after(start_time);
+                    }
+                    if let Some(end_time) = options.end_time {
+                        reader_options = reader_options.log_time_before(end_time);
+                    }
+                    if let Some(topics) = &topics {
+                        reader_options = reader_options.include_topics(topics.iter().cloned());
+                    }
+                    reader_options = reader_options.with_record_length_limit(MAX_RECORD_LENGTH);
+                    (
+                        ReaderMode::Indexed(
+                            IndexedReader::new_with_options(&summary, reader_options)
+                                .map_err(mcap_error)?,
+                        ),
+                        true,
+                        is_remote.then_some(file_size),
+                    )
+                } else {
+                    (
+                        ReaderMode::Linear {
+                            reader: open_linear_reader(&uri, &io_client, &io_stats).await?,
+                            record_buffer: Vec::new(),
+                        },
+                        false,
+                        None,
+                    )
+                }
+            }
+        };
+
+        Ok(Self {
+            uri,
+            io_client,
+            io_stats,
+            mode,
+            channels,
+            topics,
+            start_time: options.start_time,
+            end_time: options.end_time,
+            batch_size: options.batch_size,
+            finished: false,
+            indexed,
+            indexed_remote_file_size,
+            indexed_read_buffer: None,
+        })
+    }
+
+    pub fn indexed(&self) -> bool {
+        self.indexed
+    }
+
+    fn message_matches(&self, topic: &str, header: MessageHeader) -> bool {
+        if self.start_time.is_some_and(|start| header.log_time < start) {
+            return false;
+        }
+        if self.end_time.is_some_and(|end| header.log_time >= end) {
+            return false;
+        }
+        self.topics
+            .as_ref()
+            .is_none_or(|topics| topics.contains(topic))
+    }
+
+    async fn fetch_indexed_chunk(&mut self, offset: u64, length: usize) -> DaftResult<Bytes> {
+        if let Some(bytes) = self
+            .indexed_read_buffer
+            .as_ref()
+            .and_then(|buffer| buffer.slice(offset, length))
+        {
+            return Ok(bytes);
+        }
+
+        let Some(file_size) = self.indexed_remote_file_size else {
+            return fetch_exact_range(&self.uri, offset, length, &self.io_client, &self.io_stats)
+                .await;
+        };
+        let start = usize::try_from(offset)
+            .map_err(|_| mcap_error("range offset does not fit in usize"))?;
+        let available = file_size.checked_sub(start).ok_or_else(|| {
+            mcap_error(format!(
+                "chunk offset {offset} exceeds file size {file_size}"
+            ))
+        })?;
+        if length > available {
+            return Err(mcap_error(format!(
+                "unexpected EOF reading range at {offset}: requested {length} bytes, only {available} available"
+            )));
+        }
+
+        let read_length = indexed_read_length(length, available);
+        let buffer = BufferedRange {
+            start: offset,
+            bytes: fetch_exact_range(
+                &self.uri,
+                offset,
+                read_length,
+                &self.io_client,
+                &self.io_stats,
+            )
+            .await?,
+        };
+        let bytes = buffer.slice(offset, length).ok_or_else(|| {
+            DaftError::InternalError(
+                "indexed MCAP read-ahead did not contain requested chunk".to_string(),
+            )
+        })?;
+        self.indexed_read_buffer = Some(buffer);
+        Ok(bytes)
+    }
+
+    fn next_indexed_action(&mut self) -> DaftResult<IndexedAction> {
+        let ReaderMode::Indexed(reader) = &mut self.mode else {
+            return Err(DaftError::InternalError(
+                "indexed action requested from non-indexed MCAP reader".to_string(),
+            ));
+        };
+        let Some(event) = reader.next_event() else {
+            return Ok(IndexedAction::End);
+        };
+        match event.map_err(mcap_error)? {
+            IndexedReadEvent::ReadChunkRequest { offset, length } => {
+                Ok(IndexedAction::ReadChunk { offset, length })
+            }
+            IndexedReadEvent::Message { header, data } => Ok(IndexedAction::Message {
+                header,
+                data: data.to_vec(),
+            }),
+        }
+    }
+
+    async fn next_linear_action(&mut self) -> DaftResult<LinearAction> {
+        let ReaderMode::Linear {
+            reader,
+            record_buffer,
+        } = &mut self.mode
+        else {
+            return Err(DaftError::InternalError(
+                "linear action requested from non-linear MCAP reader".to_string(),
+            ));
+        };
+        let Some(opcode) = reader.next_record(record_buffer).await else {
+            return Ok(LinearAction::End);
+        };
+        match mcap::parse_record(opcode.map_err(mcap_error)?, record_buffer).map_err(mcap_error)? {
+            Record::Channel(channel) => Ok(LinearAction::Channel {
+                id: channel.id,
+                topic: channel.topic,
+            }),
+            Record::Message { header, data } => Ok(LinearAction::Message {
+                header,
+                data: data.into_owned(),
+            }),
+            _ => Ok(LinearAction::Ignore),
+        }
+    }
+
+    async fn next_message(&mut self) -> DaftResult<Option<OwnedMessage>> {
+        loop {
+            if matches!(self.mode, ReaderMode::Empty) {
+                return Ok(None);
+            }
+            if matches!(self.mode, ReaderMode::Indexed(_)) {
+                match self.next_indexed_action()? {
+                    IndexedAction::ReadChunk { offset, length } => {
+                        let bytes = self.fetch_indexed_chunk(offset, length).await?;
+                        let ReaderMode::Indexed(reader) = &mut self.mode else {
+                            unreachable!("reader mode changed while fetching MCAP chunk")
+                        };
+                        reader
+                            .insert_chunk_record_data(offset, &bytes)
+                            .map_err(mcap_error)?;
+                    }
+                    IndexedAction::Message { header, data } => {
+                        let topic = self
+                            .channels
+                            .get(&header.channel_id)
+                            .ok_or_else(|| {
+                                mcap_error(format!(
+                                    "message references unknown channel {}",
+                                    header.channel_id
+                                ))
+                            })?
+                            .clone();
+                        if self.message_matches(&topic, header) {
+                            return Ok(Some(OwnedMessage {
+                                topic,
+                                header,
+                                data,
+                            }));
+                        }
+                    }
+                    IndexedAction::End => return Ok(None),
+                }
+                continue;
+            }
+
+            match self.next_linear_action().await? {
+                LinearAction::Channel { id, topic } => {
+                    self.channels.insert(id, topic);
+                }
+                LinearAction::Message { header, data } => {
+                    let topic = self
+                        .channels
+                        .get(&header.channel_id)
+                        .ok_or_else(|| {
+                            mcap_error(format!(
+                                "message references unknown channel {}",
+                                header.channel_id
+                            ))
+                        })?
+                        .clone();
+                    if self.message_matches(&topic, header) {
+                        return Ok(Some(OwnedMessage {
+                            topic,
+                            header,
+                            data,
+                        }));
+                    }
+                }
+                LinearAction::Ignore => {}
+                LinearAction::End => return Ok(None),
+            }
+        }
+    }
+
+    pub async fn next_batch(&mut self) -> DaftResult<Option<RecordBatch>> {
+        if self.finished {
+            return Ok(None);
+        }
+        let mut builder = McapBatchBuilder::new(self.batch_size);
+        while builder.len() < self.batch_size {
+            let Some(message) = self.next_message().await? else {
+                self.finished = true;
+                break;
+            };
+            builder.push(&self.uri, message);
+        }
+        if builder.len() == 0 {
+            Ok(None)
+        } else {
+            Ok(Some(builder.finish()?))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use common_error::DaftResult;
+    use mcap::Compression;
+    use tempfile::NamedTempFile;
+
+    use super::indexed_read_length;
+    use crate::{
+        McapReadOptions,
+        test_utils::{collect_rows, make_reader, write_mcap},
+    };
+
+    #[test]
+    fn indexed_read_ahead_is_bounded() {
+        assert_eq!(
+            indexed_read_length(1024 * 1024, usize::MAX),
+            8 * 1024 * 1024
+        );
+        assert_eq!(
+            indexed_read_length(16 * 1024 * 1024, usize::MAX),
+            16 * 1024 * 1024
+        );
+        assert_eq!(
+            indexed_read_length(1024 * 1024, 3 * 1024 * 1024),
+            3 * 1024 * 1024
+        );
+    }
+
+    #[tokio::test]
+    async fn unfiltered_reader_streams_file_once() -> DaftResult<()> {
+        let file = write_mcap(true, None, 20, 32);
+        let file_size = file.as_file().metadata().unwrap().len() as usize;
+        let (mut reader, io_stats) = make_reader(&file, McapReadOptions::default()).await?;
+
+        assert!(!reader.indexed());
+        assert_eq!(collect_rows(&mut reader).await?.len(), 20);
+        drop(reader);
+        assert_eq!(io_stats.load_bytes_read(), file_size);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn indexed_reader_filters_topics_and_half_open_time_range() -> DaftResult<()> {
+        let file = write_mcap(true, None, 20, 32);
+        let options = McapReadOptions {
+            batch_size: 2,
+            start_time: Some(4),
+            end_time: Some(10),
+            topics: Some(vec!["/camera".to_string()]),
+        };
+        let (mut reader, _) = make_reader(&file, options).await?;
+        assert!(reader.indexed());
+
+        let rows = collect_rows(&mut reader).await?;
+        assert_eq!(
+            rows.iter()
+                .map(|(topic, time, _)| (topic.as_str(), *time))
+                .collect::<Vec<_>>(),
+            vec![("/camera", 4), ("/camera", 6), ("/camera", 8)]
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn indexed_reader_uses_bounded_ranges() -> DaftResult<()> {
+        let file = write_mcap(true, None, 16, 64 * 1024);
+        let file_size = file.as_file().metadata().unwrap().len() as usize;
+        let options = McapReadOptions {
+            batch_size: 1,
+            start_time: Some(8),
+            end_time: Some(9),
+            topics: Some(vec!["/camera".to_string()]),
+        };
+        let (mut reader, io_stats) = make_reader(&file, options).await?;
+        let rows = collect_rows(&mut reader).await?;
+
+        assert_eq!(rows.len(), 1);
+        assert!(
+            io_stats.load_bytes_read() < file_size / 2,
+            "filtered indexed read fetched {} of {file_size} bytes",
+            io_stats.load_bytes_read()
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn unindexed_reader_falls_back_to_linear_stream() -> DaftResult<()> {
+        let file = write_mcap(false, None, 12, 16);
+        let options = McapReadOptions {
+            batch_size: 3,
+            start_time: Some(3),
+            end_time: Some(8),
+            topics: Some(vec!["/imu".to_string()]),
+        };
+        let (mut reader, _) = make_reader(&file, options).await?;
+        assert!(!reader.indexed());
+
+        let rows = collect_rows(&mut reader).await?;
+        assert_eq!(
+            rows.iter().map(|(_, time, _)| *time).collect::<Vec<_>>(),
+            vec![3, 5, 7]
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn indexed_reader_supports_lz4() -> DaftResult<()> {
+        let file = write_mcap(true, Some(Compression::Lz4), 10, 1024);
+        let options = McapReadOptions {
+            topics: Some(vec!["/camera".to_string(), "/imu".to_string()]),
+            ..Default::default()
+        };
+        let (mut reader, _) = make_reader(&file, options).await?;
+        assert!(reader.indexed());
+        assert_eq!(collect_rows(&mut reader).await?.len(), 10);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn indexed_reader_supports_zstd() -> DaftResult<()> {
+        let file = write_mcap(true, Some(Compression::Zstd), 10, 1024);
+        let options = McapReadOptions {
+            topics: Some(vec!["/camera".to_string(), "/imu".to_string()]),
+            ..Default::default()
+        };
+        let (mut reader, _) = make_reader(&file, options).await?;
+        assert!(reader.indexed());
+        assert_eq!(collect_rows(&mut reader).await?.len(), 10);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn invalid_magic_is_rejected() -> DaftResult<()> {
+        let file = NamedTempFile::new().unwrap();
+        std::fs::write(file.path(), b"not an mcap file").unwrap();
+        let (mut reader, _) = make_reader(&file, McapReadOptions::default()).await?;
+        let result = reader.next_batch().await;
+        assert!(
+            result
+                .err()
+                .is_some_and(|error| error.to_string().to_lowercase().contains("magic"))
+        );
+        Ok(())
+    }
+}

--- a/src/daft-mcap/src/read.rs
+++ b/src/daft-mcap/src/read.rs
@@ -15,15 +15,15 @@ use daft_core::prelude::{BinaryArray, IntoSeries, Series, UInt32Array, UInt64Arr
 use daft_io::{CountingReader, GetResult, IOClient, IOStatsRef, SourceType, parse_url};
 use daft_recordbatch::RecordBatch;
 use futures::StreamExt;
-use mcap::{
-    records::{MessageHeader, Record},
-    sans_io::{IndexedReadEvent, IndexedReader, IndexedReaderOptions, indexed_reader::ReadOrder},
-};
+use mcap::records::{MessageHeader, Record};
 use tokio::io::AsyncRead;
 use tokio_util::io::StreamReader;
 
 use crate::{
-    BufferedRange, MAX_RECORD_LENGTH, McapReadOptions, fetch_exact_range, mcap_error, read_summary,
+    BufferedRange, MAX_RECORD_LENGTH, McapReadOptions, McapReadStats, fetch_exact_range,
+    fetch_range,
+    indexed::{IndexedAction, IndexedReader},
+    mcap_error, parse_summary_from_bytes_with_stats, read_summary,
 };
 
 // Read small remote files in one request.
@@ -149,18 +149,6 @@ enum ReaderMode {
     Empty,
 }
 
-enum IndexedAction {
-    ReadChunk {
-        offset: u64,
-        length: usize,
-    },
-    Message {
-        header: MessageHeader,
-        data: Vec<u8>,
-    },
-    End,
-}
-
 enum LinearAction {
     Channel {
         id: u16,
@@ -178,6 +166,7 @@ pub struct NativeMcapReader {
     uri: String,
     io_client: Arc<IOClient>,
     io_stats: IOStatsRef,
+    read_stats: McapReadStats,
     mode: ReaderMode,
     channels: BTreeMap<u16, String>,
     topics: Option<BTreeSet<String>>,
@@ -190,7 +179,24 @@ pub struct NativeMcapReader {
     indexed_read_buffer: Option<BufferedRange>,
 }
 
+impl Drop for NativeMcapReader {
+    fn drop(&mut self) {
+        tracing::debug!(stats = ?self.read_stats, "MCAP logical I/O profile");
+    }
+}
+
 impl NativeMcapReader {
+    #[tracing::instrument(
+        skip_all,
+        name = "NativeMcapReader::new",
+        fields(
+            batch_size = options.batch_size,
+            topic_filter_count = options.topics.as_ref().map_or(0, Vec::len),
+            has_start_time = options.start_time.is_some(),
+            has_end_time = options.end_time.is_some(),
+        ),
+        err
+    )]
     pub async fn new(
         uri: impl Into<String>,
         io_client: Arc<IOClient>,
@@ -205,104 +211,110 @@ impl NativeMcapReader {
         let uri = uri.into();
         let topics = options
             .topics
+            .clone()
             .map(|topics| topics.into_iter().collect::<BTreeSet<_>>());
         let empty = topics.as_ref().is_some_and(BTreeSet::is_empty)
             || options
                 .start_time
                 .zip(options.end_time)
                 .is_some_and(|(start, end)| start >= end);
-        let unfiltered =
-            topics.is_none() && options.start_time.is_none() && options.end_time.is_none();
-        let is_remote = !matches!(parse_url(&uri)?.0, SourceType::File);
 
         let mut channels = BTreeMap::new();
-        let (mode, indexed, indexed_remote_file_size) = if unfiltered {
-            (
-                ReaderMode::Linear {
-                    reader: open_linear_reader(&uri, &io_client, &io_stats).await?,
-                    record_buffer: Vec::new(),
-                },
-                false,
-                None,
-            )
+        let mut read_stats = McapReadStats::default();
+        let (mode, indexed, indexed_remote_file_size, indexed_read_buffer) = if empty {
+            // Provably-empty constraints never touch storage.
+            (ReaderMode::Empty, false, None, None)
         } else {
+            let is_remote = !matches!(parse_url(&uri)?.0, SourceType::File);
             let file_size = io_client
                 .single_url_get_size(uri.clone(), Some(io_stats.clone()))
                 .await?;
             if file_size < mcap::MAGIC.len() {
                 return Err(mcap_error("file is shorter than MCAP magic"));
             }
-            let is_small_remote = file_size <= SMALL_REMOTE_FILE_THRESHOLD && is_remote;
-            let buffered = if is_small_remote && !empty {
+
+            // Small remote files: one request buys the whole file; the summary
+            // and any chunk reads are then served from the buffer.
+            let mut buffer = if is_remote && file_size <= SMALL_REMOTE_FILE_THRESHOLD {
                 Some(fetch_exact_range(&uri, 0, file_size, &io_client, &io_stats).await?)
             } else {
-                let magic =
-                    fetch_exact_range(&uri, 0, mcap::MAGIC.len(), &io_client, &io_stats).await?;
-                if magic.as_ref() != mcap::MAGIC {
-                    return Err(mcap_error("bad leading magic"));
-                }
                 None
             };
-
-            if let Some(bytes) = buffered {
-                if !bytes.starts_with(mcap::MAGIC) {
-                    return Err(mcap_error("bad leading magic"));
+            let magic = match &buffer {
+                Some(bytes) => bytes.slice(0..mcap::MAGIC.len()),
+                None => {
+                    let bytes =
+                        fetch_range(&uri, 0, mcap::MAGIC.len(), &io_client, &io_stats).await?;
+                    if is_remote && bytes.len() == file_size {
+                        // HTTP may ignore Range, even when it advertises support.
+                        // Reuse the full response for the summary and chunk reads
+                        // so indexed files retain their log-time ordering.
+                        let magic = bytes.slice(..mcap::MAGIC.len());
+                        buffer = Some(bytes);
+                        magic
+                    } else if bytes.len() == mcap::MAGIC.len() {
+                        bytes
+                    } else {
+                        return Err(mcap_error("unexpected length reading leading magic"));
+                    }
                 }
+            };
+            if magic.as_ref() != mcap::MAGIC {
+                return Err(mcap_error("bad leading magic"));
+            }
+
+            let summary = match &buffer {
+                Some(bytes) => parse_summary_from_bytes_with_stats(bytes, &mut read_stats)?,
+                None => {
+                    read_summary(
+                        &uri,
+                        file_size as u64,
+                        is_remote,
+                        &io_client,
+                        &io_stats,
+                        &mut read_stats,
+                    )
+                    .await?
+                }
+            };
+            if let Some(summary) = &summary {
+                channels.extend(
+                    summary
+                        .channels
+                        .iter()
+                        .map(|(id, channel)| (*id, channel.topic.clone())),
+                );
+            }
+
+            let usable = summary.filter(|summary| {
+                !summary.chunk_indexes.is_empty() && !summary.channels.is_empty()
+            });
+            if let Some(summary) = usable {
+                // Prune with chunk indexes, then validate and merge decoded
+                // chunks into per-file log-time order.
+                let read_buffer = buffer.map(|bytes| BufferedRange { start: 0, bytes });
+                let remote_file_size = (is_remote && read_buffer.is_none()).then_some(file_size);
+                (
+                    ReaderMode::Indexed(IndexedReader::new(&summary, &options)?),
+                    true,
+                    remote_file_size,
+                    read_buffer,
+                )
+            } else {
+                // Unindexed fallback: stream records in file order.
+                let reader = match buffer {
+                    Some(bytes) => open_buffered_linear_reader(bytes),
+                    None => open_linear_reader(&uri, &io_client, &io_stats).await?,
+                };
                 (
                     ReaderMode::Linear {
-                        reader: open_buffered_linear_reader(bytes),
+                        reader,
                         record_buffer: Vec::new(),
                     },
                     false,
                     None,
+                    None,
                 )
-            } else if empty {
-                (ReaderMode::Empty, false, None)
-            } else {
-                let summary =
-                    read_summary(&uri, file_size, is_remote, &io_client, &io_stats).await?;
-                if let Some(summary) = &summary {
-                    channels.extend(
-                        summary
-                            .channels
-                            .iter()
-                            .map(|(id, channel)| (*id, channel.topic.clone())),
-                    );
-                }
-
-                if let Some(summary) = summary.filter(|summary| {
-                    !summary.chunk_indexes.is_empty() && !summary.channels.is_empty()
-                }) {
-                    let mut reader_options =
-                        IndexedReaderOptions::new().with_order(ReadOrder::LogTime);
-                    if let Some(start_time) = options.start_time {
-                        reader_options = reader_options.log_time_on_or_after(start_time);
-                    }
-                    if let Some(end_time) = options.end_time {
-                        reader_options = reader_options.log_time_before(end_time);
-                    }
-                    if let Some(topics) = &topics {
-                        reader_options = reader_options.include_topics(topics.iter().cloned());
-                    }
-                    reader_options = reader_options.with_record_length_limit(MAX_RECORD_LENGTH);
-                    (
-                        ReaderMode::Indexed(
-                            IndexedReader::new_with_options(&summary, reader_options)
-                                .map_err(mcap_error)?,
-                        ),
-                        true,
-                        is_remote.then_some(file_size),
-                    )
-                } else {
-                    (
-                        ReaderMode::Linear {
-                            reader: open_linear_reader(&uri, &io_client, &io_stats).await?,
-                            record_buffer: Vec::new(),
-                        },
-                        false,
-                        None,
-                    )
-                }
             }
         };
 
@@ -310,6 +322,7 @@ impl NativeMcapReader {
             uri,
             io_client,
             io_stats,
+            read_stats,
             mode,
             channels,
             topics,
@@ -319,12 +332,18 @@ impl NativeMcapReader {
             finished: false,
             indexed,
             indexed_remote_file_size,
-            indexed_read_buffer: None,
+            indexed_read_buffer,
         })
     }
 
     pub fn indexed(&self) -> bool {
         self.indexed
+    }
+
+    /// Logical reads/seeks and cache effectiveness. Storage request and byte
+    /// counts remain in the caller-provided `IOStatsContext`.
+    pub fn read_stats(&self) -> &McapReadStats {
+        &self.read_stats
     }
 
     fn message_matches(&self, topic: &str, header: MessageHeader) -> bool {
@@ -340,20 +359,24 @@ impl NativeMcapReader {
     }
 
     async fn fetch_indexed_chunk(&mut self, offset: u64, length: usize) -> DaftResult<Bytes> {
+        self.read_stats.chunk_reads += 1;
         if let Some(bytes) = self
             .indexed_read_buffer
             .as_ref()
             .and_then(|buffer| buffer.slice(offset, length))
         {
+            self.read_stats.chunk_buffer_hits += 1;
             return Ok(bytes);
         }
 
-        let Some(file_size) = self.indexed_remote_file_size else {
-            return fetch_exact_range(&self.uri, offset, length, &self.io_client, &self.io_stats)
-                .await;
-        };
+        self.read_stats.chunk_fetches += 1;
+
         let start = usize::try_from(offset)
             .map_err(|_| mcap_error("range offset does not fit in usize"))?;
+        let Some(file_size) = self.indexed_remote_file_size else {
+            return fetch_exact_range(&self.uri, start, length, &self.io_client, &self.io_stats)
+                .await;
+        };
         let available = file_size.checked_sub(start).ok_or_else(|| {
             mcap_error(format!(
                 "chunk offset {offset} exceeds file size {file_size}"
@@ -370,7 +393,7 @@ impl NativeMcapReader {
             start: offset,
             bytes: fetch_exact_range(
                 &self.uri,
-                offset,
+                start,
                 read_length,
                 &self.io_client,
                 &self.io_stats,
@@ -392,21 +415,11 @@ impl NativeMcapReader {
                 "indexed action requested from non-indexed MCAP reader".to_string(),
             ));
         };
-        let Some(event) = reader.next_event() else {
-            return Ok(IndexedAction::End);
-        };
-        match event.map_err(mcap_error)? {
-            IndexedReadEvent::ReadChunkRequest { offset, length } => {
-                Ok(IndexedAction::ReadChunk { offset, length })
-            }
-            IndexedReadEvent::Message { header, data } => Ok(IndexedAction::Message {
-                header,
-                data: data.to_vec(),
-            }),
-        }
+        reader.next_action()
     }
 
     async fn next_linear_action(&mut self) -> DaftResult<LinearAction> {
+        self.read_stats.linear_record_reads += 1;
         let ReaderMode::Linear {
             reader,
             record_buffer,
@@ -444,9 +457,7 @@ impl NativeMcapReader {
                         let ReaderMode::Indexed(reader) = &mut self.mode else {
                             unreachable!("reader mode changed while fetching MCAP chunk")
                         };
-                        reader
-                            .insert_chunk_record_data(offset, &bytes)
-                            .map_err(mcap_error)?;
+                        reader.insert_chunk(offset, bytes).await?;
                     }
                     IndexedAction::Message { header, data } => {
                         let topic = self
@@ -530,7 +541,7 @@ mod tests {
     use super::indexed_read_length;
     use crate::{
         McapReadOptions,
-        test_utils::{collect_rows, make_reader, write_mcap},
+        test_utils::{collect_rows, make_reader, write_mcap, write_mcap_out_of_order},
     };
 
     #[test]
@@ -550,15 +561,62 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn unfiltered_reader_streams_file_once() -> DaftResult<()> {
-        let file = write_mcap(true, None, 20, 32);
+    async fn unfiltered_unindexed_reader_streams_file_once() -> DaftResult<()> {
+        let file = write_mcap(false, None, 20, 32);
         let file_size = file.as_file().metadata().unwrap().len() as usize;
         let (mut reader, io_stats) = make_reader(&file, McapReadOptions::default()).await?;
 
         assert!(!reader.indexed());
         assert_eq!(collect_rows(&mut reader).await?.len(), 20);
         drop(reader);
-        assert_eq!(io_stats.load_bytes_read(), file_size);
+        // One magic probe and one summary probe, then a single linear pass.
+        let bytes_read = io_stats.load_bytes_read();
+        assert!(
+            bytes_read >= file_size && bytes_read < 2 * file_size,
+            "unindexed unfiltered read fetched {bytes_read} of {file_size} bytes"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn unfiltered_indexed_read_returns_log_time_order() -> DaftResult<()> {
+        let file = write_mcap_out_of_order(10);
+        // Fixture precondition: chunks must be physically out of log-time order.
+        let contents = bytes::Bytes::from(std::fs::read(file.path()).unwrap());
+        let summary = crate::parse_summary_from_bytes(&contents)?.expect("fixture has a summary");
+        assert!(
+            summary
+                .chunk_indexes
+                .windows(2)
+                .any(|pair| pair[0].message_start_time > pair[1].message_start_time),
+            "fixture chunks are not out of log-time order"
+        );
+
+        let (mut reader, _) = make_reader(&file, McapReadOptions::default()).await?;
+        assert!(reader.indexed());
+        let times = collect_rows(&mut reader)
+            .await?
+            .iter()
+            .map(|(_, time, _)| *time)
+            .collect::<Vec<_>>();
+        assert_eq!(times.len(), 20);
+        assert_eq!(times.first(), Some(&0));
+        let mut sorted = times.clone();
+        sorted.sort_unstable();
+        assert_eq!(times, sorted);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn empty_constraints_skip_io() -> DaftResult<()> {
+        let file = write_mcap(true, None, 4, 8);
+        let options = McapReadOptions {
+            topics: Some(vec![]),
+            ..Default::default()
+        };
+        let (mut reader, io_stats) = make_reader(&file, options).await?;
+        assert!(reader.next_batch().await?.is_none());
+        assert_eq!(io_stats.load_bytes_read(), 0);
         Ok(())
     }
 
@@ -653,11 +711,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn invalid_magic_is_rejected() -> DaftResult<()> {
+    async fn invalid_magic_is_rejected_at_open() -> DaftResult<()> {
         let file = NamedTempFile::new().unwrap();
         std::fs::write(file.path(), b"not an mcap file").unwrap();
-        let (mut reader, _) = make_reader(&file, McapReadOptions::default()).await?;
-        let result = reader.next_batch().await;
+        let result = make_reader(&file, McapReadOptions::default()).await;
         assert!(
             result
                 .err()

--- a/src/daft-mcap/src/stats.rs
+++ b/src/daft-mcap/src/stats.rs
@@ -1,0 +1,270 @@
+/// Logical MCAP operations, distinct from storage requests in `IOStatsContext`.
+///
+/// Seeks only update a parser offset; they do not themselves issue I/O. A read
+/// can hit a buffer, and a fetch can satisfy many reads. Backend GET counts are
+/// logical storage operations, not necessarily wire requests (retries,
+/// redirects, and Xet reconstruction can issue additional requests).
+#[derive(Clone, Debug, Default)]
+pub struct McapReadStats {
+    /// Footer/summary parser seek events, including fully buffered files.
+    pub summary_seeks: usize,
+    /// Footer/summary parser read events, including fully buffered files.
+    pub summary_reads: usize,
+    pub summary_buffer_hits: usize,
+    /// Range fetches made by the summary reader (excludes the magic probe).
+    pub summary_fetches: usize,
+    /// Bytes from the footer's summary start through EOF, including the footer
+    /// and trailing magic. None when no summary is present.
+    pub summary_tail_bytes: Option<u64>,
+    /// Selected indexed chunks requested by the decoder.
+    pub chunk_reads: usize,
+    pub chunk_buffer_hits: usize,
+    pub chunk_fetches: usize,
+    /// Decoded record requests in the unindexed fallback, not AsyncRead calls.
+    pub linear_record_reads: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    use daft_io::{IOConfig, IOStatsContext, get_io_client};
+    use tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
+        net::TcpListener,
+    };
+
+    use crate::{
+        McapReadOptions, NativeMcapReader,
+        test_utils::{collect_rows, make_reader, write_mcap, write_mcap_out_of_order_with_payload},
+    };
+
+    #[derive(Default)]
+    struct Requests {
+        gets: AtomicUsize,
+        heads: AtomicUsize,
+        bytes: AtomicUsize,
+    }
+
+    struct Server(tokio::task::JoinHandle<()>);
+
+    impl Drop for Server {
+        fn drop(&mut self) {
+            self.0.abort();
+        }
+    }
+
+    async fn serve(bytes: Vec<u8>) -> (String, Arc<Requests>, Server) {
+        serve_with_range_behavior(bytes, false).await
+    }
+
+    async fn serve_with_range_behavior(
+        bytes: Vec<u8>,
+        ignore_nonzero_ranges: bool,
+    ) -> (String, Arc<Requests>, Server) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let uri = format!("http://{}/fixture.mcap", listener.local_addr().unwrap());
+        let counts = Arc::new(Requests::default());
+        let server_counts = counts.clone();
+        let task = tokio::spawn(async move {
+            loop {
+                let (mut socket, _) = listener.accept().await.unwrap();
+                let mut request = Vec::new();
+                while !request.ends_with(b"\r\n\r\n") {
+                    request.push(socket.read_u8().await.unwrap());
+                    assert!(request.len() < 16384);
+                }
+                let request = String::from_utf8(request).unwrap().to_ascii_lowercase();
+                let head = request.starts_with("head ");
+                let range = request
+                    .lines()
+                    .find_map(|line| line.strip_prefix("range: bytes="))
+                    .filter(|range| !ignore_nonzero_ranges || range.starts_with("0-"));
+                let (start, end) = match range {
+                    Some(range) => {
+                        let (start, end) = range.split_once('-').unwrap();
+                        (
+                            start.parse::<usize>().unwrap(),
+                            end.parse::<usize>().unwrap() + 1,
+                        )
+                    }
+                    None => (0, bytes.len()),
+                };
+                assert!(start < end && end <= bytes.len());
+                let status = if range.is_some() {
+                    "206 Partial Content"
+                } else {
+                    "200 OK"
+                };
+                let mut headers = format!(
+                    "HTTP/1.1 {status}\r\nContent-Length: {}\r\nAccept-Ranges: bytes\r\nConnection: close\r\n",
+                    end - start
+                );
+                if range.is_some() {
+                    headers.push_str(&format!(
+                        "Content-Range: bytes {start}-{}/{}\r\n",
+                        end - 1,
+                        bytes.len()
+                    ));
+                }
+                headers.push_str("\r\n");
+                if head {
+                    server_counts.heads.fetch_add(1, Ordering::Relaxed);
+                } else {
+                    server_counts.gets.fetch_add(1, Ordering::Relaxed);
+                    server_counts
+                        .bytes
+                        .fetch_add(end - start, Ordering::Relaxed);
+                }
+                socket.write_all(headers.as_bytes()).await.unwrap();
+                if !head {
+                    socket.write_all(&bytes[start..end]).await.unwrap();
+                }
+            }
+        });
+        (uri, counts, Server(task))
+    }
+
+    #[tokio::test]
+    async fn indexed_order_is_independent_of_remote_size_and_filters() {
+        for payload_size in [8, 4096] {
+            let fixture = write_mcap_out_of_order_with_payload(10, payload_size);
+            let contents = std::fs::read(fixture.path()).unwrap();
+            let small = payload_size == 8;
+            assert_eq!(contents.len() <= 64 * 1024, small);
+            let (uri, _, _server) = serve(contents).await;
+            for filtered in [false, true] {
+                let options = if filtered {
+                    McapReadOptions {
+                        topics: Some(vec!["/camera".to_string()]),
+                        start_time: Some(2),
+                        end_time: Some(105),
+                        batch_size: 3,
+                    }
+                } else {
+                    McapReadOptions {
+                        batch_size: 3,
+                        ..Default::default()
+                    }
+                };
+                let (mut local, _) = make_reader(&fixture, options.clone()).await.unwrap();
+                let expected = collect_rows(&mut local).await.unwrap();
+                let times: Vec<_> = if filtered {
+                    (2..10).chain(100..105).collect()
+                } else {
+                    (0..10).chain(100..110).collect()
+                };
+                assert_eq!(
+                    expected
+                        .iter()
+                        .map(|(_, time, _)| *time)
+                        .collect::<Vec<_>>(),
+                    times
+                );
+
+                let io = IOStatsContext::new("MCAP remote ordering regression");
+                let client = get_io_client(true, Arc::new(IOConfig::default())).unwrap();
+                let mut remote = NativeMcapReader::new(&uri, client, io.clone(), options)
+                    .await
+                    .unwrap();
+                assert!(remote.indexed());
+                assert_eq!(collect_rows(&mut remote).await.unwrap(), expected);
+                if small {
+                    assert_eq!(io.load_get_requests(), 1);
+                    assert_eq!(remote.read_stats().chunk_fetches, 0);
+                } else {
+                    assert!(io.load_get_requests() > 1);
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn rejects_nonzero_range_response_with_unknown_origin() {
+        let fixture = write_mcap(true, None, 100, 4096);
+        let contents = std::fs::read(fixture.path()).unwrap();
+        assert!(contents.len() > 64 * 1024);
+        // The initial offset-zero probe works, but the footer GET returns the
+        // whole file. Slicing its first 37 bytes would not yield the footer.
+        let (uri, requests, _server) = serve_with_range_behavior(contents, true).await;
+        let io = IOStatsContext::new("MCAP inconsistent Range response regression");
+        let client = get_io_client(true, Arc::new(IOConfig::default())).unwrap();
+        let error = NativeMcapReader::new(uri, client, io, McapReadOptions::default())
+            .await
+            .err()
+            .expect("inconsistent range origin must not be accepted");
+        assert!(
+            error.to_string().contains("unexpected range length"),
+            "{error}"
+        );
+        assert_eq!(requests.gets.load(Ordering::Relaxed), 2);
+    }
+
+    #[tokio::test]
+    async fn remote_requests_match_io_stats_and_logical_reads() {
+        // Small files are fully buffered. Larger files use a magic GET, footer
+        // GET, one summary-tail GET, and coalesced indexed chunk GETs.
+        for payload_size in [8, 4096] {
+            let fixture = write_mcap(true, None, 100, payload_size);
+            let (uri, requests, _server) = serve(std::fs::read(fixture.path()).unwrap()).await;
+            let io = IOStatsContext::new("MCAP HTTP stats regression");
+            let client = get_io_client(true, Arc::new(IOConfig::default())).unwrap();
+            let mut reader =
+                NativeMcapReader::new(uri, client, io.clone(), McapReadOptions::default())
+                    .await
+                    .unwrap();
+            let small = payload_size == 8;
+            assert_eq!(io.load_head_requests(), 1);
+            assert_eq!(io.load_get_requests(), if small { 1 } else { 3 });
+            let stats = reader.read_stats();
+            assert_eq!(stats.summary_seeks, 2);
+            assert_eq!(stats.summary_fetches, if small { 0 } else { 2 });
+            assert!(stats.summary_tail_bytes.unwrap() > 0);
+            assert!(stats.summary_reads > stats.summary_fetches);
+            assert_eq!(
+                stats.summary_reads,
+                stats.summary_fetches + stats.summary_buffer_hits
+            );
+            let mut rows = 0;
+            while let Some(batch) = reader.next_batch().await.unwrap() {
+                rows += batch.len();
+            }
+            assert_eq!(rows, 100);
+            let stats = reader.read_stats();
+            assert!(stats.chunk_reads > 1);
+            if small {
+                assert_eq!(stats.chunk_fetches, 0);
+            } else {
+                assert!(stats.chunk_fetches > 0);
+                assert!(stats.chunk_fetches < stats.chunk_reads);
+            }
+            assert_eq!(
+                stats.chunk_reads,
+                stats.chunk_fetches + stats.chunk_buffer_hits
+            );
+            assert_eq!(stats.linear_record_reads, 0);
+            assert_eq!(
+                io.load_get_requests(),
+                if small { 1 } else { 3 + stats.chunk_fetches }
+            );
+            eprintln!(
+                "small={small} gets={} heads={} bytes={} logical={stats:?}",
+                io.load_get_requests(),
+                io.load_head_requests(),
+                io.load_bytes_read()
+            );
+            assert_eq!(
+                io.load_get_requests(),
+                requests.gets.load(Ordering::Relaxed)
+            );
+            assert_eq!(
+                io.load_head_requests(),
+                requests.heads.load(Ordering::Relaxed)
+            );
+            assert_eq!(io.load_bytes_read(), requests.bytes.load(Ordering::Relaxed));
+        }
+    }
+}

--- a/src/daft-mcap/src/test_utils.rs
+++ b/src/daft-mcap/src/test_utils.rs
@@ -1,0 +1,97 @@
+//! Shared fixtures for the in-module test suites.
+
+use std::{borrow::Cow, collections::BTreeMap, fs::File, io::BufWriter, sync::Arc};
+
+use common_error::DaftResult;
+use daft_io::{IOConfig, IOStatsContext, get_io_client};
+use mcap::{Channel, Compression, Message, WriteOptions};
+use tempfile::NamedTempFile;
+
+use crate::{McapReadOptions, NativeMcapReader};
+
+pub(crate) fn write_mcap(
+    indexed: bool,
+    compression: Option<Compression>,
+    message_count: usize,
+    payload_size: usize,
+) -> NamedTempFile {
+    let temp = NamedTempFile::new().unwrap();
+    let output = File::create(temp.path()).unwrap();
+    let mut writer = WriteOptions::new()
+        .use_chunks(indexed)
+        .chunk_size(Some((payload_size.max(1) + 256) as u64))
+        .compression(compression)
+        .create(BufWriter::new(output))
+        .unwrap();
+    let camera = Arc::new(Channel {
+        id: 1,
+        schema: None,
+        topic: "/camera".to_string(),
+        message_encoding: String::new(),
+        metadata: BTreeMap::new(),
+    });
+    let imu = Arc::new(Channel {
+        id: 2,
+        schema: None,
+        topic: "/imu".to_string(),
+        message_encoding: String::new(),
+        metadata: BTreeMap::new(),
+    });
+
+    for index in 0..message_count {
+        let channel = if index % 2 == 0 {
+            camera.clone()
+        } else {
+            imu.clone()
+        };
+        let mut data = vec![index as u8; payload_size];
+        data.extend_from_slice(&(index as u64).to_le_bytes());
+        writer
+            .write(&Message {
+                channel,
+                sequence: index as u32,
+                log_time: index as u64,
+                publish_time: index as u64 + 100,
+                data: Cow::Owned(data),
+            })
+            .unwrap();
+    }
+    writer.finish().unwrap();
+    drop(writer);
+    temp
+}
+
+pub(crate) async fn make_reader(
+    file: &NamedTempFile,
+    options: McapReadOptions,
+) -> DaftResult<(NativeMcapReader, daft_io::IOStatsRef)> {
+    let io_client = get_io_client(true, Arc::new(IOConfig::default()))?;
+    let io_stats = IOStatsContext::new("daft-mcap unit test");
+    let reader = NativeMcapReader::new(
+        file.path().to_string_lossy(),
+        io_client,
+        io_stats.clone(),
+        options,
+    )
+    .await?;
+    Ok((reader, io_stats))
+}
+
+pub(crate) async fn collect_rows(
+    reader: &mut NativeMcapReader,
+) -> DaftResult<Vec<(String, u64, Vec<u8>)>> {
+    let mut rows = Vec::new();
+    while let Some(batch) = reader.next_batch().await? {
+        let topics = batch.get_column(1).utf8()?;
+        let log_times = batch.get_column(2).u64()?;
+        let payloads = batch.get_column(5).binary()?;
+        for index in 0..batch.len() {
+            rows.push((
+                topics.get(index).unwrap().to_string(),
+                log_times.get(index).unwrap(),
+                payloads.get(index).unwrap().to_vec(),
+            ));
+        }
+    }
+    Ok(rows)
+}

--- a/src/daft-mcap/src/test_utils.rs
+++ b/src/daft-mcap/src/test_utils.rs
@@ -61,6 +61,54 @@ pub(crate) fn write_mcap(
     temp
 }
 
+/// Writes an indexed MCAP whose chunks are physically out of log-time order:
+/// a run of log times starting at 100 precedes a run starting at 0, with a
+/// chunk size small enough that the runs never share a chunk.
+pub(crate) fn write_mcap_out_of_order(messages_per_run: usize) -> NamedTempFile {
+    write_mcap_out_of_order_with_payload(messages_per_run, 8)
+}
+
+pub(crate) fn write_mcap_out_of_order_with_payload(
+    messages_per_run: usize,
+    payload_size: usize,
+) -> NamedTempFile {
+    let temp = NamedTempFile::new().unwrap();
+    let output = File::create(temp.path()).unwrap();
+    let mut writer = WriteOptions::new()
+        .use_chunks(true)
+        .chunk_size(Some(64))
+        .compression(None)
+        .create(BufWriter::new(output))
+        .unwrap();
+    let channel = Arc::new(Channel {
+        id: 1,
+        schema: None,
+        topic: "/camera".to_string(),
+        message_encoding: String::new(),
+        metadata: BTreeMap::new(),
+    });
+
+    for run_start in [100_u64, 0_u64] {
+        for offset in 0..messages_per_run as u64 {
+            let time = run_start + offset;
+            let mut data = time.to_le_bytes().to_vec();
+            data.resize(payload_size.max(data.len()), 0);
+            writer
+                .write(&Message {
+                    channel: channel.clone(),
+                    sequence: time as u32,
+                    log_time: time,
+                    publish_time: time,
+                    data: Cow::Owned(data),
+                })
+                .unwrap();
+        }
+    }
+    writer.finish().unwrap();
+    drop(writer);
+    temp
+}
+
 pub(crate) async fn make_reader(
     file: &NamedTempFile,
     options: McapReadOptions,

--- a/src/daft-mcap/tests/remote_profile.rs
+++ b/src/daft-mcap/tests/remote_profile.rs
@@ -1,0 +1,123 @@
+//! Opt-in profiling of remote MCAPs. See README.md for credentials and controls.
+
+use std::{sync::Arc, time::Instant};
+
+use daft_io::{IOConfig, IOStatsContext, IOStatsRef, get_io_client};
+use daft_mcap::{McapReadOptions, McapReadStats, NativeMcapReader};
+
+const ABC_EPISODE: &str = "hf://datasets/XDOF/ABC-130k@75ca0b88bda489f2bd935d72454593ecb90efb52/data/val/arrange_the_flowers_into_the_vase/episode_02161a65-02b6-477b-ad3a-f4f6947041cc/episode.mcap";
+const ABC_EPISODE_ROWS: usize = 288_765;
+
+fn report(
+    phase: &str,
+    indexed: bool,
+    stats: &McapReadStats,
+    io: &IOStatsRef,
+    rows: usize,
+    start: Instant,
+) {
+    eprintln!(
+        "phase={phase} rows={rows} elapsed_ms={} indexed={} gets={} heads={} lists={} bytes={} logical={:?}",
+        start.elapsed().as_millis(),
+        indexed,
+        io.load_get_requests(),
+        io.load_head_requests(),
+        io.load_list_requests(),
+        io.load_bytes_read(),
+        stats,
+    );
+}
+
+#[tokio::test]
+#[ignore = "downloads remote data; ABC-130k requires approved Hugging Face access and HF_TOKEN"]
+async fn profile_abc_130k() -> Result<(), Box<dyn std::error::Error>> {
+    let mut config = IOConfig::default();
+    config.hf.token = std::env::var("HF_TOKEN").ok().map(Into::into);
+    // HTTP range GETs give an interpretable baseline. Xet's storage-operation
+    // counter does not count individual reconstruction/CAS network requests.
+    config.hf.use_xet = std::env::var("MCAP_PROFILE_XET").as_deref() == Ok("1");
+    let client = get_io_client(true, Arc::new(config))?;
+    let uris = std::env::var("MCAP_PROFILE_URIS").unwrap_or_else(|_| ABC_EPISODE.to_string());
+    let max_batches: usize = std::env::var("MCAP_PROFILE_MAX_BATCHES")
+        .unwrap_or_else(|_| "1".into())
+        .parse()?;
+    let options = McapReadOptions {
+        topics: std::env::var("MCAP_PROFILE_TOPIC")
+            .ok()
+            .map(|topic| vec![topic]),
+        start_time: std::env::var("MCAP_PROFILE_START_TIME")
+            .ok()
+            .map(|v| v.parse())
+            .transpose()?,
+        end_time: std::env::var("MCAP_PROFILE_END_TIME")
+            .ok()
+            .map(|v| v.parse())
+            .transpose()?,
+        ..Default::default()
+    };
+    assert!(!uris.trim().is_empty(), "provide at least one MCAP URI");
+    let mut total = (0, 0, 0, 0, 0);
+    for (file, uri) in uris.split_whitespace().enumerate() {
+        eprintln!("file={file}");
+        let io = IOStatsContext::new("remote MCAP profile");
+        let start = Instant::now();
+        let mut reader =
+            NativeMcapReader::new(uri, client.clone(), io.clone(), options.clone()).await?;
+        let indexed = reader.indexed();
+        report("open", indexed, reader.read_stats(), &io, 0, start);
+        let (mut batches, mut rows) = (0, 0);
+        let mut eof = false;
+        while max_batches == 0 || batches < max_batches {
+            let Some(batch) = reader.next_batch().await? else {
+                eof = true;
+                break;
+            };
+            rows += batch.len();
+            batches += 1;
+        }
+        let stats = reader.read_stats().clone();
+        // Streaming backends publish buffered byte counters on stream drop.
+        // Flush them even when a batch cap stops an unindexed scan early.
+        drop(reader);
+        report(
+            if eof { "eof" } else { "batch_cap" },
+            indexed,
+            &stats,
+            &io,
+            rows,
+            start,
+        );
+        if uri == ABC_EPISODE
+            && options.topics.is_none()
+            && options.start_time.is_none()
+            && options.end_time.is_none()
+        {
+            assert!(indexed);
+            let expected = if max_batches == 0 {
+                ABC_EPISODE_ROWS
+            } else {
+                max_batches
+                    .saturating_mul(options.batch_size)
+                    .min(ABC_EPISODE_ROWS)
+            };
+            assert_eq!(rows, expected, "pinned ABC-130k episode row count changed");
+        }
+        assert_eq!(
+            stats.chunk_reads,
+            stats.chunk_fetches + stats.chunk_buffer_hits
+        );
+        // All supplied URIs should use a remote backend with IOStats wiring.
+        assert!(io.load_get_requests() > 0, "no remote GETs were recorded");
+        assert!(io.load_bytes_read() > 0, "no remote bytes were recorded");
+        total.0 += 1;
+        total.1 += rows;
+        total.2 += io.load_get_requests();
+        total.3 += io.load_head_requests();
+        total.4 += io.load_bytes_read();
+    }
+    eprintln!(
+        "total files={} rows={} gets={} heads={} bytes={}",
+        total.0, total.1, total.2, total.3, total.4
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Changes Made

This is **1 of 3** in the clean restack replacing #7319 and the closed #7332–#7334.

This PR adds only the internal Rust `daft-mcap` reader core in its final module layout. It supports indexed range reads, an unindexed linear fallback, LZ4 and Zstandard chunks, bounded read-ahead, CRC validation, topic/time constraints, and coalesced remote ranges. `read.rs` owns decoding, while `lib.rs` owns shared summary and range mechanics.

There is deliberately no Python bridge, native scan integration, public API change, dependency removal, or documentation/schema migration here. The crate is not yet routed into `daft.read_mcap`; that cutover is isolated in the next PR. This keeps review focused on MCAP parsing, I/O, ordering behavior for indexed reads, and record-batch construction.

## User Impact

None yet. This is an internal, tested reader foundation.

## Validation

- `cargo fmt --all --check`
- `cargo check --locked -p daft-mcap`
- `cargo test --locked -p daft-mcap` — 9 passed

## Stack

1. **Native reader core** — this PR
2. Native scan integration and API/schema cutover — #7339
3. Predicate pushdown, ordering, and profiling — #7340

## Related Issues

- Clean restack of #7319 and closed #7332–#7334.
- Follow-ups: #7329, #7330, #7331.