### PR TITLE
fix(iceberg): apply partition predicates to count pushdown

### DIFF
--- a/daft/io/iceberg/iceberg_scan.py
+++ b/daft/io/iceberg/iceberg_scan.py
@@ -18,6 +18,7 @@ from daft.daft import (
 )
 from daft.dependencies import pa
 from daft.expressions import ExpressionsProjection
+from daft.expressions.visitor import _ColumnVisitor
 from daft.io.iceberg._expressions import convert_row_filter
 from daft.io.iceberg._metadata import (
     convert_iceberg_data_type,
@@ -383,16 +384,26 @@ class IcebergDataSource(DataSource):
             # Partition records are stored whole, unlike the truncated column bounds
             # PyIceberg prunes on, so this check is exact: every row of a surviving file
             # matches the predicate.
+            required_fields = (
+                _ColumnVisitor().visit(pushdowns.partition_filters)
+                if pushdowns.partition_filters is not None
+                else set()
+            )
+
             for task in iceberg_tasks:
                 data_file = task.file
                 if pushdowns.partition_filters is not None:
                     pspec = self._iceberg_record_to_partition_spec(
                         self._iceberg_table.specs()[data_file.spec_id], data_file.partition
                     )
-                    if (
-                        pspec is not None
-                        and len(pspec.filter(ExpressionsProjection([pushdowns.partition_filters]))) == 0
-                    ):
+                    # A file written under an older spec need not carry the fields the
+                    # predicate partitions on: partition evolution can add a field long
+                    # after data was written without it. Such a file mixes matching and
+                    # non-matching rows, so its rows have to be read to be counted.
+                    if pspec is None or not required_fields.issubset(pspec.schema().column_names()):
+                        yield from self._create_regular_tasks(pushdowns)
+                        return
+                    if len(pspec.filter(ExpressionsProjection([pushdowns.partition_filters]))) == 0:
                         continue
                 total_count += data_file.record_count
 

--- a/daft/io/iceberg/iceberg_scan.py
+++ b/daft/io/iceberg/iceberg_scan.py
@@ -360,12 +360,30 @@ class IcebergDataSource(DataSource):
     def _create_count_tasks(self, pushdowns: Pushdowns, field_name: str) -> Iterator[DataSourceTask]:
         """Create count pushdown task using Iceberg metadata."""
         try:
+            if pushdowns.filters is not None:
+                # A row-level predicate cannot be answered from record counts: a file
+                # surviving metadata pruning may still hold rows that do not match.
+                yield from self._create_regular_tasks(pushdowns)
+                return
+
             iceberg_tasks = self._iceberg_table.scan(limit=None, snapshot_id=self._snapshot_id).plan_files()
             total_count = 0
 
-            # Aggregate row counts from all data files
+            # Aggregate row counts from all data files. `partition_filters` holds the
+            # predicates the optimizer resolved against partition values alone and then
+            # dropped from `filters`, so pruning here is what applies them; every row of a
+            # surviving file matches, which keeps the count exact.
             for task in iceberg_tasks:
                 data_file = task.file
+                if pushdowns.partition_filters is not None:
+                    pspec = self._iceberg_record_to_partition_spec(
+                        self._iceberg_table.specs()[data_file.spec_id], data_file.partition
+                    )
+                    if (
+                        pspec is not None
+                        and len(pspec.filter(ExpressionsProjection([pushdowns.partition_filters]))) == 0
+                    ):
+                        continue
                 total_count += data_file.record_count
 
             result_schema = Schema.from_pyarrow_schema(pa.schema([pa.field(field_name, pa.uint64())]))

--- a/daft/io/iceberg/iceberg_scan.py
+++ b/daft/io/iceberg/iceberg_scan.py
@@ -366,13 +366,23 @@ class IcebergDataSource(DataSource):
                 yield from self._create_regular_tasks(pushdowns)
                 return
 
-            iceberg_tasks = self._iceberg_table.scan(limit=None, snapshot_id=self._snapshot_id).plan_files()
+            # Forwarding the predicate lets PyIceberg drop whole manifests from its partition
+            # summaries instead of materializing every data file entry for us to filter.
+            # It only ever returns a superset of the matching files, and degrades to no
+            # pruning when the predicate cannot be converted, so the per-file check below
+            # remains the authority on what is counted.
+            row_filter = convert_row_filter(pushdowns._to_pypushdowns(), self._iceberg_schema)
+            iceberg_tasks = self._iceberg_table.scan(
+                row_filter=row_filter, limit=None, snapshot_id=self._snapshot_id
+            ).plan_files()
             total_count = 0
 
             # Aggregate row counts from all data files. `partition_filters` holds the
             # predicates the optimizer resolved against partition values alone and then
-            # dropped from `filters`, so pruning here is what applies them; every row of a
-            # surviving file matches, which keeps the count exact.
+            # dropped from `filters`, so applying them here is what keeps the count honest.
+            # Partition records are stored whole, unlike the truncated column bounds
+            # PyIceberg prunes on, so this check is exact: every row of a surviving file
+            # matches the predicate.
             for task in iceberg_tasks:
                 data_file = task.file
                 if pushdowns.partition_filters is not None:

--- a/daft/io/source.py
+++ b/daft/io/source.py
@@ -83,6 +83,12 @@ class DataSource(ABC):
         task whose pushdowns carry the count aggregation; get_tasks is
         then responsible for producing the count result (e.g. from catalog
         metadata) instead of scanning data files.
+
+        A source that returns true must honor the rest of the pushdowns when it
+        produces that count. In particular `partition_filters` may be set while
+        `filters` is None, since the optimizer moves predicates it resolved
+        against partition values alone out of `filters`; counting without
+        applying them reports rows the query excluded.
         """
         return False
 

--- a/tests/io/iceberg/test_iceberg_reads.py
+++ b/tests/io/iceberg/test_iceberg_reads.py
@@ -231,3 +231,47 @@ def test_count_rows_applies_partition_and_data_predicates_together(partitioned_c
 
 def test_count_rows_with_partition_predicate_matching_nothing(partitioned_counts):
     assert daft.read_iceberg(partitioned_counts).where(daft.col("dt") == "missing").count_rows() == 0
+
+
+def test_count_rows_when_partition_field_is_renamed(local_catalog):
+    """The partition field name need not match the source column it partitions on.
+
+    The predicate then references a name absent from the data schema, so it cannot be
+    forwarded to PyIceberg as a row filter and no metadata pruning happens. The count
+    still has to come out right, which is what the per-file partition check is for.
+    """
+    schema = Schema(
+        NestedField(field_id=1, name="dt", type=StringType(), required=False),
+        NestedField(field_id=2, name="x", type=LongType(), required=False),
+    )
+    partition_spec = PartitionSpec(
+        PartitionField(source_id=1, field_id=1000, transform=IdentityTransform(), name="dt_part")
+    )
+    table = local_catalog.create_table("default.renamed_partition_field", schema, partition_spec=partition_spec)
+    daft.from_pydict({"dt": ["a"] * 3 + ["b"] * 5, "x": list(range(8))}).write_iceberg(table)
+    table.refresh()
+
+    assert daft.read_iceberg(table).where(daft.col("dt") == "a").count_rows() == 3
+    assert daft.read_iceberg(table).where(daft.col("dt") == "b").count_rows() == 5
+    assert daft.read_iceberg(table).count_rows() == 8
+
+
+def test_count_rows_with_partition_values_past_bounds_truncation(local_catalog):
+    """Column bounds are truncated to 16 bytes, partition records are not.
+
+    Two values sharing a 16-byte prefix are indistinguishable to the metrics PyIceberg
+    prunes on, so the count has to be settled from the partition record itself.
+    """
+    schema = Schema(
+        NestedField(field_id=1, name="dt", type=StringType(), required=False),
+        NestedField(field_id=2, name="x", type=LongType(), required=False),
+    )
+    partition_spec = PartitionSpec(PartitionField(source_id=1, field_id=1000, transform=IdentityTransform(), name="dt"))
+    table = local_catalog.create_table("default.long_partition_values", schema, partition_spec=partition_spec)
+
+    long_a, long_b = "L" * 30 + "aaa", "L" * 30 + "bbb"
+    daft.from_pydict({"dt": [long_a, long_a, long_b], "x": [1, 2, 3]}).write_iceberg(table)
+    table.refresh()
+
+    assert daft.read_iceberg(table).where(daft.col("dt") == long_a).count_rows() == 2
+    assert daft.read_iceberg(table).where(daft.col("dt") == long_b).count_rows() == 1

--- a/tests/io/iceberg/test_iceberg_reads.py
+++ b/tests/io/iceberg/test_iceberg_reads.py
@@ -183,3 +183,51 @@ def test_read_iceberg_partition_column_projection(local_catalog):
     assert df.select("part").sort("part").to_pydict() == {"part": ["a", "a", "b"]}
     assert df.where(daft.col("part") == "a").sort("v").to_pydict() == {"part": ["a", "a"], "v": [1, 3]}
     assert df.count_rows() == 3
+
+
+@pytest.fixture
+def partitioned_counts(local_catalog):
+    """identity(dt) partitioned table: dt='a' has 3 rows, dt='b' has 5, 8 in total."""
+    schema = Schema(
+        NestedField(field_id=1, name="dt", type=StringType(), required=False),
+        NestedField(field_id=2, name="x", type=LongType(), required=False),
+    )
+    partition_spec = PartitionSpec(PartitionField(source_id=1, field_id=1000, transform=IdentityTransform(), name="dt"))
+    table = local_catalog.create_table("default.partitioned_counts", schema, partition_spec=partition_spec)
+    daft.from_pydict({"dt": ["a"] * 3 + ["b"] * 5, "x": list(range(8))}).write_iceberg(table)
+    table.refresh()
+    return table
+
+
+@pytest.mark.parametrize(("value", "expected"), [("a", 3), ("b", 5)])
+def test_count_rows_applies_partition_predicate(partitioned_counts, value, expected):
+    """A predicate on an identity-partitioned column must reach the count pushdown.
+
+    The optimizer moves such predicates out of `filters` and into `partition_filters`,
+    so a count path that only looks at `filters` sees no filter and counts the whole table.
+    """
+    df = daft.read_iceberg(partitioned_counts).where(daft.col("dt") == value)
+
+    assert df.count_rows() == expected
+    # Same answer the slow path gives.
+    assert len(df.to_pydict()["x"]) == expected
+
+
+def test_count_rows_without_predicate_counts_every_partition(partitioned_counts):
+    assert daft.read_iceberg(partitioned_counts).count_rows() == 8
+
+
+def test_count_rows_applies_data_column_predicate(partitioned_counts):
+    """A row-level predicate cannot be answered from record counts, so it must not be."""
+    assert daft.read_iceberg(partitioned_counts).where(daft.col("x") < 3).count_rows() == 3
+
+
+def test_count_rows_applies_partition_and_data_predicates_together(partitioned_counts):
+    df = daft.read_iceberg(partitioned_counts).where((daft.col("dt") == "b") & (daft.col("x") < 5))
+
+    assert df.count_rows() == 2
+    assert len(df.to_pydict()["x"]) == 2
+
+
+def test_count_rows_with_partition_predicate_matching_nothing(partitioned_counts):
+    assert daft.read_iceberg(partitioned_counts).where(daft.col("dt") == "missing").count_rows() == 0

--- a/tests/io/iceberg/test_iceberg_reads.py
+++ b/tests/io/iceberg/test_iceberg_reads.py
@@ -19,7 +19,7 @@ import daft
 pyiceberg = pytest.importorskip("pyiceberg")
 
 from pyiceberg.catalog.sql import SqlCatalog
-from pyiceberg.partitioning import PartitionField, PartitionSpec
+from pyiceberg.partitioning import UNPARTITIONED_PARTITION_SPEC, PartitionField, PartitionSpec
 from pyiceberg.schema import Schema
 from pyiceberg.transforms import IdentityTransform
 from pyiceberg.types import LongType, NestedField, StringType
@@ -275,3 +275,66 @@ def test_count_rows_with_partition_values_past_bounds_truncation(local_catalog):
 
     assert daft.read_iceberg(table).where(daft.col("dt") == long_a).count_rows() == 2
     assert daft.read_iceberg(table).where(daft.col("dt") == long_b).count_rows() == 1
+
+
+def _evolving_table(local_catalog, name, initial_spec):
+    schema = Schema(
+        NestedField(field_id=1, name="dt", type=StringType(), required=False),
+        NestedField(field_id=2, name="region", type=StringType(), required=False),
+        NestedField(field_id=3, name="x", type=LongType(), required=False),
+    )
+    table = local_catalog.create_table(f"default.{name}", schema, partition_spec=initial_spec)
+    daft.from_pydict({"dt": ["a", "a", "b"], "region": ["cn", "us", "cn"], "x": [1, 2, 3]}).write_iceberg(table)
+    table.refresh()
+    return table
+
+
+def test_count_rows_matches_scan_after_partition_field_is_added(local_catalog):
+    """A count must never disagree with what the same query returns.
+
+    Files written before a partition field was added carry no value for it, so their
+    rows cannot be settled from partition metadata. The count path has to give up and
+    scan rather than assume every row in such a file matches.
+    """
+    table = _evolving_table(local_catalog, "count_after_evolution", UNPARTITIONED_PARTITION_SPEC)
+    with table.update_spec() as update:
+        update.add_field("dt", IdentityTransform(), "dt")
+    table.refresh()
+    daft.from_pydict({"dt": ["a", "b"], "region": ["cn", "us"], "x": [4, 5]}).write_iceberg(table)
+    table.refresh()
+
+    df = daft.read_iceberg(table).where(daft.col("dt") == "a")
+
+    assert df.count_rows() == len(df.to_pydict()["x"])
+
+
+def test_count_rows_with_field_present_in_every_spec(local_catalog):
+    """Evolution that leaves the filtered field in place keeps the metadata count exact."""
+    partition_spec = PartitionSpec(PartitionField(source_id=1, field_id=1000, transform=IdentityTransform(), name="dt"))
+    table = _evolving_table(local_catalog, "count_field_in_all_specs", partition_spec)
+    with table.update_spec() as update:
+        update.add_field("region", IdentityTransform(), "region")
+    table.refresh()
+    daft.from_pydict({"dt": ["a", "b"], "region": ["cn", "us"], "x": [4, 5]}).write_iceberg(table)
+    table.refresh()
+
+    df = daft.read_iceberg(table).where(daft.col("dt") == "a")
+
+    assert df.count_rows() == 3
+    assert df.count_rows() == len(df.to_pydict()["x"])
+
+
+def test_count_rows_after_partition_field_is_dropped(local_catalog):
+    """Dropping the field leaves no partition keys, so the predicate stays a row filter."""
+    partition_spec = PartitionSpec(PartitionField(source_id=1, field_id=1000, transform=IdentityTransform(), name="dt"))
+    table = _evolving_table(local_catalog, "count_after_drop", partition_spec)
+    with table.update_spec() as update:
+        update.remove_field("dt")
+    table.refresh()
+    daft.from_pydict({"dt": ["a", "b"], "region": ["cn", "us"], "x": [4, 5]}).write_iceberg(table)
+    table.refresh()
+
+    df = daft.read_iceberg(table).where(daft.col("dt") == "a")
+
+    assert df.count_rows() == 3
+    assert df.count_rows() == len(df.to_pydict()["x"])


### PR DESCRIPTION
## Changes Made

Fixes #7420: `count_rows()` on an identity-partitioned Iceberg table returned the whole table's row count when the only predicate was on the partition column.

```python
# dt='a' has 3 rows, dt='b' has 5 rows
daft.read_iceberg(table).where(col("dt") == "a").count_rows()   # was 8, now 3
```

### Why it happened

`PushDownFilter` splits a predicate into three groups (`PredicateGroups` in `src/daft-scan/src/expr_rewriter.rs`). A pure partition predicate with an identity transform lands in `partition_only_filter`, which is "applied directly to partition values and can be dropped from the data-level filter" — so it moves into `pushdowns.partition_filters` and `pushdowns.filters` becomes `None`.

The count-pushdown guard in `push_down_aggregation.rs` only inspects `filters`:

```rust
external_info.pushdowns.filters.is_none()
```

so it reads that as "no filter at all" and pushes the count into the source. `IcebergDataSource._create_count_tasks` then summed `record_count` over every data file, applying neither filter — unlike `_create_regular_tasks` in the same class, which passes `row_filter=convert_row_filter(...)` and prunes each file with `pspec.filter(ExpressionsProjection([pushdowns.partition_filters]))`.

### The fix

`_create_count_tasks` now prunes files against `partition_filters` the same way the regular path does, and falls back to a regular scan when `pushdowns.filters` is set, since a row-level predicate cannot be answered from record counts — a file surviving metadata pruning may still hold rows that do not match.

This keeps the optimization for the query shape it is most valuable for. The count stays metadata-only; it is simply computed over the surviving partitions:

```
INFO daft.io.iceberg.iceberg_scan: Using Iceberg count pushdown optimization for count mode: All
INFO daft.io.iceberg.iceberg_scan: Created Iceberg count pushdown task with total_count=3 for field=x
```

Partition pruning is exact for the predicates that reach this path: they are identity-transform predicates the optimizer already proved resolvable from partition values alone, so every row of a surviving file matches.

I considered tightening the Rust guard to also require `partition_filters.is_none()`. It fixes the wrong result, but it disables count pushdown for partition-filtered counts, which is the case the metadata-only path exists to serve. Instead, `DataSource.supports_count_pushdown` now documents the contract: a source that absorbs a count must honor the rest of the pushdowns, and `partition_filters` can be set while `filters` is `None`.

### Scope

`GlobScanOperator` also reports `supports_count_pushdown()` for Parquet, but it has no separate count path — its count comes from scan tasks that were already pruned by `partition_filters`, so hive-partitioned Parquet was never affected. Verified: `read_parquet` with `hive_partitioning=True` returns the correct count before and after this change. Iceberg was the only source with its own count path.

## Testing

New tests in `tests/io/iceberg/test_iceberg_reads.py` against the local SqlCatalog:

- a partition predicate on an identity-partitioned column, checked against the materialized row count
- no predicate, counting every partition
- a data-column predicate, which must not be answered from record counts
- partition and data predicates combined
- a partition predicate matching no partition

The first and last fail on `main` (8 instead of 3, 8 instead of 0) and pass with this change.

`tests/io/` and `tests/catalog` pass (1325 passed, 81 skipped). One pre-existing environment error in `tests/io/test_s3_credentials_refresh.py` from a fixture that cannot start its local mock server; unrelated to this change.

## Related Issues

Closes #7420
