### PR TITLE
feat(io): add Iceberg COW table changelog (CDC) reads

### DIFF
--- a/daft/daft/__init__.pyi
+++ b/daft/daft/__init__.pyi
@@ -1405,6 +1405,7 @@ class PyPushdowns:
         ...
 
 PyArrowParquetType = tuple[pa.Field, dict[str, str], pa.Array, int]
+PyArrowSchemaType = tuple[list[pa.Field], dict[str, str]]
 
 def read_parquet(
     uri: str,
@@ -1451,6 +1452,12 @@ def read_parquet_schema(
     multithreaded_io: bool | None = None,
     coerce_int96_timestamp_unit: PyTimeUnit | None = None,
 ) -> PySchema: ...
+def read_parquet_arrow_schema(
+    uri: str,
+    io_config: IOConfig | None = None,
+    multithreaded_io: bool | None = None,
+    coerce_int96_timestamp_unit: PyTimeUnit | None = None,
+) -> PyArrowSchemaType: ...
 def read_csv(
     uri: str,
     convert_options: CsvConvertOptions | None = None,

--- a/daft/io/iceberg/__init__.py
+++ b/daft/io/iceberg/__init__.py
@@ -1,0 +1,3 @@
+from daft.io.iceberg._iceberg import read_iceberg_changes
+
+__all__ = ["read_iceberg_changes"]

--- a/daft/io/iceberg/_changelog_planning.py
+++ b/daft/io/iceberg/_changelog_planning.py
@@ -1,0 +1,220 @@
+"""Planning for Iceberg COW changelog (CDC) reads."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal
+
+from pyiceberg.manifest import ManifestContent, ManifestEntryStatus
+from pyiceberg.table.snapshots import Operation, ancestors_between
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from pyiceberg.io import FileIO
+    from pyiceberg.manifest import DataFile
+    from pyiceberg.table import Table
+    from pyiceberg.table.snapshots import Snapshot
+
+ChangeType = Literal["INSERT", "DELETE"]
+
+
+@dataclass(frozen=True)
+class ChangelogFileTask:
+    """A single data file's contribution to a changelog scan.
+
+    Every row in `data_file` is uniformly `change_type` — this only holds for pure
+    copy-on-write ranges, where a data file is wholly added or wholly removed by a single
+    snapshot.
+    """
+
+    data_file: DataFile
+    change_type: ChangeType
+    change_ordinal: int
+    commit_snapshot_id: int
+    spec_id: int
+    """The partition-spec id of the *manifest* this entry came from (`ManifestFile.
+    partition_spec_id`) -- individual `DataFile` records don't carry their own spec id, so
+    this must be threaded through from the enclosing manifest at planning time."""
+
+
+def _require_int_timestamp_ms(value: int | None, name: str) -> None:
+    """Enforce the "UTC millisecond epoch integer" contract for timestamp parameters.
+
+    `bool` is a subclass of `int` in Python, so a plain `isinstance(value, int)` check
+    would silently accept `True`/`False`; `type(value) is int` rejects that along with
+    `float`, `str`, `datetime`, etc. Table.snapshot_as_of_timestamp does no validation of
+    its own -- a float or bool would otherwise be silently compared against snapshot
+    timestamps and could resolve to a plausible-looking but wrong historical boundary
+    instead of raising.
+    """
+    if type(value) is not int:
+        raise TypeError(
+            f"{name} must be an int (UTC millisecond epoch timestamp), got {value!r} ({type(value).__name__})"
+        )
+
+
+def resolve_snapshot_range(
+    table: Table,
+    start_snapshot_id: int | None,
+    end_snapshot_id: int | None,
+    start_timestamp_ms: int | None,
+    end_timestamp_ms: int | None,
+) -> tuple[int | None, int]:
+    """Resolve user-provided snapshot/timestamp options into (from_snapshot_id_exclusive, to_snapshot_id_inclusive)."""
+    if start_timestamp_ms is not None:
+        _require_int_timestamp_ms(start_timestamp_ms, "start_timestamp_ms")
+    if end_timestamp_ms is not None:
+        _require_int_timestamp_ms(end_timestamp_ms, "end_timestamp_ms")
+
+    if start_snapshot_id is not None and start_timestamp_ms is not None:
+        raise ValueError("Only one of start_snapshot_id or start_timestamp_ms may be provided")
+    if end_snapshot_id is not None and end_timestamp_ms is not None:
+        raise ValueError("Only one of end_snapshot_id or end_timestamp_ms may be provided")
+
+    if start_timestamp_ms is not None:
+        start_snapshot = table.snapshot_as_of_timestamp(start_timestamp_ms, inclusive=True)
+        if start_snapshot is None:
+            raise ValueError(
+                f"No snapshot found at or before start_timestamp_ms={start_timestamp_ms}; "
+                "the table's earliest known snapshot is later than this timestamp."
+            )
+        start_snapshot_id = start_snapshot.snapshot_id
+
+    if end_timestamp_ms is not None:
+        end_snapshot = table.snapshot_as_of_timestamp(end_timestamp_ms, inclusive=True)
+        if end_snapshot is None:
+            raise ValueError(
+                f"No snapshot found at or before end_timestamp_ms={end_timestamp_ms}; "
+                "the table's earliest known snapshot is later than this timestamp."
+            )
+        end_snapshot_id = end_snapshot.snapshot_id
+
+    if end_snapshot_id is None:
+        current = table.current_snapshot()
+        if current is None:
+            raise ValueError("table has no snapshots to read changes from")
+        end_snapshot_id = current.snapshot_id
+
+    if start_snapshot_id is not None and table.snapshot_by_id(start_snapshot_id) is None:
+        raise ValueError(f"start_snapshot_id={start_snapshot_id} was not found in this table's snapshot history")
+    if table.snapshot_by_id(end_snapshot_id) is None:
+        raise ValueError(f"end_snapshot_id={end_snapshot_id} was not found in this table's snapshot history")
+
+    return start_snapshot_id, end_snapshot_id
+
+
+def _snapshot_has_delete_manifest(snapshot: Snapshot, io: FileIO) -> bool:
+    """Whether this snapshot's *currently effective* manifest list contains any delete manifest.
+
+    Deliberately checks `snapshot.manifests(io)` — the full manifest list this snapshot's
+    table state references, including manifests inherited unchanged from ancestor commits —
+    not just manifests this snapshot itself wrote. A narrower "self-added only" check would
+    let a range through even though an older, still-referenced delete manifest continues to
+    apply position/equality deletes to some data file in range; since COW changelog reads
+    never apply delete files, that would silently misclassify deleted rows as INSERTs. This
+    mirrors Iceberg's own `BaseIncrementalChangelogScan` semantics.
+    """
+    return any(manifest.content == ManifestContent.DELETES for manifest in snapshot.manifests(io))
+
+
+def ordered_changelog_snapshots(table: Table, from_id: int | None, to_id: int) -> list[Snapshot]:
+    """Return the snapshots in (from_id, to_id] ordered oldest-first.
+
+    - Snapshots whose operation is `REPLACE` (compaction / manifest rewrite) are skipped: they
+      never represent a logical data change.
+    - If any snapshot in range's currently effective manifest list contains a delete manifest,
+      raises `NotImplementedError` — daft.io.iceberg.read_iceberg_changes() only supports pure
+      copy-on-write (COW) ranges.
+    """
+    to_snapshot = table.snapshot_by_id(to_id)
+    if to_snapshot is None:
+        raise ValueError(f"end_snapshot_id={to_id} was not found in this table's snapshot history")
+
+    from_snapshot = None
+    if from_id is not None:
+        from_snapshot = table.snapshot_by_id(from_id)
+        if from_snapshot is None:
+            raise ValueError(f"start_snapshot_id={from_id} was not found in this table's snapshot history")
+
+    # ancestors_between walks newest -> oldest and is *inclusive* of from_snapshot; the
+    # requested range is exclusive of it, so we validate it was actually reached and drop it.
+    chain = list(ancestors_between(from_snapshot, to_snapshot, table.metadata))
+    if from_snapshot is not None:
+        if not chain or chain[-1].snapshot_id != from_snapshot.snapshot_id:
+            raise ValueError(
+                f"start_snapshot_id={from_id} is not an ancestor of end_snapshot_id={to_id} "
+                "(it may be later than end_snapshot_id, or on a different branch)"
+            )
+        chain = chain[:-1]
+
+    chain.reverse()  # oldest -> newest
+
+    result = []
+    for snapshot in chain:
+        operation = snapshot.summary.operation if snapshot.summary is not None else Operation.APPEND
+        if operation == Operation.REPLACE:
+            continue
+        if _snapshot_has_delete_manifest(snapshot, table.io):
+            raise NotImplementedError(
+                f"Snapshot {snapshot.snapshot_id} (operation={operation.value}) has a delete "
+                "manifest in its currently effective manifest list. daft.io.iceberg.read_iceberg_changes() "
+                "only supports pure copy-on-write (COW) snapshot ranges; merge-on-read "
+                "changelogs (position/equality deletes) are not yet supported."
+            )
+        result.append(snapshot)
+    return result
+
+
+def compute_snapshot_ordinals(snapshots: list[Snapshot]) -> dict[int, int]:
+    """Assign a dense, scan-relative ordinal to each included snapshot (oldest = 0).
+
+    This ordinal is *not* a globally stable identifier — a different snapshot range over the
+    same table will reassign ordinals from 0. Use `commit_snapshot_id` for a stable reference.
+    """
+    return {snapshot.snapshot_id: i for i, snapshot in enumerate(snapshots)}
+
+
+def plan_changelog_file_tasks(
+    table: Table,
+    snapshots: list[Snapshot],
+    ordinals: dict[int, int],
+) -> Iterator[ChangelogFileTask]:
+    """Yield one ChangelogFileTask per data file added or removed by the given snapshots.
+
+    For each snapshot, only manifests it *itself* wrote (`added_snapshot_id == snapshot_id`)
+    are scanned — manifests merely inherited unchanged from an ancestor commit are not
+    reprocessed. This is a different, narrower filter than `_snapshot_has_delete_manifest`'s
+    "currently effective manifest list" check above: this one is for precisely collecting
+    what a commit actually changed, while that one conservatively decides whether the range
+    is safe at all. These filters serve different purposes and must not be combined.
+    """
+    for snapshot in snapshots:
+        ordinal = ordinals[snapshot.snapshot_id]
+        for manifest in snapshot.manifests(table.io):
+            if manifest.content != ManifestContent.DATA:
+                # Guarded against by ordered_changelog_snapshots's delete-manifest check
+                # above; skipped defensively rather than assumed.
+                continue
+            if manifest.added_snapshot_id != snapshot.snapshot_id:
+                continue
+            # Manifests are immutable, so a manifest newly written by this commit only
+            # contains entries this commit itself changed — ADDED or DELETED. Note that for
+            # DELETED entries, `entry.snapshot_id` is the deleting commit's id (this
+            # snapshot), not the id of whichever earlier snapshot originally added the file —
+            # per the Iceberg V2 spec, a manifest entry's snapshot_id field always records
+            # "where the file was added, or deleted if status is DELETED".
+            for entry in manifest.fetch_manifest_entry(table.io, discard_deleted=False):
+                if entry.status == ManifestEntryStatus.ADDED:
+                    change_type: ChangeType = "INSERT"
+                elif entry.status == ManifestEntryStatus.DELETED:
+                    change_type = "DELETE"
+                else:
+                    continue  # EXISTING: re-filed during manifest merge, no logical change
+                yield ChangelogFileTask(
+                    data_file=entry.data_file,
+                    change_type=change_type,
+                    change_ordinal=ordinal,
+                    commit_snapshot_id=snapshot.snapshot_id,
+                    spec_id=manifest.partition_spec_id,
+                )

--- a/daft/io/iceberg/_changelog_postprocess.py
+++ b/daft/io/iceberg/_changelog_postprocess.py
@@ -1,0 +1,58 @@
+"""Carryover removal for Iceberg COW changelog (CDC) reads."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from daft.datatype import DataType
+from daft.expressions import col, lit
+from daft.functions.window import row_number
+from daft.window import Window
+
+if TYPE_CHECKING:
+    from daft.dataframe import DataFrame
+
+_METADATA_COLUMNS = ("_change_type", "_change_ordinal", "_commit_snapshot_id")
+
+
+def remove_carryovers(df: DataFrame) -> DataFrame:
+    """Cancel out same-commit DELETE+INSERT pairs of otherwise-identical rows.
+
+    Copy-on-write file rewrites carry along every unchanged row in the rewritten file as a
+    (DELETE old-file-row, INSERT new-file-row) pair, even when that specific row never
+    actually changed. Rows are partitioned by every non-metadata column plus
+    `_change_ordinal` and `_commit_snapshot_id`. Within each partition, DELETE and INSERT
+    occurrences are numbered independently and cancelled one-for-one: for a group with 3
+    INSERTs and 2 DELETEs, the first 2 INSERTs (by occurrence index) are cancelled against
+    the 2 DELETEs, leaving 1 INSERT and 0 DELETEs -- not "keep all 3 INSERTs because
+    INSERT count > DELETE count". A group-level-only decision would incorrectly retain all
+    three INSERT rows.
+
+    Including both `_change_ordinal` and `_commit_snapshot_id` in the grouping key is
+    load-bearing: without them, distinct events from different commits that happen to share
+    identical content could be wrongly cancelled against each other.
+    """
+    data_columns = [c for c in df.column_names if c not in _METADATA_COLUMNS]
+    group_key = [*data_columns, "_change_ordinal", "_commit_snapshot_id"]
+
+    # Rows within one (group_key, _change_type) partition are, by construction,
+    # byte-identical on every column that matters (all data columns plus the metadata
+    # columns used for grouping) -- they're indistinguishable, so the tie-break used to
+    # number them doesn't affect correctness; it only needs to be a valid, deterministic
+    # ordering expression within a single execution.
+    occurrence_window = Window().partition_by(*group_key, "_change_type").order_by(lit(1))
+    occurrence_index = row_number().over(occurrence_window)
+
+    count_window = Window().partition_by(*group_key)
+    n_insert = (col("_change_type") == lit("INSERT")).cast(DataType.int64()).sum().over(count_window)
+    n_delete = (col("_change_type") == lit("DELETE")).cast(DataType.int64()).sum().over(count_window)
+
+    marked = df.with_column("_carryover_occurrence", occurrence_index).with_columns(
+        {"_carryover_n_insert": n_insert, "_carryover_n_delete": n_delete}
+    )
+
+    keep = ((col("_change_type") == lit("INSERT")) & (col("_carryover_occurrence") > col("_carryover_n_delete"))) | (
+        (col("_change_type") == lit("DELETE")) & (col("_carryover_occurrence") > col("_carryover_n_insert"))
+    )
+
+    return marked.where(keep).exclude("_carryover_occurrence", "_carryover_n_insert", "_carryover_n_delete")

--- a/daft/io/iceberg/_changelog_schema.py
+++ b/daft/io/iceberg/_changelog_schema.py
@@ -1,0 +1,319 @@
+"""Schema safety gate for Iceberg COW changelog (CDC) reads.
+
+Two layers:
+
+- `validate_single_schema_table`: a cheap, table-metadata-level *fast rejection*. It is
+  NOT a safety proof -- `ExpireSnapshots.cleanExpiredMetadata(true)` can prune
+  `table.metadata.schemas` down to a single entry even though some still-referenced data
+  file was physically written under a schema that is no longer listed there.
+- `validate_task_file_schemas`: the real safety gate. It reads every distinct data file's
+  Parquet footer (via Daft's own I/O client, so it shares credentials/endpoint/protocol
+  handling with the real ScanTask read) and recursively compares its Iceberg field IDs,
+  names, requiredness, and types against the baseline schema at every nesting level
+  (top-level, struct child, list element, map key/value).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pyiceberg.io.pyarrow import pyarrow_to_schema
+from pyiceberg.types import ListType, MapType, NestedField, StructType
+
+from daft.recordbatch.recordbatch import read_parquet_arrow_schema
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    import pyarrow as pa
+    from pyiceberg.schema import Schema
+    from pyiceberg.table import Table
+    from pyiceberg.types import IcebergType
+
+    from daft.daft import StorageConfig
+    from daft.io.iceberg._changelog_planning import ChangelogFileTask
+
+
+def validate_single_schema_table(table: Table) -> Schema:
+    """Cheap, table-metadata-level fast rejection.
+
+    Not a safety proof, just an early filter to avoid unnecessary footer I/O for obviously
+    unsupported tables.
+
+    `len(table.metadata.schemas) == 1` does not prove the table never underwent schema
+    evolution: `ExpireSnapshots.cleanExpiredMetadata(true)` computes the reachable-schema
+    set from *retained snapshots' own declared schema_id*, not from the physical write
+    schema of the data files those snapshots reference, so an old schema can be pruned
+    from `metadata.schemas` even while a data file written under it is still live and
+    referenced. The real safety proof lives in `validate_task_file_schemas`.
+    """
+    if len(table.metadata.schemas) != 1:
+        raise NotImplementedError(
+            "daft.read_iceberg_changes() only supports tables whose metadata currently "
+            f"contains exactly one schema (table.metadata.schemas has "
+            f"{len(table.metadata.schemas)}); tables with any schema evolution history are "
+            "not yet supported."
+        )
+    return table.metadata.schemas[0]
+
+
+def _read_footer_arrow_schema(path: str, storage_config: StorageConfig) -> pa.Schema:
+    """Read a Parquet file's footer schema via Daft's own I/O client.
+
+    Uses the same `storage_config` the real ScanTask read will use, so credential/endpoint/
+    protocol handling can never diverge between the gate and the real read.
+    """
+    return read_parquet_arrow_schema(
+        path,
+        io_config=storage_config.io_config,
+        multithreaded_io=storage_config.multithreaded_io,
+    )
+
+
+def validate_task_file_schemas(
+    baseline_schema: Schema,
+    format_version: int,
+    storage_config: StorageConfig,
+    tasks: Iterable[ChangelogFileTask],
+) -> None:
+    """For every distinct data file referenced by `tasks`, recursively verify schema compatibility.
+
+    Verifies Iceberg field IDs, names, requiredness, and types are strictly compatible with
+    `baseline_schema` at every nesting level. This is the real schema safety proof;
+    `validate_single_schema_table` is only the fast-rejection front end.
+
+    Strict-equality contract for the first release: field-id set, per-field name, required,
+    and type must match exactly at every level (top-level, struct child, list element, map
+    key/value) -- no null/default fill for missing columns, no renaming, no type promotion.
+    De-duplicates by file path so the same physical file referenced by multiple tasks only
+    triggers one footer read.
+    """
+    _assert_globally_unique_field_ids(list(baseline_schema.fields), path="<baseline schema>", side="baseline schema")
+    seen_paths: set[str] = set()
+
+    for task in tasks:
+        path = task.data_file.file_path
+        if path in seen_paths:
+            continue
+        seen_paths.add(path)
+
+        # FileNotFoundError/PermissionError propagate as-is (I/O errors, not schema
+        # incompatibility) -- only the pyarrow_to_schema conversion below is wrapped.
+        arrow_schema = _read_footer_arrow_schema(path, storage_config)
+
+        try:
+            # format_version must be the table's own format version, not
+            # pyarrow_to_schema's default (v2): format v3 tables allow nanosecond
+            # timestamps / UnknownType that convert differently under v2 rules, which
+            # would misclassify legitimate v3 files as unsupported.
+            file_schema = pyarrow_to_schema(arrow_schema, format_version=format_version)
+        except (ValueError, TypeError) as e:
+            raise NotImplementedError(
+                f"data file {path} does not carry Iceberg field IDs (at every nesting "
+                "level) in its Parquet footer, or uses an Arrow type this conversion "
+                f"doesn't support under format_version={format_version}; "
+                "daft.read_iceberg_changes() cannot safely verify its schema compatibility."
+            ) from e
+
+        _assert_globally_unique_field_ids(list(file_schema.fields), path=path, side="data file")
+        _assert_fields_compatible(list(baseline_schema.fields), list(file_schema.fields), path, "$")
+
+
+def _assert_globally_unique_field_ids(
+    fields: list[NestedField],
+    path: str,
+    side: str,
+    _seen: dict[int, str] | None = None,
+    _logical_path: str = "$",
+) -> None:
+    """Recursively collect every field id in the schema tree along with its logical path.
+
+    Rejects as soon as the same field id shows up at two different logical paths --
+    regardless of whether they're sibling fields at the same level.
+
+    `_index_by_field_id` (used inside `_assert_fields_compatible`) only checks for
+    duplicates among sibling fields at a single level; a field id reused across nesting
+    levels (e.g. once at the top level, again inside some struct's child) wouldn't trip
+    that check, and the recursive comparison would just report a "type mismatch" at
+    whichever position it happens to notice first rather than pointing at the real cause.
+    This is a diagnostic-quality improvement, not a correctness requirement -- without it,
+    the recursive comparison usually still fails somewhere, just with a less direct error.
+    """
+    seen = _seen if _seen is not None else {}
+    for f in fields:
+        field_path = f"{_logical_path}.{f.name}"
+        if f.field_id in seen:
+            raise NotImplementedError(
+                f"{side} for {path} reuses Iceberg field id={f.field_id} at both "
+                f"{seen[f.field_id]!r} and {field_path!r}; field ids must be globally "
+                "unique within a schema."
+            )
+        seen[f.field_id] = field_path
+        _walk_type_for_field_ids(f.field_type, path, side, seen, field_path)
+
+
+def _walk_type_for_field_ids(
+    field_type: IcebergType,
+    path: str,
+    side: str,
+    seen: dict[int, str],
+    logical_path: str,
+) -> None:
+    """Container-type descent for `_assert_globally_unique_field_ids`.
+
+    Uses the same "synthesize a single-field list" trick as `_assert_types_compatible` for
+    list/map so both functions walk the type tree identically.
+    """
+    if isinstance(field_type, StructType):
+        _assert_globally_unique_field_ids(list(field_type.fields), path, side, seen, logical_path)
+    elif isinstance(field_type, ListType):
+        _assert_globally_unique_field_ids(
+            [
+                NestedField(
+                    field_type.element_id, "element", field_type.element_type, required=field_type.element_required
+                )
+            ],
+            path,
+            side,
+            seen,
+            logical_path,
+        )
+    elif isinstance(field_type, MapType):
+        _assert_globally_unique_field_ids(
+            [
+                NestedField(field_type.key_id, "key", field_type.key_type, required=True),
+                NestedField(field_type.value_id, "value", field_type.value_type, required=field_type.value_required),
+            ],
+            path,
+            side,
+            seen,
+            logical_path,
+        )
+    # PrimitiveType: no children, nothing further to walk.
+
+
+def _assert_fields_compatible(
+    baseline_fields: list[NestedField],
+    file_fields: list[NestedField],
+    path: str,
+    logical_path: str,
+) -> None:
+    """Compare one level of sibling fields by field id.
+
+    "One level" means the schema top level, a struct's children, or the single-element list
+    wrapping a list element / map key / map value. field id, name, required, and type must
+    all match. doc/default are not compared -- they aren't part of the physical schema.
+    `logical_path` is used purely for error messages, e.g. "$.orders.items.element.product_id".
+    """
+    baseline_by_id = _index_by_field_id(baseline_fields, path, logical_path, side="baseline schema")
+    file_by_id = _index_by_field_id(file_fields, path, logical_path, side="data file")
+
+    for field_id, bf in baseline_by_id.items():
+        field_path = f"{logical_path}.{bf.name}"
+        ff = file_by_id.get(field_id)
+        if ff is None:
+            raise NotImplementedError(
+                f"data file {path} is missing Iceberg field id={field_id} ({field_path}); "
+                "daft.read_iceberg_changes() requires every changelog data file to "
+                "physically contain every baseline schema field in its first release."
+            )
+        if ff.name != bf.name:
+            raise NotImplementedError(
+                f"data file {path} field id={field_id} at {field_path} has physical name "
+                f"{ff.name!r}, expected {bf.name!r}; field renaming is not yet supported "
+                "(a deliberately conservative first-release restriction, not a fundamental "
+                "limitation)."
+            )
+        if ff.required != bf.required:
+            raise NotImplementedError(
+                f"data file {path} field id={field_id} at {field_path} has "
+                f"required={ff.required}, expected required={bf.required}."
+            )
+        _assert_types_compatible(bf.field_type, ff.field_type, path, field_path)
+
+    extra_ids = set(file_by_id) - set(baseline_by_id)
+    if extra_ids:
+        raise NotImplementedError(
+            f"data file {path} at {logical_path} contains Iceberg field id(s) "
+            f"{sorted(extra_ids)} that are not present in the baseline schema; "
+            "daft.read_iceberg_changes() requires exact schema equality in its first release."
+        )
+
+
+def _index_by_field_id(
+    fields: list[NestedField],
+    path: str,
+    logical_path: str,
+    side: str,
+) -> dict[int, NestedField]:
+    result: dict[int, NestedField] = {}
+    for f in fields:
+        if f.field_id in result:
+            raise NotImplementedError(
+                f"data file {path}: duplicate Iceberg field id={f.field_id} in the {side} "
+                f"at {logical_path}; the schema is not well-formed."
+            )
+        result[f.field_id] = f
+    return result
+
+
+def _assert_types_compatible(
+    baseline_type: IcebergType,
+    file_type: IcebergType,
+    path: str,
+    logical_path: str,
+) -> None:
+    if isinstance(baseline_type, StructType) and isinstance(file_type, StructType):
+        _assert_fields_compatible(list(baseline_type.fields), list(file_type.fields), path, logical_path)
+        return
+    if isinstance(baseline_type, ListType) and isinstance(file_type, ListType):
+        # Pass logical_path itself, not f"{logical_path}.element": the synthetic field's
+        # name is already "element", and _assert_fields_compatible appends
+        # f"{logical_path}.{bf.name}" = f"{logical_path}.element" on its own; appending it
+        # again here would produce "...element.element" (the map branch below is
+        # unaffected, since its synthetic field names are "key"/"value", not a repeat of
+        # logical_path's last segment).
+        _assert_fields_compatible(
+            [
+                NestedField(
+                    baseline_type.element_id,
+                    "element",
+                    baseline_type.element_type,
+                    required=baseline_type.element_required,
+                )
+            ],
+            [NestedField(file_type.element_id, "element", file_type.element_type, required=file_type.element_required)],
+            path,
+            logical_path,
+        )
+        return
+    if isinstance(baseline_type, MapType) and isinstance(file_type, MapType):
+        _assert_fields_compatible(
+            [
+                NestedField(baseline_type.key_id, "key", baseline_type.key_type, required=True),
+                NestedField(
+                    baseline_type.value_id, "value", baseline_type.value_type, required=baseline_type.value_required
+                ),
+            ],
+            [
+                NestedField(file_type.key_id, "key", file_type.key_type, required=True),
+                NestedField(file_type.value_id, "value", file_type.value_type, required=file_type.value_required),
+            ],
+            path,
+            logical_path,
+        )
+        return
+    if isinstance(baseline_type, (StructType, ListType, MapType)) or isinstance(
+        file_type, (StructType, ListType, MapType)
+    ):
+        raise NotImplementedError(
+            f"data file {path} at {logical_path}: container type mismatch (baseline={baseline_type}, file={file_type})."
+        )
+    if baseline_type != file_type:
+        # Both sides are PrimitiveType at this point; IntegerType() == IntegerType() and
+        # friends are pyiceberg's own value-equality semantics.
+        raise NotImplementedError(
+            f"data file {path} at {logical_path}: type {file_type} differs from baseline "
+            f"schema type {baseline_type}; type promotion is not yet supported by "
+            "daft.read_iceberg_changes()."
+        )

--- a/daft/io/iceberg/_iceberg.py
+++ b/daft/io/iceberg/_iceberg.py
@@ -201,3 +201,88 @@ def read_iceberg(
     builder = LogicalPlanBuilder.from_tabular_scan(scan_operator=handle)
     builder = attach_checkpoint(builder, checkpoint)
     return DataFrame(builder)
+
+
+@PublicAPI
+def read_iceberg_changes(
+    table: Union[str, os.PathLike[str], "PyIcebergTable"],
+    start_snapshot_id: int | None = None,
+    end_snapshot_id: int | None = None,
+    start_timestamp_ms: int | None = None,
+    end_timestamp_ms: int | None = None,
+    io_config: IOConfig | None = None,
+) -> DataFrame:
+    """Create a changelog (CDC) DataFrame from a copy-on-write (COW) Iceberg table over a snapshot range.
+
+    Only pure copy-on-write snapshot ranges are supported: if any snapshot in the range has a
+    delete manifest (position/equality deletes) in its currently effective manifest list, a
+    ``NotImplementedError`` is raised rather than an incorrect result. This first release also
+    only supports tables whose metadata currently contains exactly one schema, and requires
+    every changelog data file to be strictly schema-compatible with it at every nesting level.
+
+    Every row in the returned DataFrame carries three additional columns: ``_change_type``
+    (``"INSERT"`` or ``"DELETE"``), ``_change_ordinal`` (int64, scan-relative -- not a stable
+    cross-scan identifier), and ``_commit_snapshot_id`` (int64, the Iceberg snapshot id that
+    produced the change). Carryover rows -- COW file-rewrite noise where a row's content didn't
+    actually change but still appears as a (DELETE, INSERT) pair because the whole file was
+    rewritten -- are unconditionally removed before the DataFrame is returned; this cannot be
+    disabled, matching Iceberg's own ``create_changelog_view`` procedure.
+
+    Args:
+        table (str, os.PathLike, or pyiceberg.table.Table): Same as :func:`read_iceberg`.
+        start_snapshot_id (int, optional): Snapshot ID marking the exclusive start of the range.
+            If omitted (along with ``start_timestamp_ms``), the range starts from the table's
+            first snapshot.
+        end_snapshot_id (int, optional): Snapshot ID marking the inclusive end of the range. If
+            omitted (along with ``end_timestamp_ms``), defaults to the table's current snapshot.
+        start_timestamp_ms (int, optional): UTC millisecond epoch timestamp resolved to the
+            snapshot current at or before it, then used as the exclusive start boundary. Cannot
+            be combined with ``start_snapshot_id``.
+        end_timestamp_ms (int, optional): UTC millisecond epoch timestamp resolved to the
+            snapshot current at or before it, then used as the inclusive end boundary. Cannot be
+            combined with ``end_snapshot_id``.
+        io_config (IOConfig, optional): Same as :func:`read_iceberg`.
+
+    Returns:
+        DataFrame: A DataFrame with the table's schema plus ``_change_type``, ``_change_ordinal``,
+            and ``_commit_snapshot_id`` columns.
+
+    Note:
+        This function requires the use of [PyIceberg](https://py.iceberg.apache.org/).
+
+    Examples:
+        >>> df = daft.io.iceberg.read_iceberg_changes(table, start_snapshot_id=100, end_snapshot_id=105)
+    """
+    from pyiceberg.table import StaticTable
+
+    from daft.io.iceberg.iceberg_changes_scan import IcebergChangesDataSource
+
+    if isinstance(table, (str, os.PathLike)):
+        table = StaticTable.from_metadata(metadata_location=os.fspath(table))
+
+    io_config = (
+        _convert_iceberg_file_io_properties_to_io_config(table.io.properties, table.location())
+        if io_config is None
+        else io_config
+    )
+    io_config = context.get_context().daft_planning_config.default_io_config if io_config is None else io_config
+
+    multithreaded_io = runners.get_or_create_runner().name != "ray"
+    storage_config = StorageConfig(multithreaded_io, io_config)
+
+    changes_source = IcebergChangesDataSource(
+        table,
+        start_snapshot_id=start_snapshot_id,
+        end_snapshot_id=end_snapshot_id,
+        start_timestamp_ms=start_timestamp_ms,
+        end_timestamp_ms=end_timestamp_ms,
+        storage_config=storage_config,
+    )
+
+    handle = ScanOperatorHandle.from_data_source(changes_source)
+    builder = LogicalPlanBuilder.from_tabular_scan(scan_operator=handle)
+    df = DataFrame(builder)
+
+    from daft.io.iceberg._changelog_postprocess import remove_carryovers
+
+    return remove_carryovers(df)

--- a/daft/io/iceberg/iceberg_changes_scan.py
+++ b/daft/io/iceberg/iceberg_changes_scan.py
@@ -1,0 +1,270 @@
+"""DataSource for Iceberg COW changelog (CDC) reads."""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import TYPE_CHECKING, Any
+
+from pyiceberg.schema import visit
+
+import daft
+from daft.daft import ParquetSourceConfig, StorageConfig
+from daft.dependencies import pa
+from daft.io.iceberg._changelog_planning import (
+    ChangelogFileTask,
+    compute_snapshot_ordinals,
+    ordered_changelog_snapshots,
+    plan_changelog_file_tasks,
+    resolve_snapshot_range,
+)
+from daft.io.iceberg._changelog_schema import validate_single_schema_table, validate_task_file_schemas
+from daft.io.iceberg._metadata import convert_iceberg_schema
+from daft.io.iceberg.iceberg_scan import iceberg_partition_spec_to_fields
+from daft.io.iceberg.schema_field_id_mapping_visitor import SchemaFieldIdMappingVisitor
+from daft.io.source import DataSource, DataSourceTask
+from daft.logical.schema import DataType, Schema
+from daft.recordbatch import RecordBatch
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from pyiceberg.schema import Schema as IcebergSchema
+    from pyiceberg.table import Table
+
+    from daft.io.partitioning import PartitionField
+    from daft.io.pushdowns import Pushdowns
+
+logger = logging.getLogger(__name__)
+
+# Reserved changelog metadata column names -- match the field names reserved by Iceberg's
+# Spark/core changelog integration for the same purpose.
+CHANGE_TYPE_COLUMN = "_change_type"
+CHANGE_ORDINAL_COLUMN = "_change_ordinal"
+COMMIT_SNAPSHOT_ID_COLUMN = "_commit_snapshot_id"
+_RESERVED_COLUMN_NAMES = (CHANGE_TYPE_COLUMN, CHANGE_ORDINAL_COLUMN, COMMIT_SNAPSHOT_ID_COLUMN)
+
+_CHANGELOG_METADATA_SCHEMA = Schema.from_pydict(
+    {
+        CHANGE_TYPE_COLUMN: DataType.string(),
+        CHANGE_ORDINAL_COLUMN: DataType.int64(),
+        COMMIT_SNAPSHOT_ID_COLUMN: DataType.int64(),
+    }
+)
+
+
+def _check_no_reserved_data_schema_collision(baseline_iceberg_schema: IcebergSchema) -> None:
+    """Raise if the reserved changelog column names collide with the baseline data schema.
+
+    Cheap, metadata-only, and independent of which snapshot range/spec_ids the eventual scan
+    touches, so this runs eagerly at operator construction time.
+    """
+    data_field_names = {f.name for f in baseline_iceberg_schema.fields}
+    collisions = data_field_names & set(_RESERVED_COLUMN_NAMES)
+    if collisions:
+        raise ValueError(
+            f"Iceberg table schema contains column(s) {sorted(collisions)} that collide with "
+            f"daft.io.iceberg.read_iceberg_changes()'s reserved changelog metadata column names "
+            f"{_RESERVED_COLUMN_NAMES}; rename the conflicting column(s) in the table before "
+            "using read_iceberg_changes()."
+        )
+
+
+def _check_no_reserved_partition_field_collision(table: Table, spec_ids: set[int]) -> None:
+    """Raise if the reserved changelog column names collide with any of `spec_ids`' partition fields.
+
+    `spec_ids` must be exactly the set of `spec_id`s referenced by *this scan's own planned
+    tasks*, not the
+    table's entire historical spec set -- a spec that predates or postdates the requested
+    range and was never actually read from should not be able to reject an otherwise-valid
+    scan. This is why the call site is the lazy planning path (`_get_or_plan_tasks`, after
+    `plan_changelog_file_tasks` has produced the task list), not `__init__`: which specs are
+    involved isn't knowable before planning runs.
+    """
+    for spec_id in spec_ids:
+        spec = table.specs()[spec_id]
+        partition_field_names = {f.name for f in spec.fields}
+        collisions = partition_field_names & set(_RESERVED_COLUMN_NAMES)
+        if collisions:
+            raise ValueError(
+                f"Iceberg table has a partition spec (spec_id={spec.spec_id}) containing "
+                f"partition field(s) {sorted(collisions)} that collide with "
+                f"daft.io.iceberg.read_iceberg_changes()'s reserved changelog metadata column names "
+                f"{_RESERVED_COLUMN_NAMES}; rename the conflicting partition field(s) before "
+                "using read_iceberg_changes()."
+            )
+
+
+class IcebergChangesDataSource(DataSource):
+    """Scans a copy-on-write Iceberg snapshot range as a changelog (CDC) stream.
+
+    Every row produced carries three additional columns: `_change_type` (INSERT or DELETE),
+    `_change_ordinal` (int64, scan-relative), and `_commit_snapshot_id` (int64). Planning
+    (snapshot range resolution, manifest listing, and per-file Parquet-footer schema
+    validation) is deferred to the first `get_tasks()` call and cached for the lifetime
+    of this source instance -- not done eagerly in `__init__`, so constructing this
+    source (and therefore building the `read_iceberg_changes()` DataFrame) never triggers
+    I/O on its own.
+    """
+
+    def __init__(
+        self,
+        iceberg_table: Table,
+        *,
+        start_snapshot_id: int | None,
+        end_snapshot_id: int | None,
+        start_timestamp_ms: int | None,
+        end_timestamp_ms: int | None,
+        storage_config: StorageConfig,
+    ) -> None:
+        self._iceberg_table = iceberg_table
+        self._start_snapshot_id = start_snapshot_id
+        self._end_snapshot_id = end_snapshot_id
+        self._start_timestamp_ms = start_timestamp_ms
+        self._end_timestamp_ms = end_timestamp_ms
+        self._storage_config = storage_config
+
+        # Cheap, metadata-only work: safe to do eagerly, no I/O beyond what loading the
+        # Table object already required.
+        baseline_iceberg_schema = validate_single_schema_table(iceberg_table)
+        self._baseline_iceberg_schema = baseline_iceberg_schema
+        self._format_version = iceberg_table.metadata.format_version
+
+        _check_no_reserved_data_schema_collision(baseline_iceberg_schema)
+
+        field_id_mapping = visit(baseline_iceberg_schema, SchemaFieldIdMappingVisitor())
+        self._parquet_config = ParquetSourceConfig(field_id_mapping=field_id_mapping)
+        self._schema = convert_iceberg_schema(baseline_iceberg_schema).union(_CHANGELOG_METADATA_SCHEMA)
+
+        # Planning + footer-validation cache. UNPLANNED (_cached_tasks is None) ->
+        # PLANNING (inside the lock, doing planning + footer I/O) -> VALIDATED
+        # (_cached_tasks populated, only after every file passed schema validation).
+        # Any failure during planning leaves _cached_tasks as None, i.e. back to
+        # UNPLANNED, so the next call retries from scratch rather than caching a failure.
+        #
+        # get_tasks() below is `async def`, but this lock is a plain threading.Lock, not an
+        # asyncio.Lock: planning itself (manifest listing + per-file Parquet footer
+        # validation) is synchronous I/O with no async concurrency of its own, and Daft's
+        # Rust engine can still invoke get_tasks() more than once for the same DataSource
+        # instance (e.g. once from the shard-scan optimizer rule, once when translating the
+        # physical plan) -- each invocation runs inside its own
+        # io_runtime.block_on_current_thread(...), so separate calls aren't guaranteed to
+        # share one thread or event loop the way an asyncio.Lock would require. A plain
+        # threading.Lock is what actually guards "plan + validate exactly once" here; see
+        # test_concurrent_get_tasks_reads_each_footer_only_once for the regression test that
+        # exercises this from multiple OS threads.
+        self._lock = threading.Lock()
+        self._cached_tasks: list[ChangelogFileTask] | None = None
+
+    def __getstate__(self) -> dict[str, Any]:
+        # A plain threading.Lock isn't picklable, and this operator may be pickled to a
+        # remote execution environment (e.g. the Ray runner). _cached_tasks (plain data)
+        # is fine to carry across -- if planning already completed on the sender, the
+        # receiver gets to skip redoing it; only the lock itself needs to be rebuilt fresh.
+        state = self.__dict__.copy()
+        state.pop("_lock", None)
+        return state
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        self.__dict__.update(state)
+        self._lock = threading.Lock()
+
+    @property
+    def schema(self) -> Schema:
+        return self._schema
+
+    @property
+    def name(self) -> str:
+        return f"IcebergChangesDataSource({'.'.join(self._iceberg_table.name())})"
+
+    def get_partition_fields(self) -> list[PartitionField]:
+        # A changelog range can span multiple historical partition specs;
+        # rather than picking one arbitrarily (which would misrepresent the others),
+        # report no partitioning fields.
+        return []
+
+    def _get_or_plan_tasks(self) -> list[ChangelogFileTask]:
+        with self._lock:
+            if self._cached_tasks is not None:
+                return self._cached_tasks
+
+            from_id, to_id = resolve_snapshot_range(
+                self._iceberg_table,
+                self._start_snapshot_id,
+                self._end_snapshot_id,
+                self._start_timestamp_ms,
+                self._end_timestamp_ms,
+            )
+            snapshots = ordered_changelog_snapshots(self._iceberg_table, from_id, to_id)
+            ordinals = compute_snapshot_ordinals(snapshots)
+            tasks = list(plan_changelog_file_tasks(self._iceberg_table, snapshots, ordinals))
+
+            # Scoped to exactly the spec_ids this scan's own tasks reference -- not the
+            # table's entire historical spec set, so a conflicting spec
+            # that predates or postdates this range and was never actually read from
+            # cannot reject an otherwise-valid scan.
+            _check_no_reserved_partition_field_collision(self._iceberg_table, {task.spec_id for task in tasks})
+
+            # The schema safety gate reads every distinct data file's
+            # Parquet footer via self._storage_config, the same I/O configuration the
+            # DataSourceTasks below will use. Raises if anything is unsafe; _cached_tasks stays
+            # None (UNPLANNED) so a retry re-plans from scratch rather than reusing a
+            # partial/failed result.
+            validate_task_file_schemas(
+                self._baseline_iceberg_schema,
+                self._format_version,
+                self._storage_config,
+                tasks,
+            )
+
+            self._cached_tasks = tasks
+            return tasks
+
+    def _changelog_partition_values(self, task: ChangelogFileTask) -> RecordBatch:
+        """Build the single-row constant-column batch for one changelog file task.
+
+        Combines the file's historical partition values (looked up by its own spec_id, not
+        the table's current spec -- a changelog range can span multiple historical specs)
+        with the three CDC metadata columns. Reuses the same `partition_values` mechanism
+        the existing `IcebergScanOperator` uses to inject partition column values (design
+        §2) -- Daft's `PartitionSpec.to_fill_map()` matches columns by name, independent of
+        whether they're "partition columns" in the traditional sense.
+        """
+        spec = self._iceberg_table.specs()[task.spec_id]
+        partition_fields = iceberg_partition_spec_to_fields(self._baseline_iceberg_schema, spec)
+        partition_record = task.data_file.partition
+
+        arrays: dict[str, daft.Series] = {}
+        for idx, pfield in enumerate(partition_fields):
+            field = pfield.field
+            arrow_type = field.dtype.to_arrow_dtype()
+            arrays[field.name] = daft.Series.from_arrow(
+                pa.array([partition_record[idx]], type=arrow_type), name=field.name
+            ).cast(field.dtype)
+
+        arrays[CHANGE_TYPE_COLUMN] = daft.Series.from_arrow(
+            pa.array([task.change_type], type=pa.string()), name=CHANGE_TYPE_COLUMN
+        )
+        arrays[CHANGE_ORDINAL_COLUMN] = daft.Series.from_arrow(
+            pa.array([task.change_ordinal], type=pa.int64()), name=CHANGE_ORDINAL_COLUMN
+        )
+        arrays[COMMIT_SNAPSHOT_ID_COLUMN] = daft.Series.from_arrow(
+            pa.array([task.commit_snapshot_id], type=pa.int64()), name=COMMIT_SNAPSHOT_ID_COLUMN
+        )
+        return RecordBatch.from_pydict(arrays)
+
+    async def get_tasks(self, pushdowns: Pushdowns) -> AsyncIterator[DataSourceTask]:
+        tasks = self._get_or_plan_tasks()
+        for task in tasks:
+            partition_values = self._changelog_partition_values(task)
+            yield DataSourceTask.parquet(
+                path=task.data_file.file_path,
+                schema=self._schema,
+                parquet_config=self._parquet_config,
+                pushdowns=pushdowns,
+                num_rows=task.data_file.record_count,
+                size_bytes=task.data_file.file_size_in_bytes,
+                partition_values=partition_values,
+                storage_config=self._storage_config,
+                iceberg_delete_files=None,
+            )

--- a/daft/recordbatch/recordbatch.py
+++ b/daft/recordbatch/recordbatch.py
@@ -18,6 +18,7 @@ from daft.daft import PyRecordBatch as _PyRecordBatch
 from daft.daft import read_csv as _read_csv
 from daft.daft import read_json as _read_json
 from daft.daft import read_parquet as _read_parquet
+from daft.daft import read_parquet_arrow_schema as _read_parquet_arrow_schema
 from daft.daft import read_parquet_into_pyarrow as _read_parquet_into_pyarrow
 from daft.daft import read_parquet_into_pyarrow_bulk as _read_parquet_into_pyarrow_bulk
 from daft.daft import read_parquet_statistics as _read_parquet_statistics
@@ -594,6 +595,34 @@ def read_parquet_into_pyarrow(
     else:
         # If data contains no columns, we return an empty table with the appropriate size using `Table.drop`
         return pa.table({"dummy_column": pa.array([None] * num_rows_read)}).drop(["dummy_column"])
+
+
+def read_parquet_arrow_schema(
+    path: str,
+    io_config: IOConfig | None = None,
+    multithreaded_io: bool | None = None,
+    coerce_int96_timestamp_unit: TimeUnit | None = None,
+) -> pa.Schema:
+    """Read a Parquet file's footer schema as a raw PyArrow schema.
+
+    Unlike `Schema.from_parquet` (which returns a `daft.Schema`), this does not downcast
+    through Daft's own type system: every field's Arrow metadata is preserved at every
+    nesting level (struct children, list elements, map keys/values), which Daft's own
+    `DataType.list`/`DataType.map` cannot represent (they have no room for per-field
+    metadata on their child type). This is what makes it possible to verify Iceberg's
+    `PARQUET:field_id` on nested fields, not just top-level ones.
+
+    Still a pure footer read: no row-group data pages are fetched.
+    """
+    if coerce_int96_timestamp_unit is None:
+        coerce_int96_timestamp_unit = TimeUnit.ns()
+    fields, metadata = _read_parquet_arrow_schema(
+        uri=path,
+        io_config=io_config,
+        multithreaded_io=multithreaded_io,
+        coerce_int96_timestamp_unit=coerce_int96_timestamp_unit._timeunit,
+    )
+    return pa.schema(fields, metadata=metadata)
 
 
 def read_parquet_into_pyarrow_bulk(

--- a/src/daft-parquet/src/python.rs
+++ b/src/daft-parquet/src/python.rs
@@ -324,6 +324,65 @@ pub mod pylib {
         })
     }
 
+    type PyArrowSchemaType = (PyArrowFields, std::collections::BTreeMap<String, String>);
+
+    /// Converts a raw arrow-rs `Schema` into the (fields, metadata) shape the Python side
+    /// assembles into a `pyarrow.Schema` via `pa.schema(fields, metadata=metadata)` (see
+    /// `convert_pyarrow_parquet_read_result_into_py` above for the same pattern applied to a
+    /// full read result). Every field — including struct children, list elements, and map
+    /// keys/values — round-trips through `to_pyarrow` with its Arrow metadata intact.
+    fn convert_arrow_schema_into_py(
+        py: Python,
+        schema: arrow::datatypes::SchemaRef,
+    ) -> PyResult<PyArrowSchemaType> {
+        let fields = schema
+            .fields
+            .iter()
+            .map(|f| Ok(f.to_pyarrow(py)?.unbind()))
+            .collect::<PyResult<Vec<_>>>()?;
+        Ok((fields, schema.metadata.clone().into_iter().collect()))
+    }
+
+    /// Reads a Parquet file's footer schema as a raw PyArrow schema, without going through
+    /// Daft's own `Schema`/`DataType` (unlike `read_parquet_schema` below). This is the only
+    /// way to observe Iceberg's `PARQUET:field_id` metadata on nested fields (struct children,
+    /// list elements, map keys/values): Daft's `DataType::List`/`DataType::Map` only wrap a
+    /// bare child `DataType` with no room for per-field Arrow metadata, so that information is
+    /// unrecoverable once a schema has been downcast to Daft's own type system. Still a pure
+    /// footer read — no row-group data pages are fetched.
+    #[pyfunction(signature = (
+        uri,
+        io_config=None,
+        multithreaded_io=None,
+        coerce_int96_timestamp_unit=None
+    ))]
+    pub fn read_parquet_arrow_schema(
+        py: Python,
+        uri: &str,
+        io_config: Option<IOConfig>,
+        multithreaded_io: Option<bool>,
+        coerce_int96_timestamp_unit: Option<PyTimeUnit>,
+    ) -> PyResult<PyArrowSchemaType> {
+        let schema = py.detach(|| {
+            let io_stats = IOStatsContext::new(format!("read_parquet_arrow_schema: for uri {uri}"));
+            let schema_infer = ParquetSchemaInferenceOptions::new(
+                coerce_int96_timestamp_unit.map(|tu| tu.timeunit),
+            );
+            let io_client = get_io_client(
+                multithreaded_io.unwrap_or(true),
+                io_config.unwrap_or_default().config.into(),
+            )?;
+            let runtime = common_runtime::get_io_runtime(true);
+            runtime.block_on_current_thread(crate::read::read_parquet_arrow_schema(
+                uri,
+                io_client,
+                Some(io_stats),
+                schema_infer,
+            ))
+        })?;
+        convert_arrow_schema_into_py(py, schema)
+    }
+
     #[pyfunction(signature = (uris, io_config=None, multithreaded_io=None))]
     pub fn read_parquet_statistics(
         py: Python,
@@ -359,6 +418,7 @@ pub fn register_modules(parent: &Bound<PyModule>) -> PyResult<()> {
     )?)?;
     parent.add_function(wrap_pyfunction!(pylib::read_parquet_bulk, parent)?)?;
     parent.add_function(wrap_pyfunction!(pylib::read_parquet_schema, parent)?)?;
+    parent.add_function(wrap_pyfunction!(pylib::read_parquet_arrow_schema, parent)?)?;
     parent.add_function(wrap_pyfunction!(pylib::read_parquet_statistics, parent)?)?;
     Ok(())
 }

--- a/src/daft-parquet/src/read.rs
+++ b/src/daft-parquet/src/read.rs
@@ -470,6 +470,39 @@ pub async fn read_parquet_schema_and_metadata(
     Ok((schema, adapter))
 }
 
+/// Reads a Parquet file's footer schema as a raw arrow-rs `Schema`, without downcasting to
+/// Daft's own `Schema`/`DataType`.
+///
+/// `read_parquet_schema_and_metadata` above converts the footer schema into Daft's own
+/// `Schema` on the way out, and that conversion is lossy for nested types: `DataType::List`
+/// and `DataType::Map` only wrap a bare child `DataType` (no `arrow_schema::Field`), so any
+/// per-field Arrow metadata on a list element or map key/value — including Iceberg's
+/// `PARQUET:field_id` — is discarded and cannot be recovered afterwards. Callers that need to
+/// verify Iceberg field IDs at every nesting level (see the Iceberg changelog schema gate)
+/// must read the raw arrow-rs schema instead, which keeps every nested `Field` (and therefore
+/// its metadata) intact all the way to the PyArrow FFI boundary.
+///
+/// This is still a pure footer read: no row-group data pages are fetched.
+pub async fn read_parquet_arrow_schema(
+    uri: &str,
+    io_client: Arc<IOClient>,
+    io_stats: Option<IOStatsRef>,
+    schema_inference_options: ParquetSchemaInferenceOptions,
+) -> DaftResult<arrow::datatypes::SchemaRef> {
+    let metadata =
+        crate::metadata::read_parquet_metadata(uri, None, io_client, io_stats, None, None).await?;
+    let arrow_schema = crate::schema_inference::infer_schema_from_parquet_metadata_arrowrs(
+        &metadata,
+        Some(schema_inference_options.coerce_int96_timestamp_unit),
+        schema_inference_options.string_encoding == StringEncoding::Raw,
+    )
+    .map_err(|e| crate::Error::Arrow {
+        path: uri.to_string(),
+        source: e,
+    })?;
+    Ok(Arc::new(arrow_schema))
+}
+
 pub async fn read_parquet_metadata(
     uri: &str,
     io_client: Arc<IOClient>,

--- a/tests/io/iceberg/test_iceberg_changelog_datasource.py
+++ b/tests/io/iceberg/test_iceberg_changelog_datasource.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import asyncio
+import pickle
+import threading
+
+import pyarrow as pa
+import pytest
+
+pyiceberg = pytest.importorskip("pyiceberg")
+
+from pyiceberg.catalog.sql import SqlCatalog
+from pyiceberg.schema import Schema
+from pyiceberg.table import StaticTable
+from pyiceberg.types import LongType, NestedField, StringType
+
+from daft.daft import IOConfig, StorageConfig
+from daft.io.iceberg import _changelog_schema
+from daft.io.iceberg.iceberg_changes_scan import IcebergChangesDataSource
+
+
+@pytest.fixture(scope="function")
+def local_catalog(tmpdir):
+    catalog = SqlCatalog(
+        "default",
+        uri=f"sqlite:///{tmpdir}/pyiceberg_catalog.db",
+        warehouse=f"file://{tmpdir}",
+    )
+    catalog.create_namespace("default")
+    yield catalog
+    catalog.engine.dispose()
+
+
+@pytest.fixture(scope="function")
+def cow_history_table(local_catalog):
+    schema = Schema(
+        NestedField(field_id=1, name="id", field_type=LongType(), required=False),
+        NestedField(field_id=2, name="data", field_type=StringType(), required=False),
+    )
+    table = local_catalog.create_table("default.operator_cache", schema=schema)
+    table.append(pa.table({"id": [1, 2, 3], "data": ["a", "b", "c"]}))
+    table.append(pa.table({"id": [4, 5], "data": ["d", "e"]}))
+    table.delete("id = 1")
+    table.refresh()
+    return table
+
+
+@pytest.fixture(scope="function")
+def picklable_cow_history_table(cow_history_table):
+    """A `StaticTable` view of `cow_history_table`, loaded straight from its metadata JSON.
+
+    `SqlCatalog`-backed `Table` objects hold a live SQLAlchemy engine/connection (used for
+    catalog lookups), which is fundamentally unpicklable and specific to this test's local
+    catalog setup -- not a property of `IcebergChangesDataSource` itself. `StaticTable`
+    (what `read_iceberg`/`read_iceberg_changes` actually construct for path-based tables,
+    see `daft/io/iceberg/_iceberg.py`) has no such live connection and is picklable, which
+    is what actually needs testing here: whether `IcebergChangesDataSource` itself
+    survives a pickle round-trip.
+    """
+    return StaticTable.from_metadata(cow_history_table.metadata_location)
+
+
+def _make_source(table) -> IcebergChangesDataSource:
+    return IcebergChangesDataSource(
+        table,
+        start_snapshot_id=None,
+        end_snapshot_id=None,
+        start_timestamp_ms=None,
+        end_timestamp_ms=None,
+        storage_config=StorageConfig(True, IOConfig()),
+    )
+
+
+async def _collect_tasks(source, pushdowns):
+    return [t async for t in source.get_tasks(pushdowns)]
+
+
+def _run_get_tasks(source, pushdowns):
+    """Drive `get_tasks()` to completion from a fresh event loop.
+
+    Mirrors how Daft's Rust engine actually calls it: each invocation runs inside its own
+    `io_runtime.block_on_current_thread(...)`, i.e. its own event loop, not a loop shared
+    across calls -- see `test_concurrent_get_tasks_reads_each_footer_only_once` below, which
+    exercises this from multiple OS threads at once.
+    """
+    return asyncio.run(_collect_tasks(source, pushdowns))
+
+
+def test_concurrent_get_tasks_reads_each_footer_only_once(cow_history_table, monkeypatch):
+    call_count = 0
+    lock = threading.Lock()
+    real = _changelog_schema._read_footer_arrow_schema
+
+    def counting(path, storage_config):
+        nonlocal call_count
+        with lock:
+            call_count += 1
+        return real(path, storage_config)
+
+    monkeypatch.setattr(_changelog_schema, "_read_footer_arrow_schema", counting)
+
+    source = _make_source(cow_history_table)
+
+    results: list[list] = []
+    errors: list[Exception] = []
+
+    def call_get_tasks():
+        try:
+            results.append(_run_get_tasks(source, _empty_pushdowns()))
+        except Exception as e:
+            errors.append(e)
+
+    threads = [threading.Thread(target=call_get_tasks) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, errors
+    # All 8 concurrent calls must see the same, fully-planned task set.
+    assert all(len(r) == len(results[0]) for r in results)
+
+    # There are 4 distinct data files across this table's history (file A, file B, and the
+    # rewritten file A' from the COW delete, plus the deleted-but-still-listed old file A);
+    # regardless of the exact count, the key property is: it must equal the number of
+    # *distinct file paths* referenced by the plan, not 8x that (one read per thread) or
+    # more.
+    tasks = source._cached_tasks
+    expected_distinct_files = len({t.data_file.file_path for t in tasks})
+    assert call_count == expected_distinct_files
+
+
+def test_failed_planning_retries_from_scratch_on_next_call(cow_history_table, monkeypatch):
+    attempt = 0
+    real = _changelog_schema._read_footer_arrow_schema
+
+    def flaky(path, storage_config):
+        nonlocal attempt
+        attempt += 1
+        if attempt == 1:
+            raise ConnectionError("simulated transient I/O failure")
+        return real(path, storage_config)
+
+    monkeypatch.setattr(_changelog_schema, "_read_footer_arrow_schema", flaky)
+
+    source = _make_source(cow_history_table)
+
+    # First call: the very first footer read fails -> the whole planning attempt fails,
+    # and _cached_tasks must remain None (back to UNPLANNED), not a partial/poisoned state.
+    with pytest.raises(ConnectionError):
+        _run_get_tasks(source, _empty_pushdowns())
+    assert source._cached_tasks is None
+
+    # Second call: retries planning from scratch (re-reads manifests and footers) and
+    # succeeds this time.
+    tasks = _run_get_tasks(source, _empty_pushdowns())
+    assert len(tasks) > 0
+    assert source._cached_tasks is not None
+
+
+def test_source_pickle_roundtrip_before_planning(picklable_cow_history_table):
+    source = _make_source(picklable_cow_history_table)
+    restored: IcebergChangesDataSource = pickle.loads(pickle.dumps(source))
+
+    assert restored._cached_tasks is None
+    assert restored._lock is not None
+    # Must still work after unpickling: a fresh lock, lazy planning triggered on first use.
+    tasks = _run_get_tasks(restored, _empty_pushdowns())
+    assert len(tasks) > 0
+
+
+def test_source_pickle_roundtrip_after_planning_carries_cache(picklable_cow_history_table, monkeypatch):
+    call_count = 0
+    real = _changelog_schema._read_footer_arrow_schema
+
+    def counting(path, storage_config):
+        nonlocal call_count
+        call_count += 1
+        return real(path, storage_config)
+
+    monkeypatch.setattr(_changelog_schema, "_read_footer_arrow_schema", counting)
+
+    source = _make_source(picklable_cow_history_table)
+    first_tasks = _run_get_tasks(source, _empty_pushdowns())
+    calls_before_pickle = call_count
+
+    restored: IcebergChangesDataSource = pickle.loads(pickle.dumps(source))
+    assert restored._cached_tasks is not None  # cache carried across the pickle boundary
+    second_tasks = _run_get_tasks(restored, _empty_pushdowns())
+
+    assert len(first_tasks) == len(second_tasks)
+    # No new footer reads should have happened: the receiver reused the sender's
+    # already-validated planning result instead of redoing it.
+    assert call_count == calls_before_pickle
+
+
+def _empty_pushdowns():
+    from daft.daft import PyPushdowns
+    from daft.io.pushdowns import Pushdowns
+
+    return Pushdowns._from_pypushdowns(PyPushdowns())

--- a/tests/io/iceberg/test_iceberg_changelog_planning.py
+++ b/tests/io/iceberg/test_iceberg_changelog_planning.py
@@ -1,0 +1,299 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pyarrow as pa
+import pytest
+
+pyiceberg = pytest.importorskip("pyiceberg")
+
+from pyiceberg.catalog.sql import SqlCatalog
+from pyiceberg.manifest import ManifestContent
+from pyiceberg.schema import Schema
+from pyiceberg.table.snapshots import Operation
+from pyiceberg.types import LongType, NestedField, StringType
+
+from daft.io.iceberg._changelog_planning import (
+    ChangelogFileTask,
+    _require_int_timestamp_ms,
+    _snapshot_has_delete_manifest,
+    compute_snapshot_ordinals,
+    ordered_changelog_snapshots,
+    plan_changelog_file_tasks,
+    resolve_snapshot_range,
+)
+
+
+@pytest.fixture(scope="function")
+def local_catalog(tmpdir):
+    catalog = SqlCatalog(
+        "default",
+        uri=f"sqlite:///{tmpdir}/pyiceberg_catalog.db",
+        warehouse=f"file://{tmpdir}",
+    )
+    catalog.create_namespace("default")
+    yield catalog
+    catalog.engine.dispose()
+
+
+@pytest.fixture(scope="function")
+def cow_history_table(local_catalog):
+    """A table with a pure copy-on-write history.
+
+    Two appends followed by a partial delete that forces a copy-on-write rewrite of one of
+    the appended files.
+
+    Snapshot S1 (APPEND): adds file A with rows (1, 2, 3).
+    Snapshot S2 (APPEND): adds file B with rows (4, 5).
+    Snapshot S3 (OVERWRITE, COW): deletes file A, adds file A' with rows (2, 3).
+    """
+    schema = Schema(
+        NestedField(field_id=1, name="id", field_type=LongType(), required=False),
+        NestedField(field_id=2, name="data", field_type=StringType(), required=False),
+    )
+    table = local_catalog.create_table("default.cow_history", schema=schema)
+
+    batch_a = pa.table({"id": [1, 2, 3], "data": ["a", "b", "c"]})
+    table.append(batch_a)
+
+    batch_b = pa.table({"id": [4, 5], "data": ["d", "e"]})
+    table.append(batch_b)
+
+    table.delete("id = 1")
+
+    table.refresh()
+    return table
+
+
+def test_resolve_snapshot_range_defaults_to_full_history(cow_history_table):
+    snapshots = list(cow_history_table.snapshots())
+    assert len(snapshots) == 3
+
+    from_id, to_id = resolve_snapshot_range(cow_history_table, None, None, None, None)
+    assert from_id is None
+    assert to_id == cow_history_table.current_snapshot().snapshot_id
+
+
+def test_resolve_snapshot_range_start_equals_end_is_valid(cow_history_table):
+    s1 = cow_history_table.snapshots()[0].snapshot_id
+    from_id, to_id = resolve_snapshot_range(cow_history_table, s1, s1, None, None)
+    assert from_id == s1
+    assert to_id == s1
+    # An empty (from, to] range: no snapshots in between.
+    assert ordered_changelog_snapshots(cow_history_table, from_id, to_id) == []
+
+
+def test_resolve_snapshot_range_rejects_unknown_snapshot_id(cow_history_table):
+    with pytest.raises(ValueError, match="was not found"):
+        resolve_snapshot_range(cow_history_table, None, 123456789, None, None)
+
+
+def test_resolve_snapshot_range_rejects_mutually_exclusive_start_args(cow_history_table):
+    with pytest.raises(ValueError, match="mutually exclusive|Only one of"):
+        resolve_snapshot_range(cow_history_table, 1, None, 1, None)
+
+
+@pytest.mark.parametrize("bad_value", [1.0, 1.5, True, False, "1700000000000", None])
+def test_require_int_timestamp_ms_rejects_non_int(bad_value):
+    if bad_value is None:
+        # None means "not provided" and is handled by the caller, not this validator;
+        # skip it here since _require_int_timestamp_ms is only ever called when the
+        # caller has already established the value is not None.
+        pytest.skip("None is a valid 'not provided' sentinel, handled by the caller")
+    with pytest.raises(TypeError, match="must be an int"):
+        _require_int_timestamp_ms(bad_value, "start_timestamp_ms")
+
+
+def test_require_int_timestamp_ms_accepts_plain_int():
+    _require_int_timestamp_ms(1700000000000, "start_timestamp_ms")  # must not raise
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"start_timestamp_ms": 1.5},
+        {"start_timestamp_ms": True},
+        {"end_timestamp_ms": 1.5},
+        {"end_timestamp_ms": False},
+    ],
+)
+def test_resolve_snapshot_range_rejects_non_int_timestamp(cow_history_table, kwargs):
+    full_kwargs = {
+        "start_snapshot_id": None,
+        "end_snapshot_id": None,
+        "start_timestamp_ms": None,
+        "end_timestamp_ms": None,
+    }
+    full_kwargs.update(kwargs)
+    with pytest.raises(TypeError, match="must be an int"):
+        resolve_snapshot_range(cow_history_table, **full_kwargs)
+
+
+def test_resolve_snapshot_range_timestamp_truth_table(cow_history_table):
+    s1, s2, s3 = (s.snapshot_id for s in cow_history_table.snapshots())
+    timestamps = [s.timestamp_ms for s in cow_history_table.snapshots()]
+
+    # end_timestamp_ms resolves to the snapshot current at or before it (inclusive).
+    from_id, to_id = resolve_snapshot_range(cow_history_table, None, None, None, timestamps[1])
+    assert (from_id, to_id) == (None, s2)
+
+    # start_timestamp_ms is the exclusive lower bound, resolved the same way.
+    from_id, to_id = resolve_snapshot_range(cow_history_table, None, None, timestamps[0], timestamps[2])
+    assert (from_id, to_id) == (s1, s3)
+
+    # A timestamp strictly before the table's first snapshot has no valid resolution.
+    with pytest.raises(ValueError, match="No snapshot found at or before"):
+        resolve_snapshot_range(cow_history_table, None, None, timestamps[0] - 1_000_000, None)
+
+    # start_timestamp_ms and start_snapshot_id are mutually exclusive.
+    with pytest.raises(ValueError, match="Only one of"):
+        resolve_snapshot_range(cow_history_table, s1, None, timestamps[0], None)
+    with pytest.raises(ValueError, match="Only one of"):
+        resolve_snapshot_range(cow_history_table, None, s1, None, timestamps[0])
+
+
+def test_ordered_changelog_snapshots_full_history_oldest_first(cow_history_table):
+    snapshots = list(cow_history_table.snapshots())
+    from_id, to_id = resolve_snapshot_range(cow_history_table, None, None, None, None)
+    ordered = ordered_changelog_snapshots(cow_history_table, from_id, to_id)
+
+    assert [s.snapshot_id for s in ordered] == [s.snapshot_id for s in snapshots]
+
+
+def test_ordered_changelog_snapshots_rejects_non_ancestor_start(cow_history_table):
+    # A start_snapshot_id that isn't actually an ancestor of end_snapshot_id (here: swapped).
+    s1, _, s3 = (s.snapshot_id for s in cow_history_table.snapshots())
+    with pytest.raises(ValueError, match="not an ancestor"):
+        ordered_changelog_snapshots(cow_history_table, s3, s1)
+
+
+def test_plan_changelog_file_tasks_cow_insert_delete(cow_history_table):
+    snapshots = list(cow_history_table.snapshots())
+    s1_id, s2_id, s3_id = (s.snapshot_id for s in snapshots)
+    ordinals = compute_snapshot_ordinals(snapshots)
+    assert ordinals == {s1_id: 0, s2_id: 1, s3_id: 2}
+
+    tasks = list(plan_changelog_file_tasks(cow_history_table, snapshots, ordinals))
+
+    by_commit: dict[int, list[ChangelogFileTask]] = {}
+    for task in tasks:
+        by_commit.setdefault(task.commit_snapshot_id, []).append(task)
+
+    # S1: one INSERT task for file A (3 rows).
+    assert len(by_commit[s1_id]) == 1
+    assert by_commit[s1_id][0].change_type == "INSERT"
+    assert by_commit[s1_id][0].change_ordinal == 0
+    assert by_commit[s1_id][0].data_file.record_count == 3
+
+    # S2: one INSERT task for file B (2 rows).
+    assert len(by_commit[s2_id]) == 1
+    assert by_commit[s2_id][0].change_type == "INSERT"
+    assert by_commit[s2_id][0].change_ordinal == 1
+    assert by_commit[s2_id][0].data_file.record_count == 2
+
+    # S3: COW rewrite of file A -- one DELETE (old file A, 3 rows) and one INSERT
+    # (rewritten file A', 2 rows: id=1 was removed).
+    s3_tasks = by_commit[s3_id]
+    assert len(s3_tasks) == 2
+    assert {t.change_type for t in s3_tasks} == {"INSERT", "DELETE"}
+    for t in s3_tasks:
+        assert t.change_ordinal == 2
+        if t.change_type == "DELETE":
+            assert t.data_file.record_count == 3
+        else:
+            assert t.data_file.record_count == 2
+
+
+def test_snapshot_has_delete_manifest_true_when_any_manifest_is_deletes():
+    fake_manifests = [
+        SimpleNamespace(content=ManifestContent.DATA),
+        SimpleNamespace(content=ManifestContent.DELETES),
+    ]
+    fake_snapshot = SimpleNamespace(manifests=lambda io: fake_manifests)
+    assert _snapshot_has_delete_manifest(fake_snapshot, io=None) is True
+
+
+def test_snapshot_has_delete_manifest_false_when_all_data():
+    fake_manifests = [SimpleNamespace(content=ManifestContent.DATA)]
+    fake_snapshot = SimpleNamespace(manifests=lambda io: fake_manifests)
+    assert _snapshot_has_delete_manifest(fake_snapshot, io=None) is False
+
+
+def test_ordered_changelog_snapshots_rejects_range_with_delete_manifest(cow_history_table, monkeypatch):
+    # pyiceberg 0.11.1's own table.delete() always falls back to COW (merge-on-read isn't
+    # implemented yet) and pyiceberg.table.snapshots.Snapshot is a frozen pydantic model, so
+    # there's no way to construct or fake a real MOR delete manifest here. Instead, patch
+    # _snapshot_has_delete_manifest itself (already covered in isolation by the two tests
+    # above) to simulate one being present for the last snapshot in range, which exercises
+    # ordered_changelog_snapshots's wiring: it must call the guard for every snapshot in
+    # range and propagate NotImplementedError as soon as any of them trips it. A true
+    # end-to-end test against a manifest genuinely written with position deletes is tracked
+    # as follow-up coverage once available (e.g. via a Spark-authored MOR table fixture).
+    last_snapshot_id = cow_history_table.snapshots()[-1].snapshot_id
+    original = _snapshot_has_delete_manifest
+
+    def fake_has_delete_manifest(snapshot, io):
+        if snapshot.snapshot_id == last_snapshot_id:
+            return True
+        return original(snapshot, io)
+
+    monkeypatch.setattr(
+        "daft.io.iceberg._changelog_planning._snapshot_has_delete_manifest",
+        fake_has_delete_manifest,
+    )
+
+    from_id, to_id = resolve_snapshot_range(cow_history_table, None, None, None, None)
+    with pytest.raises(NotImplementedError, match="copy-on-write"):
+        ordered_changelog_snapshots(cow_history_table, from_id, to_id)
+
+
+def _fake_snapshot(snapshot_id: int, operation: Operation) -> SimpleNamespace:
+    return SimpleNamespace(
+        snapshot_id=snapshot_id,
+        summary=SimpleNamespace(operation=operation),
+        manifests=lambda io: [],
+    )
+
+
+def test_ordered_changelog_snapshots_skips_replace_operations(cow_history_table, monkeypatch):
+    # pyiceberg 0.11.1's public write API has no way to produce a real REPLACE (compaction
+    # / manifest-rewrite) snapshot -- Table.maintenance only exposes expire_snapshots, and
+    # Transaction has no rewrite_manifests/compact_data_files. Fake the ancestors_between
+    # result instead, which is legitimate here since REPLACE-skipping only depends on
+    # `snapshot.summary.operation` and `snapshot.manifests(io)`, not real ancestry linkage.
+    to_id = cow_history_table.snapshots()[-1].snapshot_id
+    replace_snap = _fake_snapshot(999001, Operation.REPLACE)
+    append_snap = _fake_snapshot(999002, Operation.APPEND)
+    # ancestors_between walks newest -> oldest.
+    monkeypatch.setattr(
+        "daft.io.iceberg._changelog_planning.ancestors_between",
+        lambda from_snap, to_snap, metadata: [replace_snap, append_snap],
+    )
+
+    result = ordered_changelog_snapshots(cow_history_table, None, to_id)
+    assert [s.snapshot_id for s in result] == [append_snap.snapshot_id]
+
+
+def test_ordered_changelog_snapshots_all_replace_region_is_empty(cow_history_table, monkeypatch):
+    to_id = cow_history_table.snapshots()[-1].snapshot_id
+    monkeypatch.setattr(
+        "daft.io.iceberg._changelog_planning.ancestors_between",
+        lambda from_snap, to_snap, metadata: [_fake_snapshot(999003, Operation.REPLACE)],
+    )
+
+    assert ordered_changelog_snapshots(cow_history_table, None, to_id) == []
+
+
+def test_ordered_changelog_snapshots_replace_endpoint_is_skipped(cow_history_table, monkeypatch):
+    # The endpoint (newest / first in ancestors_between's newest->oldest order) being a
+    # REPLACE must not special-case anything -- it's still just skipped like any other.
+    to_id = cow_history_table.snapshots()[-1].snapshot_id
+    replace_endpoint = _fake_snapshot(999004, Operation.REPLACE)
+    real_append = _fake_snapshot(999005, Operation.APPEND)
+    monkeypatch.setattr(
+        "daft.io.iceberg._changelog_planning.ancestors_between",
+        lambda from_snap, to_snap, metadata: [replace_endpoint, real_append],
+    )
+
+    result = ordered_changelog_snapshots(cow_history_table, None, to_id)
+    assert [s.snapshot_id for s in result] == [real_append.snapshot_id]

--- a/tests/io/iceberg/test_iceberg_changelog_postprocess.py
+++ b/tests/io/iceberg/test_iceberg_changelog_postprocess.py
@@ -1,0 +1,307 @@
+from __future__ import annotations
+
+import math
+
+import pyarrow as pa
+
+import daft
+from daft.expressions import col
+from daft.io.iceberg._changelog_postprocess import remove_carryovers
+from tests.conftest import get_tests_daft_runner_name
+
+
+def _sorted_rows(df: daft.DataFrame) -> list[dict]:
+    rows = df.to_pylist()
+    return sorted(rows, key=lambda r: tuple(sorted(r.items(), key=lambda kv: kv[0])))
+
+
+def test_three_insert_two_delete_leaves_one_insert():
+    df = daft.from_pydict(
+        {
+            "id": [1, 1, 1, 1, 1],
+            "name": ["a", "a", "a", "a", "a"],
+            "_change_type": ["INSERT", "INSERT", "INSERT", "DELETE", "DELETE"],
+            "_change_ordinal": [0, 0, 0, 0, 0],
+            "_commit_snapshot_id": [100, 100, 100, 100, 100],
+        }
+    )
+    result = _sorted_rows(remove_carryovers(df))
+    assert result == [
+        {"id": 1, "name": "a", "_change_type": "INSERT", "_change_ordinal": 0, "_commit_snapshot_id": 100}
+    ]
+
+
+def test_two_insert_three_delete_leaves_one_delete():
+    df = daft.from_pydict(
+        {
+            "id": [1, 1, 1, 1, 1],
+            "name": ["a", "a", "a", "a", "a"],
+            "_change_type": ["INSERT", "INSERT", "DELETE", "DELETE", "DELETE"],
+            "_change_ordinal": [0, 0, 0, 0, 0],
+            "_commit_snapshot_id": [100, 100, 100, 100, 100],
+        }
+    )
+    result = _sorted_rows(remove_carryovers(df))
+    assert result == [
+        {"id": 1, "name": "a", "_change_type": "DELETE", "_change_ordinal": 0, "_commit_snapshot_id": 100}
+    ]
+
+
+def test_equal_counts_cancel_completely():
+    df = daft.from_pydict(
+        {
+            "id": [1, 1],
+            "name": ["a", "a"],
+            "_change_type": ["INSERT", "DELETE"],
+            "_change_ordinal": [0, 0],
+            "_commit_snapshot_id": [100, 100],
+        }
+    )
+    assert _sorted_rows(remove_carryovers(df)) == []
+
+
+def test_unrelated_row_in_same_commit_is_untouched():
+    df = daft.from_pydict(
+        {
+            "id": [1, 1, 1, 2],
+            "name": ["a", "a", "a", "b"],
+            "_change_type": ["INSERT", "INSERT", "DELETE", "DELETE"],
+            "_change_ordinal": [0, 0, 0, 0],
+            "_commit_snapshot_id": [100, 100, 100, 100],
+        }
+    )
+    result = _sorted_rows(remove_carryovers(df))
+    # "DELETE" sorts before "INSERT" lexicographically, which is what _sorted_rows's sort
+    # key (over key-alphabetical (k, v) tuples, starting with _change_type) produces.
+    assert result == [
+        {"id": 2, "name": "b", "_change_type": "DELETE", "_change_ordinal": 0, "_commit_snapshot_id": 100},
+        {"id": 1, "name": "a", "_change_type": "INSERT", "_change_ordinal": 0, "_commit_snapshot_id": 100},
+    ]
+
+
+def test_identical_content_across_different_commits_is_not_cancelled():
+    df = daft.from_pydict(
+        {
+            "id": [1, 1],
+            "name": ["a", "a"],
+            "_change_type": ["DELETE", "INSERT"],
+            "_change_ordinal": [0, 1],
+            "_commit_snapshot_id": [100, 101],
+        }
+    )
+    result = _sorted_rows(remove_carryovers(df))
+    assert result == [
+        {"id": 1, "name": "a", "_change_type": "DELETE", "_change_ordinal": 0, "_commit_snapshot_id": 100},
+        {"id": 1, "name": "a", "_change_type": "INSERT", "_change_ordinal": 1, "_commit_snapshot_id": 101},
+    ]
+
+
+def test_pure_insert_no_delete_is_untouched():
+    df = daft.from_pydict(
+        {
+            "id": [1, 2],
+            "name": ["a", "b"],
+            "_change_type": ["INSERT", "INSERT"],
+            "_change_ordinal": [0, 1],
+            "_commit_snapshot_id": [100, 101],
+        }
+    )
+    assert _sorted_rows(remove_carryovers(df)) == _sorted_rows(df)
+
+
+def test_result_independent_of_row_order():
+    base = {
+        "id": [1, 1, 1, 1, 1],
+        "name": ["a", "a", "a", "a", "a"],
+        "_change_type": ["DELETE", "INSERT", "INSERT", "INSERT", "DELETE"],
+        "_change_ordinal": [0, 0, 0, 0, 0],
+        "_commit_snapshot_id": [100, 100, 100, 100, 100],
+    }
+    reordered = {k: list(reversed(v)) for k, v in base.items()}
+    assert _sorted_rows(remove_carryovers(daft.from_pydict(base))) == _sorted_rows(
+        remove_carryovers(daft.from_pydict(reordered))
+    )
+
+
+# --- Equality semantics for the carryover grouping key ---
+
+
+def test_null_valued_column_carryover_is_cancelled():
+    # Two rows identical on every column, including a NULL in a data column: must be
+    # recognized as the same equality group and cancelled, not treated as
+    # non-comparable (SQL's NULL != NULL would otherwise prevent cancellation).
+    df = daft.from_pydict(
+        {
+            "id": [1, 1],
+            "name": [None, None],
+            "_change_type": ["INSERT", "DELETE"],
+            "_change_ordinal": [0, 0],
+            "_commit_snapshot_id": [100, 100],
+        }
+    )
+    assert _sorted_rows(remove_carryovers(df)) == []
+
+
+def test_null_valued_column_does_not_cancel_against_non_null():
+    # A NULL-valued row and a non-NULL row for the same id are NOT carryover noise --
+    # they're different content and must both survive.
+    df = daft.from_pydict(
+        {
+            "id": [1, 1],
+            "name": [None, "a"],
+            "_change_type": ["INSERT", "DELETE"],
+            "_change_ordinal": [0, 0],
+            "_commit_snapshot_id": [100, 100],
+        }
+    )
+    assert len(_sorted_rows(remove_carryovers(df))) == 2
+
+
+def test_nan_valued_column_carryover_is_cancelled():
+    # Two rows identical including a NaN float column: NaN must be treated as an
+    # ordinary comparable value for grouping purposes (bitwise/positional comparison,
+    # not IEEE-754 "NaN != NaN"), otherwise NaN-containing carryover rows could never be
+    # recognized as identical and would leak into the output.
+    df = daft.from_pydict(
+        {
+            "id": [1, 1],
+            "val": [math.nan, math.nan],
+            "_change_type": ["INSERT", "DELETE"],
+            "_change_ordinal": [0, 0],
+            "_commit_snapshot_id": [100, 100],
+        }
+    )
+    assert _sorted_rows(remove_carryovers(df)) == []
+
+
+def test_struct_column_carryover_is_cancelled():
+    df = daft.from_pydict(
+        {
+            "id": [1, 1],
+            "info": [{"a": 1, "b": "x"}, {"a": 1, "b": "x"}],
+            "_change_type": ["INSERT", "DELETE"],
+            "_change_ordinal": [0, 0],
+            "_commit_snapshot_id": [100, 100],
+        }
+    )
+    assert _sorted_rows(remove_carryovers(df)) == []
+
+
+def test_struct_column_does_not_cancel_when_field_differs():
+    df = daft.from_pydict(
+        {
+            "id": [1, 1],
+            "info": [{"a": 1, "b": "x"}, {"a": 2, "b": "x"}],
+            "_change_type": ["INSERT", "DELETE"],
+            "_change_ordinal": [0, 0],
+            "_commit_snapshot_id": [100, 100],
+        }
+    )
+    assert len(_sorted_rows(remove_carryovers(df))) == 2
+
+
+def test_list_column_carryover_is_cancelled():
+    df = daft.from_pydict(
+        {
+            "id": [1, 1],
+            "tags": [[1, 2, 3], [1, 2, 3]],
+            "_change_type": ["INSERT", "DELETE"],
+            "_change_ordinal": [0, 0],
+            "_commit_snapshot_id": [100, 100],
+        }
+    )
+    assert _sorted_rows(remove_carryovers(df)) == []
+
+
+def test_list_column_does_not_cancel_when_order_differs():
+    df = daft.from_pydict(
+        {
+            "id": [1, 1],
+            "tags": [[1, 2, 3], [3, 2, 1]],
+            "_change_type": ["INSERT", "DELETE"],
+            "_change_ordinal": [0, 0],
+            "_commit_snapshot_id": [100, 100],
+        }
+    )
+    assert len(_sorted_rows(remove_carryovers(df))) == 2
+
+
+def test_map_column_carryover_is_cancelled():
+    map_type = pa.map_(pa.field("key", pa.string(), nullable=False), pa.field("value", pa.int64()))
+    table = pa.table(
+        {
+            "id": pa.array([1, 1], type=pa.int64()),
+            "kv": pa.array([[("k", 1)], [("k", 1)]], type=map_type),
+            "_change_type": pa.array(["INSERT", "DELETE"]),
+            "_change_ordinal": pa.array([0, 0], type=pa.int64()),
+            "_commit_snapshot_id": pa.array([100, 100], type=pa.int64()),
+        }
+    )
+    df = daft.from_arrow(table)
+    assert _sorted_rows(remove_carryovers(df)) == []
+
+
+# --- Multi-partition execution consistency ---
+
+
+def test_multi_partition_carryover_matches_single_partition_result():
+    """Multi-partition carryover cancellation must match the single-partition result.
+
+    `into_partitions`/`repartition` are no-ops under the native runner (single partition
+    always), so this test is only a genuine multi-partition exercise under DAFT_RUNNER=ray;
+    it remains a harmless single-partition re-check under native.
+    """
+    data = {
+        "id": [1, 1, 1, 1, 1, 2, 3, 3],
+        "name": ["a", "a", "a", "a", "a", "b", "c", "c"],
+        "_change_type": ["INSERT", "INSERT", "INSERT", "DELETE", "DELETE", "DELETE", "INSERT", "DELETE"],
+        "_change_ordinal": [0, 0, 0, 0, 0, 0, 1, 1],
+        "_commit_snapshot_id": [100, 100, 100, 100, 100, 100, 101, 101],
+    }
+    single_partition_result = _sorted_rows(remove_carryovers(daft.from_pydict(data)))
+
+    multi_partition_df = daft.from_pydict(data).into_partitions(4)
+    if get_tests_daft_runner_name() == "ray":
+        assert multi_partition_df.num_partitions() == 4
+    multi_partition_result = _sorted_rows(remove_carryovers(multi_partition_df))
+
+    assert multi_partition_result == single_partition_result
+    # 3 INSERT/2 DELETE of (1,a) -> 1 INSERT; unrelated (2,b) DELETE untouched; (3,c)
+    # 1 INSERT/1 DELETE -> fully cancelled. "DELETE" sorts before "INSERT"
+    # lexicographically, matching _sorted_rows's key order.
+    assert multi_partition_result == [
+        {"id": 2, "name": "b", "_change_type": "DELETE", "_change_ordinal": 0, "_commit_snapshot_id": 100},
+        {"id": 1, "name": "a", "_change_type": "INSERT", "_change_ordinal": 0, "_commit_snapshot_id": 100},
+    ]
+
+
+# --- Optimizer boundary: filter must not cross the carryover window ---
+
+
+def test_filter_after_remove_carryovers_does_not_resurrect_cancelled_pairs():
+    """A cancelled carryover pair must not be resurrected by a filter applied afterward.
+
+    A carryover pair (byte-identical INSERT+DELETE) must still cancel completely even
+    when the caller applies a `.where(col("_change_type") == "INSERT")` filter on the
+    *result* of `remove_carryovers`. If the optimizer ever pushed such a filter down
+    across the carryover window (into the scan, before pairing), it would silently keep
+    the INSERT half of a carryover pair that should have cancelled -- the
+    "one side of the pair survives" failure mode.
+    """
+    df = daft.from_pydict(
+        {
+            "id": [1, 1, 2],
+            "name": ["a", "a", "b"],
+            "_change_type": ["INSERT", "DELETE", "INSERT"],
+            "_change_ordinal": [0, 0, 0],
+            "_commit_snapshot_id": [100, 100, 100],
+        }
+    )
+    resolved = remove_carryovers(df)
+    only_inserts = resolved.where(col("_change_type") == "INSERT")
+    # id=1's INSERT/DELETE pair is genuine carryover noise and must already be gone from
+    # `resolved`; filtering to INSERT afterward must not resurrect it. Only id=2's
+    # standalone INSERT should remain.
+    assert _sorted_rows(only_inserts) == [
+        {"id": 2, "name": "b", "_change_type": "INSERT", "_change_ordinal": 0, "_commit_snapshot_id": 100}
+    ]

--- a/tests/io/iceberg/test_iceberg_changelog_schema.py
+++ b/tests/io/iceberg/test_iceberg_changelog_schema.py
@@ -1,0 +1,312 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+pyiceberg = pytest.importorskip("pyiceberg")
+
+from pyiceberg.catalog.sql import SqlCatalog
+from pyiceberg.io.pyarrow import schema_to_pyarrow
+from pyiceberg.schema import Schema
+from pyiceberg.types import IntegerType, ListType, LongType, MapType, NestedField, StringType, StructType
+
+from daft.daft import IOConfig, StorageConfig
+from daft.io.iceberg._changelog_schema import (
+    _assert_globally_unique_field_ids,
+    _read_footer_arrow_schema,
+    validate_single_schema_table,
+    validate_task_file_schemas,
+)
+
+FORMAT_VERSION = 2
+
+BASELINE_SCHEMA = Schema(
+    NestedField(1, "id", LongType(), required=True),
+    NestedField(
+        2,
+        "nested",
+        StructType(
+            NestedField(10, "a", IntegerType(), required=True),
+            NestedField(11, "b", StringType(), required=False),
+        ),
+        required=False,
+    ),
+    NestedField(3, "items", ListType(21, IntegerType(), element_required=True), required=False),
+    NestedField(4, "kv", MapType(31, StringType(), 32, IntegerType(), value_required=False), required=False),
+)
+
+
+def _storage_config() -> StorageConfig:
+    return StorageConfig(True, IOConfig())
+
+
+def _task(path: str) -> SimpleNamespace:
+    return SimpleNamespace(data_file=SimpleNamespace(file_path=path))
+
+
+def _write_parquet(tmp_path, pa_schema: pa.Schema, arrays: dict[str, pa.Array] | None = None) -> str:
+    if arrays is None:
+        arrays = {f.name: pa.array([], type=f.type) for f in pa_schema}
+    table = pa.table(arrays, schema=pa_schema)
+    path = str(tmp_path / "data.parquet")
+    pq.write_table(table, path)
+    return path
+
+
+def _baseline_data() -> dict[str, pa.Array]:
+    return {
+        "id": pa.array([1], type=pa.int64()),
+        "nested": pa.array([{"a": 1, "b": "x"}], type=pa.struct([("a", pa.int32()), ("b", pa.large_string())])),
+        "items": pa.array([[1, 2]], type=pa.large_list(pa.int32())),
+        "kv": pa.array(
+            [[("k", 1)]],
+            type=pa.map_(pa.field("key", pa.large_string(), nullable=False), pa.field("value", pa.int32())),
+        ),
+    }
+
+
+def test_matching_schema_passes(tmp_path):
+    pa_schema = schema_to_pyarrow(BASELINE_SCHEMA)
+    path = _write_parquet(tmp_path, pa_schema, _baseline_data())
+    validate_task_file_schemas(BASELINE_SCHEMA, FORMAT_VERSION, _storage_config(), [_task(path)])
+
+
+def test_struct_child_field_id_mismatch_rejected(tmp_path):
+    mismatched = Schema(
+        NestedField(1, "id", LongType(), required=True),
+        NestedField(
+            2,
+            "nested",
+            StructType(
+                NestedField(999, "a", IntegerType(), required=True),  # field id 10 -> 999
+                NestedField(11, "b", StringType(), required=False),
+            ),
+            required=False,
+        ),
+        NestedField(3, "items", ListType(21, IntegerType(), element_required=True), required=False),
+        NestedField(4, "kv", MapType(31, StringType(), 32, IntegerType(), value_required=False), required=False),
+    )
+    pa_schema = schema_to_pyarrow(mismatched)
+    path = _write_parquet(tmp_path, pa_schema)
+    with pytest.raises(NotImplementedError, match="nested.a"):
+        validate_task_file_schemas(BASELINE_SCHEMA, FORMAT_VERSION, _storage_config(), [_task(path)])
+
+
+def test_list_element_field_id_mismatch_rejected(tmp_path):
+    mismatched = Schema(
+        NestedField(1, "id", LongType(), required=True),
+        NestedField(
+            2,
+            "nested",
+            StructType(
+                NestedField(10, "a", IntegerType(), required=True), NestedField(11, "b", StringType(), required=False)
+            ),
+            required=False,
+        ),
+        NestedField(3, "items", ListType(999, IntegerType(), element_required=True), required=False),  # 21 -> 999
+        NestedField(4, "kv", MapType(31, StringType(), 32, IntegerType(), value_required=False), required=False),
+    )
+    pa_schema = schema_to_pyarrow(mismatched)
+    path = _write_parquet(tmp_path, pa_schema)
+    with pytest.raises(NotImplementedError, match="items.element"):
+        validate_task_file_schemas(BASELINE_SCHEMA, FORMAT_VERSION, _storage_config(), [_task(path)])
+
+
+def test_map_key_field_id_mismatch_rejected(tmp_path):
+    mismatched = Schema(
+        NestedField(1, "id", LongType(), required=True),
+        NestedField(
+            2,
+            "nested",
+            StructType(
+                NestedField(10, "a", IntegerType(), required=True), NestedField(11, "b", StringType(), required=False)
+            ),
+            required=False,
+        ),
+        NestedField(3, "items", ListType(21, IntegerType(), element_required=True), required=False),
+        NestedField(
+            4, "kv", MapType(999, StringType(), 32, IntegerType(), value_required=False), required=False
+        ),  # 31 -> 999
+    )
+    pa_schema = schema_to_pyarrow(mismatched)
+    path = _write_parquet(tmp_path, pa_schema)
+    with pytest.raises(NotImplementedError, match="kv.key"):
+        validate_task_file_schemas(BASELINE_SCHEMA, FORMAT_VERSION, _storage_config(), [_task(path)])
+
+
+def test_missing_baseline_field_rejected(tmp_path):
+    missing = Schema(
+        NestedField(1, "id", LongType(), required=True),
+        # "nested" (field id 2) is missing entirely.
+        NestedField(3, "items", ListType(21, IntegerType(), element_required=True), required=False),
+        NestedField(4, "kv", MapType(31, StringType(), 32, IntegerType(), value_required=False), required=False),
+    )
+    pa_schema = schema_to_pyarrow(missing)
+    path = _write_parquet(tmp_path, pa_schema)
+    with pytest.raises(NotImplementedError, match="missing Iceberg field id=2"):
+        validate_task_file_schemas(BASELINE_SCHEMA, FORMAT_VERSION, _storage_config(), [_task(path)])
+
+
+def test_extra_file_field_rejected(tmp_path):
+    extra = Schema(
+        *BASELINE_SCHEMA.fields,
+        NestedField(5, "extra", StringType(), required=False),
+    )
+    pa_schema = schema_to_pyarrow(extra)
+    data = _baseline_data()
+    data["extra"] = pa.array(["z"], type=pa.large_string())
+    path = _write_parquet(tmp_path, pa_schema, data)
+    with pytest.raises(NotImplementedError, match=r"field id\(s\) \[5\]"):
+        validate_task_file_schemas(BASELINE_SCHEMA, FORMAT_VERSION, _storage_config(), [_task(path)])
+
+
+def test_type_mismatch_rejected(tmp_path):
+    mismatched = Schema(
+        NestedField(1, "id", StringType(), required=True),  # long -> string
+        NestedField(
+            2,
+            "nested",
+            StructType(
+                NestedField(10, "a", IntegerType(), required=True), NestedField(11, "b", StringType(), required=False)
+            ),
+            required=False,
+        ),
+        NestedField(3, "items", ListType(21, IntegerType(), element_required=True), required=False),
+        NestedField(4, "kv", MapType(31, StringType(), 32, IntegerType(), value_required=False), required=False),
+    )
+    pa_schema = schema_to_pyarrow(mismatched)
+    path = _write_parquet(tmp_path, pa_schema)
+    with pytest.raises(NotImplementedError, match="type promotion is not yet supported"):
+        validate_task_file_schemas(BASELINE_SCHEMA, FORMAT_VERSION, _storage_config(), [_task(path)])
+
+
+def test_required_mismatch_rejected(tmp_path):
+    mismatched = Schema(
+        NestedField(1, "id", LongType(), required=False),  # required=True -> False
+        NestedField(
+            2,
+            "nested",
+            StructType(
+                NestedField(10, "a", IntegerType(), required=True), NestedField(11, "b", StringType(), required=False)
+            ),
+            required=False,
+        ),
+        NestedField(3, "items", ListType(21, IntegerType(), element_required=True), required=False),
+        NestedField(4, "kv", MapType(31, StringType(), 32, IntegerType(), value_required=False), required=False),
+    )
+    pa_schema = schema_to_pyarrow(mismatched)
+    path = _write_parquet(tmp_path, pa_schema)
+    with pytest.raises(NotImplementedError, match="required="):
+        validate_task_file_schemas(BASELINE_SCHEMA, FORMAT_VERSION, _storage_config(), [_task(path)])
+
+
+def test_field_rename_rejected(tmp_path):
+    renamed = Schema(
+        NestedField(1, "identifier", LongType(), required=True),  # "id" -> "identifier", same field id
+        NestedField(
+            2,
+            "nested",
+            StructType(
+                NestedField(10, "a", IntegerType(), required=True), NestedField(11, "b", StringType(), required=False)
+            ),
+            required=False,
+        ),
+        NestedField(3, "items", ListType(21, IntegerType(), element_required=True), required=False),
+        NestedField(4, "kv", MapType(31, StringType(), 32, IntegerType(), value_required=False), required=False),
+    )
+    pa_schema = schema_to_pyarrow(renamed)
+    path = _write_parquet(tmp_path, pa_schema)
+    with pytest.raises(NotImplementedError, match="renaming is not yet supported"):
+        validate_task_file_schemas(BASELINE_SCHEMA, FORMAT_VERSION, _storage_config(), [_task(path)])
+
+
+def test_missing_field_id_metadata_rejected(tmp_path):
+    pa_schema = pa.schema([pa.field("id", pa.int64())])  # no PARQUET:field_id at all
+    path = _write_parquet(tmp_path, pa_schema)
+    with pytest.raises(NotImplementedError, match="does not carry Iceberg field IDs"):
+        validate_task_file_schemas(BASELINE_SCHEMA, FORMAT_VERSION, _storage_config(), [_task(path)])
+
+
+def test_duplicate_field_id_in_file_rejected(tmp_path):
+    pa_schema = pa.schema(
+        [
+            pa.field("a", pa.int64(), metadata={b"PARQUET:field_id": b"1"}),
+            pa.field("b", pa.int64(), metadata={b"PARQUET:field_id": b"1"}),  # duplicate
+        ]
+    )
+    path = _write_parquet(tmp_path, pa_schema)
+    baseline = Schema(NestedField(1, "a", LongType(), required=False))
+    # Caught by the global-uniqueness pass (_assert_globally_unique_field_ids) before
+    # _index_by_field_id's narrower same-level check ever runs -- it reports both logical
+    # paths involved, which is strictly more informative.
+    with pytest.raises(NotImplementedError, match="reuses Iceberg field id=1"):
+        validate_task_file_schemas(baseline, FORMAT_VERSION, _storage_config(), [_task(path)])
+
+
+def test_missing_file_propagates_file_not_found(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        validate_task_file_schemas(
+            BASELINE_SCHEMA, FORMAT_VERSION, _storage_config(), [_task(str(tmp_path / "does_not_exist.parquet"))]
+        )
+
+
+def test_same_path_dedup_only_reads_footer_once(tmp_path, monkeypatch):
+    pa_schema = schema_to_pyarrow(BASELINE_SCHEMA)
+    path = _write_parquet(tmp_path, pa_schema, _baseline_data())
+
+    call_count = 0
+    real = _read_footer_arrow_schema
+
+    def counting(path_arg, storage_config):
+        nonlocal call_count
+        call_count += 1
+        return real(path_arg, storage_config)
+
+    monkeypatch.setattr("daft.io.iceberg._changelog_schema._read_footer_arrow_schema", counting)
+
+    tasks = [_task(path), _task(path), _task(path)]
+    validate_task_file_schemas(BASELINE_SCHEMA, FORMAT_VERSION, _storage_config(), tasks)
+    assert call_count == 1
+
+
+def test_globally_unique_field_ids_rejects_cross_level_reuse():
+    schema = Schema(
+        NestedField(1, "id", LongType(), required=True),
+        NestedField(
+            2, "nested", StructType(NestedField(1, "a", IntegerType(), required=True)), required=False
+        ),  # reuses id=1
+    )
+    with pytest.raises(NotImplementedError, match="reuses Iceberg field id=1"):
+        _assert_globally_unique_field_ids(list(schema.fields), path="<test>", side="test schema")
+
+
+@pytest.fixture(scope="function")
+def local_catalog(tmpdir):
+    catalog = SqlCatalog(
+        "default",
+        uri=f"sqlite:///{tmpdir}/pyiceberg_catalog.db",
+        warehouse=f"file://{tmpdir}",
+    )
+    catalog.create_namespace("default")
+    yield catalog
+    catalog.engine.dispose()
+
+
+def test_validate_single_schema_table_passes_with_one_schema(local_catalog):
+    schema = Schema(NestedField(1, "id", LongType(), required=False))
+    table = local_catalog.create_table("default.single_schema", schema=schema)
+    result = validate_single_schema_table(table)
+    assert result.schema_id == table.schema().schema_id
+
+
+def test_validate_single_schema_table_rejects_multiple_schemas(local_catalog):
+    schema = Schema(NestedField(1, "id", LongType(), required=False))
+    table = local_catalog.create_table("default.multi_schema", schema=schema)
+    with table.update_schema() as update:
+        update.add_column("extra", LongType())
+    table.refresh()
+    with pytest.raises(NotImplementedError, match="exactly one schema"):
+        validate_single_schema_table(table)

--- a/tests/io/iceberg/test_iceberg_changes.py
+++ b/tests/io/iceberg/test_iceberg_changes.py
@@ -1,0 +1,349 @@
+from __future__ import annotations
+
+import pyarrow as pa
+import pytest
+
+pyiceberg = pytest.importorskip("pyiceberg")
+
+from pyiceberg.catalog.sql import SqlCatalog
+from pyiceberg.schema import Schema
+from pyiceberg.types import LongType, NestedField, StringType
+
+import daft
+from daft.io.iceberg import iceberg_changes_scan
+
+
+@pytest.fixture(scope="function")
+def local_catalog(tmpdir):
+    catalog = SqlCatalog(
+        "default",
+        uri=f"sqlite:///{tmpdir}/pyiceberg_catalog.db",
+        warehouse=f"file://{tmpdir}",
+    )
+    catalog.create_namespace("default")
+    yield catalog
+    catalog.engine.dispose()
+
+
+@pytest.fixture(scope="function")
+def cow_history_table(local_catalog):
+    """Same COW history as tests/io/iceberg/test_iceberg_changelog_planning.py.
+
+    S1 (APPEND): file A = (1,a),(2,b),(3,c).
+    S2 (APPEND): file B = (4,d),(5,e).
+    S3 (COW delete "id = 1"): DELETE file A, INSERT file A' = (2,b),(3,c).
+    """
+    schema = Schema(
+        NestedField(field_id=1, name="id", field_type=LongType(), required=False),
+        NestedField(field_id=2, name="data", field_type=StringType(), required=False),
+    )
+    table = local_catalog.create_table("default.cow_history", schema=schema)
+    table.append(pa.table({"id": [1, 2, 3], "data": ["a", "b", "c"]}))
+    table.append(pa.table({"id": [4, 5], "data": ["d", "e"]}))
+    table.delete("id = 1")
+    table.refresh()
+    return table
+
+
+def _rows_by_commit(df: daft.DataFrame) -> dict[int, list[dict]]:
+    result: dict[int, list[dict]] = {}
+    for row in df.to_pylist():
+        result.setdefault(row["_commit_snapshot_id"], []).append(row)
+    return result
+
+
+def test_full_history_changelog_matches_expected_cdc_stream(cow_history_table):
+    s1, s2, s3 = (s.snapshot_id for s in cow_history_table.snapshots())
+
+    df = daft.io.iceberg.read_iceberg_changes(cow_history_table)
+    assert set(df.column_names) == {"id", "data", "_change_type", "_change_ordinal", "_commit_snapshot_id"}
+
+    by_commit = _rows_by_commit(df)
+
+    # S1: two carryover-free INSERTs.
+    assert {(r["id"], r["data"], r["_change_type"]) for r in by_commit[s1]} == {
+        (1, "a", "INSERT"),
+        (2, "b", "INSERT"),
+        (3, "c", "INSERT"),
+    }
+    assert all(r["_change_ordinal"] == 0 for r in by_commit[s1])
+
+    # S2: two carryover-free INSERTs.
+    assert {(r["id"], r["data"], r["_change_type"]) for r in by_commit[s2]} == {
+        (4, "d", "INSERT"),
+        (5, "e", "INSERT"),
+    }
+    assert all(r["_change_ordinal"] == 1 for r in by_commit[s2])
+
+    # S3: COW rewrite of file A carried (2,b) and (3,c) over unchanged (same commit,
+    # same content) -> cancelled by remove_carryovers. Only the real deletion of (1,a)
+    # survives.
+    assert by_commit[s3] == [
+        {"id": 1, "data": "a", "_change_type": "DELETE", "_change_ordinal": 2, "_commit_snapshot_id": s3}
+    ]
+
+
+def test_partial_range_excludes_earlier_snapshots(cow_history_table):
+    s1, s2, s3 = (s.snapshot_id for s in cow_history_table.snapshots())
+
+    # (s1, s3] should only include S2 and S3's changes, not S1's.
+    df = daft.io.iceberg.read_iceberg_changes(cow_history_table, start_snapshot_id=s1, end_snapshot_id=s3)
+    commits = {row["_commit_snapshot_id"] for row in df.to_pylist()}
+    assert commits == {s2, s3}
+
+
+def test_start_equals_end_returns_empty_changelog(cow_history_table):
+    s1 = cow_history_table.snapshots()[0].snapshot_id
+    df = daft.io.iceberg.read_iceberg_changes(cow_history_table, start_snapshot_id=s1, end_snapshot_id=s1)
+    assert df.to_pylist() == []
+
+
+def test_read_iceberg_changes_does_not_eagerly_trigger_io(cow_history_table, monkeypatch):
+    """Constructing the DataFrame must not run planning/footer I/O.
+
+    Only a later execution action (like to_pylist()/collect()) should trigger planning.
+    """
+    called = False
+    original = iceberg_changes_scan.IcebergChangesDataSource._get_or_plan_tasks
+
+    def spy(self):
+        nonlocal called
+        called = True
+        return original(self)
+
+    monkeypatch.setattr(iceberg_changes_scan.IcebergChangesDataSource, "_get_or_plan_tasks", spy)
+
+    df = daft.io.iceberg.read_iceberg_changes(cow_history_table)
+    assert called is False, "constructing the DataFrame must not trigger planning"
+    df.to_pylist()
+    assert called is True
+
+
+def test_mor_range_is_rejected(cow_history_table, monkeypatch):
+    # pyiceberg 0.11.1 can't produce a real MOR delete manifest (see
+    # test_iceberg_changelog_planning.py's equivalent test for why); patch the guard
+    # function directly to simulate one being present, and verify the NotImplementedError
+    # actually propagates through DataFrame execution end-to-end, not just from the
+    # planning function in isolation.
+    last_snapshot_id = cow_history_table.snapshots()[-1].snapshot_id
+    from daft.io.iceberg import _changelog_planning
+
+    original = _changelog_planning._snapshot_has_delete_manifest
+
+    def fake(snapshot, io):
+        if snapshot.snapshot_id == last_snapshot_id:
+            return True
+        return original(snapshot, io)
+
+    monkeypatch.setattr(_changelog_planning, "_snapshot_has_delete_manifest", fake)
+
+    df = daft.io.iceberg.read_iceberg_changes(cow_history_table)
+    with pytest.raises(Exception, match="copy-on-write"):
+        df.to_pylist()
+
+
+def test_reserved_column_name_collision_rejected(local_catalog):
+    schema = Schema(
+        NestedField(field_id=1, name="id", field_type=LongType(), required=False),
+        NestedField(field_id=2, name="_change_type", field_type=StringType(), required=False),
+    )
+    table = local_catalog.create_table("default.name_collision", schema=schema)
+    table.append(pa.table({"id": [1], "_change_type": ["x"]}))
+    table.refresh()
+
+    with pytest.raises(ValueError, match="reserved changelog metadata column names"):
+        daft.io.iceberg.read_iceberg_changes(table)
+
+
+def test_reserved_partition_field_name_in_range_is_rejected(local_catalog):
+    schema = Schema(
+        NestedField(field_id=1, name="id", field_type=LongType(), required=False),
+        NestedField(field_id=2, name="data", field_type=StringType(), required=False),
+    )
+    table = local_catalog.create_table("default.partition_name_collision", schema=schema)
+    with table.update_spec() as update:
+        update.add_field("data", "identity", partition_field_name="_change_type")
+    table.refresh()
+    table.append(pa.table({"id": [1], "data": ["a"]}))
+    table.refresh()
+
+    # The requested range includes the commit written under the colliding spec, so this
+    # must be rejected.
+    with pytest.raises(ValueError, match="reserved changelog metadata column names"):
+        daft.io.iceberg.read_iceberg_changes(table).to_pylist()
+
+
+def test_reserved_partition_field_name_outside_range_is_allowed(local_catalog):
+    """A stale colliding spec outside the requested range must not reject the scan.
+
+    A partition spec with a reserved-name collision that predates the requested range
+    (and whose data files the range never touches) must not reject an otherwise-valid scan.
+    The check is scoped to spec IDs referenced by this scan's planned tasks, not the
+    table's entire historical spec set.
+    """
+    schema = Schema(
+        NestedField(field_id=1, name="id", field_type=LongType(), required=False),
+        NestedField(field_id=2, name="data", field_type=StringType(), required=False),
+    )
+    table = local_catalog.create_table("default.partition_name_collision_excluded", schema=schema)
+
+    with table.update_spec() as update:
+        update.add_field("data", "identity", partition_field_name="_change_type")
+    table.refresh()
+    table.append(pa.table({"id": [1], "data": ["a"]}))
+    table.refresh()
+    s_old = table.current_snapshot().snapshot_id
+
+    with table.update_spec() as update:
+        update.remove_field("_change_type")
+    table.refresh()
+    table.append(pa.table({"id": [2], "data": ["b"]}))
+    table.refresh()
+    s_new = table.current_snapshot().snapshot_id
+
+    # (s_old, s_new] only includes the commit written under the clean (post-evolution)
+    # spec; the colliding spec_id is never referenced by any task in this range.
+    df = daft.io.iceberg.read_iceberg_changes(table, start_snapshot_id=s_old, end_snapshot_id=s_new)
+    rows = df.to_pylist()
+    assert [(r["id"], r["data"], r["_change_type"]) for r in rows] == [(2, "b", "INSERT")]
+
+
+def test_missing_data_file_raises_instead_of_silently_skipping(cow_history_table):
+    import os
+
+    # Find the DELETE task's data file (the original file A, no longer referenced by the
+    # current table state) and delete it from disk to simulate orphan-file cleanup /
+    # expiration having removed a file the changelog range still needs.
+    s3 = cow_history_table.snapshots()[-1]
+    deleted_path = None
+    for manifest in s3.manifests(cow_history_table.io):
+        if manifest.added_snapshot_id != s3.snapshot_id:
+            continue
+        for entry in manifest.fetch_manifest_entry(cow_history_table.io, discard_deleted=False):
+            if entry.status.name == "DELETED":
+                deleted_path = entry.data_file.file_path
+    assert deleted_path is not None
+
+    local_path = deleted_path.removeprefix("file://")
+    os.remove(local_path)
+
+    df = daft.io.iceberg.read_iceberg_changes(cow_history_table)
+    with pytest.raises(Exception, match="No such file|FileNotFound|not found"):
+        df.to_pylist()
+
+
+# --- Optimizer boundary: limit/count/select must reflect the post-carryover-removal
+# stream, not a raw pre-removal scan ---
+
+
+@pytest.fixture(scope="function")
+def heavy_carryover_table(local_catalog):
+    """A COW rewrite where most rows are pure carryover noise and only one is a real change.
+
+    If limit/count ever crossed the remove_carryovers window boundary, they would see the
+    raw (carryover-inflated) row count/order instead of the resolved one.
+    """
+    schema = Schema(
+        NestedField(field_id=1, name="id", field_type=LongType(), required=False),
+        NestedField(field_id=2, name="data", field_type=StringType(), required=False),
+    )
+    table = local_catalog.create_table("default.heavy_carryover", schema=schema)
+    ids = list(range(20))
+    table.append(pa.table({"id": ids, "data": [f"v{i}" for i in ids]}))
+    # Delete a single row -> COW rewrites the file, carrying the other 19 rows over
+    # unchanged (19 INSERT+DELETE carryover pairs = 38 raw rows) alongside 1 genuine DELETE.
+    table.delete("id = 0")
+    table.refresh()
+    return table
+
+
+def test_count_rows_reflects_post_carryover_result(heavy_carryover_table):
+    df = daft.io.iceberg.read_iceberg_changes(heavy_carryover_table)
+    # 20 genuine INSERTs (first snapshot) + 1 genuine DELETE (second snapshot, after 19
+    # carryover pairs cancel) = 21, never the raw 20 + 38 = 58.
+    assert df.count_rows() == 21
+
+
+def test_limit_after_read_returns_real_rows_not_uncancelled_carryover(heavy_carryover_table):
+    df = daft.io.iceberg.read_iceberg_changes(heavy_carryover_table)
+    deletes = df.where(df["_change_type"] == "DELETE").to_pylist()
+    # Exactly one DELETE must exist (id=0); if limit/filter had crossed the carryover
+    # window, some of the 19 cancelled carryover DELETEs could have leaked through.
+    assert len(deletes) == 1
+    assert deletes[0]["id"] == 0
+
+    limited = df.limit(1).to_pylist()
+    assert len(limited) == 1
+
+
+def test_select_after_read_preserves_carryover_correctness(heavy_carryover_table):
+    df = daft.io.iceberg.read_iceberg_changes(heavy_carryover_table)
+    projected = df.select("id", "_change_type").to_pylist()
+    assert len(projected) == 21
+    assert sum(1 for r in projected if r["_change_type"] == "DELETE") == 1
+
+
+def test_select_only_cdc_metadata_columns(cow_history_table):
+    df = daft.io.iceberg.read_iceberg_changes(cow_history_table)
+    projected = df.select("_change_type", "_change_ordinal", "_commit_snapshot_id")
+    assert set(projected.column_names) == {"_change_type", "_change_ordinal", "_commit_snapshot_id"}
+    assert len(projected.to_pylist()) == len(df.to_pylist())
+
+
+# --- Partition spec evolution (non-collision case): end-to-end read spanning two specs ---
+
+
+def test_changelog_spans_two_partition_specs(local_catalog):
+    schema = Schema(
+        NestedField(field_id=1, name="id", field_type=LongType(), required=False),
+        NestedField(field_id=2, name="data", field_type=StringType(), required=False),
+    )
+    table = local_catalog.create_table("default.spec_evolution_e2e", schema=schema)
+
+    # Spec 0: unpartitioned.
+    table.append(pa.table({"id": [1], "data": ["a"]}))
+    table.refresh()
+
+    # Evolve to an identity partition on `data`.
+    with table.update_spec() as update:
+        update.add_field("data", "identity", partition_field_name="data_partition")
+    table.refresh()
+
+    # Spec 1: identity-partitioned by data.
+    table.append(pa.table({"id": [2], "data": ["b"]}))
+    table.refresh()
+
+    df = daft.io.iceberg.read_iceberg_changes(table)
+    rows = sorted(df.to_pylist(), key=lambda r: r["id"])
+    assert [(r["id"], r["data"], r["_change_type"]) for r in rows] == [
+        (1, "a", "INSERT"),
+        (2, "b", "INSERT"),
+    ]
+
+
+def test_add_files_imported_data_file_appears_in_changelog(local_catalog, tmp_path):
+    """Imported files must be treated as regular ADDED entries subject to the schema gate.
+
+    Files imported via `table.add_files()` (bypassing the normal Iceberg writer) must
+    still be picked up as regular ADDED entries and pass the schema gate -- design's
+    file-level validation must not special-case or skip externally-imported files.
+    """
+    import pyarrow.parquet as pq
+    from pyiceberg.io.pyarrow import schema_to_pyarrow
+
+    schema = Schema(
+        NestedField(field_id=1, name="id", field_type=LongType(), required=False),
+        NestedField(field_id=2, name="data", field_type=StringType(), required=False),
+    )
+    table = local_catalog.create_table("default.add_files", schema=schema)
+
+    pa_schema = schema_to_pyarrow(schema)
+    external_path = tmp_path / "external.parquet"
+    pq.write_table(pa.table({"id": [9], "data": ["z"]}, schema=pa_schema), str(external_path))
+
+    table.add_files([f"file://{external_path}"])
+    table.refresh()
+
+    df = daft.io.iceberg.read_iceberg_changes(table)
+    rows = df.to_pylist()
+    assert [(r["id"], r["data"], r["_change_type"]) for r in rows] == [(9, "z", "INSERT")]


### PR DESCRIPTION
Split out from #7356 per @srilman's review — PR 1 of 4 in that split.

Adds `daft.io.iceberg.read_iceberg_changes()`: reads a copy-on-write Iceberg
snapshot range as an INSERT/DELETE changelog, with carryover rows removed.
MOR tables and multi-schema tables are rejected rather than approximated.

Now built on the `DataSource` API (`IcebergChangesDataSource`), per
@srilman's request on #7356, following the same pattern as #7311.

Follow-ups stacked on top: `compute_updates`, `net_changes`, schema evolution.

Closes discussion in #7325.

## Test plan
- [x] `DAFT_RUNNER=native make test EXTRA_ARGS="-v tests/io/iceberg/test_iceberg_changelog_datasource.py tests/io/iceberg/test_iceberg_changes.py tests/io/iceberg/test_iceberg_changelog_planning.py tests/io/iceberg/test_iceberg_changelog_schema.py tests/io/iceberg/test_iceberg_changelog_postprocess.py"` — all passing