### PR TITLE
feat(extensions): expose foldable literal values to return_field

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2815,7 +2815,7 @@ dependencies = [
 
 [[package]]
 name = "daft-ext"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "arrow-array 56.2.0",
  "arrow-array 57.3.0",
@@ -2851,7 +2851,7 @@ dependencies = [
 
 [[package]]
 name = "daft-ext-macros"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -290,8 +290,8 @@ daft-core = {path = "src/daft-core"}
 daft-groupby = {path = "src/daft-groupby"}
 daft-dsl = {path = "src/daft-dsl"}
 daft-ext-internal = {path = "src/daft-ext-internal"}
-daft-ext-macros = {path = "src/daft-ext-macros", version = "0.1.1"}
-daft-ext = {path = "src/daft-ext", version = "0.1.1"}
+daft-ext-macros = {path = "src/daft-ext-macros", version = "0.2.0"}
+daft-ext = {path = "src/daft-ext", version = "0.2.0"}
 daft-file = {path = "src/daft-file"}
 daft-functions = {path = "src/daft-functions"}
 daft-functions-binary = {path = "src/daft-functions-binary"}

--- a/docs/extensions/authoring.md
+++ b/docs/extensions/authoring.md
@@ -207,16 +207,17 @@ impl DaftScalarFunction for Greet {
     }
 
     /// Type checking.
-    /// Receives input fields as C Data Interface `ArrowSchema` types.
-    /// Use `.as_raw()` / `.into()` to convert between arrow-rs and ABI types.
-    fn return_field(&self, args: &[ArrowSchema]) -> DaftResult<ArrowSchema> {
+    /// Receives one `ArgDescriptor` per argument, carrying that argument's
+    /// field (and its value, when the argument is a foldable constant — see
+    /// [Literal arguments](#literal-arguments)).
+    fn return_field(&self, args: &[ArgDescriptor]) -> DaftResult<ArrowSchema> {
         if args.len() != 1 {
             return Err(DaftError::TypeError(format!(
                 "greet: expected 1 argument, got {}",
                 args.len()
             )));
         }
-        let field = Field::try_from(&args[0])?;
+        let field = Field::try_from(args[0].field())?;
         let dt = field.data_type();
         if *dt != DataType::Utf8 && *dt != DataType::LargeUtf8 {
             return Err(DaftError::TypeError(format!(
@@ -258,6 +259,57 @@ impl DaftScalarFunction for Greet {
     }
 }
 ```
+
+### Literal arguments
+
+`return_field` sees argument *values*, not just their types. When an argument
+folds to a constant during planning — `lit(3)`, or an expression the optimizer
+folded into one — `ArgDescriptor::literal` carries that value as a length-1
+array typed exactly like `ArgDescriptor::field`. Arguments that are plain
+columns carry no literal.
+
+This is what lets an output type depend on an argument's value:
+
+```rust
+/// `splat(value, count)` repeats each value into a `FixedSizeList` whose
+/// width is the *value* of `count`.
+fn return_field(&self, args: &[ArgDescriptor]) -> DaftResult<ArrowSchema> {
+    // `with_literal` gives you an arrow-rs array for the duration of the
+    // closure; it returns `Ok(None)` when the argument is not a constant.
+    let count = with_literal(&args[1], |array| {
+        Ok(array.as_primitive::<Int64Type>().value(0))
+    })?
+    .ok_or_else(|| {
+        DaftError::TypeError("splat: 'count' must be a literal, not a column".into())
+    })?;
+
+    let item = Field::new("item", DataType::Int64, true);
+    export_field(&Field::new(
+        "splat",
+        DataType::FixedSizeList(Arc::new(item), count as i32),
+        true,
+    ))
+}
+```
+
+!!! warning "Descriptors are borrowed"
+
+    The host owns the descriptors and releases them as soon as `return_field`
+    returns. Copy out whatever you need (`count` above is an `i64`); never
+    retain an array that borrows from a descriptor, and never release one
+    yourself.
+
+!!! note "Not every constant is visible"
+
+    A literal is present on a best-effort basis: values with no Arrow
+    representation (Python objects, for instance) arrive as if they were not
+    constant. Treat a missing literal as a plain type-check failure — as in the
+    example above — rather than assuming it can't happen.
+
+`call` still receives every argument as an array, literals included (typically
+as a length-1 column). Daft resolves the return field with the same literals it
+captured during planning, so the output type your `return_field` computed is the
+one execution uses.
 
 !!! tip "ABI pattern"
 
@@ -312,6 +364,8 @@ impl DaftAggregateFunction for MySum {
     }
 
     /// Declare the output type given the input field schemas.
+    /// Aggregates receive bare `ArrowSchema`s — argument descriptors are a
+    /// scalar-function feature today.
     fn return_field(&self, _args: &[ArrowSchema]) -> DaftResult<ArrowSchema> {
         Ok(ArrowSchema::try_from(&Field::new("my_sum", DataType::Int64, true))?)
     }
@@ -500,12 +554,15 @@ Follow the Daft extension authoring guide at docs/extensions/authoring.md. Here 
 - Register aggregate functions via `session.define_aggregate_function(Arc::new(MyAgg))`.
 - Each scalar function is a struct implementing `DaftScalarFunction` with:
   - `name(&self) -> &CStr` — use `c"<extension_name>_<fn_name>"` prefix to avoid collisions.
-  - `return_field(&self, args: &[ArrowSchema]) -> DaftResult<ArrowSchema>` — use `.as_raw()` to
-    borrow as arrow-rs `FFI_ArrowSchema` for type checking, then `.into()` to return output.
+  - `return_field(&self, args: &[ArgDescriptor]) -> DaftResult<ArrowSchema>` — use
+    `import_field(args[i].field())` for type checking, and `with_literal(&args[i], ..)` to read
+    the value of an argument that folds to a constant, then `export_field` to return the output.
   - `call(&self, args: &[ArrowData]) -> DaftResult<ArrowData>` — use `ArrowData::take_arg` then
     `.into()` to convert to arrow-rs FFI types, compute, then `.into()` to return the result.
 - Each aggregate function is a struct implementing `DaftAggregateFunction` with:
-  - `name`, `return_field` — same as scalar functions.
+  - `name` — same as scalar functions.
+  - `return_field(&self, args: &[ArrowSchema]) -> DaftResult<ArrowSchema>` — note that aggregates
+    take bare `ArrowSchema`s, not `ArgDescriptor`s.
   - `state_fields(&self, args: &[ArrowSchema]) -> DaftResult<Vec<ArrowSchema>>` — intermediate state schema.
   - `aggregate(&self, inputs: Vec<ArrowData>) -> DaftResult<Vec<ArrowData>>` — partial aggregation.
   - `combine(&self, states: Vec<ArrowData>) -> DaftResult<Vec<ArrowData>>` — merge partial states.

--- a/docs/extensions/authoring.md
+++ b/docs/extensions/authoring.md
@@ -263,53 +263,61 @@ impl DaftScalarFunction for Greet {
 ### Literal arguments
 
 `return_field` sees argument *values*, not just their types. When an argument
-folds to a constant during planning — `lit(3)`, or an expression the optimizer
-folded into one — `ArgDescriptor::literal` carries that value as a length-1
-array typed exactly like `ArgDescriptor::field`. Arguments that are plain
-columns carry no literal.
+is a literal — `lit(3)`, or `daft.lit(3)` from Python — `ArgDescriptor::literal`
+carries its value as a length-1 array typed exactly like `ArgDescriptor::field`.
+Every other argument carries no literal.
 
-This is what lets an output type depend on an argument's value:
+Read scalars with the typed accessors — `literal_i64`, `literal_u64`,
+`literal_f64`, `literal_bool`, `literal_string`, `literal_binary`. Each returns
+`Ok(None)` when the argument is not a literal (or its value is null), and an
+error when it is a literal of the wrong type:
 
 ```rust
 /// `splat(value, count)` repeats each value into a `FixedSizeList` whose
 /// width is the *value* of `count`.
 fn return_field(&self, args: &[ArgDescriptor]) -> DaftResult<ArrowSchema> {
-    // `with_literal` gives you an arrow-rs array for the duration of the
-    // closure; it returns `Ok(None)` when the argument is not a constant.
-    let count = with_literal(&args[1], |array| {
-        Ok(array.as_primitive::<Int64Type>().value(0))
-    })?
-    .ok_or_else(|| {
+    let value_field = import_field(args[0].field())?;
+
+    let count = literal_i64(&args[1])?.ok_or_else(|| {
         DaftError::TypeError("splat: 'count' must be a literal, not a column".into())
     })?;
 
     let item = Field::new("item", DataType::Int64, true);
     export_field(&Field::new(
-        "splat",
+        value_field.name(),
         DataType::FixedSizeList(Arc::new(item), count as i32),
         true,
     ))
 }
 ```
 
-!!! warning "Descriptors are borrowed"
+For a literal that is not a scalar — a list, a struct — use `with_literal`,
+which hands your closure the arrow-rs array itself. It is `unsafe`: the array
+borrows buffers the host owns only for the duration of `return_field`, so
+nothing derived from it may escape the closure.
 
-    The host owns the descriptors and releases them as soon as `return_field`
-    returns. Copy out whatever you need (`count` above is an `i64`); never
-    retain an array that borrows from a descriptor, and never release one
-    yourself.
+!!! warning "Name the output after your first argument"
 
-!!! note "Not every constant is visible"
+    Daft derives an expression's name from its *first input*, while the column's
+    schema entry comes from `return_field`. Returning a field with some other
+    name makes the two disagree, and projection pushdown will prune the column
+    the query asked for. Echo `import_field(args[0].field())?.name()`, as above
+    and as `#[daft_func]` does.
 
-    A literal is present on a best-effort basis: values with no Arrow
-    representation (Python objects, for instance) arrive as if they were not
-    constant. Treat a missing literal as a plain type-check failure — as in the
-    example above — rather than assuming it can't happen.
+!!! note "Only literals, and only what Arrow can carry"
+
+    An argument is visible as a literal when it is *already* a literal at the
+    point the call is planned. A constant expression that has not been folded
+    (`lit(1) + lit(2)`) is not, and neither is a Python-object literal, which
+    has no representation an extension can plan against. Treat a missing literal
+    as a plain type-check failure — as in the example above — rather than
+    assuming it can't happen.
 
 `call` still receives every argument as an array, literals included (typically
 as a length-1 column). Daft resolves the return field with the same literals it
 captured during planning, so the output type your `return_field` computed is the
-one execution uses.
+one execution uses — but `call` must still derive the same shape from its own
+arguments, so keep that logic shared between the two.
 
 !!! tip "ABI pattern"
 
@@ -555,8 +563,9 @@ Follow the Daft extension authoring guide at docs/extensions/authoring.md. Here 
 - Each scalar function is a struct implementing `DaftScalarFunction` with:
   - `name(&self) -> &CStr` — use `c"<extension_name>_<fn_name>"` prefix to avoid collisions.
   - `return_field(&self, args: &[ArgDescriptor]) -> DaftResult<ArrowSchema>` — use
-    `import_field(args[i].field())` for type checking, and `with_literal(&args[i], ..)` to read
-    the value of an argument that folds to a constant, then `export_field` to return the output.
+    `import_field(args[i].field())` for type checking, and `literal_i64(&args[i])` (or
+    `literal_string` / `literal_f64` / ...) to read the value of a literal argument, then
+    `export_field` to return the output. Name the output field after `args[0]`'s field.
   - `call(&self, args: &[ArrowData]) -> DaftResult<ArrowData>` — use `ArrowData::take_arg` then
     `.into()` to convert to arrow-rs FFI types, compute, then `.into()` to return the result.
 - Each aggregate function is a struct implementing `DaftAggregateFunction` with:

--- a/examples/hello/hello/__init__.py
+++ b/examples/hello/hello/__init__.py
@@ -13,6 +13,15 @@ def greet(name: Expression) -> Expression:
     return daft.get_function("greet", name)
 
 
+def splat(value: Expression, count: int) -> Expression:
+    """Repeat each value into a fixed-size list of length `count`.
+
+    `count` must be a literal: the output type's width is resolved during
+    planning from the literal's value.
+    """
+    return daft.get_function("splat", value, daft.lit(count))
+
+
 def string_count(name: Expression) -> Expression:
     """Count non-null strings."""
     return daft.get_aggregate_function("string_count", name)

--- a/examples/hello/src/lib.rs
+++ b/examples/hello/src/lib.rs
@@ -1,6 +1,9 @@
 use std::{ffi::CStr, sync::Arc};
 
-use arrow_array::{Array, ArrayRef};
+use arrow_array::{
+    Array, ArrayRef, Int64Array,
+    builder::{FixedSizeListBuilder, Int64Builder},
+};
 use arrow_schema::{DataType, Field};
 use daft_ext::{daft_extension, prelude::*};
 
@@ -12,6 +15,7 @@ struct HelloExtension;
 impl DaftExtension for HelloExtension {
     fn install(session: &mut dyn DaftSession) {
         session.define_function(Arc::new(Greet));
+        session.define_function(Arc::new(Splat));
         session.define_aggregate_function(Arc::new(StringCount));
     }
 }
@@ -21,6 +25,108 @@ impl DaftExtension for HelloExtension {
 #[daft_func]
 fn greet(name: &str) -> String {
     format!("Hello, {}!", name)
+}
+
+// ── Scalar Function with a value-dependent output type ─────────────
+
+/// The most one call may produce, so a typo in a query can't ask for a
+/// terabyte-wide column.
+const SPLAT_MAX_COUNT: i64 = 1 << 20;
+
+/// `splat(value, count)` repeats each value into a `FixedSizeList` of length
+/// `count`. The *width of the output type* comes from the value of `count`,
+/// which is only knowable because planning hands us foldable literals.
+struct Splat;
+
+impl DaftScalarFunction for Splat {
+    fn name(&self) -> &CStr {
+        c"splat"
+    }
+
+    fn return_field(&self, args: &[ArgDescriptor]) -> DaftResult<ArrowSchema> {
+        if args.len() != 2 {
+            return Err(DaftError::TypeError(format!(
+                "splat: expected 2 arguments, got {}",
+                args.len()
+            )));
+        }
+
+        let value_field = import_field(args[0].field())?;
+        if *value_field.data_type() != DataType::Int64 {
+            return Err(DaftError::TypeError(format!(
+                "splat: expected an Int64 first argument, got {:?}",
+                value_field.data_type()
+            )));
+        }
+
+        // `count` is only present when the argument folds to a constant; a
+        // column here is a planning error, not a runtime one.
+        let count = with_literal(&args[1], read_count)?.ok_or_else(|| {
+            DaftError::TypeError("splat: 'count' must be a literal, not a column".to_string())
+        })?;
+
+        let item = Field::new("item", DataType::Int64, true);
+        export_field(&Field::new(
+            "splat",
+            DataType::FixedSizeList(Arc::new(item), count as i32),
+            true,
+        ))
+    }
+
+    fn call(&self, args: Vec<ArrowData>) -> DaftResult<ArrowData> {
+        if args.len() != 2 {
+            return Err(DaftError::TypeError(format!(
+                "splat: expected 2 arguments in call, got {}",
+                args.len()
+            )));
+        }
+        let mut args = args.into_iter();
+        let values = import_array(args.next().expect("checked above"))?;
+        let counts = import_array(args.next().expect("checked above"))?;
+
+        let values = downcast_i64(&values, "value")?;
+        let count = read_count(&counts)?;
+
+        let mut builder =
+            FixedSizeListBuilder::new(Int64Builder::new(), count as i32).with_field(Arc::new(
+                Field::new("item", DataType::Int64, true),
+            ));
+        for i in 0..values.len() {
+            let value = (!values.is_null(i)).then(|| values.value(i));
+            for _ in 0..count {
+                builder.values().append_option(value);
+            }
+            builder.append(value.is_some());
+        }
+
+        export_array(Arc::new(builder.finish()), "splat")
+    }
+}
+
+fn downcast_i64<'a>(array: &'a ArrayRef, what: &str) -> DaftResult<&'a Int64Array> {
+    array.as_any().downcast_ref::<Int64Array>().ok_or_else(|| {
+        DaftError::TypeError(format!(
+            "splat: expected an Int64 {what}, got {:?}",
+            array.data_type()
+        ))
+    })
+}
+
+/// Read and validate the repeat count from a length-1 array.
+fn read_count(array: &ArrayRef) -> DaftResult<i64> {
+    let counts = downcast_i64(array, "count")?;
+    if counts.is_empty() || counts.is_null(0) {
+        return Err(DaftError::TypeError(
+            "splat: 'count' must not be null".to_string(),
+        ));
+    }
+    let count = counts.value(0);
+    if count <= 0 || count > SPLAT_MAX_COUNT {
+        return Err(DaftError::TypeError(format!(
+            "splat: 'count' must be between 1 and {SPLAT_MAX_COUNT}, got {count}"
+        )));
+    }
+    Ok(count)
 }
 
 // ── Aggregate Function ─────────────────────────────────────────────

--- a/examples/hello/src/lib.rs
+++ b/examples/hello/src/lib.rs
@@ -59,38 +59,54 @@ impl DaftScalarFunction for Splat {
             )));
         }
 
-        // `count` is only present when the argument folds to a constant; a
-        // column here is a planning error, not a runtime one.
-        let count = with_literal(&args[1], read_count)?.ok_or_else(|| {
+        // `count` is only present when the argument is a literal; a column here
+        // is a planning error, not a runtime one.
+        let count = validate_count(literal_i64(&args[1])?.ok_or_else(|| {
             DaftError::TypeError("splat: 'count' must be a literal, not a column".to_string())
-        })?;
+        })?)?;
 
         let item = Field::new("item", DataType::Int64, true);
+        // Name the output after the first argument, per the convention in the
+        // authoring guide — Daft derives an expression's name from its first
+        // input, and a different name here breaks projection pushdown.
         export_field(&Field::new(
-            "splat",
+            value_field.name(),
             DataType::FixedSizeList(Arc::new(item), count as i32),
             true,
         ))
     }
 
-    fn call(&self, args: Vec<ArrowData>) -> DaftResult<ArrowData> {
+    fn call(&self, mut args: Vec<ArrowData>) -> DaftResult<ArrowData> {
         if args.len() != 2 {
+            // The host handed us ownership of these; release them rather than
+            // leaking on the way out.
+            for arg in &mut args {
+                unsafe { arg.release() };
+            }
             return Err(DaftError::TypeError(format!(
                 "splat: expected 2 arguments in call, got {}",
                 args.len()
             )));
         }
         let mut args = args.into_iter();
-        let values = import_array(args.next().expect("checked above"))?;
-        let counts = import_array(args.next().expect("checked above"))?;
+        let values_data = args.next().expect("checked above");
+        let counts_data = args.next().expect("checked above");
+
+        let name = import_field(&values_data.schema)?.name().clone();
+        let values = import_array(values_data)?;
+        let counts = import_array(counts_data)?;
 
         let values = downcast_i64(&values, "value")?;
-        let count = read_count(&counts)?;
-
-        let mut builder =
-            FixedSizeListBuilder::new(Int64Builder::new(), count as i32).with_field(Arc::new(
-                Field::new("item", DataType::Int64, true),
+        let counts = downcast_i64(&counts, "count")?;
+        if counts.is_empty() || counts.is_null(0) {
+            return Err(DaftError::TypeError(
+                "splat: 'count' must not be null".to_string(),
             ));
+        }
+        let count = validate_count(counts.value(0))?;
+
+        let mut builder = FixedSizeListBuilder::new(Int64Builder::new(), count as i32)
+            .with_field(Arc::new(Field::new("item", DataType::Int64, true)));
         for i in 0..values.len() {
             let value = (!values.is_null(i)).then(|| values.value(i));
             for _ in 0..count {
@@ -99,7 +115,7 @@ impl DaftScalarFunction for Splat {
             builder.append(value.is_some());
         }
 
-        export_array(Arc::new(builder.finish()), "splat")
+        export_array(Arc::new(builder.finish()), &name)
     }
 }
 
@@ -112,15 +128,8 @@ fn downcast_i64<'a>(array: &'a ArrayRef, what: &str) -> DaftResult<&'a Int64Arra
     })
 }
 
-/// Read and validate the repeat count from a length-1 array.
-fn read_count(array: &ArrayRef) -> DaftResult<i64> {
-    let counts = downcast_i64(array, "count")?;
-    if counts.is_empty() || counts.is_null(0) {
-        return Err(DaftError::TypeError(
-            "splat: 'count' must not be null".to_string(),
-        ));
-    }
-    let count = counts.value(0);
+/// `return_field` and `call` must agree on the width, so they share this.
+fn validate_count(count: i64) -> DaftResult<i64> {
     if count <= 0 || count > SPLAT_MAX_COUNT {
         return Err(DaftError::TypeError(format!(
             "splat: 'count' must be between 1 and {SPLAT_MAX_COUNT}, got {count}"

--- a/examples/hello/tests/test_hello.py
+++ b/examples/hello/tests/test_hello.py
@@ -18,7 +18,8 @@ def test_greet():
     with sess:
         result = df.select(greet(col("name"))).collect().to_pydict()
 
-    values = result["greet"]
+    # `#[daft_func]` names the output after the first argument's field.
+    values = result["name"]
     assert values[0] == "Hello, John!"
     assert values[1] == "Hello, Paul!"
 
@@ -32,7 +33,7 @@ def test_greet_null():
     with sess:
         result = df.select(greet(col("name"))).collect().to_pydict()
 
-    values = result["greet"]
+    values = result["name"]
     assert values[0] == "Hello, George!"
     assert values[1] == "Hello, Ringo!"
     assert values[2] is None
@@ -65,11 +66,12 @@ def test_splat_width_comes_from_literal():
 
     with sess:
         df = df.select(splat(col("x"), 3))
+        # The output is named after the first argument (SDK convention).
         expected = daft.DataType.fixed_size_list(daft.DataType.int64(), 3)
-        assert df.schema()["splat"].dtype == expected
+        assert df.schema()["x"].dtype == expected
         result = df.collect().to_pydict()
 
-    assert result["splat"] == [[1, 1, 1], [2, 2, 2], None]
+    assert result["x"] == [[1, 1, 1], [2, 2, 2], None]
 
 
 def test_splat_requires_a_literal_count():

--- a/examples/hello/tests/test_hello.py
+++ b/examples/hello/tests/test_hello.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import hello
 import pytest
-from hello import greet, string_count
+from hello import greet, splat, string_count
 
 import daft
 from daft import col
@@ -55,6 +55,32 @@ def test_greet_show(capsys):
     assert "Hello, Paul!" in captured
     # Print it so the test runner shows the formatted table
     print(captured)
+
+
+def test_splat_width_comes_from_literal():
+    sess = Session()
+    sess.load_extension(hello)
+
+    df = daft.from_pydict({"x": [1, 2, None]})
+
+    with sess:
+        df = df.select(splat(col("x"), 3))
+        expected = daft.DataType.fixed_size_list(daft.DataType.int64(), 3)
+        assert df.schema()["splat"].dtype == expected
+        result = df.collect().to_pydict()
+
+    assert result["splat"] == [[1, 1, 1], [2, 2, 2], None]
+
+
+def test_splat_requires_a_literal_count():
+    sess = Session()
+    sess.load_extension(hello)
+
+    df = daft.from_pydict({"x": [1, 2, 3], "k": [3, 3, 3]})
+
+    with sess:
+        with pytest.raises(Exception, match="must be a literal"):
+            df.select(daft.get_function("splat", col("x"), col("k"))).schema()
 
 
 def test_string_count():

--- a/examples/hello_cpp/src/hello_cpp.cpp
+++ b/examples/hello_cpp/src/hello_cpp.cpp
@@ -9,12 +9,20 @@
 
 // ── Daft ABI (must match daft-ext repr(C) layouts) ─────────────────
 
-static constexpr uint32_t DAFT_ABI_VERSION = 1;
+static constexpr uint32_t DAFT_ABI_VERSION = 2;
+
+// Planning-time description of one argument: its field, plus its value when the
+// argument folds to a constant. `literal.release == nullptr` means "not a
+// foldable constant". The host owns both members for the duration of the call.
+struct ArgDescriptor {
+    ArrowSchema field;
+    ArrowArray literal;
+};
 
 struct FFI_ScalarFunction {
     const void *ctx;
     const char *(*name)(const void *ctx);
-    int (*get_return_field)(const void *ctx, const ArrowSchema *args, size_t args_count,
+    int (*get_return_field)(const void *ctx, const ArgDescriptor *args, size_t args_count,
                             ArrowSchema *ret, char **errmsg);
     int (*call)(const void *ctx, const ArrowArray *args, const ArrowSchema *args_schemas,
                 size_t args_count, ArrowArray *ret_array, ArrowSchema *ret_schema, char **errmsg);
@@ -43,14 +51,14 @@ static void module_free_string(char *s) { free(s); }
 
 static const char *greet_name(const void *) { return "greet_cpp"; }
 
-static int greet_get_return_field(const void *, const ArrowSchema *args, size_t args_count,
+static int greet_get_return_field(const void *, const ArgDescriptor *args, size_t args_count,
                                   ArrowSchema *ret, char **errmsg) {
     if (args_count != 1) {
         *errmsg = alloc_error("greet_cpp: expected 1 argument, got " + std::to_string(args_count));
         return 1;
     }
 
-    const char *fmt = args[0].format;
+    const char *fmt = args[0].field.format;
     if (strcmp(fmt, "u") != 0 && strcmp(fmt, "U") != 0) {
         *errmsg = alloc_error(std::string("greet_cpp: expected string argument, got format '") +
                               fmt + "'");

--- a/src/daft-ext-internal/src/aggregate.rs
+++ b/src/daft-ext-internal/src/aggregate.rs
@@ -173,6 +173,16 @@ impl AggregateFunctionHandle {
     }
 }
 
+/// Release schemas the host exported for a planning call.
+///
+/// `get_return_field` / `get_state_schema` only borrow their arguments, and
+/// [`ArrowSchema`] has no `Drop` impl, so the host must release them itself.
+fn release_schemas(schemas: &mut [ArrowSchema]) {
+    for schema in schemas {
+        unsafe { schema.release() };
+    }
+}
+
 #[typetag::serde(name = "AggregateFunctionHandle")]
 impl AggFn for AggregateFunctionHandle {
     fn name(&self) -> &str {
@@ -187,7 +197,7 @@ impl AggFn for AggregateFunctionHandle {
             .enumerate()
             .map(|(i, dt)| Field::new(format!("arg{i}"), dt.clone()))
             .collect();
-        let ffi_schemas = Self::fields_to_ffi_schemas(&fields)?;
+        let mut ffi_schemas = Self::fields_to_ffi_schemas(&fields)?;
 
         let mut ret_schema = ArrowSchema::empty();
         let mut errmsg: *mut c_char = std::ptr::null_mut();
@@ -200,6 +210,7 @@ impl AggFn for AggregateFunctionHandle {
                 &raw mut errmsg,
             )
         };
+        release_schemas(&mut ffi_schemas);
         inner.check(rc, errmsg, "error in extension get_return_field")?;
 
         let field = Self::ffi_schema_to_field(ret_schema)?;
@@ -208,7 +219,7 @@ impl AggFn for AggregateFunctionHandle {
 
     fn state_fields(&self, inputs: &[Field]) -> DaftResult<Vec<Field>> {
         let inner = self.inner()?;
-        let ffi_schemas = Self::fields_to_ffi_schemas(inputs)?;
+        let mut ffi_schemas = Self::fields_to_ffi_schemas(inputs)?;
 
         let mut ret_schema = ArrowSchema::empty();
         let mut errmsg: *mut c_char = std::ptr::null_mut();
@@ -221,6 +232,7 @@ impl AggFn for AggregateFunctionHandle {
                 &raw mut errmsg,
             )
         };
+        release_schemas(&mut ffi_schemas);
         inner.check(rc, errmsg, "error in extension get_state_schema")?;
 
         let mut children = unsafe { ret_schema.take_struct_children() };

--- a/src/daft-ext-internal/src/function.rs
+++ b/src/daft-ext-internal/src/function.rs
@@ -1,7 +1,7 @@
 use std::{
     ffi::{CStr, c_char},
     path::PathBuf,
-    sync::Arc,
+    sync::{Arc, OnceLock},
 };
 
 use common_error::{DaftError, DaftResult};
@@ -27,11 +27,17 @@ fn export_field(field: &Field) -> DaftResult<ArrowSchema> {
 
 /// Materialize a literal as a length-1 array of `dtype`, for the ABI.
 ///
-/// Returns `None` when the literal has no Arrow representation (Python objects,
-/// for instance) or cannot be represented as `dtype`. Extensions see that as
-/// "this argument is not a foldable constant", which is always a safe answer —
-/// planning must never fail because a value could not be described.
+/// Returns `None` when the literal has no meaningful Arrow representation or
+/// cannot be represented as `dtype`. Extensions see that as "this argument is
+/// not a constant", which is always a safe answer — planning must never fail
+/// because a value could not be described.
 fn export_literal(literal: &Literal, dtype: &DataType) -> Option<ArrowArray> {
+    // Python objects only cross the ABI as pickled bytes, which is not something
+    // an extension can plan against — and pickling would take the GIL here.
+    if dtype.is_python() {
+        return None;
+    }
+
     let series = Series::from_literals(vec![literal.clone()]).ok()?;
     // Literal types are lossy (`FixedSizeList` round-trips as `List`, and so
     // on), so restore the argument's declared type: extensions read the literal
@@ -115,6 +121,12 @@ pub struct ScalarFunctionHandle {
     /// `get_return_field` and `call` so that planning and execution always agree
     /// on the output field, even though `call` only ever sees arrays.
     literals: Arc<[Option<Literal>]>,
+    /// Memoized `(argument fields, return field)` for this call site.
+    ///
+    /// A call site's argument fields don't change between batches, so this turns
+    /// what would be an FFI round trip plus a literal materialization per batch
+    /// into one per plan.
+    return_field_cache: Arc<OnceLock<(Vec<Field>, Field)>>,
     inner: Option<Arc<Inner>>,
 }
 
@@ -134,6 +146,7 @@ impl ScalarFunctionHandle {
             name,
             module_path,
             literals: Arc::from([]),
+            return_field_cache: Arc::default(),
             inner: Some(Arc::new(Inner { ffi, module })),
         }
     }
@@ -180,6 +193,23 @@ impl ScalarFunctionHandle {
         Ok(descriptors)
     }
 
+    /// Resolve the return field for the given argument fields, going through
+    /// the module only the first time a given argument list is seen.
+    fn resolved_return_field(&self, fields: &[Field]) -> DaftResult<Field> {
+        if let Some((cached_fields, ret)) = self.return_field_cache.get()
+            && cached_fields == fields
+        {
+            return Ok(ret.clone());
+        }
+
+        let ret = self.ffi_return_field(fields)?;
+        // A miss on an already-populated cache means this handle was reused with
+        // a different argument list; recomputing every time is correct, just
+        // slower, so ignore the `set` failure.
+        let _ = self.return_field_cache.set((fields.to_vec(), ret.clone()));
+        Ok(ret)
+    }
+
     /// Invoke the module's `get_return_field` for the given argument fields.
     fn ffi_return_field(&self, fields: &[Field]) -> DaftResult<Field> {
         let inner = self.inner()?;
@@ -197,7 +227,14 @@ impl ScalarFunctionHandle {
             )
         };
         release_descriptors(&mut descriptors);
-        inner.check(rc, errmsg, "unknown error in extension get_return_field")?;
+        if rc != 0 {
+            // A well-behaved module leaves `ret` untouched on failure, but a
+            // buggy one may have written to it; don't leak what it wrote.
+            unsafe { ret_schema.release() };
+            return Err(inner
+                .check(rc, errmsg, "unknown error in extension get_return_field")
+                .expect_err("rc is non-zero"));
+        }
 
         let ffi_schema: arrow::ffi::FFI_ArrowSchema = unsafe { ret_schema.into_owned() };
         let arrow_field = arrow_schema::Field::try_from(&ffi_schema)
@@ -219,7 +256,7 @@ impl ScalarUDF for ScalarFunctionHandle {
             .map(|expr| expr.to_field(schema))
             .collect::<DaftResult<_>>()?;
 
-        self.ffi_return_field(&fields)
+        self.resolved_return_field(&fields)
     }
 
     fn call(&self, args: FunctionArgs<Series>, _ctx: &EvalContext) -> DaftResult<Series> {
@@ -233,7 +270,7 @@ impl ScalarUDF for ScalarFunctionHandle {
         // the arguments: ownership of those transfers to the module, so an
         // early return after exporting them would leak.
         let arg_fields: Vec<Field> = series_vec.iter().map(|s| s.field().clone()).collect();
-        let ret_daft_field = self.ffi_return_field(&arg_fields)?;
+        let ret_daft_field = self.resolved_return_field(&arg_fields)?;
 
         let mut ffi_arrays: Vec<ArrowArray> = Vec::with_capacity(series_vec.len());
         let mut ffi_schemas: Vec<ArrowSchema> = Vec::with_capacity(series_vec.len());
@@ -321,6 +358,7 @@ impl<'de> Deserialize<'de> for ScalarFunctionHandle {
         {
             return Ok(Self {
                 literals,
+                return_field_cache: Arc::default(),
                 ..existing
             });
         }
@@ -333,6 +371,7 @@ impl<'de> Deserialize<'de> for ScalarFunctionHandle {
             name,
             module_path: h.module_path,
             literals,
+            return_field_cache: Arc::default(),
             inner: None,
         })
     }
@@ -359,6 +398,7 @@ impl ScalarFunctionFactory for ScalarFunctionHandle {
 
         Ok(BuiltinScalarFnVariant::Sync(Arc::new(Self {
             literals,
+            return_field_cache: Arc::default(),
             ..self.clone()
         })))
     }
@@ -924,7 +964,7 @@ mod tests {
         // Driver: a planned call site carrying a captured literal.
         let planned = ScalarFunctionHandle {
             literals: Arc::from([None, Some(Literal::Int64(7))]),
-            ..registry_entry.clone()
+            ..registry_entry
         };
         let json = serde_json::to_string(&planned).unwrap();
 

--- a/src/daft-ext-internal/src/function.rs
+++ b/src/daft-ext-internal/src/function.rs
@@ -12,10 +12,52 @@ use daft_dsl::{
         BuiltinScalarFnVariant, FunctionArgs, ScalarFunctionFactory, ScalarUDF, scalar::EvalContext,
     },
 };
-use daft_ext::abi::{ArrowArray, ArrowSchema, FFI_ScalarFunction};
+use daft_ext::abi::{ArgDescriptor, ArrowArray, ArrowSchema, FFI_ScalarFunction};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::module::ModuleHandle;
+
+/// Export a daft [`Field`] as a C Data Interface schema.
+fn export_field(field: &Field) -> DaftResult<ArrowSchema> {
+    let arrow_field = field.to_arrow()?;
+    let ffi = arrow::ffi::FFI_ArrowSchema::try_from(&arrow_field)
+        .map_err(|e| DaftError::InternalError(format!("schema export failed: {e}")))?;
+    Ok(unsafe { ArrowSchema::from_owned(ffi) })
+}
+
+/// Materialize a literal as a length-1 array of `dtype`, for the ABI.
+///
+/// Returns `None` when the literal has no Arrow representation (Python objects,
+/// for instance) or cannot be represented as `dtype`. Extensions see that as
+/// "this argument is not a foldable constant", which is always a safe answer —
+/// planning must never fail because a value could not be described.
+fn export_literal(literal: &Literal, dtype: &DataType) -> Option<ArrowArray> {
+    let series = Series::from_literals(vec![literal.clone()]).ok()?;
+    // Literal types are lossy (`FixedSizeList` round-trips as `List`, and so
+    // on), so restore the argument's declared type: extensions read the literal
+    // through the descriptor's field.
+    let series = if series.data_type() == dtype {
+        series
+    } else {
+        series.cast(dtype).ok()?
+    };
+    let array = series.to_arrow().ok()?;
+    let mut data = array.to_data();
+    data.align_buffers();
+    let ffi = arrow::ffi::FFI_ArrowArray::new(&data);
+    Some(unsafe { ArrowArray::from_owned(ffi) })
+}
+
+/// Release every descriptor in `descriptors`.
+///
+/// The host owns the descriptors it passes to `get_return_field`; extensions
+/// only borrow them. Neither [`ArrowSchema`] nor [`ArrowArray`] has a `Drop`
+/// impl, so dropping the `Vec` without this would leak.
+fn release_descriptors(descriptors: &mut [ArgDescriptor]) {
+    for descriptor in descriptors {
+        unsafe { descriptor.release() };
+    }
+}
 
 /// Bundles an `FFI_ScalarFunction` vtable with its parent `ModuleHandle`.
 ///
@@ -66,6 +108,13 @@ unsafe impl Sync for Inner {}
 pub struct ScalarFunctionHandle {
     name: &'static str,
     module_path: Option<PathBuf>,
+    /// Values of the arguments that folded to constants when this call site was
+    /// planned, positionally; `None` where the argument is not a constant.
+    ///
+    /// Captured once in [`ScalarFunctionFactory::get_function`] and used by both
+    /// `get_return_field` and `call` so that planning and execution always agree
+    /// on the output field, even though `call` only ever sees arrays.
+    literals: Arc<[Option<Literal>]>,
     inner: Option<Arc<Inner>>,
 }
 
@@ -84,6 +133,7 @@ impl ScalarFunctionHandle {
         Self {
             name,
             module_path,
+            literals: Arc::from([]),
             inner: Some(Arc::new(Inner { ffi, module })),
         }
     }
@@ -94,6 +144,66 @@ impl ScalarFunctionHandle {
             DaftError::InternalError(format!("extension function '{}' is not loaded", self.name,))
         })
     }
+
+    /// The literal captured for argument `index`, if any.
+    ///
+    /// Falls back to "no literal" when the arity does not match what was
+    /// captured — a handle can be built for one argument list and reused with
+    /// another (SQL registration, for one), and a positional mismatch must not
+    /// hand an extension the wrong value.
+    fn literal_at(&self, index: usize, arity: usize) -> Option<&Literal> {
+        if self.literals.len() != arity {
+            return None;
+        }
+        self.literals[index].as_ref()
+    }
+
+    /// Build the argument descriptors passed to the module's `get_return_field`.
+    ///
+    /// The caller owns the result and must pass it to [`release_descriptors`].
+    fn build_descriptors(&self, fields: &[Field]) -> DaftResult<Vec<ArgDescriptor>> {
+        let mut descriptors = Vec::with_capacity(fields.len());
+        for (i, field) in fields.iter().enumerate() {
+            let schema = match export_field(field) {
+                Ok(schema) => schema,
+                Err(e) => {
+                    // Don't leak the descriptors already built.
+                    release_descriptors(&mut descriptors);
+                    return Err(e);
+                }
+            };
+            let literal = self
+                .literal_at(i, fields.len())
+                .and_then(|literal| export_literal(literal, &field.dtype));
+            descriptors.push(ArgDescriptor::new(schema, literal));
+        }
+        Ok(descriptors)
+    }
+
+    /// Invoke the module's `get_return_field` for the given argument fields.
+    fn ffi_return_field(&self, fields: &[Field]) -> DaftResult<Field> {
+        let inner = self.inner()?;
+        let mut descriptors = self.build_descriptors(fields)?;
+
+        let mut ret_schema = ArrowSchema::empty();
+        let mut errmsg: *mut c_char = std::ptr::null_mut();
+        let rc = unsafe {
+            (inner.ffi.get_return_field)(
+                inner.ffi.ctx,
+                descriptors.as_ptr(),
+                descriptors.len(),
+                &raw mut ret_schema,
+                &raw mut errmsg,
+            )
+        };
+        release_descriptors(&mut descriptors);
+        inner.check(rc, errmsg, "unknown error in extension get_return_field")?;
+
+        let ffi_schema: arrow::ffi::FFI_ArrowSchema = unsafe { ret_schema.into_owned() };
+        let arrow_field = arrow_schema::Field::try_from(&ffi_schema)
+            .map_err(|e| DaftError::InternalError(format!("schema import failed: {e}")))?;
+        Field::try_from(&arrow_field)
+    }
 }
 
 #[typetag::serde]
@@ -103,47 +213,27 @@ impl ScalarUDF for ScalarFunctionHandle {
     }
 
     fn get_return_field(&self, args: FunctionArgs<ExprRef>, schema: &Schema) -> DaftResult<Field> {
-        let inner = self.inner()?;
-
-        let arrow_fields: Vec<arrow_schema::Field> = args
+        let fields: Vec<Field> = args
             .into_inner()
             .into_iter()
-            .map(|expr| expr.to_field(schema)?.to_arrow())
+            .map(|expr| expr.to_field(schema))
             .collect::<DaftResult<_>>()?;
 
-        let ffi_schemas: Vec<ArrowSchema> = arrow_fields
-            .iter()
-            .map(|f| {
-                let ffi = arrow::ffi::FFI_ArrowSchema::try_from(f)
-                    .map_err(|e| DaftError::InternalError(format!("schema export failed: {e}")))?;
-                Ok(unsafe { ArrowSchema::from_owned(ffi) })
-            })
-            .collect::<DaftResult<_>>()?;
-
-        let mut ret_schema = ArrowSchema::empty();
-        let mut errmsg: *mut c_char = std::ptr::null_mut();
-
-        let rc = unsafe {
-            (inner.ffi.get_return_field)(
-                inner.ffi.ctx,
-                ffi_schemas.as_ptr(),
-                ffi_schemas.len(),
-                &raw mut ret_schema,
-                &raw mut errmsg,
-            )
-        };
-        inner.check(rc, errmsg, "unknown error in extension get_return_field")?;
-
-        let ffi_schema: arrow::ffi::FFI_ArrowSchema = unsafe { ret_schema.into_owned() };
-        let arrow_field = arrow_schema::Field::try_from(&ffi_schema)
-            .map_err(|e| DaftError::InternalError(format!("schema import failed: {e}")))?;
-
-        Field::try_from(&arrow_field)
+        self.ffi_return_field(&fields)
     }
 
     fn call(&self, args: FunctionArgs<Series>, _ctx: &EvalContext) -> DaftResult<Series> {
         let inner = self.inner()?;
         let series_vec: Vec<Series> = args.into_inner();
+
+        // Get expected return field via get_return_field (the call FFI only
+        // returns a bare array whose schema has an empty field name). The
+        // descriptors carry the literals captured at planning time, so this
+        // resolves to the same field the planner saw. Do this before exporting
+        // the arguments: ownership of those transfers to the module, so an
+        // early return after exporting them would leak.
+        let arg_fields: Vec<Field> = series_vec.iter().map(|s| s.field().clone()).collect();
+        let ret_daft_field = self.ffi_return_field(&arg_fields)?;
 
         let mut ffi_arrays: Vec<ArrowArray> = Vec::with_capacity(series_vec.len());
         let mut ffi_schemas: Vec<ArrowSchema> = Vec::with_capacity(series_vec.len());
@@ -159,31 +249,6 @@ impl ScalarUDF for ScalarFunctionHandle {
             ffi_arrays.push(unsafe { ArrowArray::from_owned(ffi_array) });
             ffi_schemas.push(unsafe { ArrowSchema::from_owned(ffi_schema) });
         }
-
-        // Get expected return field via get_return_field (the call FFI only
-        // returns a bare array whose schema has an empty field name).
-        let mut ret_field_schema = ArrowSchema::empty();
-        let mut field_errmsg: *mut c_char = std::ptr::null_mut();
-        let field_rc = unsafe {
-            (inner.ffi.get_return_field)(
-                inner.ffi.ctx,
-                ffi_schemas.as_ptr(),
-                ffi_schemas.len(),
-                &raw mut ret_field_schema,
-                &raw mut field_errmsg,
-            )
-        };
-        inner.check(
-            field_rc,
-            field_errmsg,
-            "error in extension get_return_field",
-        )?;
-
-        let ffi_field_schema: arrow::ffi::FFI_ArrowSchema =
-            unsafe { ret_field_schema.into_owned() };
-        let ret_arrow_field = arrow_schema::Field::try_from(&ffi_field_schema)
-            .map_err(|e| DaftError::InternalError(format!("schema import failed: {e}")))?;
-        let ret_daft_field = Field::try_from(&ret_arrow_field)?;
 
         // Execute the function.
         let mut ret_array = ArrowArray::empty();
@@ -220,9 +285,12 @@ impl ScalarUDF for ScalarFunctionHandle {
 impl Serialize for ScalarFunctionHandle {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         use serde::ser::SerializeStruct;
-        let mut s = serializer.serialize_struct("ScalarFunctionHandle", 2)?;
+        let mut s = serializer.serialize_struct("ScalarFunctionHandle", 3)?;
         s.serialize_field("name", self.name)?;
         s.serialize_field("module_path", &self.module_path)?;
+        // Carried to the worker so it resolves the same return field as the
+        // driver did.
+        s.serialize_field("literals", self.literals.as_ref())?;
         s.end()
     }
 }
@@ -237,16 +305,24 @@ impl<'de> Deserialize<'de> for ScalarFunctionHandle {
             // predate this field.
             #[serde(default)]
             module_path: Option<PathBuf>,
+            #[serde(default)]
+            literals: Vec<Option<Literal>>,
         }
         let h = Helper::deserialize(deserializer)?;
+        let literals: Arc<[Option<Literal>]> = Arc::from(h.literals);
 
-        // If the module is loaded in this process, return the live handle
-        // directly so `inner` is populated and FFI calls work.
+        // If the module is loaded in this process, adopt the live handle's FFI
+        // vtable so calls work — but keep this call site's captured literals,
+        // which the registry entry (one per function, not per call site) has no
+        // way to know about.
         if let Some(path) = &h.module_path
             && let Some(existing) =
                 crate::module::lookup_extension_function(path, &h.name).map_err(D::Error::custom)?
         {
-            return Ok(existing);
+            return Ok(Self {
+                literals,
+                ..existing
+            });
         }
 
         // Fall back to a handle with `inner: None`. Calls will error with
@@ -256,6 +332,7 @@ impl<'de> Deserialize<'de> for ScalarFunctionHandle {
         Ok(Self {
             name,
             module_path: h.module_path,
+            literals,
             inner: None,
         })
     }
@@ -268,10 +345,22 @@ impl ScalarFunctionFactory for ScalarFunctionHandle {
 
     fn get_function(
         &self,
-        _args: FunctionArgs<ExprRef>,
+        args: FunctionArgs<ExprRef>,
         _schema: &Schema,
     ) -> DaftResult<BuiltinScalarFnVariant> {
-        Ok(BuiltinScalarFnVariant::Sync(Arc::new(self.clone())))
+        // Capture which arguments fold to constants for this call site. This is
+        // the only point where the argument *expressions* are in hand; `call`
+        // sees arrays only.
+        let literals: Arc<[Option<Literal>]> = args
+            .into_inner()
+            .iter()
+            .map(|expr| expr.as_literal().cloned())
+            .collect();
+
+        Ok(BuiltinScalarFnVariant::Sync(Arc::new(Self {
+            literals,
+            ..self.clone()
+        })))
     }
 }
 
@@ -312,7 +401,7 @@ mod tests {
 
     unsafe extern "C" fn mock_get_return_field(
         _ctx: *const c_void,
-        _args: *const ArrowSchema,
+        _args: *const ArgDescriptor,
         _args_count: usize,
         ret: *mut ArrowSchema,
         _errmsg: *mut *mut c_char,
@@ -569,7 +658,7 @@ mod tests {
 
     unsafe extern "C" fn meta_mock_get_return_field(
         _ctx: *const c_void,
-        _args: *const ArrowSchema,
+        _args: *const ArgDescriptor,
         _args_count: usize,
         ret: *mut ArrowSchema,
         _errmsg: *mut *mut c_char,
@@ -664,6 +753,192 @@ mod tests {
         assert!(
             METADATA_SEEN.load(Ordering::SeqCst),
             "extension metadata was not preserved in the FFI schema"
+        );
+    }
+
+    // --- mock whose output field depends on a literal argument's value ---
+
+    /// Reads the single i64 out of a length-1 literal array.
+    unsafe fn read_literal_i64(array: &ArrowArray) -> i64 {
+        unsafe {
+            let bufs = std::slice::from_raw_parts(array.buffers.cast_const(), 2);
+            *bufs[1].cast::<i64>().add(array.offset as usize)
+        }
+    }
+
+    unsafe extern "C" fn width_mock_name(_ctx: *const c_void) -> *const c_char {
+        c"width".as_ptr()
+    }
+
+    /// Names its output `width_<n>` after the value of argument 1, which must
+    /// be a foldable constant.
+    unsafe extern "C" fn width_mock_get_return_field(
+        _ctx: *const c_void,
+        args: *const ArgDescriptor,
+        args_count: usize,
+        ret: *mut ArrowSchema,
+        errmsg: *mut *mut c_char,
+    ) -> c_int {
+        let descriptors = unsafe { std::slice::from_raw_parts(args, args_count) };
+        let Some(literal) = descriptors.get(1).and_then(ArgDescriptor::literal) else {
+            let msg = CString::new("width: argument 1 must be a literal").unwrap();
+            unsafe { std::ptr::write(errmsg, msg.into_raw()) };
+            return 1;
+        };
+        let width = unsafe { read_literal_i64(literal) };
+
+        let field = arrow_schema::Field::new(
+            format!("width_{width}"),
+            arrow_schema::DataType::Int64,
+            false,
+        );
+        let schema: ArrowSchema = unsafe {
+            ArrowSchema::from_owned(arrow::ffi::FFI_ArrowSchema::try_from(&field).unwrap())
+        };
+        unsafe { std::ptr::write(ret, schema) };
+        0
+    }
+
+    unsafe extern "C" fn width_mock_call(
+        _ctx: *const c_void,
+        args: *const ArrowArray,
+        args_schemas: *const ArrowSchema,
+        args_count: usize,
+        ret_array: *mut ArrowArray,
+        ret_schema: *mut ArrowSchema,
+        _errmsg: *mut *mut c_char,
+    ) -> c_int {
+        // Take ownership of every argument so nothing leaks.
+        let mut len = 0usize;
+        for i in 0..args_count {
+            let abi_array = unsafe { std::ptr::read(args.add(i)) };
+            let abi_schema = unsafe { std::ptr::read(args_schemas.add(i)) };
+            let ffi_array: arrow::ffi::FFI_ArrowArray = unsafe { abi_array.into_owned() };
+            let ffi_schema: arrow::ffi::FFI_ArrowSchema = unsafe { abi_schema.into_owned() };
+            let data = unsafe { arrow::ffi::from_ffi(ffi_array, &ffi_schema) }.unwrap();
+            if i == 0 {
+                len = data.len();
+            }
+        }
+
+        let output: arrow_array::ArrayRef =
+            Arc::new(arrow_array::Int64Array::from(vec![0i64; len]));
+        let (ffi_arr, ffi_sch) = arrow::ffi::to_ffi(&output.to_data()).unwrap();
+        unsafe {
+            std::ptr::write(ret_array, ArrowArray::from_owned(ffi_arr));
+            std::ptr::write(ret_schema, ArrowSchema::from_owned(ffi_sch));
+        }
+        0
+    }
+
+    fn make_width_factory() -> ScalarFunctionHandle {
+        let ctx = Box::into_raw(Box::new(IncrementCtx));
+        let ffi = FFI_ScalarFunction {
+            ctx: ctx.cast(),
+            name: width_mock_name,
+            get_return_field: width_mock_get_return_field,
+            call: width_mock_call,
+            fini: mock_fini,
+        };
+        ScalarFunctionHandle::new(ffi, make_mock_module_handle())
+    }
+
+    #[test]
+    fn test_return_field_sees_literal_value() {
+        let factory = make_width_factory();
+        let args =
+            FunctionArgs::new_unnamed(vec![daft_dsl::resolved_col("x"), daft_dsl::lit(3i64)]);
+        let udf =
+            ScalarFunctionFactory::get_function(&factory, args.clone(), &Schema::empty()).unwrap();
+        let BuiltinScalarFnVariant::Sync(udf) = udf else {
+            panic!("expected a sync function");
+        };
+
+        let schema = Schema::new(vec![Field::new("x", DataType::Int64)]);
+        let field = udf.get_return_field(args, &schema).unwrap();
+        assert_eq!(field.name.as_ref(), "width_3");
+    }
+
+    #[test]
+    fn test_return_field_errors_when_argument_is_not_foldable() {
+        let factory = make_width_factory();
+        let args = FunctionArgs::new_unnamed(vec![
+            daft_dsl::resolved_col("x"),
+            daft_dsl::resolved_col("y"),
+        ]);
+        let udf =
+            ScalarFunctionFactory::get_function(&factory, args.clone(), &Schema::empty()).unwrap();
+        let BuiltinScalarFnVariant::Sync(udf) = udf else {
+            panic!("expected a sync function");
+        };
+
+        let schema = Schema::new(vec![
+            Field::new("x", DataType::Int64),
+            Field::new("y", DataType::Int64),
+        ]);
+        let err = udf.get_return_field(args, &schema).unwrap_err();
+        assert!(err.to_string().contains("must be a literal"), "{err}");
+    }
+
+    #[test]
+    fn test_call_resolves_same_field_as_planning() {
+        let factory = make_width_factory();
+        let args =
+            FunctionArgs::new_unnamed(vec![daft_dsl::resolved_col("x"), daft_dsl::lit(4i64)]);
+        let udf = ScalarFunctionFactory::get_function(&factory, args, &Schema::empty()).unwrap();
+        let BuiltinScalarFnVariant::Sync(udf) = udf else {
+            panic!("expected a sync function");
+        };
+
+        // `call` only ever sees arrays, so the literal has to come from what was
+        // captured at planning time.
+        let column: arrow_array::ArrayRef = Arc::new(arrow_array::Int64Array::from(vec![1, 2, 3]));
+        let column = Series::from_arrow(Field::new("x", DataType::Int64), column).unwrap();
+        let literal = Series::from_literals(vec![Literal::Int64(4)]).unwrap();
+
+        let args = FunctionArgs::new_unnamed(vec![column, literal]);
+        let ctx = EvalContext { row_count: 3 };
+        let result = udf.call(args, &ctx).unwrap();
+        assert_eq!(result.field().name.as_ref(), "width_4");
+        assert_eq!(result.len(), 3);
+    }
+
+    #[test]
+    fn test_serde_preserves_captured_literals() {
+        // Simulate the driver → worker hop: the worker's registry entry is the
+        // one built at load time and carries no literals, so the call site's
+        // literals have to survive serialization.
+        let path = std::path::PathBuf::from("/mock/test_serde_preserves_captured_literals/mock");
+        let registry_entry = ScalarFunctionHandle {
+            module_path: Some(path.clone()),
+            ..make_width_factory()
+        };
+        crate::module::insert_test_module(path.clone());
+        crate::module::register_extension_function(
+            &path,
+            "width".to_string(),
+            registry_entry.clone(),
+        )
+        .unwrap();
+
+        // Driver: a planned call site carrying a captured literal.
+        let planned = ScalarFunctionHandle {
+            literals: Arc::from([None, Some(Literal::Int64(7))]),
+            ..registry_entry.clone()
+        };
+        let json = serde_json::to_string(&planned).unwrap();
+
+        // Worker: the registry supplies the vtable, the plan supplies literals.
+        let deser: ScalarFunctionHandle = serde_json::from_str(&json).unwrap();
+        assert_eq!(deser.literals.to_vec(), vec![None, Some(Literal::Int64(7))]);
+        assert!(deser.inner.is_some(), "expected the vtable to re-attach");
+
+        let args =
+            FunctionArgs::new_unnamed(vec![daft_dsl::resolved_col("x"), daft_dsl::lit(7i64)]);
+        let schema = Schema::new(vec![Field::new("x", DataType::Int64)]);
+        assert_eq!(
+            deser.get_return_field(args, &schema).unwrap().name.as_ref(),
+            "width_7"
         );
     }
 

--- a/src/daft-ext-internal/src/function.rs
+++ b/src/daft-ext-internal/src/function.rs
@@ -54,6 +54,19 @@ fn export_literal(literal: &Literal, dtype: &DataType) -> Option<ArrowArray> {
     Some(unsafe { ArrowArray::from_owned(ffi) })
 }
 
+/// Whether two argument lists would produce identical descriptors.
+///
+/// `Field`'s own `PartialEq` skips metadata, but metadata crosses the ABI and an
+/// extension may derive its output from it — so a cache keyed on `Field::eq`
+/// would hand back a stale return field for two fields that differ only there.
+fn same_fields(left: &[Field], right: &[Field]) -> bool {
+    left.len() == right.len()
+        && left
+            .iter()
+            .zip(right)
+            .all(|(a, b)| a.name == b.name && a.dtype == b.dtype && a.metadata == b.metadata)
+}
+
 /// Release every descriptor in `descriptors`.
 ///
 /// The host owns the descriptors it passes to `get_return_field`; extensions
@@ -197,7 +210,7 @@ impl ScalarFunctionHandle {
     /// the module only the first time a given argument list is seen.
     fn resolved_return_field(&self, fields: &[Field]) -> DaftResult<Field> {
         if let Some((cached_fields, ret)) = self.return_field_cache.get()
-            && cached_fields == fields
+            && same_fields(cached_fields, fields)
         {
             return Ok(ret.clone());
         }
@@ -941,6 +954,26 @@ mod tests {
         let result = udf.call(args, &ctx).unwrap();
         assert_eq!(result.field().name.as_ref(), "width_4");
         assert_eq!(result.len(), 3);
+    }
+
+    #[test]
+    fn test_return_field_cache_distinguishes_metadata() {
+        // `Field::eq` skips metadata, but extensions can read it off the
+        // descriptor, so it has to be part of the cache key.
+        let plain = Field::new("x", DataType::Int64);
+        let metadata: std::collections::BTreeMap<String, String> =
+            std::iter::once(("unit".to_string(), "meters".to_string())).collect();
+        let annotated = plain.clone().with_metadata(metadata);
+
+        assert_eq!(plain, annotated, "Field::eq is expected to skip metadata");
+        assert!(!same_fields(
+            std::slice::from_ref(&plain),
+            std::slice::from_ref(&annotated)
+        ));
+        assert!(same_fields(
+            std::slice::from_ref(&plain),
+            std::slice::from_ref(&plain.clone())
+        ));
     }
 
     #[test]

--- a/src/daft-ext-macros/Cargo.toml
+++ b/src/daft-ext-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "daft-ext-macros"
 description = "Proc macros for Daft extensions"
-version = "0.1.1"
+version = "0.2.0"
 edition = {workspace = true}
 license = "Apache-2.0"
 homepage = "https://docs.daft.ai"

--- a/src/daft-ext-macros/src/lib.rs
+++ b/src/daft-ext-macros/src/lib.rs
@@ -190,7 +190,7 @@ fn daft_func_batch_impl(
 
             fn return_field(
                 &self,
-                args: &[::daft_ext::abi::ArrowSchema],
+                args: &[::daft_ext::abi::ArgDescriptor],
             ) -> ::daft_ext::prelude::DaftResult<::daft_ext::abi::ArrowSchema> {
                 if args.len() != #param_count {
                     return Err(::daft_ext::prelude::DaftError::TypeError(
@@ -203,7 +203,7 @@ fn daft_func_batch_impl(
                 let name = if args.is_empty() {
                     #ffi_name_str.to_string()
                 } else {
-                    ::daft_ext::prelude::import_field(&args[0])?
+                    ::daft_ext::prelude::import_field(args[0].field())?
                         .name()
                         .clone()
                 };
@@ -512,7 +512,7 @@ fn daft_func_impl(
             let idx = i;
             quote! {
                 {
-                    let __field = ::daft_ext::prelude::import_field(&args[#idx])?;
+                    let __field = ::daft_ext::prelude::import_field(args[#idx].field())?;
                     let __expected = #expected_dtype;
                     if *__field.data_type() != __expected {
                         return Err(::daft_ext::prelude::DaftError::TypeError(
@@ -539,7 +539,7 @@ fn daft_func_impl(
 
             fn return_field(
                 &self,
-                args: &[::daft_ext::abi::ArrowSchema],
+                args: &[::daft_ext::abi::ArgDescriptor],
             ) -> ::daft_ext::prelude::DaftResult<::daft_ext::abi::ArrowSchema> {
                 if args.len() != #param_count {
                     return Err(::daft_ext::prelude::DaftError::TypeError(
@@ -555,7 +555,7 @@ fn daft_func_impl(
                 let name = if args.is_empty() {
                     #ffi_name_str.to_string()
                 } else {
-                    ::daft_ext::prelude::import_field(&args[0])?
+                    ::daft_ext::prelude::import_field(args[0].field())?
                         .name()
                         .clone()
                 };

--- a/src/daft-ext/Cargo.toml
+++ b/src/daft-ext/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "daft-ext"
 description = "Daft extension SDK for building custom extensions"
-version = "0.1.1"
+version = "0.2.0"
 edition = {workspace = true}
 license = "Apache-2.0"
 homepage = "https://docs.daft.ai"
@@ -32,7 +32,7 @@ arrow-58 = ["dep:arrow-schema-58", "dep:arrow-data-58", "dep:arrow-array-58"]
 arrow-59 = ["dep:arrow-schema-59", "dep:arrow-data-59", "dep:arrow-array-59"]
 
 [dependencies]
-daft-ext-macros = {path = "../daft-ext-macros", version = "0.1.1"}
+daft-ext-macros = {path = "../daft-ext-macros", version = "0.2.0"}
 # Arrow C Data Interface compatibility (optional, feature-gated)
 arrow-schema-56 = {package = "arrow-schema", version = "56", features = ["ffi"], optional = true}
 arrow-data-56 = {package = "arrow-data", version = "56", features = ["ffi"], optional = true}

--- a/src/daft-ext/src/abi/arrow.rs
+++ b/src/daft-ext/src/abi/arrow.rs
@@ -59,6 +59,25 @@ impl ArrowSchema {
         self.release.is_none()
     }
 
+    /// Invoke the release callback, leaving `self` in the released state.
+    ///
+    /// This is a no-op if the schema is already released. Because this type has
+    /// no `Drop` impl, owners must call this (or transfer ownership) to avoid
+    /// leaking the producer's allocation.
+    ///
+    /// # Safety
+    ///
+    /// The caller must own this schema — releasing a borrowed schema, or
+    /// releasing the same schema twice from different owners, is undefined
+    /// behavior.
+    pub unsafe fn release(&mut self) {
+        if let Some(release) = self.release {
+            unsafe { release(std::ptr::from_mut(self)) };
+            // A conforming producer clears `release`, but don't rely on it.
+            self.release = None;
+        }
+    }
+
     /// Borrow a foreign C Data Interface schema as ours (zero-copy).
     ///
     /// # Safety
@@ -204,6 +223,25 @@ impl ArrowArray {
     /// Whether this array has been released (release callback is None).
     pub fn is_released(&self) -> bool {
         self.release.is_none()
+    }
+
+    /// Invoke the release callback, leaving `self` in the released state.
+    ///
+    /// This is a no-op if the array is already released. Because this type has
+    /// no `Drop` impl, owners must call this (or transfer ownership) to avoid
+    /// leaking the producer's allocation.
+    ///
+    /// # Safety
+    ///
+    /// The caller must own this array — releasing a borrowed array, or
+    /// releasing the same array twice from different owners, is undefined
+    /// behavior.
+    pub unsafe fn release(&mut self) {
+        if let Some(release) = self.release {
+            unsafe { release(std::ptr::from_mut(self)) };
+            // A conforming producer clears `release`, but don't rely on it.
+            self.release = None;
+        }
     }
 
     /// Borrow a foreign C Data Interface array as ours (zero-copy).

--- a/src/daft-ext/src/abi/arrow.rs
+++ b/src/daft-ext/src/abi/arrow.rs
@@ -18,6 +18,23 @@ pub struct ArrowData {
     pub array: ArrowArray,
 }
 
+impl ArrowData {
+    /// Release both members, leaving them in the released state.
+    ///
+    /// Useful for discarding arguments an implementation does not consume —
+    /// neither member has a `Drop` impl, so simply dropping them leaks.
+    ///
+    /// # Safety
+    ///
+    /// The caller must own this data; see [`ArrowSchema::release`].
+    pub unsafe fn release(&mut self) {
+        unsafe {
+            self.schema.release();
+            self.array.release();
+        }
+    }
+}
+
 /// ArrowSchema C Data Interface.
 ///
 /// See: <https://arrow.apache.org/docs/format/CDataInterface.html#the-arrowschema-structure>

--- a/src/daft-ext/src/abi/mod.rs
+++ b/src/daft-ext/src/abi/mod.rs
@@ -64,10 +64,10 @@ unsafe impl Sync for FFI_Module {}
 
 /// Planning-time description of a single argument to a scalar function.
 ///
-/// Carries the argument's field, plus its *value* when the argument folds to a
-/// constant during planning (`lit(...)`, or an expression the optimizer folded
-/// into one). Arguments that are not foldable — plain columns, or the result of
-/// a row-dependent expression — carry a released `literal`.
+/// Carries the argument's field, plus its *value* when the argument is a
+/// literal at the point the call is planned. Every other argument — a column, or
+/// any expression, including one that is constant but not yet folded — carries a
+/// released `literal`.
 ///
 /// **Ownership:** the host owns both members for the duration of the
 /// `get_return_field` call and releases them afterwards. The module borrows

--- a/src/daft-ext/src/abi/mod.rs
+++ b/src/daft-ext/src/abi/mod.rs
@@ -17,7 +17,12 @@ use std::ffi::{c_char, c_int, c_void};
 pub use arrow::{ArrowArray, ArrowArrayStream, ArrowData, ArrowSchema};
 
 /// Modules built against a different ABI version are rejected at load time.
-pub const DAFT_ABI_VERSION: u32 = 1;
+///
+/// History:
+/// - `1` — initial release.
+/// - `2` — `FFI_ScalarFunction::get_return_field` takes [`ArgDescriptor`]s
+///   instead of bare [`ArrowSchema`]s.
+pub const DAFT_ABI_VERSION: u32 = 2;
 
 /// Symbol that every Daft module cdylib must export.
 ///
@@ -57,6 +62,70 @@ pub struct FFI_Module {
 unsafe impl Send for FFI_Module {}
 unsafe impl Sync for FFI_Module {}
 
+/// Planning-time description of a single argument to a scalar function.
+///
+/// Carries the argument's field, plus its *value* when the argument folds to a
+/// constant during planning (`lit(...)`, or an expression the optimizer folded
+/// into one). Arguments that are not foldable — plain columns, or the result of
+/// a row-dependent expression — carry a released `literal`.
+///
+/// **Ownership:** the host owns both members for the duration of the
+/// `get_return_field` call and releases them afterwards. The module borrows
+/// them; it must not release them, and must not retain anything derived from
+/// them past the call.
+///
+/// **Invariant:** when present, `literal` is a length-1 array whose type is
+/// exactly the type described by `field`.
+#[repr(C)]
+pub struct ArgDescriptor {
+    /// The argument's field (name + type + metadata). Always present.
+    pub field: ArrowSchema,
+
+    /// The argument's constant value as a length-1 array, or a released array
+    /// (`release == NULL`) when the argument is not a foldable constant.
+    pub literal: ArrowArray,
+}
+
+impl ArgDescriptor {
+    /// Build a descriptor from a field and an optional literal value.
+    pub fn new(field: ArrowSchema, literal: Option<ArrowArray>) -> Self {
+        Self {
+            field,
+            literal: literal.unwrap_or_else(ArrowArray::empty),
+        }
+    }
+
+    /// The argument's field.
+    pub fn field(&self) -> &ArrowSchema {
+        &self.field
+    }
+
+    /// The argument's constant value, or `None` if it is not a foldable constant.
+    pub fn literal(&self) -> Option<&ArrowArray> {
+        (!self.literal.is_released()).then_some(&self.literal)
+    }
+
+    /// Whether the argument folds to a constant at planning time.
+    pub fn has_literal(&self) -> bool {
+        !self.literal.is_released()
+    }
+
+    /// Release both members, leaving the descriptor in the released state.
+    ///
+    /// # Safety
+    ///
+    /// The caller must own this descriptor; see [`ArrowSchema::release`].
+    pub unsafe fn release(&mut self) {
+        unsafe {
+            self.field.release();
+            self.literal.release();
+        }
+    }
+}
+
+// SAFETY: ArgDescriptor is two plain C structs, both of which are Send.
+unsafe impl Send for ArgDescriptor {}
+
 /// Virtual function table for a scalar function.
 ///
 /// The host calls methods through these function pointers. `ctx` is an opaque
@@ -71,9 +140,11 @@ pub struct FFI_ScalarFunction {
     /// The returned pointer borrows from `ctx` and is valid until `fini`.
     pub name: unsafe extern "C" fn(ctx: *const c_void) -> *const c_char,
 
-    /// Compute the output field given input fields.
+    /// Compute the output field given the input argument descriptors.
     ///
-    /// `args` points to `args_count` Arrow field schemas (C Data Interface).
+    /// `args` points to `args_count` [`ArgDescriptor`]s, each carrying the
+    /// argument's field plus its value when it folds to a constant. The host
+    /// owns the descriptors and releases them once this call returns.
     /// On success, writes the result schema to `*ret`.
     /// On error, writes a null-terminated message to `*errmsg`
     /// (freed by `FFI_Module::free_string`).
@@ -81,7 +152,7 @@ pub struct FFI_ScalarFunction {
     /// Returns 0 on success, non-zero on error.
     pub get_return_field: unsafe extern "C" fn(
         ctx: *const c_void,
-        args: *const ArrowSchema,
+        args: *const ArgDescriptor,
         args_count: usize,
         ret: *mut ArrowSchema,
         errmsg: *mut *mut c_char,
@@ -256,7 +327,28 @@ mod tests {
     fn constants() {
         // !! THIS TEST EXISTS SO THAT THESE ARE NOT CHANGED BY ACCIDENT
         // IT MEANS WE HAVE TO MANUALLY UPDATE IN TWO PLACES !!
-        assert_eq!(DAFT_ABI_VERSION, 1);
+        assert_eq!(DAFT_ABI_VERSION, 2);
         assert_eq!(DAFT_MODULE_MAGIC_SYMBOL, "daft_module_magic");
+    }
+
+    #[test]
+    fn arg_descriptor_layout() {
+        // The descriptor is two C Data Interface structs back to back; C/C++
+        // modules mirror this layout by hand.
+        assert_eq!(
+            std::mem::size_of::<ArgDescriptor>(),
+            std::mem::size_of::<ArrowSchema>() + std::mem::size_of::<ArrowArray>()
+        );
+    }
+
+    #[test]
+    fn arg_descriptor_literal_presence() {
+        let without = ArgDescriptor::new(ArrowSchema::empty(), None);
+        assert!(!without.has_literal());
+        assert!(without.literal().is_none());
+
+        // A released array is indistinguishable from an absent literal.
+        let released = ArgDescriptor::new(ArrowSchema::empty(), Some(ArrowArray::empty()));
+        assert!(!released.has_literal());
     }
 }

--- a/src/daft-ext/src/function.rs
+++ b/src/daft-ext/src/function.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use crate::{
-    abi::{ArrowArray, ArrowData, ArrowSchema, FFI_ScalarFunction},
+    abi::{ArgDescriptor, ArrowArray, ArrowData, ArrowSchema, FFI_ScalarFunction},
     error::DaftResult,
     ffi::trampoline::trampoline,
 };
@@ -12,7 +12,17 @@ use crate::{
 /// Trait that extension authors implement to define a scalar function.
 pub trait DaftScalarFunction {
     fn name(&self) -> &CStr;
-    fn return_field(&self, args: &[ArrowSchema]) -> DaftResult<ArrowSchema>;
+
+    /// Compute the output field from the planning-time argument descriptors.
+    ///
+    /// Each [`ArgDescriptor`] carries the argument's field via
+    /// [`ArgDescriptor::field`], plus its value via [`ArgDescriptor::literal`]
+    /// when the argument folds to a constant during planning. Output types may
+    /// therefore depend on literal argument *values*, not just their types.
+    ///
+    /// The descriptors are borrowed for the duration of this call only.
+    fn return_field(&self, args: &[ArgDescriptor]) -> DaftResult<ArrowSchema>;
+
     fn call(&self, args: Vec<ArrowData>) -> DaftResult<ArrowData>;
 }
 
@@ -41,23 +51,23 @@ unsafe extern "C" fn ffi_name(ctx: *const c_void) -> *const c_char {
         .as_ptr()
 }
 
-/// Returns the output field given the input fields.
+/// Returns the output field given the input argument descriptors.
 #[rustfmt::skip]
 unsafe extern "C" fn ffi_get_return_field(
     ctx:        *const c_void,
-    args:       *const ArrowSchema,
+    args:       *const ArgDescriptor,
     args_count: usize,
     ret:        *mut ArrowSchema,
     errmsg:     *mut *mut c_char,
 ) -> c_int {
     unsafe { trampoline(errmsg, "panic in get_return_field", || {
         let ctx = &*ctx.cast::<DaftScalarFunctionRef>();
-        let schemas = if args_count == 0 {
+        let descriptors = if args_count == 0 {
             &[]
         } else {
             std::slice::from_raw_parts(args, args_count)
         };
-        let result = ctx.return_field(schemas)?;
+        let result = ctx.return_field(descriptors)?;
         std::ptr::write(ret, result);
         Ok(())
     })}
@@ -177,7 +187,7 @@ mod tests {
             c"increment"
         }
 
-        fn return_field(&self, _args: &[ArrowSchema]) -> DaftResult<ArrowSchema> {
+        fn return_field(&self, _args: &[ArgDescriptor]) -> DaftResult<ArrowSchema> {
             let field = Field::new("result", DataType::Int32, false);
             Ok(export_schema(&Schema::new(vec![field])))
         }
@@ -209,7 +219,7 @@ mod tests {
         let vtable = into_ffi(Arc::new(IncrementFn));
 
         let field = Field::new("x", DataType::Int32, false);
-        let ffi_schema = export_schema(&Schema::new(vec![field]));
+        let arg = ArgDescriptor::new(export_schema(&Schema::new(vec![field])), None);
 
         let mut ret_schema = ArrowSchema::empty();
         let mut errmsg: *mut c_char = std::ptr::null_mut();
@@ -217,7 +227,7 @@ mod tests {
         let rc = unsafe {
             (vtable.get_return_field)(
                 vtable.ctx,
-                &raw const ffi_schema,
+                &raw const arg,
                 1,
                 &raw mut ret_schema,
                 &raw mut errmsg,
@@ -273,7 +283,7 @@ mod tests {
             fn name(&self) -> &CStr {
                 c"failing"
             }
-            fn return_field(&self, _: &[ArrowSchema]) -> DaftResult<ArrowSchema> {
+            fn return_field(&self, _: &[ArgDescriptor]) -> DaftResult<ArrowSchema> {
                 Err(DaftError::TypeError("bad type".into()))
             }
             fn call(&self, _: Vec<ArrowData>) -> DaftResult<ArrowData> {
@@ -313,7 +323,7 @@ mod tests {
             fn name(&self) -> &CStr {
                 c"call_fail"
             }
-            fn return_field(&self, _: &[ArrowSchema]) -> DaftResult<ArrowSchema> {
+            fn return_field(&self, _: &[ArgDescriptor]) -> DaftResult<ArrowSchema> {
                 Ok(export_schema(&Schema::new(vec![Field::new(
                     "x",
                     DataType::Int32,
@@ -365,7 +375,7 @@ mod tests {
             fn name(&self) -> &CStr {
                 c"no_args"
             }
-            fn return_field(&self, args: &[ArrowSchema]) -> DaftResult<ArrowSchema> {
+            fn return_field(&self, args: &[ArgDescriptor]) -> DaftResult<ArrowSchema> {
                 assert!(args.is_empty());
                 Ok(export_schema(&Schema::new(vec![Field::new(
                     "result",
@@ -400,6 +410,106 @@ mod tests {
         unsafe { (vtable.fini)(vtable.ctx.cast_mut()) };
     }
 
+    /// Read the first i32 of a length-1 literal array (non-null, zero-offset).
+    fn read_literal_i32(array: &ArrowArray) -> i32 {
+        unsafe {
+            let bufs = std::slice::from_raw_parts(array.buffers.cast_const(), 2);
+            *bufs[1].cast::<i32>()
+        }
+    }
+
+    /// Names its output after the value of its second argument, which must be
+    /// a foldable constant — the shape of a value-dependent return type.
+    struct WidthFn;
+
+    impl DaftScalarFunction for WidthFn {
+        fn name(&self) -> &CStr {
+            c"width"
+        }
+
+        fn return_field(&self, args: &[ArgDescriptor]) -> DaftResult<ArrowSchema> {
+            let width = args
+                .get(1)
+                .and_then(ArgDescriptor::literal)
+                .ok_or_else(|| DaftError::TypeError("width: arg 1 must be a literal".into()))?;
+            let field = Field::new(
+                format!("width_{}", read_literal_i32(width)),
+                DataType::Int32,
+                false,
+            );
+            Ok(export_schema(&Schema::new(vec![field])))
+        }
+
+        fn call(&self, _: Vec<ArrowData>) -> DaftResult<ArrowData> {
+            Ok(make_int32(&[0]))
+        }
+    }
+
+    #[test]
+    fn vtable_get_return_field_reads_literal() {
+        let vtable = into_ffi(Arc::new(WidthFn));
+
+        let column = ArgDescriptor::new(
+            export_schema(&Schema::new(vec![Field::new("x", DataType::Int32, false)])),
+            None,
+        );
+        let literal = make_int32(&[3]);
+        let args = [
+            column,
+            ArgDescriptor::new(literal.schema, Some(literal.array)),
+        ];
+
+        let mut ret_schema = ArrowSchema::empty();
+        let mut errmsg: *mut c_char = std::ptr::null_mut();
+
+        let rc = unsafe {
+            (vtable.get_return_field)(
+                vtable.ctx,
+                args.as_ptr(),
+                args.len(),
+                &raw mut ret_schema,
+                &raw mut errmsg,
+            )
+        };
+        assert_eq!(rc, 0, "get_return_field should succeed");
+        assert_eq!(import_schema(&ret_schema).field(0).name(), "width_3");
+
+        unsafe { (vtable.fini)(vtable.ctx.cast_mut()) };
+    }
+
+    #[test]
+    fn vtable_get_return_field_missing_literal() {
+        let vtable = into_ffi(Arc::new(WidthFn));
+
+        let field = || {
+            ArgDescriptor::new(
+                export_schema(&Schema::new(vec![Field::new("x", DataType::Int32, false)])),
+                None,
+            )
+        };
+        let args = [field(), field()];
+
+        let mut ret_schema = ArrowSchema::empty();
+        let mut errmsg: *mut c_char = std::ptr::null_mut();
+
+        let rc = unsafe {
+            (vtable.get_return_field)(
+                vtable.ctx,
+                args.as_ptr(),
+                args.len(),
+                &raw mut ret_schema,
+                &raw mut errmsg,
+            )
+        };
+        assert_ne!(rc, 0, "a non-foldable argument should surface an error");
+        assert!(!errmsg.is_null());
+        let err_str = unsafe { CStr::from_ptr(errmsg) }.to_str().unwrap();
+        assert!(err_str.contains("must be a literal"), "{err_str}");
+
+        unsafe { free_string(errmsg) };
+        unsafe { (vtable.fini)(vtable.ctx.cast_mut()) };
+    }
+
     #[test]
     fn fini_is_callable() {
         struct DisposableFn;
@@ -407,7 +517,7 @@ mod tests {
             fn name(&self) -> &CStr {
                 c"disposable"
             }
-            fn return_field(&self, _: &[ArrowSchema]) -> DaftResult<ArrowSchema> {
+            fn return_field(&self, _: &[ArgDescriptor]) -> DaftResult<ArrowSchema> {
                 Ok(export_schema(&Schema::new(vec![Field::new(
                     "x",
                     DataType::Null,

--- a/src/daft-ext/src/function.rs
+++ b/src/daft-ext/src/function.rs
@@ -474,6 +474,10 @@ mod tests {
         assert_eq!(rc, 0, "get_return_field should succeed");
         assert_eq!(import_schema(&ret_schema).field(0).name(), "width_3");
 
+        // The host owns the descriptors it passes in.
+        for mut arg in args {
+            unsafe { arg.release() };
+        }
         unsafe { (vtable.fini)(vtable.ctx.cast_mut()) };
     }
 
@@ -506,6 +510,9 @@ mod tests {
         let err_str = unsafe { CStr::from_ptr(errmsg) }.to_str().unwrap();
         assert!(err_str.contains("must be a literal"), "{err_str}");
 
+        for mut arg in args {
+            unsafe { arg.release() };
+        }
         unsafe { free_string(errmsg) };
         unsafe { (vtable.fini)(vtable.ctx.cast_mut()) };
     }

--- a/src/daft-ext/src/helpers.rs
+++ b/src/daft-ext/src/helpers.rs
@@ -161,10 +161,6 @@ macro_rules! impl_helpers {
         /// null, and an error when the literal is present but not a signed
         /// integer.
         pub fn literal_i64(arg: &ArgDescriptor) -> DaftResult<Option<i64>> {
-            use $arrow_array_crate::{
-                cast::AsArray as _,
-                types::{Int8Type, Int16Type, Int32Type, Int64Type},
-            };
             read_literal(arg, "literal_i64", |array| match array.data_type() {
                 $arrow_schema_crate::DataType::Int8 => {
                     Some(i64::from(array.as_primitive::<Int8Type>().value(0)))
@@ -188,10 +184,6 @@ macro_rules! impl_helpers {
         /// null, and an error when the literal is present but not an unsigned
         /// integer.
         pub fn literal_u64(arg: &ArgDescriptor) -> DaftResult<Option<u64>> {
-            use $arrow_array_crate::{
-                cast::AsArray as _,
-                types::{UInt8Type, UInt16Type, UInt32Type, UInt64Type},
-            };
             read_literal(arg, "literal_u64", |array| match array.data_type() {
                 $arrow_schema_crate::DataType::UInt8 => {
                     Some(u64::from(array.as_primitive::<UInt8Type>().value(0)))
@@ -214,10 +206,6 @@ macro_rules! impl_helpers {
         /// Returns `Ok(None)` when the argument is not a literal or its value is
         /// null, and an error when the literal is present but not a float.
         pub fn literal_f64(arg: &ArgDescriptor) -> DaftResult<Option<f64>> {
-            use $arrow_array_crate::{
-                cast::AsArray as _,
-                types::{Float32Type, Float64Type},
-            };
             read_literal(arg, "literal_f64", |array| match array.data_type() {
                 $arrow_schema_crate::DataType::Float32 => {
                     Some(f64::from(array.as_primitive::<Float32Type>().value(0)))

--- a/src/daft-ext/src/helpers.rs
+++ b/src/daft-ext/src/helpers.rs
@@ -9,7 +9,7 @@ macro_rules! impl_helpers {
         use $arrow_schema_crate::Field;
 
         use crate::{
-            abi::{ArrowArray, ArrowData, ArrowSchema},
+            abi::{ArgDescriptor, ArrowArray, ArrowData, ArrowSchema},
             error::{DaftError, DaftResult},
         };
 
@@ -52,6 +52,59 @@ macro_rules! impl_helpers {
             let ffi = $arrow_array_crate::ffi::FFI_ArrowSchema::try_from(field)
                 .map_err(|e| DaftError::RuntimeError(format!("schema export failed: {e}")))?;
             Ok(unsafe { ArrowSchema::from_owned(ffi) })
+        }
+
+        /// Release callback for a borrowed view over a C Data Interface struct.
+        ///
+        /// The buffers belong to the descriptor the view was taken from, so
+        /// there is nothing to free — but the callback must be non-null for
+        /// arrow-rs to accept the struct as un-released.
+        unsafe extern "C" fn noop_release_array(array: *mut ArrowArray) {
+            unsafe { (*array).release = None };
+        }
+
+        unsafe extern "C" fn noop_release_schema(schema: *mut ArrowSchema) {
+            unsafe { (*schema).release = None };
+        }
+
+        /// Import an argument's literal value as an arrow-rs array, for the
+        /// duration of `f`.
+        ///
+        /// Returns `Ok(None)` when the argument is not a foldable constant.
+        /// Otherwise `f` is called with a length-1 array whose type is the one
+        /// described by [`ArgDescriptor::field`].
+        ///
+        /// The array borrows the descriptor's buffers, which the host owns only
+        /// for the duration of `return_field` — hence the scoped closure rather
+        /// than a returned [`ArrayRef`].
+        pub fn with_literal<R>(
+            arg: &ArgDescriptor,
+            f: impl FnOnce(&ArrayRef) -> DaftResult<R>,
+        ) -> DaftResult<Option<R>> {
+            let Some(literal) = arg.literal() else {
+                return Ok(None);
+            };
+
+            // Shallow, non-owning views: same pointers, but a release callback
+            // that frees nothing. Dropping the arrow-rs wrappers must not free
+            // buffers still owned by the host.
+            let mut array_view: ArrowArray = unsafe { std::ptr::read(literal) };
+            array_view.release = Some(noop_release_array);
+            array_view.private_data = std::ptr::null_mut();
+
+            let mut schema_view: ArrowSchema = unsafe { std::ptr::read(arg.field()) };
+            schema_view.release = Some(noop_release_schema);
+            schema_view.private_data = std::ptr::null_mut();
+
+            let ffi_array: $arrow_array_crate::ffi::FFI_ArrowArray =
+                unsafe { array_view.into_owned() };
+            let ffi_schema: $arrow_array_crate::ffi::FFI_ArrowSchema =
+                unsafe { schema_view.into_owned() };
+
+            let data = unsafe { $arrow_array_crate::ffi::from_ffi(ffi_array, &ffi_schema) }
+                .map_err(|e| DaftError::RuntimeError(format!("literal FFI import failed: {e}")))?;
+            let array = $arrow_array_crate::make_array(data);
+            f(&array).map(Some)
         }
 
         /// Create an arrow-rs [`Field`] with the given name and [`DataType`](arrow DataType).

--- a/src/daft-ext/src/helpers.rs
+++ b/src/daft-ext/src/helpers.rs
@@ -5,7 +5,14 @@
 #[allow(unused_macros)]
 macro_rules! impl_helpers {
     ($arrow_schema_crate:ident, $arrow_data_crate:ident, $arrow_array_crate:ident) => {
-        use $arrow_array_crate::ArrayRef;
+        use $arrow_array_crate::{
+            Array as _, ArrayRef,
+            cast::AsArray as _,
+            types::{
+                Float32Type, Float64Type, Int8Type, Int16Type, Int32Type, Int64Type, UInt8Type,
+                UInt16Type, UInt32Type, UInt64Type,
+            },
+        };
         use $arrow_schema_crate::Field;
 
         use crate::{
@@ -134,7 +141,6 @@ macro_rules! impl_helpers {
             // public accessors below, and `read` returns an owned value.
             let value = unsafe {
                 with_literal(arg, |array| {
-                    use $arrow_array_crate::Array as _;
                     if array.is_empty() || array.is_null(0) {
                         return Ok(None);
                     }
@@ -228,7 +234,6 @@ macro_rules! impl_helpers {
         /// Returns `Ok(None)` when the argument is not a literal or its value is
         /// null, and an error when the literal is present but not a boolean.
         pub fn literal_bool(arg: &ArgDescriptor) -> DaftResult<Option<bool>> {
-            use $arrow_array_crate::cast::AsArray as _;
             read_literal(arg, "literal_bool", |array| match array.data_type() {
                 $arrow_schema_crate::DataType::Boolean => Some(array.as_boolean().value(0)),
                 _ => None,
@@ -240,7 +245,6 @@ macro_rules! impl_helpers {
         /// Returns `Ok(None)` when the argument is not a literal or its value is
         /// null, and an error when the literal is present but not a string.
         pub fn literal_string(arg: &ArgDescriptor) -> DaftResult<Option<String>> {
-            use $arrow_array_crate::cast::AsArray as _;
             read_literal(arg, "literal_string", |array| match array.data_type() {
                 $arrow_schema_crate::DataType::Utf8 => {
                     Some(array.as_string::<i32>().value(0).to_owned())
@@ -257,7 +261,6 @@ macro_rules! impl_helpers {
         /// Returns `Ok(None)` when the argument is not a literal or its value is
         /// null, and an error when the literal is present but not binary.
         pub fn literal_binary(arg: &ArgDescriptor) -> DaftResult<Option<Vec<u8>>> {
-            use $arrow_array_crate::cast::AsArray as _;
             read_literal(arg, "literal_binary", |array| match array.data_type() {
                 $arrow_schema_crate::DataType::Binary => {
                     Some(array.as_binary::<i32>().value(0).to_vec())

--- a/src/daft-ext/src/helpers.rs
+++ b/src/daft-ext/src/helpers.rs
@@ -74,10 +74,23 @@ macro_rules! impl_helpers {
         /// Otherwise `f` is called with a length-1 array whose type is the one
         /// described by [`ArgDescriptor::field`].
         ///
-        /// The array borrows the descriptor's buffers, which the host owns only
-        /// for the duration of `return_field` — hence the scoped closure rather
-        /// than a returned [`ArrayRef`].
-        pub fn with_literal<R>(
+        /// Most functions want one of the safe scalar accessors instead
+        /// ([`literal_i64`], [`literal_u64`], [`literal_f64`], [`literal_bool`],
+        /// [`literal_string`], [`literal_binary`]); reach for this only when the
+        /// literal is a nested or otherwise non-scalar value.
+        ///
+        /// # Safety
+        ///
+        /// - `arg` must be a descriptor supplied by the host to
+        ///   [`DaftScalarFunction::return_field`](crate::function::DaftScalarFunction::return_field),
+        ///   so that its `literal` really is described by its `field`. A
+        ///   hand-built descriptor whose field does not describe its array makes
+        ///   arrow-rs reinterpret the buffers.
+        /// - Nothing derived from the array may escape `f`. The array borrows the
+        ///   descriptor's buffers, and the host releases those as soon as
+        ///   `return_field` returns; a clone, slice, or `ArrayData` that outlives
+        ///   the call is a use-after-free. Copy values out instead.
+        pub unsafe fn with_literal<R>(
             arg: &ArgDescriptor,
             f: impl FnOnce(&ArrayRef) -> DaftResult<R>,
         ) -> DaftResult<Option<R>> {
@@ -105,6 +118,155 @@ macro_rules! impl_helpers {
                 .map_err(|e| DaftError::RuntimeError(format!("literal FFI import failed: {e}")))?;
             let array = $arrow_array_crate::make_array(data);
             f(&array).map(Some)
+        }
+
+        /// Read a scalar out of an argument's literal value.
+        ///
+        /// `read` is handed the length-1 literal array and returns the value at
+        /// index 0, or `None` if the array is not of a type it understands.
+        /// Safe: the value is copied out, so nothing borrowed escapes.
+        fn read_literal<T>(
+            arg: &ArgDescriptor,
+            what: &str,
+            read: impl FnOnce(&ArrayRef) -> Option<T>,
+        ) -> DaftResult<Option<T>> {
+            // SAFETY: `arg` is a host-supplied descriptor by the contract of the
+            // public accessors below, and `read` returns an owned value.
+            let value = unsafe {
+                with_literal(arg, |array| {
+                    use $arrow_array_crate::Array as _;
+                    if array.is_empty() || array.is_null(0) {
+                        return Ok(None);
+                    }
+                    read(array).map(Some).ok_or_else(|| {
+                        DaftError::TypeError(format!(
+                            "{what}: literal has type {:?}",
+                            array.data_type()
+                        ))
+                    })
+                })?
+            };
+            Ok(value.flatten())
+        }
+
+        /// Read a signed integer literal (`Int8` through `Int64`).
+        ///
+        /// Returns `Ok(None)` when the argument is not a literal or its value is
+        /// null, and an error when the literal is present but not a signed
+        /// integer.
+        pub fn literal_i64(arg: &ArgDescriptor) -> DaftResult<Option<i64>> {
+            use $arrow_array_crate::{
+                cast::AsArray as _,
+                types::{Int8Type, Int16Type, Int32Type, Int64Type},
+            };
+            read_literal(arg, "literal_i64", |array| match array.data_type() {
+                $arrow_schema_crate::DataType::Int8 => {
+                    Some(i64::from(array.as_primitive::<Int8Type>().value(0)))
+                }
+                $arrow_schema_crate::DataType::Int16 => {
+                    Some(i64::from(array.as_primitive::<Int16Type>().value(0)))
+                }
+                $arrow_schema_crate::DataType::Int32 => {
+                    Some(i64::from(array.as_primitive::<Int32Type>().value(0)))
+                }
+                $arrow_schema_crate::DataType::Int64 => {
+                    Some(array.as_primitive::<Int64Type>().value(0))
+                }
+                _ => None,
+            })
+        }
+
+        /// Read an unsigned integer literal (`UInt8` through `UInt64`).
+        ///
+        /// Returns `Ok(None)` when the argument is not a literal or its value is
+        /// null, and an error when the literal is present but not an unsigned
+        /// integer.
+        pub fn literal_u64(arg: &ArgDescriptor) -> DaftResult<Option<u64>> {
+            use $arrow_array_crate::{
+                cast::AsArray as _,
+                types::{UInt8Type, UInt16Type, UInt32Type, UInt64Type},
+            };
+            read_literal(arg, "literal_u64", |array| match array.data_type() {
+                $arrow_schema_crate::DataType::UInt8 => {
+                    Some(u64::from(array.as_primitive::<UInt8Type>().value(0)))
+                }
+                $arrow_schema_crate::DataType::UInt16 => {
+                    Some(u64::from(array.as_primitive::<UInt16Type>().value(0)))
+                }
+                $arrow_schema_crate::DataType::UInt32 => {
+                    Some(u64::from(array.as_primitive::<UInt32Type>().value(0)))
+                }
+                $arrow_schema_crate::DataType::UInt64 => {
+                    Some(array.as_primitive::<UInt64Type>().value(0))
+                }
+                _ => None,
+            })
+        }
+
+        /// Read a floating-point literal (`Float32` or `Float64`).
+        ///
+        /// Returns `Ok(None)` when the argument is not a literal or its value is
+        /// null, and an error when the literal is present but not a float.
+        pub fn literal_f64(arg: &ArgDescriptor) -> DaftResult<Option<f64>> {
+            use $arrow_array_crate::{
+                cast::AsArray as _,
+                types::{Float32Type, Float64Type},
+            };
+            read_literal(arg, "literal_f64", |array| match array.data_type() {
+                $arrow_schema_crate::DataType::Float32 => {
+                    Some(f64::from(array.as_primitive::<Float32Type>().value(0)))
+                }
+                $arrow_schema_crate::DataType::Float64 => {
+                    Some(array.as_primitive::<Float64Type>().value(0))
+                }
+                _ => None,
+            })
+        }
+
+        /// Read a boolean literal.
+        ///
+        /// Returns `Ok(None)` when the argument is not a literal or its value is
+        /// null, and an error when the literal is present but not a boolean.
+        pub fn literal_bool(arg: &ArgDescriptor) -> DaftResult<Option<bool>> {
+            use $arrow_array_crate::cast::AsArray as _;
+            read_literal(arg, "literal_bool", |array| match array.data_type() {
+                $arrow_schema_crate::DataType::Boolean => Some(array.as_boolean().value(0)),
+                _ => None,
+            })
+        }
+
+        /// Read a string literal (`Utf8` or `LargeUtf8`).
+        ///
+        /// Returns `Ok(None)` when the argument is not a literal or its value is
+        /// null, and an error when the literal is present but not a string.
+        pub fn literal_string(arg: &ArgDescriptor) -> DaftResult<Option<String>> {
+            use $arrow_array_crate::cast::AsArray as _;
+            read_literal(arg, "literal_string", |array| match array.data_type() {
+                $arrow_schema_crate::DataType::Utf8 => {
+                    Some(array.as_string::<i32>().value(0).to_owned())
+                }
+                $arrow_schema_crate::DataType::LargeUtf8 => {
+                    Some(array.as_string::<i64>().value(0).to_owned())
+                }
+                _ => None,
+            })
+        }
+
+        /// Read a binary literal (`Binary` or `LargeBinary`).
+        ///
+        /// Returns `Ok(None)` when the argument is not a literal or its value is
+        /// null, and an error when the literal is present but not binary.
+        pub fn literal_binary(arg: &ArgDescriptor) -> DaftResult<Option<Vec<u8>>> {
+            use $arrow_array_crate::cast::AsArray as _;
+            read_literal(arg, "literal_binary", |array| match array.data_type() {
+                $arrow_schema_crate::DataType::Binary => {
+                    Some(array.as_binary::<i32>().value(0).to_vec())
+                }
+                $arrow_schema_crate::DataType::LargeBinary => {
+                    Some(array.as_binary::<i64>().value(0).to_vec())
+                }
+                _ => None,
+            })
         }
 
         /// Create an arrow-rs [`Field`] with the given name and [`DataType`](arrow DataType).

--- a/src/daft-ext/src/prelude.rs
+++ b/src/daft-ext/src/prelude.rs
@@ -6,9 +6,12 @@ pub use daft_ext_macros::{daft_extension, daft_func, daft_func_batch};
     feature = "arrow-58",
     feature = "arrow-59"
 ))]
-pub use crate::helpers::{export_array, export_field, import_array, import_field};
+pub use crate::helpers::{export_array, export_field, import_array, import_field, with_literal};
 pub use crate::{
-    abi::{ArrowArray, ArrowArrayStream, ArrowData, ArrowSchema, ffi::strings::free_string},
+    abi::{
+        ArgDescriptor, ArrowArray, ArrowArrayStream, ArrowData, ArrowSchema,
+        ffi::strings::free_string,
+    },
     aggregate::{DaftAggregateFunction, DaftAggregateFunctionRef},
     error::{DaftError, DaftResult},
     function::{DaftScalarFunction, DaftScalarFunctionRef},

--- a/src/daft-ext/src/prelude.rs
+++ b/src/daft-ext/src/prelude.rs
@@ -6,7 +6,10 @@ pub use daft_ext_macros::{daft_extension, daft_func, daft_func_batch};
     feature = "arrow-58",
     feature = "arrow-59"
 ))]
-pub use crate::helpers::{export_array, export_field, import_array, import_field, with_literal};
+pub use crate::helpers::{
+    export_array, export_field, import_array, import_field, literal_binary, literal_bool,
+    literal_f64, literal_i64, literal_string, literal_u64, with_literal,
+};
 pub use crate::{
     abi::{
         ArgDescriptor, ArrowArray, ArrowArrayStream, ArrowData, ArrowSchema,

--- a/src/daft-ext/src/session.rs
+++ b/src/daft-ext/src/session.rs
@@ -57,7 +57,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        abi::{ArrowData, ArrowSchema, FFI_AggregateFunction, FFI_ScalarFunction},
+        abi::{ArgDescriptor, ArrowData, ArrowSchema, FFI_AggregateFunction, FFI_ScalarFunction},
         error::DaftResult,
         function::DaftScalarFunction,
     };
@@ -112,7 +112,7 @@ mod tests {
             fn name(&self) -> &CStr {
                 c"my_add"
             }
-            fn return_field(&self, _: &[ArrowSchema]) -> DaftResult<ArrowSchema> {
+            fn return_field(&self, _: &[ArgDescriptor]) -> DaftResult<ArrowSchema> {
                 Ok(export_schema(&Schema::new(vec![Field::new(
                     "sum",
                     DataType::Int32,
@@ -160,7 +160,7 @@ mod tests {
             fn name(&self) -> &CStr {
                 c"fn_a"
             }
-            fn return_field(&self, _: &[ArrowSchema]) -> DaftResult<ArrowSchema> {
+            fn return_field(&self, _: &[ArgDescriptor]) -> DaftResult<ArrowSchema> {
                 Ok(export_schema(&Schema::new(vec![Field::new(
                     "a",
                     DataType::Int32,
@@ -177,7 +177,7 @@ mod tests {
             fn name(&self) -> &CStr {
                 c"fn_b"
             }
-            fn return_field(&self, _: &[ArrowSchema]) -> DaftResult<ArrowSchema> {
+            fn return_field(&self, _: &[ArgDescriptor]) -> DaftResult<ArrowSchema> {
                 Ok(export_schema(&Schema::new(vec![Field::new(
                     "b",
                     DataType::Utf8,

--- a/src/daft-ext/tests/daft_func.rs
+++ b/src/daft-ext/tests/daft_func.rs
@@ -1,4 +1,9 @@
-#![cfg(any(feature = "arrow-56", feature = "arrow-57", feature = "arrow-58"))]
+#![cfg(any(
+    feature = "arrow-56",
+    feature = "arrow-57",
+    feature = "arrow-58",
+    feature = "arrow-59"
+))]
 
 use std::sync::Arc;
 

--- a/src/daft-ext/tests/literals.rs
+++ b/src/daft-ext/tests/literals.rs
@@ -1,0 +1,88 @@
+//! Tests for reading literal argument values out of an [`ArgDescriptor`].
+//!
+//! These exercise the borrowed-view import in `helpers`: the descriptor owns the
+//! buffers, the extension only reads through them, and releasing the descriptor
+//! afterwards must still be correct.
+
+#![cfg(any(feature = "arrow-56", feature = "arrow-57", feature = "arrow-58"))]
+
+use std::sync::Arc;
+
+use daft_ext::{
+    helpers::_codegen::{
+        ArrayRef, BooleanArray, DataType, Int32Array, Int64Array, LargeStringArray,
+    },
+    prelude::*,
+};
+
+/// Build a descriptor over a length-1 array, the way the host does.
+fn descriptor(name: &str, array: ArrayRef) -> ArgDescriptor {
+    let data = export_array(array, name).unwrap();
+    ArgDescriptor::new(data.schema, Some(data.array))
+}
+
+fn column(name: &str, dtype: DataType) -> ArgDescriptor {
+    let field = daft_ext::helpers::new_field(name, dtype);
+    ArgDescriptor::new(export_field(&field).unwrap(), None)
+}
+
+#[test]
+fn reads_signed_integers() {
+    let mut arg = descriptor("k", Arc::new(Int64Array::from(vec![7i64])));
+    assert_eq!(literal_i64(&arg).unwrap(), Some(7));
+    unsafe { arg.release() };
+
+    // Narrower signed types widen.
+    let mut arg = descriptor("k", Arc::new(Int32Array::from(vec![-3i32])));
+    assert_eq!(literal_i64(&arg).unwrap(), Some(-3));
+    unsafe { arg.release() };
+}
+
+#[test]
+fn reads_other_scalar_types() {
+    let mut arg = descriptor("b", Arc::new(BooleanArray::from(vec![true])));
+    assert_eq!(literal_bool(&arg).unwrap(), Some(true));
+    unsafe { arg.release() };
+
+    let mut arg = descriptor("s", Arc::new(LargeStringArray::from(vec!["hi"])));
+    assert_eq!(literal_string(&arg).unwrap().as_deref(), Some("hi"));
+    unsafe { arg.release() };
+}
+
+#[test]
+fn absent_literal_reads_as_none() {
+    // A column argument carries no literal — not an error, just absent.
+    let mut arg = column("x", DataType::Int64);
+    assert_eq!(literal_i64(&arg).unwrap(), None);
+    assert_eq!(literal_string(&arg).unwrap(), None);
+    unsafe { arg.release() };
+}
+
+#[test]
+fn null_literal_reads_as_none() {
+    let mut arg = descriptor("k", Arc::new(Int64Array::from(vec![None::<i64>])));
+    assert_eq!(literal_i64(&arg).unwrap(), None);
+    unsafe { arg.release() };
+}
+
+#[test]
+fn wrong_type_is_an_error() {
+    let mut arg = descriptor("s", Arc::new(LargeStringArray::from(vec!["hi"])));
+    let err = literal_i64(&arg).unwrap_err();
+    assert!(err.to_string().contains("literal has type"), "{err}");
+    unsafe { arg.release() };
+}
+
+#[test]
+fn with_literal_sees_the_whole_array() {
+    let mut arg = descriptor("k", Arc::new(Int64Array::from(vec![11i64])));
+
+    // SAFETY: a well-formed descriptor, and only a copied-out value escapes.
+    let len = unsafe { with_literal(&arg, |array| Ok(array.len())) }.unwrap();
+    assert_eq!(len, Some(1));
+
+    // Releasing afterwards must still free exactly once — the borrowed view
+    // handed to arrow-rs owns nothing.
+    unsafe { arg.release() };
+    assert!(arg.literal().is_none());
+}

--- a/src/daft-ext/tests/literals.rs
+++ b/src/daft-ext/tests/literals.rs
@@ -4,7 +4,12 @@
 //! buffers, the extension only reads through them, and releasing the descriptor
 //! afterwards must still be correct.
 
-#![cfg(any(feature = "arrow-56", feature = "arrow-57", feature = "arrow-58"))]
+#![cfg(any(
+    feature = "arrow-56",
+    feature = "arrow-57",
+    feature = "arrow-58",
+    feature = "arrow-59"
+))]
 
 use std::sync::Arc;
 

--- a/tests/extensions/test_extension_runtime.py
+++ b/tests/extensions/test_extension_runtime.py
@@ -42,6 +42,63 @@ def test_extension_ray_runner(hello_extension_path: str):
     assert proc.returncode == 0, proc.stdout + proc.stderr
 
 
+def test_extension_literal_dependent_return_type(hello_extension_path: str):
+    """The output type's width comes from a literal argument's value."""
+    script = textwrap.dedent(f"""
+        import daft
+        daft.set_runner_native()
+        daft.load_extension({hello_extension_path!r})
+
+        df = daft.from_pydict({{"x": [1, 2, None]}})
+        df = df.select(daft.get_function("splat", daft.col("x"), daft.lit(3)))
+
+        expected = daft.DataType.fixed_size_list(daft.DataType.int64(), 3)
+        assert df.schema()["splat"].dtype == expected, df.schema()
+
+        result = df.to_pydict()
+        assert result["splat"] == [[1, 1, 1], [2, 2, 2], None], result
+    """)
+    proc = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+
+
+def test_extension_literal_dependent_return_type_ray(hello_extension_path: str):
+    """The captured literal survives the driver → worker plan round-trip."""
+    script = textwrap.dedent(f"""
+        import ray, daft
+        ray.init(num_cpus=2, ignore_reinit_error=True, log_to_driver=True)
+        daft.load_extension({hello_extension_path!r})
+        daft.set_runner_ray(noop_if_initialized=True)
+
+        df = daft.from_pydict({{"x": [1, 2, 3]}})
+        df = df.select(daft.get_function("splat", daft.col("x"), daft.lit(2)))
+
+        result = df.to_pydict()
+        assert result["splat"] == [[1, 1], [2, 2], [3, 3]], result
+    """)
+    proc = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+
+
+def test_extension_non_foldable_argument_errors(hello_extension_path: str):
+    """A column where a literal is required fails during planning."""
+    script = textwrap.dedent(f"""
+        import daft
+        daft.set_runner_native()
+        daft.load_extension({hello_extension_path!r})
+
+        df = daft.from_pydict({{"x": [1, 2, 3], "k": [3, 3, 3]}})
+        try:
+            df.select(daft.get_function("splat", daft.col("x"), daft.col("k"))).schema()
+        except Exception as e:
+            assert "must be a literal" in str(e), e
+        else:
+            raise AssertionError("expected a planning error")
+    """)
+    proc = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+
+
 def test_extension_ray_runner_aggregate(hello_extension_path: str):
     """Aggregate extension functions also work on Ray workers after deserialization."""
     script = textwrap.dedent(f"""

--- a/tests/extensions/test_extension_runtime.py
+++ b/tests/extensions/test_extension_runtime.py
@@ -52,11 +52,13 @@ def test_extension_literal_dependent_return_type(hello_extension_path: str):
         df = daft.from_pydict({{"x": [1, 2, None]}})
         df = df.select(daft.get_function("splat", daft.col("x"), daft.lit(3)))
 
+        # The output takes its name from the first argument, per the SDK
+        # convention that keeps `Expr::name` and the schema field in agreement.
         expected = daft.DataType.fixed_size_list(daft.DataType.int64(), 3)
-        assert df.schema()["splat"].dtype == expected, df.schema()
+        assert df.schema()["x"].dtype == expected, df.schema()
 
         result = df.to_pydict()
-        assert result["splat"] == [[1, 1, 1], [2, 2, 2], None], result
+        assert result["x"] == [[1, 1, 1], [2, 2, 2], None], result
     """)
     proc = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True)
     assert proc.returncode == 0, proc.stdout + proc.stderr
@@ -74,7 +76,30 @@ def test_extension_literal_dependent_return_type_ray(hello_extension_path: str):
         df = df.select(daft.get_function("splat", daft.col("x"), daft.lit(2)))
 
         result = df.to_pydict()
-        assert result["splat"] == [[1, 1], [2, 2], [3, 3]], result
+        assert result["x"] == [[1, 1], [2, 2], [3, 3]], result
+    """)
+    proc = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+
+
+def test_extension_survives_projection_pushdown(hello_extension_path: str):
+    """A value-dependent output column survives a downstream projection.
+
+    Daft derives an expression's name from its first input, so an extension that
+    returns a differently-named field makes projection pushdown prune the very
+    column it needs.
+    """
+    script = textwrap.dedent(f"""
+        import daft
+        daft.set_runner_native()
+        daft.load_extension({hello_extension_path!r})
+
+        df = daft.from_pydict({{"x": [1, 2], "y": [10, 20]}})
+        df = df.select(daft.get_function("splat", daft.col("x"), daft.lit(3)), daft.col("y"))
+        assert df.schema().column_names() == ["x", "y"], df.schema()
+
+        result = df.select(daft.col("x")).to_pydict()
+        assert result["x"] == [[1, 1, 1], [2, 2, 2]], result
     """)
     proc = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True)
     assert proc.returncode == 0, proc.stdout + proc.stderr


### PR DESCRIPTION
## Changes Made

Scalar extension functions were planned from types alone — `lit("...")` and `col("text")` both arrived as a bare `LargeUtf8` field — so an output type could not depend on an argument's *value*. This adds an argument descriptor at the ABI boundary carrying the field plus, when the argument is a literal, its value.

**ABI (`daft-ext`)**

```rust
#[repr(C)]
pub struct ArgDescriptor {
    pub field: ArrowSchema,
    pub literal: ArrowArray, // released when the argument is not a literal
}

fn return_field(&self, args: &[ArgDescriptor]) -> DaftResult<ArrowSchema>;
```

`FFI_ScalarFunction::get_return_field` now takes descriptors, and `DAFT_ABI_VERSION` goes `1 → 2` so a module built against v1 is rejected at load rather than misreading the argument array. When present, `literal` is a length-1 array whose type is exactly the one `field` describes; the host owns both members and releases them once the call returns.

Extensions read scalars with `literal_i64` / `literal_u64` / `literal_f64` / `literal_bool` / `literal_string` / `literal_binary` (safe — the value is copied out), or with `unsafe fn with_literal` for nested values.

**Host (`daft-ext-internal`)**

`call` only ever sees arrays, so it cannot recover which arguments were constant. Each call site's literals are captured once, in `ScalarFunctionFactory::get_function` — the only point where the argument *expressions* are in hand — and used for both planning and execution, so the two always resolve the same output field. They ride along in the serialized plan for Ray workers, and the resolved field is memoized per call site so execution makes no per-batch FFI call.

Behaviour is unchanged for existing functions: an absent literal reproduces today's results exactly.

Also fixed along the way, in the code this touches: the exported argument schemas were leaked on every planning call, for both scalar and aggregate extension functions.

**Example, docs, tests**

`examples/hello` gains `splat(value, count)`, whose output `FixedSizeList` width comes from the value of `count` — the smallest thing that could not be expressed before. The authoring guide documents literal arguments, the borrowing contract, and the output-naming constraint (below).

Rust: 74 tests across `daft-ext` / `daft-ext-internal`, including a new suite for the literal import. Python: new end-to-end tests under `tests/extensions/` covering the value-dependent type on both runners, the not-a-literal error, and projection pushdown. `tests/dataframe` + `tests/expressions` (37,583 tests) pass unchanged.

### Notes for reviewers

The first commit was put through an independent adversarial review; the second commit is the fixes. Two are worth calling out:

- **Output field naming is load-bearing.** `Expr::name()` derives a scalar function's name from its *first input*, while the column's schema entry comes from `return_field`. An extension returning a differently-named field makes the two disagree and projection pushdown prunes the column the query needs — `select(splat(x, 3), y).select(x)` lost both projections. The example now echoes `args[0]`'s name (as `#[daft_func]` already did), there is a regression test, and the guide documents it. The underlying inconsistency in `Expr::name()` is untouched here.
- **`with_literal` is `unsafe`.** It hands out an arrow-rs array borrowing host-owned buffers; nothing derived from it may outlive the call. The safe typed accessors exist so that ordinary functions never need it.

Known trade-offs, deliberately taken:

- A captured literal is serialized twice — once as the `Expr::Literal` in `inputs`, once on the handle. Bounded 2×, and only for literals actually passed to extension functions.
- Only arguments that are *already* literals when the call is planned are visible; a constant expression the optimizer would later fold (`lit(1) + lit(2)`) is not, because capture happens at expression construction. Documented rather than papered over.
- `BuiltinScalarFn.inputs` and the captured literals could in principle drift if a rewrite rule replaced a literal child with a different literal at the same position. No existing rule does; using the captured values in *both* paths means planning and execution can never disagree with each other, which is the property that matters.

Aggregate functions still take bare `ArrowSchema`s — out of scope here.

## Related Issues

Closes #7375

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PxSpgiYEeedfaRjMRJzzfD

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxSpgiYEeedfaRjMRJzzfD)_