### PR TITLE
fix(shuffle): stop into_partitions coalesce from panicking under flight shuffle

### DIFF
--- a/src/daft-distributed/src/pipeline_node/into_partitions.rs
+++ b/src/daft-distributed/src/pipeline_node/into_partitions.rs
@@ -103,6 +103,28 @@ impl IntoPartitionsNode {
                 .by_ref()
                 .take(chunk_size)
                 .map(|builder| {
+                    // Under Flight, each input task must end in a flight write so its
+                    // outputs materialize as `FlightPartitionRef`s for the coalesce
+                    // read below; a raw child task materializes plain object refs,
+                    // which fail the flight downcast (#7002).
+                    let builder = if matches!(
+                        self.shuffle_context.backend(),
+                        ShuffleBackend::Flight { .. }
+                    ) {
+                        let node_id = self.node_id();
+                        let backend = self.shuffle_context.backend().clone();
+                        builder.map_plan(self.as_ref(), |plan| {
+                            LocalPhysicalPlan::into_partitions(
+                                plan,
+                                1,
+                                backend,
+                                StatsState::NotMaterialized,
+                                LocalNodeContext::new(Some(node_id as usize)),
+                            )
+                        })
+                    } else {
+                        builder
+                    };
                     let submittable_task = builder.build(self.context.query_idx, task_id_counter);
                     submittable_task.submit(scheduler_handle)
                 })
@@ -131,15 +153,19 @@ impl IntoPartitionsNode {
                 .collect::<Vec<_>>();
 
             let node_id = self.node_id();
-            let shuffle_backend = self.shuffle_context.backend().clone();
             let builder = self.shuffle_context.build_refs_task_builder(
                 partition_refs,
                 self.as_ref(),
                 move |input| {
+                    // The trailing `into_partitions(1)` only concatenates the read
+                    // refs into a single partition, so it must stay on the Ray
+                    // (in-memory) backend: a Flight-backed op here would write the
+                    // node's final outputs back to the flight cache, and downstream
+                    // consumers expect ordinary partition refs (#7002).
                     LocalPhysicalPlan::into_partitions(
                         input,
                         1,
-                        shuffle_backend,
+                        ShuffleBackend::Ray,
                         StatsState::NotMaterialized,
                         LocalNodeContext::new(Some(node_id as usize)),
                     )

--- a/src/daft-distributed/src/pipeline_node/random_shuffle.rs
+++ b/src/daft-distributed/src/pipeline_node/random_shuffle.rs
@@ -14,18 +14,15 @@ use daft_schema::schema::SchemaRef;
 use super::{PipelineNodeImpl, TaskBuilderStream};
 use crate::{
     pipeline_node::{
-        ClusteringStrategy, DistributedPipelineNode, MaterializedOutput, NodeID,
-        PipelineNodeConfig, PipelineNodeContext, shuffles::backends::ShuffleContext,
+        ClusteringStrategy, DistributedPipelineNode, NodeID, PipelineNodeConfig,
+        PipelineNodeContext, shuffles::backends::ShuffleContext,
     },
     plan::{PlanConfig, PlanExecutionContext, TaskIDCounter},
     scheduling::{
         scheduler::SchedulerHandle,
         task::{SwordfishTask, SwordfishTaskBuilder},
     },
-    utils::{
-        channel::{Sender, create_channel},
-        transpose::transpose_materialized_outputs_from_stream,
-    },
+    utils::channel::{Sender, create_channel},
 };
 
 pub(crate) struct RandomShuffleNode {
@@ -71,42 +68,6 @@ impl RandomShuffleNode {
         }
     }
 
-    fn local_sort_with_random_key(
-        &self,
-        partition_group: Vec<MaterializedOutput>,
-        partition_idx: usize,
-    ) -> DaftResult<SwordfishTaskBuilder> {
-        let partition_refs = partition_group
-            .into_iter()
-            .flat_map(|output| output.into_inner().0)
-            .collect::<Vec<_>>();
-
-        let partition_seed = self.seed.map(|s| {
-            let mut hasher = DefaultHasher::new();
-            s.hash(&mut hasher);
-            partition_idx.hash(&mut hasher);
-            hasher.finish()
-        });
-
-        let sort_by = BoundExpr::bind_all(
-            &[random_int_expr(i64::MIN, i64::MAX, partition_seed)],
-            &self.config.schema,
-        )?;
-        let node_id = self.node_id();
-        Ok(self
-            .shuffle_context
-            .build_refs_task_builder(partition_refs, self, |input| {
-                LocalPhysicalPlan::sort(
-                    input,
-                    sort_by,
-                    vec![false],
-                    vec![false],
-                    StatsState::NotMaterialized,
-                    LocalNodeContext::new(Some(node_id as usize)),
-                )
-            }))
-    }
-
     async fn execution_loop(
         self: Arc<Self>,
         input_node: TaskBuilderStream,
@@ -121,14 +82,37 @@ impl RandomShuffleNode {
             task_id_counter.clone(),
         );
 
-        let partition_groups =
-            transpose_materialized_outputs_from_stream(outputs, num_partitions).await?;
-
-        for (partition_idx, partition_group) in partition_groups.into_iter().enumerate() {
-            let task = self.local_sort_with_random_key(partition_group, partition_idx)?;
-            let _ = result_tx.send(task).await;
-        }
-        Ok(())
+        let seed = self.seed;
+        let schema = self.config.schema.clone();
+        let node_id = self.node_id();
+        self.shuffle_context
+            .emit_read_tasks_from_stream(
+                outputs,
+                num_partitions,
+                self.as_ref(),
+                result_tx,
+                &mut |partition_idx, input| {
+                    let partition_seed = seed.map(|s| {
+                        let mut hasher = DefaultHasher::new();
+                        s.hash(&mut hasher);
+                        partition_idx.hash(&mut hasher);
+                        hasher.finish()
+                    });
+                    let sort_by = BoundExpr::bind_all(
+                        &[random_int_expr(i64::MIN, i64::MAX, partition_seed)],
+                        &schema,
+                    )?;
+                    Ok(LocalPhysicalPlan::sort(
+                        input,
+                        sort_by,
+                        vec![false],
+                        vec![false],
+                        StatsState::NotMaterialized,
+                        LocalNodeContext::new(Some(node_id as usize)),
+                    ))
+                },
+            )
+            .await
     }
 }
 

--- a/src/daft-distributed/src/pipeline_node/shuffles/backends/flight.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/backends/flight.rs
@@ -3,7 +3,8 @@ use std::{collections::BTreeMap, sync::Arc};
 use common_error::DaftResult;
 use common_partitioning::PartitionRef;
 use daft_local_plan::{
-    FlightShuffleReadInput, LocalNodeContext, LocalPhysicalPlan, ShuffleReadBackend,
+    FlightShuffleReadInput, LocalNodeContext, LocalPhysicalPlan, LocalPhysicalPlanRef,
+    ShuffleReadBackend,
 };
 use daft_logical_plan::stats::StatsState;
 use daft_partition_refs::FlightPartitionRef;
@@ -121,6 +122,9 @@ pub(crate) async fn emit_read_tasks(
     read_inputs: Vec<FlightShuffleReadInput>,
     node: &dyn PipelineNodeImpl,
     result_tx: Sender<SwordfishTaskBuilder>,
+    wrap_plan: &mut (
+             dyn FnMut(usize, LocalPhysicalPlanRef) -> DaftResult<LocalPhysicalPlanRef> + Send
+         ),
 ) -> DaftResult<()> {
     for read_input in read_inputs {
         // Fresh plan per task: `SwordfishTaskBuilder::build` mutates the plan in
@@ -132,7 +136,9 @@ pub(crate) async fn emit_read_tasks(
             StatsState::NotMaterialized,
             LocalNodeContext::new(Some(node_id as usize)),
         );
-        let task = SwordfishTaskBuilder::new(shuffle_read_plan, node, node_id)
+        let partition_idx = read_input.partition_idx as usize;
+        let plan = wrap_plan(partition_idx, shuffle_read_plan)?;
+        let task = SwordfishTaskBuilder::new(plan, node, node_id)
             .with_flight_shuffle_reads(node_id, vec![read_input]);
 
         let _ = result_tx.send(task).await;

--- a/src/daft-distributed/src/pipeline_node/shuffles/backends/mod.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/backends/mod.rs
@@ -122,7 +122,8 @@ impl ShuffleContext {
         }
     }
 
-    /// Group a stream of map-task outputs into per-partition read tasks.
+    /// Group a stream of map-task outputs into per-partition read tasks, applying
+    /// `wrap_plan(partition_idx, read_plan)` on top of each partition's read plan.
     ///
     /// The Ray backend transposes the full (tasks x partitions) matrix of object refs.
     /// The flight backend folds the stream into per-server map-input lists shared by
@@ -134,6 +135,9 @@ impl ShuffleContext {
         num_partitions: usize,
         node: &dyn PipelineNodeImpl,
         result_tx: Sender<SwordfishTaskBuilder>,
+        wrap_plan: &mut (
+                 dyn FnMut(usize, LocalPhysicalPlanRef) -> DaftResult<LocalPhysicalPlanRef> + Send
+             ),
     ) -> DaftResult<()> {
         match &self.backend {
             ShuffleBackend::Ray => {
@@ -149,6 +153,7 @@ impl ShuffleContext {
                     partition_groups,
                     node,
                     result_tx,
+                    wrap_plan,
                 )
                 .await
             }
@@ -165,6 +170,7 @@ impl ShuffleContext {
                     read_inputs,
                     node,
                     result_tx,
+                    wrap_plan,
                 )
                 .await
             }

--- a/src/daft-distributed/src/pipeline_node/shuffles/backends/ray.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/backends/ray.rs
@@ -1,5 +1,7 @@
 use common_error::DaftResult;
-use daft_local_plan::{LocalNodeContext, LocalPhysicalPlan, ShuffleReadBackend};
+use daft_local_plan::{
+    LocalNodeContext, LocalPhysicalPlan, LocalPhysicalPlanRef, ShuffleReadBackend,
+};
 use daft_logical_plan::stats::StatsState;
 use daft_schema::schema::SchemaRef;
 
@@ -15,8 +17,11 @@ pub(crate) async fn emit_read_tasks(
     partition_groups: Vec<Vec<MaterializedOutput>>,
     node: &dyn PipelineNodeImpl,
     result_tx: Sender<SwordfishTaskBuilder>,
+    wrap_plan: &mut (
+             dyn FnMut(usize, LocalPhysicalPlanRef) -> DaftResult<LocalPhysicalPlanRef> + Send
+         ),
 ) -> DaftResult<()> {
-    for partition_group in partition_groups {
+    for (partition_idx, partition_group) in partition_groups.into_iter().enumerate() {
         let psets = partition_group
             .into_iter()
             .flat_map(|output| output.into_inner().0)
@@ -29,9 +34,9 @@ pub(crate) async fn emit_read_tasks(
             StatsState::NotMaterialized,
             LocalNodeContext::new(Some(node_id as usize)),
         );
+        let plan = wrap_plan(partition_idx, shuffle_read)?;
 
-        let builder =
-            SwordfishTaskBuilder::new(shuffle_read, node, node_id).with_psets(node_id, psets);
+        let builder = SwordfishTaskBuilder::new(plan, node, node_id).with_psets(node_id, psets);
 
         let _ = result_tx.send(builder).await;
     }

--- a/src/daft-distributed/src/pipeline_node/shuffles/repartition.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/repartition.rs
@@ -87,7 +87,13 @@ impl RepartitionNode {
         );
 
         self.shuffle_context
-            .emit_read_tasks_from_stream(outputs, self.num_partitions, self.as_ref(), result_tx)
+            .emit_read_tasks_from_stream(
+                outputs,
+                self.num_partitions,
+                self.as_ref(),
+                result_tx,
+                &mut |_, plan| Ok(plan),
+            )
             .await
     }
 }

--- a/tests/dataframe/test_shuffles.py
+++ b/tests/dataframe/test_shuffles.py
@@ -297,6 +297,47 @@ def test_flight_into_partitions(flight_shuffle_ctx, input_partitions, output_par
 
 @pytest.mark.skipif(
     get_tests_daft_runner_name() != "ray",
+    reason="shuffle tests are meant for the ray runner",
+)
+@pytest.mark.parametrize(
+    "input_partitions, output_partitions",
+    [(8, 2), (7, 1)],
+)
+def test_flight_into_partitions_coalesce_from_scan(flight_shuffle_ctx, input_partitions, output_partitions):
+    """Coalesce over a genuine multi-task source under `flight_shuffle`.
+
+    Regression test for #7002. The optimizer folds consecutive `into_partitions`
+    calls (DropRepartition), so the coalesce parametrizations of
+    `test_flight_into_partitions` collapse into a single split from one partition
+    and never reach the distributed coalesce branch. A multi-partition scan source
+    does reach it, and previously panicked with "expected flight partition ref"
+    because coalesce submitted its input tasks without a flight write sink.
+    """
+    rows_per_partition = 100
+    with flight_shuffle_ctx():
+        df = read_generator(
+            generator(input_partitions, lambda: rows_per_partition, lambda: 8),
+            schema=daft.Schema._from_field_name_and_types(
+                [
+                    ("ids", daft.DataType.uint64()),
+                    ("ints", daft.DataType.uint64()),
+                    ("bytes", daft.DataType.binary()),
+                ]
+            ),
+        ).into_partitions(output_partitions)
+
+        buf = io.StringIO()
+        df.explain(show_all=True, file=buf)
+        plan = buf.getvalue()
+        assert "IntoPartitions(Flight)" in plan, f"expected IntoPartitions(Flight) in plan:\n{plan}"
+
+        collected = df.collect()
+        assert len(list(collected.iter_partitions())) == output_partitions
+        assert len(collected) == input_partitions * rows_per_partition
+
+
+@pytest.mark.skipif(
+    get_tests_daft_runner_name() != "ray",
     reason="distributed IntoPartitions tests require the ray runner",
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Fixes the "expected flight partition ref" panic when `into_partitions(N)` coalesces partitions under `shuffle_algorithm="flight_shuffle"` (#7002). The coalesce branch of `IntoPartitionsNode` was broken in two places: its input tasks materialized plain object refs that the Flight read path could not downcast, and its output tasks ended in a Flight write whose refs the terminal result stream cannot consume.

## Why

`coalesce_tasks` submitted its input builders as-is, so their outputs materialized as ordinary Ray object refs. The subsequent `build_refs_task_builder` call on the Flight backend downcasts every ref to `FlightPartitionRef` and panics on the mismatch. This path had zero test coverage because the optimizer's `DropRepartition` rule folds consecutive `into_partitions` calls: the coalesce parametrizations of `test_flight_into_partitions` collapse into a single split from one partition and never reach the distributed coalesce branch. Reading from a real multi-partition source (as in #7002's reproducer) does reach it.

Fixing the input side exposed a second latent bug on the output side: the coalesce read task wrapped its plan in `into_partitions(1, <node backend>)`, and under Flight that op writes the node's final outputs back to the flight cache, so downstream consumers (including `PythonPartitionRefStream`, which downcasts to `RayPartitionRef`) panic on the flight refs.

#7154 previously attempted this fix by routing the coalesce read through the Ray object store unconditionally, and independently identified the same output-side concat bug. This PR instead keeps the coalesced data on the flight cache path (input tasks write to flight, only the final concat is in-memory), so coalesce under `flight_shuffle` avoids the object-store pressure that backend exists to avoid. It also adds the regression coverage that the folded-plan gap was hiding, and applies on top of the #7402 and #7412 refactors.

## Changes Made

- `into_partitions.rs` `coalesce_tasks`: under the Flight backend, wrap each input builder with `into_partitions(1, <flight backend>)` via `map_plan` before submitting, so input outputs materialize as `FlightPartitionRef`s; the Ray backend path is unchanged
- `into_partitions.rs` `coalesce_tasks`: the trailing `into_partitions(1)` on the coalesce read task now always uses `ShuffleBackend::Ray`, since it only concatenates the read refs in memory and the node's outputs must leave as ordinary partition refs
- `tests/dataframe/test_shuffles.py`: add `test_flight_into_partitions_coalesce_from_scan`, which reads a multi-partition generator source (so `DropRepartition` cannot fold the plan) and coalesces under `flight_shuffle`; parametrized over (8, 2) and (7, 1)

## Behavior

- `read_parquet(...).into_partitions(N)` and similar coalescing plans no longer panic under `flight_shuffle`; input data now moves through the flight cache instead of the Ray object store during the coalesce
- Ray backend coalesce is unchanged
- Verified the new test reproduces the exact #7002 panic before the fix ("task N panicked with message \"expected flight partition ref\"") and passes after

## Test Plan

- New regression test: `DAFT_RUNNER=ray pytest tests/dataframe/test_shuffles.py::test_flight_into_partitions_coalesce_from_scan` fails with the #7002 panic before the fix, passes after
- Full shuffle suite: `DAFT_RUNNER=ray pytest tests/dataframe/test_shuffles.py`: 41 passed
- `cargo test -p daft-distributed --lib`: 68 passed
- `cargo check -p daft-distributed --lib` (and `--features python`), `cargo fmt`, `cargo clippy --no-deps` clean

## Related Issues

Closes #7002.
