### PR TITLE
refactor(shuffle): unify distributed shuffle backend config onto daft-local-plan ShuffleBackend

### DIFF
--- a/src/daft-distributed/src/pipeline_node/into_partitions.rs
+++ b/src/daft-distributed/src/pipeline_node/into_partitions.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use common_error::DaftResult;
 use common_metrics::ops::{NodeCategory, NodeType};
 use common_runtime::OrderedJoinSet;
-use daft_local_plan::{LocalNodeContext, LocalPhysicalPlan};
+use daft_local_plan::{LocalNodeContext, LocalPhysicalPlan, ShuffleBackend};
 use daft_logical_plan::stats::StatsState;
 use daft_schema::schema::SchemaRef;
 use futures::StreamExt;
@@ -12,8 +12,7 @@ use super::{PipelineNodeImpl, TaskBuilderStream, clustering::BoundClusteringSpec
 use crate::{
     pipeline_node::{
         ClusteringStrategy, DistributedPipelineNode, NodeID, PipelineNodeConfig,
-        PipelineNodeContext,
-        shuffles::backends::{DistributedShuffleBackend, ShuffleBackend},
+        PipelineNodeContext, shuffles::backends::ShuffleContext,
     },
     plan::{PlanConfig, PlanExecutionContext, TaskIDCounter},
     scheduling::{
@@ -28,7 +27,7 @@ pub(crate) struct IntoPartitionsNode {
     config: PipelineNodeConfig,
     context: PipelineNodeContext,
     num_partitions: usize,
-    shuffle_backend: ShuffleBackend,
+    shuffle_context: ShuffleContext,
     child: DistributedPipelineNode,
 }
 
@@ -40,7 +39,7 @@ impl IntoPartitionsNode {
         plan_config: &PlanConfig,
         num_partitions: usize,
         schema: SchemaRef,
-        backend: DistributedShuffleBackend,
+        backend: ShuffleBackend,
         child: DistributedPipelineNode,
     ) -> Self {
         let context = PipelineNodeContext::new(
@@ -56,13 +55,13 @@ impl IntoPartitionsNode {
             plan_config.config.clone(),
             ClusteringStrategy::Explicit(BoundClusteringSpec::unknown(num_partitions)),
         );
-        let shuffle_backend = ShuffleBackend::new(&context, schema, backend);
+        let shuffle_context = ShuffleContext::new(&context, schema, backend);
 
         Self {
             config,
             context,
             num_partitions,
-            shuffle_backend,
+            shuffle_context,
             child,
         }
     }
@@ -132,8 +131,8 @@ impl IntoPartitionsNode {
                 .collect::<Vec<_>>();
 
             let node_id = self.node_id();
-            let shuffle_backend = self.shuffle_backend.local_shuffle_backend();
-            let builder = self.shuffle_backend.build_refs_task_builder(
+            let shuffle_backend = self.shuffle_context.backend().clone();
+            let builder = self.shuffle_context.build_refs_task_builder(
                 partition_refs,
                 self.as_ref(),
                 move |input| {
@@ -190,7 +189,7 @@ impl IntoPartitionsNode {
                 LocalPhysicalPlan::into_partitions(
                     plan,
                     num_outputs,
-                    self.shuffle_backend.local_shuffle_backend(),
+                    self.shuffle_context.backend().clone(),
                     StatsState::NotMaterialized,
                     LocalNodeContext::new(Some(self.node_id() as usize)),
                 )
@@ -213,7 +212,7 @@ impl IntoPartitionsNode {
             if let Some(output) = materialized_outputs {
                 for output in output.split_into_materialized_outputs() {
                     let partition_refs = output.into_inner().0;
-                    let builder = self.shuffle_backend.build_refs_task_builder(
+                    let builder = self.shuffle_context.build_refs_task_builder(
                         partition_refs,
                         self.as_ref(),
                         |input| input,
@@ -252,7 +251,7 @@ impl IntoPartitionsNode {
                             LocalPhysicalPlan::into_partitions(
                                 plan,
                                 1,
-                                self.shuffle_backend.local_shuffle_backend(),
+                                self.shuffle_context.backend().clone(),
                                 StatsState::NotMaterialized,
                                 LocalNodeContext::new(Some(node_id as usize)),
                             )
@@ -304,10 +303,7 @@ impl PipelineNodeImpl for IntoPartitionsNode {
     }
 
     fn multiline_display(&self, _verbose: bool) -> Vec<String> {
-        let backend_name = match self.shuffle_backend.backend() {
-            DistributedShuffleBackend::Ray => "Ray",
-            DistributedShuffleBackend::Flight(_) => "Flight",
-        };
+        let backend_name = self.shuffle_context.backend().name();
         vec![
             format!("IntoPartitions({})", backend_name),
             format!("Num partitions = {}", self.num_partitions),
@@ -318,7 +314,7 @@ impl PipelineNodeImpl for IntoPartitionsNode {
         self: Arc<Self>,
         plan_context: &mut PlanExecutionContext,
     ) -> TaskBuilderStream {
-        self.shuffle_backend.register_cleanup(plan_context);
+        self.shuffle_context.register_cleanup(plan_context);
         let input_stream = self.child.clone().produce_tasks(plan_context);
         let (result_tx, result_rx) = create_channel(1);
 

--- a/src/daft-distributed/src/pipeline_node/random_shuffle.rs
+++ b/src/daft-distributed/src/pipeline_node/random_shuffle.rs
@@ -7,7 +7,7 @@ use common_error::DaftResult;
 use common_metrics::ops::{NodeCategory, NodeType};
 use daft_dsl::expr::bound_expr::BoundExpr;
 use daft_functions::random::random_int_expr;
-use daft_local_plan::{LocalNodeContext, LocalPhysicalPlan};
+use daft_local_plan::{LocalNodeContext, LocalPhysicalPlan, ShuffleBackend};
 use daft_logical_plan::{partitioning::RandomShuffleConfig, stats::StatsState};
 use daft_schema::schema::SchemaRef;
 
@@ -15,8 +15,7 @@ use super::{PipelineNodeImpl, TaskBuilderStream};
 use crate::{
     pipeline_node::{
         ClusteringStrategy, DistributedPipelineNode, MaterializedOutput, NodeID,
-        PipelineNodeConfig, PipelineNodeContext,
-        shuffles::backends::{DistributedShuffleBackend, ShuffleBackend},
+        PipelineNodeConfig, PipelineNodeContext, shuffles::backends::ShuffleContext,
     },
     plan::{PlanConfig, PlanExecutionContext, TaskIDCounter},
     scheduling::{
@@ -33,7 +32,7 @@ pub(crate) struct RandomShuffleNode {
     config: PipelineNodeConfig,
     context: PipelineNodeContext,
     seed: Option<u64>,
-    shuffle_backend: ShuffleBackend,
+    shuffle_context: ShuffleContext,
     child: DistributedPipelineNode,
 }
 
@@ -45,7 +44,7 @@ impl RandomShuffleNode {
         plan_config: &PlanConfig,
         seed: Option<u64>,
         output_schema: SchemaRef,
-        backend: DistributedShuffleBackend,
+        backend: ShuffleBackend,
         child: DistributedPipelineNode,
     ) -> Self {
         let context = PipelineNodeContext::new(
@@ -62,12 +61,12 @@ impl RandomShuffleNode {
             plan_config.config.clone(),
             ClusteringStrategy::Passthrough { child: &child },
         );
-        let shuffle_backend = ShuffleBackend::new(&context, output_schema, backend);
+        let shuffle_context = ShuffleContext::new(&context, output_schema, backend);
         Self {
             config,
             context,
             seed,
-            shuffle_backend,
+            shuffle_context,
             child,
         }
     }
@@ -95,7 +94,7 @@ impl RandomShuffleNode {
         )?;
         let node_id = self.node_id();
         Ok(self
-            .shuffle_backend
+            .shuffle_context
             .build_refs_task_builder(partition_refs, self, |input| {
                 LocalPhysicalPlan::sort(
                     input,
@@ -147,10 +146,7 @@ impl PipelineNodeImpl for RandomShuffleNode {
     }
 
     fn multiline_display(&self, _verbose: bool) -> Vec<String> {
-        let backend_name = match self.shuffle_backend.backend() {
-            DistributedShuffleBackend::Ray => "Ray",
-            DistributedShuffleBackend::Flight(_) => "Flight",
-        };
+        let backend_name = self.shuffle_context.backend().name();
         vec![
             format!(
                 "RandomShuffle({}): random row order (via random repartition + random_int + sort)",
@@ -165,20 +161,20 @@ impl PipelineNodeImpl for RandomShuffleNode {
         plan_context: &mut PlanExecutionContext,
     ) -> TaskBuilderStream {
         let input_node = self.child.clone().produce_tasks(plan_context);
-        self.shuffle_backend.register_cleanup(plan_context);
+        self.shuffle_context.register_cleanup(plan_context);
 
         let num_partitions = self.child.config().clustering_spec.num_partitions();
         let node_id = self.node_id();
         let schema = self.config.schema.clone();
         let seed = self.seed;
-        let local_shuffle_backend = self.shuffle_backend.local_shuffle_backend();
+        let shuffle_backend = self.shuffle_context.backend().clone();
 
         let partitioned_input = input_node.pipeline_instruction(self.clone(), move |input| {
             LocalPhysicalPlan::repartition_write(
                 input,
                 num_partitions,
                 schema.clone(),
-                local_shuffle_backend.clone(),
+                shuffle_backend.clone(),
                 daft_logical_plan::partitioning::RepartitionSpec::Random(
                     RandomShuffleConfig::new_with_seed(Some(num_partitions), seed),
                 ),

--- a/src/daft-distributed/src/pipeline_node/shuffles/backends/flight.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/backends/flight.rs
@@ -17,21 +17,14 @@ use crate::{
     utils::channel::Sender,
 };
 
-#[derive(Clone, Default)]
-pub(crate) struct FlightShuffleBackendConfig {
-    pub(crate) shuffle_id: u64,
-    pub(crate) shuffle_dirs: Vec<String>,
-    pub(crate) compression: Option<String>,
-}
-
 pub(crate) fn register_cleanup(
-    backend: &FlightShuffleBackendConfig,
+    shuffle_id: u64,
+    shuffle_dirs: &[String],
     plan_context: &mut PlanExecutionContext,
 ) {
-    let shuffle_dirs_to_register: Vec<String> = backend
-        .shuffle_dirs
+    let shuffle_dirs_to_register: Vec<String> = shuffle_dirs
         .iter()
-        .map(|base_dir| format!("{}/daft_shuffle/{}", base_dir, backend.shuffle_id))
+        .map(|base_dir| format!("{}/daft_shuffle/{}", base_dir, shuffle_id))
         .collect();
     plan_context.register_shuffle_dirs(shuffle_dirs_to_register);
 }

--- a/src/daft-distributed/src/pipeline_node/shuffles/backends/mod.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/backends/mod.rs
@@ -1,8 +1,7 @@
 use common_error::DaftResult;
 use common_partitioning::PartitionRef;
 use daft_local_plan::{
-    LocalNodeContext, LocalPhysicalPlan, LocalPhysicalPlanRef,
-    ShuffleBackend as LocalShuffleBackend, ShuffleReadBackend,
+    LocalNodeContext, LocalPhysicalPlan, LocalPhysicalPlanRef, ShuffleBackend, ShuffleReadBackend,
 };
 use daft_logical_plan::stats::StatsState;
 use daft_schema::schema::SchemaRef;
@@ -17,48 +16,44 @@ use crate::{
 mod flight;
 mod ray;
 
-pub(crate) use flight::FlightShuffleBackendConfig;
-
 fn make_shuffle_id(context: &PipelineNodeContext) -> u64 {
     ((context.query_idx as u64) << 32) | (context.node_id as u64)
 }
 
+/// A shuffle node's resolved backend: the plan-level [`ShuffleBackend`] with this
+/// node's `shuffle_id` stamped in, plus the node handles task building needs.
 #[derive(Clone)]
-pub(crate) enum DistributedShuffleBackend {
-    Ray,
-    Flight(FlightShuffleBackendConfig),
-}
-
-#[derive(Clone)]
-pub(crate) struct ShuffleBackend {
-    backend: DistributedShuffleBackend,
+pub(crate) struct ShuffleContext {
+    backend: ShuffleBackend,
     schema: SchemaRef,
     node_id: NodeID,
 }
 
-impl ShuffleBackend {
+impl ShuffleContext {
     pub(crate) fn new(
         context: &PipelineNodeContext,
         schema: SchemaRef,
-        backend: DistributedShuffleBackend,
+        backend: ShuffleBackend,
     ) -> Self {
         Self {
             schema,
             node_id: context.node_id,
             backend: match backend {
-                DistributedShuffleBackend::Ray => DistributedShuffleBackend::Ray,
-                DistributedShuffleBackend::Flight(backend) => {
-                    DistributedShuffleBackend::Flight(FlightShuffleBackendConfig {
-                        shuffle_id: make_shuffle_id(context),
-                        shuffle_dirs: backend.shuffle_dirs,
-                        compression: backend.compression,
-                    })
-                }
+                ShuffleBackend::Ray => ShuffleBackend::Ray,
+                ShuffleBackend::Flight {
+                    shuffle_dirs,
+                    compression,
+                    ..
+                } => ShuffleBackend::Flight {
+                    shuffle_id: make_shuffle_id(context),
+                    shuffle_dirs,
+                    compression,
+                },
             },
         }
     }
 
-    pub(crate) fn backend(&self) -> &DistributedShuffleBackend {
+    pub(crate) fn backend(&self) -> &ShuffleBackend {
         &self.backend
     }
 
@@ -72,24 +67,14 @@ impl ShuffleBackend {
 
     pub(crate) fn register_cleanup(&self, plan_context: &mut PlanExecutionContext) {
         match &self.backend {
-            DistributedShuffleBackend::Ray => {}
-            DistributedShuffleBackend::Flight(backend) => {
-                flight::register_cleanup(backend, plan_context);
+            ShuffleBackend::Ray => {}
+            ShuffleBackend::Flight {
+                shuffle_id,
+                shuffle_dirs,
+                ..
+            } => {
+                flight::register_cleanup(*shuffle_id, shuffle_dirs, plan_context);
             }
-        }
-    }
-
-    /// The local-plan `ShuffleBackend` matching this distributed shuffle
-    /// backend, for use when building local ops like `IntoPartitions`,
-    /// `GatherWrite`, or `RepartitionWrite`.
-    pub(crate) fn local_shuffle_backend(&self) -> LocalShuffleBackend {
-        match self.backend.clone() {
-            DistributedShuffleBackend::Ray => LocalShuffleBackend::Ray,
-            DistributedShuffleBackend::Flight(cfg) => LocalShuffleBackend::Flight {
-                shuffle_id: cfg.shuffle_id,
-                shuffle_dirs: cfg.shuffle_dirs,
-                compression: cfg.compression,
-            },
         }
     }
 
@@ -109,7 +94,7 @@ impl ShuffleBackend {
     {
         let node_id = self.node_id;
         match &self.backend {
-            DistributedShuffleBackend::Ray => {
+            ShuffleBackend::Ray => {
                 let total_size_bytes = partition_refs.iter().map(|p| p.size_bytes()).sum::<usize>();
                 let in_memory_scan = LocalPhysicalPlan::in_memory_scan(
                     node_id,
@@ -121,7 +106,7 @@ impl ShuffleBackend {
                 let plan = wrap_plan(in_memory_scan);
                 SwordfishTaskBuilder::new(plan, node, node_id).with_psets(node_id, partition_refs)
             }
-            DistributedShuffleBackend::Flight(_) => {
+            ShuffleBackend::Flight { .. } => {
                 let read_inputs = flight::read_inputs_from_refs(partition_refs);
                 let shuffle_read = LocalPhysicalPlan::shuffle_read(
                     node_id,
@@ -151,7 +136,7 @@ impl ShuffleBackend {
         result_tx: Sender<SwordfishTaskBuilder>,
     ) -> DaftResult<()> {
         match &self.backend {
-            DistributedShuffleBackend::Ray => {
+            ShuffleBackend::Ray => {
                 let partition_groups =
                     crate::utils::transpose::transpose_materialized_outputs_from_stream(
                         materialized_stream,
@@ -167,11 +152,11 @@ impl ShuffleBackend {
                 )
                 .await
             }
-            DistributedShuffleBackend::Flight(cfg) => {
+            ShuffleBackend::Flight { shuffle_id, .. } => {
                 let read_inputs = flight::fold_outputs_from_stream(
                     materialized_stream,
                     num_partitions,
-                    cfg.shuffle_id,
+                    *shuffle_id,
                 )
                 .await?;
                 flight::emit_read_tasks(

--- a/src/daft-distributed/src/pipeline_node/shuffles/gather.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/gather.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use common_error::DaftResult;
 use common_metrics::ops::{NodeCategory, NodeType};
-use daft_local_plan::{LocalNodeContext, LocalPhysicalPlan};
+use daft_local_plan::{LocalNodeContext, LocalPhysicalPlan, ShuffleBackend};
 use daft_logical_plan::stats::StatsState;
 use daft_schema::schema::SchemaRef;
 use futures::TryStreamExt;
@@ -11,8 +11,7 @@ use crate::{
     pipeline_node::{
         ClusteringStrategy, DistributedPipelineNode, MaterializedOutput, NodeID,
         PipelineNodeConfig, PipelineNodeContext, PipelineNodeImpl, TaskBuilderStream,
-        clustering::BoundClusteringSpec,
-        shuffles::backends::{DistributedShuffleBackend, ShuffleBackend},
+        clustering::BoundClusteringSpec, shuffles::backends::ShuffleContext,
     },
     plan::{PlanConfig, PlanExecutionContext, TaskIDCounter},
     scheduling::{
@@ -25,7 +24,7 @@ use crate::{
 pub(crate) struct GatherNode {
     config: PipelineNodeConfig,
     context: PipelineNodeContext,
-    shuffle_backend: ShuffleBackend,
+    shuffle_context: ShuffleContext,
     child: DistributedPipelineNode,
 }
 
@@ -36,7 +35,7 @@ impl GatherNode {
         node_id: NodeID,
         plan_config: &PlanConfig,
         schema: SchemaRef,
-        backend: DistributedShuffleBackend,
+        backend: ShuffleBackend,
         child: DistributedPipelineNode,
     ) -> Self {
         let context = PipelineNodeContext::new(
@@ -52,11 +51,11 @@ impl GatherNode {
             plan_config.config.clone(),
             ClusteringStrategy::Explicit(BoundClusteringSpec::unknown(1)),
         );
-        let shuffle_backend = ShuffleBackend::new(&context, schema, backend);
+        let shuffle_context = ShuffleContext::new(&context, schema, backend);
         Self {
             config,
             context,
-            shuffle_backend,
+            shuffle_context,
             child,
         }
     }
@@ -84,7 +83,7 @@ impl GatherNode {
             .flat_map(|output| output.into_inner().0)
             .collect();
         let task = self
-            .shuffle_backend
+            .shuffle_context
             .build_refs_task_builder(refs, self.as_ref(), |plan| plan);
         let _ = result_tx.send(task).await;
         Ok(())
@@ -105,11 +104,7 @@ impl PipelineNodeImpl for GatherNode {
     }
 
     fn multiline_display(&self, _verbose: bool) -> Vec<String> {
-        let backend_name = match self.shuffle_backend.backend() {
-            DistributedShuffleBackend::Ray => "RayGather",
-            DistributedShuffleBackend::Flight(_) => "FlightGather",
-        };
-        vec![backend_name.to_string()]
+        vec![format!("{}Gather", self.shuffle_context.backend().name())]
     }
 
     fn produce_tasks(
@@ -117,16 +112,16 @@ impl PipelineNodeImpl for GatherNode {
         plan_context: &mut PlanExecutionContext,
     ) -> TaskBuilderStream {
         let input_node = self.child.clone().produce_tasks(plan_context);
-        self.shuffle_backend.register_cleanup(plan_context);
+        self.shuffle_context.register_cleanup(plan_context);
 
-        let schema = self.shuffle_backend.schema().clone();
-        let node_id = self.shuffle_backend.node_id();
-        let local_shuffle_backend = self.shuffle_backend.local_shuffle_backend();
+        let schema = self.shuffle_context.schema().clone();
+        let node_id = self.shuffle_context.node_id();
+        let shuffle_backend = self.shuffle_context.backend().clone();
         let local_gather_write_node = input_node.pipeline_instruction(self.clone(), move |input| {
             LocalPhysicalPlan::gather_write(
                 input,
                 schema.clone(),
-                local_shuffle_backend.clone(),
+                shuffle_backend.clone(),
                 StatsState::NotMaterialized,
                 LocalNodeContext::new(Some(node_id as usize)),
             )

--- a/src/daft-distributed/src/pipeline_node/shuffles/repartition.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/repartition.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use common_error::DaftResult;
 use common_metrics::ops::{NodeCategory, NodeType};
-use daft_local_plan::{LocalNodeContext, LocalPhysicalPlan};
+use daft_local_plan::{LocalNodeContext, LocalPhysicalPlan, ShuffleBackend};
 use daft_logical_plan::{partitioning::RepartitionSpec, stats::StatsState};
 use daft_schema::schema::SchemaRef;
 
@@ -10,8 +10,7 @@ use crate::{
     pipeline_node::{
         ClusteringStrategy, DistributedPipelineNode, NodeID, PipelineNodeConfig,
         PipelineNodeContext, PipelineNodeImpl, TaskBuilderStream,
-        clustering::clustering_from_repartition_spec,
-        shuffles::backends::{DistributedShuffleBackend, ShuffleBackend},
+        clustering::clustering_from_repartition_spec, shuffles::backends::ShuffleContext,
     },
     plan::{PlanConfig, PlanExecutionContext, TaskIDCounter},
     scheduling::{
@@ -25,7 +24,7 @@ pub(crate) struct RepartitionNode {
     config: PipelineNodeConfig,
     context: PipelineNodeContext,
     repartition_spec: RepartitionSpec,
-    shuffle_backend: ShuffleBackend,
+    shuffle_context: ShuffleContext,
     num_partitions: usize,
     child: DistributedPipelineNode,
 }
@@ -40,7 +39,7 @@ impl RepartitionNode {
         repartition_spec: RepartitionSpec,
         schema: SchemaRef,
         num_partitions: usize,
-        backend: DistributedShuffleBackend,
+        backend: ShuffleBackend,
         child: DistributedPipelineNode,
     ) -> DaftResult<Self> {
         let context = PipelineNodeContext::new(
@@ -68,7 +67,7 @@ impl RepartitionNode {
             config,
             context: context.clone(),
             repartition_spec,
-            shuffle_backend: ShuffleBackend::new(&context, schema, backend),
+            shuffle_context: ShuffleContext::new(&context, schema, backend),
             num_partitions,
             child,
         })
@@ -87,7 +86,7 @@ impl RepartitionNode {
             task_id_counter,
         );
 
-        self.shuffle_backend
+        self.shuffle_context
             .emit_read_tasks_from_stream(outputs, self.num_partitions, self.as_ref(), result_tx)
             .await
     }
@@ -112,11 +111,11 @@ impl PipelineNodeImpl for RepartitionNode {
     ) -> TaskBuilderStream {
         let input_node = self.child.clone().produce_tasks(plan_context);
         let self_arc = self.clone();
-        self.shuffle_backend.register_cleanup(plan_context);
+        self.shuffle_context.register_cleanup(plan_context);
 
-        let schema = self.shuffle_backend.schema().clone();
-        let node_id = self.shuffle_backend.node_id();
-        let local_shuffle_backend = self.shuffle_backend.local_shuffle_backend();
+        let schema = self.shuffle_context.schema().clone();
+        let node_id = self.shuffle_context.node_id();
+        let shuffle_backend = self.shuffle_context.backend().clone();
         let num_partitions = self.num_partitions;
         let repartition_spec = self.repartition_spec.clone();
         let local_shuffle_write_node =
@@ -125,7 +124,7 @@ impl PipelineNodeImpl for RepartitionNode {
                     input,
                     num_partitions,
                     schema.clone(),
-                    local_shuffle_backend.clone(),
+                    shuffle_backend.clone(),
                     repartition_spec.clone(),
                     StatsState::NotMaterialized,
                     LocalNodeContext::new(Some(node_id as usize)),
@@ -153,10 +152,7 @@ impl PipelineNodeImpl for RepartitionNode {
     }
 
     fn multiline_display(&self, _verbose: bool) -> Vec<String> {
-        let backend_name = match self.shuffle_backend.backend() {
-            DistributedShuffleBackend::Ray => "RayShuffle",
-            DistributedShuffleBackend::Flight(_) => "FlightShuffle",
-        };
+        let backend_name = format!("{}Shuffle", self.shuffle_context.backend().name());
         let mut res = vec![format!(
             "{backend_name}: {}",
             self.repartition_spec.var_name()

--- a/src/daft-distributed/src/pipeline_node/shuffles/translate_shuffle.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/translate_shuffle.rs
@@ -2,16 +2,14 @@ use std::sync::Arc;
 
 use common_display::utils::bytes_to_human_readable;
 use common_error::DaftResult;
+use daft_local_plan::ShuffleBackend;
 use daft_logical_plan::partitioning::RepartitionSpec;
 use daft_schema::schema::SchemaRef;
 
 use crate::pipeline_node::{
     DistributedPipelineNode,
     shuffles::{
-        backends::{DistributedShuffleBackend, FlightShuffleBackendConfig},
-        gather::GatherNode,
-        pre_shuffle_merge::PreShuffleMergeNode,
-        repartition::RepartitionNode,
+        gather::GatherNode, pre_shuffle_merge::PreShuffleMergeNode, repartition::RepartitionNode,
     },
     translate::LogicalPlanToPipelineNodeTranslator,
 };
@@ -23,15 +21,16 @@ const PARTITION_SLOT_HEAD_MEMORY_BYTES: usize = 3 * 1024;
 
 impl LogicalPlanToPipelineNodeTranslator {
     /// Pick the shuffle backend implied by the current execution config.
-    pub(crate) fn select_backend(&self) -> DistributedShuffleBackend {
+    pub(crate) fn select_backend(&self) -> ShuffleBackend {
         if self.plan_config.config.shuffle_algorithm.as_str() == "flight_shuffle" {
-            DistributedShuffleBackend::Flight(FlightShuffleBackendConfig {
+            ShuffleBackend::Flight {
+                // Placeholder; each shuffle node stamps its own id in `ShuffleContext::new`.
+                shuffle_id: 0,
                 shuffle_dirs: self.plan_config.config.flight_shuffle_dirs.clone(),
                 compression: self.plan_config.config.flight_shuffle_compression.clone(),
-                ..Default::default()
-            })
+            }
         } else {
-            DistributedShuffleBackend::Ray
+            ShuffleBackend::Ray
         }
     }
 
@@ -57,7 +56,7 @@ impl LogicalPlanToPipelineNodeTranslator {
         repartition_spec: RepartitionSpec,
         schema: SchemaRef,
         child: DistributedPipelineNode,
-        backend: DistributedShuffleBackend,
+        backend: ShuffleBackend,
         input_size_bytes: usize,
     ) -> DaftResult<DistributedPipelineNode> {
         let input_num_partitions = child.config().clustering_spec.num_partitions();
@@ -163,12 +162,12 @@ impl LogicalPlanToPipelineNodeTranslator {
     /// would cause Ray object-store / head-node memory pressure. Skipped on flight_shuffle.
     pub(crate) fn maybe_warn_large_shuffle(
         &mut self,
-        backend: &DistributedShuffleBackend,
+        backend: &ShuffleBackend,
         input_size_bytes: usize,
         input_num_partitions: usize,
         output_num_partitions: usize,
     ) {
-        if matches!(backend, DistributedShuffleBackend::Flight(_)) {
+        if matches!(backend, ShuffleBackend::Flight { .. }) {
             return;
         }
 

--- a/src/daft-local-plan/src/plan.rs
+++ b/src/daft-local-plan/src/plan.rs
@@ -2427,6 +2427,15 @@ pub enum ShuffleBackend {
     },
 }
 
+impl ShuffleBackend {
+    pub fn name(&self) -> &'static str {
+        match self {
+            Self::Ray => "Ray",
+            Self::Flight { .. } => "Flight",
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize)]
 #[cfg_attr(debug_assertions, derive(Debug))]
 pub struct VLLMProject {


### PR DESCRIPTION
## Summary

Removes the duplicated shuffle backend config types in the distributed runner and uses `daft_local_plan::ShuffleBackend` as the single config enum for shuffle backend selection across distributed and local execution. Follows up on the reviewer suggestion in #7221 to share the `ShuffleBackend` enum between the two engines.

## Why

`DistributedShuffleBackend` and `FlightShuffleBackendConfig` in `daft-distributed` were field-for-field duplicates of the plan-level `ShuffleBackend` enum in `daft-local-plan`, bridged by a hand-written `local_shuffle_backend()` conversion called at 6 sites. `daft-distributed` already depends on `daft-local-plan`, so the plan enum can serve both engines directly with no new crate edges. Suggested by @srilman in review of #7221; part of the phase 2 shuffle cleanup in #6472.

## Changes Made

- Deleted `DistributedShuffleBackend` and `FlightShuffleBackendConfig` from `pipeline_node/shuffles/backends`
- Renamed the per-node wrapper struct `ShuffleBackend` to `ShuffleContext` so the name `ShuffleBackend` refers to the plan-level enum everywhere (matching `sort.rs`, which already imports it directly)
- `ShuffleContext::new` still stamps the per-node `shuffle_id` via `make_shuffle_id`; `select_backend()` now builds `ShuffleBackend::Flight` with a placeholder `shuffle_id: 0` that each node overwrites
- Deleted the `local_shuffle_backend()` bridge; call sites pass `backend().clone()` into the local plan builders
- `flight::register_cleanup` now takes `shuffle_id` and `shuffle_dirs` directly instead of the deleted config struct
- Added `ShuffleBackend::name()` in `daft-local-plan`, replacing four hand-rolled display matches in `gather.rs`, `repartition.rs`, `random_shuffle.rs`, and `into_partitions.rs`

## Behavior

Functionally equivalent for all inputs. The enum swap is config plumbing only: backend selection, shuffle id stamping, task building, and cleanup registration are unchanged. Explain output is unchanged (`name()` produces the same strings as the removed match blocks).

## Test Plan

- `cargo check -p daft-distributed -p daft-local-plan` clean
- `cargo check -p daft-distributed --features python` clean (the CI configuration)
- `cargo fmt -p daft-distributed -p daft-local-plan` clean
- `cargo clippy -p daft-distributed -p daft-local-plan --lib --no-deps` clean, no warnings in touched files
- No behavior change; the existing shuffle suite (`tests/dataframe/test_shuffles.py`) covers both backends

## Related Issues

Part of #6472. Follow-up to #7221 and #7275.
