### PR TITLE
chore: Ignore Dependabot warnings in benchmarks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
   directory: /
   schedule:
     interval: monthly
+  exclude-paths:
+  - "benchmarking/**"
   groups:
     # Python updates are mainly dev-only, so we can group them together.
     all:


### PR DESCRIPTION
## Changes Made

We want to ignore dependency warnings in the `benchmarking` subfolder because we may want to update the benchmark results as we update dependencies rather than blindly upgrading. Right now this creates a lot of noise on GitHub