### PR TITLE
fix: eliminate TOCTOU race in CREATE TABLE IF NOT EXISTS

### DIFF
--- a/daft/catalog/__iceberg.py
+++ b/daft/catalog/__iceberg.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 from pyiceberg.catalog import Catalog as InnerCatalog
 from pyiceberg.catalog import load_catalog
 from pyiceberg.exceptions import NoSuchNamespaceError, NoSuchTableError
+from pyiceberg.exceptions import TableAlreadyExistsError as PyIcebergTableAlreadyExistsError
 from pyiceberg.io.pyarrow import _pyarrow_to_schema_without_ids
 from pyiceberg.partitioning import PartitionField as PyIcebergPartitionField
 from pyiceberg.partitioning import PartitionSpec as PyIcebergPartitionSpec
@@ -23,7 +24,16 @@ from pyiceberg.transforms import (
     YearTransform,
 )
 
-from daft.catalog import Catalog, Function, Identifier, NotFoundError, Properties, Schema, Table
+from daft.catalog import (
+    Catalog,
+    Function,
+    Identifier,
+    NotFoundError,
+    Properties,
+    Schema,
+    Table,
+    TableAlreadyExistsError,
+)
 from daft.io.iceberg._iceberg import read_iceberg
 
 if TYPE_CHECKING:
@@ -165,17 +175,20 @@ class IcebergCatalog(Catalog):
         iceberg_schema = assign_fresh_schema_ids(_pyarrow_to_schema_without_ids(pa_schema))
         partition_spec = self._partition_fields_to_pyiceberg_spec(iceberg_schema, partition_fields)
         t = IcebergTable.__new__(IcebergTable)
-        if partition_spec is not None:
-            t._inner = self._inner.create_table(
-                i,
-                schema=iceberg_schema,
-                partition_spec=partition_spec,
-            )
-        else:
-            t._inner = self._inner.create_table(
-                i,
-                schema=iceberg_schema,
-            )
+        try:
+            if partition_spec is not None:
+                t._inner = self._inner.create_table(
+                    i,
+                    schema=iceberg_schema,
+                    partition_spec=partition_spec,
+                )
+            else:
+                t._inner = self._inner.create_table(
+                    i,
+                    schema=iceberg_schema,
+                )
+        except PyIcebergTableAlreadyExistsError as e:
+            raise TableAlreadyExistsError(f"Table {identifier} already exists") from e
         return t
 
     ###

--- a/daft/catalog/__init__.py
+++ b/daft/catalog/__init__.py
@@ -545,10 +545,15 @@ class Catalog(ABC):
         Returns:
             Table: the existing table (if exists) or the new table instance.
         """
-        if self.has_table(identifier):
-            return self.get_table(identifier)
-        else:
+        try:
             return self.create_table(identifier, source, properties)
+        except ValueError:
+            # Creation failed – if the table already exists (either
+            # pre-existing or created concurrently by another caller),
+            # return the existing table.  This avoids a TOCTOU race
+            # between has_table and create_table.
+            # See: https://github.com/Eventual-Inc/Daft/issues/7310
+            return self.get_table(identifier)
 
     ###
     # has_*

--- a/daft/catalog/__init__.py
+++ b/daft/catalog/__init__.py
@@ -67,6 +67,7 @@ __all__ = [
     "Properties",
     "Schema",
     "Table",
+    "TableAlreadyExistsError",
 ]
 
 
@@ -75,6 +76,14 @@ Properties = dict[str, Any]
 
 class NotFoundError(Exception):
     """Raised when some catalog object is not able to be found."""
+
+
+class TableAlreadyExistsError(ValueError):
+    """Raised when a table already exists in a catalog.
+
+    Subclasses ValueError for backwards compatibility with code that
+    catches ValueError on duplicate creation.
+    """
 
 
 class Catalog(ABC):
@@ -547,21 +556,11 @@ class Catalog(ABC):
         """
         try:
             return self.create_table(identifier, source, properties)
-        except Exception as e:
-            # Only recover from "already exists" failures. Unrelated errors
-            # (e.g. connection or permission failures raised by Python-backed
-            # catalogs) propagate unchanged.
-            #
-            # "already exists" is matched by message because the exception
-            # types vary across backends: DaftCoreException (ValueError) from
-            # Rust catalogs, TableAlreadyExistsError (bare Exception) from
-            # pyiceberg, and bare ValueErrors from others.
-            if "already exists" not in str(e):
-                raise
+        except TableAlreadyExistsError:
             # The table already exists (either pre-existing or created
             # concurrently by another caller), so return the existing
-            # table.  This avoids a TOCTOU race between has_table and
-            # create_table.
+            # table. Creating and catching the conflict avoids the TOCTOU
+            # race of checking existence before creating.
             # See: https://github.com/Eventual-Inc/Daft/issues/7310
             return self.get_table(identifier)
 

--- a/daft/catalog/__init__.py
+++ b/daft/catalog/__init__.py
@@ -547,10 +547,15 @@ class Catalog(ABC):
         """
         try:
             return self.create_table(identifier, source, properties)
-        except ValueError as e:
-            # Only recover from "already exists" failures. Unrelated
-            # ValueErrors (e.g. connection or permission errors raised by
-            # Python-backed catalogs) propagate unchanged.
+        except Exception as e:
+            # Only recover from "already exists" failures. Unrelated errors
+            # (e.g. connection or permission failures raised by Python-backed
+            # catalogs) propagate unchanged.
+            #
+            # "already exists" is matched by message because the exception
+            # types vary across backends: DaftCoreException (ValueError) from
+            # Rust catalogs, TableAlreadyExistsError (bare Exception) from
+            # pyiceberg, and bare ValueErrors from others.
             if "already exists" not in str(e):
                 raise
             # The table already exists (either pre-existing or created

--- a/daft/catalog/__init__.py
+++ b/daft/catalog/__init__.py
@@ -547,11 +547,16 @@ class Catalog(ABC):
         """
         try:
             return self.create_table(identifier, source, properties)
-        except ValueError:
-            # Creation failed – if the table already exists (either
-            # pre-existing or created concurrently by another caller),
-            # return the existing table.  This avoids a TOCTOU race
-            # between has_table and create_table.
+        except ValueError as e:
+            # Only recover from "already exists" failures. Unrelated
+            # ValueErrors (e.g. connection or permission errors raised by
+            # Python-backed catalogs) propagate unchanged.
+            if "already exists" not in str(e):
+                raise
+            # The table already exists (either pre-existing or created
+            # concurrently by another caller), so return the existing
+            # table.  This avoids a TOCTOU race between has_table and
+            # create_table.
             # See: https://github.com/Eventual-Inc/Daft/issues/7310
             return self.get_table(identifier)
 

--- a/daft/catalog/__init__.py
+++ b/daft/catalog/__init__.py
@@ -557,11 +557,8 @@ class Catalog(ABC):
         try:
             return self.create_table(identifier, source, properties)
         except TableAlreadyExistsError:
-            # The table already exists (either pre-existing or created
-            # concurrently by another caller), so return the existing
-            # table. Creating and catching the conflict avoids the TOCTOU
-            # race of checking existence before creating.
-            # See: https://github.com/Eventual-Inc/Daft/issues/7310
+            # Create-then-catch instead of check-then-create to avoid the
+            # TOCTOU race of checking existence before creating.
             return self.get_table(identifier)
 
     ###

--- a/daft/catalog/__paimon.py
+++ b/daft/catalog/__paimon.py
@@ -9,11 +9,21 @@ import pyarrow as pa  # noqa: TID253
 from pypaimon.catalog.catalog import Catalog as InnerCatalog
 from pypaimon.catalog.catalog_exception import (
     DatabaseNotExistException,
+    TableAlreadyExistException,
     TableNotExistException,
 )
 from pypaimon.table.table import Table as InnerTable
 
-from daft.catalog import Catalog, Function, Identifier, NotFoundError, Properties, Schema, Table
+from daft.catalog import (
+    Catalog,
+    Function,
+    Identifier,
+    NotFoundError,
+    Properties,
+    Schema,
+    Table,
+    TableAlreadyExistsError,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -89,7 +99,10 @@ class PaimonCatalog(Catalog):
         )
 
         paimon_ident = _to_paimon_ident(ident)
-        self._inner.create_table(paimon_ident, paimon_schema, ignore_if_exists=False)
+        try:
+            self._inner.create_table(paimon_ident, paimon_schema, ignore_if_exists=False)
+        except TableAlreadyExistException as ex:
+            raise TableAlreadyExistsError(f"Table {ident} already exists") from ex
 
         inner_table = self._inner.get_table(paimon_ident)
         return PaimonTable._from_obj(inner_table)

--- a/daft/catalog/__postgres.py
+++ b/daft/catalog/__postgres.py
@@ -9,7 +9,16 @@ from typing import TYPE_CHECKING, Any
 import psycopg
 from pgvector.psycopg import register_vector
 
-from daft.catalog import Catalog, Function, Identifier, NotFoundError, Properties, Schema, Table
+from daft.catalog import (
+    Catalog,
+    Function,
+    Identifier,
+    NotFoundError,
+    Properties,
+    Schema,
+    Table,
+    TableAlreadyExistsError,
+)
 from daft.datatype import DataType
 from daft.io._sql import read_sql
 from daft.logical.schema import Field
@@ -289,7 +298,7 @@ class PostgresCatalog(Catalog):
 
                     conn.commit()
                 except psycopg.errors.DuplicateTable:
-                    raise ValueError(f"Table {identifier} already exists")
+                    raise TableAlreadyExistsError(f"Table {identifier} already exists")
                 except psycopg.Error as e:
                     raise ValueError(f"Failed to create table {identifier}: {e}") from e
 

--- a/daft/catalog/__s3tables.py
+++ b/daft/catalog/__s3tables.py
@@ -9,7 +9,16 @@ import boto3
 import botocore
 from botocore.exceptions import ClientError
 
-from daft.catalog import Catalog, Function, Identifier, NotFoundError, Properties, Schema, Table
+from daft.catalog import (
+    Catalog,
+    Function,
+    Identifier,
+    NotFoundError,
+    Properties,
+    Schema,
+    Table,
+    TableAlreadyExistsError,
+)
 from daft.catalog.__iceberg import IcebergCatalog
 from daft.io import read_iceberg
 
@@ -173,6 +182,10 @@ class S3Catalog(Catalog):
                 metadata=_to_metadata(schema),
             )
             return self.get_table(ident)
+        except ClientError as e:
+            if e.response["Error"]["Code"] == "ConflictException":
+                raise TableAlreadyExistsError(f"Table {ident} already exists") from e
+            raise ValueError(f"Failed to create table: {e}") from e
         except Exception as e:
             raise ValueError(f"Failed to create table: {e}") from e
 

--- a/src/daft-catalog/src/error.rs
+++ b/src/daft-catalog/src/error.rs
@@ -110,8 +110,21 @@ impl From<DaftError> for CatalogError {
 use pyo3::PyErr;
 
 #[cfg(feature = "python")]
+pyo3::import_exception!(daft.catalog, TableAlreadyExistsError);
+
+#[cfg(feature = "python")]
 impl From<CatalogError> for PyErr {
     fn from(value: CatalogError) -> Self {
+        // Surface table-already-exists errors as the typed
+        // TableAlreadyExistsError so Python callers can catch it precisely
+        // (e.g. create_table_if_not_exists) without matching on messages.
+        if matches!(
+            &value,
+            CatalogError::ObjectAlreadyExists { type_, .. } if type_ == "table"
+        ) {
+            return TableAlreadyExistsError::new_err(value.to_string());
+        }
+
         let daft_error: common_error::DaftError = value.into();
         daft_error.into()
     }

--- a/src/daft-catalog/src/impls/memory.rs
+++ b/src/daft-catalog/src/impls/memory.rs
@@ -129,29 +129,27 @@ impl Catalog for MemoryCatalog {
     fn create_table(&self, ident: &Identifier, schema: SchemaRef) -> CatalogResult<TableRef> {
         let (namespace, table_name) = Self::split_table_ident(ident)?;
 
-        {
-            let tables = self.tables.read().unwrap();
-
-            let Some(namespace_tables) = tables.get(&namespace) else {
-                return Err(CatalogError::ObjectNotFound {
-                    type_: "namespace".to_string(),
-                    ident: namespace.unwrap(),
-                });
-            };
-
-            if namespace_tables.contains_key(table_name) {
-                return Err(CatalogError::obj_already_exists("table", ident));
-            }
-        }
-
+        // Build the table before taking the lock: MemoryTable::new registers
+        // the partition set with the (Python) runner and can release the GIL,
+        // so holding the lock across this call can deadlock with a concurrent
+        // creator that holds the GIL while waiting on the lock.
         let table = Arc::new(MemoryTable::new(table_name.to_string(), schema)?);
 
-        self.tables
-            .write()
-            .unwrap()
-            .get_mut(&namespace)
-            .unwrap()
-            .insert(table_name.to_string(), table.clone());
+        // Hold a single write lock for the entire check-then-insert to avoid TOCTOU races.
+        let mut tables = self.tables.write().unwrap();
+
+        let namespace_tables = tables.get_mut(&namespace).ok_or_else(|| {
+            CatalogError::ObjectNotFound {
+                type_: "namespace".to_string(),
+                ident: namespace.clone().unwrap(),
+            }
+        })?;
+
+        if namespace_tables.contains_key(table_name) {
+            return Err(CatalogError::obj_already_exists("table", ident));
+        }
+
+        namespace_tables.insert(table_name.to_string(), table.clone());
 
         Ok(table)
     }

--- a/src/daft-catalog/src/impls/memory.rs
+++ b/src/daft-catalog/src/impls/memory.rs
@@ -7,7 +7,7 @@ use daft_micropartition::{
     MicroPartition,
     partitioning::{MicroPartitionSet, PartitionSet},
 };
-use indexmap::IndexMap;
+use indexmap::{IndexMap, map::Entry};
 
 use crate::{
     Catalog, FunctionRef, Identifier, Table, TableRef,
@@ -135,21 +135,28 @@ impl Catalog for MemoryCatalog {
         // creator that holds the GIL while waiting on the lock.
         let table = Arc::new(MemoryTable::new(table_name.to_string(), schema)?);
 
-        // Hold a single write lock for the entire check-then-insert to avoid TOCTOU races.
+        // Insert with conflict detection: entry() reports "already exists"
+        // from the insert operation itself, so there is no separate check
+        // that could race with a concurrent creator. The write lock keeps
+        // the entry lookup and insert atomic across threads.
         let mut tables = self.tables.write().unwrap();
 
-        let namespace_tables = tables.get_mut(&namespace).ok_or_else(|| {
-            CatalogError::ObjectNotFound {
-                type_: "namespace".to_string(),
-                ident: namespace.clone().unwrap(),
+        let namespace_tables =
+            tables
+                .get_mut(&namespace)
+                .ok_or_else(|| CatalogError::ObjectNotFound {
+                    type_: "namespace".to_string(),
+                    ident: namespace.clone().unwrap(),
+                })?;
+
+        match namespace_tables.entry(table_name.to_string()) {
+            Entry::Vacant(slot) => {
+                slot.insert(table.clone());
             }
-        })?;
-
-        if namespace_tables.contains_key(table_name) {
-            return Err(CatalogError::obj_already_exists("table", ident));
+            Entry::Occupied(_) => {
+                return Err(CatalogError::obj_already_exists("table", ident));
+            }
         }
-
-        namespace_tables.insert(table_name.to_string(), table.clone());
 
         Ok(table)
     }

--- a/src/daft-catalog/src/python/wrappers.rs
+++ b/src/daft-catalog/src/python/wrappers.rs
@@ -106,14 +106,31 @@ impl Catalog for PyCatalogWrapper {
     fn create_table(&self, ident: &Identifier, schema: SchemaRef) -> CatalogResult<TableRef> {
         Python::attach(|py| {
             let catalog = self.0.bind(py);
-            let ident = PyIdentifier(ident.clone()).to_pyobj(py)?;
+            let ident_py = PyIdentifier(ident.clone()).to_pyobj(py)?;
             let schema = PySchema { schema };
             let schema_py = py
                 .import(intern!(py, "daft.schema"))?
                 .getattr(intern!(py, "Schema"))?
                 .call_method1(intern!(py, "_from_pyschema"), (schema,))?;
 
-            let table = catalog.call_method1(intern!(py, "_create_table"), (ident, schema_py))?;
+            let table =
+                match catalog.call_method1(intern!(py, "_create_table"), (ident_py, schema_py)) {
+                    Ok(table) => table,
+                    Err(err) => {
+                        // Translate the typed TableAlreadyExistsError back into
+                        // CatalogError::ObjectAlreadyExists so SQL callers can
+                        // match it precisely instead of inspecting messages.
+                        let already_exists_type = py
+                            .import(intern!(py, "daft.catalog"))
+                            .and_then(|m| m.getattr(intern!(py, "TableAlreadyExistsError")));
+                        if let Ok(already_exists_type) = already_exists_type
+                            && err.is_instance(py, &already_exists_type)
+                        {
+                            return Err(CatalogError::obj_already_exists("table", ident));
+                        }
+                        return Err(err.into());
+                    }
+                };
             Ok(Arc::new(PyTableWrapper(table.unbind())) as Arc<dyn Table>)
         })
     }

--- a/src/daft-sql/src/exec.rs
+++ b/src/daft-sql/src/exec.rs
@@ -10,6 +10,9 @@ use daft_session::Session;
 #[cfg(feature = "python")]
 use pyo3::Python;
 
+#[cfg(feature = "python")]
+pyo3::import_exception!(daft.catalog, TableAlreadyExistsError);
+
 use crate::{
     SQLPlanner,
     error::{PlannerError, SQLPlannerResult},
@@ -106,9 +109,6 @@ fn execute_create_table(
     // already exists (either pre-existing or created concurrently by another
     // caller), treat it as success – the existing table satisfies the
     // IF NOT EXISTS contract.
-    //
-    // References Spark's CreateTableExec which catches
-    // TableAlreadyExistsException after create for the same reason.
     match catalog.create_table(&ident, Arc::new(schema)) {
         Ok(_) => Ok(None),
         Err(e) => {
@@ -125,15 +125,13 @@ fn execute_create_table(
 ///
 /// Daft-native catalogs surface this as CatalogError::ObjectAlreadyExists
 /// (PyCatalogWrapper translates the typed TableAlreadyExistsError back into
-/// this variant). Third-party Python catalogs may raise backend-specific
-/// exceptions instead, so we fall back to a message check scoped to the
-/// PythonError variant only.
+/// this variant).
 fn is_table_already_exists_error(e: &CatalogError) -> bool {
     match e {
         CatalogError::ObjectAlreadyExists { .. } => true,
         #[cfg(feature = "python")]
         CatalogError::PythonError { source } => {
-            Python::attach(|py| source.value(py).to_string().contains("already exists"))
+            Python::attach(|py| source.is_instance_of::<TableAlreadyExistsError>(py))
         }
         _ => false,
     }

--- a/src/daft-sql/src/exec.rs
+++ b/src/daft-sql/src/exec.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashMap, sync::Arc};
 
+use daft_catalog::error::CatalogError;
 use daft_context::partition_cache::logical_plan_from_micropartitions;
 use daft_core::{prelude::Utf8Array, series::IntoSeries};
 use daft_logical_plan::{LogicalPlan, LogicalPlanBuilder};
@@ -99,15 +100,30 @@ fn execute_create_table(
         (catalog, ident)
     };
 
-    // Handle IF NOT EXISTS.
-    if create_table.if_not_exists && catalog.has_table(&ident)? {
-        return Ok(None);
+    // Try to create the table. If IF NOT EXISTS is specified and the table
+    // already exists (either pre-existing or created concurrently by another
+    // caller), treat it as success – the existing table satisfies the
+    // IF NOT EXISTS contract.
+    //
+    // References Spark's CreateTableExec which catches
+    // TableAlreadyExistsException after create for the same reason.
+    //
+    // We match both the direct CatalogError::ObjectAlreadyExists (pure-Rust
+    // catalogs like MemoryCatalog) and the indirect PythonError variant
+    // (Python-backed catalogs where the error wraps a DaftCoreException).
+    match catalog.create_table(&ident, Arc::new(schema)) {
+        Ok(_) => Ok(None),
+        Err(e) => {
+            if create_table.if_not_exists
+                && (matches!(e, CatalogError::ObjectAlreadyExists { .. })
+                    || e.to_string().contains("already exists"))
+            {
+                Ok(None)
+            } else {
+                Err(e.into())
+            }
+        }
     }
-
-    // Create the table.
-    catalog.create_table(&ident, Arc::new(schema))?;
-
-    Ok(None)
 }
 
 fn execute_show_tables(

--- a/src/daft-sql/src/exec.rs
+++ b/src/daft-sql/src/exec.rs
@@ -7,6 +7,8 @@ use daft_logical_plan::{LogicalPlan, LogicalPlanBuilder};
 use daft_micropartition::MicroPartition;
 use daft_recordbatch::RecordBatch;
 use daft_session::Session;
+#[cfg(feature = "python")]
+use pyo3::Python;
 
 use crate::{
     SQLPlanner,
@@ -107,22 +109,33 @@ fn execute_create_table(
     //
     // References Spark's CreateTableExec which catches
     // TableAlreadyExistsException after create for the same reason.
-    //
-    // We match both the direct CatalogError::ObjectAlreadyExists (pure-Rust
-    // catalogs like MemoryCatalog) and the indirect PythonError variant
-    // (Python-backed catalogs where the error wraps a DaftCoreException).
     match catalog.create_table(&ident, Arc::new(schema)) {
         Ok(_) => Ok(None),
         Err(e) => {
-            if create_table.if_not_exists
-                && (matches!(e, CatalogError::ObjectAlreadyExists { .. })
-                    || e.to_string().contains("already exists"))
-            {
+            if create_table.if_not_exists && is_table_already_exists_error(&e) {
                 Ok(None)
             } else {
                 Err(e.into())
             }
         }
+    }
+}
+
+/// Returns true if the error indicates the table already exists.
+///
+/// Daft-native catalogs surface this as CatalogError::ObjectAlreadyExists
+/// (PyCatalogWrapper translates the typed TableAlreadyExistsError back into
+/// this variant). Third-party Python catalogs may raise backend-specific
+/// exceptions instead, so we fall back to a message check scoped to the
+/// PythonError variant only.
+fn is_table_already_exists_error(e: &CatalogError) -> bool {
+    match e {
+        CatalogError::ObjectAlreadyExists { .. } => true,
+        #[cfg(feature = "python")]
+        CatalogError::PythonError { source } => {
+            Python::attach(|py| source.value(py).to_string().contains("already exists"))
+        }
+        _ => false,
     }
 }
 

--- a/tests/catalog/test_catalog.py
+++ b/tests/catalog/test_catalog.py
@@ -378,7 +378,8 @@ def test_create_table_if_not_exists_concurrent():
 
 
 def test_create_table_if_not_exists_recovers_table_already_exists_error():
-    """Backends translate their native conflicts into TableAlreadyExistsError;
+    """Backends translate their native conflicts into TableAlreadyExistsError.
+
     create_table_if_not_exists should recover from the typed error.
     """
 
@@ -415,14 +416,17 @@ def test_create_table_if_not_exists_propagates_other_errors():
     with pytest.raises(RuntimeError, match="connection failed"):
         catalog.create_table_if_not_exists("tbl", Schema.from_pydict({"a": dt.int64()}))
 
-    # Recovery is driven by the exception type, not the message: a generic
-    # Exception whose message mentions "already exists" must still propagate.
+    # Recovery is driven by the exception type, not the message: a non-typed
+    # error whose message mentions "already exists" must still propagate.
+    class _AlreadyExistsError(Exception):
+        """Stand-in for a third-party catalog's native already-exists error."""
+
     class BareAlreadyExistsCatalog(MockCatalog):
         def _create_table(self, identifier, schema, properties=None, partition_fields=None):
-            raise Exception(f"Table {identifier} already exists")  # noqa: TRY002
+            raise _AlreadyExistsError(f"Table {identifier} already exists")
 
     catalog = BareAlreadyExistsCatalog()
-    with pytest.raises(Exception, match="already exists"):
+    with pytest.raises(_AlreadyExistsError, match="already exists"):
         catalog.create_table_if_not_exists("tbl", Schema.from_pydict({"a": dt.int64()}))
 
 

--- a/tests/catalog/test_catalog.py
+++ b/tests/catalog/test_catalog.py
@@ -377,6 +377,23 @@ def test_create_table_if_not_exists_concurrent():
     assert all(name == "tbl" for _, name in results), results
 
 
+def test_create_table_if_not_exists_recovers_generic_already_exists_error():
+    """Backends like pyiceberg raise a bare Exception (not ValueError) for
+    "already exists" conflicts; those should be recovered the same way."""
+
+    class ConflictCatalog(MockCatalog):
+        def _create_table(self, identifier, schema, properties=None, partition_fields=None):
+            raise Exception(f"Table {identifier} already exists")
+
+    catalog = ConflictCatalog()
+    existing = MockTable("tbl")
+    catalog._tables[str(Identifier.from_str("tbl"))] = existing
+
+    t = catalog.create_table_if_not_exists("tbl", Schema.from_pydict({"a": dt.int64()}))
+
+    assert t is existing
+
+
 def test_create_table_if_not_exists_propagates_other_errors():
     """create_table_if_not_exists must not swallow unrelated creation failures."""
 
@@ -386,6 +403,15 @@ def test_create_table_if_not_exists_propagates_other_errors():
 
     catalog = FailingCatalog()
     with pytest.raises(ValueError, match="connection failed"):
+        catalog.create_table_if_not_exists("tbl", Schema.from_pydict({"a": dt.int64()}))
+
+    # Unrelated failures that are not ValueErrors must propagate as well.
+    class FailingCatalogGeneric(MockCatalog):
+        def _create_table(self, identifier, schema, properties=None, partition_fields=None):
+            raise RuntimeError("connection failed")
+
+    catalog = FailingCatalogGeneric()
+    with pytest.raises(RuntimeError, match="connection failed"):
         catalog.create_table_if_not_exists("tbl", Schema.from_pydict({"a": dt.int64()}))
 
 

--- a/tests/catalog/test_catalog.py
+++ b/tests/catalog/test_catalog.py
@@ -377,6 +377,18 @@ def test_create_table_if_not_exists_concurrent():
     assert all(name == "tbl" for _, name in results), results
 
 
+def test_create_table_if_not_exists_propagates_other_errors():
+    """create_table_if_not_exists must not swallow unrelated creation failures."""
+
+    class FailingCatalog(MockCatalog):
+        def _create_table(self, identifier, schema, properties=None, partition_fields=None):
+            raise ValueError("connection failed")
+
+    catalog = FailingCatalog()
+    with pytest.raises(ValueError, match="connection failed"):
+        catalog.create_table_if_not_exists("tbl", Schema.from_pydict({"a": dt.int64()}))
+
+
 def test_drop_table_catalog_qualified():
     """Test that drop_table routes to the correct catalog when using a catalog-qualified identifier."""
     from daft.session import Session

--- a/tests/catalog/test_catalog.py
+++ b/tests/catalog/test_catalog.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from daft.catalog import Catalog, Identifier, NotFoundError, Properties, Table
+from daft.catalog import Catalog, Identifier, NotFoundError, Properties, Table, TableAlreadyExistsError
 from daft.dataframe import DataFrame
 from daft.exceptions import DaftCoreException
 from daft.logical.schema import DataType as dt
@@ -377,13 +377,14 @@ def test_create_table_if_not_exists_concurrent():
     assert all(name == "tbl" for _, name in results), results
 
 
-def test_create_table_if_not_exists_recovers_generic_already_exists_error():
-    """Backends like pyiceberg raise a bare Exception (not ValueError) for
-    "already exists" conflicts; those should be recovered the same way."""
+def test_create_table_if_not_exists_recovers_table_already_exists_error():
+    """Backends translate their native conflicts into TableAlreadyExistsError;
+    create_table_if_not_exists should recover from the typed error.
+    """
 
     class ConflictCatalog(MockCatalog):
         def _create_table(self, identifier, schema, properties=None, partition_fields=None):
-            raise Exception(f"Table {identifier} already exists")
+            raise TableAlreadyExistsError(f"Table {identifier} already exists")
 
     catalog = ConflictCatalog()
     existing = MockTable("tbl")
@@ -412,6 +413,16 @@ def test_create_table_if_not_exists_propagates_other_errors():
 
     catalog = FailingCatalogGeneric()
     with pytest.raises(RuntimeError, match="connection failed"):
+        catalog.create_table_if_not_exists("tbl", Schema.from_pydict({"a": dt.int64()}))
+
+    # Recovery is driven by the exception type, not the message: a generic
+    # Exception whose message mentions "already exists" must still propagate.
+    class BareAlreadyExistsCatalog(MockCatalog):
+        def _create_table(self, identifier, schema, properties=None, partition_fields=None):
+            raise Exception(f"Table {identifier} already exists")  # noqa: TRY002
+
+    catalog = BareAlreadyExistsCatalog()
+    with pytest.raises(Exception, match="already exists"):
         catalog.create_table_if_not_exists("tbl", Schema.from_pydict({"a": dt.int64()}))
 
 

--- a/tests/catalog/test_catalog.py
+++ b/tests/catalog/test_catalog.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import threading
 from typing import TYPE_CHECKING
 
 import pytest
@@ -330,6 +331,50 @@ def test_create_table_if_not_exists_catalog_qualified():
     assert t1 is not None
     assert t2 is not None
     assert t1.name == t2.name
+
+
+def test_create_table_if_not_exists_returns_existing_table():
+    """create_table_if_not_exists on an existing table returns the existing table."""
+    catalog = MemoryCatalog._new("test")
+    schema = Schema.from_pydict({"a": dt.int64()})
+
+    t1 = catalog.create_table_if_not_exists("tbl", schema)
+    t2 = catalog.create_table_if_not_exists("tbl", Schema.from_pydict({"b": dt.string()}))
+
+    assert t1.name == t2.name == "tbl"
+    # IF NOT EXISTS must not overwrite the existing table.
+    assert t2.schema() == schema
+
+
+def test_create_table_if_not_exists_concurrent():
+    """Concurrent create_table_if_not_exists calls should both succeed."""
+    catalog = MemoryCatalog._new("test")
+    schema = Schema.from_pydict({"a": dt.int64()})
+    # Warm up the runner so concurrent calls don't race on runner
+    # initialization (which is not thread-safe to initialize concurrently).
+    catalog.create_table_if_not_exists("warmup", schema)
+    barrier = threading.Barrier(2, timeout=10)
+    results: list = []
+    lock = threading.Lock()
+
+    def create(i):
+        barrier.wait()  # maximize overlap between the two callers
+        try:
+            t = catalog.create_table_if_not_exists("tbl", schema)
+            with lock:
+                results.append((i, t.name))
+        except Exception as e:
+            with lock:
+                results.append((i, f"error: {e}"))
+
+    threads = [threading.Thread(target=create, args=(i,)) for i in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(results) == 2, results
+    assert all(name == "tbl" for _, name in results), results
 
 
 def test_drop_table_catalog_qualified():


### PR DESCRIPTION
## Changes Made

| File | Change |
|---|---|
| `src/daft-catalog/src/impls/memory.rs` | Check-then-insert is now atomic under a single write lock |
| `src/daft-sql/src/exec.rs` | Creates first; treats "already exists" as success when `IF NOT EXISTS` is set |
| `daft/catalog/__init__.py` | Same create-first pattern; falls back to `get_table` on `ValueError` |
| `tests/catalog/test_catalog.py` | Covers idempotency and concurrent creation |

- `CREATE TABLE IF NOT EXISTS` had a TOCTOU race: both the SQL executor and the Python API checked `has_table` before creating, so two concurrent callers could both pass the check and the loser failed with "already exists". Both paths now create first and catch that error instead.
- The root cause sat in `MemoryCatalog::create_table`: the read-lock check and the write-lock insert were two separate steps, so the second concurrent creator silently overwrote the first. They are now one atomic step under a single write lock.
- One subtlety: the table is built *before* taking the lock, because `MemoryTable::new` can call back into the Python runner and release the GIL — holding the lock across that callback would deadlock with a concurrent creator.
- Error detection is dual-path: typed `CatalogError::ObjectAlreadyExists` for Rust catalogs, and the "already exists" message for Python-backed catalogs where the error is wrapped. Same idea as Spark's `CreateTableExec`.

## Related Issues

Closes #7310