### PR TITLE
fix(utf8): return empty strings for empty substr results

### DIFF
--- a/src/daft-functions-utf8/src/substr.rs
+++ b/src/daft-functions-utf8/src/substr.rs
@@ -256,8 +256,8 @@ where
             };
 
             match (val, s, l) {
-                (Some(val), Some(s), Some(l)) => Ok(substring(val, s, Some(l))),
-                (Some(val), Some(s), None) => Ok(substring(val, s, None)),
+                (Some(val), Some(s), Some(l)) => Ok(Some(substring(val, s, Some(l)))),
+                (Some(val), Some(s), None) => Ok(Some(substring(val, s, None))),
                 _ => Ok(None),
             }
         })
@@ -266,29 +266,19 @@ where
     Ok(res.rename(name))
 }
 
-fn substring(s: &str, start: usize, len: Option<usize>) -> Option<&str> {
+fn substring(s: &str, start: usize, len: Option<usize>) -> &str {
     let mut char_indices = s.char_indices();
+    let start_pos = char_indices.nth(start).map_or(s.len(), |(idx, _)| idx);
 
-    if let Some((start_pos, _)) = char_indices.nth(start) {
-        let len = match len {
-            Some(len) => {
-                if len == 0 {
-                    return None;
-                }
+    let len = match len {
+        Some(0) => return &s[start_pos..start_pos],
+        Some(len) => len,
+        None => return &s[start_pos..],
+    };
 
-                len
-            }
-            None => {
-                return Some(&s[start_pos..]);
-            }
-        };
+    let end_pos = char_indices
+        .nth(len.saturating_sub(1))
+        .map_or(s.len(), |(idx, _)| idx);
 
-        let end_pos = char_indices
-            .nth(len.saturating_sub(1))
-            .map_or(s.len(), |(idx, _)| idx);
-
-        Some(&s[start_pos..end_pos])
-    } else {
-        None
-    }
+    &s[start_pos..end_pos]
 }

--- a/tests/recordbatch/utf8/test_substr.py
+++ b/tests/recordbatch/utf8/test_substr.py
@@ -7,4 +7,18 @@ from daft.recordbatch import MicroPartition
 def test_utf8_substr():
     table = MicroPartition.from_pydict({"col": ["foo", None, "barbarbar", "quux", "1", ""]})
     result = table.eval_expression_list([col("col").substr(0, 5)])
-    assert result.to_pydict() == {"col": ["foo", None, "barba", "quux", "1", None]}
+    assert result.to_pydict() == {"col": ["foo", None, "barba", "quux", "1", ""]}
+
+
+def test_utf8_substr_empty_results_are_empty_strings():
+    table = MicroPartition.from_pydict(
+        {
+            "col": ["hello", "hello", "", "☃😉🌈", "☃😉🌈"],
+            "start": [0, 5, 0, 3, 4],
+            "length": [0, 2, 3, 1, 1],
+        }
+    )
+
+    result = table.eval_expression_list([col("col").substr(col("start"), col("length"))])
+
+    assert result.to_pydict() == {"col": ["", "", "", "", ""]}

--- a/tests/series/test_utf8_ops.py
+++ b/tests/series/test_utf8_ops.py
@@ -1245,8 +1245,8 @@ def test_series_utf8_ilike_empty_arrs() -> None:
         pytest.param(["foo"] * 4, [0] * 4, [None] * 4, ["foo"] * 4, id="All null length"),
         pytest.param(["foo"] * 4, [None] * 4, [None] * 4, [None] * 4, id="All null length and length"),
         pytest.param(["😃😌😝", "abc😃😄😅"], [1, 3], [None], ["😌😝", "😃😄😅"], id="With emojis"),
-        pytest.param(["foo"], [0], [0], [None], id="Zero length"),
-        pytest.param(["foo"], [5], [10], [None], id="Start over the string length"),
+        pytest.param(["foo"], [0], [0], [""], id="Zero length"),
+        pytest.param(["foo"], [5], [10], [""], id="Start over the string length"),
         pytest.param(["foo", "bar"], [0, 1], [None, None], ["foo", "ar"], id="None series length"),
     ],
 )


### PR DESCRIPTION
## Changes Made

- Return valid empty strings when `substr` produces no characters because the input is empty, the requested length is zero, or the start is at/past the end.
- Keep genuine null propagation separate from substring boundary handling by making the internal `substring` helper return `&str`.
- Clamp out-of-range character positions to the UTF-8 byte boundary at the end of the string.
- Add MicroPartition and Series regression coverage for empty, boundary, out-of-range, and multibyte UTF-8 inputs.

Before this change, these valid empty results were collected as Arrow nulls, changing downstream `is_null`, aggregation, and serialization semantics. Genuine null inputs continue to produce null outputs.

This is intentionally a narrow fix for empty-result semantics. It does not change the existing behavior for negative start or length arguments.

## Related Issues

Partially addresses #3700.

## Testing

- `CARGO_TARGET_DIR=/home/bdu/code/open_source/Daft/target make build`
- `DAFT_RUNNER=native .venv/bin/python -m pytest -q tests/recordbatch/utf8/test_substr.py tests/series/test_utf8_ops.py -k substr` — 36 passed
- `DAFT_RUNNER=native .venv/bin/python -m pytest -q tests/sql/test_utf8_exprs.py` — 1 passed
- `CARGO_TARGET_DIR=/home/bdu/code/open_source/Daft/target cargo test -p daft-functions-utf8` — 46 passed
- `cargo fmt --check`
- `git diff --check`

## AI Usage

OpenAI Codex assisted with issue analysis, implementation, code review, and test execution. The resulting behavior was verified with the commands listed above, including explicit checks that real null inputs remain null and empty substring results become valid empty strings.
