### PR TITLE
fix(distributed): harden idle-worker downscaling against scheduler races

### DIFF
--- a/daft/runners/__init__.py
+++ b/daft/runners/__init__.py
@@ -84,10 +84,13 @@ def set_runner_ray(
         downscale_enabled: Enable/disable retiring idle Ray workers (scale-in). If not provided,
             falls back to the ``DAFT_AUTOSCALING_DOWNSCALE_ENABLED`` environment variable (default: False).
         downscale_idle_seconds: Minimum number of seconds a worker must be idle before it becomes eligible
-            for retirement. If not provided, falls back to ``DAFT_AUTOSCALING_DOWNSCALE_IDLE_SECONDS``
-            (default: 60).
+            for retirement by the background reaper (which runs across query boundaries; workers idle for
+            less than this stay warm for the next query). If not provided, falls back to
+            ``DAFT_AUTOSCALING_DOWNSCALE_IDLE_SECONDS`` (default: 60).
         min_survivor_workers: Minimum number of Ray workers to keep alive even if they are idle.
-            If not provided, falls back to ``DAFT_AUTOSCALING_MIN_SURVIVOR_WORKERS`` (default: 1).
+            These workers form a warm pool that persists across queries for the lifetime of the
+            driver process. If not provided, falls back to ``DAFT_AUTOSCALING_MIN_SURVIVOR_WORKERS``
+            (default: 1).
         pending_release_exclude_seconds: Grace period (TTL) for recently-released worker IDs during
             worker discovery, to prevent the autoscaler from immediately respawning them. If not
             provided, falls back to ``DAFT_AUTOSCALING_PENDING_RELEASE_EXCLUDE_SECONDS`` (default: 120).

--- a/docs/distributed/ray.md
+++ b/docs/distributed/ray.md
@@ -166,4 +166,8 @@ daft.set_runner_ray(
 )
 ```
 
-Or via environment variables (useful for Ray Jobs / KubeRay manifests): `DAFT_AUTOSCALING_DOWNSCALE_ENABLED` (default: false), `DAFT_AUTOSCALING_DOWNSCALE_IDLE_SECONDS` (default: 60), `DAFT_AUTOSCALING_MIN_SURVIVOR_WORKERS` (default: 1), and `DAFT_AUTOSCALING_PENDING_RELEASE_EXCLUDE_SECONDS` (default: 120).
+Or via environment variables (useful for Ray Jobs / KubeRay manifests): `DAFT_AUTOSCALING_DOWNSCALE_ENABLED` (default: false), `DAFT_AUTOSCALING_DOWNSCALE_IDLE_SECONDS` (default: 60), `DAFT_AUTOSCALING_MIN_SURVIVOR_WORKERS` (default: 1), `DAFT_AUTOSCALING_PENDING_RELEASE_EXCLUDE_SECONDS` (default: 120), and `DAFT_AUTOSCALING_REAPER_INTERVAL_SECONDS` (default: 5) which controls how often the background reaper checks for idle workers.
+
+!!! note "How retirement works"
+
+    Idle workers are retired by a background reaper that runs for the lifetime of the Daft session, independent of query boundaries. Retirement is two-phase: a worker idle for at least `DAFT_AUTOSCALING_DOWNSCALE_IDLE_SECONDS` is first hidden from the scheduler (draining), then released on a later reaper cycle if it is still idle. When a query finishes, Daft clears its outstanding autoscaler requests but does **not** immediately kill idle workers — they stay warm for the next query until they pass the idle threshold. The last `DAFT_AUTOSCALING_MIN_SURVIVOR_WORKERS` workers (default: 1) are kept alive as a warm pool for as long as the driver process lives, so on shared clusters you may want to set it to 0 for one-shot jobs.

--- a/src/daft-distributed/src/python/ray/worker.rs
+++ b/src/daft-distributed/src/python/ray/worker.rs
@@ -130,13 +130,19 @@ impl RaySwordfishWorker {
     }
 
     #[allow(dead_code)]
-    pub fn shutdown(&self, py: Python<'_>) {
+    pub fn shutdown(&self, py: Python<'_>) -> DaftResult<()> {
         self.ray_worker_handle
-            .call_method0(py, pyo3::intern!(py, "shutdown"))
-            .expect("Failed to shutdown RaySwordfishWorker");
+            .call_method0(py, pyo3::intern!(py, "shutdown"))?;
+        Ok(())
     }
 
-    pub fn release(&mut self, py: Python<'_>) {
+    /// Attempt to shut this worker's actor down.
+    ///
+    /// Returns `Ok(false)` when the worker picked up work after being selected
+    /// for retirement, and `Err` when the actor shutdown itself failed. In both
+    /// cases the worker is still alive and usable, so the caller must put it
+    /// back into the manager's state rather than dropping it.
+    pub fn release(&mut self, py: Python<'_>) -> DaftResult<bool> {
         let inflight = self.active_task_details.len();
         if inflight > 0 {
             tracing::warn!(
@@ -145,12 +151,17 @@ impl RaySwordfishWorker {
                 inflight_tasks = inflight,
                 "Cannot release worker because it has active tasks."
             );
-            return;
+            return Ok(false);
         }
 
         self.set_state(ActorState::Releasing);
-        self.shutdown(py);
+        if let Err(e) = self.shutdown(py) {
+            // The actor is still out there; hand it back in a usable state.
+            self.set_state(ActorState::Idle);
+            return Err(e);
+        }
         self.set_state(ActorState::Released);
+        Ok(true)
     }
 }
 

--- a/src/daft-distributed/src/python/ray/worker_manager.rs
+++ b/src/daft-distributed/src/python/ray/worker_manager.rs
@@ -16,7 +16,7 @@ use crate::scheduling::{
     },
     scheduler::WorkerSnapshot,
     task::{SwordfishTask, TaskContext, TaskResourceRequest},
-    worker::{Worker, WorkerId, WorkerManager},
+    worker::{AutoscaleDemandId, Worker, WorkerId, WorkerManager},
 };
 
 const REFRESH_INTERVAL_SECS: Duration = Duration::from_secs(5);
@@ -25,14 +25,33 @@ const DEFAULT_AUTOSCALE_INTERVAL_SECS: u64 = 5;
 // We read the same variable so our rate-limit matches Ray's actual cycle length.
 const RAY_AUTOSCALER_UPDATE_INTERVAL_ENV: &str = "AUTOSCALER_UPDATE_INTERVAL_S";
 
+/// The autoscaling demand currently held by one owner (one running plan).
+///
+/// Ray's `request_resources` is a single cluster-wide slot that each call *replaces*,
+/// so the manager keeps one of these per owner and always publishes the concatenation
+/// of every live owner's `bundles`. Ending one plan then cannot cancel the capacity
+/// another plan is still waiting on.
+#[derive(Debug, Default)]
+struct AutoscaleDemand {
+    /// The bundles this owner last asked Ray for, in `request_resources` shape.
+    bundles: Vec<HashMap<&'static str, i64>>,
+    /// High-water mark of what this owner has requested so far. The request grows by one
+    /// bundle per autoscaler cycle, so this is ramp state and it is deliberately
+    /// per-owner: a newly started plan must not inherit an older plan's ramp.
+    high_water_mark: ResourceRequest,
+    /// When this owner last published, used to rate-limit its ramp to Ray's cycle.
+    last_request_time: Option<Instant>,
+}
+
 struct RayWorkerManagerState {
     ray_workers: HashMap<WorkerId, RaySwordfishWorker>,
     // Workers marked by the reaper as draining: still alive (and counted toward the
-    // min-survivor floor) but hidden from `worker_snapshots()` so the scheduler stops
-    // assigning new work to them. Released on a later reaper tick if still idle.
+    // min-survivor floor) but flagged in `worker_snapshots()` so the scheduler stops
+    // assigning them new work. Released on a later reaper tick if still idle.
     draining_workers: HashSet<WorkerId>,
     last_refresh: Option<Instant>,
-    max_resources_requested: ResourceRequest,
+    /// Live autoscaling demand, keyed by the plan that asked for it.
+    autoscale_demands: HashMap<AutoscaleDemandId, AutoscaleDemand>,
     pending_release_blacklist: HashMap<WorkerId, Instant>,
     last_autoscale_request_time: Option<Instant>,
     autoscale_interval_secs: Duration,
@@ -40,6 +59,18 @@ struct RayWorkerManagerState {
 }
 
 impl RayWorkerManagerState {
+    /// The bundles to publish to Ray: the concatenation of every live owner's demand.
+    ///
+    /// `request_resources` replaces the cluster-wide demand on every call, so this must
+    /// always be the full picture. An empty result is the "no demand" request, i.e. what
+    /// `clear_autoscaling_requests()` sends.
+    fn all_autoscale_bundles(&self) -> Vec<HashMap<&'static str, i64>> {
+        self.autoscale_demands
+            .values()
+            .flat_map(|demand| demand.bundles.iter().cloned())
+            .collect()
+    }
+
     fn refresh_workers(&mut self) -> DaftResult<()> {
         let should_refresh = match self.last_refresh {
             None => true,
@@ -101,7 +132,7 @@ impl RayWorkerManager {
             ray_workers: HashMap::new(),
             draining_workers: HashSet::new(),
             last_refresh: None,
-            max_resources_requested: ResourceRequest::default(),
+            autoscale_demands: HashMap::new(),
             pending_release_blacklist: HashMap::new(),
             last_autoscale_request_time: None,
             autoscale_interval_secs: Duration::from_secs(
@@ -124,8 +155,9 @@ impl RayWorkerManager {
         // manager is dropped.
         //
         // Retirement is two-phase (drain, then release on a later tick) so a worker is
-        // only ever killed after it has been hidden from scheduler snapshots for at least
-        // one full reaper interval — see `scheduling::downscale` for the race analysis.
+        // only ever killed after it has been flagged as draining in scheduler snapshots
+        // for at least one full reaper interval — see `scheduling::downscale` for the
+        // race analysis.
         let reaper_state = Arc::downgrade(&state);
         let spawn_result = std::thread::Builder::new()
             .name("daft-idle-reaper".to_string())
@@ -145,9 +177,10 @@ impl RayWorkerManager {
                     // The reaper is a detached thread with no supervisor: a stray panic
                     // (including lock poisoning from another thread) must not silently
                     // kill retirement for the rest of the session.
-                    let tick_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(
-                        || Self::reap_idle_workers(&state),
-                    ));
+                    let tick_result =
+                        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                            Self::reap_idle_workers(&state)
+                        }));
                     match tick_result {
                         Ok(Ok(_)) => {}
                         Ok(Err(e)) => {
@@ -229,13 +262,15 @@ impl WorkerManager for RayWorkerManager {
         // Refresh workers if needed (internally rate-limited)
         state.refresh_workers()?;
 
-        // Draining workers are deliberately hidden from the scheduler so no new tasks
-        // are assigned to them while the reaper decides whether to release them.
+        // Draining workers stay visible but are tagged, so the scheduler stops giving
+        // them discretionary work while hard-affinity tasks that can only run there can
+        // still resolve their target. Hiding them outright made such tasks permanently
+        // unschedulable: the hard-affinity path has no fallback and simply fails when
+        // the worker is absent from the snapshots.
         Ok(state
             .ray_workers
             .values()
-            .filter(|w| !state.draining_workers.contains(w.id()))
-            .map(WorkerSnapshot::from)
+            .map(|w| WorkerSnapshot::from(w).with_draining(state.draining_workers.contains(w.id())))
             .collect::<Vec<_>>())
     }
 
@@ -265,7 +300,16 @@ impl WorkerManager for RayWorkerManager {
             .expect("Failed to lock RayWorkerManagerState");
         Python::attach(|py| {
             for worker in state.ray_workers.values() {
-                worker.shutdown(py);
+                // Best effort: a failure to tear one actor down must not abort the
+                // shutdown of the remaining workers.
+                if let Err(e) = worker.shutdown(py) {
+                    tracing::error!(
+                        target: "ray_worker_manager",
+                        worker_id = %worker.id(),
+                        error = %e,
+                        "Failed to shut down worker during teardown"
+                    );
+                }
             }
         });
         Ok(())
@@ -298,22 +342,37 @@ impl WorkerManager for RayWorkerManager {
     ///
     /// Algorithm: since we cannot detect failures and don't know the cluster's max capacity,
     /// we ramp up demand gradually. In each autoscaler cycle, we send one more bundle than the
-    /// previous request (tracked via `max_resources_requested` as a high-water mark). The
+    /// previous request (tracked as a per-owner high-water mark). The
     /// high-water mark is floored to current cluster resources so the very first cycle
     /// immediately requests scaling beyond current capacity.
-    fn try_autoscale(&self, bundles: Vec<TaskResourceRequest>) -> DaftResult<()> {
+    fn try_autoscale(
+        &self,
+        demand_id: AutoscaleDemandId,
+        bundles: Vec<TaskResourceRequest>,
+    ) -> DaftResult<()> {
         let mut state = self
             .state
             .lock()
             .expect("Failed to lock RayWorkerManagerState");
 
-        // 1. Only attempt to grow the request once per Ray autoscaler reconciliation cycle.
-        //    Sending more frequently would just overwrite the previous value before Ray processes it.
-        if let Some(last_time) = state.last_autoscale_request_time
-            && last_time.elapsed() < state.autoscale_interval_secs
-        {
-            return Ok(());
-        }
+        // 1. Only attempt to grow this owner's request once per Ray autoscaler
+        //    reconciliation cycle. Sending more frequently would just overwrite the
+        //    previous value before Ray processes it. The rate limit is per owner: a
+        //    plan that just started must not have to wait out another plan's cycle.
+        //    Note we deliberately do not register the owner here — an owner that bails
+        //    out below never published anything, so it must not appear in the demand map.
+        let autoscale_interval = state.autoscale_interval_secs;
+        let high_water_mark = match state.autoscale_demands.get(&demand_id) {
+            Some(demand) => {
+                if let Some(last_time) = demand.last_request_time
+                    && last_time.elapsed() < autoscale_interval
+                {
+                    return Ok(());
+                }
+                demand.high_water_mark.clone()
+            }
+            None => ResourceRequest::default(),
+        };
 
         // 2. Floor the high-water mark to at least the current cluster's total resources.
         //    On cold start (high-water mark is 0), this lets us skip straight to requesting
@@ -330,18 +389,15 @@ impl WorkerManager for RayWorkerManager {
                     acc.2 + worker.total_memory_bytes(),
                 )
             });
-        let high_water_mark_cpus = state
-            .max_resources_requested
+        let high_water_mark_cpus = high_water_mark
             .num_cpus()
             .unwrap_or(0.0)
             .max(cluster_num_cpus);
-        let high_water_mark_gpus = state
-            .max_resources_requested
+        let high_water_mark_gpus = high_water_mark
             .num_gpus()
             .unwrap_or(0.0)
             .max(cluster_num_gpus);
-        let high_water_mark_memory = state
-            .max_resources_requested
+        let high_water_mark_memory = high_water_mark
             .memory_bytes()
             .unwrap_or(0)
             .max(cluster_memory_bytes);
@@ -376,10 +432,10 @@ impl WorkerManager for RayWorkerManager {
             return Ok(());
         }
 
-        // 5. Send the selected bundles to Ray's autoscaler via request_resources().
-        //    Strip zero-valued GPU/memory keys so Ray doesn't interpret them as a demand
-        //    for zero-resource bundles on specialized nodes.
-        let python_bundles = selected_bundles
+        // 5. Translate the selected bundles into Ray's `request_resources` shape. Strip
+        //    zero-valued GPU/memory keys so Ray doesn't interpret them as a demand for
+        //    zero-resource bundles on specialized nodes.
+        let own_bundles = selected_bundles
             .iter()
             .map(|bundle| {
                 let mut dict = HashMap::new();
@@ -396,9 +452,33 @@ impl WorkerManager for RayWorkerManager {
             })
             .collect::<Vec<_>>();
 
+        // 6. Record this request as this owner's new high-water mark, so its next cycle
+        //    requests exactly one bundle more and never sends a smaller request.
+        let own_bundle_count = own_bundles.len();
+        let demand = state.autoscale_demands.entry(demand_id).or_default();
+        demand.bundles = own_bundles;
+        demand.high_water_mark =
+            ResourceRequest::try_new_internal(Some(cpu_sum), Some(gpu_sum), Some(memory_sum))?;
+        demand.last_request_time = Some(Instant::now());
+
+        // 7. Publish the union of every live owner's demand. `request_resources` replaces
+        //    the cluster-wide slot on every call, so sending only our own bundles would
+        //    silently cancel the capacity a concurrently running plan is waiting on.
+        let published_bundles = state.all_autoscale_bundles();
+
+        tracing::debug!(
+            target: "ray_worker_manager",
+            demand_id = %demand_id,
+            own_bundles = own_bundle_count,
+            total_bundles = published_bundles.len(),
+            live_owners = state.autoscale_demands.len(),
+            "Publishing autoscaling demand"
+        );
+
         Python::attach(|py| -> DaftResult<()> {
             let flotilla_module = py.import(pyo3::intern!(py, "daft.runners.flotilla"))?;
-            flotilla_module.call_method1(pyo3::intern!(py, "try_autoscale"), (python_bundles,))?;
+            flotilla_module
+                .call_method1(pyo3::intern!(py, "try_autoscale"), (published_bundles,))?;
             Ok(())
         })?;
 
@@ -409,42 +489,44 @@ impl WorkerManager for RayWorkerManager {
         state.pending_release_blacklist.clear();
         state.draining_workers.clear();
         state.last_refresh = None;
-
-        // 6. Record this request as the new high-water mark so the next cycle will
-        //    request exactly one bundle more, and so we never send a smaller request.
-        state.max_resources_requested =
-            ResourceRequest::try_new_internal(Some(cpu_sum), Some(gpu_sum), Some(memory_sum))?;
+        // Cluster-wide guard used by the reaper: any recent scale-up, from any owner,
+        // suppresses retirement for a full autoscaler cycle.
         state.last_autoscale_request_time = Some(Instant::now());
 
         Ok(())
     }
 
-    fn clear_autoscale_demand(&self) -> DaftResult<()> {
+    fn clear_autoscale_demand(&self, demand_id: AutoscaleDemandId) -> DaftResult<()> {
         // Tell Ray's autoscaler to stop provisioning capacity for a job that has
         // finished. This is demand-clearing only — it does not retire any workers.
         // Draining the idle warm pool is owned by the background reaper so retirement
         // has a single authority (see #5683).
-        {
+        let remaining_bundles = {
             let mut state = self
                 .state
                 .lock()
                 .expect("Failed to lock RayWorkerManagerState");
             // If this job never sent a scale-up request, there is no demand of ours in
             // Ray's autoscaler to clear. Skipping the call avoids touching Python on the
-            // default (non-autoscaling) path and avoids clobbering the cluster-wide
+            // default (non-autoscaling) path and avoids writing to the cluster-wide
             // `request_resources` slot that another job may be using.
-            if state.last_autoscale_request_time.is_none() {
+            if state.autoscale_demands.remove(&demand_id).is_none() {
                 return Ok(());
             }
-            state.max_resources_requested = ResourceRequest::default();
-            // Also reset the scale-up guard: with no outstanding demand there is nothing
-            // for the reaper's guard to protect, so idle workers can drain on schedule.
-            state.last_autoscale_request_time = None;
-        }
+            if state.autoscale_demands.is_empty() {
+                // Nothing of ours is outstanding any more, so the reaper's scale-up guard
+                // has nothing left to protect and idle workers can drain on schedule.
+                state.last_autoscale_request_time = None;
+            }
+            // Re-publish whatever other plans still need. When nothing is left this is an
+            // empty request, which is exactly `clear_autoscaling_requests()`.
+            state.all_autoscale_bundles()
+        };
 
         Python::attach(|py| -> DaftResult<()> {
             let flotilla_module = py.import(pyo3::intern!(py, "daft.runners.flotilla"))?;
-            flotilla_module.call_method0(pyo3::intern!(py, "clear_autoscaling_requests"))?;
+            flotilla_module
+                .call_method1(pyo3::intern!(py, "try_autoscale"), (remaining_bundles,))?;
             Ok(())
         })?;
         Ok(())
@@ -540,11 +622,11 @@ impl RayWorkerManager {
                 }
             }
 
-            // Only reset the autoscale high-water mark and force a worker refresh when
-            // we actually retired something; a no-op tick must not perturb shared
-            // autoscaling state.
+            // Only force a worker refresh when we actually retired something; a no-op
+            // tick must not perturb shared state. Autoscaling demand is deliberately
+            // untouched here: it belongs to whichever plans are still running, and the
+            // reaper is not one of them.
             if !workers_to_release.is_empty() {
-                state.max_resources_requested = ResourceRequest::default();
                 state.last_refresh = None;
             }
 
@@ -560,7 +642,7 @@ impl RayWorkerManager {
             tracing::info!(
                 target: "ray_worker_manager",
                 drained,
-                "Downscale: marked idle workers as draining (hidden from scheduler)"
+                "Downscale: marked idle workers as draining (skipped by the scheduler)"
             );
         }
 
@@ -575,19 +657,54 @@ impl RayWorkerManager {
         );
 
         let mut released = 0usize;
-        Python::attach(|py| -> DaftResult<()> {
+        // Workers we removed from state but could not actually shut down: they are
+        // still alive out there, so they must go back into the manager's state
+        // instead of being leaked (invisible to the scheduler, yet consuming cluster
+        // resources until the blacklist TTL expires).
+        let mut not_released = Vec::new();
+        Python::attach(|py| {
             for mut worker in workers_to_release {
-                worker.release(py);
-                released += 1;
+                match worker.release(py) {
+                    Ok(true) => released += 1,
+                    Ok(false) => {
+                        // Picked up work between selection and release.
+                        not_released.push(worker);
+                    }
+                    Err(e) => {
+                        tracing::error!(
+                            target: "ray_worker_manager",
+                            worker_id = %worker.id(),
+                            error = %e,
+                            "Failed to release worker; returning it to the pool"
+                        );
+                        not_released.push(worker);
+                    }
+                }
             }
-            Ok(())
-        })?;
+        });
 
-        Python::attach(|py| -> DaftResult<()> {
-            let flotilla_module = py.import(pyo3::intern!(py, "daft.runners.flotilla"))?;
-            flotilla_module.call_method0(pyo3::intern!(py, "clear_autoscaling_requests"))?;
-            Ok(())
-        })?;
+        if !not_released.is_empty() {
+            let mut state = Self::lock_state(state_arc);
+            for worker in not_released {
+                let worker_id = worker.id().clone();
+                state.pending_release_blacklist.remove(&worker_id);
+                state.draining_workers.remove(&worker_id);
+                state.ray_workers.insert(worker_id, worker);
+            }
+            // The pool changed under us; make the next snapshot re-read it.
+            state.last_refresh = None;
+        }
+
+        if released == 0 {
+            return Ok(0);
+        }
+
+        // Note: we deliberately do not touch Ray's autoscaling request here. It is the
+        // union of the demand published by every live plan, keyed by owner, and each owner
+        // retracts its own slice when it finishes (`clear_autoscale_demand`). Retiring an
+        // idle worker does not change that union, and because `request_resources` replaces
+        // the cluster-wide slot on every call, clearing it here — as this code used to —
+        // would cancel capacity that a still-running plan is waiting on.
 
         tracing::info!(
             target: "ray_worker_manager",

--- a/src/daft-distributed/src/python/ray/worker_manager.rs
+++ b/src/daft-distributed/src/python/ray/worker_manager.rs
@@ -1,6 +1,6 @@
 use std::{
-    collections::HashMap,
-    sync::{Arc, Mutex},
+    collections::{HashMap, HashSet},
+    sync::{Arc, Mutex, MutexGuard},
     time::{Duration, Instant},
 };
 
@@ -10,6 +10,10 @@ use pyo3::prelude::*;
 
 use super::{task::RayTaskResultHandle, worker::RaySwordfishWorker};
 use crate::scheduling::{
+    downscale::{
+        DEFAULT_REAPER_INTERVAL_SECONDS, DownscalePolicy, REAPER_INTERVAL_SECONDS_ENV,
+        WorkerStatus, plan_reap,
+    },
     scheduler::WorkerSnapshot,
     task::{SwordfishTask, TaskContext, TaskResourceRequest},
     worker::{Worker, WorkerId, WorkerManager},
@@ -23,6 +27,10 @@ const RAY_AUTOSCALER_UPDATE_INTERVAL_ENV: &str = "AUTOSCALER_UPDATE_INTERVAL_S";
 
 struct RayWorkerManagerState {
     ray_workers: HashMap<WorkerId, RaySwordfishWorker>,
+    // Workers marked by the reaper as draining: still alive (and counted toward the
+    // min-survivor floor) but hidden from `worker_snapshots()` so the scheduler stops
+    // assigning new work to them. Released on a later reaper tick if still idle.
+    draining_workers: HashSet<WorkerId>,
     last_refresh: Option<Instant>,
     max_resources_requested: ResourceRequest,
     pending_release_blacklist: HashMap<WorkerId, Instant>,
@@ -89,22 +97,94 @@ pub(crate) struct RayWorkerManager {
 
 impl RayWorkerManager {
     pub fn new(worker_startup_timeout: usize) -> Self {
-        Self {
-            state: Arc::new(Mutex::new(RayWorkerManagerState {
-                ray_workers: HashMap::new(),
-                last_refresh: None,
-                max_resources_requested: ResourceRequest::default(),
-                pending_release_blacklist: HashMap::new(),
-                last_autoscale_request_time: None,
-                autoscale_interval_secs: Duration::from_secs(
-                    std::env::var(RAY_AUTOSCALER_UPDATE_INTERVAL_ENV)
+        let state = Arc::new(Mutex::new(RayWorkerManagerState {
+            ray_workers: HashMap::new(),
+            draining_workers: HashSet::new(),
+            last_refresh: None,
+            max_resources_requested: ResourceRequest::default(),
+            pending_release_blacklist: HashMap::new(),
+            last_autoscale_request_time: None,
+            autoscale_interval_secs: Duration::from_secs(
+                std::env::var(RAY_AUTOSCALER_UPDATE_INTERVAL_ENV)
+                    .ok()
+                    .and_then(|val| val.parse::<u64>().ok())
+                    .unwrap_or(DEFAULT_AUTOSCALE_INTERVAL_SECS),
+            ),
+            worker_startup_timeout,
+        }));
+
+        // Background reaper: the single authority for retiring idle workers. The scheduler
+        // no longer retires workers at all, which avoids two actors racing over the same
+        // pool. This detached thread runs on its own timer, independent of query
+        // boundaries, so genuinely idle workers past the min-survivor floor are drained
+        // whether they went idle mid-query, between queries, or after the final query of a
+        // session — cases the per-query scheduler loop could never all cover. Workers idle
+        // for less than the threshold stay warm for the next query. It is a no-op unless
+        // downscaling is enabled, and it holds a Weak handle so it self-terminates once the
+        // manager is dropped.
+        //
+        // Retirement is two-phase (drain, then release on a later tick) so a worker is
+        // only ever killed after it has been hidden from scheduler snapshots for at least
+        // one full reaper interval — see `scheduling::downscale` for the race analysis.
+        let reaper_state = Arc::downgrade(&state);
+        let spawn_result = std::thread::Builder::new()
+            .name("daft-idle-reaper".to_string())
+            .spawn(move || {
+                loop {
+                    // Re-read every tick, matching how the downscale policy env vars are
+                    // re-read per tick, so the cadence can be tuned at runtime.
+                    let interval = std::env::var(REAPER_INTERVAL_SECONDS_ENV)
                         .ok()
-                        .and_then(|val| val.parse::<u64>().ok())
-                        .unwrap_or(DEFAULT_AUTOSCALE_INTERVAL_SECS),
-                ),
-                worker_startup_timeout,
-            })),
+                        .and_then(|v| v.parse::<u64>().ok())
+                        .unwrap_or(DEFAULT_REAPER_INTERVAL_SECONDS)
+                        .max(1);
+                    std::thread::sleep(Duration::from_secs(interval));
+                    let Some(state) = reaper_state.upgrade() else {
+                        break;
+                    };
+                    // The reaper is a detached thread with no supervisor: a stray panic
+                    // (including lock poisoning from another thread) must not silently
+                    // kill retirement for the rest of the session.
+                    let tick_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(
+                        || Self::reap_idle_workers(&state),
+                    ));
+                    match tick_result {
+                        Ok(Ok(_)) => {}
+                        Ok(Err(e)) => {
+                            tracing::warn!(
+                                target: "ray_worker_manager",
+                                error = %e,
+                                "Background idle reaper tick failed"
+                            );
+                        }
+                        Err(_) => {
+                            tracing::error!(
+                                target: "ray_worker_manager",
+                                "Background idle reaper tick panicked; continuing"
+                            );
+                        }
+                    }
+                }
+            });
+        if let Err(e) = spawn_result {
+            tracing::error!(
+                target: "ray_worker_manager",
+                error = %e,
+                "Failed to spawn idle reaper thread; idle workers will not be retired"
+            );
         }
+
+        Self { state }
+    }
+
+    /// Lock the shared state, recovering from poisoning. Used on the reaper path so a
+    /// panic elsewhere cannot permanently disable retirement.
+    fn lock_state(
+        state_arc: &Arc<Mutex<RayWorkerManagerState>>,
+    ) -> MutexGuard<'_, RayWorkerManagerState> {
+        state_arc
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
     }
 }
 
@@ -149,9 +229,12 @@ impl WorkerManager for RayWorkerManager {
         // Refresh workers if needed (internally rate-limited)
         state.refresh_workers()?;
 
+        // Draining workers are deliberately hidden from the scheduler so no new tasks
+        // are assigned to them while the reaper decides whether to release them.
         Ok(state
             .ray_workers
             .values()
+            .filter(|w| !state.draining_workers.contains(w.id()))
             .map(WorkerSnapshot::from)
             .collect::<Vec<_>>())
     }
@@ -172,6 +255,7 @@ impl WorkerManager for RayWorkerManager {
             .lock()
             .expect("Failed to lock RayWorkerManagerState");
         state.ray_workers.remove(&worker_id);
+        state.draining_workers.remove(&worker_id);
     }
 
     fn shutdown(&self) -> DaftResult<()> {
@@ -319,8 +403,11 @@ impl WorkerManager for RayWorkerManager {
         })?;
 
         // Scaling up should immediately allow workers on recently retired nodes to be re-created,
-        // and force a refresh so we can observe newly provisioned nodes quickly.
+        // and force a refresh so we can observe newly provisioned nodes quickly. Demand is
+        // rising, so also put any draining workers back in service immediately instead of
+        // letting the reaper release capacity we are about to need.
         state.pending_release_blacklist.clear();
+        state.draining_workers.clear();
         state.last_refresh = None;
 
         // 6. Record this request as the new high-water mark so the next cycle will
@@ -332,79 +419,72 @@ impl WorkerManager for RayWorkerManager {
         Ok(())
     }
 
-    fn retire_idle_workers(
-        &self,
-        skip_due_to_pending_scale_up: bool,
-        force_all_when_cluster_idle: bool,
-    ) -> DaftResult<usize> {
-        // 1. Read downscale configuration from the environment. The worker manager owns
-        //    every gating decision so the scheduler can stay backend-agnostic.
-        //
-        //    - `DAFT_AUTOSCALING_DOWNSCALE_ENABLED`: Enables the downscaling feature.
-        //      "1" or "true" (case-insensitive) enables it. Defaults to false.
-        //    - `DAFT_AUTOSCALING_MIN_SURVIVOR_WORKERS`: Minimum number of workers to keep
-        //      running even if they are idle. Prevents brief idle periods from collapsing
-        //      the cluster to zero. Defaults to 1.
-        let downscale_enabled = std::env::var("DAFT_AUTOSCALING_DOWNSCALE_ENABLED")
-            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-            .unwrap_or(false);
-        if !downscale_enabled {
-            return Ok(0);
-        }
-
-        let min_survivor_workers: usize = std::env::var("DAFT_AUTOSCALING_MIN_SURVIVOR_WORKERS")
-            .ok()
-            .and_then(|v| v.parse::<usize>().ok())
-            .unwrap_or(1);
-
-        // 2. Final-shutdown sweep clears any lingering autoscaling demand even when no
-        //    workers end up retired this cycle.
-        if force_all_when_cluster_idle {
-            Python::attach(|py| -> DaftResult<()> {
-                let flotilla_module = py.import(pyo3::intern!(py, "daft.runners.flotilla"))?;
-                flotilla_module.call_method0(pyo3::intern!(py, "clear_autoscaling_requests"))?;
-                Ok(())
-            })?;
-        }
-
-        // 3. During an active scale-up, skip downscale so we don't undo demand we just
-        //    sent to Ray's autoscaler.
-        if skip_due_to_pending_scale_up && !force_all_when_cluster_idle {
-            return Ok(0);
-        }
-
-        // 4. Determine how many workers we are allowed to retire while honoring the
-        //    `min_survivor_workers` floor. The shutdown path bypasses the floor.
-        let allowed_to_retire = {
-            let state = self
+    fn clear_autoscale_demand(&self) -> DaftResult<()> {
+        // Tell Ray's autoscaler to stop provisioning capacity for a job that has
+        // finished. This is demand-clearing only — it does not retire any workers.
+        // Draining the idle warm pool is owned by the background reaper so retirement
+        // has a single authority (see #5683).
+        {
+            let mut state = self
                 .state
                 .lock()
                 .expect("Failed to lock RayWorkerManagerState");
-            let num_workers = state.ray_workers.len();
-            if force_all_when_cluster_idle {
-                num_workers
-            } else {
-                num_workers.saturating_sub(min_survivor_workers)
+            // If this job never sent a scale-up request, there is no demand of ours in
+            // Ray's autoscaler to clear. Skipping the call avoids touching Python on the
+            // default (non-autoscaling) path and avoids clobbering the cluster-wide
+            // `request_resources` slot that another job may be using.
+            if state.last_autoscale_request_time.is_none() {
+                return Ok(());
             }
-        };
-        if allowed_to_retire == 0 {
-            return Ok(0);
+            state.max_resources_requested = ResourceRequest::default();
+            // Also reset the scale-up guard: with no outstanding demand there is nothing
+            // for the reaper's guard to protect, so idle workers can drain on schedule.
+            state.last_autoscale_request_time = None;
         }
 
-        let idle_secs_threshold: Option<u64> = if force_all_when_cluster_idle {
-            None
-        } else {
-            Some(
-                std::env::var("DAFT_AUTOSCALING_DOWNSCALE_IDLE_SECONDS")
-                    .ok()
-                    .and_then(|v| v.parse::<u64>().ok())
-                    .unwrap_or(60),
-            )
-        };
+        Python::attach(|py| -> DaftResult<()> {
+            let flotilla_module = py.import(pyo3::intern!(py, "daft.runners.flotilla"))?;
+            flotilla_module.call_method0(pyo3::intern!(py, "clear_autoscaling_requests"))?;
+            Ok(())
+        })?;
+        Ok(())
+    }
+}
 
-        let now = Instant::now();
+impl RayWorkerManager {
+    /// Core idle-retirement routine, run exclusively by the background reaper thread.
+    /// This is the single retirement authority: the scheduler never retires workers, so
+    /// there is no second actor racing over the same pool.
+    ///
+    /// All policy decisions (enable flag, min-survivor floor, idle threshold, scale-up
+    /// guard, two-phase draining) live in `scheduling::downscale::plan_reap`, computed
+    /// from a single consistent snapshot of the state taken under one lock so the guard,
+    /// floor, and candidate selection cannot diverge. This function only gathers inputs
+    /// and applies the plan.
+    fn reap_idle_workers(state_arc: &Arc<Mutex<RayWorkerManagerState>>) -> DaftResult<usize> {
+        // Read the downscale policy from the environment on every tick. The worker
+        // manager owns every gating decision so the scheduler can stay backend-agnostic.
+        let policy = DownscalePolicy::from_env();
 
-        // Determine the Ray head node id so we can avoid retiring its worker.
+        // Cheap early-outs under the lock before touching Python: when downscaling is
+        // disabled the reaper must be a pure no-op (aside from restoring any workers
+        // left draining if the flag was flipped off mid-drain), and an empty or
+        // at-the-floor pool with nothing draining needs no head-node lookup.
+        {
+            let mut state = Self::lock_state(state_arc);
+            if !policy.enabled {
+                state.draining_workers.clear();
+                return Ok(0);
+            }
+            if state.draining_workers.is_empty()
+                && state.ray_workers.len() <= policy.min_survivor_workers
+            {
+                return Ok(0);
+            }
+        }
+
+        // Determine the Ray head node id so we can avoid retiring its worker. Done
+        // outside the state lock: never hold the lock across Python/GIL calls.
         let head_node_id: Option<String> = Python::attach(|py| {
             let flotilla_module = py.import(pyo3::intern!(py, "daft.runners.flotilla"))?;
             let head_id_obj =
@@ -413,48 +493,46 @@ impl WorkerManager for RayWorkerManager {
             DaftResult::Ok(head_id)
         })?;
 
-        let (workers_to_release, survivors_after, blacklisted_after) = {
-            let mut state = self
-                .state
-                .lock()
-                .expect("Failed to lock RayWorkerManagerState");
+        // Single critical section: snapshot worker statuses, compute the plan, and apply
+        // all state transitions atomically with respect to the scheduler's dispatch path.
+        let (workers_to_release, drained, survivors_after, blacklisted_after) = {
+            let mut state = Self::lock_state(state_arc);
 
-            let mut candidates: Vec<(WorkerId, Duration)> = state
+            // Scale-up guard, derived from our own state. If a scale-up request went to
+            // Ray within the last autoscaler cycle, Ray may still be provisioning nodes
+            // for it — the plan suppresses retirement (and cancels in-progress drains)
+            // rather than undoing demand we just signaled. Note this is deliberately
+            // *stronger* than the old scheduler-supplied same-tick flag: retirement is
+            // paused for a full autoscaler cycle after every scale-up request.
+            let scale_up_in_flight = state
+                .last_autoscale_request_time
+                .is_some_and(|last_time| last_time.elapsed() < state.autoscale_interval_secs);
+
+            let now = Instant::now();
+            let statuses: Vec<WorkerStatus> = state
                 .ray_workers
-                .iter()
-                .filter_map(|(wid, w)| {
-                    // Skip the head node entirely from retirement consideration.
-                    if let Some(ref head_id) = head_node_id
-                        && wid.as_ref() == head_id
-                    {
-                        return None;
-                    }
-
-                    if w.is_idle() {
-                        let idle_for = w.idle_duration(now);
-                        if let Some(threshold) = idle_secs_threshold {
-                            if idle_for.as_secs() >= threshold {
-                                Some((wid.clone(), idle_for))
-                            } else {
-                                None
-                            }
-                        } else {
-                            Some((wid.clone(), idle_for))
-                        }
-                    } else {
-                        None
-                    }
+                .values()
+                .map(|w| WorkerStatus {
+                    worker_id: w.id().clone(),
+                    is_head_node: head_node_id.as_deref() == Some(w.id().as_ref()),
+                    idle_for: w.is_idle().then(|| w.idle_duration(now)),
+                    draining: state.draining_workers.contains(w.id()),
                 })
                 .collect();
 
-            candidates.sort_by_key(|(_, d)| std::cmp::Reverse(d.as_secs()));
+            let plan = plan_reap(&policy, scale_up_in_flight, &statuses);
 
-            let selected: Vec<(WorkerId, Duration)> =
-                candidates.into_iter().take(allowed_to_retire).collect();
+            for wid in &plan.undrain {
+                state.draining_workers.remove(wid);
+            }
+            for wid in &plan.drain {
+                state.draining_workers.insert(wid.clone());
+            }
 
-            let mut workers_to_release = Vec::with_capacity(selected.len());
-            for (wid, _idle_for) in selected {
-                if let Some(worker) = state.ray_workers.remove(&wid) {
+            let mut workers_to_release = Vec::with_capacity(plan.release.len());
+            for wid in &plan.release {
+                if let Some(worker) = state.ray_workers.remove(wid) {
+                    state.draining_workers.remove(wid);
                     state
                         .pending_release_blacklist
                         .insert(wid.clone(), Instant::now());
@@ -462,14 +540,29 @@ impl WorkerManager for RayWorkerManager {
                 }
             }
 
-            let survivors_after = state.ray_workers.len();
-            let blacklisted_after = state.pending_release_blacklist.len();
+            // Only reset the autoscale high-water mark and force a worker refresh when
+            // we actually retired something; a no-op tick must not perturb shared
+            // autoscaling state.
+            if !workers_to_release.is_empty() {
+                state.max_resources_requested = ResourceRequest::default();
+                state.last_refresh = None;
+            }
 
-            state.max_resources_requested = ResourceRequest::default();
-            state.last_refresh = None;
-
-            (workers_to_release, survivors_after, blacklisted_after)
+            (
+                workers_to_release,
+                plan.drain.len(),
+                state.ray_workers.len(),
+                state.pending_release_blacklist.len(),
+            )
         };
+
+        if drained > 0 {
+            tracing::info!(
+                target: "ray_worker_manager",
+                drained,
+                "Downscale: marked idle workers as draining (hidden from scheduler)"
+            );
+        }
 
         if workers_to_release.is_empty() {
             return Ok(0);

--- a/src/daft-distributed/src/python/ray/worker_manager.rs
+++ b/src/daft-distributed/src/python/ray/worker_manager.rs
@@ -16,7 +16,7 @@ use crate::scheduling::{
     },
     scheduler::WorkerSnapshot,
     task::{SwordfishTask, TaskContext, TaskResourceRequest},
-    worker::{AutoscaleDemandId, Worker, WorkerId, WorkerManager},
+    worker::{AutoscaleDemandId, DispatchLifecycleGuard, Worker, WorkerId, WorkerManager},
 };
 
 const REFRESH_INTERVAL_SECS: Duration = Duration::from_secs(5);
@@ -124,6 +124,7 @@ impl RayWorkerManagerState {
 // Wrapper around the RaySwordfishWorkerManager class in the distributed_swordfish module.
 pub(crate) struct RayWorkerManager {
     state: Arc<Mutex<RayWorkerManagerState>>,
+    dispatch_gate: Arc<Mutex<()>>,
 }
 
 impl RayWorkerManager {
@@ -154,10 +155,9 @@ impl RayWorkerManager {
         // downscaling is enabled, and it holds a Weak handle so it self-terminates once the
         // manager is dropped.
         //
-        // Retirement is two-phase (drain, then release on a later tick) so a worker is
-        // only ever killed after it has been flagged as draining in scheduler snapshots
-        // for at least one full reaper interval — see `scheduling::downscale` for the
-        // race analysis.
+        // Always acquire the dispatch gate before state locks or Python attachment.
+        let dispatch_gate = Arc::new(Mutex::new(()));
+        let reaper_dispatch_gate = dispatch_gate.clone();
         let reaper_state = Arc::downgrade(&state);
         let spawn_result = std::thread::Builder::new()
             .name("daft-idle-reaper".to_string())
@@ -179,7 +179,7 @@ impl RayWorkerManager {
                     // kill retirement for the rest of the session.
                     let tick_result =
                         std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                            Self::reap_idle_workers(&state)
+                            Self::reap_idle_workers(&state, &reaper_dispatch_gate)
                         }));
                     match tick_result {
                         Ok(Ok(_)) => {}
@@ -207,7 +207,10 @@ impl RayWorkerManager {
             );
         }
 
-        Self { state }
+        Self {
+            state,
+            dispatch_gate,
+        }
     }
 
     /// Lock the shared state, recovering from poisoning. Used on the reaper path so a
@@ -223,6 +226,14 @@ impl RayWorkerManager {
 
 impl WorkerManager for RayWorkerManager {
     type Worker = RaySwordfishWorker;
+
+    fn begin_dispatch(&self) -> DispatchLifecycleGuard<'_> {
+        DispatchLifecycleGuard::new(
+            self.dispatch_gate
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner),
+        )
+    }
 
     fn submit_tasks_to_workers(
         &self,
@@ -502,10 +513,7 @@ impl WorkerManager for RayWorkerManager {
         // Draining the idle warm pool is owned by the background reaper so retirement
         // has a single authority (see #5683).
         let remaining_bundles = {
-            let mut state = self
-                .state
-                .lock()
-                .expect("Failed to lock RayWorkerManagerState");
+            let mut state = Self::lock_state(&self.state);
             // If this job never sent a scale-up request, there is no demand of ours in
             // Ray's autoscaler to clear. Skipping the call avoids touching Python on the
             // default (non-autoscaling) path and avoids writing to the cluster-wide
@@ -543,7 +551,16 @@ impl RayWorkerManager {
     /// from a single consistent snapshot of the state taken under one lock so the guard,
     /// floor, and candidate selection cannot diverge. This function only gathers inputs
     /// and applies the plan.
-    fn reap_idle_workers(state_arc: &Arc<Mutex<RayWorkerManagerState>>) -> DaftResult<usize> {
+    fn reap_idle_workers(
+        state_arc: &Arc<Mutex<RayWorkerManagerState>>,
+        dispatch_gate: &Mutex<()>,
+    ) -> DaftResult<usize> {
+        // Keep retirement, including failed-release reinsertion, outside snapshot-to-submit.
+        let _dispatch_guard = match dispatch_gate.try_lock() {
+            Ok(guard) => guard,
+            Err(std::sync::TryLockError::WouldBlock) => return Ok(0),
+            Err(std::sync::TryLockError::Poisoned(error)) => error.into_inner(),
+        };
         // Read the downscale policy from the environment on every tick. The worker
         // manager owns every gating decision so the scheduler can stay backend-agnostic.
         let policy = DownscalePolicy::from_env();
@@ -715,5 +732,45 @@ impl RayWorkerManager {
         );
 
         Ok(released)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::mpsc;
+
+    use super::*;
+
+    #[test]
+    fn reaper_skips_dispatch_before_locking_state() {
+        let manager = RayWorkerManager {
+            state: Arc::new(Mutex::new(RayWorkerManagerState {
+                ray_workers: HashMap::new(),
+                draining_workers: HashSet::new(),
+                last_refresh: None,
+                autoscale_demands: HashMap::new(),
+                pending_release_blacklist: HashMap::new(),
+                last_autoscale_request_time: None,
+                autoscale_interval_secs: Duration::from_secs(5),
+                worker_startup_timeout: 1,
+            })),
+            dispatch_gate: Arc::new(Mutex::new(())),
+        };
+        let dispatch_guard = manager.begin_dispatch();
+        let state_guard = RayWorkerManager::lock_state(&manager.state);
+        let state = manager.state.clone();
+        let dispatch_gate = manager.dispatch_gate.clone();
+        let (tx, rx) = mpsc::channel();
+        let reaper = std::thread::spawn(move || {
+            tx.send(RayWorkerManager::reap_idle_workers(&state, &dispatch_gate))
+                .unwrap();
+        });
+
+        let result = rx.recv_timeout(Duration::from_secs(5));
+        drop(state_guard);
+        drop(dispatch_guard);
+        reaper.join().unwrap();
+        assert_eq!(result.unwrap().unwrap(), 0);
+        assert!(manager.dispatch_gate.try_lock().is_ok());
     }
 }

--- a/src/daft-distributed/src/scheduling/downscale.rs
+++ b/src/daft-distributed/src/scheduling/downscale.rs
@@ -251,7 +251,7 @@ mod tests {
             (MIN_SURVIVOR_WORKERS_ENV, "3"),
             (DOWNSCALE_IDLE_SECONDS_ENV, "10"),
         ]);
-        let policy = DownscalePolicy::from_lookup(|k| env.get(k).map(|v| v.to_string()));
+        let policy = DownscalePolicy::from_lookup(|k| env.get(k).map(|v| (*v).to_string()));
         assert!(policy.enabled);
         assert_eq!(policy.min_survivor_workers, 3);
         assert_eq!(policy.idle_threshold, Duration::from_secs(10));

--- a/src/daft-distributed/src/scheduling/downscale.rs
+++ b/src/daft-distributed/src/scheduling/downscale.rs
@@ -11,16 +11,19 @@
 //! snapshot taken just before retirement):
 //!
 //! 1. **Drain**: a worker idle past the threshold is marked as draining. A
-//!    draining worker stays alive and can still accept tasks, but is hidden
-//!    from `worker_snapshots()` so the scheduler stops assigning new work to it.
+//!    draining worker stays alive and can still accept tasks, but is flagged as
+//!    such in `worker_snapshots()` so the scheduler stops assigning new work to
+//!    it wherever it has an alternative. Hard-affinity tasks, which have no
+//!    fallback worker, may still be placed there — that immediately makes the
+//!    worker non-idle, so the next tick puts it back in service.
 //! 2. **Release**: on a later reaper tick, a draining worker that is *still*
 //!    idle is actually released. If it picked up work in the meantime (the
 //!    race resolving in favor of the task), it is put back in service instead.
 //!
-//! A release can therefore only happen after the worker has been invisible to
-//! the scheduler for at least one full reaper interval, which is orders of
-//! magnitude longer than the synchronous snapshot->dispatch span in the
-//! scheduler loop.
+//! A release can therefore only happen after the worker has been off the
+//! scheduler's list of candidates for at least one full reaper interval, which
+//! is orders of magnitude longer than the synchronous snapshot->dispatch span in
+//! the scheduler loop.
 
 // The runtime consumer (RayWorkerManager) only exists under the `python` feature;
 // without it this module is exercised by unit tests alone.
@@ -100,7 +103,7 @@ pub(crate) struct ReapPlan {
     /// Draining workers that stayed idle past the threshold for a full reaper
     /// cycle: safe to release now.
     pub release: Vec<WorkerId>,
-    /// Newly idle-past-threshold workers to mark as draining (hidden from
+    /// Newly idle-past-threshold workers to mark as draining (flagged in
     /// scheduler snapshots, released on a later tick if still idle).
     pub drain: Vec<WorkerId>,
     /// Draining workers to put back in service: they picked up work, downscale
@@ -158,9 +161,8 @@ pub(crate) fn plan_reap(
     let mut drain_candidates: Vec<(WorkerId, Duration)> = Vec::new();
 
     for w in workers {
-        let eligible = !w.is_head_node
-            && w.idle_for
-                .is_some_and(|idle| idle >= policy.idle_threshold);
+        let eligible =
+            !w.is_head_node && w.idle_for.is_some_and(|idle| idle >= policy.idle_threshold);
         match (w.draining, eligible) {
             (true, true) => release_candidates.push((w.worker_id.clone(), w.idle_for.unwrap())),
             // Draining worker picked up work (the dispatch/drain race resolving
@@ -258,7 +260,7 @@ mod tests {
     #[test]
     fn test_disabled_is_noop_and_undrains_everything() {
         // Flag flipped off mid-drain: draining workers must be restored so they
-        // don't stay hidden from scheduler snapshots forever.
+        // don't stay flagged as retiring forever.
         let plan = plan_reap(
             &policy(false, 1, 60),
             false,
@@ -316,7 +318,11 @@ mod tests {
 
     #[test]
     fn test_idle_threshold_protects_recently_busy_workers() {
-        let plan = plan_reap(&policy(true, 0, 60), false, &[worker("w1", Some(30), false)]);
+        let plan = plan_reap(
+            &policy(true, 0, 60),
+            false,
+            &[worker("w1", Some(30), false)],
+        );
         assert_eq!(plan, ReapPlan::default());
     }
 

--- a/src/daft-distributed/src/scheduling/downscale.rs
+++ b/src/daft-distributed/src/scheduling/downscale.rs
@@ -1,0 +1,384 @@
+//! Pure decision logic for retiring (scaling down) idle workers.
+//!
+//! This module is deliberately backend-agnostic and free of any Python/Ray
+//! dependencies so the retirement policy can be unit-tested without a live
+//! cluster. The backend worker manager (see `RayWorkerManager`) gathers a
+//! consistent snapshot of worker statuses under its state lock, calls
+//! [`plan_reap`], and applies the returned plan.
+//!
+//! Retirement is two-phase to avoid racing with the scheduler's
+//! snapshot->dispatch window (a worker could be selected for dispatch from a
+//! snapshot taken just before retirement):
+//!
+//! 1. **Drain**: a worker idle past the threshold is marked as draining. A
+//!    draining worker stays alive and can still accept tasks, but is hidden
+//!    from `worker_snapshots()` so the scheduler stops assigning new work to it.
+//! 2. **Release**: on a later reaper tick, a draining worker that is *still*
+//!    idle is actually released. If it picked up work in the meantime (the
+//!    race resolving in favor of the task), it is put back in service instead.
+//!
+//! A release can therefore only happen after the worker has been invisible to
+//! the scheduler for at least one full reaper interval, which is orders of
+//! magnitude longer than the synchronous snapshot->dispatch span in the
+//! scheduler loop.
+
+// The runtime consumer (RayWorkerManager) only exists under the `python` feature;
+// without it this module is exercised by unit tests alone.
+#![cfg_attr(not(feature = "python"), allow(dead_code))]
+
+use std::time::Duration;
+
+use super::worker::WorkerId;
+
+pub(crate) const DOWNSCALE_ENABLED_ENV: &str = "DAFT_AUTOSCALING_DOWNSCALE_ENABLED";
+pub(crate) const DOWNSCALE_IDLE_SECONDS_ENV: &str = "DAFT_AUTOSCALING_DOWNSCALE_IDLE_SECONDS";
+pub(crate) const MIN_SURVIVOR_WORKERS_ENV: &str = "DAFT_AUTOSCALING_MIN_SURVIVOR_WORKERS";
+pub(crate) const REAPER_INTERVAL_SECONDS_ENV: &str = "DAFT_AUTOSCALING_REAPER_INTERVAL_SECONDS";
+
+const DEFAULT_IDLE_SECONDS: u64 = 60;
+const DEFAULT_MIN_SURVIVOR_WORKERS: usize = 1;
+pub(crate) const DEFAULT_REAPER_INTERVAL_SECONDS: u64 = 5;
+
+/// Downscale configuration, read from the environment by the background reaper
+/// on every tick so it can be reconfigured at runtime.
+#[derive(Debug, Clone)]
+pub(crate) struct DownscalePolicy {
+    /// Master switch (`DAFT_AUTOSCALING_DOWNSCALE_ENABLED`). Defaults to false.
+    pub enabled: bool,
+    /// Minimum number of workers kept alive even when idle
+    /// (`DAFT_AUTOSCALING_MIN_SURVIVOR_WORKERS`). Prevents brief idle periods
+    /// from collapsing the warm pool between queries in a session (#5683).
+    pub min_survivor_workers: usize,
+    /// Minimum idle time before a worker becomes eligible for retirement
+    /// (`DAFT_AUTOSCALING_DOWNSCALE_IDLE_SECONDS`), so workers that were busy
+    /// moments ago survive into the next query instead of being rebuilt.
+    pub idle_threshold: Duration,
+}
+
+impl DownscalePolicy {
+    pub fn from_env() -> Self {
+        Self::from_lookup(|key| std::env::var(key).ok())
+    }
+
+    fn from_lookup(get: impl Fn(&str) -> Option<String>) -> Self {
+        let enabled = get(DOWNSCALE_ENABLED_ENV)
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false);
+        let min_survivor_workers = get(MIN_SURVIVOR_WORKERS_ENV)
+            .and_then(|v| v.parse::<usize>().ok())
+            .unwrap_or(DEFAULT_MIN_SURVIVOR_WORKERS);
+        let idle_threshold = Duration::from_secs(
+            get(DOWNSCALE_IDLE_SECONDS_ENV)
+                .and_then(|v| v.parse::<u64>().ok())
+                .unwrap_or(DEFAULT_IDLE_SECONDS),
+        );
+        Self {
+            enabled,
+            min_survivor_workers,
+            idle_threshold,
+        }
+    }
+}
+
+/// Point-in-time status of a single worker, gathered under the worker
+/// manager's state lock so the whole plan is computed from one consistent
+/// snapshot (guard, floor, and candidate selection cannot diverge).
+#[derive(Debug, Clone)]
+pub(crate) struct WorkerStatus {
+    pub worker_id: WorkerId,
+    /// The Ray head node's worker is never retired.
+    pub is_head_node: bool,
+    /// `Some(duration)` if the worker is idle, `None` if it has active tasks.
+    pub idle_for: Option<Duration>,
+    /// Whether the worker was marked as draining on a previous tick.
+    pub draining: bool,
+}
+
+/// The state transitions to apply for one reaper tick.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(crate) struct ReapPlan {
+    /// Draining workers that stayed idle past the threshold for a full reaper
+    /// cycle: safe to release now.
+    pub release: Vec<WorkerId>,
+    /// Newly idle-past-threshold workers to mark as draining (hidden from
+    /// scheduler snapshots, released on a later tick if still idle).
+    pub drain: Vec<WorkerId>,
+    /// Draining workers to put back in service: they picked up work, downscale
+    /// was disabled, a scale-up is in flight, or the floor no longer allows
+    /// retiring them.
+    pub undrain: Vec<WorkerId>,
+}
+
+/// Compute the retirement plan for one reaper tick.
+///
+/// `scale_up_in_flight` should be true when a scale-up request was sent to the
+/// backend autoscaler within the last autoscaler cycle. This is intentionally
+/// conservative: retirement is suppressed (and in-progress drains cancelled)
+/// for a full cycle after *every* scale-up request, not just the tick it was
+/// sent on, because the autoscaler may still be provisioning the capacity we
+/// asked for — retiring workers then would contradict the demand we signaled.
+pub(crate) fn plan_reap(
+    policy: &DownscalePolicy,
+    scale_up_in_flight: bool,
+    workers: &[WorkerStatus],
+) -> ReapPlan {
+    let all_draining = || -> Vec<WorkerId> {
+        workers
+            .iter()
+            .filter(|w| w.draining)
+            .map(|w| w.worker_id.clone())
+            .collect()
+    };
+
+    // Downscaling switched off (possibly mid-drain): nothing may stay hidden
+    // from the scheduler.
+    if !policy.enabled {
+        return ReapPlan {
+            undrain: all_draining(),
+            ..Default::default()
+        };
+    }
+
+    // Scale-up guard: demand is rising, cancel drains instead of fighting the
+    // autoscaler over the same capacity.
+    if scale_up_in_flight {
+        return ReapPlan {
+            undrain: all_draining(),
+            ..Default::default()
+        };
+    }
+
+    // Honor the min-survivor floor so we never collapse the warm pool between
+    // queries in a session (#5683). Draining workers are still alive and count
+    // toward the pool.
+    let allowed_to_retire = workers.len().saturating_sub(policy.min_survivor_workers);
+
+    let mut undrain = Vec::new();
+    let mut release_candidates: Vec<(WorkerId, Duration)> = Vec::new();
+    let mut drain_candidates: Vec<(WorkerId, Duration)> = Vec::new();
+
+    for w in workers {
+        let eligible = !w.is_head_node
+            && w.idle_for
+                .is_some_and(|idle| idle >= policy.idle_threshold);
+        match (w.draining, eligible) {
+            (true, true) => release_candidates.push((w.worker_id.clone(), w.idle_for.unwrap())),
+            // Draining worker picked up work (the dispatch/drain race resolving
+            // in favor of the task) or is otherwise no longer eligible: back in
+            // service.
+            (true, false) => undrain.push(w.worker_id.clone()),
+            (false, true) => drain_candidates.push((w.worker_id.clone(), w.idle_for.unwrap())),
+            (false, false) => {}
+        }
+    }
+
+    // Longest-idle first.
+    release_candidates.sort_by_key(|(_, idle)| std::cmp::Reverse(*idle));
+    drain_candidates.sort_by_key(|(_, idle)| std::cmp::Reverse(*idle));
+
+    // Release up to the floor allowance; any excess draining workers (e.g. the
+    // floor was raised since they were marked) go back in service rather than
+    // staying hidden forever.
+    let mut release_iter = release_candidates.into_iter();
+    let release: Vec<WorkerId> = release_iter
+        .by_ref()
+        .take(allowed_to_retire)
+        .map(|(wid, _)| wid)
+        .collect();
+    undrain.extend(release_iter.map(|(wid, _)| wid));
+
+    // Cap total hidden capacity (releases this tick + new drains) at the
+    // allowance so draining never dips the visible pool below the floor.
+    let remaining_allowance = allowed_to_retire.saturating_sub(release.len());
+    let drain: Vec<WorkerId> = drain_candidates
+        .into_iter()
+        .take(remaining_allowance)
+        .map(|(wid, _)| wid)
+        .collect();
+
+    ReapPlan {
+        release,
+        drain,
+        undrain,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashMap, sync::Arc};
+
+    use super::*;
+
+    fn policy(enabled: bool, floor: usize, idle_secs: u64) -> DownscalePolicy {
+        DownscalePolicy {
+            enabled,
+            min_survivor_workers: floor,
+            idle_threshold: Duration::from_secs(idle_secs),
+        }
+    }
+
+    fn worker(id: &str, idle_secs: Option<u64>, draining: bool) -> WorkerStatus {
+        WorkerStatus {
+            worker_id: Arc::from(id),
+            is_head_node: false,
+            idle_for: idle_secs.map(Duration::from_secs),
+            draining,
+        }
+    }
+
+    fn ids(mut v: Vec<WorkerId>) -> Vec<String> {
+        v.sort();
+        v.into_iter().map(|w| w.to_string()).collect()
+    }
+
+    #[test]
+    fn test_policy_from_lookup_defaults() {
+        let policy = DownscalePolicy::from_lookup(|_| None);
+        assert!(!policy.enabled);
+        assert_eq!(policy.min_survivor_workers, DEFAULT_MIN_SURVIVOR_WORKERS);
+        assert_eq!(
+            policy.idle_threshold,
+            Duration::from_secs(DEFAULT_IDLE_SECONDS)
+        );
+    }
+
+    #[test]
+    fn test_policy_from_lookup_parses_values() {
+        let env: HashMap<&str, &str> = HashMap::from([
+            (DOWNSCALE_ENABLED_ENV, "true"),
+            (MIN_SURVIVOR_WORKERS_ENV, "3"),
+            (DOWNSCALE_IDLE_SECONDS_ENV, "10"),
+        ]);
+        let policy = DownscalePolicy::from_lookup(|k| env.get(k).map(|v| v.to_string()));
+        assert!(policy.enabled);
+        assert_eq!(policy.min_survivor_workers, 3);
+        assert_eq!(policy.idle_threshold, Duration::from_secs(10));
+    }
+
+    #[test]
+    fn test_disabled_is_noop_and_undrains_everything() {
+        // Flag flipped off mid-drain: draining workers must be restored so they
+        // don't stay hidden from scheduler snapshots forever.
+        let plan = plan_reap(
+            &policy(false, 1, 60),
+            false,
+            &[
+                worker("w1", Some(120), true),
+                worker("w2", Some(120), false),
+            ],
+        );
+        assert!(plan.release.is_empty());
+        assert!(plan.drain.is_empty());
+        assert_eq!(ids(plan.undrain), vec!["w1"]);
+    }
+
+    #[test]
+    fn test_scale_up_guard_cancels_drains_and_suppresses_retirement() {
+        let plan = plan_reap(
+            &policy(true, 0, 60),
+            true,
+            &[
+                worker("w1", Some(120), true),
+                worker("w2", Some(120), false),
+            ],
+        );
+        assert!(plan.release.is_empty());
+        assert!(plan.drain.is_empty());
+        assert_eq!(ids(plan.undrain), vec!["w1"]);
+    }
+
+    #[test]
+    fn test_two_phase_drain_then_release() {
+        // Tick 1: idle-past-threshold worker is only marked as draining.
+        let workers = [worker("w1", Some(120), false), worker("w2", Some(0), false)];
+        let plan = plan_reap(&policy(true, 1, 60), false, &workers);
+        assert!(plan.release.is_empty());
+        assert_eq!(ids(plan.drain), vec!["w1"]);
+        assert!(plan.undrain.is_empty());
+
+        // Tick 2: still idle -> released.
+        let workers = [worker("w1", Some(125), true), worker("w2", Some(5), false)];
+        let plan = plan_reap(&policy(true, 1, 60), false, &workers);
+        assert_eq!(ids(plan.release), vec!["w1"]);
+        assert!(plan.drain.is_empty());
+        assert!(plan.undrain.is_empty());
+    }
+
+    #[test]
+    fn test_draining_worker_that_picked_up_tasks_is_undrained() {
+        // The dispatch/drain race resolved in favor of the task: the worker is
+        // busy again and must be put back in service, not released.
+        let plan = plan_reap(&policy(true, 0, 60), false, &[worker("w1", None, true)]);
+        assert!(plan.release.is_empty());
+        assert!(plan.drain.is_empty());
+        assert_eq!(ids(plan.undrain), vec!["w1"]);
+    }
+
+    #[test]
+    fn test_idle_threshold_protects_recently_busy_workers() {
+        let plan = plan_reap(&policy(true, 0, 60), false, &[worker("w1", Some(30), false)]);
+        assert_eq!(plan, ReapPlan::default());
+    }
+
+    #[test]
+    fn test_min_survivor_floor_is_never_violated() {
+        // Three draining workers all idle past threshold, floor of 1: only two
+        // may be released; the third goes back in service instead of staying
+        // hidden below the floor.
+        let plan = plan_reap(
+            &policy(true, 1, 60),
+            false,
+            &[
+                worker("w1", Some(300), true),
+                worker("w2", Some(200), true),
+                worker("w3", Some(100), true),
+            ],
+        );
+        assert_eq!(ids(plan.release), vec!["w1", "w2"]);
+        assert!(plan.drain.is_empty());
+        assert_eq!(ids(plan.undrain), vec!["w3"]);
+    }
+
+    #[test]
+    fn test_new_drains_capped_by_allowance_after_releases() {
+        // Floor 1 with 4 workers: allowance is 3. Two draining workers are
+        // released, so only one more may start draining this tick.
+        let plan = plan_reap(
+            &policy(true, 1, 60),
+            false,
+            &[
+                worker("w1", Some(300), true),
+                worker("w2", Some(200), true),
+                worker("w3", Some(150), false),
+                worker("w4", Some(100), false),
+            ],
+        );
+        assert_eq!(ids(plan.release), vec!["w1", "w2"]);
+        // Longest-idle non-draining candidate wins the remaining slot.
+        assert_eq!(ids(plan.drain), vec!["w3"]);
+        assert!(plan.undrain.is_empty());
+    }
+
+    #[test]
+    fn test_head_node_is_never_drained_or_released() {
+        let mut head = worker("head", Some(1000), false);
+        head.is_head_node = true;
+        let plan = plan_reap(&policy(true, 0, 60), false, &[head]);
+        assert_eq!(plan, ReapPlan::default());
+    }
+
+    #[test]
+    fn test_zero_floor_allows_draining_entire_pool() {
+        let plan = plan_reap(
+            &policy(true, 0, 60),
+            false,
+            &[
+                worker("w1", Some(120), false),
+                worker("w2", Some(90), false),
+            ],
+        );
+        assert!(plan.release.is_empty());
+        assert_eq!(ids(plan.drain), vec!["w1", "w2"]);
+        assert!(plan.undrain.is_empty());
+    }
+}

--- a/src/daft-distributed/src/scheduling/downscale.rs
+++ b/src/daft-distributed/src/scheduling/downscale.rs
@@ -6,9 +6,7 @@
 //! consistent snapshot of worker statuses under its state lock, calls
 //! [`plan_reap`], and applies the returned plan.
 //!
-//! Retirement is two-phase to avoid racing with the scheduler's
-//! snapshot->dispatch window (a worker could be selected for dispatch from a
-//! snapshot taken just before retirement):
+//! Retirement is two-phase to let schedulers prefer non-draining workers:
 //!
 //! 1. **Drain**: a worker idle past the threshold is marked as draining. A
 //!    draining worker stays alive and can still accept tasks, but is flagged as
@@ -20,10 +18,7 @@
 //!    idle is actually released. If it picked up work in the meantime (the
 //!    race resolving in favor of the task), it is put back in service instead.
 //!
-//! A release can therefore only happen after the worker has been off the
-//! scheduler's list of candidates for at least one full reaper interval, which
-//! is orders of magnitude longer than the synchronous snapshot->dispatch span in
-//! the scheduler loop.
+//! The worker manager's dispatch gate serializes retirement with snapshot-to-submit.
 
 // The runtime consumer (RayWorkerManager) only exists under the `python` feature;
 // without it this module is exercised by unit tests alone.

--- a/src/daft-distributed/src/scheduling/local_worker.rs
+++ b/src/daft-distributed/src/scheduling/local_worker.rs
@@ -31,7 +31,7 @@ use super::{
         SwordfishTask, Task, TaskContext, TaskDetails, TaskResourceRequest, TaskResultHandle,
         TaskStatus,
     },
-    worker::{Worker, WorkerId, WorkerManager},
+    worker::{AutoscaleDemandId, Worker, WorkerId, WorkerManager},
 };
 use crate::pipeline_node::MaterializedOutput;
 
@@ -330,7 +330,11 @@ impl WorkerManager for LocalSwordfishWorkerManager {
             .collect())
     }
 
-    fn try_autoscale(&self, _resource_requests: Vec<TaskResourceRequest>) -> DaftResult<()> {
+    fn try_autoscale(
+        &self,
+        _demand_id: AutoscaleDemandId,
+        _resource_requests: Vec<TaskResourceRequest>,
+    ) -> DaftResult<()> {
         Ok(())
     }
 

--- a/src/daft-distributed/src/scheduling/mod.rs
+++ b/src/daft-distributed/src/scheduling/mod.rs
@@ -1,4 +1,5 @@
 pub(super) mod dispatcher;
+pub(crate) mod downscale;
 #[cfg(test)]
 pub(crate) mod local_worker;
 pub(super) mod scheduler;

--- a/src/daft-distributed/src/scheduling/scheduler/default.rs
+++ b/src/daft-distributed/src/scheduling/scheduler/default.rs
@@ -48,7 +48,7 @@ impl<T: Task> DefaultScheduler<T> {
     fn try_schedule_spread_task(&self, task: &T) -> Option<WorkerId> {
         self.worker_snapshots
             .iter()
-            .filter(|(_, worker)| worker.can_schedule_task(task))
+            .filter(|(_, worker)| worker.accepts_new_work() && worker.can_schedule_task(task))
             .max_by_key(|(_, worker)| {
                 (worker.available_num_cpus() + worker.available_num_gpus()) as usize
             })
@@ -65,6 +65,11 @@ impl<T: Task> DefaultScheduler<T> {
     ) -> Option<WorkerId> {
         if let Some(worker) = self.worker_snapshots.get(worker_id)
             && worker.can_schedule_task(task)
+            // A draining worker is on its way out, so prefer somewhere else whenever
+            // we have that choice. Hard affinity has no alternative: refusing to place
+            // here would strand the task forever, and the worker is still alive and
+            // gets taken out of draining as soon as it picks the task up.
+            && (!soft || worker.accepts_new_work())
         {
             return Some(worker.worker_id.clone());
         }
@@ -91,18 +96,23 @@ impl<T: Task> DefaultScheduler<T> {
             return false;
         }
 
-        // If there are no workers, we need to autoscale
-        if self.worker_snapshots.is_empty() {
+        // Draining workers are on their way out, so their capacity must not be counted
+        // as usable here: otherwise a fully-draining pool looks fully provisioned and we
+        // never ask for replacements. Requesting a scale-up also makes the backend
+        // cancel the in-flight drains, which resolves this in our favor.
+        let total_capacity: usize = self
+            .worker_snapshots
+            .values()
+            .filter(|worker| worker.accepts_new_work())
+            .map(|worker| worker.total_num_cpus() as usize)
+            .sum();
+
+        // If there is no usable capacity, we need to autoscale
+        if total_capacity == 0 {
             return true;
         }
 
         // If the ratio of pending tasks to total capacity is greater than the autoscaling threshold, we need to autoscale
-        let total_capacity: usize = self
-            .worker_snapshots
-            .values()
-            .map(|worker| worker.total_num_cpus() as usize)
-            .sum();
-
         let ratio = self.pending_tasks.len() as f64 / total_capacity as f64;
 
         ratio > self.autoscaling_threshold
@@ -175,7 +185,7 @@ mod tests {
     use crate::scheduling::{
         scheduler::test_utils::{
             create_schedulable_task, create_spread_task, create_worker_affinity_task,
-            setup_scheduler, setup_workers,
+            setup_scheduler, setup_scheduler_with_draining, setup_workers,
         },
         tests::{MockTask, MockTaskBuilder},
         worker::tests::MockWorker,
@@ -735,5 +745,75 @@ mod tests {
 
         // Should not request autoscaling
         assert!(scheduler.get_autoscaling_request().is_none());
+    }
+
+    #[test]
+    fn test_default_scheduler_spread_avoids_draining_worker() {
+        let worker_1: WorkerId = Arc::from("worker1");
+        let worker_2: WorkerId = Arc::from("worker2");
+
+        // worker1 has the most capacity, but is being retired.
+        let workers = setup_workers(&[(worker_1.clone(), 10), (worker_2.clone(), 1)]);
+        let mut scheduler: DefaultScheduler<MockTask> =
+            setup_scheduler_with_draining(&workers, &[worker_1.clone()]);
+
+        scheduler.enqueue_tasks(vec![create_spread_task(Some(1))]);
+        let (result, _) = scheduler.schedule_tasks();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].worker_id, worker_2);
+    }
+
+    #[test]
+    fn test_default_scheduler_soft_affinity_falls_back_off_draining_worker() {
+        let worker_1: WorkerId = Arc::from("worker1");
+        let worker_2: WorkerId = Arc::from("worker2");
+
+        let workers = setup_workers(&[(worker_1.clone(), 2), (worker_2.clone(), 2)]);
+        let mut scheduler: DefaultScheduler<MockTask> =
+            setup_scheduler_with_draining(&workers, &[worker_1.clone()]);
+
+        // Soft affinity has an alternative, so it must not pin work onto a worker
+        // that is on its way out.
+        scheduler.enqueue_tasks(vec![create_worker_affinity_task(&worker_1, true, Some(1))]);
+        let (result, _) = scheduler.schedule_tasks();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].worker_id, worker_2);
+    }
+
+    #[test]
+    fn test_default_scheduler_hard_affinity_still_schedules_on_draining_worker() {
+        let worker_1: WorkerId = Arc::from("worker1");
+        let worker_2: WorkerId = Arc::from("worker2");
+
+        let workers = setup_workers(&[(worker_1.clone(), 2), (worker_2.clone(), 2)]);
+        let mut scheduler: DefaultScheduler<MockTask> =
+            setup_scheduler_with_draining(&workers, &[worker_1.clone()]);
+
+        // Hard affinity has no fallback worker: skipping the draining target would
+        // leave the task permanently unschedulable.
+        scheduler.enqueue_tasks(vec![create_worker_affinity_task(&worker_1, false, Some(1))]);
+        let (result, _) = scheduler.schedule_tasks();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].worker_id, worker_1);
+        assert_eq!(scheduler.num_pending_tasks(), 0);
+    }
+
+    #[test]
+    fn test_default_scheduler_fully_draining_pool_requests_autoscale() {
+        let worker_1: WorkerId = Arc::from("worker1");
+
+        let workers = setup_workers(&[(worker_1.clone(), 10)]);
+        let mut scheduler: DefaultScheduler<MockTask> =
+            setup_scheduler_with_draining(&workers, &[worker_1]);
+
+        // Capacity that is being retired must not count as provisioned capacity.
+        scheduler.enqueue_tasks(vec![create_spread_task(Some(1))]);
+        let (result, _) = scheduler.schedule_tasks();
+
+        assert!(result.is_empty());
+        assert!(scheduler.get_autoscaling_request().is_some());
     }
 }

--- a/src/daft-distributed/src/scheduling/scheduler/default.rs
+++ b/src/daft-distributed/src/scheduling/scheduler/default.rs
@@ -755,7 +755,7 @@ mod tests {
         // worker1 has the most capacity, but is being retired.
         let workers = setup_workers(&[(worker_1.clone(), 10), (worker_2.clone(), 1)]);
         let mut scheduler: DefaultScheduler<MockTask> =
-            setup_scheduler_with_draining(&workers, &[worker_1.clone()]);
+            setup_scheduler_with_draining(&workers, std::slice::from_ref(&worker_1));
 
         scheduler.enqueue_tasks(vec![create_spread_task(Some(1))]);
         let (result, _) = scheduler.schedule_tasks();
@@ -771,7 +771,7 @@ mod tests {
 
         let workers = setup_workers(&[(worker_1.clone(), 2), (worker_2.clone(), 2)]);
         let mut scheduler: DefaultScheduler<MockTask> =
-            setup_scheduler_with_draining(&workers, &[worker_1.clone()]);
+            setup_scheduler_with_draining(&workers, std::slice::from_ref(&worker_1));
 
         // Soft affinity has an alternative, so it must not pin work onto a worker
         // that is on its way out.
@@ -787,9 +787,9 @@ mod tests {
         let worker_1: WorkerId = Arc::from("worker1");
         let worker_2: WorkerId = Arc::from("worker2");
 
-        let workers = setup_workers(&[(worker_1.clone(), 2), (worker_2.clone(), 2)]);
+        let workers = setup_workers(&[(worker_1.clone(), 2), (worker_2, 2)]);
         let mut scheduler: DefaultScheduler<MockTask> =
-            setup_scheduler_with_draining(&workers, &[worker_1.clone()]);
+            setup_scheduler_with_draining(&workers, std::slice::from_ref(&worker_1));
 
         // Hard affinity has no fallback worker: skipping the draining target would
         // leave the task permanently unschedulable.
@@ -807,7 +807,7 @@ mod tests {
 
         let workers = setup_workers(&[(worker_1.clone(), 10)]);
         let mut scheduler: DefaultScheduler<MockTask> =
-            setup_scheduler_with_draining(&workers, &[worker_1]);
+            setup_scheduler_with_draining(&workers, std::slice::from_ref(&worker_1));
 
         // Capacity that is being retired must not count as provisioned capacity.
         scheduler.enqueue_tasks(vec![create_spread_task(Some(1))]);

--- a/src/daft-distributed/src/scheduling/scheduler/linear.rs
+++ b/src/daft-distributed/src/scheduling/scheduler/linear.rs
@@ -28,7 +28,7 @@ impl<T: Task> LinearScheduler<T> {
     fn try_schedule_spread_task(&self, task: &T) -> Option<WorkerId> {
         self.worker_snapshots
             .iter()
-            .filter(|(_, worker)| worker.can_schedule_task(task))
+            .filter(|(_, worker)| worker.accepts_new_work() && worker.can_schedule_task(task))
             .max_by_key(|(_, worker)| {
                 (worker.available_num_cpus() + worker.available_num_gpus()) as usize
             })
@@ -43,6 +43,11 @@ impl<T: Task> LinearScheduler<T> {
     ) -> Option<WorkerId> {
         if let Some(worker) = self.worker_snapshots.get(worker_id)
             && worker.can_schedule_task(task)
+            // A draining worker is on its way out, so prefer somewhere else whenever
+            // we have that choice. Hard affinity has no alternative: refusing to place
+            // here would strand the task forever, and the worker is still alive and
+            // gets taken out of draining as soon as it picks the task up.
+            && (!soft || worker.accepts_new_work())
         {
             return Some(worker.worker_id.clone());
         }
@@ -69,8 +74,14 @@ impl<T: Task> LinearScheduler<T> {
             return false;
         }
 
-        // If there are no workers, we need to autoscale
-        if self.worker_snapshots.is_empty() {
+        // If no worker can take new work, we need to autoscale. Draining workers are on
+        // their way out and must not be counted as usable capacity; asking for a
+        // scale-up also makes the backend cancel the in-flight drains.
+        if !self
+            .worker_snapshots
+            .values()
+            .any(|worker| worker.accepts_new_work())
+        {
             return true;
         }
 

--- a/src/daft-distributed/src/scheduling/scheduler/mod.rs
+++ b/src/daft-distributed/src/scheduling/scheduler/mod.rs
@@ -183,6 +183,11 @@ pub(crate) struct WorkerSnapshot {
     total_num_cpus: f64,
     total_num_gpus: f64,
     active_task_details: HashMap<TaskContext, TaskDetails>,
+    /// The worker is being retired by the backend and should not be given new
+    /// discretionary work. It is still alive and still reachable, so tasks that
+    /// *must* run on this specific worker (hard affinity, which has no fallback)
+    /// may still be placed here.
+    draining: bool,
 }
 
 impl WorkerSnapshot {
@@ -197,7 +202,21 @@ impl WorkerSnapshot {
             total_num_cpus,
             total_num_gpus,
             active_task_details,
+            draining: false,
         }
+    }
+
+    pub fn with_draining(mut self, draining: bool) -> Self {
+        self.draining = draining;
+        self
+    }
+
+    /// Whether the scheduler may freely place new work on this worker. False for
+    /// workers the backend has started retiring: they stay in the snapshots so
+    /// hard-affinity lookups keep resolving, but every placement path that has an
+    /// alternative must pick a different worker.
+    pub fn accepts_new_work(&self) -> bool {
+        !self.draining
     }
 
     pub fn active_num_cpus(&self) -> f64 {
@@ -298,6 +317,25 @@ pub(super) mod test_utils {
             workers
                 .values()
                 .map(WorkerSnapshot::from)
+                .collect::<Vec<_>>()
+                .as_slice(),
+        );
+        scheduler
+    }
+
+    // Same as `setup_scheduler`, but flags the listed workers as draining (i.e. the
+    // backend has started retiring them).
+    pub fn setup_scheduler_with_draining<S: Scheduler<MockTask> + Default>(
+        workers: &HashMap<WorkerId, MockWorker>,
+        draining: &[WorkerId],
+    ) -> S {
+        let mut scheduler = S::default();
+        scheduler.update_worker_state(
+            workers
+                .values()
+                .map(|worker| {
+                    WorkerSnapshot::from(worker).with_draining(draining.contains(worker.id()))
+                })
                 .collect::<Vec<_>>()
                 .as_slice(),
         );

--- a/src/daft-distributed/src/scheduling/scheduler/scheduler_actor.rs
+++ b/src/daft-distributed/src/scheduling/scheduler/scheduler_actor.rs
@@ -18,7 +18,7 @@ use crate::{
     scheduling::{
         dispatcher::Dispatcher,
         task::{Task, TaskID},
-        worker::{Worker, WorkerManager},
+        worker::{AutoscaleDemandId, Worker, WorkerManager},
     },
     statistics::{StatisticsManagerRef, TaskEvent},
     utils::channel::{
@@ -42,6 +42,11 @@ struct SchedulerLoop<W: Worker, S: Scheduler<W::Task>> {
     worker_manager: Arc<dyn WorkerManager<Worker = W>>,
     statistics_manager: StatisticsManagerRef,
     input_exhausted: bool,
+    /// Identifies this loop's slice of the cluster-wide autoscaling demand.
+    /// Ray's `request_resources()` is a single replace-on-write slot, so the worker
+    /// manager keys demand by owner and always publishes the union; without this,
+    /// concurrent plans would overwrite each other's requests.
+    autoscale_demand_id: AutoscaleDemandId,
 }
 
 impl<W, S> SchedulerLoop<W, S>
@@ -63,6 +68,7 @@ where
             worker_manager,
             statistics_manager,
             input_exhausted: false,
+            autoscale_demand_id: AutoscaleDemandId::new(),
         }
     }
 
@@ -102,8 +108,11 @@ where
     async fn run(mut self) -> DaftResult<()> {
         let loop_result = self.event_loop().await;
 
-        // Job complete (successfully or not): clear any outstanding Ray autoscaling demand
+        // Job complete (successfully or not): retract this loop's autoscaling demand
         // so the autoscaler stops provisioning capacity for work that no longer exists.
+        // Only our own slice is dropped — demand published by other concurrently running
+        // plans stays in effect, since Ray's request_resources() is a single cluster-wide
+        // slot that the worker manager maintains as the union of all live owners.
         // This must also run when the loop exits with an error — a failed query is exactly
         // the case where the demand we signaled no longer has work behind it, and Ray's
         // request_resources() is sticky. It is best-effort: a cleanup failure must not
@@ -113,7 +122,10 @@ where
         // next query in the session and drained by the worker manager's background reaper
         // once workers pass the idle threshold (see #5683). This keeps retirement under a
         // single authority.
-        if let Err(e) = self.worker_manager.clear_autoscale_demand() {
+        if let Err(e) = self
+            .worker_manager
+            .clear_autoscale_demand(self.autoscale_demand_id)
+        {
             tracing::warn!(
                 target: SCHEDULER_LOG_TARGET,
                 error = %e,
@@ -157,7 +169,8 @@ where
                     autoscaling_request = %format!("{:#?}", request),
                     "Sending autoscaling request"
                 );
-                self.worker_manager.try_autoscale(request)?;
+                self.worker_manager
+                    .try_autoscale(self.autoscale_demand_id, request)?;
             }
 
             // 2: Get all tasks that are ready to be scheduled
@@ -453,6 +466,8 @@ impl Drop for SubmittedTask {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
     use rand::Rng;
 
     use super::*;
@@ -470,6 +485,7 @@ mod tests {
         scheduler_handle_ref: Arc<SchedulerHandle<MockTask>>,
         worker_manager: Arc<MockWorkerManager>,
         joinset: JoinSet<DaftResult<()>>,
+        autoscale_demand_id: AutoscaleDemandId,
     }
 
     impl SchedulerActorTestContext {
@@ -496,6 +512,7 @@ mod tests {
             worker_manager.clone(),
             StatisticsManagerRef::default(),
         );
+        let autoscale_demand_id = loop_state.autoscale_demand_id;
         joinset.spawn(loop_state.run());
         let scheduler_handle = SchedulerHandle::new(scheduler_sender);
 
@@ -503,6 +520,7 @@ mod tests {
             scheduler_handle_ref: Arc::new(scheduler_handle),
             worker_manager,
             joinset,
+            autoscale_demand_id,
         }
     }
 
@@ -538,6 +556,72 @@ mod tests {
         // On completion the scheduler clears outstanding autoscaling demand exactly once,
         // and does not retire workers (that is the reaper's job).
         assert_eq!(ctx.worker_manager.clear_demand_call_count(), 1);
+        // ...and it retracts its own demand slice, not the cluster-wide request.
+        assert_eq!(
+            ctx.worker_manager.cleared_demand_ids(),
+            vec![ctx.autoscale_demand_id]
+        );
+        Ok(())
+    }
+
+    /// Ray's `request_resources()` is a single cluster-wide slot, so autoscaling demand
+    /// must be attributed per plan: two concurrently running scheduler loops each own a
+    /// slice, and finishing one must only retract that one. Otherwise a finishing query
+    /// cancels the capacity a still-running query is waiting on.
+    #[tokio::test]
+    async fn test_concurrent_scheduler_loops_own_separate_autoscale_demand() -> DaftResult<()> {
+        // Start with an empty pool so the loops are pushed onto the autoscaling path.
+        let worker_manager = Arc::new(MockWorkerManager::new(setup_workers(&[])));
+        let mut joinset = JoinSet::new();
+        let mut handles = Vec::new();
+        let mut demand_ids = Vec::new();
+
+        for _ in 0..2 {
+            let (scheduler_sender, scheduler_receiver) = create_unbounded_channel();
+            let loop_state = SchedulerLoop::new(
+                DefaultScheduler::<MockTask>::default(),
+                scheduler_receiver,
+                worker_manager.clone(),
+                StatisticsManagerRef::default(),
+            );
+            demand_ids.push(loop_state.autoscale_demand_id);
+            joinset.spawn(loop_state.run());
+            handles.push(SchedulerHandle::new(scheduler_sender));
+        }
+
+        assert_ne!(
+            demand_ids[0], demand_ids[1],
+            "concurrent scheduler loops must not share an autoscaling demand id"
+        );
+
+        for handle in &handles {
+            let task = MockTaskBuilder::new(create_mock_partition_ref(100, 100)).build();
+            let submitted = SubmittableTask::task_only(task).submit(handle)?;
+            assert_eq!(submitted.await?.unwrap().partitions().len(), 1);
+        }
+
+        drop(handles);
+        while let Some(result) = joinset.join_next().await {
+            result??;
+        }
+
+        // Whether a given loop had to ask for capacity is timing-dependent (the mock
+        // manager materializes workers into a shared pool), but every request that is
+        // made must be attributed to the loop that made it.
+        let owners = demand_ids.iter().copied().collect::<HashSet<_>>();
+        for requested in worker_manager.autoscale_demand_ids() {
+            assert!(
+                owners.contains(&requested),
+                "autoscaling request published under an unknown owner"
+            );
+        }
+
+        // Both loops finished, so both slices — and only those — are retracted.
+        let cleared = worker_manager
+            .cleared_demand_ids()
+            .into_iter()
+            .collect::<HashSet<_>>();
+        assert_eq!(cleared, owners);
         Ok(())
     }
 

--- a/src/daft-distributed/src/scheduling/scheduler/scheduler_actor.rs
+++ b/src/daft-distributed/src/scheduling/scheduler/scheduler_actor.rs
@@ -100,6 +100,33 @@ where
 
     #[instrument(name = "FlotillaScheduler", skip_all)]
     async fn run(mut self) -> DaftResult<()> {
+        let loop_result = self.event_loop().await;
+
+        // Job complete (successfully or not): clear any outstanding Ray autoscaling demand
+        // so the autoscaler stops provisioning capacity for work that no longer exists.
+        // This must also run when the loop exits with an error — a failed query is exactly
+        // the case where the demand we signaled no longer has work behind it, and Ray's
+        // request_resources() is sticky. It is best-effort: a cleanup failure must not
+        // mask the loop's own result or fail an otherwise-successful job.
+        //
+        // We deliberately do NOT retire idle workers here — the warm pool is kept for the
+        // next query in the session and drained by the worker manager's background reaper
+        // once workers pass the idle threshold (see #5683). This keeps retirement under a
+        // single authority.
+        if let Err(e) = self.worker_manager.clear_autoscale_demand() {
+            tracing::warn!(
+                target: SCHEDULER_LOG_TARGET,
+                error = %e,
+                "Failed to clear autoscaling demand on job completion; continuing"
+            );
+        }
+
+        loop_result?;
+        tracing::info!(target: SCHEDULER_LOG_TARGET, "Scheduler event loop completed");
+        Ok(())
+    }
+
+    async fn event_loop(&mut self) -> DaftResult<()> {
         let mut tick_interval = tokio::time::interval(SCHEDULER_TICK_INTERVAL);
 
         while !self.input_exhausted
@@ -124,7 +151,6 @@ where
             // We do this before scheduling tasks to ensure that the autoscaler sees the true demand
             // and not just the residual demand after scheduling.
             let autoscaling_request = self.scheduler.get_autoscaling_request();
-            let sent_scale_up_request = autoscaling_request.is_some();
             if let Some(request) = autoscaling_request {
                 tracing::info!(
                     target: SCHEDULER_LOG_TARGET,
@@ -164,23 +190,6 @@ where
                     .dispatch_tasks(scheduled_tasks, &self.worker_manager)?;
             }
 
-            // 3b: Ask the worker manager to retire idle workers when downscaling is configured.
-            //
-            // The worker manager owns the entire downscale policy: enable flag, idle thresholds,
-            // min-survivor floor, head-node protection, and blacklist TTLs. The scheduler only
-            // hands it the per-tick context it has — namely whether a scale-up was just sent —
-            // so the worker manager can avoid undoing scale-up demand in the same cycle.
-            let retired = self
-                .worker_manager
-                .retire_idle_workers(sent_scale_up_request, false)?;
-            if retired > 0 {
-                tracing::info!(
-                    target: SCHEDULER_LOG_TARGET,
-                    retired,
-                    "Downscale: retired idle workers"
-                );
-            }
-
             // 4: Concurrently wait for new tasks, task completions, or periodic tick.
             let Self {
                 task_rx,
@@ -188,7 +197,7 @@ where
                 worker_manager,
                 input_exhausted,
                 ..
-            } = &mut self;
+            } = &mut *self;
             let worker_manager: &Arc<dyn WorkerManager<Worker = W>> = worker_manager;
             let select_result = tokio::select! {
                 maybe_new_task = task_rx.recv(), if !*input_exhausted => {
@@ -215,18 +224,6 @@ where
             }
         }
 
-        // Final downscale on job completion: best-effort clear of Ray demand and idle actors.
-        // The worker manager itself is responsible for honoring the enable flag.
-        let final_retired = self.worker_manager.retire_idle_workers(false, true)?;
-        if final_retired > 0 {
-            tracing::info!(
-                target: SCHEDULER_LOG_TARGET,
-                final_retired,
-                "Final downscale completed"
-            );
-        }
-
-        tracing::info!(target: SCHEDULER_LOG_TARGET, "Scheduler event loop completed");
         Ok(())
     }
 }
@@ -509,40 +506,67 @@ mod tests {
         }
     }
 
-    /// The scheduler now defers all downscale gating (enable flag, min-survivor floor,
-    /// idle thresholds) to the worker manager. From the scheduler's point of view, it
-    /// just calls `retire_idle_workers` every tick — this test verifies the call wiring
-    /// and the per-tick context (skip-due-to-pending-scale-up flag) we hand off.
+    /// Retirement of idle workers is now owned entirely by the worker manager's own
+    /// background reaper, not the scheduler. This test verifies the scheduler no longer
+    /// drives retirement on normal ticks — it never touches the worker pool for downscale
+    /// purposes, so there is a single retirement authority (see #5683).
     #[tokio::test]
-    async fn test_scheduler_actor_invokes_retire_idle_workers_each_tick() -> DaftResult<()> {
+    async fn test_scheduler_actor_does_not_retire_during_ticks() -> DaftResult<()> {
         let ctx = setup_scheduler_actor_test_context(&[
             (Arc::from("worker1"), 1),
             (Arc::from("worker2"), 1),
         ]);
 
         tokio::time::sleep(Duration::from_millis(20)).await;
-        assert!(ctx.worker_manager.retire_call_count() > 0);
-        // No tasks have been enqueued so no scale-up was sent — `skip_due_to_pending_scale_up`
-        // must be false. The shutdown path is exercised by `cleanup`, which lifts
-        // `force_all_when_cluster_idle` to true; we only check the per-tick args here.
-        assert_eq!(ctx.worker_manager.last_retire_args(), Some((false, false)));
+        // The scheduler must not clear demand mid-query; that only happens on completion.
+        assert_eq!(ctx.worker_manager.clear_demand_call_count(), 0);
 
         ctx.cleanup().await?;
         Ok(())
     }
 
     #[tokio::test]
-    async fn test_scheduler_actor_invokes_final_retire_on_shutdown() -> DaftResult<()> {
+    async fn test_scheduler_actor_clears_demand_on_shutdown() -> DaftResult<()> {
         let ctx = setup_scheduler_actor_test_context(&[(Arc::from("worker1"), 1)]);
 
-        // Drop the scheduler handle so the loop drains and exits, triggering the final downscale.
+        // Drop the scheduler handle so the loop drains and exits, triggering the demand clear.
         drop(ctx.scheduler_handle_ref);
         let mut joinset = ctx.joinset;
         while let Some(result) = joinset.join_next().await {
             result??;
         }
-        // The final invocation must request a forced retirement.
-        assert_eq!(ctx.worker_manager.last_retire_args(), Some((false, true)));
+        // On completion the scheduler clears outstanding autoscaling demand exactly once,
+        // and does not retire workers (that is the reaper's job).
+        assert_eq!(ctx.worker_manager.clear_demand_call_count(), 1);
+        Ok(())
+    }
+
+    /// A failed query is exactly the case where previously signaled autoscaling demand no
+    /// longer has work behind it, and Ray's request_resources() is sticky — so the
+    /// scheduler must clear demand on the error-exit path too, not just on clean shutdown.
+    #[tokio::test]
+    async fn test_scheduler_actor_clears_demand_on_error_exit() -> DaftResult<()> {
+        let ctx = setup_scheduler_actor_test_context(&[(Arc::from("worker1"), 1)]);
+
+        // Force the next scheduler iteration to fail at the top of the loop.
+        ctx.worker_manager.set_fail_worker_snapshots(true);
+
+        // Submit a task so the loop keeps iterating (and hits the injected failure).
+        let task = MockTaskBuilder::new(create_mock_partition_ref(100, 100)).build();
+        let submittable_task = SubmittableTask::task_only(task);
+        let _submitted_task = submittable_task.submit(&ctx.scheduler_handle_ref)?;
+
+        drop(ctx.scheduler_handle_ref);
+        let mut joinset = ctx.joinset;
+        let mut saw_error = false;
+        while let Some(result) = joinset.join_next().await {
+            if result?.is_err() {
+                saw_error = true;
+            }
+        }
+        assert!(saw_error, "scheduler loop should have exited with an error");
+        // Demand must be cleared exactly once even though the loop exited with an error.
+        assert_eq!(ctx.worker_manager.clear_demand_call_count(), 1);
         Ok(())
     }
 

--- a/src/daft-distributed/src/scheduling/scheduler/scheduler_actor.rs
+++ b/src/daft-distributed/src/scheduling/scheduler/scheduler_actor.rs
@@ -106,35 +106,70 @@ where
 
     #[instrument(name = "FlotillaScheduler", skip_all)]
     async fn run(mut self) -> DaftResult<()> {
-        let loop_result = self.event_loop().await;
+        self.event_loop().await?;
+        tracing::info!(target: SCHEDULER_LOG_TARGET, "Scheduler event loop completed");
+        Ok(())
+    }
 
-        // Job complete (successfully or not): retract this loop's autoscaling demand
-        // so the autoscaler stops provisioning capacity for work that no longer exists.
-        // Only our own slice is dropped — demand published by other concurrently running
-        // plans stays in effect, since Ray's request_resources() is a single cluster-wide
-        // slot that the worker manager maintains as the union of all live owners.
-        // This must also run when the loop exits with an error — a failed query is exactly
-        // the case where the demand we signaled no longer has work behind it, and Ray's
-        // request_resources() is sticky. It is best-effort: a cleanup failure must not
-        // mask the loop's own result or fail an otherwise-successful job.
-        //
-        // We deliberately do NOT retire idle workers here — the warm pool is kept for the
-        // next query in the session and drained by the worker manager's background reaper
-        // once workers pass the idle threshold (see #5683). This keeps retirement under a
-        // single authority.
-        if let Err(e) = self
-            .worker_manager
-            .clear_autoscale_demand(self.autoscale_demand_id)
-        {
-            tracing::warn!(
+    fn schedule_and_dispatch(&mut self) -> DaftResult<()> {
+        let _dispatch_guard = self.worker_manager.begin_dispatch();
+        let worker_snapshots = self.worker_manager.worker_snapshots()?;
+        tracing::info!(
+            target: SCHEDULER_LOG_TARGET,
+            num_workers = worker_snapshots.len(),
+            pending_tasks = self.scheduler.num_pending_tasks(),
+            "Received worker snapshots"
+        );
+        tracing::debug!(
+            target: SCHEDULER_LOG_TARGET,
+            worker_snapshots = %format!("{:#?}", worker_snapshots)
+        );
+
+        self.scheduler.update_worker_state(&worker_snapshots);
+
+        // 1: Send autoscaling request if needed (scale up).
+        // We do this before scheduling tasks to ensure that the autoscaler sees the true demand
+        // and not just the residual demand after scheduling.
+        let autoscaling_request = self.scheduler.get_autoscaling_request();
+        if let Some(request) = autoscaling_request {
+            tracing::info!(
                 target: SCHEDULER_LOG_TARGET,
-                error = %e,
-                "Failed to clear autoscaling demand on job completion; continuing"
+                autoscaling_request = %format!("{:#?}", request),
+                "Sending autoscaling request"
             );
+            self.worker_manager
+                .try_autoscale(self.autoscale_demand_id, request)?;
         }
 
-        loop_result?;
-        tracing::info!(target: SCHEDULER_LOG_TARGET, "Scheduler event loop completed");
+        // 2: Get all tasks that are ready to be scheduled
+        let (scheduled_tasks, cancelled_tasks) = self.scheduler.schedule_tasks();
+        for task in &cancelled_tasks {
+            self.statistics_manager.handle_event(TaskEvent::Cancelled {
+                context: task.task_context(),
+            })?;
+        }
+        // 3: Dispatch tasks directly to the dispatcher
+        if !scheduled_tasks.is_empty() {
+            tracing::info!(
+                target: SCHEDULER_LOG_TARGET,
+                num_tasks = scheduled_tasks.len(),
+                "Scheduling tasks for dispatch"
+            );
+            tracing::debug!(
+                target: SCHEDULER_LOG_TARGET,
+                scheduled_tasks = %format!("{:#?}", scheduled_tasks)
+            );
+
+            for task in &scheduled_tasks {
+                self.statistics_manager.handle_event(TaskEvent::Scheduled {
+                    context: task.task().task_context(),
+                    worker_id: task.worker_id(),
+                })?;
+            }
+
+            self.dispatcher
+                .dispatch_tasks(scheduled_tasks, &self.worker_manager)?;
+        }
         Ok(())
     }
 
@@ -145,63 +180,7 @@ where
             || self.scheduler.num_pending_tasks() > 0
             || self.dispatcher.has_running_tasks()
         {
-            let worker_snapshots = self.worker_manager.worker_snapshots()?;
-            tracing::info!(
-                target: SCHEDULER_LOG_TARGET,
-                num_workers = worker_snapshots.len(),
-                pending_tasks = self.scheduler.num_pending_tasks(),
-                "Received worker snapshots"
-            );
-            tracing::debug!(
-                target: SCHEDULER_LOG_TARGET,
-                worker_snapshots = %format!("{:#?}", worker_snapshots)
-            );
-
-            self.scheduler.update_worker_state(&worker_snapshots);
-
-            // 1: Send autoscaling request if needed (scale up).
-            // We do this before scheduling tasks to ensure that the autoscaler sees the true demand
-            // and not just the residual demand after scheduling.
-            let autoscaling_request = self.scheduler.get_autoscaling_request();
-            if let Some(request) = autoscaling_request {
-                tracing::info!(
-                    target: SCHEDULER_LOG_TARGET,
-                    autoscaling_request = %format!("{:#?}", request),
-                    "Sending autoscaling request"
-                );
-                self.worker_manager
-                    .try_autoscale(self.autoscale_demand_id, request)?;
-            }
-
-            // 2: Get all tasks that are ready to be scheduled
-            let (scheduled_tasks, cancelled_tasks) = self.scheduler.schedule_tasks();
-            for task in &cancelled_tasks {
-                self.statistics_manager.handle_event(TaskEvent::Cancelled {
-                    context: task.task_context(),
-                })?;
-            }
-            // 3: Dispatch tasks directly to the dispatcher
-            if !scheduled_tasks.is_empty() {
-                tracing::info!(
-                    target: SCHEDULER_LOG_TARGET,
-                    num_tasks = scheduled_tasks.len(),
-                    "Scheduling tasks for dispatch"
-                );
-                tracing::debug!(
-                    target: SCHEDULER_LOG_TARGET,
-                    scheduled_tasks = %format!("{:#?}", scheduled_tasks)
-                );
-
-                for task in &scheduled_tasks {
-                    self.statistics_manager.handle_event(TaskEvent::Scheduled {
-                        context: task.task().task_context(),
-                        worker_id: task.worker_id(),
-                    })?;
-                }
-
-                self.dispatcher
-                    .dispatch_tasks(scheduled_tasks, &self.worker_manager)?;
-            }
+            self.schedule_and_dispatch()?;
 
             // 4: Concurrently wait for new tasks, task completions, or periodic tick.
             let Self {
@@ -238,6 +217,22 @@ where
         }
 
         Ok(())
+    }
+}
+
+impl<W: Worker, S: Scheduler<W::Task>> Drop for SchedulerLoop<W, S> {
+    fn drop(&mut self) {
+        // Aborting the owning JoinSet drops the future without returning from event_loop.
+        if let Err(e) = self
+            .worker_manager
+            .clear_autoscale_demand(self.autoscale_demand_id)
+        {
+            tracing::warn!(
+                target: SCHEDULER_LOG_TARGET,
+                error = %e,
+                "Failed to clear autoscaling demand on scheduler shutdown"
+            );
+        }
     }
 }
 
@@ -466,7 +461,10 @@ impl Drop for SubmittedTask {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
+    use std::{
+        collections::HashSet,
+        sync::{Barrier, Mutex, TryLockError},
+    };
 
     use rand::Rng;
 
@@ -476,7 +474,10 @@ mod tests {
             scheduler::test_utils::setup_workers,
             task::tests::MockTaskFailure,
             tests::{MockTask, MockTaskBuilder, create_mock_partition_ref},
-            worker::{WorkerId, tests::MockWorkerManager},
+            worker::{
+                WorkerId,
+                tests::{MockWorker, MockWorkerManager},
+            },
         },
         utils::channel::create_channel,
     };
@@ -651,6 +652,245 @@ mod tests {
         assert!(saw_error, "scheduler loop should have exited with an error");
         // Demand must be cleared exactly once even though the loop exited with an error.
         assert_eq!(ctx.worker_manager.clear_demand_call_count(), 1);
+        Ok(())
+    }
+
+    fn unspawned_scheduler_loop(
+        worker_manager: Arc<MockWorkerManager>,
+    ) -> (
+        SchedulerLoop<MockWorker, DefaultScheduler<MockTask>>,
+        SchedulerHandle<MockTask>,
+    ) {
+        let (sender, receiver) = create_unbounded_channel();
+        (
+            SchedulerLoop::new(
+                DefaultScheduler::with_autoscaling_threshold(1.25),
+                receiver,
+                worker_manager,
+                StatisticsManagerRef::default(),
+            ),
+            SchedulerHandle::new(sender),
+        )
+    }
+
+    fn enqueue_mock_task(
+        loop_state: &mut SchedulerLoop<MockWorker, DefaultScheduler<MockTask>>,
+        task_id: TaskID,
+    ) -> DaftResult<SubmittedTask> {
+        let task = MockTaskBuilder::default().with_task_id(task_id).build();
+        let (pending, submitted) =
+            SchedulerHandle::prepare_task_for_submission(SubmittableTask::task_only(task));
+        loop_state.handle_new_tasks(Some(pending))?;
+        Ok(submitted)
+    }
+
+    #[tokio::test]
+    async fn test_scheduler_abort_clears_only_its_published_demand() -> DaftResult<()> {
+        let manager = Arc::new(MockWorkerManager::new(setup_workers(&[])));
+        manager.enable_dispatch_gate_checks();
+        manager.set_autoscale_creates_workers(false);
+        let (mut aborted, aborted_handle) = unspawned_scheduler_loop(manager.clone());
+        let (mut live, live_handle) = unspawned_scheduler_loop(manager.clone());
+        let aborted_id = aborted.autoscale_demand_id;
+        let live_id = live.autoscale_demand_id;
+        assert_ne!(aborted_id, live_id);
+        let aborted_task = enqueue_mock_task(&mut aborted, 0)?;
+        let live_task = enqueue_mock_task(&mut live, 1)?;
+
+        let mut aborted = Box::pin(aborted.run());
+        let mut live = Box::pin(live.run());
+        // Poll through publication to the scheduler's await without any timer sleeps.
+        // No workers are materialized, so both owners still have unsatisfied demand.
+        assert!(futures::poll!(aborted.as_mut()).is_pending());
+        assert!(futures::poll!(live.as_mut()).is_pending());
+        assert_eq!(
+            manager.active_demand_ids(),
+            HashSet::from([aborted_id, live_id])
+        );
+        assert_eq!(manager.clear_demand_call_count(), 0);
+        assert!(manager.dispatch_gate.try_lock().is_ok());
+
+        // Abort a future that has already published, not one that was never polled.
+        // Keep its input handle alive so channel closure cannot explain cleanup.
+        let mut joinset = JoinSet::new();
+        joinset.spawn(aborted);
+        joinset.abort_all();
+        let mut aborted_count = 0;
+        while let Some(result) = joinset.join_next().await {
+            assert!(result.is_err(), "the scheduler should have been aborted");
+            aborted_count += 1;
+        }
+        assert_eq!(aborted_count, 1);
+        assert_eq!(manager.clear_demand_call_count(), 1);
+        assert_eq!(manager.cleared_demand_ids(), vec![aborted_id]);
+        assert_eq!(manager.active_demand_ids(), HashSet::from([live_id]));
+        assert!(manager.dispatch_gate.try_lock().is_ok());
+        assert!(aborted_task.await?.is_none());
+        drop(aborted_handle);
+
+        // Let the other owner finish normally. An input task wakes it immediately,
+        // avoiding dependence on the scheduler's next periodic tick.
+        manager.set_autoscale_creates_workers(true);
+        let wake_task =
+            SubmittableTask::task_only(MockTaskBuilder::default().with_task_id(2).build())
+                .submit(&live_handle)?;
+        drop(live_handle);
+        live.await?;
+        assert!(live_task.await?.is_some());
+        assert!(wake_task.await?.is_some());
+        assert_eq!(manager.cleared_demand_ids(), vec![aborted_id, live_id]);
+        assert_eq!(manager.clear_demand_call_count(), 2);
+        assert!(manager.active_demand_ids().is_empty());
+        assert!(manager.dispatch_gate.try_lock().is_ok());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_scheduler_releases_dispatch_gate_while_awaiting() -> DaftResult<()> {
+        let worker_id: WorkerId = Arc::from("worker1");
+        let manager = Arc::new(MockWorkerManager::new(setup_workers(&[(
+            worker_id.clone(),
+            1,
+        )])));
+        manager.enable_dispatch_gate_checks();
+        let (mut loop_state, handle) = unspawned_scheduler_loop(manager.clone());
+        let demand_id = loop_state.autoscale_demand_id;
+        let submitted = enqueue_mock_task(&mut loop_state, 0)?;
+        let mut running = Box::pin(loop_state.run());
+
+        // On this current-thread runtime the dispatched result future has not run
+        // yet: the scheduler is awaiting input/completion with an active worker.
+        assert!(futures::poll!(running.as_mut()).is_pending());
+        assert!(manager.dispatch_gate.try_lock().is_ok());
+        assert!(!manager.try_reap_idle_worker(&worker_id));
+        assert_eq!(manager.clear_demand_call_count(), 0);
+
+        drop(handle);
+        running.await?;
+        assert!(submitted.await?.is_some());
+        assert_eq!(manager.cleared_demand_ids(), vec![demand_id]);
+        assert!(manager.dispatch_gate.try_lock().is_ok());
+        Ok(())
+    }
+
+    async fn assert_dispatch_error_releases_gate(
+        worker_configs: &[(WorkerId, usize)],
+        inject_failure: fn(&MockWorkerManager, bool),
+        expected_error: &str,
+    ) -> DaftResult<()> {
+        let manager = Arc::new(MockWorkerManager::new(setup_workers(worker_configs)));
+        manager.enable_dispatch_gate_checks();
+        inject_failure(&manager, true);
+        manager.set_fail_clear_demand(true);
+        let (mut loop_state, _handle) = unspawned_scheduler_loop(manager.clone());
+        let demand_id = loop_state.autoscale_demand_id;
+        let _submitted = enqueue_mock_task(&mut loop_state, 0)?;
+
+        let error = loop_state.run().await.unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            format!("DaftError::InternalError {expected_error}")
+        );
+        assert!(manager.dispatch_gate.try_lock().is_ok());
+        // The cleanup hook also checks the gate is free before injecting its own
+        // error; it must neither replace the dispatch error nor be called twice.
+        assert_eq!(manager.clear_demand_call_count(), 1);
+        assert_eq!(manager.cleared_demand_ids(), vec![demand_id]);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_snapshot_error_releases_gate_and_preserves_original_error() -> DaftResult<()> {
+        assert_dispatch_error_releases_gate(
+            &[],
+            MockWorkerManager::set_fail_worker_snapshots,
+            "injected worker_snapshots failure",
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_autoscale_error_releases_gate_and_preserves_original_error() -> DaftResult<()> {
+        assert_dispatch_error_releases_gate(
+            &[],
+            MockWorkerManager::set_fail_autoscale,
+            "injected autoscale failure",
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_submit_error_releases_gate_and_preserves_original_error() -> DaftResult<()> {
+        assert_dispatch_error_releases_gate(
+            &[(Arc::from("worker1"), 1)],
+            MockWorkerManager::set_fail_submit,
+            "injected submit failure",
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_failure_preserves_successful_scheduler_result() -> DaftResult<()> {
+        let manager = Arc::new(MockWorkerManager::new(setup_workers(&[])));
+        manager.enable_dispatch_gate_checks();
+        manager.set_fail_clear_demand(true);
+        let (loop_state, handle) = unspawned_scheduler_loop(manager.clone());
+        let demand_id = loop_state.autoscale_demand_id;
+        drop(handle);
+
+        loop_state.run().await?;
+        assert_eq!(manager.clear_demand_call_count(), 1);
+        assert_eq!(manager.cleared_demand_ids(), vec![demand_id]);
+        assert!(manager.dispatch_gate.try_lock().is_ok());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_scheduler_dispatch_wins_reaper_between_snapshot_and_submit() -> DaftResult<()> {
+        let worker_id: WorkerId = Arc::from("worker1");
+        let manager = Arc::new(MockWorkerManager::new(setup_workers(&[(
+            worker_id.clone(),
+            1,
+        )])));
+        manager.enable_dispatch_gate_checks();
+        let (mut loop_state, handle) = unspawned_scheduler_loop(manager.clone());
+        let submitted = enqueue_mock_task(&mut loop_state, 0)?;
+        let observation = Arc::new(Mutex::new(None));
+        let reaper_observation = observation.clone();
+        let reaper_manager = manager.clone();
+        let reaper_worker_id = worker_id.clone();
+        manager.set_after_snapshot_hook(move || {
+            let barrier = Arc::new(Barrier::new(2));
+            let reaper_barrier = barrier.clone();
+            let reaper = std::thread::spawn(move || {
+                reaper_barrier.wait();
+                let gate_held = matches!(
+                    reaper_manager.dispatch_gate.try_lock(),
+                    Err(TryLockError::WouldBlock)
+                );
+                let retired = reaper_manager.try_reap_idle_worker(&reaper_worker_id);
+                (gate_held, retired)
+            });
+            barrier.wait();
+            // Joining inside the snapshot hook guarantees the attempted retirement
+            // happens before submit, while the worker-map lock is already released.
+            *reaper_observation.lock().unwrap() = Some(reaper.join().unwrap());
+        });
+
+        // No standalone test guard: the scheduler itself must acquire the gate.
+        loop_state.schedule_and_dispatch()?;
+        assert_eq!(*observation.lock().unwrap(), Some((true, false)));
+        assert_eq!(loop_state.scheduler.num_pending_tasks(), 0);
+        assert!(loop_state.dispatcher.has_running_tasks());
+        assert!(manager.dispatch_gate.try_lock().is_ok());
+        // Once dispatch releases the gate, registered active work prevents reaping.
+        assert!(!manager.try_reap_idle_worker(&worker_id));
+
+        drop(handle);
+        loop_state.run().await?;
+        assert!(submitted.await?.is_some());
+        // The mock reaper is functional: it can retire this worker after completion.
+        assert!(manager.try_reap_idle_worker(&worker_id));
         Ok(())
     }
 

--- a/src/daft-distributed/src/scheduling/worker.rs
+++ b/src/daft-distributed/src/scheduling/worker.rs
@@ -51,27 +51,19 @@ pub(crate) trait WorkerManager: Send + Sync {
     }
     #[allow(dead_code)]
     fn shutdown(&self) -> DaftResult<()>;
-    /// Optionally retire idle workers to allow the backend to scale in.
+    /// Clear any outstanding autoscaling (scale-up) demand previously sent to the
+    /// backend's autoscaler. The scheduler calls this (best-effort) whenever a job
+    /// finishes — successfully or with an error — so the autoscaler stops provisioning
+    /// capacity for work that no longer exists.
     ///
-    /// The worker manager owns the entire downscale policy: enable flag, idle thresholds,
-    /// minimum-survivor floor, head-node protection, blacklist TTLs, etc. The scheduler
-    /// only hands it per-tick context that it has visibility into:
-    ///
-    /// * `skip_due_to_pending_scale_up`: set when the scheduler just sent a scale-up
-    ///   request in the same tick. The worker manager is expected to skip retirement so
-    ///   it does not undo demand it just signaled to the autoscaler.
-    /// * `force_all_when_cluster_idle`: set on job shutdown to bypass idle-time thresholds
-    ///   so any remaining idle workers can be released.
-    ///
-    /// Returns the number of workers that were retired. The default implementation is a
-    /// no-op for backends that do not support worker retirement.
-    #[allow(unused_variables)]
-    fn retire_idle_workers(
-        &self,
-        skip_due_to_pending_scale_up: bool,
-        force_all_when_cluster_idle: bool,
-    ) -> DaftResult<usize> {
-        Ok(0)
+    /// Idle-worker *retirement* is intentionally NOT triggered here. Retirement is
+    /// owned solely by the worker manager's own background reaper, which lives across
+    /// query boundaries and is the single retirement authority (see RayWorkerManager).
+    /// Keeping the scheduler out of the retirement decision avoids two independent
+    /// actors racing over the same worker pool. The default implementation is a no-op
+    /// for backends without an autoscaler.
+    fn clear_autoscale_demand(&self) -> DaftResult<()> {
+        Ok(())
     }
 }
 
@@ -89,28 +81,27 @@ pub(crate) mod tests {
     #[derive(Clone)]
     pub struct MockWorkerManager {
         workers: Arc<Mutex<HashMap<WorkerId, MockWorker>>>,
-        retire_call_count: Arc<AtomicUsize>,
-        last_retire_args: Arc<Mutex<Option<(bool, bool)>>>,
+        clear_demand_call_count: Arc<AtomicUsize>,
+        fail_worker_snapshots: Arc<AtomicBool>,
     }
 
     impl MockWorkerManager {
         pub fn new(workers: HashMap<WorkerId, MockWorker>) -> Self {
             Self {
                 workers: Arc::new(Mutex::new(workers)),
-                retire_call_count: Arc::new(AtomicUsize::new(0)),
-                last_retire_args: Arc::new(Mutex::new(None)),
+                clear_demand_call_count: Arc::new(AtomicUsize::new(0)),
+                fail_worker_snapshots: Arc::new(AtomicBool::new(false)),
             }
         }
 
-        pub fn retire_call_count(&self) -> usize {
-            self.retire_call_count.load(Ordering::SeqCst)
+        pub fn clear_demand_call_count(&self) -> usize {
+            self.clear_demand_call_count.load(Ordering::SeqCst)
         }
 
-        pub fn last_retire_args(&self) -> Option<(bool, bool)> {
-            *self
-                .last_retire_args
-                .lock()
-                .expect("Failed to lock last_retire_args")
+        /// Make subsequent `worker_snapshots` calls fail, to exercise the scheduler's
+        /// error-exit path.
+        pub fn set_fail_worker_snapshots(&self, fail: bool) {
+            self.fail_worker_snapshots.store(fail, Ordering::SeqCst);
         }
     }
 
@@ -158,6 +149,11 @@ pub(crate) mod tests {
         }
 
         fn worker_snapshots(&self) -> DaftResult<Vec<WorkerSnapshot>> {
+            if self.fail_worker_snapshots.load(Ordering::SeqCst) {
+                return Err(common_error::DaftError::InternalError(
+                    "injected worker_snapshots failure".to_string(),
+                ));
+            }
             Ok(self
                 .workers
                 .lock()
@@ -192,19 +188,10 @@ pub(crate) mod tests {
             Ok(())
         }
 
-        fn retire_idle_workers(
-            &self,
-            skip_due_to_pending_scale_up: bool,
-            force_all_when_cluster_idle: bool,
-        ) -> DaftResult<usize> {
+        fn clear_autoscale_demand(&self) -> DaftResult<()> {
             // Mock implementation: distributed Ray autoscaler is not exercised in unit tests.
-            self.retire_call_count.fetch_add(1, Ordering::SeqCst);
-            *self
-                .last_retire_args
-                .lock()
-                .expect("Failed to lock last_retire_args") =
-                Some((skip_due_to_pending_scale_up, force_all_when_cluster_idle));
-            Ok(0)
+            self.clear_demand_call_count.fetch_add(1, Ordering::SeqCst);
+            Ok(())
         }
     }
 

--- a/src/daft-distributed/src/scheduling/worker.rs
+++ b/src/daft-distributed/src/scheduling/worker.rs
@@ -1,4 +1,11 @@
-use std::{collections::HashMap, fmt::Debug, sync::Arc};
+use std::{
+    collections::HashMap,
+    fmt::Debug,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+};
 
 use common_error::DaftResult;
 
@@ -9,6 +16,30 @@ use crate::scheduling::{
 };
 
 pub(crate) type WorkerId = Arc<str>;
+
+/// Identifies one owner of autoscaling demand: in practice one scheduler event loop,
+/// i.e. one running plan.
+///
+/// Backends whose autoscaler exposes a single, replace-on-write demand slot (Ray's
+/// `ray.autoscaler.sdk.request_resources` is exactly that) cannot simply forward the
+/// latest caller's request: doing so silently discards the demand of every other plan
+/// running against the same cluster. Tagging each request with its owner lets the
+/// backend keep per-owner books and always publish the union of what is still live.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct AutoscaleDemandId(u64);
+
+impl AutoscaleDemandId {
+    pub fn new() -> Self {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        Self(COUNTER.fetch_add(1, Ordering::Relaxed))
+    }
+}
+
+impl std::fmt::Display for AutoscaleDemandId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
 
 pub(crate) trait Worker: Send + Sync + Debug + 'static {
     type Task: Task;
@@ -42,7 +73,16 @@ pub(crate) trait WorkerManager: Send + Sync {
     fn mark_task_finished(&self, task_context: TaskContext, worker_id: WorkerId);
     fn mark_worker_died(&self, worker_id: WorkerId);
     fn worker_snapshots(&self) -> DaftResult<Vec<WorkerSnapshot>>;
-    fn try_autoscale(&self, resource_requests: Vec<TaskResourceRequest>) -> DaftResult<()>;
+    /// Signal scale-up demand on behalf of `demand_id`.
+    ///
+    /// Backends with a single, replace-on-write demand slot must publish the union of
+    /// the demand currently held by *all* owners, not just this one — otherwise two
+    /// concurrent plans keep cancelling each other's requests.
+    fn try_autoscale(
+        &self,
+        demand_id: AutoscaleDemandId,
+        resource_requests: Vec<TaskResourceRequest>,
+    ) -> DaftResult<()>;
     fn cleanup_shuffle_dirs(
         &self,
         _dirs: Vec<String>,
@@ -51,10 +91,14 @@ pub(crate) trait WorkerManager: Send + Sync {
     }
     #[allow(dead_code)]
     fn shutdown(&self) -> DaftResult<()>;
-    /// Clear any outstanding autoscaling (scale-up) demand previously sent to the
-    /// backend's autoscaler. The scheduler calls this (best-effort) whenever a job
-    /// finishes — successfully or with an error — so the autoscaler stops provisioning
-    /// capacity for work that no longer exists.
+    /// Drop the autoscaling (scale-up) demand previously signaled by `demand_id`. The
+    /// scheduler calls this (best-effort) whenever a job finishes — successfully or
+    /// with an error — so the autoscaler stops provisioning capacity for work that no
+    /// longer exists.
+    ///
+    /// Only this owner's demand is released: any demand still held by other concurrent
+    /// plans must survive, so backends that share one demand slot re-publish the
+    /// remainder instead of clearing the slot outright.
     ///
     /// Idle-worker *retirement* is intentionally NOT triggered here. Retirement is
     /// owned solely by the worker manager's own background reaper, which lives across
@@ -62,7 +106,7 @@ pub(crate) trait WorkerManager: Send + Sync {
     /// Keeping the scheduler out of the retirement decision avoids two independent
     /// actors racing over the same worker pool. The default implementation is a no-op
     /// for backends without an autoscaler.
-    fn clear_autoscale_demand(&self) -> DaftResult<()> {
+    fn clear_autoscale_demand(&self, _demand_id: AutoscaleDemandId) -> DaftResult<()> {
         Ok(())
     }
 }
@@ -83,6 +127,10 @@ pub(crate) mod tests {
         workers: Arc<Mutex<HashMap<WorkerId, MockWorker>>>,
         clear_demand_call_count: Arc<AtomicUsize>,
         fail_worker_snapshots: Arc<AtomicBool>,
+        /// Owners seen by `try_autoscale`, in call order.
+        autoscale_demand_ids: Arc<Mutex<Vec<AutoscaleDemandId>>>,
+        /// Owners seen by `clear_autoscale_demand`, in call order.
+        cleared_demand_ids: Arc<Mutex<Vec<AutoscaleDemandId>>>,
     }
 
     impl MockWorkerManager {
@@ -91,11 +139,27 @@ pub(crate) mod tests {
                 workers: Arc::new(Mutex::new(workers)),
                 clear_demand_call_count: Arc::new(AtomicUsize::new(0)),
                 fail_worker_snapshots: Arc::new(AtomicBool::new(false)),
+                autoscale_demand_ids: Arc::new(Mutex::new(Vec::new())),
+                cleared_demand_ids: Arc::new(Mutex::new(Vec::new())),
             }
         }
 
         pub fn clear_demand_call_count(&self) -> usize {
             self.clear_demand_call_count.load(Ordering::SeqCst)
+        }
+
+        pub fn autoscale_demand_ids(&self) -> Vec<AutoscaleDemandId> {
+            self.autoscale_demand_ids
+                .lock()
+                .expect("Failed to lock autoscale_demand_ids")
+                .clone()
+        }
+
+        pub fn cleared_demand_ids(&self) -> Vec<AutoscaleDemandId> {
+            self.cleared_demand_ids
+                .lock()
+                .expect("Failed to lock cleared_demand_ids")
+                .clone()
         }
 
         /// Make subsequent `worker_snapshots` calls fail, to exercise the scheduler's
@@ -163,7 +227,15 @@ pub(crate) mod tests {
                 .collect())
         }
 
-        fn try_autoscale(&self, resource_requests: Vec<TaskResourceRequest>) -> DaftResult<()> {
+        fn try_autoscale(
+            &self,
+            demand_id: AutoscaleDemandId,
+            resource_requests: Vec<TaskResourceRequest>,
+        ) -> DaftResult<()> {
+            self.autoscale_demand_ids
+                .lock()
+                .expect("Failed to lock autoscale_demand_ids")
+                .push(demand_id);
             // add 1 worker for each num_cpus
             let num_workers = resource_requests.len();
             let mut workers = self.workers.lock().expect("Failed to lock workers");
@@ -188,8 +260,12 @@ pub(crate) mod tests {
             Ok(())
         }
 
-        fn clear_autoscale_demand(&self) -> DaftResult<()> {
+        fn clear_autoscale_demand(&self, demand_id: AutoscaleDemandId) -> DaftResult<()> {
             // Mock implementation: distributed Ray autoscaler is not exercised in unit tests.
+            self.cleared_demand_ids
+                .lock()
+                .expect("Failed to lock cleared_demand_ids")
+                .push(demand_id);
             self.clear_demand_call_count.fetch_add(1, Ordering::SeqCst);
             Ok(())
         }

--- a/src/daft-distributed/src/scheduling/worker.rs
+++ b/src/daft-distributed/src/scheduling/worker.rs
@@ -63,8 +63,23 @@ pub(crate) trait Worker: Send + Sync + Debug + 'static {
     }
 }
 
+#[derive(Default)]
+pub(crate) struct DispatchLifecycleGuard<'a> {
+    _lock: Option<std::sync::MutexGuard<'a, ()>>,
+}
+
+impl<'a> DispatchLifecycleGuard<'a> {
+    pub(crate) fn new(lock: std::sync::MutexGuard<'a, ()>) -> Self {
+        Self { _lock: Some(lock) }
+    }
+}
+
 pub(crate) trait WorkerManager: Send + Sync {
     type Worker: Worker;
+
+    fn begin_dispatch(&self) -> DispatchLifecycleGuard<'_> {
+        DispatchLifecycleGuard::default()
+    }
 
     fn submit_tasks_to_workers(
         &self,
@@ -113,9 +128,12 @@ pub(crate) trait WorkerManager: Send + Sync {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use std::sync::{
-        Mutex,
-        atomic::{AtomicBool, AtomicUsize, Ordering},
+    use std::{
+        collections::HashSet,
+        sync::{
+            Mutex, TryLockError,
+            atomic::{AtomicBool, AtomicUsize, Ordering},
+        },
     };
 
     use super::*;
@@ -125,8 +143,16 @@ pub(crate) mod tests {
     #[derive(Clone)]
     pub struct MockWorkerManager {
         workers: Arc<Mutex<HashMap<WorkerId, MockWorker>>>,
+        pub dispatch_gate: Arc<Mutex<()>>,
+        check_dispatch_gate: Arc<AtomicBool>,
         clear_demand_call_count: Arc<AtomicUsize>,
         fail_worker_snapshots: Arc<AtomicBool>,
+        fail_autoscale: Arc<AtomicBool>,
+        fail_submit: Arc<AtomicBool>,
+        fail_clear_demand: Arc<AtomicBool>,
+        autoscale_creates_workers: Arc<AtomicBool>,
+        after_snapshot_hook: Arc<Mutex<Option<Box<dyn FnOnce() + Send>>>>,
+        active_demand_ids: Arc<Mutex<HashSet<AutoscaleDemandId>>>,
         /// Owners seen by `try_autoscale`, in call order.
         autoscale_demand_ids: Arc<Mutex<Vec<AutoscaleDemandId>>>,
         /// Owners seen by `clear_autoscale_demand`, in call order.
@@ -137,8 +163,16 @@ pub(crate) mod tests {
         pub fn new(workers: HashMap<WorkerId, MockWorker>) -> Self {
             Self {
                 workers: Arc::new(Mutex::new(workers)),
+                dispatch_gate: Arc::new(Mutex::new(())),
+                check_dispatch_gate: Arc::new(AtomicBool::new(false)),
                 clear_demand_call_count: Arc::new(AtomicUsize::new(0)),
                 fail_worker_snapshots: Arc::new(AtomicBool::new(false)),
+                fail_autoscale: Arc::new(AtomicBool::new(false)),
+                fail_submit: Arc::new(AtomicBool::new(false)),
+                fail_clear_demand: Arc::new(AtomicBool::new(false)),
+                autoscale_creates_workers: Arc::new(AtomicBool::new(true)),
+                after_snapshot_hook: Arc::new(Mutex::new(None)),
+                active_demand_ids: Arc::new(Mutex::new(HashSet::new())),
                 autoscale_demand_ids: Arc::new(Mutex::new(Vec::new())),
                 cleared_demand_ids: Arc::new(Mutex::new(Vec::new())),
             }
@@ -167,25 +201,96 @@ pub(crate) mod tests {
         pub fn set_fail_worker_snapshots(&self, fail: bool) {
             self.fail_worker_snapshots.store(fail, Ordering::SeqCst);
         }
+
+        pub fn set_fail_autoscale(&self, fail: bool) {
+            self.fail_autoscale.store(fail, Ordering::SeqCst);
+        }
+
+        pub fn set_fail_submit(&self, fail: bool) {
+            self.fail_submit.store(fail, Ordering::SeqCst);
+        }
+
+        pub fn set_fail_clear_demand(&self, fail: bool) {
+            self.fail_clear_demand.store(fail, Ordering::SeqCst);
+        }
+
+        pub fn set_autoscale_creates_workers(&self, enabled: bool) {
+            self.autoscale_creates_workers
+                .store(enabled, Ordering::SeqCst);
+        }
+
+        pub fn active_demand_ids(&self) -> HashSet<AutoscaleDemandId> {
+            self.active_demand_ids.lock().unwrap().clone()
+        }
+
+        // Dispatcher-only tests intentionally submit without the scheduler's gate.
+        pub fn enable_dispatch_gate_checks(&self) {
+            self.check_dispatch_gate.store(true, Ordering::SeqCst);
+        }
+
+        fn assert_dispatch_gate_held(&self) {
+            if self.check_dispatch_gate.load(Ordering::SeqCst) {
+                assert!(
+                    matches!(self.dispatch_gate.try_lock(), Err(TryLockError::WouldBlock)),
+                    "scheduler must hold the dispatch gate"
+                );
+            }
+        }
+
+        pub fn set_after_snapshot_hook(&self, hook: impl FnOnce() + Send + 'static) {
+            *self.after_snapshot_hook.lock().unwrap() = Some(Box::new(hook));
+        }
+
+        // Model a reaper using the same lifecycle gate and checking for active work.
+        pub fn try_reap_idle_worker(&self, worker_id: &WorkerId) -> bool {
+            let _guard = match self.dispatch_gate.try_lock() {
+                Ok(guard) => guard,
+                Err(TryLockError::WouldBlock) => return false,
+                Err(TryLockError::Poisoned(_)) => panic!("dispatch gate poisoned"),
+            };
+            let mut workers = self.workers.lock().unwrap();
+            if workers
+                .get(worker_id)
+                .is_some_and(|worker| worker.active_task_details().is_empty())
+            {
+                workers.remove(worker_id);
+                true
+            } else {
+                false
+            }
+        }
     }
 
     impl WorkerManager for MockWorkerManager {
         type Worker = MockWorker;
 
+        fn begin_dispatch(&self) -> DispatchLifecycleGuard<'_> {
+            DispatchLifecycleGuard::new(self.dispatch_gate.lock().unwrap())
+        }
+
         fn submit_tasks_to_workers(
             &self,
             tasks_per_worker: HashMap<WorkerId, Vec<MockTask>>,
         ) -> DaftResult<Vec<MockTaskResultHandle>> {
+            self.assert_dispatch_gate_held();
+            if self.fail_submit.load(Ordering::SeqCst) {
+                return Err(common_error::DaftError::InternalError(
+                    "injected submit failure".to_string(),
+                ));
+            }
             let mut result = Vec::new();
             for (worker_id, tasks) in tasks_per_worker {
                 for task in tasks {
                     // Update the worker's active task count
-                    if let Some(worker) = self
-                        .workers
-                        .lock()
-                        .expect("Failed to lock workers")
-                        .get(&worker_id)
-                    {
+                    let workers = self.workers.lock().expect("Failed to lock workers");
+                    let worker = workers.get(&worker_id);
+                    if self.check_dispatch_gate.load(Ordering::SeqCst) {
+                        assert!(
+                            worker.is_some(),
+                            "worker disappeared between snapshot and submit"
+                        );
+                    }
+                    if let Some(worker) = worker {
                         worker.add_active_task(&task);
                     }
                     result.push(MockTaskResultHandle::new(task));
@@ -213,18 +318,26 @@ pub(crate) mod tests {
         }
 
         fn worker_snapshots(&self) -> DaftResult<Vec<WorkerSnapshot>> {
+            self.assert_dispatch_gate_held();
             if self.fail_worker_snapshots.load(Ordering::SeqCst) {
                 return Err(common_error::DaftError::InternalError(
                     "injected worker_snapshots failure".to_string(),
                 ));
             }
-            Ok(self
+            let snapshots = self
                 .workers
                 .lock()
                 .expect("Failed to lock workers")
                 .values()
                 .map(WorkerSnapshot::from)
-                .collect())
+                .collect();
+            // Release the worker-map lock before allowing the reaper to run. Only
+            // the scheduler's lifecycle gate should protect these snapshots now.
+            let hook = self.after_snapshot_hook.lock().unwrap().take();
+            if let Some(hook) = hook {
+                hook();
+            }
+            Ok(snapshots)
         }
 
         fn try_autoscale(
@@ -232,10 +345,20 @@ pub(crate) mod tests {
             demand_id: AutoscaleDemandId,
             resource_requests: Vec<TaskResourceRequest>,
         ) -> DaftResult<()> {
+            self.assert_dispatch_gate_held();
             self.autoscale_demand_ids
                 .lock()
                 .expect("Failed to lock autoscale_demand_ids")
                 .push(demand_id);
+            if self.fail_autoscale.load(Ordering::SeqCst) {
+                return Err(common_error::DaftError::InternalError(
+                    "injected autoscale failure".to_string(),
+                ));
+            }
+            self.active_demand_ids.lock().unwrap().insert(demand_id);
+            if !self.autoscale_creates_workers.load(Ordering::SeqCst) {
+                return Ok(());
+            }
             // add 1 worker for each num_cpus
             let num_workers = resource_requests.len();
             let mut workers = self.workers.lock().expect("Failed to lock workers");
@@ -262,11 +385,23 @@ pub(crate) mod tests {
 
         fn clear_autoscale_demand(&self, demand_id: AutoscaleDemandId) -> DaftResult<()> {
             // Mock implementation: distributed Ray autoscaler is not exercised in unit tests.
+            if self.check_dispatch_gate.load(Ordering::SeqCst) {
+                assert!(
+                    self.dispatch_gate.try_lock().is_ok(),
+                    "dispatch gate must be released before demand cleanup"
+                );
+            }
             self.cleared_demand_ids
                 .lock()
                 .expect("Failed to lock cleared_demand_ids")
                 .push(demand_id);
             self.clear_demand_call_count.fetch_add(1, Ordering::SeqCst);
+            if self.fail_clear_demand.load(Ordering::SeqCst) {
+                return Err(common_error::DaftError::InternalError(
+                    "injected clear_autoscale_demand failure".to_string(),
+                ));
+            }
+            self.active_demand_ids.lock().unwrap().remove(&demand_id);
             Ok(())
         }
     }

--- a/src/daft-distributed/src/scheduling/worker.rs
+++ b/src/daft-distributed/src/scheduling/worker.rs
@@ -139,6 +139,8 @@ pub(crate) mod tests {
     use super::*;
     use crate::scheduling::tests::{MockTask, MockTaskResultHandle};
 
+    type AfterSnapshotHook = Box<dyn FnOnce() + Send>;
+
     /// A mock implementation of the WorkerManager trait for testing
     #[derive(Clone)]
     pub struct MockWorkerManager {
@@ -151,7 +153,7 @@ pub(crate) mod tests {
         fail_submit: Arc<AtomicBool>,
         fail_clear_demand: Arc<AtomicBool>,
         autoscale_creates_workers: Arc<AtomicBool>,
-        after_snapshot_hook: Arc<Mutex<Option<Box<dyn FnOnce() + Send>>>>,
+        after_snapshot_hook: Arc<Mutex<Option<AfterSnapshotHook>>>,
         active_demand_ids: Arc<Mutex<HashSet<AutoscaleDemandId>>>,
         /// Owners seen by `try_autoscale`, in call order.
         autoscale_demand_ids: Arc<Mutex<Vec<AutoscaleDemandId>>>,


### PR DESCRIPTION
## Changes Made

**`src/daft-distributed/src/scheduling/downscale.rs` (new)**
- Pure, backend-agnostic retirement policy: `DownscalePolicy::from_env()` + `plan_reap()`, which computes the per-tick state transitions (`release` / `drain` / `undrain`) from one consistent snapshot of worker statuses. No Python/Ray dependencies, so the entire decision logic is unit-testable. All `DAFT_AUTOSCALING_*` env var names live here as constants.
- Invariants encoded in `plan_reap()`: head node is never retired; workers idle less than the threshold are never touched; total hidden capacity (releases + drains) never dips the visible pool below `min_survivor_workers`; disabling the feature or an in-flight scale-up cancels all in-progress drains so no worker stays hidden from the scheduler indefinitely.

**`src/daft-distributed/src/python/ray/worker_manager.rs`**
- Added a `draining_workers` set to `RayWorkerManagerState`. `worker_snapshots()` filters draining workers out so the scheduler stops assigning work to them, while they remain alive and able to accept already-dispatched tasks — this is what closes the snapshot→dispatch race.
- `reap_idle_workers()` now gathers worker statuses, derives the scale-up guard, applies the `plan_reap()` result, and resets the autoscale high-water mark all inside a single critical section (Python/GIL calls stay outside the lock). The high-water-mark/refresh reset only happens when workers were actually released.
- `try_autoscale()` clears all draining marks (rising demand should not release capacity); `mark_worker_died()` cleans up the draining mark.
- `clear_autoscale_demand()` short-circuits when the job never sent a scale-up request, so the default (non-autoscaling) path never calls into Python or clobbers the cluster-wide `request_resources` slot; it also resets the scale-up guard timestamp.
- Reaper thread hardening: each tick wrapped in `catch_unwind`, poisoned-lock recovery via `PoisonError::into_inner`, `warn!`/`error!` logging for tick failures and thread-spawn failure.

**`src/daft-distributed/src/scheduling/scheduler/scheduler_actor.rs`**
- Split `run()` into `run()` + `event_loop()`: outstanding autoscaler demand is now cleared on both clean and error exits (Ray's `request_resources` is sticky, and a failed query is exactly the case where the signaled demand no longer has work behind it). The cleanup is best-effort — a failure logs a warning instead of masking the loop's own result.

**`src/daft-distributed/src/scheduling/worker.rs`**
- Trait doc updated for the best-effort/always-on-exit contract; `MockWorkerManager` gained `set_fail_worker_snapshots()` fault injection to exercise the scheduler's error-exit path in tests.

**`docs/distributed/ray.md`, `daft/runners/__init__.py`**
- Documented `DAFT_AUTOSCALING_REAPER_INTERVAL_SECONDS` (default: 5) and the warm-pool retirement semantics: two-phase drain→release, and that `min_survivor_workers` workers persist for the driver's lifetime (recommend setting it to 0 for one-shot jobs on shared clusters).

## Related Issues

Related to #5683 (idle Ray workers not being scaled down in flotilla mode). This PR hardens the worker-retirement half of that issue — it does not address the UDFActor state-management half.
