### PR TITLE
fix: ls pagination

### DIFF
--- a/src/daft-io/src/azure_blob.rs
+++ b/src/daft-io/src/azure_blob.rs
@@ -734,6 +734,7 @@ impl ObjectSource for AzureBlobSource {
         Ok(LSResult {
             files,
             continuation_token: None,
+            not_found_if_empty: false,
         })
     }
 

--- a/src/daft-io/src/google_cloud.rs
+++ b/src/daft-io/src/google_cloud.rs
@@ -427,31 +427,28 @@ impl GCSClientWrapper {
                 .await?;
             forced_directory_ls_result.not_found_if_empty = !key.is_empty();
 
-            // If no items were obtained, then this is actually a file and we perform a second ls to obtain just the file's
-            // details as the one-and-only-one entry
-            if forced_directory_ls_result.files.is_empty() {
-                let mut file_result = self
-                    .ls_impl(
-                        client,
-                        bucket,
-                        key,
-                        Some(GCS_DELIMITER),
-                        continuation_token,
-                        page_size,
-                        io_stats.as_ref(),
-                    )
-                    .await?;
+            if forced_directory_ls_result.files.is_empty()
+                && continuation_token.is_none()
+                && !key.is_empty()
+            {
+                // get_size() acquires its own connection permit.
+                drop(_permit);
 
-                // Only retain exact matches (since the API does prefix lists by default)
                 let target_path = format!("{GCS_SCHEME}://{bucket}/{key}");
-                file_result.files.retain(|fm| fm.filepath == target_path);
-
-                if file_result.files.is_empty() {
-                    // This page is empty, but the complete paginated directory listing might not be.
-                    Ok(forced_directory_ls_result)
-                } else {
-                    file_result.not_found_if_empty = forced_directory_ls_result.not_found_if_empty;
-                    Ok(file_result)
+                match self.get_size(&target_path, io_stats.clone()).await {
+                    Ok(size) => Ok(LSResult {
+                        files: vec![FileMetadata {
+                            filepath: target_path,
+                            size: Some(size as u64),
+                            filetype: FileType::File,
+                        }],
+                        continuation_token: forced_directory_ls_result.continuation_token,
+                        not_found_if_empty: forced_directory_ls_result.not_found_if_empty,
+                    }),
+                    // Keep the empty directory result. iter_dir will follow
+                    // its token before deciding whether the path is missing.
+                    Err(super::Error::NotFound { .. }) => Ok(forced_directory_ls_result),
+                    Err(error) => Err(error),
                 }
             } else {
                 Ok(forced_directory_ls_result)

--- a/src/daft-io/src/google_cloud.rs
+++ b/src/daft-io/src/google_cloud.rs
@@ -385,6 +385,7 @@ impl GCSClientWrapper {
         Ok(LSResult {
             files: files.chain(dirs).collect(),
             continuation_token: ls_response.next_page_token,
+            not_found_if_empty: false,
         })
     }
 
@@ -413,7 +414,7 @@ impl GCSClientWrapper {
             } else {
                 format!("{}{GCS_DELIMITER}", key.trim_end_matches(GCS_DELIMITER))
             };
-            let forced_directory_ls_result = self
+            let mut forced_directory_ls_result = self
                 .ls_impl(
                     client,
                     bucket,
@@ -424,6 +425,7 @@ impl GCSClientWrapper {
                     io_stats.as_ref(),
                 )
                 .await?;
+            forced_directory_ls_result.not_found_if_empty = !key.is_empty();
 
             // If no items were obtained, then this is actually a file and we perform a second ls to obtain just the file's
             // details as the one-and-only-one entry
@@ -444,15 +446,13 @@ impl GCSClientWrapper {
                 let target_path = format!("{GCS_SCHEME}://{bucket}/{key}");
                 file_result.files.retain(|fm| fm.filepath == target_path);
 
-                // Not dir and not file, so it is missing
                 if file_result.files.is_empty() {
-                    return Err(Error::NotFound {
-                        path: path.to_string(),
-                    }
-                    .into());
+                    // This page is empty, but the complete paginated directory listing might not be.
+                    Ok(forced_directory_ls_result)
+                } else {
+                    file_result.not_found_if_empty = forced_directory_ls_result.not_found_if_empty;
+                    Ok(file_result)
                 }
-
-                Ok(file_result)
             } else {
                 Ok(forced_directory_ls_result)
             }

--- a/src/daft-io/src/http.rs
+++ b/src/daft-io/src/http.rs
@@ -507,6 +507,7 @@ impl ObjectSource for HttpSource {
                 Ok(LSResult {
                     files: file_metadatas,
                     continuation_token: None,
+                    not_found_if_empty: false,
                 })
             }
             // All other forms of content-type is treated as a raw file
@@ -517,6 +518,7 @@ impl ObjectSource for HttpSource {
                     size: response.content_length(),
                 }],
                 continuation_token: None,
+                not_found_if_empty: false,
             }),
         }
     }

--- a/src/daft-io/src/huggingface/mod.rs
+++ b/src/daft-io/src/huggingface/mod.rs
@@ -625,6 +625,7 @@ impl ObjectSource for HFSource {
         Ok(LSResult {
             files,
             continuation_token,
+            not_found_if_empty: false,
         })
     }
 

--- a/src/daft-io/src/local.rs
+++ b/src/daft-io/src/local.rs
@@ -260,6 +260,7 @@ impl ObjectSource for LocalSource {
         Ok(LSResult {
             files,
             continuation_token: None,
+            not_found_if_empty: false,
         })
     }
 

--- a/src/daft-io/src/mock.rs
+++ b/src/daft-io/src/mock.rs
@@ -2,6 +2,7 @@
 mod tests {
     use std::{
         any::Any,
+        collections::VecDeque,
         sync::{Arc, Mutex},
     };
 
@@ -9,10 +10,10 @@ mod tests {
     use async_trait::async_trait;
     use bytes::Bytes;
     use common_file_formats::FileFormat;
-    use futures::{StreamExt, stream::BoxStream};
+    use futures::{StreamExt, TryStreamExt, stream::BoxStream};
 
     use crate::{
-        Error, FileMetadata, GetRange, GetResult, IOStatsRef, ObjectSource, Result,
+        Error, FileMetadata, FileType, GetRange, GetResult, IOStatsRef, ObjectSource, Result,
         object_io::{LSResult, StreamingRetryParams},
     };
 
@@ -37,6 +38,10 @@ mod tests {
         fail_get_remaining: Mutex<usize>,
         // the total received get requests
         requests: Arc<Mutex<Vec<Option<GetRange>>>>,
+        // Predetermined listing pages returned by ls().
+        ls_pages: Mutex<VecDeque<LSResult>>,
+        // The continuation token supplied to each ls() request.
+        ls_requests: Arc<Mutex<Vec<Option<String>>>>,
     }
 
     impl MockSource {
@@ -48,7 +53,14 @@ mod tests {
                 fail_error: MockFailError::UnableToReadBytes,
                 fail_get_remaining: Mutex::new(0),
                 requests: Arc::new(Mutex::new(Vec::new())),
+                ls_pages: Mutex::new(VecDeque::new()),
+                ls_requests: Arc::new(Mutex::new(Vec::new())),
             }
+        }
+
+        fn with_ls_pages(self, pages: Vec<LSResult>) -> Self {
+            *self.ls_pages.lock().unwrap() = pages.into();
+            self
         }
 
         fn with_fail_error(mut self, err: MockFailError) -> Self {
@@ -164,18 +176,113 @@ mod tests {
             &self,
             _path: &str,
             _posix: bool,
-            _continuation_token: Option<&str>,
+            continuation_token: Option<&str>,
             _page_size: Option<i32>,
             _io_stats: Option<IOStatsRef>,
         ) -> Result<LSResult> {
-            Err(Error::NotImplementedSource {
-                store: "mock".to_string(),
+            self.ls_requests
+                .lock()
+                .unwrap()
+                .push(continuation_token.map(str::to_owned));
+
+            let page = self.ls_pages.lock().unwrap().pop_front();
+            page.ok_or_else(|| Error::NotImplementedSource {
+                store: "mock ls page was not configured".to_string(),
             })
         }
 
         fn as_any_arc(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
             self
         }
+    }
+
+    fn mock_ls_result(
+        files: Vec<FileMetadata>,
+        continuation_token: Option<&str>,
+        not_found_if_empty: bool,
+    ) -> LSResult {
+        LSResult {
+            files,
+            continuation_token: continuation_token.map(str::to_owned),
+            not_found_if_empty,
+        }
+    }
+
+    fn mock_file(path: &str) -> FileMetadata {
+        FileMetadata {
+            filepath: path.to_string(),
+            size: Some(10),
+            filetype: FileType::File,
+        }
+    }
+
+    async fn collect_iter_dir(source: &MockSource) -> Result<Vec<FileMetadata>> {
+        let stream = source
+            .iter_dir("mock://bucket/directory", true, None, None)
+            .await?;
+        stream.try_collect().await
+    }
+
+    #[tokio::test]
+    async fn test_iter_dir_follows_token_after_empty_page() {
+        let expected_file = mock_file("mock://bucket/directory/file.parquet");
+        let source = MockSource::new(Vec::new(), 1, None).with_ls_pages(vec![
+            mock_ls_result(Vec::new(), Some("page-2"), true),
+            mock_ls_result(vec![expected_file.clone()], None, true),
+        ]);
+
+        let files = collect_iter_dir(&source).await.unwrap();
+
+        assert_eq!(files, vec![expected_file]);
+        assert_eq!(
+            *source.ls_requests.lock().unwrap(),
+            vec![None, Some("page-2".to_string())]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_iter_dir_remembers_files_from_earlier_pages() {
+        let expected_file = mock_file("mock://bucket/directory/file.parquet");
+        let source = MockSource::new(Vec::new(), 1, None).with_ls_pages(vec![
+            mock_ls_result(vec![expected_file.clone()], Some("page-2"), true),
+            mock_ls_result(Vec::new(), None, true),
+        ]);
+
+        let files = collect_iter_dir(&source).await.unwrap();
+
+        assert_eq!(files, vec![expected_file]);
+    }
+
+    #[tokio::test]
+    async fn test_iter_dir_returns_not_found_after_all_pages_are_empty() {
+        let source = MockSource::new(Vec::new(), 1, None).with_ls_pages(vec![
+            mock_ls_result(Vec::new(), Some("page-2"), true),
+            mock_ls_result(Vec::new(), None, true),
+        ]);
+
+        let result = collect_iter_dir(&source).await;
+
+        assert!(matches!(result, Err(Error::NotFound { .. })));
+        assert_eq!(
+            *source.ls_requests.lock().unwrap(),
+            vec![None, Some("page-2".to_string())]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_iter_dir_allows_empty_result_when_source_policy_allows_it() {
+        let source = MockSource::new(Vec::new(), 1, None).with_ls_pages(vec![
+            mock_ls_result(Vec::new(), Some("page-2"), false),
+            mock_ls_result(Vec::new(), None, false),
+        ]);
+
+        let files = collect_iter_dir(&source).await.unwrap();
+
+        assert!(files.is_empty());
+        assert_eq!(
+            *source.ls_requests.lock().unwrap(),
+            vec![None, Some("page-2".to_string())]
+        );
     }
 
     #[tokio::test]

--- a/src/daft-io/src/object_io.rs
+++ b/src/daft-io/src/object_io.rs
@@ -276,6 +276,8 @@ pub struct FileMetadata {
 pub struct LSResult {
     pub files: Vec<FileMetadata>,
     pub continuation_token: Option<String>,
+    /// Whether an empty result across all pages means that the requested path was not found.
+    pub not_found_if_empty: bool,
 }
 
 use async_stream::stream;
@@ -356,31 +358,33 @@ pub trait ObjectSource: Sync + Send {
         let uri = uri.to_string();
         let s = stream! {
             let lsr = self.ls(&uri, posix, None, page_size, io_stats.clone()).await?;
+            let mut found_any = !lsr.files.is_empty();
+            let not_found_if_empty = lsr.not_found_if_empty;
             for fm in lsr.files {
                 yield Ok(fm);
             }
 
-            let mut continuation_token = lsr.continuation_token.clone();
-            while continuation_token.is_some() {
-                // Note: There might some race conditions here that the list response is empty
-                // even though the continuation token of previous response is not empty, so skip NotFound error here.
-                // TODO(desmond): Ideally we should patch how `ls` produces NotFound errors. See issue #4982
-                let lsr_result = self.ls(&uri, posix, continuation_token.as_deref(), page_size, io_stats.clone()).await;
-                match lsr_result {
-                    Ok(lsr) => {
-                        continuation_token.clone_from(&lsr.continuation_token);
-                        for fm in lsr.files {
-                            yield Ok(fm);
-                        }
-                    },
-                    Err(err) => {
-                        if matches!(err, super::Error::NotFound { .. }) {
-                            continuation_token = None;
-                        } else {
-                            yield Err(err);
-                        }
-                    }
+            let mut continuation_token = lsr.continuation_token;
+            while let Some(token) = continuation_token {
+                let lsr = self
+                    .ls(&uri, posix, Some(&token), page_size, io_stats.clone())
+                    .await?;
+                found_any |= !lsr.files.is_empty();
+                continuation_token = lsr.continuation_token;
+                for fm in lsr.files {
+                    yield Ok(fm);
                 }
+            }
+
+            if !found_any && not_found_if_empty {
+                yield Err(super::Error::NotFound {
+                    path: uri.clone(),
+                    source: std::io::Error::new(
+                        std::io::ErrorKind::NotFound,
+                        "listing returned no files",
+                    )
+                    .into(),
+                });
             }
         };
         Ok(s.boxed())

--- a/src/daft-io/src/opendal_source.rs
+++ b/src/daft-io/src/opendal_source.rs
@@ -296,6 +296,7 @@ impl ObjectSource for OpenDALSource {
             return Ok(LSResult {
                 files: vec![],
                 continuation_token: None,
+                not_found_if_empty: false,
             });
         }
 
@@ -345,6 +346,7 @@ impl ObjectSource for OpenDALSource {
         Ok(LSResult {
             files,
             continuation_token: None,
+            not_found_if_empty: false,
         })
     }
 

--- a/src/daft-io/src/s3_like.rs
+++ b/src/daft-io/src/s3_like.rs
@@ -1029,6 +1029,7 @@ impl S3LikeSource {
                 Ok(LSResult {
                     files,
                     continuation_token,
+                    not_found_if_empty: false,
                 })
             }
             Err(SdkError::ServiceError(err)) => {
@@ -1438,7 +1439,7 @@ impl ObjectSource for S3LikeSource {
             } else {
                 format!("{}{S3_DELIMITER}", key.trim_end_matches(S3_DELIMITER))
             };
-            let lsr = {
+            let mut lsr = {
                 let permit = self
                     .connection_pool_sema
                     .acquire()
@@ -1457,6 +1458,7 @@ impl ObjectSource for S3LikeSource {
                 )
                 .await?
             };
+            lsr.not_found_if_empty = !key.is_empty();
             if let Some(is) = io_stats.as_ref() {
                 is.mark_list_requests(1);
             }
@@ -1469,7 +1471,7 @@ impl ObjectSource for S3LikeSource {
                     .context(UnableToGrabSemaphoreSnafu)?;
                 // Might be a File
                 let key = key.trim_end_matches(S3_DELIMITER);
-                let mut lsr = self
+                let mut file_lsr = self
                     .list_impl(
                         permit,
                         scheme.as_str(),
@@ -1485,13 +1487,15 @@ impl ObjectSource for S3LikeSource {
                     is.mark_list_requests(1);
                 }
                 let target_path = format!("{scheme}://{bucket}/{key}");
-                lsr.files.retain(|f| f.filepath == target_path);
+                file_lsr.files.retain(|f| f.filepath == target_path);
 
-                if lsr.files.is_empty() {
-                    // Isn't a file or a directory
-                    return Err(Error::NotFound { path: path.into() }.into());
+                if file_lsr.files.is_empty() {
+                    // This page is empty, but the complete paginated directory listing might not be.
+                    Ok(lsr)
+                } else {
+                    file_lsr.not_found_if_empty = lsr.not_found_if_empty;
+                    Ok(file_lsr)
                 }
-                Ok(lsr)
             } else {
                 Ok(lsr)
             }

--- a/src/daft-io/src/s3_like.rs
+++ b/src/daft-io/src/s3_like.rs
@@ -1463,38 +1463,30 @@ impl ObjectSource for S3LikeSource {
                 is.mark_list_requests(1);
             }
 
-            if lsr.files.is_empty() && key.contains(S3_DELIMITER) {
-                let permit = self
-                    .connection_pool_sema
-                    .acquire()
-                    .await
-                    .context(UnableToGrabSemaphoreSnafu)?;
-                // Might be a File
-                let key = key.trim_end_matches(S3_DELIMITER);
-                let mut file_lsr = self
-                    .list_impl(
-                        permit,
-                        scheme.as_str(),
-                        bucket.as_str(),
-                        key,
-                        Some(S3_DELIMITER.into()),
-                        continuation_token.map(String::from),
-                        &self.default_region,
-                        page_size,
-                    )
-                    .await?;
-                if let Some(is) = io_stats.as_ref() {
-                    is.mark_list_requests(1);
-                }
-                let target_path = format!("{scheme}://{bucket}/{key}");
-                file_lsr.files.retain(|f| f.filepath == target_path);
+            if lsr.files.is_empty() && continuation_token.is_none() && key.contains(S3_DELIMITER) {
+                // The directory page is empty, so check whether the requested
+                // path is an exact object. HEAD is an exact lookup and has no
+                // pagination token.
+                let exact_key = key.trim_end_matches(S3_DELIMITER);
+                let target_path = format!("{scheme}://{bucket}/{exact_key}");
 
-                if file_lsr.files.is_empty() {
-                    // This page is empty, but the complete paginated directory listing might not be.
-                    Ok(lsr)
-                } else {
-                    file_lsr.not_found_if_empty = lsr.not_found_if_empty;
-                    Ok(file_lsr)
+                match self.get_size(&target_path, io_stats.clone()).await {
+                    Ok(size) => Ok(LSResult {
+                        files: vec![FileMetadata {
+                            filepath: target_path,
+                            size: Some(size as u64),
+                            filetype: FileType::File,
+                        }],
+                        // The outer operation is still walking the directory
+                        // listing, so only its token may leave this function.
+                        continuation_token: lsr.continuation_token,
+                        not_found_if_empty: lsr.not_found_if_empty,
+                    }),
+                    // The exact file does not exist. This is not yet enough to
+                    // conclude that the requested path is missing: later
+                    // directory pages may still contain entries.
+                    Err(super::Error::NotFound { .. }) => Ok(lsr),
+                    Err(error) => Err(error),
                 }
             } else {
                 Ok(lsr)


### PR DESCRIPTION
## Changes Made

S3 and GCS can return an empty page while still providing a continuation token.

This change:

- Makes `iter_dir()` consume all continuation pages before deciding `NotFound`.
- Tracks whether any page contained files.
- Adds an `LSResult` policy for empty complete listings.
- Preserves directory continuation tokens during exact-file fallback.
- Adds tests.

## Related Issues
Closes #4982 
<!-- Link to related GitHub issues, e.g., "Closes #123" -->
