### PR TITLE
fix(udf): preserve field names when unnesting with_column

### DIFF
--- a/src/daft-logical-plan/src/builder/mod.rs
+++ b/src/daft-logical-plan/src/builder/mod.rs
@@ -366,7 +366,32 @@ impl LogicalPlanBuilder {
             .allow_explode(true)
             .build();
 
-        let columns = expr_resolver.resolve(columns, self.plan.clone())?;
+        let columns = columns
+            .into_iter()
+            .map(|column| {
+                let had_top_level_alias = matches!(column.as_ref(), Expr::Alias(..));
+                let resolved = expr_resolver.resolve(vec![column], self.plan.clone())?;
+
+                // A wildcard can expand one expression into several output columns. A
+                // with_column(s) alias names the single-expression case, but applying it to
+                // every expanded field creates duplicate column names. Preserve each expanded
+                // expression's field name instead.
+                if had_top_level_alias && resolved.len() > 1 {
+                    Ok(resolved
+                        .into_iter()
+                        .map(|expr| match expr.as_ref() {
+                            Expr::Alias(child, _) => child.clone(),
+                            _ => expr,
+                        })
+                        .collect::<Vec<_>>())
+                } else {
+                    Ok(resolved)
+                }
+            })
+            .collect::<DaftResult<Vec<_>>>()?
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
 
         let schema = self.schema();
         let current_col_names = schema.field_names().collect::<HashSet<_>>();

--- a/tests/udf/test_cls.py
+++ b/tests/udf/test_cls.py
@@ -195,6 +195,31 @@ def test_cls_unnest_struct(concurrency):
     }
 
 
+def test_cls_unnest_struct_with_column_preserves_field_names():
+    df = daft.from_pydict({"input": ["daft is cool"]})
+
+    @daft.cls()
+    class Processor:
+        def __init__(self, suffix: str):
+            self.suffix = suffix
+
+        @daft.method(
+            return_dtype=DataType.struct({"bar": DataType.string(), "some_int": DataType.int64()}),
+            unnest=True,
+        )
+        def process(self, value: str):
+            return {"bar": value + self.suffix, "some_int": 3}
+
+    result = df.with_column("result", Processor("bar").process(df["input"])).collect()
+
+    assert result.column_names == ["input", "bar", "some_int"]
+    assert result.to_pydict() == {
+        "input": ["daft is cool"],
+        "bar": ["daft is coolbar"],
+        "some_int": [3],
+    }
+
+
 def test_cls_multiple_methods():
     df = daft.from_pydict({"text": ["hello", "world", "daft"]})
 


### PR DESCRIPTION
## Changes Made

- Preserve the expansion group for each expression passed to `LogicalPlanBuilder::with_columns`.
- When a top-level `with_column(s)` alias expands into multiple wildcard outputs, remove the copied outer alias so each expanded struct field keeps its own name.
- Keep existing alias behavior unchanged for expressions that resolve to a single output column.
- Add a regression test for a `daft.method(unnest=True)` struct result passed through `with_column`.

Previously, `with_column("result", ...)` propagated `result` to every unnested field, producing duplicate `result` columns and making `bar` and `some_int` inaccessible. The fixed output retains the struct field names.

## Related Issues

Fixes #5448.

## Testing

- `CARGO_TARGET_DIR=/home/bdu/code/open_source/Daft/target make build`
- `DAFT_RUNNER=native .venv/bin/python -m pytest -q tests/udf/test_cls.py` — 37 passed
- `DAFT_RUNNER=native .venv/bin/python -m pytest -q tests/dataframe/test_with_column.py tests/dataframe/test_with_columns.py` — 24 passed
- `CARGO_TARGET_DIR=/home/bdu/code/open_source/Daft/target cargo test -p daft-logical-plan` — 271 passed, 3 ignored
- `.venv/bin/ruff check tests/udf/test_cls.py`
- `cargo fmt --check`
- `git diff --check`

## AI Usage

OpenAI Codex assisted with issue analysis, implementation, code review, and test execution. The diff was verified against the reported UDF reproduction, the existing `with_column(s)` test suites, and the full `daft-logical-plan` Rust test suite.
