### PR TITLE
fix(distributed): surface background errors while input is pending

### DIFF
--- a/src/daft-distributed/src/utils/stream.rs
+++ b/src/daft-distributed/src/utils/stream.rs
@@ -73,43 +73,29 @@ where
                         Poll::Pending => {}
                     }
 
-                    let mut joinset_complete = false;
-                    let mut background_error = None;
-                    if let Some(active_joinset) = joinset.as_mut() {
-                        loop {
-                            match active_joinset.poll_join_next(cx) {
-                                // Keep polling after successful completions so the remaining
-                                // tasks register this stream's waker before we return Pending.
-                                Poll::Ready(Some(Ok(Ok(())))) => {}
-                                Poll::Ready(Some(Ok(Err(e)))) => {
-                                    background_error = Some(e);
-                                    break;
-                                }
-                                Poll::Ready(Some(Err(e))) => {
-                                    background_error = Some(e);
-                                    break;
-                                }
-                                Poll::Ready(None) => {
-                                    joinset_complete = true;
-                                    break;
-                                }
-                                Poll::Pending => break,
+                    loop {
+                        let Some(active_joinset) = joinset.as_mut() else {
+                            return Some(Poll::Pending);
+                        };
+
+                        match active_joinset.poll_join_next(cx) {
+                            // Keep polling after successful completions so the remaining
+                            // tasks register this stream's waker before we return Pending.
+                            Poll::Ready(Some(Ok(Ok(())))) => {}
+                            Poll::Ready(Some(Ok(Err(e)) | Err(e))) => {
+                                // Stop forwarding input, but retain the remaining tasks so they
+                                // can observe the closed input channel and complete cleanup.
+                                let joinset = joinset.take().expect("JoinSet should exist");
+                                *state = ForwardingStreamState::AwaitingTasks(joinset);
+                                return Some(Poll::Ready(Some(Err(e))));
                             }
+                            Poll::Ready(None) => {
+                                *joinset = None;
+                                return Some(Poll::Pending);
+                            }
+                            Poll::Pending => return Some(Poll::Pending),
                         }
                     }
-
-                    if let Some(error) = background_error {
-                        // Stop forwarding input, but retain the remaining tasks so they can
-                        // observe the closed input channel and complete their cleanup paths.
-                        let joinset = joinset.take().expect("JoinSet should exist");
-                        *state = ForwardingStreamState::AwaitingTasks(joinset);
-                        return Some(Poll::Ready(Some(Err(error))));
-                    }
-
-                    if joinset_complete {
-                        *joinset = None;
-                    }
-                    Some(Poll::Pending)
                 }
                 // AwaitingTasks: Input stream is done, awaiting background tasks to complete
                 ForwardingStreamState::AwaitingTasks(joinset) => match joinset.poll_join_next(cx) {

--- a/src/daft-distributed/src/utils/stream.rs
+++ b/src/daft-distributed/src/utils/stream.rs
@@ -58,16 +58,36 @@ where
                     input_stream,
                     joinset,
                 } => {
+                    if let Some(active_joinset) = joinset.as_mut() {
+                        match active_joinset.poll_join_next(cx) {
+                            Poll::Ready(Some(Ok(Ok(())))) => {}
+                            Poll::Ready(Some(Ok(Err(e)))) => {
+                                active_joinset.abort_all();
+                                *state = ForwardingStreamState::Complete;
+                                return Some(Poll::Ready(Some(Err(e))));
+                            }
+                            Poll::Ready(Some(Err(e))) => {
+                                active_joinset.abort_all();
+                                *state = ForwardingStreamState::Complete;
+                                return Some(Poll::Ready(Some(Err(e))));
+                            }
+                            Poll::Ready(None) => *joinset = None,
+                            Poll::Pending => {}
+                        }
+                    }
+
                     match input_stream.poll_next_unpin(cx) {
-                        // Received a result from the stream, forward it
+                        // Received a result from the stream, forward it.
                         Poll::Ready(Some(result)) => Some(Poll::Ready(Some(Ok(result)))),
-                        // Input stream is done, transition to awaiting tasks
+                        // Input stream is done, transition to awaiting tasks.
                         Poll::Ready(None) => {
-                            let joinset = joinset.take().expect("JoinSet should exist");
-                            *state = ForwardingStreamState::AwaitingTasks(joinset);
+                            *state = match joinset.take() {
+                                Some(joinset) => ForwardingStreamState::AwaitingTasks(joinset),
+                                None => ForwardingStreamState::Complete,
+                            };
                             None
                         }
-                        // Still waiting for more results from the stream
+                        // Still waiting for more results from the stream.
                         Poll::Pending => Some(Poll::Pending),
                     }
                 }
@@ -76,8 +96,16 @@ where
                     // Received a result from a background task
                     Poll::Ready(Some(result)) => match result {
                         Ok(Ok(())) => None,
-                        Ok(Err(e)) => Some(Poll::Ready(Some(Err(e)))),
-                        Err(e) => Some(Poll::Ready(Some(Err(e)))),
+                        Ok(Err(e)) => {
+                            joinset.abort_all();
+                            *state = ForwardingStreamState::Complete;
+                            Some(Poll::Ready(Some(Err(e))))
+                        }
+                        Err(e) => {
+                            joinset.abort_all();
+                            *state = ForwardingStreamState::Complete;
+                            Some(Poll::Ready(Some(Err(e))))
+                        }
                     },
                     // All background tasks are complete
                     Poll::Ready(None) => {
@@ -102,6 +130,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use common_error::DaftError;
 
     use super::*;
@@ -130,6 +160,56 @@ mod tests {
             count += 1;
         }
         assert_eq!(count, 10);
+    }
+
+    #[tokio::test]
+    async fn test_joinable_forwarding_stream_surfaces_background_error_while_input_pending() {
+        let mut joinset = JoinSet::new();
+        joinset.spawn(async move { Err(DaftError::InternalError("test error".to_string())) });
+
+        let input_stream = futures::stream::pending::<usize>();
+        let mut stream = JoinableForwardingStream::new(input_stream, joinset);
+
+        let result = tokio::time::timeout(Duration::from_secs(1), stream.next())
+            .await
+            .expect("background error should be surfaced while input is pending")
+            .expect("stream should emit an error item");
+
+        assert!(matches!(&result, Err(DaftError::InternalError(_))));
+        assert!(result.unwrap_err().to_string().contains("test error"));
+        assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_joinable_forwarding_stream_keeps_pending_after_background_success() {
+        let mut joinset = JoinSet::new();
+        joinset.spawn(async move { Ok(()) });
+
+        let input_stream = futures::stream::pending::<usize>();
+        let mut stream = JoinableForwardingStream::new(input_stream, joinset);
+
+        let result = tokio::time::timeout(Duration::from_millis(50), stream.next()).await;
+        assert!(
+            result.is_err(),
+            "background success must not end a pending input stream"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_joinable_forwarding_stream_preserves_input_after_background_tasks_complete() {
+        let mut joinset = JoinSet::new();
+        for _ in 0..3 {
+            joinset.spawn(async move { Ok(()) });
+        }
+
+        let input_stream = futures::stream::iter([1, 2, 3]);
+        let stream = JoinableForwardingStream::new(input_stream, joinset);
+        let results = stream.collect::<Vec<_>>().await;
+
+        assert_eq!(
+            results.into_iter().collect::<DaftResult<Vec<_>>>().unwrap(),
+            vec![1, 2, 3]
+        );
     }
 
     #[tokio::test]
@@ -164,8 +244,9 @@ mod tests {
             }
         }
         assert!(stream.next().await.is_none());
-        // 9 results because we consume the stream before joining the tasks
-        assert_eq!(count, 9);
+        // The stream should fail fast once a background task errors instead of draining
+        // all remaining input items first.
+        assert!(count < 9);
     }
 
     #[tokio::test]
@@ -200,7 +281,8 @@ mod tests {
             }
         }
         assert!(stream.next().await.is_none());
-        // 9 results because we consume the stream before joining the tasks
-        assert_eq!(count, 9);
+        // The stream should fail fast once a background task panics instead of draining
+        // all remaining input items first.
+        assert!(count < 9);
     }
 }

--- a/src/daft-distributed/src/utils/stream.rs
+++ b/src/daft-distributed/src/utils/stream.rs
@@ -58,22 +58,33 @@ where
                     input_stream,
                     joinset,
                 } => {
+                    let mut joinset_complete = false;
                     if let Some(active_joinset) = joinset.as_mut() {
-                        match active_joinset.poll_join_next(cx) {
-                            Poll::Ready(Some(Ok(Ok(())))) => {}
-                            Poll::Ready(Some(Ok(Err(e)))) => {
-                                active_joinset.abort_all();
-                                *state = ForwardingStreamState::Complete;
-                                return Some(Poll::Ready(Some(Err(e))));
+                        loop {
+                            match active_joinset.poll_join_next(cx) {
+                                // Keep polling after successful completions so the remaining
+                                // tasks register this stream's waker before we return Pending.
+                                Poll::Ready(Some(Ok(Ok(())))) => continue,
+                                Poll::Ready(Some(Ok(Err(e)))) => {
+                                    active_joinset.abort_all();
+                                    *state = ForwardingStreamState::Complete;
+                                    return Some(Poll::Ready(Some(Err(e))));
+                                }
+                                Poll::Ready(Some(Err(e))) => {
+                                    active_joinset.abort_all();
+                                    *state = ForwardingStreamState::Complete;
+                                    return Some(Poll::Ready(Some(Err(e))));
+                                }
+                                Poll::Ready(None) => {
+                                    joinset_complete = true;
+                                    break;
+                                }
+                                Poll::Pending => break,
                             }
-                            Poll::Ready(Some(Err(e))) => {
-                                active_joinset.abort_all();
-                                *state = ForwardingStreamState::Complete;
-                                return Some(Poll::Ready(Some(Err(e))));
-                            }
-                            Poll::Ready(None) => *joinset = None,
-                            Poll::Pending => {}
                         }
+                    }
+                    if joinset_complete {
+                        *joinset = None;
                     }
 
                     match input_stream.poll_next_unpin(cx) {
@@ -192,6 +203,41 @@ mod tests {
         assert!(
             result.is_err(),
             "background success must not end a pending input stream"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_joinable_forwarding_stream_wakes_for_error_after_background_success() {
+        let (error_tx, error_rx) = tokio::sync::oneshot::channel();
+        let mut joinset = JoinSet::new();
+        joinset.spawn(async move { Ok(()) });
+        joinset.spawn(async move {
+            error_rx.await.unwrap();
+            Err(DaftError::InternalError("delayed test error".to_string()))
+        });
+
+        // Let the successful task finish before the stream is first polled.
+        tokio::task::yield_now().await;
+
+        let input_stream = futures::stream::pending::<usize>();
+        let mut stream = JoinableForwardingStream::new(input_stream, joinset);
+        let next = stream.next();
+        tokio::pin!(next);
+
+        assert!(futures::poll!(&mut next).is_pending());
+        error_tx.send(()).unwrap();
+
+        let result = tokio::time::timeout(Duration::from_secs(1), next)
+            .await
+            .expect("delayed background error should wake the stream")
+            .expect("stream should emit an error item");
+
+        assert!(matches!(&result, Err(DaftError::InternalError(_))));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("delayed test error")
         );
     }
 

--- a/src/daft-distributed/src/utils/stream.rs
+++ b/src/daft-distributed/src/utils/stream.rs
@@ -64,7 +64,7 @@ where
                             match active_joinset.poll_join_next(cx) {
                                 // Keep polling after successful completions so the remaining
                                 // tasks register this stream's waker before we return Pending.
-                                Poll::Ready(Some(Ok(Ok(())))) => continue,
+                                Poll::Ready(Some(Ok(Ok(())))) => {}
                                 Poll::Ready(Some(Ok(Err(e)))) => {
                                     active_joinset.abort_all();
                                     *state = ForwardingStreamState::Complete;

--- a/src/daft-distributed/src/utils/stream.rs
+++ b/src/daft-distributed/src/utils/stream.rs
@@ -7,21 +7,9 @@ use common_error::DaftResult;
 use common_runtime::JoinSet;
 use futures::{Stream, StreamExt};
 
-#[derive(Debug)]
-enum ForwardingStreamState<S: Stream + Send + Unpin + 'static> {
-    // Active: Forwarding results from input stream and tracking background tasks
-    Active {
-        input_stream: S,
-        joinset: Option<JoinSet<DaftResult<()>>>,
-    },
-    // AwaitingTasks: Input forwarding has stopped, awaiting background tasks to complete
-    AwaitingTasks(JoinSet<DaftResult<()>>),
-    // Complete: Both stream and background tasks are finished
-    Complete,
-}
-
 pub(crate) struct JoinableForwardingStream<S: Stream + Send + Unpin + 'static> {
-    state: ForwardingStreamState<S>,
+    input_stream: Option<S>,
+    joinset: Option<JoinSet<DaftResult<()>>>,
 }
 
 impl<S> JoinableForwardingStream<S>
@@ -30,10 +18,8 @@ where
 {
     pub fn new(input_stream: S, joinset: JoinSet<DaftResult<()>>) -> Self {
         Self {
-            state: ForwardingStreamState::Active {
-                input_stream,
-                joinset: Some(joinset),
-            },
+            input_stream: Some(input_stream),
+            joinset: Some(joinset),
         }
     }
 }
@@ -45,83 +31,37 @@ where
     type Item = DaftResult<S::Item>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        fn poll_inner<S>(
-            state: &mut ForwardingStreamState<S>,
-            cx: &mut Context<'_>,
-        ) -> Option<Poll<Option<DaftResult<S::Item>>>>
-        where
-            S: Stream + Send + Unpin + 'static,
-        {
-            match state {
-                // Active: Forwarding results from input stream and tracking background tasks
-                ForwardingStreamState::Active {
-                    input_stream,
-                    joinset,
-                } => {
-                    match input_stream.poll_next_unpin(cx) {
-                        // Preserve the existing input priority when data is ready.
-                        Poll::Ready(Some(result)) => return Some(Poll::Ready(Some(Ok(result)))),
-                        // Input stream is done, transition to awaiting tasks.
-                        Poll::Ready(None) => {
-                            *state = match joinset.take() {
-                                Some(joinset) => ForwardingStreamState::AwaitingTasks(joinset),
-                                None => ForwardingStreamState::Complete,
-                            };
-                            return None;
-                        }
-                        // Register the input waker before checking background tasks.
-                        Poll::Pending => {}
-                    }
+        let this = &mut *self;
 
-                    loop {
-                        let Some(active_joinset) = joinset.as_mut() else {
-                            return Some(Poll::Pending);
-                        };
-
-                        match active_joinset.poll_join_next(cx) {
-                            // Keep polling after successful completions so the remaining
-                            // tasks register this stream's waker before we return Pending.
-                            Poll::Ready(Some(Ok(Ok(())))) => {}
-                            Poll::Ready(Some(Ok(Err(e)) | Err(e))) => {
-                                // Stop forwarding input, but retain the remaining tasks so they
-                                // can observe the closed input channel and complete cleanup.
-                                let joinset = joinset.take().expect("JoinSet should exist");
-                                *state = ForwardingStreamState::AwaitingTasks(joinset);
-                                return Some(Poll::Ready(Some(Err(e))));
-                            }
-                            Poll::Ready(None) => {
-                                *joinset = None;
-                                return Some(Poll::Pending);
-                            }
-                            Poll::Pending => return Some(Poll::Pending),
-                        }
-                    }
-                }
-                // AwaitingTasks: Input stream is done, awaiting background tasks to complete
-                ForwardingStreamState::AwaitingTasks(joinset) => match joinset.poll_join_next(cx) {
-                    // Received a result from a background task
-                    Poll::Ready(Some(result)) => match result {
-                        Ok(Ok(())) => None,
-                        Ok(Err(e)) => Some(Poll::Ready(Some(Err(e)))),
-                        Err(e) => Some(Poll::Ready(Some(Err(e)))),
-                    },
-                    // All background tasks are complete
-                    Poll::Ready(None) => {
-                        *state = ForwardingStreamState::Complete;
-                        None
-                    }
-                    // Still waiting for background tasks to complete
-                    Poll::Pending => Some(Poll::Pending),
-                },
-                // Complete: Both stream and background tasks are finished
-                ForwardingStreamState::Complete => Some(Poll::Ready(None)),
+        if let Some(input_stream) = this.input_stream.as_mut() {
+            match input_stream.poll_next_unpin(cx) {
+                // Preserve the existing input priority when data is ready.
+                Poll::Ready(Some(result)) => return Poll::Ready(Some(Ok(result))),
+                Poll::Ready(None) => this.input_stream = None,
+                // Register the input waker before checking background tasks.
+                Poll::Pending => {}
             }
         }
 
-        loop {
-            if let Some(poll) = poll_inner(&mut self.state, cx) {
-                return poll;
+        // Keep draining so every remaining task registers this stream's waker.
+        while let Some(joinset) = this.joinset.as_mut() {
+            match joinset.poll_join_next(cx) {
+                Poll::Ready(Some(Ok(Ok(())))) => {}
+                Poll::Ready(Some(Ok(Err(e)) | Err(e))) => {
+                    // Stop forwarding input, but retain the remaining tasks so they
+                    // can observe the closed input channel and complete cleanup.
+                    this.input_stream = None;
+                    return Poll::Ready(Some(Err(e)));
+                }
+                Poll::Ready(None) => this.joinset = None,
+                Poll::Pending => return Poll::Pending,
             }
+        }
+
+        if this.input_stream.is_some() {
+            Poll::Pending
+        } else {
+            Poll::Ready(None)
         }
     }
 }

--- a/src/daft-distributed/src/utils/stream.rs
+++ b/src/daft-distributed/src/utils/stream.rs
@@ -14,7 +14,7 @@ enum ForwardingStreamState<S: Stream + Send + Unpin + 'static> {
         input_stream: S,
         joinset: Option<JoinSet<DaftResult<()>>>,
     },
-    // AwaitingTasks: Input stream is done, awaiting background tasks to complete
+    // AwaitingTasks: Input forwarding has stopped, awaiting background tasks to complete
     AwaitingTasks(JoinSet<DaftResult<()>>),
     // Complete: Both stream and background tasks are finished
     Complete,
@@ -58,7 +58,23 @@ where
                     input_stream,
                     joinset,
                 } => {
+                    match input_stream.poll_next_unpin(cx) {
+                        // Preserve the existing input priority when data is ready.
+                        Poll::Ready(Some(result)) => return Some(Poll::Ready(Some(Ok(result)))),
+                        // Input stream is done, transition to awaiting tasks.
+                        Poll::Ready(None) => {
+                            *state = match joinset.take() {
+                                Some(joinset) => ForwardingStreamState::AwaitingTasks(joinset),
+                                None => ForwardingStreamState::Complete,
+                            };
+                            return None;
+                        }
+                        // Register the input waker before checking background tasks.
+                        Poll::Pending => {}
+                    }
+
                     let mut joinset_complete = false;
+                    let mut background_error = None;
                     if let Some(active_joinset) = joinset.as_mut() {
                         loop {
                             match active_joinset.poll_join_next(cx) {
@@ -66,14 +82,12 @@ where
                                 // tasks register this stream's waker before we return Pending.
                                 Poll::Ready(Some(Ok(Ok(())))) => {}
                                 Poll::Ready(Some(Ok(Err(e)))) => {
-                                    active_joinset.abort_all();
-                                    *state = ForwardingStreamState::Complete;
-                                    return Some(Poll::Ready(Some(Err(e))));
+                                    background_error = Some(e);
+                                    break;
                                 }
                                 Poll::Ready(Some(Err(e))) => {
-                                    active_joinset.abort_all();
-                                    *state = ForwardingStreamState::Complete;
-                                    return Some(Poll::Ready(Some(Err(e))));
+                                    background_error = Some(e);
+                                    break;
                                 }
                                 Poll::Ready(None) => {
                                     joinset_complete = true;
@@ -83,40 +97,27 @@ where
                             }
                         }
                     }
+
+                    if let Some(error) = background_error {
+                        // Stop forwarding input, but retain the remaining tasks so they can
+                        // observe the closed input channel and complete their cleanup paths.
+                        let joinset = joinset.take().expect("JoinSet should exist");
+                        *state = ForwardingStreamState::AwaitingTasks(joinset);
+                        return Some(Poll::Ready(Some(Err(error))));
+                    }
+
                     if joinset_complete {
                         *joinset = None;
                     }
-
-                    match input_stream.poll_next_unpin(cx) {
-                        // Received a result from the stream, forward it.
-                        Poll::Ready(Some(result)) => Some(Poll::Ready(Some(Ok(result)))),
-                        // Input stream is done, transition to awaiting tasks.
-                        Poll::Ready(None) => {
-                            *state = match joinset.take() {
-                                Some(joinset) => ForwardingStreamState::AwaitingTasks(joinset),
-                                None => ForwardingStreamState::Complete,
-                            };
-                            None
-                        }
-                        // Still waiting for more results from the stream.
-                        Poll::Pending => Some(Poll::Pending),
-                    }
+                    Some(Poll::Pending)
                 }
                 // AwaitingTasks: Input stream is done, awaiting background tasks to complete
                 ForwardingStreamState::AwaitingTasks(joinset) => match joinset.poll_join_next(cx) {
                     // Received a result from a background task
                     Poll::Ready(Some(result)) => match result {
                         Ok(Ok(())) => None,
-                        Ok(Err(e)) => {
-                            joinset.abort_all();
-                            *state = ForwardingStreamState::Complete;
-                            Some(Poll::Ready(Some(Err(e))))
-                        }
-                        Err(e) => {
-                            joinset.abort_all();
-                            *state = ForwardingStreamState::Complete;
-                            Some(Poll::Ready(Some(Err(e))))
-                        }
+                        Ok(Err(e)) => Some(Poll::Ready(Some(Err(e)))),
+                        Err(e) => Some(Poll::Ready(Some(Err(e)))),
                     },
                     // All background tasks are complete
                     Poll::Ready(None) => {
@@ -259,6 +260,94 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_joinable_forwarding_stream_error_allows_remaining_tasks_to_cleanup() {
+        let (release_cleanup_tx, release_cleanup_rx) = tokio::sync::oneshot::channel();
+        let (cleanup_done_tx, cleanup_done_rx) = tokio::sync::oneshot::channel();
+
+        let mut joinset = JoinSet::new();
+        joinset.spawn(async move { Err(DaftError::InternalError("test error".to_string())) });
+        joinset.spawn(async move {
+            release_cleanup_rx.await.unwrap();
+            cleanup_done_tx.send(()).unwrap();
+            Ok(())
+        });
+
+        // Ensure the error is ready while the cleanup task remains blocked.
+        tokio::task::yield_now().await;
+
+        let mut stream = JoinableForwardingStream::new(futures::stream::empty::<usize>(), joinset);
+        let result = tokio::time::timeout(Duration::from_secs(1), stream.next())
+            .await
+            .expect("background error should be surfaced")
+            .expect("stream should emit an error item");
+        assert!(result.unwrap_err().to_string().contains("test error"));
+
+        release_cleanup_tx.send(()).unwrap();
+        tokio::time::timeout(Duration::from_secs(1), cleanup_done_rx)
+            .await
+            .expect("remaining background tasks should not be aborted")
+            .expect("cleanup task should finish normally");
+        assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_joinable_forwarding_stream_active_error_stops_input_and_keeps_cleanup_running() {
+        let (input_tx, input_rx) = create_channel(1);
+        let (release_cleanup_tx, release_cleanup_rx) = tokio::sync::oneshot::channel();
+        let (cleanup_done_tx, cleanup_done_rx) = tokio::sync::oneshot::channel();
+
+        let mut joinset = JoinSet::new();
+        joinset.spawn(async move { Err(DaftError::InternalError("test error".to_string())) });
+        joinset.spawn(async move {
+            release_cleanup_rx.await.unwrap();
+            cleanup_done_tx.send(()).unwrap();
+            Ok(())
+        });
+
+        tokio::task::yield_now().await;
+
+        let mut stream = JoinableForwardingStream::new(
+            tokio_stream::wrappers::ReceiverStream::new(input_rx),
+            joinset,
+        );
+        let result = tokio::time::timeout(Duration::from_secs(1), stream.next())
+            .await
+            .expect("background error should be surfaced while input is pending")
+            .expect("stream should emit an error item");
+        assert!(result.unwrap_err().to_string().contains("test error"));
+
+        // The input receiver is dropped as part of fail-fast, while cleanup tasks keep
+        // running independently even if the consumer does not poll the stream again.
+        assert!(input_tx.send(1).await.is_err());
+        release_cleanup_tx.send(()).unwrap();
+        tokio::time::timeout(Duration::from_secs(1), cleanup_done_rx)
+            .await
+            .expect("remaining background tasks should continue without another stream poll")
+            .expect("cleanup task should finish normally");
+        assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_joinable_forwarding_stream_preserves_ready_input_before_background_error() {
+        let mut joinset = JoinSet::new();
+        joinset.spawn(async move { Err(DaftError::InternalError("test error".to_string())) });
+        tokio::task::yield_now().await;
+
+        let mut stream = JoinableForwardingStream::new(futures::stream::iter([42usize]), joinset);
+        assert_eq!(stream.next().await.unwrap().unwrap(), 42);
+        assert!(
+            stream
+                .next()
+                .await
+                .unwrap()
+                .unwrap_err()
+                .to_string()
+                .contains("test error")
+        );
+        assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test]
     async fn test_joinable_forwarding_stream_basic_error() {
         let (tx, rx) = create_channel(1);
 
@@ -268,8 +357,8 @@ mod tests {
             joinset.spawn(async move {
                 if i == 5 {
                     return Err(DaftError::InternalError("test error".to_string()));
-                } else {
-                    tx.send(1).await.unwrap();
+                } else if tx.send(1).await.is_err() {
+                    return Ok(());
                 }
                 Ok(())
             });
@@ -280,19 +369,20 @@ mod tests {
             JoinableForwardingStream::new(tokio_stream::wrappers::ReceiverStream::new(rx), joinset);
 
         let mut count = 0;
+        let mut saw_error = false;
         while let Some(result) = stream.next().await {
             if let Err(e) = result {
                 assert!(matches!(e, DaftError::InternalError(_)));
                 assert!(e.to_string().contains("test error"));
+                saw_error = true;
             } else {
                 assert_eq!(result.unwrap(), 1);
                 count += 1;
             }
         }
         assert!(stream.next().await.is_none());
-        // The stream should fail fast once a background task errors instead of draining
-        // all remaining input items first.
-        assert!(count < 9);
+        assert!(saw_error);
+        assert!(count <= 9);
     }
 
     #[tokio::test]
@@ -305,8 +395,8 @@ mod tests {
             joinset.spawn(async move {
                 if i == 5 {
                     panic!("test panic");
-                } else {
-                    tx.send(1).await.unwrap();
+                } else if tx.send(1).await.is_err() {
+                    return Ok(());
                 }
                 Ok(())
             });
@@ -317,18 +407,19 @@ mod tests {
             JoinableForwardingStream::new(tokio_stream::wrappers::ReceiverStream::new(rx), joinset);
 
         let mut count = 0;
+        let mut saw_panic = false;
         while let Some(result) = stream.next().await {
             if let Err(e) = result {
                 assert!(matches!(e, DaftError::JoinError(_)));
                 assert!(e.to_string().contains("test panic"));
+                saw_panic = true;
             } else {
                 assert_eq!(result.unwrap(), 1);
                 count += 1;
             }
         }
         assert!(stream.next().await.is_none());
-        // The stream should fail fast once a background task panics instead of draining
-        // all remaining input items first.
-        assert!(count < 9);
+        assert!(saw_panic);
+        assert!(count <= 9);
     }
 }


### PR DESCRIPTION
`JoinableForwardingStream` previously polled background tasks only after its input stream closed. If a scheduler or materializer task failed while the input remained `Pending`, that error stayed queued in the `JoinSet` and the driver could wait indefinitely for another partition.

This change surfaces background failures without changing ready-input priority or the stream's existing drop semantics.

## Changes Made

- Poll the input first so ready data keeps its existing priority.
- While the input is pending, poll completed background tasks until the remaining tasks register the stream waker.
- On a task error or panic, stop input forwarding, emit the error immediately, and transition to `AwaitingTasks` with the remaining `JoinSet`.
- Continue forwarding input after successful background completions, and stop polling an exhausted `JoinSet`.
- Add regression coverage for pending input, delayed failures, wakeup preservation, ready-input priority, remaining-task behavior after failure, and task errors/panics.

## Validation

- `cargo test -p daft-distributed test_joinable_forwarding_stream -- --nocapture`: 10 passed.
- `cargo test -p daft-distributed`: 75 passed, 1 ignored.
- Fork Ray verification: 2 independent repetitions; each ran the focused Ray case 5 times and the CI-equivalent Python 3.10 Ray unit suite. Both repetitions passed in 40m 41s and 44m 13s.
- Community PR CI: 35 successful checks and 1 expected skip.
- `cargo fmt --all -- --check` and `git diff --check` passed.

## Related Issues

Closes #7394