### PR TITLE
fix(catalog): declare noop auth for Gravitino Iceberg REST catalogs

### DIFF
--- a/daft/catalog/__gravitino/_catalog.py
+++ b/daft/catalog/__gravitino/_catalog.py
@@ -294,11 +294,19 @@ def _is_rest_iceberg_table(table_info: GravitinoTableInfo) -> bool:
 def _open_iceberg_table_via_rest(table_info: GravitinoTableInfo, io_config: IOConfig | None) -> PyIcebergTable:
     from pyiceberg.catalog import load_catalog
 
-    props = table_info.properties.copy()
+    props: dict[str, Any] = dict(table_info.properties)
     props.update(_io_config_to_pyiceberg_props(io_config))
     props["type"] = "rest"
     if not props.get("warehouse"):
         props.pop("warehouse", None)
+
+    # With no credential configured, PyIceberg still installs a LegacyOAuth2AuthManager whose
+    # `auth_header()` formats the unset token unconditionally, sending a literal
+    # `Authorization: Bearer None`. Servers that require no auth reject that with 401 instead
+    # of ignoring it, so declare "no auth" explicitly. Catalogs that do need bearer/OAuth2 auth
+    # carry `credential`/`token`/`auth` in their Gravitino properties and are left alone.
+    if not any(key in props for key in ("credential", "token", "auth")):
+        props["auth"] = {"type": "noop"}
 
     catalog = load_catalog(table_info.catalog, **props)
     return catalog.load_table(f"{table_info.schema}.{table_info.name}")

--- a/tests/catalog/test_gravitino.py
+++ b/tests/catalog/test_gravitino.py
@@ -712,9 +712,37 @@ class TestGravitinoTable:
                 "s3.endpoint": "http://localhost:9000",
                 "s3.session-token": "test-token",
                 "s3.region": "us-west-2",
+                "auth": {"type": "noop"},
             },
         )
         mock_load_catalog.return_value.load_table.assert_called_once_with("schema1.test_table")
+
+    @pytest.mark.parametrize(
+        "configured_auth",
+        [
+            {"token": "abc123"},
+            {"credential": "client:secret"},
+            {"auth": {"type": "oauth2"}},
+        ],
+    )
+    def test_open_iceberg_table_via_rest_keeps_configured_auth(self, mock_inner_table, configured_auth):
+        """A catalog that configures its own auth must not be overridden with noop."""
+        mock_inner_table.table_info.catalog = "catalog1"
+        mock_inner_table.table_info.schema = "schema1"
+        mock_inner_table.table_info.properties = {
+            "catalog-backend": "rest",
+            "uri": "http://localhost:8181",
+            **configured_auth,
+        }
+
+        with patch("pyiceberg.catalog.load_catalog") as mock_load_catalog:
+            _open_iceberg_table_via_rest(mock_inner_table.table_info, None)
+
+        passed = mock_load_catalog.call_args.kwargs
+        for key, value in configured_auth.items():
+            assert passed[key] == value
+        if "auth" not in configured_auth:
+            assert "auth" not in passed
 
     def test_append_with_invalid_option(self, gravitino_table):
         """Test append with invalid option raises error."""


### PR DESCRIPTION
## Changes Made

`_open_iceberg_table_via_rest` passed no auth configuration to PyIceberg's `RestCatalog`. On pyiceberg 0.11.1 that isn't the same as "no credentials": `RestCatalog` installs a `LegacyOAuth2AuthManager` whose `auth_header()` formats the unset token unconditionally, so Daft sent a literal `Authorization: Bearer None`. REST catalogs that require no auth reject that with 401, which makes them unreadable through Gravitino.

Declare `auth={"type": "noop"}` when the catalog properties carry none of `credential` / `token` / `auth`, so no `Authorization` header is sent. Catalogs that do configure auth keep their current behavior.

Tested against a live Gravitino Iceberg REST service on pyiceberg 0.7.0, 0.8.1 and 0.11.1 — only 0.11.1 was broken; on the older versions the extra property is inert, so this is a no-op there.

AI disclosure: analysis and patch written with Claude; verified by hand against the live
deployment and with `tests/catalog/test_gravitino.py`.

## Related Issues

Closes #7416