### PR TITLE
refactor(shuffle): migrate random shuffle reads onto shared read-task emission

### DIFF
--- a/src/daft-distributed/src/pipeline_node/random_shuffle.rs
+++ b/src/daft-distributed/src/pipeline_node/random_shuffle.rs
@@ -14,18 +14,15 @@ use daft_schema::schema::SchemaRef;
 use super::{PipelineNodeImpl, TaskBuilderStream};
 use crate::{
     pipeline_node::{
-        ClusteringStrategy, DistributedPipelineNode, MaterializedOutput, NodeID,
-        PipelineNodeConfig, PipelineNodeContext, shuffles::backends::ShuffleContext,
+        ClusteringStrategy, DistributedPipelineNode, NodeID, PipelineNodeConfig,
+        PipelineNodeContext, shuffles::backends::ShuffleContext,
     },
     plan::{PlanConfig, PlanExecutionContext, TaskIDCounter},
     scheduling::{
         scheduler::SchedulerHandle,
         task::{SwordfishTask, SwordfishTaskBuilder},
     },
-    utils::{
-        channel::{Sender, create_channel},
-        transpose::transpose_materialized_outputs_from_stream,
-    },
+    utils::channel::{Sender, create_channel},
 };
 
 pub(crate) struct RandomShuffleNode {
@@ -71,42 +68,6 @@ impl RandomShuffleNode {
         }
     }
 
-    fn local_sort_with_random_key(
-        &self,
-        partition_group: Vec<MaterializedOutput>,
-        partition_idx: usize,
-    ) -> DaftResult<SwordfishTaskBuilder> {
-        let partition_refs = partition_group
-            .into_iter()
-            .flat_map(|output| output.into_inner().0)
-            .collect::<Vec<_>>();
-
-        let partition_seed = self.seed.map(|s| {
-            let mut hasher = DefaultHasher::new();
-            s.hash(&mut hasher);
-            partition_idx.hash(&mut hasher);
-            hasher.finish()
-        });
-
-        let sort_by = BoundExpr::bind_all(
-            &[random_int_expr(i64::MIN, i64::MAX, partition_seed)],
-            &self.config.schema,
-        )?;
-        let node_id = self.node_id();
-        Ok(self
-            .shuffle_context
-            .build_refs_task_builder(partition_refs, self, |input| {
-                LocalPhysicalPlan::sort(
-                    input,
-                    sort_by,
-                    vec![false],
-                    vec![false],
-                    StatsState::NotMaterialized,
-                    LocalNodeContext::new(Some(node_id as usize)),
-                )
-            }))
-    }
-
     async fn execution_loop(
         self: Arc<Self>,
         input_node: TaskBuilderStream,
@@ -121,14 +82,37 @@ impl RandomShuffleNode {
             task_id_counter.clone(),
         );
 
-        let partition_groups =
-            transpose_materialized_outputs_from_stream(outputs, num_partitions).await?;
-
-        for (partition_idx, partition_group) in partition_groups.into_iter().enumerate() {
-            let task = self.local_sort_with_random_key(partition_group, partition_idx)?;
-            let _ = result_tx.send(task).await;
-        }
-        Ok(())
+        let seed = self.seed;
+        let schema = self.config.schema.clone();
+        let node_id = self.node_id();
+        self.shuffle_context
+            .emit_read_tasks_from_stream(
+                outputs,
+                num_partitions,
+                self.as_ref(),
+                result_tx,
+                &mut |partition_idx, input| {
+                    let partition_seed = seed.map(|s| {
+                        let mut hasher = DefaultHasher::new();
+                        s.hash(&mut hasher);
+                        partition_idx.hash(&mut hasher);
+                        hasher.finish()
+                    });
+                    let sort_by = BoundExpr::bind_all(
+                        &[random_int_expr(i64::MIN, i64::MAX, partition_seed)],
+                        &schema,
+                    )?;
+                    Ok(LocalPhysicalPlan::sort(
+                        input,
+                        sort_by,
+                        vec![false],
+                        vec![false],
+                        StatsState::NotMaterialized,
+                        LocalNodeContext::new(Some(node_id as usize)),
+                    ))
+                },
+            )
+            .await
     }
 }
 

--- a/src/daft-distributed/src/pipeline_node/shuffles/backends/flight.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/backends/flight.rs
@@ -3,7 +3,8 @@ use std::{collections::BTreeMap, sync::Arc};
 use common_error::DaftResult;
 use common_partitioning::PartitionRef;
 use daft_local_plan::{
-    FlightShuffleReadInput, LocalNodeContext, LocalPhysicalPlan, ShuffleReadBackend,
+    FlightShuffleReadInput, LocalNodeContext, LocalPhysicalPlan, LocalPhysicalPlanRef,
+    ShuffleReadBackend,
 };
 use daft_logical_plan::stats::StatsState;
 use daft_partition_refs::FlightPartitionRef;
@@ -121,6 +122,9 @@ pub(crate) async fn emit_read_tasks(
     read_inputs: Vec<FlightShuffleReadInput>,
     node: &dyn PipelineNodeImpl,
     result_tx: Sender<SwordfishTaskBuilder>,
+    wrap_plan: &mut (
+             dyn FnMut(usize, LocalPhysicalPlanRef) -> DaftResult<LocalPhysicalPlanRef> + Send
+         ),
 ) -> DaftResult<()> {
     for read_input in read_inputs {
         // Fresh plan per task: `SwordfishTaskBuilder::build` mutates the plan in
@@ -132,7 +136,9 @@ pub(crate) async fn emit_read_tasks(
             StatsState::NotMaterialized,
             LocalNodeContext::new(Some(node_id as usize)),
         );
-        let task = SwordfishTaskBuilder::new(shuffle_read_plan, node, node_id)
+        let partition_idx = read_input.partition_idx as usize;
+        let plan = wrap_plan(partition_idx, shuffle_read_plan)?;
+        let task = SwordfishTaskBuilder::new(plan, node, node_id)
             .with_flight_shuffle_reads(node_id, vec![read_input]);
 
         let _ = result_tx.send(task).await;

--- a/src/daft-distributed/src/pipeline_node/shuffles/backends/mod.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/backends/mod.rs
@@ -122,7 +122,8 @@ impl ShuffleContext {
         }
     }
 
-    /// Group a stream of map-task outputs into per-partition read tasks.
+    /// Group a stream of map-task outputs into per-partition read tasks, applying
+    /// `wrap_plan(partition_idx, read_plan)` on top of each partition's read plan.
     ///
     /// The Ray backend transposes the full (tasks x partitions) matrix of object refs.
     /// The flight backend folds the stream into per-server map-input lists shared by
@@ -134,6 +135,9 @@ impl ShuffleContext {
         num_partitions: usize,
         node: &dyn PipelineNodeImpl,
         result_tx: Sender<SwordfishTaskBuilder>,
+        wrap_plan: &mut (
+                 dyn FnMut(usize, LocalPhysicalPlanRef) -> DaftResult<LocalPhysicalPlanRef> + Send
+             ),
     ) -> DaftResult<()> {
         match &self.backend {
             ShuffleBackend::Ray => {
@@ -149,6 +153,7 @@ impl ShuffleContext {
                     partition_groups,
                     node,
                     result_tx,
+                    wrap_plan,
                 )
                 .await
             }
@@ -165,6 +170,7 @@ impl ShuffleContext {
                     read_inputs,
                     node,
                     result_tx,
+                    wrap_plan,
                 )
                 .await
             }

--- a/src/daft-distributed/src/pipeline_node/shuffles/backends/ray.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/backends/ray.rs
@@ -1,5 +1,7 @@
 use common_error::DaftResult;
-use daft_local_plan::{LocalNodeContext, LocalPhysicalPlan, ShuffleReadBackend};
+use daft_local_plan::{
+    LocalNodeContext, LocalPhysicalPlan, LocalPhysicalPlanRef, ShuffleReadBackend,
+};
 use daft_logical_plan::stats::StatsState;
 use daft_schema::schema::SchemaRef;
 
@@ -15,8 +17,11 @@ pub(crate) async fn emit_read_tasks(
     partition_groups: Vec<Vec<MaterializedOutput>>,
     node: &dyn PipelineNodeImpl,
     result_tx: Sender<SwordfishTaskBuilder>,
+    wrap_plan: &mut (
+             dyn FnMut(usize, LocalPhysicalPlanRef) -> DaftResult<LocalPhysicalPlanRef> + Send
+         ),
 ) -> DaftResult<()> {
-    for partition_group in partition_groups {
+    for (partition_idx, partition_group) in partition_groups.into_iter().enumerate() {
         let psets = partition_group
             .into_iter()
             .flat_map(|output| output.into_inner().0)
@@ -29,9 +34,9 @@ pub(crate) async fn emit_read_tasks(
             StatsState::NotMaterialized,
             LocalNodeContext::new(Some(node_id as usize)),
         );
+        let plan = wrap_plan(partition_idx, shuffle_read)?;
 
-        let builder =
-            SwordfishTaskBuilder::new(shuffle_read, node, node_id).with_psets(node_id, psets);
+        let builder = SwordfishTaskBuilder::new(plan, node, node_id).with_psets(node_id, psets);
 
         let _ = result_tx.send(builder).await;
     }

--- a/src/daft-distributed/src/pipeline_node/shuffles/repartition.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/repartition.rs
@@ -87,7 +87,13 @@ impl RepartitionNode {
         );
 
         self.shuffle_context
-            .emit_read_tasks_from_stream(outputs, self.num_partitions, self.as_ref(), result_tx)
+            .emit_read_tasks_from_stream(
+                outputs,
+                self.num_partitions,
+                self.as_ref(),
+                result_tx,
+                &mut |_, plan| Ok(plan),
+            )
             .await
     }
 }


### PR DESCRIPTION
## Summary

Migrates `RandomShuffleNode`'s read side onto the shared `ShuffleContext::emit_read_tasks_from_stream`, which gains a `wrap_plan(partition_idx, read_plan)` hook so callers can put an operator on top of each partition's read plan. Random shuffle previously transposed the full matrix of materialized outputs by hand and built one task per partition group, bypassing the shared machinery from #7402.

## Why

On the Flight backend, the manual `transpose_materialized_outputs_from_stream` call collects the full O(map_tasks x num_partitions) matrix of partition refs on the coordinator. `emit_read_tasks_from_stream` already routes Flight through the folding path that keeps coordinator memory at O(map_tasks + num_partitions) (see the doc comment on `fold_outputs_from_stream`), so random shuffle now gets that memory behavior for free. It also removes the last hand-rolled read-task loop among the migrated shuffle nodes, and the `wrap_plan` hook is the same extension the upcoming `SortNode` migration needs for its final-sort phase.

Follow-up to #7402 and #7275. Part of #6472.

## Changes Made

- `shuffles/backends/mod.rs`: `emit_read_tasks_from_stream` takes `wrap_plan: &mut (dyn FnMut(usize, LocalPhysicalPlanRef) -> DaftResult<LocalPhysicalPlanRef> + Send)` and threads it into both backend arms
- `shuffles/backends/ray.rs`, `shuffles/backends/flight.rs`: `emit_read_tasks` applies `wrap_plan(partition_idx, shuffle_read_plan)` before building each `SwordfishTaskBuilder`
- `random_shuffle.rs`: `execution_loop` calls `emit_read_tasks_from_stream` with a closure that binds the per-partition seeded `random_int_expr` sort on top of the read plan; deletes `local_sort_with_random_key` and the manual transpose
- `shuffles/repartition.rs`: passes the identity closure

## Behavior

- Flight: coordinator no longer holds the full ref matrix for random shuffle; read tasks are built from the folded per-server input lists, same as repartition. Permutation semantics are unchanged (same per-partition seed hash, same sort).
- Ray: per-partition read plans change from `in_memory_scan` to `shuffle_read(Ray)` with the same psets attached, matching what `RepartitionNode`'s read side has always built. Functionally equivalent for all inputs.

## Test Plan

- `cargo check -p daft-distributed --lib` and `--features python` clean
- `cargo fmt -p daft-distributed` clean
- `cargo clippy -p daft-distributed --lib --no-deps` clean (remaining warnings pre-existing in untouched files)
- `cargo test -p daft-distributed --lib`: 68 passed, 0 failed
- Existing `tests/dataframe/test_shuffles.py::test_flight_random_shuffle` and `::test_ray_random_shuffle` cover permutation correctness under both backends on CI

## Related Issues

Part of #6472.
