### PR TITLE
feat: add LeRobot dataset writer

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -44,6 +44,7 @@ from daft.dataframe.preview import (
     resolve_show_defaults,
 )
 from daft.datatype import DataType
+from daft.dependencies import pa, pc
 from daft.errors import ExpressionTypeError
 from daft.execution.native_executor import NativeExecutor
 from daft.expressions import Expression, ExpressionsProjection, col, lit
@@ -2594,6 +2595,175 @@ class DataFrame:
             write_kwargs=write_kwargs,
         )
         return self.write_sink(sink)
+
+    @DataframePublicAPI
+    def write_lerobot(
+        self,
+        uri: str | pathlib.Path,
+        fps: int,
+        *,
+        task_column: str = "task",
+        robot_type: str | None = None,
+        features: dict[str, dict[str, Any]] | None = None,
+        overwrite: bool = False,
+        chunks_size: int = 1000,
+        data_files_size_in_mb: int = 100,
+        io_config: IOConfig | None = None,
+    ) -> "DataFrame":
+        """Write a frame-level DataFrame in the LeRobot v3 dataset format.
+
+        The input must contain ``episode_index`` and ``frame_index`` columns, both
+        contiguous and zero-based, plus a string task column. If ``timestamp`` is
+        absent, it is generated as ``frame_index / fps``. Daft generates the global
+        ``index`` and ``task_index`` columns and writes the frame data, episode/task
+        metadata, feature statistics, and ``meta/info.json``.
+
+        This initial implementation supports scalar and fixed-shape tabular
+        features. Image and video encoding are not yet supported.
+
+        Args:
+            uri: Local directory or object-store URI for the output dataset.
+            fps: Dataset frame rate. Must be a positive integer.
+            task_column: Input string column containing the task for each frame.
+            robot_type: Optional robot type stored in ``meta/info.json``.
+            features: Optional LeRobot feature descriptors for all non-canonical
+                columns. When omitted, descriptors are inferred from Arrow scalar
+                and fixed-size-list types.
+            overwrite: Replace the destination if it already exists. Defaults to
+                False.
+            chunks_size: Maximum number of files per chunk directory.
+            data_files_size_in_mb: Target maximum uncompressed size of each data
+                Parquet shard. Episodes are never split between final shards.
+            io_config: Optional IO configuration for remote storage.
+
+        Note:
+            On a multi-node Ray cluster, local output paths must be on a
+            filesystem shared by every worker. Object-store URIs are supported.
+
+        Returns:
+            A one-row DataFrame containing the output path and total episode,
+            frame, and task counts.
+
+        Examples:
+            >>> import daft
+            >>> df = daft.from_pydict(
+            ...     {
+            ...         "episode_index": [0, 0, 1],
+            ...         "frame_index": [0, 1, 0],
+            ...         "task": ["pick", "pick", "place"],
+            ...         "action": [0.1, 0.2, 0.3],
+            ...     }
+            ... )
+            >>> df.write_lerobot("/tmp/my_lerobot_dataset", fps=30)  # doctest: +SKIP
+        """
+        # Keep this import lazy: importing ``daft.io`` while this module is
+        # initializing creates a cycle through ``daft.io._blob -> DataFrame``.
+        from daft.io.lerobot.sink import (
+            _TASK_COLUMN,
+            LeRobotSink,
+            feature_arrow_type,
+            normalize_lerobot_features,
+        )
+
+        columns = self.column_names
+        required = {"episode_index", "frame_index", task_column}
+        missing = sorted(required - set(columns))
+        if missing:
+            raise ValueError(f"write_lerobot is missing required columns: {missing}")
+        if task_column in {"episode_index", "frame_index", "timestamp", "index", "task_index", _TASK_COLUMN}:
+            raise ValueError(f"task_column conflicts with a reserved LeRobot column: {task_column!r}")
+        if _TASK_COLUMN in columns:
+            raise ValueError(f"Input contains Daft's reserved internal column {_TASK_COLUMN!r}")
+
+        input_schema = self.schema()
+        if input_schema[task_column].dtype != DataType.string():
+            raise ValueError(f"task_column must be String, got {input_schema[task_column].dtype}")
+        for index_column in ("episode_index", "frame_index"):
+            if not input_schema[index_column].dtype.is_integer():
+                raise ValueError(f"{index_column} must have an integer type, got {input_schema[index_column].dtype}")
+
+        reserved = {"episode_index", "frame_index", "timestamp", "index", "task_index", task_column}
+        feature_names = [name for name in columns if name not in reserved]
+        normalized_features = normalize_lerobot_features(input_schema.to_pyarrow_schema(), feature_names, features, fps)
+
+        prepared = self
+        for name in feature_names:
+            target_type = DataType.from_arrow_type(feature_arrow_type(name, normalized_features[name]))
+            prepared = prepared.with_column(name, col(name).cast(target_type))
+        prepared = prepared.with_column("episode_index", col("episode_index").cast(DataType.int64()))
+        prepared = prepared.with_column("frame_index", col("frame_index").cast(DataType.int64()))
+        if "timestamp" in columns:
+            prepared = prepared.with_column("timestamp", col("timestamp").cast(DataType.float32()))
+        else:
+            prepared = prepared.with_column(
+                "timestamp", (col("frame_index").cast(DataType.float64()) / lit(fps)).cast(DataType.float32())
+            )
+        prepared = prepared.with_column(_TASK_COLUMN, col(task_column))
+        prepared = prepared.select(
+            *feature_names,
+            "episode_index",
+            "frame_index",
+            "timestamp",
+            _TASK_COLUMN,
+        )
+        globally_sorted = get_or_create_runner().name != "native"
+        if globally_sorted:
+            prepared = prepared.sort(["episode_index", "frame_index"])
+
+        resolved_io_config = get_context().daft_planning_config.default_io_config if io_config is None else io_config
+        sink = LeRobotSink(
+            uri=str(uri),
+            fps=fps,
+            features=normalized_features,
+            robot_type=robot_type,
+            overwrite=overwrite,
+            chunks_size=chunks_size,
+            data_files_size_in_mb=data_files_size_in_mb,
+            io_config=resolved_io_config,
+            globally_sorted=globally_sorted,
+        )
+        if not globally_sorted:
+            # Native execution does not currently execute Python DataSink operators.
+            # Normalize input partitions with Arrow and stage them one at a time
+            # so large datasets are not materialized on the driver. The sink
+            # splits native staging files at episode boundaries and globally
+            # orders those fragments during finalize.
+            sink.start()
+            try:
+                write_results: list[Any] = []
+                for partition in self.iter_partitions(results_buffer_size=1):
+                    assert isinstance(partition, MicroPartition)
+                    input_table = partition.to_arrow()
+                    output_columns: dict[str, Any] = {}
+                    for name in feature_names:
+                        output_columns[name] = pc.cast(
+                            input_table[name], feature_arrow_type(name, normalized_features[name])
+                        )
+                    output_columns["episode_index"] = pc.cast(input_table["episode_index"], pa.int64())
+                    output_columns["frame_index"] = pc.cast(input_table["frame_index"], pa.int64())
+                    if "timestamp" in columns:
+                        output_columns["timestamp"] = pc.cast(input_table["timestamp"], pa.float32())
+                    else:
+                        output_columns["timestamp"] = pc.cast(
+                            pc.divide(
+                                pc.cast(input_table["frame_index"], pa.float64()),
+                                pa.scalar(fps, type=pa.float64()),
+                            ),
+                            pa.float32(),
+                        )
+                    output_columns[_TASK_COLUMN] = input_table[task_column]
+                    normalized_partition = MicroPartition.from_arrow(pa.table(output_columns))
+                    write_results.extend(sink.write(iter([normalized_partition])))
+                result_partition = sink.finalize(write_results)
+            except Exception:
+                sink.abort()
+                raise
+            return DataFrame._from_micropartitions(result_partition)
+        try:
+            return prepared.write_sink(sink)
+        except Exception:
+            sink.abort()
+            raise
 
     def write_huggingface(
         self,

--- a/daft/datasets/lerobot.py
+++ b/daft/datasets/lerobot.py
@@ -185,7 +185,7 @@ class Feature(TypedDict):
 class LeRobotInfo(TypedDict, total=False):
     codebase_version: str
     data_path: str
-    video_path: str
+    video_path: str | None
     fps: float
     features: dict[str, Feature]
     chunks_size: int

--- a/daft/io/lerobot/__init__.py
+++ b/daft/io/lerobot/__init__.py
@@ -1,0 +1,1 @@
+"""LeRobot dataset write support."""

--- a/daft/io/lerobot/sink.py
+++ b/daft/io/lerobot/sink.py
@@ -1,0 +1,1018 @@
+from __future__ import annotations
+
+import json
+import math
+import os
+import re
+import struct
+import uuid
+import warnings
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, cast
+
+from daft.datatype import DataType
+from daft.dependencies import pa, pafs, pc, pq
+from daft.filesystem import _resolve_paths_and_filesystem
+from daft.io.sink import DataSink, WriteResult
+from daft.recordbatch import MicroPartition
+from daft.schema import Schema
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from daft.daft import IOConfig
+
+
+_TASK_COLUMN = "__daft_lerobot_task"
+_DATA_PATH = "data/chunk-{chunk_index:03d}/file-{file_index:03d}.parquet"
+_EPISODES_PATH = "meta/episodes/chunk-{chunk_index:03d}/file-{file_index:03d}.parquet"
+_CANONICAL_FEATURES: dict[str, dict[str, Any]] = {
+    "timestamp": {"dtype": "float32", "shape": [1], "names": None},
+    "frame_index": {"dtype": "int64", "shape": [1], "names": None},
+    "episode_index": {"dtype": "int64", "shape": [1], "names": None},
+    "index": {"dtype": "int64", "shape": [1], "names": None},
+    "task_index": {"dtype": "int64", "shape": [1], "names": None},
+}
+_NUMPY_DTYPES: dict[str, pa.DataType] = {
+    "bool": pa.bool_(),
+    "int8": pa.int8(),
+    "int16": pa.int16(),
+    "int32": pa.int32(),
+    "int64": pa.int64(),
+    "uint8": pa.uint8(),
+    "uint16": pa.uint16(),
+    "uint32": pa.uint32(),
+    "uint64": pa.uint64(),
+    "float16": pa.float16(),
+    "float32": pa.float32(),
+    "float64": pa.float64(),
+    "string": pa.string(),
+}
+_QUANTILES = (0.01, 0.10, 0.50, 0.90, 0.99)
+_ARROW_CONTAINER_KEY = "__daft_arrow_container"
+_ARROW_TENSOR_TYPE_KEY = "__daft_arrow_tensor_type"
+_SUPPORTED_CODEBASE_VERSION = re.compile(r"^v(?:2\.(?:0|1)|3(?:\.\d+)?)$")
+
+
+@dataclass(frozen=True)
+class LeRobotStagedShard:
+    path: str
+    min_episode_index: int
+    min_frame_index: int
+
+
+@dataclass
+class _PreparedEpisode:
+    table: pa.Table
+    metadata: dict[str, Any]
+    stats: dict[str, dict[str, list[int | float]]]
+
+
+def _primitive_arrow_type(dtype: str) -> pa.DataType:
+    try:
+        return _NUMPY_DTYPES[dtype]
+    except KeyError:
+        raise ValueError(f"Unsupported LeRobot dtype {dtype!r}; supported dtypes are {sorted(_NUMPY_DTYPES)}") from None
+
+
+def feature_arrow_type(name: str, feature: dict[str, Any]) -> pa.DataType:
+    """Return the Arrow storage type for a LeRobot feature descriptor."""
+    dtype = str(feature.get("dtype"))
+    if dtype in {"image", "video", "language"}:
+        raise NotImplementedError(
+            f"write_lerobot does not yet support {dtype!r} feature {name!r}; "
+            "encode visual columns before writing or omit them"
+        )
+    primitive = _primitive_arrow_type(dtype)
+    shape = feature.get("shape")
+    if not isinstance(shape, (list, tuple)) or not shape or not all(isinstance(v, int) and v > 0 for v in shape):
+        raise ValueError(f"LeRobot feature {name!r} must have a non-empty positive integer shape, got {shape!r}")
+    container = feature.get(_ARROW_CONTAINER_KEY)
+    if container == "tensor":
+        return feature[_ARROW_TENSOR_TYPE_KEY]
+    preserve_container = container == "fixed_size_list"
+    if dtype == "string" and not preserve_container:
+        if list(shape) != [1]:
+            raise ValueError(f"String feature {name!r} must have shape [1], got {shape!r}")
+        return primitive
+    if list(shape) == [1] and not preserve_container:
+        return primitive
+    result = primitive
+    for size in reversed(shape):
+        result = pa.list_(result, int(size))
+    return result
+
+
+def _infer_primitive_and_shape(arrow_type: pa.DataType) -> tuple[pa.DataType, list[int]]:
+    if isinstance(arrow_type, pa.FixedShapeTensorType):
+        return arrow_type.value_type, list(arrow_type.shape)
+
+    shape: list[int] = []
+    current = arrow_type
+    while pa.types.is_fixed_size_list(current):
+        shape.append(current.list_size)
+        current = current.value_type
+    if pa.types.is_list(current) or pa.types.is_large_list(current):
+        raise ValueError("variable-length list columns cannot be represented as fixed-shape LeRobot features")
+    return current, shape or [1]
+
+
+def _dtype_name(arrow_type: pa.DataType) -> str:
+    if pa.types.is_large_string(arrow_type):
+        return "string"
+    for name, candidate in _NUMPY_DTYPES.items():
+        if arrow_type == candidate:
+            return name
+    raise ValueError(f"Arrow type {arrow_type} cannot be represented as a LeRobot feature")
+
+
+def normalize_lerobot_features(
+    arrow_schema: pa.Schema,
+    feature_names: list[str],
+    features: dict[str, dict[str, Any]] | None,
+    fps: int,
+) -> dict[str, dict[str, Any]]:
+    """Infer and validate LeRobot descriptors for the user feature columns."""
+    if not isinstance(fps, int) or isinstance(fps, bool) or fps <= 0:
+        raise ValueError(f"fps must be a positive integer, got {fps!r}")
+
+    supplied = features or {}
+    unknown = sorted(set(supplied) - set(feature_names))
+    if unknown:
+        raise ValueError(f"features contains descriptors for columns that are not written: {unknown}")
+
+    normalized: dict[str, dict[str, Any]] = {}
+    for name in feature_names:
+        if "/" in name:
+            raise ValueError(f"LeRobot feature names cannot contain '/': {name!r}")
+        field = arrow_schema.field(name)
+        if name in supplied:
+            descriptor = dict(supplied[name])
+            descriptor["shape"] = list(descriptor.get("shape", []))
+            descriptor.setdefault("names", None)
+        else:
+            primitive, shape = _infer_primitive_and_shape(field.type)
+            descriptor = {"dtype": _dtype_name(primitive), "shape": shape, "names": None}
+
+        if isinstance(field.type, pa.FixedShapeTensorType):
+            if field.type.permutation is not None:
+                raise ValueError(f"Permuted FixedShapeTensor column {name!r} is not supported")
+            if descriptor["shape"] != list(field.type.shape):
+                raise ValueError(
+                    f"Column {name!r} has FixedShapeTensor shape {list(field.type.shape)!r}, "
+                    f"which does not match declared LeRobot shape {descriptor['shape']!r}"
+                )
+            descriptor[_ARROW_CONTAINER_KEY] = "tensor"
+            descriptor[_ARROW_TENSOR_TYPE_KEY] = field.type
+        elif pa.types.is_fixed_size_list(field.type) and descriptor["dtype"] != "string":
+            # LeRobot uses shape [1] for both scalar values and one-element
+            # vectors. Preserve Arrow's container storage so the latter is not
+            # incorrectly cast to a scalar. This private hint is removed before
+            # descriptors are persisted to info.json.
+            descriptor[_ARROW_CONTAINER_KEY] = "fixed_size_list"
+
+        target_type = feature_arrow_type(name, descriptor)
+        if not (pa.types.is_string(target_type) and pa.types.is_large_string(field.type)):
+            try:
+                pc.cast(pa.array([], type=field.type), target_type)
+            except (pa.ArrowInvalid, pa.ArrowNotImplementedError, TypeError) as exc:
+                raise ValueError(
+                    f"Column {name!r} with Arrow type {field.type} cannot be cast to declared "
+                    f"LeRobot feature {descriptor!r}"
+                ) from exc
+        normalized[name] = descriptor
+    return normalized
+
+
+def _json_value(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: _json_value(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_value(item) for item in value]
+    return value
+
+
+def _flatten_numbers(value: Any) -> list[float]:
+    if isinstance(value, (list, tuple)):
+        return [number for item in value for number in _flatten_numbers(item)]
+    return [float(value)]
+
+
+def _reshape_numbers(values: list[float], shape: tuple[int, ...]) -> Any:
+    if len(shape) == 1:
+        return values
+    stride = math.prod(shape[1:])
+    return [_reshape_numbers(values[offset : offset + stride], shape[1:]) for offset in range(0, len(values), stride)]
+
+
+def _reshape_like(values: list[float], template: Any) -> Any:
+    iterator = iter(values)
+
+    def rebuild(item: Any) -> Any:
+        if isinstance(item, list):
+            return [rebuild(child) for child in item]
+        return next(iterator)
+
+    return rebuild(template)
+
+
+def _numeric_coordinates(values: pa.Array) -> Iterator[pa.Array]:
+    if pa.types.is_fixed_size_list(values.type):
+        for index in range(values.type.list_size):
+            yield from _numeric_coordinates(pc.list_element(values, index))
+    else:
+        # LeRobot statistics use float64 even for integer features. Match that
+        # lossy conversion for int64/uint64 values outside float64's exact range
+        # while preserving the original integers in the data shards.
+        yield pc.cast(values, pa.float64(), safe=False)
+
+
+def _tensor_to_fixed_size_lists(values: pa.ExtensionArray, shape: list[int], primitive: pa.DataType) -> pa.Array:
+    """Convert Arrow's flat FixedShapeTensor storage to LeRobot's nested list storage."""
+    storage = values.storage
+    result = pc.cast(storage.values, primitive)
+    if shape == [1]:
+        return pc.if_else(storage.is_null(), pa.scalar(None, type=primitive), result)
+    for depth, size in enumerate(reversed(shape)):
+        mask = storage.is_null() if depth == len(shape) - 1 else None
+        result = pa.FixedSizeListArray.from_arrays(result, size, mask=mask)
+    return result
+
+
+def _weighted_average(left: float, right: float, left_count: int, right_count: int) -> float:
+    total = left_count + right_count
+    return left * (left_count / total) + right * (right_count / total)
+
+
+def _combined_std(
+    left_std: float,
+    right_std: float,
+    left_mean: float,
+    right_mean: float,
+    mean: float,
+    left_count: int,
+    right_count: int,
+) -> float:
+    left_delta = left_mean - mean
+    right_delta = right_mean - mean
+    scale = max(abs(left_std), abs(right_std), abs(left_delta), abs(right_delta))
+    if scale == 0:
+        return 0.0
+    if math.isinf(scale):
+        return math.inf
+    total = left_count + right_count
+    variance = (
+        ((left_std / scale) ** 2 + (left_delta / scale) ** 2) * left_count
+        + ((right_std / scale) ** 2 + (right_delta / scale) ** 2) * right_count
+    ) / total
+    return scale * math.sqrt(variance)
+
+
+def _feature_stats(table: pa.Table, features: dict[str, dict[str, Any]]) -> dict[str, dict[str, list[int | float]]]:
+    stats: dict[str, dict[str, list[int | float]]] = {}
+    for name, feature in features.items():
+        if feature["dtype"] in {"string", "language", "image", "video"}:
+            continue
+        column = table[name].combine_chunks()
+        if column.null_count:
+            raise ValueError(f"LeRobot feature {name!r} contains null values")
+        shape = tuple(feature["shape"])
+        coordinate_count = math.prod(shape)
+        flat_stats: dict[str, list[float]] = {
+            "min": [],
+            "max": [],
+            "mean": [],
+            "std": [],
+            **{f"q{int(quantile * 100):02d}": [] for quantile in _QUANTILES},
+        }
+        observed_coordinates = 0
+        for coordinate in _numeric_coordinates(column):
+            observed_coordinates += 1
+            if coordinate.null_count:
+                raise ValueError(f"LeRobot feature {name!r} contains null values")
+            if not pc.all(pc.is_finite(coordinate)).as_py():
+                raise ValueError(f"LeRobot feature {name!r} contains non-finite values")
+            flat_stats["min"].append(float(pc.min(coordinate).as_py()))
+            flat_stats["max"].append(float(pc.max(coordinate).as_py()))
+            flat_stats["mean"].append(float(pc.mean(coordinate).as_py()))
+            flat_stats["std"].append(float(pc.stddev(coordinate, ddof=0).as_py()))
+            for quantile in _QUANTILES:
+                key = f"q{int(quantile * 100):02d}"
+                flat_stats[key].append(float(pc.quantile(coordinate, q=quantile, interpolation="linear")[0].as_py()))
+        if observed_coordinates != coordinate_count:
+            raise ValueError(f"LeRobot feature {name!r} does not match declared shape {list(shape)!r}")
+        feature_stats: dict[str, Any] = {key: _reshape_numbers(values, shape) for key, values in flat_stats.items()}
+        feature_stats["count"] = [len(table)]
+        stats[name] = _json_value(feature_stats)
+    return stats
+
+
+def _aggregate_stats(
+    current: dict[str, dict[str, list[int | float]]] | None,
+    incoming: dict[str, dict[str, list[int | float]]],
+) -> dict[str, dict[str, list[int | float]]]:
+    if current is None:
+        return incoming
+    result: dict[str, dict[str, list[int | float]]] = {}
+    for name in current.keys() | incoming.keys():
+        if name not in current:
+            result[name] = incoming[name]
+            continue
+        if name not in incoming:
+            result[name] = current[name]
+            continue
+        left, right = current[name], incoming[name]
+        left_count = int(left["count"][0])
+        right_count = int(right["count"][0])
+        total = left_count + right_count
+        left_mean = _flatten_numbers(left["mean"])
+        right_mean = _flatten_numbers(right["mean"])
+        mean = [
+            _weighted_average(left_value, right_value, left_count, right_count)
+            for left_value, right_value in zip(left_mean, right_mean, strict=True)
+        ]
+        left_std = _flatten_numbers(left["std"])
+        right_std = _flatten_numbers(right["std"])
+        std = [
+            _combined_std(
+                left_std_value,
+                right_std_value,
+                left_mean_value,
+                right_mean_value,
+                mean_value,
+                left_count,
+                right_count,
+            )
+            for left_std_value, right_std_value, left_mean_value, right_mean_value, mean_value in zip(
+                left_std, right_std, left_mean, right_mean, mean, strict=True
+            )
+        ]
+        template = left["mean"]
+        merged: dict[str, Any] = {
+            "min": _reshape_like(
+                [
+                    min(left_value, right_value)
+                    for left_value, right_value in zip(
+                        _flatten_numbers(left["min"]), _flatten_numbers(right["min"]), strict=True
+                    )
+                ],
+                template,
+            ),
+            "max": _reshape_like(
+                [
+                    max(left_value, right_value)
+                    for left_value, right_value in zip(
+                        _flatten_numbers(left["max"]), _flatten_numbers(right["max"]), strict=True
+                    )
+                ],
+                template,
+            ),
+            "mean": _reshape_like(mean, template),
+            "std": _reshape_like(std, template),
+            "count": [total],
+        }
+        for quantile in _QUANTILES:
+            key = f"q{int(quantile * 100):02d}"
+            # Match LeRobot's aggregate_feature_stats semantics. Exact global
+            # quantiles cannot be recovered from per-episode summaries, so
+            # lower quantiles use the minimum estimate and upper quantiles use
+            # the maximum estimate as conservative bounds.
+            operation = min if quantile <= 0.5 else max
+            merged[key] = _reshape_like(
+                [
+                    operation(left_value, right_value)
+                    for left_value, right_value in zip(
+                        _flatten_numbers(left[key]), _flatten_numbers(right[key]), strict=True
+                    )
+                ],
+                template,
+            )
+        result[name] = _json_value(merged)
+    return result
+
+
+def _episode_ranges(table: pa.Table) -> list[tuple[int, int]]:
+    episode_indices = table["episode_index"].combine_chunks().to_pylist()
+    starts = [0]
+    starts.extend(
+        index for index in range(1, len(episode_indices)) if episode_indices[index] != episode_indices[index - 1]
+    )
+    stops = [*starts[1:], len(table)]
+    return list(zip(starts, stops, strict=True))
+
+
+def _tasks_table(task_indices: dict[str, int]) -> pa.Table:
+    pandas_metadata = {
+        "index_columns": ["task"],
+        "column_indexes": [
+            {
+                "name": None,
+                "field_name": None,
+                "pandas_type": "unicode",
+                "numpy_type": "object",
+                "metadata": {"encoding": "UTF-8"},
+            }
+        ],
+        "columns": [
+            {
+                "name": "task_index",
+                "field_name": "task_index",
+                "pandas_type": "int64",
+                "numpy_type": "int64",
+                "metadata": None,
+            },
+            {
+                "name": "task",
+                "field_name": "task",
+                "pandas_type": "unicode",
+                "numpy_type": "object",
+                "metadata": None,
+            },
+        ],
+        "attributes": {},
+        "creator": {"library": "pyarrow", "version": str(pa.__version__)},
+        "pandas_version": "0.0.0",
+    }
+    table = pa.table(
+        {
+            "task_index": pa.array(range(len(task_indices)), type=pa.int64()),
+            "task": pa.array(list(task_indices), type=pa.string()),
+        }
+    )
+    return table.replace_schema_metadata({b"pandas": json.dumps(pandas_metadata).encode("utf-8")})
+
+
+class LeRobotSink(DataSink[LeRobotStagedShard]):
+    def __init__(
+        self,
+        uri: str,
+        fps: int,
+        features: dict[str, dict[str, Any]],
+        robot_type: str | None,
+        overwrite: bool,
+        chunks_size: int,
+        data_files_size_in_mb: int,
+        io_config: IOConfig | None,
+        globally_sorted: bool = True,
+    ) -> None:
+        if not uri.strip() or uri.strip() in {"/", ".", "file:///"}:
+            raise ValueError(f"Refusing to write a LeRobot dataset to unsafe path {uri!r}")
+        if not isinstance(chunks_size, int) or isinstance(chunks_size, bool) or chunks_size <= 0:
+            raise ValueError(f"chunks_size must be a positive integer, got {chunks_size!r}")
+        if (
+            not isinstance(data_files_size_in_mb, int)
+            or isinstance(data_files_size_in_mb, bool)
+            or data_files_size_in_mb <= 0
+        ):
+            raise ValueError(f"data_files_size_in_mb must be a positive integer, got {data_files_size_in_mb!r}")
+        self.uri = uri.rstrip("/")
+        self.fps = fps
+        self._tensor_features = {
+            name for name, feature in features.items() if feature.get(_ARROW_CONTAINER_KEY) == "tensor"
+        }
+        self._one_element_list_features = {
+            name
+            for name, feature in features.items()
+            if feature.get(_ARROW_CONTAINER_KEY) == "fixed_size_list" and feature["shape"] == [1]
+        }
+        self.features = {
+            name: {
+                key: value
+                for key, value in feature.items()
+                if key not in {_ARROW_CONTAINER_KEY, _ARROW_TENSOR_TYPE_KEY}
+            }
+            for name, feature in features.items()
+        }
+        self.feature_names = list(features)
+        self.robot_type = robot_type
+        self.overwrite = overwrite
+        self.chunks_size = chunks_size
+        self.data_files_size_in_mb = data_files_size_in_mb
+        self.io_config = io_config
+        self.globally_sorted = globally_sorted
+        self._staging_id = uuid.uuid4().hex
+        self._resolved_root: str | None = None
+
+    def name(self) -> str:
+        return "LeRobot Dataset Write"
+
+    def schema(self) -> Schema:
+        return Schema.from_pydict(
+            {
+                "path": DataType.string(),
+                "num_episodes": DataType.int64(),
+                "num_frames": DataType.int64(),
+                "num_tasks": DataType.int64(),
+            }
+        )
+
+    def _filesystem(self) -> tuple[str, pafs.FileSystem]:
+        [root], filesystem = _resolve_paths_and_filesystem(self.uri, io_config=self.io_config)
+        if self._resolved_root is not None:
+            return self._resolved_root, filesystem
+        root = self._validate_destination(root, filesystem)
+        return root, filesystem
+
+    @staticmethod
+    def _validate_destination(root: str, filesystem: pafs.FileSystem) -> str:
+        if isinstance(filesystem, pafs.LocalFileSystem):
+            canonical_root = os.path.realpath(root)
+            canonical_cwd = os.path.realpath(os.getcwd())
+            try:
+                is_cwd_or_ancestor = os.path.commonpath([canonical_root, canonical_cwd]) == canonical_root
+            except ValueError:
+                is_cwd_or_ancestor = False
+            if canonical_root == os.path.sep or is_cwd_or_ancestor:
+                raise ValueError(f"Refusing to write a LeRobot dataset to unsafe local path {root!r}")
+
+            absolute = os.path.abspath(root.rstrip(os.path.sep) or os.path.sep)
+            if os.path.islink(absolute):
+                raise ValueError(f"Refusing to write a LeRobot dataset through symlink path {root!r}")
+            return canonical_root
+
+        normalized = root.strip("/")
+        if not normalized or "/" not in normalized:
+            raise ValueError(f"Refusing to write a LeRobot dataset to object-store bucket root {root!r}")
+        return root.rstrip("/")
+
+    @staticmethod
+    def _path(root: str, relative: str) -> str:
+        return f"{root.rstrip('/')}/{relative.lstrip('/')}"
+
+    def _sibling_path(self, root: str, kind: str) -> str:
+        parent, _, name = root.rstrip("/").rpartition("/")
+        sibling = f".{name}.daft-lr-{kind}-{self._staging_id}"
+        return self._path(parent, sibling) if parent else sibling
+
+    def _transaction_path(self, root: str) -> str:
+        return self._sibling_path(root, "staging")
+
+    def _input_staging_path(self, root: str) -> str:
+        return self._path(self._transaction_path(root), ".input")
+
+    def _validate_existing_destination(
+        self, filesystem: pafs.FileSystem, root: str, destination_info: pafs.FileInfo
+    ) -> None:
+        if destination_info.type == pafs.FileType.Directory:
+            children = filesystem.get_file_info(pafs.FileSelector(root, recursive=False))
+            if not children:
+                return
+        marker_path = self._path(root, "meta/info.json")
+        marker = filesystem.get_file_info(marker_path)
+        if marker.type == pafs.FileType.File:
+            try:
+                with filesystem.open_input_stream(marker_path) as stream:
+                    info = json.loads(stream.read())
+                if not isinstance(info, dict):
+                    raise TypeError("info.json must contain an object")
+                version = info.get("codebase_version")
+                if not isinstance(version, str) or _SUPPORTED_CODEBASE_VERSION.fullmatch(version) is None:
+                    raise ValueError(f"unsupported codebase_version {version!r}")
+                if not isinstance(info.get("features"), dict):
+                    raise TypeError("features must be an object")
+                if not isinstance(info.get("data_path"), str) or not info["data_path"]:
+                    raise ValueError("data_path must be a non-empty string")
+                fps = info.get("fps")
+                if not isinstance(fps, (int, float)) or isinstance(fps, bool) or fps <= 0:
+                    raise ValueError("fps must be positive")
+                for key in ("total_episodes", "total_frames", "total_tasks"):
+                    value = info.get(key)
+                    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+                        raise ValueError(f"{key} must be a non-negative integer")
+
+                if info["total_episodes"] > 0:
+                    major = int(version[1])
+                    episodes_path = self._path(root, "meta/episodes" if major == 3 else "meta/episodes.jsonl")
+                    episodes_info = filesystem.get_file_info(episodes_path)
+                    expected_type = pafs.FileType.Directory if major == 3 else pafs.FileType.File
+                    if episodes_info.type != expected_type:
+                        raise ValueError(f"missing episode metadata at {episodes_path!r}")
+                if info["total_frames"] > 0:
+                    data_info = filesystem.get_file_info(self._path(root, "data"))
+                    if data_info.type != pafs.FileType.Directory:
+                        raise ValueError("missing data directory")
+            except (json.JSONDecodeError, OSError, TypeError, UnicodeDecodeError, ValueError) as exc:
+                raise ValueError(
+                    f"Refusing to overwrite non-LeRobot destination {self.uri!r}: invalid meta/info.json ({exc})"
+                ) from exc
+            return
+        raise ValueError(
+            f"Refusing to overwrite non-LeRobot destination {self.uri!r}; "
+            "choose an empty directory or remove it explicitly"
+        )
+
+    @staticmethod
+    def _delete_path(filesystem: pafs.FileSystem, path: str) -> None:
+        info = filesystem.get_file_info(path)
+        if info.type == pafs.FileType.Directory:
+            filesystem.delete_dir(path)
+        elif info.type == pafs.FileType.File:
+            filesystem.delete_file(path)
+
+    @classmethod
+    def _copy_path(
+        cls,
+        filesystem: pafs.FileSystem,
+        source: str,
+        destination: str,
+        *,
+        commit_marker_last: bool = False,
+    ) -> None:
+        info = filesystem.get_file_info(source)
+        if info.type == pafs.FileType.File:
+            parent = destination.rsplit("/", 1)[0]
+            if parent:
+                filesystem.create_dir(parent, recursive=True)
+            filesystem.copy_file(source, destination)
+            return
+        if info.type != pafs.FileType.Directory:
+            raise FileNotFoundError(source)
+
+        filesystem.create_dir(destination, recursive=True)
+        selector = pafs.FileSelector(source, recursive=True)
+        children = filesystem.get_file_info(selector)
+        for child in children:
+            relative = child.path[len(source.rstrip("/")) :].lstrip("/")
+            target = cls._path(destination, relative)
+            if child.type == pafs.FileType.Directory:
+                filesystem.create_dir(target, recursive=True)
+        files = [child for child in children if child.type == pafs.FileType.File]
+        if commit_marker_last:
+            files.sort(key=lambda child: child.path.endswith("/meta/info.json"))
+        for child in files:
+            relative = child.path[len(source.rstrip("/")) :].lstrip("/")
+            target = cls._path(destination, relative)
+            parent = target.rsplit("/", 1)[0]
+            if parent:
+                filesystem.create_dir(parent, recursive=True)
+            filesystem.copy_file(child.path, target)
+
+    def _publish(self, filesystem: pafs.FileSystem, root: str) -> None:
+        transaction = self._transaction_path(root)
+        backup = self._sibling_path(root, "backup")
+        destination_info = filesystem.get_file_info(root)
+        destination_exists = destination_info.type != pafs.FileType.NotFound
+        if destination_exists and not self.overwrite:
+            raise FileExistsError(
+                f"LeRobot destination already exists: {self.uri!r}; pass overwrite=True to replace it"
+            )
+        if destination_exists:
+            self._validate_existing_destination(filesystem, root, destination_info)
+
+        if isinstance(filesystem, pafs.LocalFileSystem):
+            if destination_exists:
+                filesystem.move(root, backup)
+            try:
+                filesystem.move(transaction, root)
+            except Exception:
+                self._delete_path(filesystem, root)
+                if destination_exists:
+                    filesystem.move(backup, root)
+                raise
+            if destination_exists:
+                try:
+                    self._delete_path(filesystem, backup)
+                except OSError as exc:
+                    warnings.warn(f"Failed to remove LeRobot transaction backup {backup!r}: {exc}", stacklevel=2)
+            return
+
+        # Object stores generally cannot atomically rename a directory. Keep a
+        # full backup until all staged files have been copied, and restore it if
+        # publication fails.
+        if destination_exists:
+            try:
+                self._copy_path(filesystem, root, backup)
+            except Exception:
+                # Backup creation happens before the destination is touched. If
+                # it fails, remove only the partial backup and leave the intact
+                # destination in place.
+                try:
+                    self._delete_path(filesystem, backup)
+                except OSError as cleanup_error:
+                    warnings.warn(f"Failed to remove partial LeRobot backup {backup!r}: {cleanup_error}", stacklevel=2)
+                raise
+        try:
+            if destination_exists:
+                self._delete_path(filesystem, root)
+            self._copy_path(filesystem, transaction, root, commit_marker_last=True)
+        except Exception:
+            try:
+                self._delete_path(filesystem, root)
+                if destination_exists:
+                    self._copy_path(filesystem, backup, root)
+            except Exception as rollback_error:
+                raise RuntimeError(
+                    f"Failed to publish LeRobot dataset and rollback also failed; backup retained at {backup!r}"
+                ) from rollback_error
+            raise
+        else:
+            for cleanup_path in (transaction, backup if destination_exists else None):
+                if cleanup_path is None:
+                    continue
+                try:
+                    self._delete_path(filesystem, cleanup_path)
+                except OSError as exc:
+                    warnings.warn(
+                        f"Failed to remove LeRobot transaction artifact {cleanup_path!r}: {exc}", stacklevel=2
+                    )
+
+    def abort(self) -> None:
+        root, filesystem = self._filesystem()
+        self._delete_path(filesystem, self._transaction_path(root))
+
+    def start(self) -> None:
+        [unvalidated_root], filesystem = _resolve_paths_and_filesystem(self.uri, io_config=self.io_config)
+        root = self._validate_destination(unvalidated_root, filesystem)
+        self._resolved_root = root
+        info = filesystem.get_file_info(root)
+        if info.type != pafs.FileType.NotFound and not self.overwrite:
+            raise FileExistsError(
+                f"LeRobot destination already exists: {self.uri!r}; pass overwrite=True to replace it"
+            )
+        if info.type != pafs.FileType.NotFound:
+            self._validate_existing_destination(filesystem, root, info)
+        transaction = self._transaction_path(root)
+        self._delete_path(filesystem, transaction)
+        filesystem.create_dir(self._input_staging_path(root), recursive=True)
+
+    def write(self, micropartitions: Iterator[MicroPartition]) -> Iterator[WriteResult[LeRobotStagedShard]]:
+        root, filesystem = self._filesystem()
+        staging = self._input_staging_path(root)
+        for partition in micropartitions:
+            if len(partition) == 0:
+                continue
+            table = partition.to_arrow()
+            for name in self._one_element_list_features:
+                normalized = pc.list_element(table[name].combine_chunks(), 0)
+                table = table.set_column(table.schema.get_field_index(name), name, normalized)
+            for name in self._tensor_features:
+                values = table[name].combine_chunks()
+                if not isinstance(values, pa.ExtensionArray):
+                    raise TypeError(f"Expected FixedShapeTensor storage for LeRobot feature {name!r}")
+                normalized = _tensor_to_fixed_size_lists(
+                    values,
+                    self.features[name]["shape"],
+                    _primitive_arrow_type(self.features[name]["dtype"]),
+                )
+                table = table.set_column(table.schema.get_field_index(name), name, normalized)
+            sort_indices = pc.sort_indices(
+                table, sort_keys=[("episode_index", "ascending"), ("frame_index", "ascending")]
+            )
+            table = table.take(sort_indices)
+            fragments = [table]
+            if not self.globally_sorted:
+                # Native execution streams partitions without a global shuffle.
+                # Stage one fragment per episode so finalize can order and merge
+                # interleaved episode ranges without retaining the dataset in RAM.
+                fragments = [table.slice(start, stop - start) for start, stop in _episode_ranges(table)]
+
+            for fragment in fragments:
+                first_episode = int(fragment["episode_index"][0].as_py())
+                first_frame = int(fragment["frame_index"][0].as_py())
+                path = self._path(staging, f"part-{uuid.uuid4().hex}.parquet")
+                pq.write_table(fragment, path, filesystem=filesystem, compression="snappy", use_dictionary=True)
+                size = filesystem.get_file_info(path).size
+                yield WriteResult(
+                    result=LeRobotStagedShard(path, first_episode, first_frame),
+                    bytes_written=max(size, 0),
+                    rows_written=len(fragment),
+                )
+
+    def _write_json(self, filesystem: pafs.FileSystem, path: str, value: Any) -> None:
+        parent = path.rsplit("/", 1)[0]
+        filesystem.create_dir(parent, recursive=True)
+        with filesystem.open_output_stream(path) as stream:
+            stream.write(json.dumps(_json_value(value), indent=4, ensure_ascii=False).encode("utf-8"))
+
+    def _prepare_episode(
+        self,
+        table: pa.Table,
+        expected_episode: int,
+        dataset_from_index: int,
+        task_indices: dict[str, int],
+    ) -> _PreparedEpisode:
+        if len(table) == 0:
+            raise ValueError("LeRobot episodes must contain at least one frame")
+        raw_episode_values = table["episode_index"].combine_chunks().to_pylist()
+        if any(not isinstance(value, int) for value in raw_episode_values):
+            raise ValueError("episode_index must contain integers and no nulls")
+        episode_values = cast("list[int]", raw_episode_values)
+        episode_index = episode_values[0]
+        if episode_index != expected_episode or any(value != episode_index for value in episode_values):
+            raise ValueError(
+                "episode_index must be zero-based and contiguous; "
+                f"expected episode {expected_episode}, got {episode_index}"
+            )
+        raw_frame_indices = table["frame_index"].combine_chunks().to_pylist()
+        if any(not isinstance(value, int) for value in raw_frame_indices):
+            raise ValueError("frame_index must contain integers and no nulls")
+        frame_indices = cast("list[int]", raw_frame_indices)
+        if frame_indices != list(range(len(table))):
+            raise ValueError(
+                f"frame_index for episode {episode_index} must be zero-based and contiguous; got {frame_indices[:10]}"
+            )
+
+        timestamps = table["timestamp"].combine_chunks().to_pylist()
+        for frame_index, timestamp in enumerate(timestamps):
+            if timestamp is None or not math.isfinite(float(timestamp)):
+                raise ValueError(f"timestamp contains an invalid value in episode {episode_index}")
+            expected_timestamp = struct.unpack("<f", struct.pack("<f", frame_index / self.fps))[0]
+            if abs(float(timestamp) - expected_timestamp) > 1e-4:
+                raise ValueError(
+                    f"timestamp for episode {episode_index}, frame {frame_index} must equal frame_index / fps "
+                    f"within 1e-4 seconds; got {timestamp}, expected {expected_timestamp}"
+                )
+
+        raw_tasks = table[_TASK_COLUMN].combine_chunks().to_pylist()
+        if any(not isinstance(task, str) or not task for task in raw_tasks):
+            raise ValueError("task_column must contain non-empty strings and no nulls")
+        tasks = cast("list[str]", raw_tasks)
+        for task in tasks:
+            if task not in task_indices:
+                task_indices[task] = len(task_indices)
+
+        canonical_arrays: dict[str, pa.Array | pa.ChunkedArray] = {
+            "timestamp": pc.cast(table["timestamp"], pa.float32()),
+            "frame_index": pa.chunked_array([pa.array(frame_indices, type=pa.int64())]),
+            "episode_index": pa.chunked_array([pa.array(episode_values, type=pa.int64())]),
+            "index": pa.chunked_array(
+                [pa.array(range(dataset_from_index, dataset_from_index + len(table)), type=pa.int64())]
+            ),
+            "task_index": pa.chunked_array([pa.array([task_indices[task] for task in tasks], type=pa.int64())]),
+        }
+        output_names = [*self.feature_names, *canonical_arrays]
+        output_arrays = [*[table[name] for name in self.feature_names], *canonical_arrays.values()]
+        output = pa.Table.from_arrays(output_arrays, names=output_names)
+        all_features = {**self.features, **_CANONICAL_FEATURES}
+        stats = _feature_stats(output, all_features)
+        episode_tasks = sorted(set(tasks), key=task_indices.__getitem__)
+        metadata: dict[str, Any] = {
+            "episode_index": episode_index,
+            "tasks": episode_tasks,
+            "length": len(table),
+            "dataset_from_index": dataset_from_index,
+            "dataset_to_index": dataset_from_index + len(table),
+        }
+        for feature_name, feature_stats in stats.items():
+            for stat_name, value in feature_stats.items():
+                metadata[f"stats/{feature_name}/{stat_name}"] = value
+        return _PreparedEpisode(output, metadata, stats)
+
+    def _write_final_shard(
+        self,
+        filesystem: pafs.FileSystem,
+        root: str,
+        episodes: list[_PreparedEpisode],
+        file_number: int,
+    ) -> None:
+        chunk_index = file_number // self.chunks_size
+        file_index = file_number % self.chunks_size
+        data_relative = _DATA_PATH.format(chunk_index=chunk_index, file_index=file_index)
+        data_path = self._path(root, data_relative)
+        filesystem.create_dir(data_path.rsplit("/", 1)[0], recursive=True)
+        writer: pq.ParquetWriter | None = None
+        try:
+            for episode in episodes:
+                if writer is None:
+                    writer = pq.ParquetWriter(
+                        data_path,
+                        episode.table.schema,
+                        filesystem=filesystem,
+                        compression="snappy",
+                        use_dictionary=True,
+                    )
+                writer.write_table(episode.table)
+        finally:
+            if writer is not None:
+                writer.close()
+
+        episode_relative = _EPISODES_PATH.format(chunk_index=chunk_index, file_index=file_index)
+        episode_path = self._path(root, episode_relative)
+        filesystem.create_dir(episode_path.rsplit("/", 1)[0], recursive=True)
+        metadata_rows = []
+        for episode in episodes:
+            metadata_rows.append(
+                {
+                    **episode.metadata,
+                    "data/chunk_index": chunk_index,
+                    "data/file_index": file_index,
+                    "meta/episodes/chunk_index": chunk_index,
+                    "meta/episodes/file_index": file_index,
+                }
+            )
+        pq.write_table(
+            pa.Table.from_pylist(metadata_rows),
+            episode_path,
+            filesystem=filesystem,
+            compression="snappy",
+            use_dictionary=True,
+        )
+
+    def finalize(self, write_results: list[WriteResult[LeRobotStagedShard]]) -> MicroPartition:
+        root, filesystem = self._filesystem()
+        transaction = self._transaction_path(root)
+        staging = self._input_staging_path(root)
+        task_indices: dict[str, int] = {}
+        global_stats: dict[str, dict[str, list[int | float]]] | None = None
+        expected_episode = 0
+        dataset_from_index = 0
+        pending_table: pa.Table | None = None
+        buffered: list[_PreparedEpisode] = []
+        buffered_bytes = 0
+        file_number = 0
+        target_bytes = self.data_files_size_in_mb * 1024 * 1024
+
+        def flush_buffer() -> None:
+            nonlocal buffered, buffered_bytes, file_number
+            if not buffered:
+                return
+            self._write_final_shard(filesystem, transaction, buffered, file_number)
+            file_number += 1
+            buffered = []
+            buffered_bytes = 0
+
+        def consume_episode(table: pa.Table) -> None:
+            nonlocal expected_episode, dataset_from_index, global_stats, buffered_bytes
+            # A single episode can be split across several distributed write tasks.
+            # Sort again after concatenation rather than relying on task completion
+            # order (or on non-overlapping partition ranges).
+            table = table.take(
+                pc.sort_indices(table, sort_keys=[("episode_index", "ascending"), ("frame_index", "ascending")])
+            )
+            episode = self._prepare_episode(table, expected_episode, dataset_from_index, task_indices)
+            if buffered and buffered_bytes + episode.table.nbytes > target_bytes:
+                flush_buffer()
+            buffered.append(episode)
+            buffered_bytes += episode.table.nbytes
+            global_stats = _aggregate_stats(global_stats, episode.stats)
+            expected_episode += 1
+            dataset_from_index += len(episode.table)
+
+        try:
+            if not write_results:
+                raise ValueError("Cannot write an empty LeRobot dataset")
+
+            shards = sorted(
+                (result.result for result in write_results),
+                key=lambda result: (result.min_episode_index, result.min_frame_index, result.path),
+            )
+            for shard in shards:
+                table = pq.read_table(shard.path, filesystem=filesystem)
+                sort_indices = pc.sort_indices(
+                    table, sort_keys=[("episode_index", "ascending"), ("frame_index", "ascending")]
+                )
+                table = table.take(sort_indices)
+                for start, stop in _episode_ranges(table):
+                    current = table.slice(start, stop - start)
+                    current_episode = int(current["episode_index"][0].as_py())
+                    if pending_table is None:
+                        pending_table = current
+                    elif int(pending_table["episode_index"][0].as_py()) == current_episode:
+                        pending_table = pa.concat_tables([pending_table, current])
+                    else:
+                        consume_episode(pending_table)
+                        pending_table = current
+            if pending_table is not None:
+                consume_episode(pending_table)
+            flush_buffer()
+
+            task_table = _tasks_table(task_indices)
+            tasks_path = self._path(transaction, "meta/tasks.parquet")
+            filesystem.create_dir(tasks_path.rsplit("/", 1)[0], recursive=True)
+            pq.write_table(task_table, tasks_path, filesystem=filesystem, compression="snappy")
+
+            assert global_stats is not None
+            self._write_json(filesystem, self._path(transaction, "meta/stats.json"), global_stats)
+            info = {
+                "codebase_version": "v3.0",
+                "robot_type": self.robot_type,
+                "total_episodes": expected_episode,
+                "total_frames": dataset_from_index,
+                "total_tasks": len(task_indices),
+                "chunks_size": self.chunks_size,
+                "data_files_size_in_mb": self.data_files_size_in_mb,
+                "video_files_size_in_mb": 200,
+                "fps": self.fps,
+                "splits": {"train": f"0:{expected_episode}"},
+                "data_path": _DATA_PATH,
+                "video_path": None,
+                "features": {**self.features, **_CANONICAL_FEATURES},
+            }
+            self._write_json(filesystem, self._path(transaction, "meta/info.json"), info)
+            self._delete_path(filesystem, staging)
+            self._publish(filesystem, root)
+        except Exception:
+            self.abort()
+            raise
+
+        return MicroPartition.from_pydict(
+            {
+                "path": [self.uri],
+                "num_episodes": pa.array([expected_episode], type=pa.int64()),
+                "num_frames": pa.array([dataset_from_index], type=pa.int64()),
+                "num_tasks": pa.array([len(task_indices)], type=pa.int64()),
+            }
+        )
+
+
+__all__ = ["LeRobotSink", "feature_arrow_type", "normalize_lerobot_features"]

--- a/docs/api/io.md
+++ b/docs/api/io.md
@@ -136,6 +136,10 @@ Daft offers a variety of approaches to creating a DataFrame from reading various
     options:
         heading_level: 3
 
+::: daft.dataframe.DataFrame.write_lerobot
+    options:
+        heading_level: 3
+
 ::: daft.dataframe.DataFrame.write_turbopuffer
     options:
         heading_level: 3

--- a/docs/datasets/lerobot.md
+++ b/docs/datasets/lerobot.md
@@ -50,6 +50,29 @@ frames = load_episode_frames(long, repo)
 
 [`read_tasks`](../api/datasets.md#daft.datasets.lerobot.read_tasks) loads task metadata, preferring `meta/tasks.parquet` and falling back to `meta/tasks.jsonl` (the v2 default).
 
+## Write a LeRobot v3 dataset
+
+Use [`DataFrame.write_lerobot`](../api/io.md#daft.dataframe.DataFrame.write_lerobot) to write a frame-level DataFrame as a LeRobot v3 dataset. Each row is one frame. The input must have zero-based, contiguous `episode_index` and `frame_index` columns and a string `task` column. Daft generates `timestamp` when it is absent, as well as the global `index`, `task_index`, episode metadata, task table, and feature statistics.
+
+```python
+import daft
+
+df = daft.from_pydict(
+    {
+        "episode_index": [0, 0, 1],
+        "frame_index": [0, 1, 0],
+        "task": ["pick", "pick", "place"],
+        "action": [0.1, 0.2, 0.3],
+    }
+)
+
+result = df.write_lerobot("/tmp/robot-runs", fps=30)
+```
+
+Scalar Arrow columns are inferred automatically. Vector and tensor columns must use fixed-size-list Arrow types, or provide explicit LeRobot feature descriptors with the `features` argument. The initial writer supports tabular features; image and video encoding are not yet supported.
+
+The writer runs with both Daft's native and Ray runners. For a multi-node Ray cluster, use an object-store URI or a local filesystem mounted at the same path on every worker.
+
 ## Video frames
 
 With `load_video_frames`, [`read`](../api/datasets.md#daft.datasets.lerobot.read) decodes each frame from its MP4 by **timestamp**: Daft combines the episode's `from_timestamp` offset within the file with the frame's episode-local `timestamp`, and matches the closest decoded frame within half a frame period.

--- a/tests/datasets/test_lerobot_write.py
+++ b/tests/datasets/test_lerobot_write.py
@@ -1,0 +1,641 @@
+from __future__ import annotations
+
+import json
+import math
+import os
+import subprocess
+import sys
+import textwrap
+
+import pyarrow as pa
+import pyarrow.fs as pafs
+import pyarrow.parquet as pq
+import pytest
+
+import daft
+from daft.datasets.lerobot import read
+from daft.io.lerobot.sink import LeRobotSink
+from daft.recordbatch import MicroPartition
+
+
+def _frame_df() -> daft.DataFrame:
+    table = pa.table(
+        {
+            # Deliberately unordered: the writer owns canonical ordering.
+            "episode_index": pa.array([1, 0, 0, 1], type=pa.int64()),
+            "frame_index": pa.array([1, 1, 0, 0], type=pa.int64()),
+            "task": ["place", "pick", "pick", "place"],
+            "action": pa.array([[0.3, 0.4], [0.1, 0.2], [0.0, 0.1], [0.2, 0.3]], type=pa.list_(pa.float32(), 2)),
+            "success": pa.array([True, False, False, True]),
+        }
+    )
+    return daft.from_arrow(table)
+
+
+def test_write_lerobot_round_trip(tmp_path):
+    root = tmp_path / "dataset"
+
+    result = _frame_df().write_lerobot(root, fps=10, robot_type="test-bot").to_pydict()
+
+    assert result == {
+        "path": [str(root)],
+        "num_episodes": [2],
+        "num_frames": [4],
+        "num_tasks": [2],
+    }
+
+    info = json.loads((root / "meta" / "info.json").read_text())
+    assert info["codebase_version"] == "v3.0"
+    assert info["robot_type"] == "test-bot"
+    assert info["video_path"] is None
+    assert info["total_episodes"] == 2
+    assert info["total_frames"] == 4
+    assert info["total_tasks"] == 2
+    assert info["splits"] == {"train": "0:2"}
+    assert info["features"]["action"] == {"dtype": "float32", "shape": [2], "names": None}
+    assert info["features"]["success"] == {"dtype": "bool", "shape": [1], "names": None}
+
+    frames = pq.read_table(root / "data/chunk-000/file-000.parquet").to_pydict()
+    assert frames["episode_index"] == [0, 0, 1, 1]
+    assert frames["frame_index"] == [0, 1, 0, 1]
+    assert frames["index"] == [0, 1, 2, 3]
+    assert frames["task_index"] == [0, 0, 1, 1]
+    assert frames["timestamp"] == pytest.approx([0.0, 0.1, 0.0, 0.1])
+    assert frames["action"] == [
+        [0.0, pytest.approx(0.1)],
+        [pytest.approx(0.1), pytest.approx(0.2)],
+        [pytest.approx(0.2), pytest.approx(0.3)],
+        [pytest.approx(0.3), pytest.approx(0.4)],
+    ]
+
+    episodes = pq.read_table(root / "meta/episodes/chunk-000/file-000.parquet").to_pydict()
+    assert episodes["length"] == [2, 2]
+    assert episodes["dataset_from_index"] == [0, 2]
+    assert episodes["dataset_to_index"] == [2, 4]
+    assert episodes["tasks"] == [["pick"], ["place"]]
+    assert episodes["stats/action/count"] == [[2], [2]]
+    assert episodes["meta/episodes/chunk_index"] == [0, 0]
+
+    tasks = pq.read_table(root / "meta/tasks.parquet").to_pydict()
+    assert tasks == {"task_index": [0, 1], "task": ["pick", "place"]}
+
+    stats = json.loads((root / "meta" / "stats.json").read_text())
+    assert stats["action"]["count"] == [4]
+    assert stats["action"]["min"] == pytest.approx([0.0, 0.1])
+    assert stats["action"]["max"] == pytest.approx([0.3, 0.4])
+
+    if os.getenv("DAFT_RUNNER") == "ray":
+        # Exercise Daft's LeRobot reader as well as direct Parquet validation.
+        round_tripped = read(str(root)).sort("index").to_pydict()
+        assert round_tripped["episode_index"] == [0, 0, 1, 1]
+        assert round_tripped["frame_index"] == [0, 1, 0, 1]
+        assert round_tripped["action"] == frames["action"]
+
+
+def test_write_lerobot_casts_explicit_fixed_shape_feature(tmp_path):
+    table = pa.table(
+        {
+            "episode_index": [0, 0],
+            "frame_index": [0, 1],
+            "task": ["pick", "pick"],
+            "action": pa.array([[1, 2], [3, 4]], type=pa.list_(pa.int64())),
+        }
+    )
+
+    daft.from_arrow(table).write_lerobot(
+        tmp_path / "dataset",
+        fps=30,
+        features={"action": {"dtype": "float32", "shape": [2], "names": ["x", "y"]}},
+    )
+
+    info = json.loads((tmp_path / "dataset/meta/info.json").read_text())
+    assert info["features"]["action"] == {"dtype": "float32", "shape": [2], "names": ["x", "y"]}
+    written = pq.read_table(tmp_path / "dataset/data/chunk-000/file-000.parquet").to_pydict()["action"]
+    assert written == [[1.0, 2.0], [3.0, 4.0]]
+
+
+def test_write_lerobot_normalizes_one_element_fixed_size_list_to_scalar(tmp_path):
+    root = tmp_path / "dataset"
+    table = pa.table(
+        {
+            "episode_index": [0, 0],
+            "frame_index": [0, 1],
+            "task": ["pick", "pick"],
+            "scalar": pa.array([1.0, 2.0], type=pa.float32()),
+            "vector": pa.array([[1.0], [2.0]], type=pa.list_(pa.float32(), 1)),
+        }
+    )
+
+    daft.from_arrow(table).write_lerobot(root, fps=30)
+
+    info = json.loads((root / "meta/info.json").read_text())
+    assert info["features"]["scalar"] == {"dtype": "float32", "shape": [1], "names": None}
+    assert info["features"]["vector"] == {"dtype": "float32", "shape": [1], "names": None}
+    written = pq.read_table(root / "data/chunk-000/file-000.parquet")
+    assert written.schema.field("scalar").type == pa.float32()
+    assert written.schema.field("vector").type == pa.float32()
+    assert written["vector"].to_pylist() == [1.0, 2.0]
+
+
+@pytest.mark.parametrize("shape", [[1], [2, 2]])
+def test_write_lerobot_normalizes_fixed_shape_tensor_storage(tmp_path, shape):
+    root = tmp_path / "dataset"
+    tensor_type = pa.fixed_shape_tensor(pa.float32(), shape)
+    width = math.prod(shape)
+    storage = pa.array(
+        [list(map(float, range(width))), list(map(float, range(width, 2 * width)))],
+        type=tensor_type.storage_type,
+    )
+    tensor = pa.ExtensionArray.from_storage(tensor_type, storage)
+    table = pa.table(
+        {
+            "episode_index": [0, 0],
+            "frame_index": [0, 1],
+            "task": ["pick", "pick"],
+            "observation": tensor,
+        }
+    )
+
+    daft.from_arrow(table).write_lerobot(root, fps=30)
+
+    info = json.loads((root / "meta/info.json").read_text())
+    assert info["features"]["observation"] == {"dtype": "float32", "shape": shape, "names": None}
+    table = pq.read_table(root / "data/chunk-000/file-000.parquet")
+    written = table["observation"].to_pylist()
+    if shape == [1]:
+        assert table.schema.field("observation").type == pa.float32()
+        assert written == [0.0, 1.0]
+    else:
+        assert written == [[[0.0, 1.0], [2.0, 3.0]], [[4.0, 5.0], [6.0, 7.0]]]
+
+
+@pytest.mark.parametrize("storage_kind", ["list", "tensor"])
+def test_write_lerobot_one_element_container_preserves_parent_null(tmp_path, storage_kind):
+    if storage_kind == "list":
+        values = pa.array([None], type=pa.list_(pa.float32(), 1))
+    else:
+        tensor_type = pa.fixed_shape_tensor(pa.float32(), [1])
+        values = pa.ExtensionArray.from_storage(tensor_type, pa.array([None], type=tensor_type.storage_type))
+    table = pa.table(
+        {
+            "episode_index": [0],
+            "frame_index": [0],
+            "task": ["pick"],
+            "observation": values,
+        }
+    )
+
+    with pytest.raises(ValueError, match="contains null values"):
+        daft.from_arrow(table).write_lerobot(tmp_path / "dataset", fps=30)
+
+
+def test_write_lerobot_rejects_mismatched_fixed_shape_tensor_descriptor(tmp_path):
+    tensor_type = pa.fixed_shape_tensor(pa.float32(), [2, 2])
+    storage = pa.array([[0.0, 1.0, 2.0, 3.0]], type=tensor_type.storage_type)
+    table = pa.table(
+        {
+            "episode_index": [0],
+            "frame_index": [0],
+            "task": ["pick"],
+            "observation": pa.ExtensionArray.from_storage(tensor_type, storage),
+        }
+    )
+
+    with pytest.raises(ValueError, match=r"FixedShapeTensor shape \[2, 2\].*declared LeRobot shape \[4\]"):
+        daft.from_arrow(table).write_lerobot(
+            tmp_path / "dataset",
+            fps=30,
+            features={"observation": {"dtype": "float32", "shape": [4], "names": None}},
+        )
+
+
+@pytest.mark.parametrize(
+    ("episode_index", "frame_index", "message"),
+    [
+        ([1], [0], "episode_index must be zero-based"),
+        ([0, 0], [0, 2], "frame_index for episode 0 must be zero-based"),
+        ([0, 2], [0, 0], "episode_index must be zero-based"),
+    ],
+)
+def test_write_lerobot_rejects_invalid_episode_frames(tmp_path, episode_index, frame_index, message):
+    df = daft.from_pydict(
+        {
+            "episode_index": episode_index,
+            "frame_index": frame_index,
+            "task": ["pick"] * len(episode_index),
+            "action": [1.0] * len(episode_index),
+        }
+    )
+
+    with pytest.raises(ValueError, match=message):
+        df.write_lerobot(tmp_path / "invalid", fps=30)
+
+
+def test_write_lerobot_requires_overwrite_for_existing_destination(tmp_path):
+    root = tmp_path / "dataset"
+    _frame_df().write_lerobot(root, fps=10)
+
+    with pytest.raises(FileExistsError, match="overwrite=True"):
+        _frame_df().write_lerobot(root, fps=10)
+
+    result = _frame_df().write_lerobot(root, fps=10, overwrite=True).to_pydict()
+    assert result["num_frames"] == [4]
+
+
+def test_write_lerobot_overwrite_validation_failure_preserves_destination(tmp_path):
+    root = tmp_path / "dataset"
+    _frame_df().write_lerobot(root, fps=10)
+    original_info = (root / "meta/info.json").read_bytes()
+    original_frames = pq.read_table(root / "data/chunk-000/file-000.parquet").to_pydict()
+
+    invalid = daft.from_pydict(
+        {
+            "episode_index": [1],
+            "frame_index": [0],
+            "task": ["invalid"],
+            "action": [999.0],
+        }
+    )
+    with pytest.raises(ValueError, match="episode_index must be zero-based"):
+        invalid.write_lerobot(root, fps=10, overwrite=True)
+
+    assert (root / "meta/info.json").read_bytes() == original_info
+    assert pq.read_table(root / "data/chunk-000/file-000.parquet").to_pydict() == original_frames
+    assert not list(tmp_path.glob(".dataset.daft-lr-*-*"))
+
+
+def test_write_lerobot_refuses_destructive_local_destinations_before_delete(tmp_path, monkeypatch):
+    working_directory = tmp_path / "working"
+    working_directory.mkdir()
+    sentinel = working_directory / "keep-me"
+    sentinel.write_text("safe")
+    monkeypatch.chdir(working_directory)
+
+    for unsafe_path in (working_directory, working_directory / "child" / "..", working_directory.parent):
+        sink = LeRobotSink(str(unsafe_path), 30, {}, None, True, 1000, 100, None)
+        with pytest.raises(ValueError, match="unsafe local path"):
+            sink.start()
+        assert sentinel.read_text() == "safe"
+
+
+def test_write_lerobot_refuses_symlink_destination(tmp_path):
+    target = tmp_path / "target"
+    target.mkdir()
+    sentinel = target / "keep-me"
+    sentinel.write_text("safe")
+    link = tmp_path / "link"
+    link.symlink_to(target, target_is_directory=True)
+
+    sink = LeRobotSink(str(link), 30, {}, None, True, 1000, 100, None)
+    with pytest.raises(ValueError, match="symlink"):
+        sink.start()
+    assert sentinel.read_text() == "safe"
+
+
+def test_write_lerobot_allows_symlink_ancestor(tmp_path):
+    target = tmp_path / "target"
+    target.mkdir()
+    link = tmp_path / "link"
+    link.symlink_to(target, target_is_directory=True)
+
+    _frame_df().write_lerobot(link / "dataset", fps=10)
+
+    assert (target / "dataset/meta/info.json").exists()
+
+
+def test_write_lerobot_refuses_to_overwrite_non_lerobot_directory(tmp_path):
+    root = tmp_path / "ordinary-directory"
+    root.mkdir()
+    sentinel = root / "keep-me"
+    sentinel.write_text("safe")
+
+    with pytest.raises(ValueError, match="non-LeRobot destination"):
+        _frame_df().write_lerobot(root, fps=10, overwrite=True)
+
+    assert sentinel.read_text() == "safe"
+
+
+@pytest.mark.parametrize("marker", ["not-json", '{"codebase_version": "v3.0"}'])
+def test_write_lerobot_refuses_invalid_info_marker(tmp_path, marker):
+    root = tmp_path / "ordinary-directory"
+    (root / "meta").mkdir(parents=True)
+    (root / "meta/info.json").write_text(marker)
+    sentinel = root / "keep-me"
+    sentinel.write_text("safe")
+
+    with pytest.raises(ValueError, match="non-LeRobot destination"):
+        _frame_df().write_lerobot(root, fps=10, overwrite=True)
+
+    assert sentinel.read_text() == "safe"
+    assert (root / "meta/info.json").read_text() == marker
+
+
+def test_write_lerobot_refuses_object_store_bucket_root():
+    with pytest.raises(ValueError, match="bucket root"):
+        LeRobotSink._validate_destination("bucket", pafs._MockFileSystem())
+
+
+def test_write_lerobot_object_store_backup_failure_preserves_destination(monkeypatch):
+    filesystem = pafs._MockFileSystem()
+    root = "bucket/dataset"
+    sink = LeRobotSink("s3://bucket/dataset", 30, {}, None, True, 1000, 100, None)
+    transaction = sink._transaction_path(root)
+    backup = sink._sibling_path(root, "backup")
+
+    old_info = json.dumps(
+        {
+            "codebase_version": "v3.0",
+            "fps": 30,
+            "features": {},
+            "data_path": "data/chunk-{chunk_index:03d}/file-{file_index:03d}.parquet",
+            "total_episodes": 0,
+            "total_frames": 0,
+            "total_tasks": 0,
+        }
+    ).encode()
+    for path, content in (
+        (f"{root}/meta/info.json", old_info),
+        (f"{root}/data/keep", b"intact"),
+        (f"{transaction}/meta/info.json", b'{"version": "new"}'),
+    ):
+        filesystem.create_dir(path.rsplit("/", 1)[0], recursive=True)
+        with filesystem.open_output_stream(path) as stream:
+            stream.write(content)
+
+    original_copy = sink._copy_path
+
+    def fail_during_backup(filesystem, source, destination, *, commit_marker_last=False):
+        if destination == backup:
+            filesystem.create_dir(backup, recursive=True)
+            with filesystem.open_output_stream(f"{backup}/partial") as stream:
+                stream.write(b"partial")
+            raise OSError("injected backup copy failure")
+        return original_copy(filesystem, source, destination, commit_marker_last=commit_marker_last)
+
+    monkeypatch.setattr(sink, "_copy_path", fail_during_backup)
+
+    with pytest.raises(OSError, match="injected backup copy failure"):
+        sink._publish(filesystem, root)
+
+    with filesystem.open_input_stream(f"{root}/meta/info.json") as stream:
+        assert stream.read() == old_info
+    with filesystem.open_input_stream(f"{root}/data/keep") as stream:
+        assert stream.read() == b"intact"
+    assert filesystem.get_file_info(backup).type == pafs.FileType.NotFound
+
+
+def test_write_lerobot_rejects_unsupported_video_feature(tmp_path):
+    df = daft.from_pydict(
+        {
+            "episode_index": [0],
+            "frame_index": [0],
+            "task": ["pick"],
+            "camera": [b"not-a-frame"],
+        }
+    )
+
+    with pytest.raises(NotImplementedError, match="video.*camera"):
+        df.write_lerobot(
+            tmp_path / "dataset",
+            fps=30,
+            features={"camera": {"dtype": "video", "shape": [3, 32, 32], "names": None}},
+        )
+
+
+def test_write_lerobot_rejects_invalid_timestamp(tmp_path):
+    df = daft.from_pydict(
+        {
+            "episode_index": [0, 0],
+            "frame_index": [0, 1],
+            "timestamp": [0.0, 0.5],
+            "task": ["pick", "pick"],
+            "action": [1.0, 2.0],
+        }
+    )
+
+    with pytest.raises(ValueError, match="frame_index / fps"):
+        df.write_lerobot(tmp_path / "dataset", fps=10)
+
+
+def test_write_lerobot_accepts_generated_float32_timestamp_for_long_episode(tmp_path):
+    num_frames = 100_001
+    df = daft.from_pydict(
+        {
+            "episode_index": [0] * num_frames,
+            "frame_index": list(range(num_frames)),
+            "task": ["long"] * num_frames,
+        }
+    )
+
+    df.write_lerobot(tmp_path / "dataset", fps=3)
+
+    frames = pq.read_table(tmp_path / "dataset/data/chunk-000/file-000.parquet", columns=["timestamp"])
+    assert frames["timestamp"][-1].as_py() == pa.scalar(100_000 / 3, pa.float32()).as_py()
+
+
+def test_write_lerobot_rejects_non_integer_indices(tmp_path):
+    df = daft.from_pydict(
+        {
+            "episode_index": [0.0],
+            "frame_index": [0],
+            "task": ["pick"],
+            "action": [1.0],
+        }
+    )
+
+    with pytest.raises(ValueError, match="episode_index must have an integer type"):
+        df.write_lerobot(tmp_path / "dataset", fps=10)
+
+
+def test_write_lerobot_parquet_has_one_row_group_per_episode(tmp_path):
+    root = tmp_path / "dataset"
+    _frame_df().write_lerobot(root, fps=10)
+
+    parquet = pq.ParquetFile(root / "data/chunk-000/file-000.parquet")
+    assert parquet.num_row_groups == 2
+
+
+def test_write_lerobot_tasks_parquet_has_named_pandas_index(tmp_path):
+    pandas = pytest.importorskip("pandas")
+    root = tmp_path / "dataset"
+    _frame_df().write_lerobot(root, fps=10)
+
+    tasks = pandas.read_parquet(root / "meta/tasks.parquet")
+
+    assert tasks.index.name == "task"
+    assert tasks.index.tolist() == ["pick", "place"]
+    assert tasks.columns.tolist() == ["task_index"]
+    assert tasks["task_index"].tolist() == [0, 1]
+
+
+def test_write_lerobot_does_not_require_numpy_or_pandas(tmp_path):
+    root = tmp_path / "dataset"
+    script = textwrap.dedent(
+        f"""
+        import builtins
+        from pathlib import Path
+
+        real_import = builtins.__import__
+
+        def block_optional_dependencies(name, *args, **kwargs):
+            if name.split(".")[0] in {{"numpy", "pandas"}}:
+                raise ImportError(f"blocked optional dependency: {{name}}")
+            return real_import(name, *args, **kwargs)
+
+        builtins.__import__ = block_optional_dependencies
+
+        import daft
+
+        daft.from_pydict(
+            {{
+                "episode_index": [0],
+                "frame_index": [0],
+                "task": ["pick"],
+                "action": [1.0],
+            }}
+        ).write_lerobot(Path({str(root)!r}), fps=10)
+        """
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "DAFT_RUNNER": "native"},
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (root / "meta/info.json").exists()
+
+
+def test_write_lerobot_aggregates_conservative_quantile_bounds(tmp_path):
+    root = tmp_path / "dataset"
+    daft.from_pydict(
+        {
+            "episode_index": [0, 1, 1, 1],
+            "frame_index": [0, 0, 1, 2],
+            "task": ["task"] * 4,
+            "action": [0.0, 10.0, 20.0, 30.0],
+        }
+    ).write_lerobot(root, fps=10)
+
+    stats = json.loads((root / "meta/stats.json").read_text())
+    assert stats["action"]["q01"] == pytest.approx([0.0])
+    assert stats["action"]["q50"] == pytest.approx([0.0])
+    assert stats["action"]["q90"] == pytest.approx([28.0])
+    assert stats["action"]["q99"] == pytest.approx([29.8])
+
+
+@pytest.mark.parametrize("value", [math.nan, math.inf, -math.inf])
+def test_write_lerobot_rejects_non_finite_feature_values(tmp_path, value):
+    df = daft.from_pydict(
+        {
+            "episode_index": [0],
+            "frame_index": [0],
+            "task": ["task"],
+            "action": [value],
+        }
+    )
+
+    with pytest.raises(ValueError, match="non-finite values"):
+        df.write_lerobot(tmp_path / "dataset", fps=10)
+
+
+def test_write_lerobot_stats_handle_extreme_finite_values(tmp_path):
+    root = tmp_path / "dataset"
+    daft.from_pydict(
+        {
+            "episode_index": [0, 0, 1, 1],
+            "frame_index": [0, 1, 0, 1],
+            "task": ["task"] * 4,
+            "action": [-1e308, 1e308, -1e308, 1e308],
+        }
+    ).write_lerobot(root, fps=10)
+
+    stats = json.loads((root / "meta/stats.json").read_text())
+    assert stats["action"]["mean"] == [0.0]
+    assert math.isinf(stats["action"]["std"][0])
+
+
+@pytest.mark.parametrize(
+    ("arrow_type", "value"),
+    [
+        (pa.int64(), 2**53 + 1),
+        (pa.uint64(), 2**63 + 1),
+    ],
+)
+def test_write_lerobot_stats_accept_large_integer_features(tmp_path, arrow_type, value):
+    root = tmp_path / "dataset"
+    table = pa.table(
+        {
+            "episode_index": [0],
+            "frame_index": [0],
+            "task": ["task"],
+            "value": pa.array([value], type=arrow_type),
+        }
+    )
+
+    daft.from_arrow(table).write_lerobot(root, fps=10)
+
+    frames = pq.read_table(root / "data/chunk-000/file-000.parquet")
+    assert frames["value"][0].as_py() == value
+    stats = json.loads((root / "meta/stats.json").read_text())
+    assert stats["value"]["count"] == [1]
+
+
+def test_write_lerobot_rejects_slash_in_feature_name(tmp_path):
+    df = daft.from_pydict(
+        {
+            "episode_index": [0],
+            "frame_index": [0],
+            "task": ["pick"],
+            "observation/state": [1.0],
+        }
+    )
+
+    with pytest.raises(ValueError, match="feature names cannot contain"):
+        df.write_lerobot(tmp_path / "dataset", fps=10)
+
+
+@pytest.mark.skipif(os.getenv("DAFT_RUNNER") == "ray", reason="exercises the native streaming fallback")
+def test_write_lerobot_native_streams_prepared_partitions(tmp_path, monkeypatch):
+    table = _frame_df().to_arrow()
+    df = daft.DataFrame._from_micropartitions(
+        MicroPartition.from_arrow(table.slice(0, 2)),
+        MicroPartition.from_arrow(table.slice(2, 2)),
+    )
+
+    def fail_to_arrow(*args, **kwargs):
+        raise AssertionError("write_lerobot must not materialize the full DataFrame with to_arrow")
+
+    monkeypatch.setattr(daft.DataFrame, "to_arrow", fail_to_arrow)
+    df.write_lerobot(tmp_path / "dataset", fps=10)
+
+    assert pq.read_metadata(tmp_path / "dataset/data/chunk-000/file-000.parquet").num_rows == 4
+
+
+@pytest.mark.skipif(os.getenv("DAFT_RUNNER") != "ray", reason="exercises the distributed Ray sink path")
+def test_write_lerobot_merges_episodes_across_partitions(tmp_path):
+    root = tmp_path / "dataset"
+    episode_index = [0] * 8 + [1] * 8
+    frame_index = list(range(8)) * 2
+    # Repartition before writing so Ray has several independently executing
+    # sink tasks, including an episode boundary that is not a partition boundary.
+    df = daft.from_pydict(
+        {
+            "episode_index": episode_index,
+            "frame_index": frame_index,
+            "task": ["pick"] * 8 + ["place"] * 8,
+            "action": [float(value) for value in range(16)],
+        }
+    ).repartition(3)
+
+    result = df.write_lerobot(root, fps=20).to_pydict()
+
+    assert result["num_episodes"] == [2]
+    assert result["num_frames"] == [16]
+    frames = pq.read_table(root / "data/chunk-000/file-000.parquet").to_pydict()
+    assert frames["episode_index"] == episode_index
+    assert frames["frame_index"] == frame_index
+    assert frames["index"] == list(range(16))


### PR DESCRIPTION
## Changes Made

- Add `DataFrame.write_lerobot` for tabular LeRobot v3 datasets, including canonical frame ordering, feature descriptors, episode metadata, task metadata, and dataset statistics.
- Support both runners: native writes input partitions incrementally, while Ray executes the distributed sink after a global episode/frame sort.
- Publish through sibling staging/backup paths so failed overwrites preserve the previous dataset; reject unsafe roots, symlink destinations, bucket roots, and non-LeRobot directories.
- Keep the core writer free of optional NumPy/Pandas runtime dependencies while emitting Pandas-compatible task index metadata.
- Document the API and add native/Ray round-trip, compatibility, transaction-safety, numeric-boundary, and dependency-boundary tests.

## Validation

- Pre-commit hooks: mypy, ruff, formatting, codespell, dependency checks
- `DAFT_RUNNER=native ... tests/datasets/test_lerobot_write.py`: 37 passed, 1 skipped
- `DAFT_RUNNER=ray ... tests/datasets/test_lerobot_write.py`: 37 passed, 1 skipped
- `DAFT_RUNNER=ray ... tests/datasets/test_lerobot.py`: 12 passed

## Related Issues

Closes #6296

Closes #7413