### PR TITLE
docs(sql): document table function options

### DIFF
--- a/docs/connectors/generic-file-source-options.md
+++ b/docs/connectors/generic-file-source-options.md
@@ -25,25 +25,6 @@ df = daft.read_iceberg(table, ignore_corrupt_files=True)
 df.collect()
 ```
 
-The same option is available on the SQL table functions as a named argument:
-
-```python
-df = daft.sql("""
-    SELECT * FROM read_parquet('s3://my-bucket/data/**/*.parquet', ignore_corrupt_files => true)
-""")
-df.collect()
-```
-
-`read_csv` and `read_iceberg` accept it the same way. Named arguments also accept the
-`:=` form (`ignore_corrupt_files := true`), and `df.skipped_corrupt_files` works
-identically for dataframes built through SQL:
-
-```python
-df = daft.sql("SELECT * FROM read_csv('s3://my-bucket/data/**/*.csv', ignore_corrupt_files => true)")
-df.collect()
-print(df.skipped_corrupt_files)
-```
-
 ### What counts as "corrupt"
 
 Daft skips a file when it encounters a problem that is specific to the file itself and cannot be resolved by retrying:

--- a/docs/connectors/generic-file-source-options.md
+++ b/docs/connectors/generic-file-source-options.md
@@ -25,6 +25,25 @@ df = daft.read_iceberg(table, ignore_corrupt_files=True)
 df.collect()
 ```
 
+The same option is available on the SQL table functions as a named argument:
+
+```python
+df = daft.sql("""
+    SELECT * FROM read_parquet('s3://my-bucket/data/**/*.parquet', ignore_corrupt_files => true)
+""")
+df.collect()
+```
+
+`read_csv` and `read_iceberg` accept it the same way. Named arguments also accept the
+`:=` form (`ignore_corrupt_files := true`), and `df.skipped_corrupt_files` works
+identically for dataframes built through SQL:
+
+```python
+df = daft.sql("SELECT * FROM read_csv('s3://my-bucket/data/**/*.csv', ignore_corrupt_files => true)")
+df.collect()
+print(df.skipped_corrupt_files)
+```
+
 ### What counts as "corrupt"
 
 Daft skips a file when it encounters a problem that is specific to the file itself and cannot be resolved by retrying:
@@ -114,6 +133,10 @@ This pattern — **errors visible, impact contained, tooling to fix** — lets a
 | Parquet (`read_parquet`) | Yes (bad footer, wrong magic bytes, file too small) | Yes (corrupt row group data) |
 | CSV (`read_csv`) | Yes (unreadable file, truncated) | Yes (bad encoding, wrong field count in chunk) |
 | Iceberg (`read_iceberg`) | Yes (data files go through the Rust Parquet reader) | Yes |
+
+All three are supported from both the Python API and the SQL table functions. See
+[Table Function Options](../sql/index.md#table-function-options) for the full list of
+named arguments each SQL reader accepts.
 
 !!! note "Iceberg delete files"
     Corruption in Iceberg *delete files* is not covered. If a delete file is unreadable, Daft will raise an error regardless of `ignore_corrupt_files`. Delete files are small metadata structures and corruption there generally indicates a more serious catalog inconsistency.

--- a/docs/sql/index.md
+++ b/docs/sql/index.md
@@ -121,8 +121,9 @@ A list of paths is written as a SQL array:
 
 These mirror the corresponding Python reader arguments — see
 [`read_parquet`][daft.read_parquet], [`read_csv`][daft.read_csv],
-[`read_json`][daft.read_json], and [`read_iceberg`][daft.read_iceberg] for what each one
-does, and [Generic File Source Options](../connectors/generic-file-source-options.md)
+[`read_json`][daft.read_json], [`read_iceberg`][daft.read_iceberg], and
+[`read_deltalake`][daft.read_deltalake] for what each one does, and
+[Generic File Source Options](../connectors/generic-file-source-options.md)
 for `ignore_corrupt_files` in depth.
 
 A `schema` is given as a struct literal mapping column names to type names:

--- a/docs/sql/index.md
+++ b/docs/sql/index.md
@@ -85,6 +85,63 @@ In the above example, we query the DataFrame called `"my_special_df"` by simply 
     daft.sql("SELECT * FROM read_iceberg('s3://.../metadata.json')")
     ```
 
+### Table Function Options
+
+Table functions take the path as the first positional argument, plus any of the options
+below. Named arguments use either `=>` or `:=`:
+
+=== "🐍 Python"
+    ```python
+    daft.sql("SELECT * FROM read_csv('data.csv', has_headers => false)")
+    daft.sql("SELECT * FROM read_csv('data.csv', has_headers := false)")
+    ```
+
+`read_parquet`, `read_csv`, `read_json`, and `read_deltalake` also accept the path itself
+as a named `path` argument:
+
+=== "🐍 Python"
+    ```python
+    daft.sql("SELECT * FROM read_csv(path => 'data.csv')")
+    ```
+
+A list of paths is written as a SQL array:
+
+=== "🐍 Python"
+    ```python
+    daft.sql("SELECT * FROM read_parquet(['a.parquet', 'b.parquet'])")
+    ```
+
+| Function | Options |
+|---|---|
+| `read_parquet` | `infer_schema`, `schema`, `coerce_int96_timestamp_unit`, `chunk_size`, `multithreaded`, `io_config`, `file_path_column`, `hive_partitioning`, `ignore_corrupt_files` |
+| `read_csv` | `infer_schema`, `schema`, `has_headers`, `delimiter`, `double_quote`, `quote`, `escape_char`, `comment`, `allow_variable_columns`, `io_config`, `file_path_column`, `hive_partitioning`, `buffer_size`, `chunk_size`, `ignore_corrupt_files` |
+| `read_json` | `infer_schema`, `schema`, `io_config`, `file_path_column`, `hive_partitioning`, `buffer_size`, `chunk_size`, `skip_empty_files` |
+| `read_iceberg` | `snapshot_id`, `branch`, `tag`, `io_config`, `ignore_corrupt_files` |
+| `read_deltalake` | `io_config` |
+
+These mirror the corresponding Python reader arguments — see
+[`read_parquet`][daft.read_parquet], [`read_csv`][daft.read_csv],
+[`read_json`][daft.read_json], and [`read_iceberg`][daft.read_iceberg] for what each one
+does, and [Generic File Source Options](../connectors/generic-file-source-options.md)
+for `ignore_corrupt_files` in depth.
+
+A `schema` is given as a struct literal mapping column names to type names:
+
+=== "🐍 Python"
+    ```python
+    daft.sql("""
+        SELECT * FROM read_csv('data.csv', schema := {'a': 'int64', 'b': 'string'})
+    """)
+    ```
+
+For Iceberg, `snapshot_id`, `branch`, and `tag` select which version to read and are
+mutually exclusive:
+
+=== "🐍 Python"
+    ```python
+    daft.sql("SELECT * FROM read_iceberg('/warehouse/db/t/metadata/v3.metadata.json', branch => 'audit')")
+    ```
+
 ### SQL Expressions
 
 SQL has the concept of expressions as well. Here is an example of a simple addition expression, adding columns `A` and `B` in SQL to produce a new column `C`.

--- a/docs/sql/index.md
+++ b/docs/sql/index.md
@@ -143,6 +143,16 @@ mutually exclusive:
     daft.sql("SELECT * FROM read_iceberg('/warehouse/db/t/metadata/v3.metadata.json', branch => 'audit')")
     ```
 
+`ignore_corrupt_files` skips unreadable files instead of failing the query, and
+`df.skipped_corrupt_files` reports what was skipped once the DataFrame is materialized:
+
+=== "🐍 Python"
+    ```python
+    df = daft.sql("SELECT * FROM read_csv('s3://my-bucket/data/**/*.csv', ignore_corrupt_files => true)")
+    df.collect()
+    print(df.skipped_corrupt_files)
+    ```
+
 ### SQL Expressions
 
 SQL has the concept of expressions as well. Here is an example of a simple addition expression, adding columns `A` and `B` in SQL to produce a new column `C`.


### PR DESCRIPTION
## Changes Made

**`docs/sql/index.md` — new "Table Function Options" section**

The SQL reference had only two bare examples:

```python
daft.sql("SELECT * FROM read_parquet('s3://...')")
daft.sql("SELECT * FROM read_iceberg('s3://.../metadata.json')")
```

Nothing documented the named arguments each reader accepts, so options like `snapshot_id`, `branch`, `tag`, `hive_partitioning`, and `ignore_corrupt_files` were only discoverable by reading `src/daft-sql/src/table_provider/`. Added:

- argument syntax: both `=>` and `:=`, which functions accept a named `path`, path arrays, struct-literal `schema`
- a per-function option table for `read_parquet`, `read_csv`, `read_json`, `read_iceberg`, `read_deltalake`
- an Iceberg version-selection example, noting `snapshot_id`/`branch`/`tag` are mutually exclusive
- links out to the Python reader API docs rather than restating what each option does

**`docs/connectors/generic-file-source-options.md` — add the SQL form**

The page described `ignore_corrupt_files` as if it were Python-only, but all three SQL readers support it now (#7130, #7133, #7264). Added the SQL usage, noted `df.skipped_corrupt_files` works the same for SQL-built dataframes, and cross-linked the two pages.

## Testing

Every option name and syntax form in the new tables was executed against this branch rather than read off the source — including the `=>` / `:=` variants, named `path` (verified `read_parquet`/`read_csv`/`read_json`/`read_deltalake` accept it and that `read_iceberg` does not, so it is excluded from that sentence), path arrays, and struct-literal schemas.

`make docs` builds clean: warning count is identical to `main` (49 pre-existing, none from these pages), the `#table-function-options` anchor resolves, and the cross-page link renders as `../../sql/#table-function-options`.

## Related Issues

None — follow-up documentation for #7130, #7133, and #7264.