### PR TITLE
feat(lerobot): support v2.0/v2.1 dataset layouts

### DIFF
--- a/daft/datasets/lerobot.py
+++ b/daft/datasets/lerobot.py
@@ -1,9 +1,11 @@
-"""LeRobot Dataset v3.0 helpers for `daft.datasets`.
+"""LeRobot Dataset helpers for `daft.datasets`.
 
-This module reads the file-based LeRobot v3 layout (`meta/episodes`, `data`,
-`videos`) and exposes episode-level scans plus frame expansion utilities.
+Supports the episode-per-file v2.0/v2.1 layout (`meta/episodes.jsonl`,
+`data/chunk-XXX/episode_YYYYYY.parquet`) used by datasets such as AgiBot World
+2026, and the file-based v3 layout (`meta/episodes/**/*.parquet`, shared
+Parquet/MP4 shards).
 
-See https://huggingface.co/docs/lerobot/lerobot-dataset-v3 for format details.
+See https://huggingface.co/docs/lerobot/lerobot-dataset-v3 for v3 details.
 """
 
 from __future__ import annotations
@@ -19,7 +21,7 @@ from daft.dependencies import av, pil_image
 from daft.exceptions import DaftCoreException
 from daft.expressions import col, lit
 from daft.file import VideoFile
-from daft.functions import lpad
+from daft.functions import format, lpad
 from daft.functions.file_ import video_file
 from daft.series import Series
 from daft.udf import func
@@ -85,32 +87,31 @@ def _decode_one_shard(
     best_arr: dict[int, Any] = {}
     decoded = 0
 
-    with file.open() as f_open:
-        with av.open(f_open) as container:
-            stream = container.streams.video[0]
-            for cluster in clusters:
-                earliest = cluster[0][1]
-                latest = cluster[-1][1]
-                # Match LeRobot: seek backwards to preceding keyframe, then decode forwards.
-                container.seek(max(0, int(earliest * av.time_base)), backward=True)
-                for vf in container.decode(stream):
-                    if vf.pts is None:
-                        continue
-                    current_ts = float(vf.pts * stream.time_base)
-                    arr = None  # convert lazily: most frames improve no target
-                    for row, target in cluster:
-                        dist = abs(current_ts - target)
-                        if dist < best_dist[row]:
-                            if arr is None:
-                                arr = vf.to_ndarray(format="rgb24")
-                            best_dist[row] = dist
-                            best_arr[row] = arr
+    with file.open() as f_open, av.open(f_open) as container:
+        stream = container.streams.video[0]
+        for cluster in clusters:
+            earliest = cluster[0][1]
+            latest = cluster[-1][1]
+            # Match LeRobot: seek backwards to preceding keyframe, then decode forwards.
+            container.seek(max(0, int(earliest * av.time_base)), backward=True)
+            for vf in container.decode(stream):
+                if vf.pts is None:
+                    continue
+                current_ts = float(vf.pts * stream.time_base)
+                arr = None  # convert lazily: most frames improve no target
+                for row, target in cluster:
+                    dist = abs(current_ts - target)
+                    if dist < best_dist[row]:
+                        if arr is None:
+                            arr = vf.to_ndarray(format="rgb24")
+                        best_dist[row] = dist
+                        best_arr[row] = arr
 
-                    decoded += 1
-                    if decoded >= _DECODE_FRAME_BUDGET:
-                        raise ValueError("Exceeded decode frame budget while aligning to parquet timestamps.")
-                    if current_ts >= latest + tail_s:
-                        break
+                decoded += 1
+                if decoded >= _DECODE_FRAME_BUDGET:
+                    raise ValueError("Exceeded decode frame budget while aligning to parquet timestamps.")
+                if current_ts >= latest + tail_s:
+                    break
 
     if decoded == 0:
         raise ValueError(f"No frames decoded from shard while seeking timestamp {targets[0][1]:.6f}s.")
@@ -182,20 +183,102 @@ class Feature(TypedDict):
     dtype: str
 
 
-class LeRobotInfo(TypedDict):
+class LeRobotInfo(TypedDict, total=False):
     codebase_version: str
     data_path: str
     video_path: str
     fps: float
     features: dict[str, Feature]
+    chunks_size: int
+
+
+_PATH_PLACEHOLDER = re.compile(r"\{([a-zA-Z_][a-zA-Z0-9_]*)(?::([^}]+))?\}")
+_VERSION = re.compile(r"^v(\d+)(?:\.(\d+))?$")
+
+_DEFAULT_CHUNKS_SIZE = 1000
+_V2_VIDEO_PATH = "videos/chunk-{episode_chunk:03d}/{video_key}/episode_{episode_index:06d}.mp4"
+
+
+def _parse_version(codebase_version: str) -> tuple[int, int]:
+    """Parse ``v2.1`` / ``v3.0`` into ``(major, minor)``."""
+    m = _VERSION.fullmatch(codebase_version.strip())
+    if not m:
+        raise ValueError(
+            f"Unrecognized LeRobot codebase_version {codebase_version!r}; expected a string like 'v2.1' or 'v3.0'."
+        )
+    return int(m.group(1)), int(m.group(2) or 0)
 
 
 def _read_info(normalized_uri: str, io_config: IOConfig | None = None) -> LeRobotInfo:
     with daft.open_file(f"{normalized_uri}/meta/info.json", io_config=io_config) as f:
         info = cast("LeRobotInfo", json.load(f))
-        if info["codebase_version"] != "v3.0":
-            raise ValueError("`daft.datasets.lerobot` currently only supports LeRobot datasets of v3 and above")
+        version = info.get("codebase_version", "")
+        major, _minor = _parse_version(version)
+        if major not in (2, 3):
+            raise ValueError(
+                f"`daft.datasets.lerobot` currently supports LeRobot datasets v2.0, v2.1, and v3.x (got {version!r})"
+            )
         return info
+
+
+def _is_v3(info: LeRobotInfo) -> bool:
+    return _parse_version(info["codebase_version"])[0] >= 3
+
+
+def _video_keys(info: LeRobotInfo) -> list[str]:
+    return [name for name, feat_info in info.get("features", {}).items() if feat_info["dtype"] == "video"]
+
+
+def _format_path_template(
+    template: str,
+    *,
+    root: str,
+    bindings: dict[str, Any],
+) -> Any:
+    """Turn a LeRobot ``info.json`` path template into a Daft string expression.
+
+    Numeric placeholders such as ``{episode_index:06d}`` are padded; string
+    bindings (for example ``video_key``) are spliced in as literals.
+    """
+    format_string = ""
+    args: list[Any] = []
+    last = 0
+    for m in _PATH_PLACEHOLDER.finditer(template):
+        format_string += template[last : m.start()]
+        name, spec = m.group(1), m.group(2)
+        if name not in bindings:
+            raise ValueError(f"Unknown placeholder {{{name}}} in LeRobot path template {template!r}")
+        val = bindings[name]
+        if isinstance(val, str):
+            format_string += val
+        else:
+            if spec and spec.endswith("d"):
+                width = int(spec[:-1]) if spec[:-1] else 0
+                val = lpad(val.cast(DataType.string), width, "0")
+            else:
+                val = val.cast(DataType.string)
+            format_string += "{}"
+            args.append(val)
+        last = m.end()
+    format_string += template[last:]
+    prefix = root.rstrip("/") + "/"
+    if not args:
+        return lit(prefix + format_string)
+    return format(prefix + format_string, *args)
+
+
+def _v2_path_bindings(info: LeRobotInfo, video_key: str | None = None) -> dict[str, Any]:
+    chunks_size = int(info.get("chunks_size") or _DEFAULT_CHUNKS_SIZE)
+    episode_index = col("episode_index")
+    chunk = episode_index // lit(chunks_size)
+    bindings: dict[str, Any] = {
+        "episode_index": episode_index,
+        "episode_chunk": chunk,
+        "chunk_index": chunk,
+    }
+    if video_key is not None:
+        bindings["video_key"] = video_key
+    return bindings
 
 
 @PublicAPI
@@ -205,12 +288,15 @@ def read(
     include_stats: bool = False,
     load_video_frames: str | list[str] | bool = False,
 ) -> DataFrame:
-    """Read a LeRobot v3 dataset as a lazy DataFrame with one row per frame.
+    """Read a LeRobot v2 or v3 dataset as a lazy DataFrame with one row per frame.
 
-    Reads the per-episode metadata under ``meta/episodes`` and the per-frame
-    sensor data under ``data``, joins them on ``episode_index``, and broadcasts
-    each episode's metadata across its frames. Optionally decodes the matching
-    video frame for one or more camera keys into an image column.
+    Reads per-episode metadata and the per-frame sensor data under ``data``,
+    joins them on ``episode_index``, and broadcasts each episode's metadata
+    across its frames. Optionally decodes the matching video frame for one or
+    more camera keys into an image column.
+
+    v2.0/v2.1 datasets (including AgiBot World 2026 after unpacking) store one
+    Parquet/MP4 file per episode. v3 packs many episodes into shared shards.
 
     Args:
         dataset_uri: Huggingface repo id (``org/name``), or a local / remote
@@ -243,7 +329,7 @@ def read(
     # Load video frames into memory
     if load_video_frames is not False:
         if load_video_frames is True:
-            video_keys = [name for name, feat_info in info["features"].items() if feat_info["dtype"] == "video"]
+            video_keys = _video_keys(info)
         elif isinstance(load_video_frames, str):
             video_keys = [load_video_frames]
         elif isinstance(load_video_frames, list) and all(isinstance(k, str) for k in load_video_frames):
@@ -251,12 +337,13 @@ def read(
         else:
             raise ValueError(f"Invalid value provided for argument load_video_frames=`{load_video_frames}`")
 
-        # An MP4 shard packs many episodes back to back, so the shard's internal
-        # frame numbering is NOT the parquet's episode-local `frame_index` (which
-        # resets to 0 each episode). Seeking by `frame_index` only happens to work
-        # for the first episode in each shard. Instead, seek by absolute timestamp:
-        # `from_timestamp` (where this episode begins in the shard) + the per-frame
-        # episode-local `timestamp`. That keeps a single coordinate system end to end.
+        # Seek by absolute timestamp inside the MP4: `from_timestamp` (where this
+        # episode begins in the file) + the per-frame episode-local `timestamp`.
+        # v3 shards pack many episodes back to back, so `from_timestamp` is the
+        # offset within the shard. v2 stores one MP4 per episode, so
+        # `from_timestamp` is 0 and the episode-local timestamp is already
+        # absolute in that file. Seeking by `frame_index` is wrong for v3 (it
+        # only happens to work for the first episode in each shard).
         fps = float(info["fps"])
         tolerance_s = 1.0 / fps / 2.0  # half a frame period: any closer frame is unambiguously "the" frame
 
@@ -290,24 +377,27 @@ def read_episodes(
     include_stats: bool = False,
     include_video_metadata: bool = False,
 ) -> DataFrame:
-    """Read LeRobot v3 episode metadata as a lazy DataFrame (one row per episode).
+    """Read LeRobot episode metadata as a lazy DataFrame (one row per episode).
 
-    This reads the `meta/episodes/**/*.parquet` path under the dataset root.
+    v3 reads ``meta/episodes/**/*.parquet``. v2.0/v2.1 (including AgiBot World
+    2026) reads ``meta/episodes.jsonl``. Extra per-episode fields such as
+    AgiBot's ``instruction_segments`` / ``key_frame`` are kept as columns.
 
     Args:
         dataset_uri: Huggingface repo id (`org/name`),
             or a local / remote directory (`s3://...`, `hf://datasets/...`)
         io_config: Optional IO configuration for remote reads.
         include_meta: If True, keep the internal ``meta/episodes/*`` columns
-            (the chunk/file indices locating each episode's own metadata shard).
-            These are bookkeeping for random access into the sharded metadata
-            and carry no analytical value once the rows are loaded. Defaults to
+            (v3 chunk/file indices locating each episode's own metadata shard).
+            No effect on v2, which has no such bookkeeping columns. Defaults to
             False.
-        include_stats: If True, keep the per-episode ``stats/*`` columns
-            (per-feature min/max/mean/std/quantiles). Defaults to False.
+        include_stats: If True, keep per-episode statistics. On v3 these are
+            ``stats/*`` columns in the episode parquet; on v2.1 they are joined
+            from ``meta/episodes_stats.jsonl``. Defaults to False.
         include_video_metadata: If True, keep the per-episode ``videos/{key}/*``
-            columns (the chunk/file indices and from/to timestamps locating each
-            episode's footage within its video shard). Defaults to False.
+            columns (chunk/file indices and from/to timestamps locating each
+            episode's footage). On v2, ``from_timestamp`` is 0 because each
+            episode has its own MP4. Defaults to False.
 
     Returns:
         Lazy DataFrame of episode metadata, one row per episode. Always includes
@@ -316,16 +406,40 @@ def read_episodes(
     """
     root = _normalize_dataset_root(dataset_uri)
     info = _read_info(root, io_config=io_config)
+    if _is_v3(info):
+        return _read_episodes_v3(
+            root,
+            info,
+            io_config=io_config,
+            include_meta=include_meta,
+            include_stats=include_stats,
+            include_video_metadata=include_video_metadata,
+        )
+    return _read_episodes_v2(
+        root,
+        info,
+        io_config=io_config,
+        include_stats=include_stats,
+        include_video_metadata=include_video_metadata,
+    )
+
+
+def _read_episodes_v3(
+    root: str,
+    info: LeRobotInfo,
+    *,
+    io_config: IOConfig | None,
+    include_meta: bool,
+    include_stats: bool,
+    include_video_metadata: bool,
+) -> DataFrame:
     df = daft.read_parquet(f"{root}/meta/episodes/**/*.parquet", io_config=io_config)
     if not include_meta:
         df = df.exclude(*(c for c in df.column_names if c.startswith("meta/")))
     if not include_stats:
         df = df.exclude(*(c for c in df.column_names if c.startswith("stats/")))
 
-    # Get the video keys
-    video_keys = set(name for name, feat_info in info["features"].items() if feat_info["dtype"] == "video")
-
-    for key in video_keys:
+    for key in _video_keys(info):
         file_name_expr = (
             lit(f"{root}/videos/{key}/chunk-")
             + lpad(col(f"videos/{key}/chunk_index").cast(DataType.string), 3, "0")
@@ -333,12 +447,41 @@ def read_episodes(
             + lpad(col(f"videos/{key}/file_index").cast(DataType.string), 3, "0")
             + lit(".mp4")
         )
-
         df = df.with_column(f"videos/{key}/video", video_file(file_name_expr, verify=False, io_config=io_config))
 
     if not include_video_metadata:
         df = df.exclude(*(c for c in df.column_names if c.startswith("videos/") and not c.endswith("/video")))
+    return df
 
+
+def _read_episodes_v2(
+    root: str,
+    info: LeRobotInfo,
+    *,
+    io_config: IOConfig | None,
+    include_stats: bool,
+    include_video_metadata: bool,
+) -> DataFrame:
+    df = daft.read_json(f"{root}/meta/episodes.jsonl", io_config=io_config)
+
+    if include_stats:
+        try:
+            stats_df = daft.read_json(f"{root}/meta/episodes_stats.jsonl", io_config=io_config)
+            df = df.join(stats_df, on="episode_index")
+        except (OSError, DaftCoreException, FileNotFoundError):
+            pass
+
+    video_path = info.get("video_path") or _V2_VIDEO_PATH
+    bindings = _v2_path_bindings(info)
+    for key in _video_keys(info):
+        bindings["video_key"] = key
+        file_name_expr = _format_path_template(video_path, root=root, bindings=bindings)
+        df = df.with_column(f"videos/{key}/video", video_file(file_name_expr, verify=False, io_config=io_config))
+        # One MP4 per episode: episode-local timestamps are already absolute.
+        df = df.with_column(f"videos/{key}/from_timestamp", lit(0.0))
+
+    if not include_video_metadata:
+        df = df.exclude(*(c for c in df.column_names if c.startswith("videos/") and not c.endswith("/video")))
     return df
 
 
@@ -350,9 +493,10 @@ def load_episode_frames(
 ) -> DataFrame:
     """Expand an episode-level DataFrame into a frame-level DataFrame.
 
-    Reads the per-frame parquet under ``data/**`` and joins it to the provided
-    episode metadata on ``episode_index``, producing one row per frame. Episode
-    metadata is broadcast across each episode's frames.
+    Reads the per-frame parquet under ``data/**`` (v3 shared shards or v2
+    per-episode files) and joins it to the provided episode metadata on
+    ``episode_index``, producing one row per frame. Episode metadata is
+    broadcast across each episode's frames.
 
     Filter ``episodes`` before calling this to expand only the episodes you need;
     only the surviving episodes contribute to the join.

--- a/daft/datasets/lerobot.py
+++ b/daft/datasets/lerobot.py
@@ -1,9 +1,8 @@
 """LeRobot Dataset helpers for `daft.datasets`.
 
 Supports the episode-per-file v2.0/v2.1 layout (`meta/episodes.jsonl`,
-`data/chunk-XXX/episode_YYYYYY.parquet`) used by datasets such as AgiBot World
-2026, and the file-based v3 layout (`meta/episodes/**/*.parquet`, shared
-Parquet/MP4 shards).
+`data/chunk-XXX/episode_YYYYYY.parquet`) and the file-based v3 layout
+(`meta/episodes/**/*.parquet`, shared Parquet/MP4 shards).
 
 See https://huggingface.co/docs/lerobot/lerobot-dataset-v3 for v3 details.
 """
@@ -295,8 +294,8 @@ def read(
     across its frames. Optionally decodes the matching video frame for one or
     more camera keys into an image column.
 
-    v2.0/v2.1 datasets (including AgiBot World 2026 after unpacking) store one
-    Parquet/MP4 file per episode. v3 packs many episodes into shared shards.
+    v2.0/v2.1 datasets store one Parquet/MP4 file per episode. v3 packs many
+    episodes into shared shards.
 
     Args:
         dataset_uri: Huggingface repo id (``org/name``), or a local / remote
@@ -379,9 +378,9 @@ def read_episodes(
 ) -> DataFrame:
     """Read LeRobot episode metadata as a lazy DataFrame (one row per episode).
 
-    v3 reads ``meta/episodes/**/*.parquet``. v2.0/v2.1 (including AgiBot World
-    2026) reads ``meta/episodes.jsonl``. Extra per-episode fields such as
-    AgiBot's ``instruction_segments`` / ``key_frame`` are kept as columns.
+    v3 reads ``meta/episodes/**/*.parquet``. v2.0/v2.1 reads
+    ``meta/episodes.jsonl``. Extra per-episode fields present in that metadata
+    are kept as columns.
 
     Args:
         dataset_uri: Huggingface repo id (`org/name`),

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -32,7 +32,7 @@
         * [Batch Inference](use-case/batch-inference.md)
     * Datasets
         * [Common Crawl](datasets/common-crawl.md)
-        * [LeRobot v3](datasets/lerobot.md)
+        * [LeRobot](datasets/lerobot.md)
         * [DROID](datasets/droid.md)
     * Data Connectors
         * [Overview](connectors/index.md)

--- a/docs/api/datasets.md
+++ b/docs/api/datasets.md
@@ -11,9 +11,9 @@ Check out our [Common Crawl dataset guide](../datasets/common-crawl.md) for more
         filters: ["!^_"]
         heading_level: 3
 
-## LeRobot v3
+## LeRobot
 
-See the [LeRobot v3 dataset guide](../datasets/lerobot.md) for episode vs frame workflows and Hub/local paths.
+See the [LeRobot dataset guide](../datasets/lerobot.md) for v2.1 / v3 layouts, episode vs frame workflows, and Hub/local paths.
 
 ::: daft.datasets.lerobot.read
     options:

--- a/docs/datasets/lerobot.md
+++ b/docs/datasets/lerobot.md
@@ -1,6 +1,8 @@
-# LeRobot v3 datasets with Daft
+# LeRobot datasets with Daft
 
-[LeRobot Dataset v3.0](https://huggingface.co/docs/lerobot/lerobot-dataset-v3) stores robot learning data as chunked Parquet (`meta/episodes`, `data/`) and per-camera MP4 shards under `videos/`. Daft exposes this layout under [`daft.datasets.lerobot`](../api/datasets.md) so you can stay at **episode granularity** for filtering, then expand to **frames** only for the episodes you need.
+[LeRobot](https://huggingface.co/docs/lerobot/lerobot-dataset-v3) stores robot learning data as Parquet (`meta/`, `data/`) plus per-camera MP4 under `videos/`. Daft exposes this layout under [`daft.datasets.lerobot`](../api/datasets.md) so you can stay at **episode granularity** for filtering, then expand to **frames** only for the episodes you need.
+
+The reader accepts **v2.0 / v2.1** (one Parquet and one MP4 per episode — the layout used by [AgiBot World 2026](https://huggingface.co/datasets/agibot-world/AgiBotWorld2026) after unpacking) and **v3.0** (many episodes packed into shared Parquet/MP4 shards). Version is taken from `meta/info.json` → `codebase_version`.
 
 !!! warning "Beta"
 
@@ -8,7 +10,7 @@
 
 ## Frame-level reads
 
-Use [`daft.datasets.lerobot.read`](../api/datasets.md#daft.datasets.lerobot.read) for the common case: a lazy DataFrame with one row per frame, episode metadata broadcast onto each frame. Pass `load_video_frames=True` (or a camera key / list of keys) to also decode each row's camera image from the MP4 shards.
+Use [`daft.datasets.lerobot.read`](../api/datasets.md#daft.datasets.lerobot.read) for the common case: a lazy DataFrame with one row per frame, episode metadata broadcast onto each frame. Pass `load_video_frames=True` (or a camera key / list of keys) to also decode each row's camera image from the MP4 files.
 
 ```python
 import daft
@@ -19,13 +21,18 @@ df = lerobot.read("your-org/your-robot-dataset", load_video_frames=True)
 
 `dataset_uri` can be:
 
-- A local directory that contains `meta/`, `data/`, etc.
-- An `hf://datasets/org/name` URI (Hub layout matches the on-disk v3 tree)
+- A local directory that contains `meta/`, `data/`, etc. (for AgiBot World 2026, point at an **extracted** task directory, not the Hub repo of `.tar.gz` shards)
+- An `hf://datasets/org/name` URI (Hub layout matches the on-disk tree)
 - A bare `org/name` string, which is interpreted as `hf://datasets/org/name`
 
 ## Episode metadata
 
-Use [`daft.datasets.lerobot.read_episodes`](../api/datasets.md#daft.datasets.lerobot.read_episodes) to scan `meta/episodes/**/*.parquet` (one row per episode). Per-episode `meta/` and `stats/` columns are hidden by default; opt in with `include_meta=True` / `include_stats=True`.
+Use [`daft.datasets.lerobot.read_episodes`](../api/datasets.md#daft.datasets.lerobot.read_episodes) for one row per episode:
+
+- **v3:** `meta/episodes/**/*.parquet`
+- **v2:** `meta/episodes.jsonl` (extra fields such as AgiBot's `instruction_segments` are kept as columns)
+
+Per-episode `meta/` and `stats/` columns are hidden by default; opt in with `include_meta=True` / `include_stats=True`. On v2.1, stats are joined from `meta/episodes_stats.jsonl`.
 
 ```python
 import daft
@@ -41,11 +48,25 @@ frames = load_episode_frames(long, repo)
 
 ## Tasks
 
-[`read_tasks`](../api/datasets.md#daft.datasets.lerobot.read_tasks) loads task metadata, preferring `meta/tasks.parquet` and falling back to legacy `meta/tasks.jsonl`.
+[`read_tasks`](../api/datasets.md#daft.datasets.lerobot.read_tasks) loads task metadata, preferring `meta/tasks.parquet` and falling back to `meta/tasks.jsonl` (the v2 default).
 
 ## Video frames
 
-With `load_video_frames`, [`read`](../api/datasets.md#daft.datasets.lerobot.read) decodes each frame from its MP4 shard by **timestamp**: a shard packs many episodes back to back, so Daft combines the episode's `from_timestamp` offset within the shard with the frame's episode-local `timestamp`, and matches the closest decoded frame within half a frame period. Decoding requires PyAV and Pillow (`pip install av pillow`).
+With `load_video_frames`, [`read`](../api/datasets.md#daft.datasets.lerobot.read) decodes each frame from its MP4 by **timestamp**: Daft combines the episode's `from_timestamp` offset within the file with the frame's episode-local `timestamp`, and matches the closest decoded frame within half a frame period.
+
+- **v3:** a shard packs many episodes back to back, so `from_timestamp` is where that episode starts inside the shard.
+- **v2:** each episode has its own MP4, so `from_timestamp` is `0`.
+
+Decoding requires PyAV and Pillow (`pip install av pillow`).
+
+## Layout cheat sheet
+
+| | v2.0 / v2.1 | v3.0 |
+|---|---|---|
+| Episode metadata | `meta/episodes.jsonl` | `meta/episodes/**/*.parquet` |
+| Frame data | `data/chunk-XXX/episode_YYYYYY.parquet` | `data/chunk-XXX/file-YYY.parquet` (many episodes) |
+| Video | one MP4 per episode per camera | shared MP4 shards + `from_timestamp` |
+| Tasks | `meta/tasks.jsonl` | `meta/tasks.parquet` (jsonl fallback) |
 
 ## API reference
 

--- a/docs/datasets/lerobot.md
+++ b/docs/datasets/lerobot.md
@@ -2,7 +2,7 @@
 
 [LeRobot](https://huggingface.co/docs/lerobot/lerobot-dataset-v3) stores robot learning data as Parquet (`meta/`, `data/`) plus per-camera MP4 under `videos/`. Daft exposes this layout under [`daft.datasets.lerobot`](../api/datasets.md) so you can stay at **episode granularity** for filtering, then expand to **frames** only for the episodes you need.
 
-The reader accepts **v2.0 / v2.1** (one Parquet and one MP4 per episode — the layout used by [AgiBot World 2026](https://huggingface.co/datasets/agibot-world/AgiBotWorld2026) after unpacking) and **v3.0** (many episodes packed into shared Parquet/MP4 shards). Version is taken from `meta/info.json` → `codebase_version`.
+The reader accepts **v2.0 / v2.1** (one Parquet and one MP4 per episode) and **v3.0** (many episodes packed into shared Parquet/MP4 shards). Version is taken from `meta/info.json` → `codebase_version`.
 
 !!! warning "Beta"
 
@@ -21,7 +21,7 @@ df = lerobot.read("your-org/your-robot-dataset", load_video_frames=True)
 
 `dataset_uri` can be:
 
-- A local directory that contains `meta/`, `data/`, etc. (for AgiBot World 2026, point at an **extracted** task directory, not the Hub repo of `.tar.gz` shards)
+- A local directory that contains `meta/`, `data/`, etc.
 - An `hf://datasets/org/name` URI (Hub layout matches the on-disk tree)
 - A bare `org/name` string, which is interpreted as `hf://datasets/org/name`
 
@@ -30,7 +30,7 @@ df = lerobot.read("your-org/your-robot-dataset", load_video_frames=True)
 Use [`daft.datasets.lerobot.read_episodes`](../api/datasets.md#daft.datasets.lerobot.read_episodes) for one row per episode:
 
 - **v3:** `meta/episodes/**/*.parquet`
-- **v2:** `meta/episodes.jsonl` (extra fields such as AgiBot's `instruction_segments` are kept as columns)
+- **v2:** `meta/episodes.jsonl` (any extra per-episode fields in that file are kept as columns)
 
 Per-episode `meta/` and `stats/` columns are hidden by default; opt in with `include_meta=True` / `include_stats=True`. On v2.1, stats are joined from `meta/episodes_stats.jsonl`.
 

--- a/tests/datasets/test_lerobot.py
+++ b/tests/datasets/test_lerobot.py
@@ -9,7 +9,14 @@ import pyarrow.parquet as pq
 import pytest
 
 import daft
-from daft.datasets.lerobot import load_episode_frames, read, read_episodes, read_tasks
+from daft.datasets.lerobot import (
+    _V2_VIDEO_PATH,
+    _format_path_template,
+    load_episode_frames,
+    read,
+    read_episodes,
+    read_tasks,
+)
 
 
 def _write_table(path, table: pa.Table) -> None:
@@ -576,7 +583,7 @@ def test_v21_read_load_video_frames(tiny_lerobot_v21_video):
         assert img0.mode == "RGB"
         assert img0.size[0] > 10 and img0.size[1] > 10
     else:
-        import numpy as np
+        np = pytest.importorskip("numpy")
 
         assert isinstance(img0, np.ndarray)
         assert img0.ndim == 3 and img0.shape[2] >= 3
@@ -601,8 +608,6 @@ def test_v21_video_frames_match_raw_pyav_decode(tiny_lerobot_v21_video):
 
 
 def test_format_path_template_pads_episode_chunk():
-    from daft.datasets.lerobot import _V2_VIDEO_PATH, _format_path_template
-
     df = daft.from_pydict({"episode_index": [0, 1000]})
     df = df.with_column(
         "path",
@@ -623,8 +628,6 @@ def test_format_path_template_pads_episode_chunk():
 
 
 def test_format_path_template_chunk_index_alias():
-    from daft.datasets.lerobot import _format_path_template
-
     template = "videos/chunk-{chunk_index:03d}/{video_key}/episode_{episode_index:06d}.mp4"
     df = daft.from_pydict({"episode_index": [42]})
     df = df.with_column(

--- a/tests/datasets/test_lerobot.py
+++ b/tests/datasets/test_lerobot.py
@@ -244,10 +244,10 @@ def tiny_lerobot_v21(tmp_path):
 
 
 @pytest.fixture
-def tiny_lerobot_v21_agibot(tmp_path):
-    """v2.1 layout plus AgiBot-style extra episode metadata."""
+def tiny_lerobot_v21_extra_fields(tmp_path):
+    """v2.1 layout plus extra per-episode metadata columns."""
     return _write_tiny_v2(
-        tmp_path / "ds_agibot",
+        tmp_path / "ds_v21_extra",
         version="v2.1",
         extra_episode_fields={
             "instruction_segments": [{"start": 0, "end": 2, "instruction": "pick the cube"}],
@@ -550,8 +550,8 @@ def test_v21_read_tasks_jsonl(tiny_lerobot_v21):
     assert t.to_pydict()["task"] == ["pick"]
 
 
-def test_v21_agibot_extra_episode_fields(tiny_lerobot_v21_agibot):
-    ep = read_episodes(tiny_lerobot_v21_agibot).sort("episode_index").collect()
+def test_v21_extra_episode_fields(tiny_lerobot_v21_extra_fields):
+    ep = read_episodes(tiny_lerobot_v21_extra_fields).sort("episode_index").collect()
     assert "instruction_segments" in ep.column_names
     segments = ep.to_pydict()["instruction_segments"]
     assert segments[0][0]["instruction"] == "pick the cube"

--- a/tests/datasets/test_lerobot.py
+++ b/tests/datasets/test_lerobot.py
@@ -180,13 +180,137 @@ def test_read_episodes_meta_and_stats_columns(tiny_lerobot_v3):
     assert "stats/action_mean" in with_stats
 
 
-def test_read_episodes_rejects_non_v3(tmp_path):
+def _write_jsonl(path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+
+
+def _write_tiny_v2(root: pathlib.Path, *, version: str = "v2.1", extra_episode_fields: dict | None = None):
+    """Minimal on-disk LeRobot v2 layout (two episodes, one parquet each)."""
+    extra_episode_fields = extra_episode_fields or {}
+    (root / "data" / "chunk-000").mkdir(parents=True)
+
+    episodes = []
+    for ep_idx in (0, 1):
+        row = {"episode_index": ep_idx, "tasks": ["pick"], "length": 2, **extra_episode_fields}
+        episodes.append(row)
+        frames_tbl = pa.table(
+            {
+                "index": [ep_idx * 2, ep_idx * 2 + 1],
+                "episode_index": [ep_idx, ep_idx],
+                "frame_index": [0, 1],
+                "timestamp": [0.0, 1 / 30],
+                "task_index": [0, 0],
+            }
+        )
+        _write_table(root / "data" / "chunk-000" / f"episode_{ep_idx:06d}.parquet", frames_tbl)
+
+    _write_jsonl(root / "meta" / "episodes.jsonl", episodes)
+    _write_jsonl(
+        root / "meta" / "episodes_stats.jsonl",
+        [
+            {"episode_index": 0, "stats": {"action": {"mean": [0.1]}}},
+            {"episode_index": 1, "stats": {"action": {"mean": [0.2]}}},
+        ],
+    )
+    _write_jsonl(root / "meta" / "tasks.jsonl", [{"task_index": 0, "task": "pick"}])
+
+    info = {
+        "codebase_version": version,
+        "fps": 30,
+        "chunks_size": 1000,
+        "data_path": "data/chunk-{episode_chunk:03d}/episode_{episode_index:06d}.parquet",
+        "video_path": "videos/chunk-{episode_chunk:03d}/{video_key}/episode_{episode_index:06d}.mp4",
+        "features": {},
+        "total_episodes": 2,
+        "total_frames": 4,
+        "total_tasks": 1,
+    }
+    (root / "meta").mkdir(parents=True, exist_ok=True)
+    (root / "meta" / "info.json").write_text(json.dumps(info), encoding="utf-8")
+    return str(root)
+
+
+@pytest.fixture
+def tiny_lerobot_v21(tmp_path):
+    return _write_tiny_v2(tmp_path / "ds_v21", version="v2.1")
+
+
+@pytest.fixture
+def tiny_lerobot_v21_agibot(tmp_path):
+    """v2.1 layout plus AgiBot-style extra episode metadata."""
+    return _write_tiny_v2(
+        tmp_path / "ds_agibot",
+        version="v2.1",
+        extra_episode_fields={
+            "instruction_segments": [{"start": 0, "end": 2, "instruction": "pick the cube"}],
+        },
+    )
+
+
+@pytest.fixture
+def tiny_lerobot_v21_video(tmp_path):
+    """Single-episode v2.1 dataset with one MP4 per camera."""
+    av = pytest.importorskip("av")
+    pytest.importorskip("PIL", reason="Pillow required for decoded image rows")
+
+    root = tmp_path / "ds_v21_vid"
+    video_key = "camera.test"
+    video_dir = root / "videos" / "chunk-000" / video_key
+    video_dir.mkdir(parents=True)
+    (root / "data" / "chunk-000").mkdir(parents=True)
+    shutil.copy(pathlib.Path("tests/assets/sample_video.mp4"), video_dir / "episode_000000.mp4")
+
+    with av.open(str(video_dir / "episode_000000.mp4")) as c:
+        s = c.streams.video[0]
+        fps = float(s.average_rate)
+        timestamps = []
+        for fr in c.decode(s):
+            if fr.pts is not None:
+                timestamps.append(float(fr.pts * s.time_base))
+            if len(timestamps) >= 3:
+                break
+        assert len(timestamps) == 3
+
+    n_frames = len(timestamps)
+
+    _write_table(
+        root / "data" / "chunk-000" / "episode_000000.parquet",
+        pa.table(
+            {
+                "index": list(range(n_frames)),
+                "episode_index": [0] * n_frames,
+                "frame_index": list(range(n_frames)),
+                "timestamp": timestamps,
+                "task_index": [0] * n_frames,
+            }
+        ),
+    )
+    _write_jsonl(root / "meta" / "episodes.jsonl", [{"episode_index": 0, "tasks": ["pick"], "length": n_frames}])
+    _write_jsonl(root / "meta" / "tasks.jsonl", [{"task_index": 0, "task": "pick"}])
+
+    info = {
+        "codebase_version": "v2.1",
+        "fps": fps,
+        "chunks_size": 1000,
+        "data_path": "data/chunk-{episode_chunk:03d}/episode_{episode_index:06d}.parquet",
+        "video_path": "videos/chunk-{episode_chunk:03d}/{video_key}/episode_{episode_index:06d}.mp4",
+        "features": {video_key: {"dtype": "video"}},
+        "total_episodes": 1,
+        "total_frames": n_frames,
+        "total_tasks": 1,
+    }
+    (root / "meta" / "info.json").write_text(json.dumps(info), encoding="utf-8")
+    return str(root)
+
+
+def test_read_episodes_rejects_unsupported_version(tmp_path):
     root = tmp_path / "ds_old"
     (root / "meta").mkdir(parents=True)
-    info = {"codebase_version": "v2.1", "fps": 30, "features": {}}
+    info = {"codebase_version": "v1.0", "fps": 30, "features": {}}
     (root / "meta" / "info.json").write_text(json.dumps(info), encoding="utf-8")
 
-    with pytest.raises(ValueError, match="v3"):
+    with pytest.raises(ValueError, match="v2.0"):
         read_episodes(str(root))
 
 
@@ -381,3 +505,138 @@ def test_batched_decode_tolerance_violation_raises(tmp_path):
     )
     with pytest.raises(Exception, match="No frame matched timestamp"):
         df.select("img").collect()
+
+
+def test_v21_read_episodes_and_load_episode_frames(tiny_lerobot_v21):
+    ep = read_episodes(tiny_lerobot_v21).sort("episode_index")
+    assert ep.count_rows() == 2
+    assert "tasks" in ep.column_names
+    assert "videos/" not in "".join(ep.column_names)
+
+    frames = load_episode_frames(ep, tiny_lerobot_v21).sort("index")
+    assert frames.count_rows() == 4
+    assert set(frames.to_pydict()["episode_index"]) == {0, 1}
+
+    f0 = load_episode_frames(ep.where(daft.col("episode_index") == 0), tiny_lerobot_v21).sort("frame_index")
+    assert f0.count_rows() == 2
+    assert f0.to_pydict()["episode_index"] == [0, 0]
+
+
+def test_v21_read_frame_rows(tiny_lerobot_v21):
+    df = read(tiny_lerobot_v21).sort("index").collect()
+    assert df.count_rows() == 4
+    for expected in ("episode_index", "frame_index", "timestamp"):
+        assert expected in df.column_names
+
+
+def test_v21_read_episodes_stats_column(tiny_lerobot_v21):
+    default_cols = read_episodes(tiny_lerobot_v21).column_names
+    assert "stats" not in default_cols
+
+    with_stats = read_episodes(tiny_lerobot_v21, include_stats=True).column_names
+    assert "stats" in with_stats
+
+
+def test_v21_read_tasks_jsonl(tiny_lerobot_v21):
+    t = read_tasks(tiny_lerobot_v21).collect()
+    assert t.count_rows() == 1
+    assert t.to_pydict()["task"] == ["pick"]
+
+
+def test_v21_agibot_extra_episode_fields(tiny_lerobot_v21_agibot):
+    ep = read_episodes(tiny_lerobot_v21_agibot).sort("episode_index").collect()
+    assert "instruction_segments" in ep.column_names
+    segments = ep.to_pydict()["instruction_segments"]
+    assert segments[0][0]["instruction"] == "pick the cube"
+
+
+def test_v20_read_episodes(tmp_path):
+    root = _write_tiny_v2(tmp_path / "ds_v20", version="v2.0")
+    ep = read_episodes(root).sort("episode_index")
+    assert ep.count_rows() == 2
+
+
+def test_v21_video_path_and_from_timestamp(tiny_lerobot_v21_video):
+    ep = read_episodes(tiny_lerobot_v21_video, include_video_metadata=True)
+    cols = ep.column_names
+    assert "videos/camera.test/video" in cols
+    assert "videos/camera.test/from_timestamp" in cols
+    row = ep.collect().to_pydict()
+    assert row["videos/camera.test/from_timestamp"] == [0.0]
+    video_path = row["videos/camera.test/video"][0]
+    path = video_path.path if hasattr(video_path, "path") else str(video_path)
+    assert path.endswith("videos/chunk-000/camera.test/episode_000000.mp4")
+
+
+def test_v21_read_load_video_frames(tiny_lerobot_v21_video):
+    df = read(tiny_lerobot_v21_video, load_video_frames=["camera.test"]).select("camera.test").collect()
+    assert df.count_rows() == 3
+    img0 = df.to_pydict()["camera.test"][0]
+    if hasattr(img0, "mode"):
+        assert img0.mode == "RGB"
+        assert img0.size[0] > 10 and img0.size[1] > 10
+    else:
+        import numpy as np
+
+        assert isinstance(img0, np.ndarray)
+        assert img0.ndim == 3 and img0.shape[2] >= 3
+    assert not any(c.startswith("videos/") for c in read(tiny_lerobot_v21_video, load_video_frames=True).column_names)
+
+
+def test_v21_video_frames_match_raw_pyav_decode(tiny_lerobot_v21_video):
+    av = pytest.importorskip("av")
+    np = pytest.importorskip("numpy")
+
+    df = read(tiny_lerobot_v21_video, load_video_frames=["camera.test"]).sort("frame_index").collect()
+    decoded = df.to_pydict()["camera.test"]
+
+    shard = pathlib.Path(tiny_lerobot_v21_video) / "videos/chunk-000/camera.test/episode_000000.mp4"
+    with av.open(str(shard)) as c:
+        stream = c.streams.video[0]
+        ground_truth = [f.to_ndarray(format="rgb24") for f, _ in zip(c.decode(stream), range(len(decoded)))]
+
+    assert len(decoded) == len(ground_truth)
+    for got, want in zip(decoded, ground_truth):
+        assert np.array_equal(np.asarray(got)[..., :3], want)
+
+
+def test_format_path_template_pads_episode_chunk():
+    from daft.datasets.lerobot import _V2_VIDEO_PATH, _format_path_template
+
+    df = daft.from_pydict({"episode_index": [0, 1000]})
+    df = df.with_column(
+        "path",
+        _format_path_template(
+            _V2_VIDEO_PATH,
+            root="/ds",
+            bindings={
+                "episode_index": daft.col("episode_index"),
+                "episode_chunk": daft.col("episode_index") // 1000,
+                "chunk_index": daft.col("episode_index") // 1000,
+                "video_key": "observation.images.top_head",
+            },
+        ),
+    )
+    paths = df.to_pydict()["path"]
+    assert paths[0] == "/ds/videos/chunk-000/observation.images.top_head/episode_000000.mp4"
+    assert paths[1] == "/ds/videos/chunk-001/observation.images.top_head/episode_001000.mp4"
+
+
+def test_format_path_template_chunk_index_alias():
+    from daft.datasets.lerobot import _format_path_template
+
+    template = "videos/chunk-{chunk_index:03d}/{video_key}/episode_{episode_index:06d}.mp4"
+    df = daft.from_pydict({"episode_index": [42]})
+    df = df.with_column(
+        "path",
+        _format_path_template(
+            template,
+            root="/ds",
+            bindings={
+                "episode_index": daft.col("episode_index"),
+                "chunk_index": daft.col("episode_index") // 1000,
+                "video_key": "cam",
+            },
+        ),
+    )
+    assert df.to_pydict()["path"] == ["/ds/videos/chunk-000/cam/episode_000042.mp4"]


### PR DESCRIPTION
## Changes Made

`daft.datasets.lerobot` now detects `meta/info.json` `codebase_version` and reads both layouts with the same public API (`read`, `read_episodes`, `load_episode_frames`, `read_tasks`):

- **v2.0 / v2.1:** `meta/episodes.jsonl`, one Parquet + one MP4 per episode (AgiBot World 2026 after unpacking a task dir). Video `from_timestamp` is `0`. Extra episode fields such as `instruction_segments` are kept as columns. MP4 paths follow `info.json` `video_path` (`{episode_chunk}` / `{chunk_index}`).
- **v3.x:** existing sharded `meta/episodes/**/*.parquet` + shared MP4 shards (unchanged).

Hub root `agibot-world/AgiBotWorld2026` is `.tar.gz`; point `dataset_uri` at an extracted directory that contains `meta/`, `data/`, and `videos/`.

## Related Issues

Closes #7380

## Test plan

- [x] `tests/datasets/test_lerobot.py` (v3 regression + v2.0/v2.1 fixtures, AgiBot extra fields, video decode, path templates)
- [x] `make build` / ruff / mypy / pre-commit on touched files