### PR TITLE
fix(distributed): release limit's output channel at input exhaustion

### DIFF
--- a/src/daft-distributed/src/pipeline_node/into_partitions.rs
+++ b/src/daft-distributed/src/pipeline_node/into_partitions.rs
@@ -234,7 +234,11 @@ impl IntoPartitionsNode {
         result_tx: Sender<SwordfishTaskBuilder>,
         scheduler_handle: SchedulerHandle<SwordfishTask>,
     ) -> DaftResult<()> {
-        // Collect all input builders without materializing to count them
+        // Collect all input builders without materializing to count them.
+        // Note that this drains the child's stream to exhaustion before a
+        // single task is submitted, so a child whose own loop needs its emitted
+        // tasks to *run* must release its sender once its input is exhausted
+        // rather than when its loop ends — see `LimitNode::limit_execution_loop`.
         let input_builders: Vec<SwordfishTaskBuilder> = input_stream.collect().await;
         let num_input_tasks = input_builders.len();
 

--- a/src/daft-distributed/src/pipeline_node/limit.rs
+++ b/src/daft-distributed/src/pipeline_node/limit.rs
@@ -141,6 +141,18 @@ impl LimitNode {
         let mut contributors: Option<HashSet<TaskID>> = None;
         let mut limit_completed = Box::pin(await_limit_completion(&actor));
         let mut input_exhausted = false;
+        // Held in an `Option` so the sender is dropped — closing our output
+        // stream — the moment there is nothing left to forward, rather than
+        // when this loop ends. The loop only makes progress once the tasks it
+        // emitted are actually running, because completion is reported through
+        // the counter actor. But a downstream node may buffer our whole builder
+        // stream before submitting anything: `IntoPartitionsNode` has to count
+        // its input tasks before it can choose between coalescing and
+        // splitting, so it drains us to exhaustion first. Holding the sender
+        // past exhaustion deadlocks the two — it waits for a stream close that
+        // never comes, we wait for tasks it never submits, and the query hangs
+        // with the actor spinning in `await_limit_completion`.
+        let mut result_tx = Some(result_tx);
         while !limit_loop_done(
             contributors.as_ref(),
             &completed_ids,
@@ -165,6 +177,7 @@ impl LimitNode {
                 builder_opt = input_task_stream.next(), if !input_exhausted => {
                     let Some(builder) = builder_opt else {
                         input_exhausted = true;
+                        result_tx = None;
                         continue;
                     };
                     let limit = self.limit;
@@ -186,8 +199,12 @@ impl LimitNode {
                         .add_notify_token();
 
                     running_tasks.spawn(notify_token);
-                    if result_tx.send(builder).await.is_err() {
+                    let sender = result_tx
+                        .as_ref()
+                        .expect("limit result sender is live until the input stream ends");
+                    if sender.send(builder).await.is_err() {
                         input_exhausted = true;
+                        result_tx = None;
                     }
                 }
                 else => break,

--- a/tests/dataframe/test_distributed_limit.py
+++ b/tests/dataframe/test_distributed_limit.py
@@ -170,3 +170,81 @@ def test_distributed_limit_retries_after_worker_death(tmp_path):
         "If 0 is missing, the limit actor failed to rewind the crashed "
         "task's claim in start_task."
     )
+
+
+def _materialize_with_deadline(df, timeout_s=120):
+    """Materialize `df` in a daemon thread, failing the test if it doesn't finish.
+
+    `@pytest.mark.timeout` can't guard the deadlock these tests cover: the query
+    blocks inside the Rust runtime holding the GIL, so a SIGALRM handler never
+    gets a chance to run and pytest-timeout's signal method hangs right along
+    with it. A watchdog in a separate thread is the only one that can report.
+    The thread is a daemon so a regression fails this test and lets the rest of
+    the session continue instead of wedging the run.
+    """
+    import threading
+
+    outcome: dict = {}
+
+    def target():
+        try:
+            outcome["result"] = df.to_pydict()
+        except BaseException as e:
+            outcome["error"] = e
+
+    thread = threading.Thread(target=target, daemon=True)
+    thread.start()
+    thread.join(timeout_s)
+    if thread.is_alive():
+        pytest.fail(f"query did not finish within {timeout_s}s — the distributed limit deadlocked instead of returning")
+    if "error" in outcome:
+        raise outcome["error"]
+    return outcome["result"]
+
+
+@pytest.mark.skipif(get_tests_daft_runner_name() != "ray", reason="requires Ray Runner to be in use")
+@pytest.mark.parametrize("num_partitions", [1, 4, 16])
+def test_limit_under_into_partitions_does_not_hang(num_partitions):
+    """`into_partitions` on top of a `Limit` must not deadlock the query.
+
+    `PushDownLimit` commutes `Limit-IntoPartitions` into `IntoPartitions-Limit`,
+    so `IntoPartitionsNode` ends up consuming `LimitNode`'s task-builder stream.
+    It has to count its input tasks before it can decide whether to coalesce or
+    split, so it drains that stream to exhaustion before submitting anything —
+    while `LimitNode`'s loop only finishes once the tasks it emitted have run
+    and claimed rows from the counter actor. If `LimitNode` holds its output
+    channel open until its loop ends, neither side can move: no task is ever
+    submitted, no `claim` ever arrives, and the query hangs forever with the
+    actor spinning in `_LimitCounterImpl.await_limit_completion`.
+
+    `num_partitions` covers all three `IntoPartitionsNode` shapes against the
+    8-task input: coalesce to one task, coalesce to four, and split to sixteen.
+    """
+    import daft
+
+    df = daft.range(0, 10_000, partitions=8).into_partitions(num_partitions).limit(10)
+    result = _materialize_with_deadline(df)
+
+    assert len(result["id"]) == 10
+    assert len(set(result["id"])) == 10, f"limit returned duplicate rows: {result['id']}"
+
+
+@pytest.mark.skipif(get_tests_daft_runner_name() != "ray", reason="requires Ray Runner to be in use")
+def test_limit_under_into_partitions_offset_and_overshoot():
+    """The same deadlock, on the paths that don't early-stop.
+
+    With `limit > total rows` the counter never reaches zero, so the loop has to
+    end by draining its input rather than by the actor reporting completion —
+    the output channel has to be released in that case too. `limit(0)` is the
+    other no-contributor path.
+    """
+    import daft
+
+    df = daft.range(0, 100, partitions=8).into_partitions(3).offset(10).limit(20)
+    assert len(_materialize_with_deadline(df)["id"]) == 20
+
+    df = daft.range(0, 100, partitions=8).into_partitions(3).limit(1000)
+    assert len(_materialize_with_deadline(df)["id"]) == 100
+
+    df = daft.range(0, 100, partitions=8).into_partitions(3).limit(0)
+    assert len(_materialize_with_deadline(df)["id"]) == 0

--- a/tests/dataframe/test_distributed_limit.py
+++ b/tests/dataframe/test_distributed_limit.py
@@ -9,10 +9,13 @@ path is otherwise uncovered.
 
 from __future__ import annotations
 
+import threading
+
 import pytest
 
 ray = pytest.importorskip("ray")
 
+import daft
 from daft.execution.ray_distributed_limit import _LimitCounterImpl
 from tests.conftest import get_tests_daft_runner_name
 
@@ -182,8 +185,6 @@ def _materialize_with_deadline(df, timeout_s=120):
     The thread is a daemon so a regression fails this test and lets the rest of
     the session continue instead of wedging the run.
     """
-    import threading
-
     outcome: dict = {}
 
     def target():
@@ -220,8 +221,6 @@ def test_limit_under_into_partitions_does_not_hang(num_partitions):
     `num_partitions` covers all three `IntoPartitionsNode` shapes against the
     8-task input: coalesce to one task, coalesce to four, and split to sixteen.
     """
-    import daft
-
     df = daft.range(0, 10_000, partitions=8).into_partitions(num_partitions).limit(10)
     result = _materialize_with_deadline(df)
 
@@ -238,8 +237,6 @@ def test_limit_under_into_partitions_offset_and_overshoot():
     the output channel has to be released in that case too. `limit(0)` is the
     other no-contributor path.
     """
-    import daft
-
     df = daft.range(0, 100, partitions=8).into_partitions(3).offset(10).limit(20)
     assert len(_materialize_with_deadline(df)["id"]) == 20
 


### PR DESCRIPTION
## Changes Made

`LIMIT` hangs forever on the Ray runner whenever an `into_partitions` node sits above it. No error, no timeout — the query just sits there, occupying the cluster until something outside kills the job.

### Repro

```python
import glob
import daft

daft.set_runner_ray()
df = daft.read_parquet(sorted(glob.glob("/path/to/*.parquet")))  # 8 files is enough

df = df.into_partitions(8)             # hangs
# df = df.repartition(8, "some_col")   # returns
# df = df                              # returns

print(len(df.limit(10).to_pydict()["some_col"]))
```

Hangs for any `num_partitions`, including `into_partitions(1)`, so it is not a parallelism
problem. It reproduces on `daft.range(0, 10_000, partitions=8).into_partitions(4).limit(10)` too —
the result must be materialized (`count_rows()` lets the optimizer fold the limit away) and the
source must produce more than one scan task (a single-partition `InMemoryScan` gets the
`into_partitions` node dropped by `DropRepartition`).

### Root cause

`PushDownLimit` commutes `Limit-IntoPartitions` into `IntoPartitions-Limit`
(`push_down_limit.rs`), so `IntoPartitionsNode` ends up consuming `LimitNode`'s task-builder
stream:

```
IntoPartitions(4) ← Limit(10) ← ScanTask×8
```

Both sides then wait on each other:

- `IntoPartitionsNode::execute_into_partitions` does `input_stream.collect().await`
  (`into_partitions.rs:242`) — it has to count its input tasks before it can choose between
  coalescing and splitting, so it drains the stream to exhaustion **before submitting anything**.
- `LimitNode::limit_execution_loop` only finishes once the tasks it emitted have actually run and
  claimed rows from the counter actor — and it held its output channel open until its loop ended.

So no task is ever submitted, no `claim` ever arrives, and `_LimitCounterImpl.await_limit_completion`
spins forever. That spin has no timeout, which is why the symptom is a permanent hang rather than a
failure. `repartition` is unaffected because it materializes its input stream
(`shuffles/repartition.rs`), submitting each task as it arrives.

### Fix

`LimitNode` now drops its output sender as soon as there is nothing left to forward — the input
stream ended, or the downstream went away — instead of when its loop ends. That closes the stream,
the downstream node gets those tasks running, and the loop can observe the claims it is waiting for.
The loop's termination conditions, early-stop and cancellation semantics are unchanged.

### Tests

Four regression tests in `tests/dataframe/test_distributed_limit.py` cover all three
`IntoPartitionsNode` shapes (coalesce to 1, coalesce to 4, split to 16) plus the paths that finish
by draining the input rather than by early-stopping (offset, `limit > total rows`, `limit(0)`).

They use a thread watchdog rather than `@pytest.mark.timeout`: the deadlock blocks inside the Rust
runtime holding the GIL, so pytest-timeout's SIGALRM handler never gets a chance to run and hangs
right along with the query. Verified against an unpatched build — the tests fail cleanly at the
deadline instead of wedging the session.

Verified locally:

| | before | after |
|---|---|---|
| `into_partitions(1/2/8/16)` + `limit(10)` | hang | 10 rows |
| `daft.sql("... LIMIT 10")` over `into_partitions(8)` | hang | 10 rows |
| `repartition(8, col)` / plain scan | 10 rows | 10 rows |

Also checked: `offset`, `limit(0)`, `limit > total rows` (returns all 1.6M rows), output partition
count preserved, and `limit` after a filter.

- `tests/dataframe` on the Ray runner: 8553 passed, 0 failed
- `cargo test -p daft-distributed`: 68 passed
- fmt / clippy / pre-commit clean

### Follow-up (not in this PR)

While tracing this I measured a separate, larger issue: when the limit cannot be pushed into the
scan, a distributed `LIMIT` saves no work at all. `DistributedLimitSink` discards the `done` flag
the counter actor returns (`distributed_limit.rs:74`) and always answers `NeedMoreInput`, so every
task drains its whole partition even after the global limit is satisfied. On 8×1M-row parquet with a
row-wise UDF predicate (not pushable into the scan), `LIMIT 10` took 51.7s versus 51.1s for the same
query with no limit at all — while the native runner, whose `LimitSink` returns `Finished`, took
19.2s.

Honouring `done` is not a one-line change: `Finished` currently means "terminate this node"
(`base.rs:325`), and flotilla reuses one local pipeline per plan fingerprint across many tasks, so
short-circuiting one task kills the shared pipeline and later tasks fail with
`Plan execution task has died; cannot enqueue new input` (`run.rs:554`). It needs per-input
termination in the streaming-sink framework. Happy to open a separate PR for that if there is
interest.

## Related Issues

No existing issue — this is the first report, so the repro and analysis above are the whole story.