### PR TITLE
fix(distributed): keep task tokens alive when combining task builders

### DIFF
--- a/src/daft-distributed/src/pipeline_node/actor_udf.rs
+++ b/src/daft-distributed/src/pipeline_node/actor_udf.rs
@@ -186,7 +186,7 @@ impl ActorUDF {
 
             let modified_builder = self.append_actor_udf_to_builder(builder, actors);
             let (builder_with_token, notify_token) = modified_builder.add_notify_token();
-            running_tasks.spawn(notify_token);
+            running_tasks.spawn(notify_token.wait_for_all());
             if result_tx.send(builder_with_token).await.is_err() {
                 break;
             }
@@ -196,9 +196,7 @@ impl ActorUDF {
         drop(result_tx);
         // Wait for all tasks to finish.
         while let Some(result) = running_tasks.join_next().await {
-            if result?.is_err() {
-                break;
-            }
+            result?;
         }
         // Only teardown actors after all tasks are finished.
         udf_actors.teardown();

--- a/src/daft-distributed/src/pipeline_node/into_partitions.rs
+++ b/src/daft-distributed/src/pipeline_node/into_partitions.rs
@@ -234,7 +234,11 @@ impl IntoPartitionsNode {
         result_tx: Sender<SwordfishTaskBuilder>,
         scheduler_handle: SchedulerHandle<SwordfishTask>,
     ) -> DaftResult<()> {
-        // Collect all input builders without materializing to count them
+        // Collect all input builders without materializing to count them.
+        // Note that this drains the child's stream to exhaustion before a
+        // single task is submitted, so a child whose own loop needs its emitted
+        // tasks to *run* must release its sender once its input is exhausted
+        // rather than when its loop ends — see `LimitNode::limit_execution_loop`.
         let input_builders: Vec<SwordfishTaskBuilder> = input_stream.collect().await;
         let num_input_tasks = input_builders.len();
 

--- a/src/daft-distributed/src/pipeline_node/join/key_filtering_join.rs
+++ b/src/daft-distributed/src/pipeline_node/join/key_filtering_join.rs
@@ -259,30 +259,20 @@ impl KeyFilteringJoinNode {
                 self.append_key_filter_to_builder(builder, filter_predicate.clone());
 
             let (builder_with_token, notify_token) = modified_builder.add_notify_token();
-            running_tasks.spawn(notify_token);
+            running_tasks.spawn(notify_token.wait_for_all());
             if result_tx.send(builder_with_token).await.is_err() {
                 break;
             }
         }
 
         // Wait for all left-side tasks to finish.
-        let mut first_error = None;
         while let Some(result) = running_tasks.join_next().await {
-            match result? {
-                Ok(_) => {}
-                Err(err) if first_error.is_none() => first_error = Some(err),
-                Err(_) => {}
-            }
+            result?;
         }
 
         // Teardown actors after all tasks are finished.
         resources.teardown();
 
-        if let Some(err) = first_error {
-            return Err(DaftError::InternalError(format!(
-                "Sender of OneShot Channel dropped before sending task completion notification: {err}"
-            )));
-        }
         Ok(())
     }
 

--- a/src/daft-distributed/src/pipeline_node/limit.rs
+++ b/src/daft-distributed/src/pipeline_node/limit.rs
@@ -141,6 +141,18 @@ impl LimitNode {
         let mut contributors: Option<HashSet<TaskID>> = None;
         let mut limit_completed = Box::pin(await_limit_completion(&actor));
         let mut input_exhausted = false;
+        // Held in an `Option` so the sender is dropped — closing our output
+        // stream — the moment there is nothing left to forward, rather than
+        // when this loop ends. The loop only makes progress once the tasks it
+        // emitted are actually running, because completion is reported through
+        // the counter actor. But a downstream node may buffer our whole builder
+        // stream before submitting anything: `IntoPartitionsNode` has to count
+        // its input tasks before it can choose between coalescing and
+        // splitting, so it drains us to exhaustion first. Holding the sender
+        // past exhaustion deadlocks the two — it waits for a stream close that
+        // never comes, we wait for tasks it never submits, and the query hangs
+        // with the actor spinning in `await_limit_completion`.
+        let mut result_tx = Some(result_tx);
         while !limit_loop_done(
             contributors.as_ref(),
             &completed_ids,
@@ -165,6 +177,7 @@ impl LimitNode {
                 builder_opt = input_task_stream.next(), if !input_exhausted => {
                     let Some(builder) = builder_opt else {
                         input_exhausted = true;
+                        result_tx = None;
                         continue;
                     };
                     let limit = self.limit;
@@ -186,8 +199,12 @@ impl LimitNode {
                         .add_notify_token();
 
                     running_tasks.spawn(notify_token);
-                    if result_tx.send(builder).await.is_err() {
+                    let sender = result_tx
+                        .as_ref()
+                        .expect("limit result sender is live until the input stream ends");
+                    if sender.send(builder).await.is_err() {
                         input_exhausted = true;
+                        result_tx = None;
                     }
                 }
                 else => break,

--- a/src/daft-distributed/src/pipeline_node/limit.rs
+++ b/src/daft-distributed/src/pipeline_node/limit.rs
@@ -4,7 +4,6 @@ use common_error::DaftResult;
 use common_metrics::ops::{NodeCategory, NodeType};
 #[cfg(feature = "python")]
 use common_py_serde::PyObjectWrapper;
-use common_runtime::JoinSet;
 use daft_local_plan::{LocalNodeContext, LocalPhysicalPlan};
 use daft_logical_plan::stats::StatsState;
 use daft_schema::schema::SchemaRef;
@@ -18,7 +17,7 @@ use super::{DistributedPipelineNode, PipelineNodeImpl, TaskBuilderStream};
 use crate::{
     pipeline_node::{ClusteringStrategy, NodeID, PipelineNodeConfig, PipelineNodeContext},
     plan::{PlanConfig, PlanExecutionContext},
-    scheduling::task::{SwordfishTaskBuilder, TaskID},
+    scheduling::task::{SwordfishTaskBuilder, TaskID, TaskNotifyToken},
     utils::channel::{Sender, create_channel},
 };
 
@@ -65,7 +64,7 @@ fn limit_loop_done(
     contributors: Option<&HashSet<TaskID>>,
     completed_ids: &HashSet<TaskID>,
     input_exhausted: bool,
-    running_tasks_empty: bool,
+    tasks_settled: bool,
 ) -> bool {
     // Early-stop: the actor reported the limit was hit and at least one task
     // contributed rows. We're done as soon as every contributor's task has
@@ -77,8 +76,9 @@ fn limit_loop_done(
     }
     // Natural drain: limit was never hit (e.g. `limit > total rows`) or hit
     // with no contributors (e.g. `limit == 0`). Done when input is exhausted
-    // and no forwarded tasks are still running.
-    input_exhausted && running_tasks_empty
+    // and every task derived from a forwarded builder has finished — see
+    // `tasks_settled` in the loop for why "derived from" is not "forwarded".
+    input_exhausted && tasks_settled
 }
 
 pub(crate) struct LimitNode {
@@ -136,7 +136,17 @@ impl LimitNode {
         .await?;
 
         let parent_cancel = CancellationToken::new();
-        let mut running_tasks = JoinSet::new();
+        // One token for every builder we forward, rather than one channel per
+        // builder: a downstream node may turn a single builder into several
+        // tasks — `CrossJoinNode` crosses each of ours with every builder from
+        // the other side — and every one of those tasks reports back here. The
+        // channel closes only once they have all finished *and* no builder that
+        // could spawn another survives, which is exactly the condition for
+        // tearing the counter actor down: a live task that reaches a torn-down
+        // actor fails and is retried forever.
+        let (notify_token, mut task_completions) = TaskNotifyToken::new();
+        let mut notify_token = Some(notify_token);
+        let mut tasks_settled = false;
         let mut completed_ids: HashSet<TaskID> = HashSet::new();
         let mut contributors: Option<HashSet<TaskID>> = None;
         let mut limit_completed = Box::pin(await_limit_completion(&actor));
@@ -157,7 +167,7 @@ impl LimitNode {
             contributors.as_ref(),
             &completed_ids,
             input_exhausted,
-            running_tasks.is_empty(),
+            tasks_settled,
         ) {
             tokio::select! {
                 biased;
@@ -169,22 +179,30 @@ impl LimitNode {
                             .collect(),
                     );
                 }
-                Some(join_result) = running_tasks.join_next(), if !running_tasks.is_empty() => {
-                    if let Ok(Ok(task_id)) = join_result {
-                        completed_ids.insert(task_id);
+                completed = task_completions.recv(), if !tasks_settled => {
+                    match completed {
+                        Some(task_id) => {
+                            completed_ids.insert(task_id);
+                        }
+                        // Every token clone is gone: nothing is running and
+                        // nothing more can be derived from what we forwarded.
+                        None => tasks_settled = true,
                     }
                 }
                 builder_opt = input_task_stream.next(), if !input_exhausted => {
                     let Some(builder) = builder_opt else {
                         input_exhausted = true;
                         result_tx = None;
+                        // Drop our own clone so the notify channel can close
+                        // once the forwarded builders and their tasks are done.
+                        notify_token = None;
                         continue;
                     };
                     let limit = self.limit;
                     let offset = self.offset;
                     let node_id = self.node_id();
                     let actor_for_plan = actor.clone();
-                    let (builder, notify_token) = builder
+                    let builder = builder
                         .map_plan(self.as_ref(), move |input| {
                             LocalPhysicalPlan::distributed_limit(
                                 input,
@@ -196,15 +214,20 @@ impl LimitNode {
                             )
                         })
                         .with_cancel_token(parent_cancel.child_token())
-                        .add_notify_token();
+                        .with_notify_token(
+                            notify_token
+                                .as_ref()
+                                .expect("limit notify token is live until the input stream ends")
+                                .clone(),
+                        );
 
-                    running_tasks.spawn(notify_token);
                     let sender = result_tx
                         .as_ref()
                         .expect("limit result sender is live until the input stream ends");
                     if sender.send(builder).await.is_err() {
                         input_exhausted = true;
                         result_tx = None;
+                        notify_token = None;
                     }
                 }
                 else => break,

--- a/src/daft-distributed/src/pipeline_node/vllm.rs
+++ b/src/daft-distributed/src/pipeline_node/vllm.rs
@@ -101,16 +101,14 @@ impl VLLMNode {
             });
 
             let (builder_with_token, notify_token) = modified_builder.add_notify_token();
-            running_tasks.spawn(notify_token);
+            running_tasks.spawn(notify_token.wait_for_all());
             if result_tx.send(builder_with_token).await.is_err() {
                 break;
             }
         }
         // Wait for all tasks to finish.
         while let Some(result) = running_tasks.join_next().await {
-            if result?.is_err() {
-                break;
-            }
+            result?;
         }
 
         Ok(())

--- a/src/daft-distributed/src/scheduling/scheduler/scheduler_actor.rs
+++ b/src/daft-distributed/src/scheduling/scheduler/scheduler_actor.rs
@@ -17,12 +17,12 @@ use crate::{
     pipeline_node::MaterializedOutput,
     scheduling::{
         dispatcher::Dispatcher,
-        task::{Task, TaskID},
+        task::{Task, TaskID, TaskNotifyToken},
         worker::{Worker, WorkerManager},
     },
     statistics::{StatisticsManagerRef, TaskEvent},
     utils::channel::{
-        OneshotReceiver, OneshotSender, UnboundedReceiver, UnboundedSender, create_oneshot_channel,
+        OneshotReceiver, UnboundedReceiver, UnboundedSender, create_oneshot_channel,
         create_unbounded_channel,
     },
 };
@@ -353,14 +353,14 @@ impl<T: Task> SchedulerHandle<T> {
 pub(crate) struct SubmittableTask<T: Task> {
     task: T,
     cancel_token: CancellationToken,
-    notify_tokens: Vec<OneshotSender<TaskID>>,
+    notify_tokens: Vec<TaskNotifyToken>,
 }
 
 impl<T: Task> SubmittableTask<T> {
     pub fn new(
         task: T,
         cancel_token: CancellationToken,
-        notify_tokens: Vec<OneshotSender<TaskID>>,
+        notify_tokens: Vec<TaskNotifyToken>,
     ) -> Self {
         Self {
             task,
@@ -389,7 +389,7 @@ pub(crate) struct SubmittedTask {
     _task_id: TaskID,
     result_rx: OneshotReceiver<DaftResult<Option<MaterializedOutput>>>,
     cancel_token: Option<CancellationToken>,
-    notify_tokens: Vec<OneshotSender<TaskID>>,
+    notify_tokens: Vec<TaskNotifyToken>,
     finished: bool,
 }
 
@@ -398,7 +398,7 @@ impl SubmittedTask {
         task_id: TaskID,
         result_rx: OneshotReceiver<DaftResult<Option<MaterializedOutput>>>,
         cancel_token: Option<CancellationToken>,
-        notify_tokens: Vec<OneshotSender<TaskID>>,
+        notify_tokens: Vec<TaskNotifyToken>,
     ) -> Self {
         Self {
             _task_id: task_id,
@@ -424,7 +424,7 @@ impl Future for SubmittedTask {
                 self.finished = true;
                 let task_id = self._task_id;
                 for notify_token in self.notify_tokens.drain(..) {
-                    let _ = notify_token.send(task_id);
+                    notify_token.notify(task_id);
                 }
                 Poll::Ready(result)
             }
@@ -433,7 +433,7 @@ impl Future for SubmittedTask {
                 self.finished = true;
                 let task_id = self._task_id;
                 for notify_token in self.notify_tokens.drain(..) {
-                    let _ = notify_token.send(task_id);
+                    notify_token.notify(task_id);
                 }
                 Poll::Ready(Ok(None))
             }

--- a/src/daft-distributed/src/scheduling/task.rs
+++ b/src/daft-distributed/src/scheduling/task.rs
@@ -17,7 +17,7 @@ use crate::{
     },
     plan::{QueryIdx, TaskIDCounter},
     scheduling::scheduler::SubmittableTask,
-    utils::channel::{OneshotReceiver, OneshotSender, create_oneshot_channel},
+    utils::channel::{UnboundedReceiver, UnboundedSender, create_unbounded_channel},
 };
 
 #[derive(Debug, Clone)]
@@ -306,6 +306,76 @@ impl Task for SwordfishTask {
     }
 }
 
+/// A pipeline node's handle on the tasks derived from a builder it emitted.
+///
+/// Cloned along with the builder — including by [`SwordfishTaskBuilder::combine_with`],
+/// which fans one builder out into several tasks — so every derived task reports
+/// its `TaskID` back through the same channel. The channel closes only once every
+/// clone is gone: every derived task has finished *and* no builder that could
+/// derive another one is still alive. That is what lets a node distinguish "no
+/// tasks running right now" from "no tasks will ever run again", which it needs
+/// before tearing down resources those tasks reference.
+#[derive(Debug, Clone)]
+pub(crate) struct TaskNotifyToken(UnboundedSender<TaskID>);
+
+impl TaskNotifyToken {
+    pub fn new() -> (Self, TaskNotifyReceiver) {
+        let (tx, rx) = create_unbounded_channel();
+        (Self(tx), TaskNotifyReceiver(rx))
+    }
+
+    /// Report a completed (or cancelled) task to whoever registered this token.
+    pub fn notify(&self, task_id: TaskID) {
+        let _ = self.0.send(task_id);
+    }
+}
+
+/// Receiving end of a [`TaskNotifyToken`].
+#[derive(Debug)]
+pub(crate) struct TaskNotifyReceiver(UnboundedReceiver<TaskID>);
+
+impl TaskNotifyReceiver {
+    /// The next derived task to finish, or `None` once every task that could
+    /// report has finished and no builder holding the token remains.
+    pub async fn recv(&mut self) -> Option<TaskID> {
+        self.0.recv().await
+    }
+
+    /// Wait until every task derived from the builder has finished.
+    /// For nodes that only need the "all done" edge, not the individual IDs.
+    pub async fn wait_for_all(mut self) {
+        while self.0.recv().await.is_some() {}
+    }
+}
+
+/// Build the cancellation token for a task derived from `parents`.
+///
+/// Each parent contributes a *child* token rather than being shared directly, so
+/// cancelling one derived task never cancels its siblings or the builder it was
+/// derived from. With more than one parent — a combined task whose two sides are
+/// each cancellable — a watcher forwards whichever parent fires first.
+fn derive_cancel_token(parents: &[&CancellationToken]) -> Option<CancellationToken> {
+    match parents {
+        [] => None,
+        [parent] => Some(parent.child_token()),
+        parents => {
+            let merged = CancellationToken::new();
+            let cancelled = parents
+                .iter()
+                .map(|parent| Box::pin((*parent).clone().cancelled_owned()))
+                .collect::<Vec<_>>();
+            let to_cancel = merged.clone();
+            // Combining only ever happens inside a node's execution loop, so a
+            // runtime is always present here.
+            tokio::spawn(async move {
+                futures::future::select_all(cancelled).await;
+                to_cancel.cancel();
+            });
+            Some(merged)
+        }
+    }
+}
+
 /// Hash multiple u32 values into a PlanFingerprint.
 pub(crate) fn hash_fingerprint(parts: &[u32]) -> PlanFingerprint {
     use std::hash::{DefaultHasher, Hash, Hasher};
@@ -327,7 +397,7 @@ pub(crate) struct SwordfishTaskBuilder {
     context: HashMap<String, String>,
     node_context: Option<PipelineNodeContext>,
     pending_node_ids: Vec<NodeID>,
-    notify_tokens: Vec<OneshotSender<TaskID>>,
+    notify_tokens: Vec<TaskNotifyToken>,
     cancel_token: Option<CancellationToken>,
     /// Fingerprint identifying tasks with functionally identical plans.
     /// Assigned by pipeline nodes: tasks with the same fingerprint can share a pipeline.
@@ -417,6 +487,22 @@ impl SwordfishTaskBuilder {
             node.node_id(),
         ]);
 
+        // Both sides' tokens carry over: this builder produces a task that both
+        // sides' nodes are waiting on, and a side may be combined again — the
+        // caller keeps the inputs around as templates to cross with later
+        // arrivals. Dropping them here strands the nodes that registered them,
+        // which is how a `LIMIT` under a cross join used to hang forever.
+        let mut notify_tokens = left.notify_tokens.clone();
+        notify_tokens.extend(right.notify_tokens.clone());
+
+        let cancel_token = derive_cancel_token(
+            &left
+                .cancel_token
+                .iter()
+                .chain(right.cancel_token.iter())
+                .collect::<Vec<_>>(),
+        );
+
         Self {
             plan: combined_plan,
             config: left.config.clone(),
@@ -426,8 +512,8 @@ impl SwordfishTaskBuilder {
             context: left.context.clone(),
             node_context: left.node_context.clone(),
             pending_node_ids,
-            notify_tokens: vec![],
-            cancel_token: None,
+            notify_tokens,
+            cancel_token,
             plan_fingerprint,
         }
     }
@@ -466,12 +552,19 @@ impl SwordfishTaskBuilder {
         self
     }
 
-    /// Add a notify token to the builder. The receiver fires when the task
-    /// completes (or is cancelled) with the assigned `TaskID`.
-    pub fn add_notify_token(mut self) -> (Self, OneshotReceiver<TaskID>) {
-        let (notify_token, notify_rx) = create_oneshot_channel();
+    /// Add a notify token to the builder. The receiver reports the `TaskID` of
+    /// every task derived from this builder as it completes (or is cancelled),
+    /// and closes once no more can be derived. See [`TaskNotifyToken`].
+    pub fn add_notify_token(self) -> (Self, TaskNotifyReceiver) {
+        let (notify_token, notify_rx) = TaskNotifyToken::new();
+        (self.with_notify_token(notify_token), notify_rx)
+    }
+
+    /// Register an existing notify token, so one receiver can cover every
+    /// builder a node emits rather than one channel per builder.
+    pub fn with_notify_token(mut self, notify_token: TaskNotifyToken) -> Self {
         self.notify_tokens.push(notify_token);
-        (self, notify_rx)
+        self
     }
 
     pub fn with_cancel_token(mut self, cancel_token: CancellationToken) -> Self {
@@ -970,5 +1063,71 @@ pub(super) mod tests {
             }
         );
         assert!(heap.pop().is_none()); // Heap should be empty
+    }
+
+    /// `CrossJoinNode` keeps the builders it receives as templates and crosses
+    /// each one with every builder from the other side, so a combined builder's
+    /// task is the only thing either side's node ever gets to observe. Dropping
+    /// the tokens here left `LimitNode` waiting on tasks that could no longer
+    /// report, which hung the query.
+    #[tokio::test]
+    async fn combine_with_keeps_both_sides_notify_tokens() {
+        use crate::pipeline_node::tests::{MockNode, make_builder};
+
+        let (left_node, right_node, join_node) =
+            (MockNode::new(10), MockNode::new(20), MockNode::new(30));
+        let (left, mut left_rx) = make_builder(&left_node, 1).add_notify_token();
+        let (right, mut right_rx) = make_builder(&right_node, 2).add_notify_token();
+
+        let combined = SwordfishTaskBuilder::combine_with(&left, &right, &join_node, |l, _| l);
+
+        assert_eq!(combined.notify_tokens.len(), 2);
+        for token in &combined.notify_tokens {
+            token.notify(7);
+        }
+        assert_eq!(left_rx.recv().await, Some(7));
+        assert_eq!(right_rx.recv().await, Some(7));
+
+        // The templates still hold a clone each, so neither channel has closed:
+        // more tasks can still be derived from them.
+        drop(combined);
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), left_rx.recv())
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn combine_with_derives_a_cancel_token_from_both_sides() {
+        use crate::pipeline_node::tests::{MockNode, make_builder};
+
+        let (left_node, right_node, join_node) =
+            (MockNode::new(10), MockNode::new(20), MockNode::new(30));
+        let (left_cancel, right_cancel) = (CancellationToken::new(), CancellationToken::new());
+        let left = make_builder(&left_node, 1).with_cancel_token(left_cancel.clone());
+        let right = make_builder(&right_node, 2).with_cancel_token(right_cancel.clone());
+
+        let combined = SwordfishTaskBuilder::combine_with(&left, &right, &join_node, |l, _| l);
+        let derived = combined
+            .cancel_token
+            .clone()
+            .expect("a combined task is cancellable if either side is");
+
+        // Cancelling the derived task is scoped to it: a cross join derives many
+        // tasks from the same pair of templates.
+        derived.cancel();
+        assert!(!left_cancel.is_cancelled());
+        assert!(!right_cancel.is_cancelled());
+
+        // Either side reaches the task it was combined into.
+        for parent in [&left_cancel, &right_cancel] {
+            let combined = SwordfishTaskBuilder::combine_with(&left, &right, &join_node, |l, _| l);
+            let derived = combined.cancel_token.clone().unwrap();
+            parent.cancel();
+            tokio::time::timeout(Duration::from_secs(5), derived.cancelled())
+                .await
+                .expect("cancelling either side must cancel the combined task");
+        }
     }
 }

--- a/tests/dataframe/test_distributed_limit.py
+++ b/tests/dataframe/test_distributed_limit.py
@@ -10,6 +10,7 @@ path is otherwise uncovered.
 from __future__ import annotations
 
 import threading
+from collections import Counter
 
 import pytest
 
@@ -270,8 +271,6 @@ def test_limit_under_cross_join_does_not_hang(limit_on_left):
     not deterministic. The cross product's shape is: every row the limit let
     through pairs with every one of the other side's rows.
     """
-    from collections import Counter
-
     limit = 100
     other_rows = 5
 

--- a/tests/dataframe/test_distributed_limit.py
+++ b/tests/dataframe/test_distributed_limit.py
@@ -16,6 +16,7 @@ import pytest
 ray = pytest.importorskip("ray")
 
 import daft
+from daft import DataType, col, func
 from daft.execution.ray_distributed_limit import _LimitCounterImpl
 from tests.conftest import get_tests_daft_runner_name
 
@@ -245,3 +246,97 @@ def test_limit_under_into_partitions_offset_and_overshoot():
 
     df = daft.range(0, 100, partitions=8).into_partitions(3).limit(0)
     assert len(_materialize_with_deadline(df)["id"]) == 0
+
+
+@pytest.mark.skipif(get_tests_daft_runner_name() != "ray", reason="requires Ray Runner to be in use")
+@pytest.mark.parametrize("limit_on_left", [True, False])
+def test_limit_under_cross_join_does_not_hang(limit_on_left):
+    """A `LIMIT` on either side of a cross join must not deadlock the query.
+
+    `CrossJoinNode` builds its tasks with `SwordfishTaskBuilder::combine_with`,
+    fusing a builder from each side into one task and keeping both sides'
+    builders as templates to cross with whatever arrives later. So a builder
+    `LimitNode` forwarded turns into *n* tasks, none of which is the builder
+    that was handed to the join.
+
+    `combine_with` used to drop the notify token and the cancel token when it
+    merged, which stranded `LimitNode`: the tasks that actually ran reported to
+    nobody, `contributors.is_subset(completed_ids)` was never satisfied, and the
+    query hung forever with no error and no timeout. Tokens now carry into every
+    derived task, so the limit loop sees each one finish.
+
+    Asserted on shape rather than on which rows survive: a distributed limit
+    claims rows first-come-first-served across tasks, so the surviving set is
+    not deterministic. The cross product's shape is: every row the limit let
+    through pairs with every one of the other side's rows.
+    """
+    from collections import Counter
+
+    limit = 100
+    other_rows = 5
+
+    @func(return_dtype=DataType.int64())
+    def identity(v: int) -> int:
+        # Blocks limit pushdown into the scan, so the limit is a real
+        # `distributed_limit` inside the fused cross-join task.
+        return v
+
+    limited = daft.range(0, 400, partitions=4).select(identity(col("id")).alias("lid")).limit(limit)
+    whole = daft.range(0, other_rows, partitions=1).select(col("id").alias("rid"))
+
+    joined = limited.join(whole, how="cross") if limit_on_left else whole.join(limited, how="cross")
+    result = _materialize_with_deadline(joined)
+
+    assert len(result["lid"]) == limit * other_rows, (
+        f"cross join produced {len(result['lid'])} rows, expected {limit * other_rows}"
+    )
+    assert Counter(result["rid"]) == {r: limit for r in range(other_rows)}, (
+        f"rows are not evenly paired: {Counter(result['rid'])}"
+    )
+
+
+@pytest.mark.skipif(get_tests_daft_runner_name() != "ray", reason="requires Ray Runner to be in use")
+def test_limit_under_cross_join_natural_drain():
+    """The cross-join deadlock on the path where the limit is never hit.
+
+    With `limit > total rows` the counter actor never reports completion, so the
+    limit loop can only end by draining: input exhausted *and* nothing derived
+    from a forwarded builder still running. Cross join's templates keep deriving
+    tasks after the input is exhausted, so "nothing running right now" is not
+    enough — tearing the counter actor down there kills an actor that in-flight
+    tasks still talk to, and they retry against it forever.
+    """
+    limited = daft.range(0, 20, partitions=4).limit(1000)
+    whole = daft.range(0, 3, partitions=1).select(col("id").alias("rid"))
+
+    result = _materialize_with_deadline(limited.join(whole, how="cross"))
+    assert len(result["id"]) == 20 * 3
+
+
+@pytest.mark.skipif(get_tests_daft_runner_name() != "ray", reason="requires Ray Runner to be in use")
+@pytest.mark.xfail(
+    strict=True,
+    reason="Known defect, independent of the deadlock this file's other cross-join tests cover: "
+    "CrossJoinNode fuses the limited side into one task per builder on the other side, and every "
+    "one of those copies claims from the same counter actor. The budget is meant to be shared "
+    "across distinct input partitions, not across duplicates of the same partition, so each row "
+    "the limit lets through survives in only one of the tasks it should appear in. The native "
+    "runner returns the full cross product for this query.",
+)
+def test_limit_under_cross_join_pairs_with_every_partition_of_the_other_side():
+    """Every row a `LIMIT` lets through must pair with the *whole* other side.
+
+    The other side has more than one partition here, so `CrossJoinNode` fans
+    each limited builder out into several tasks — the case where the shared
+    counter actor silently drops rows. With a single-partition other side (the
+    other cross-join tests here) each builder becomes exactly one task and the
+    count comes out right, which is why this needs its own case.
+    """
+    limit = 100
+    other_rows, other_partitions = 50, 2
+
+    limited = daft.range(0, 400, partitions=4).limit(limit)
+    whole = daft.range(0, other_rows, partitions=other_partitions).select(col("id").alias("rid"))
+
+    result = _materialize_with_deadline(limited.join(whole, how="cross"))
+    assert len(result["rid"]) == limit * other_rows

--- a/tests/dataframe/test_distributed_limit.py
+++ b/tests/dataframe/test_distributed_limit.py
@@ -170,3 +170,81 @@ def test_distributed_limit_retries_after_worker_death(tmp_path):
         "If 0 is missing, the limit actor failed to rewind the crashed "
         "task's claim in start_task."
     )
+
+
+def _materialize_with_deadline(df, timeout_s=120):
+    """Materialize `df` in a daemon thread, failing the test if it doesn't finish.
+
+    `@pytest.mark.timeout` can't guard the deadlock these tests cover: the query
+    blocks inside the Rust runtime holding the GIL, so a SIGALRM handler never
+    gets a chance to run and pytest-timeout's signal method hangs right along
+    with it. A watchdog in a separate thread is the only one that can report.
+    The thread is a daemon so a regression fails this test and lets the rest of
+    the session continue instead of wedging the run.
+    """
+    import threading
+
+    outcome: dict = {}
+
+    def target():
+        try:
+            outcome["result"] = df.to_pydict()
+        except BaseException as e:
+            outcome["error"] = e
+
+    thread = threading.Thread(target=target, daemon=True)
+    thread.start()
+    thread.join(timeout_s)
+    if thread.is_alive():
+        pytest.fail(f"query did not finish within {timeout_s}s — the distributed limit deadlocked instead of returning")
+    if "error" in outcome:
+        raise outcome["error"]
+    return outcome["result"]
+
+
+@pytest.mark.skipif(get_tests_daft_runner_name() != "ray", reason="requires Ray Runner to be in use")
+@pytest.mark.parametrize("num_partitions", [1, 4, 16])
+def test_limit_under_into_partitions_does_not_hang(num_partitions):
+    """`into_partitions` on top of a `Limit` must not deadlock the query.
+
+    `PushDownLimit` commutes `Limit-IntoPartitions` into `IntoPartitions-Limit`,
+    so `IntoPartitionsNode` ends up consuming `LimitNode`'s task-builder stream.
+    It has to count its input tasks before it can decide whether to coalesce or
+    split, so it drains that stream to exhaustion before submitting anything —
+    while `LimitNode`'s loop only finishes once the tasks it emitted have run
+    and claimed rows from the counter actor. If `LimitNode` holds its output
+    channel open until its loop ends, neither side can move: no task is ever
+    submitted, no `claim` ever arrives, and the query hangs forever with the
+    actor spinning in `_LimitCounterImpl.await_limit_completion`.
+
+    `num_partitions` covers all three `IntoPartitionsNode` shapes against the
+    8-task input: coalesce to one task, coalesce to four, and split to sixteen.
+    """
+    import daft
+
+    df = daft.range(0, 10_000, partitions=8).into_partitions(num_partitions).limit(10)
+    result = _materialize_with_deadline(df)
+
+    assert len(result["id"]) == 10
+    assert len(set(result["id"])) == 10, f"limit returned duplicate rows: {result['id']}"
+
+
+@pytest.mark.skipif(get_tests_daft_runner_name() != "ray", reason="requires Ray Runner to be in use")
+def test_limit_under_into_partitions_offset_and_overshoot():
+    """The same deadlock, on the paths that don't early-stop.
+
+    With `limit > total rows` the counter never reaches zero, so the loop has to
+    end by draining its input rather than by the actor reporting completion —
+    the output channel has to be released in that case too. `limit(0)` is the
+    other no-contributor path.
+    """
+    import daft
+
+    df = daft.range(0, 100, partitions=8).into_partitions(3).offset(10).limit(20)
+    assert len(_materialize_with_deadline(df)["id"]) == 20
+
+    df = daft.range(0, 100, partitions=8).into_partitions(3).limit(1000)
+    assert len(_materialize_with_deadline(df)["id"]) == 100
+
+    df = daft.range(0, 100, partitions=8).into_partitions(3).limit(0)
+    assert len(_materialize_with_deadline(df)["id"]) == 0

--- a/tests/dataframe/test_distributed_limit.py
+++ b/tests/dataframe/test_distributed_limit.py
@@ -9,10 +9,13 @@ path is otherwise uncovered.
 
 from __future__ import annotations
 
+import threading
+
 import pytest
 
 ray = pytest.importorskip("ray")
 
+import daft
 from daft.execution.ray_distributed_limit import _LimitCounterImpl
 from tests.conftest import get_tests_daft_runner_name
 
@@ -182,8 +185,6 @@ def _materialize_with_deadline(df, timeout_s=120):
     The thread is a daemon so a regression fails this test and lets the rest of
     the session continue instead of wedging the run.
     """
-    import threading
-
     outcome: dict = {}
 
     def target():
@@ -220,8 +221,6 @@ def test_limit_under_into_partitions_does_not_hang(num_partitions):
     `num_partitions` covers all three `IntoPartitionsNode` shapes against the
     8-task input: coalesce to one task, coalesce to four, and split to sixteen.
     """
-    import daft
-
     df = daft.range(0, 10_000, partitions=8).into_partitions(num_partitions).limit(10)
     result = _materialize_with_deadline(df)
 
@@ -238,8 +237,6 @@ def test_limit_under_into_partitions_offset_and_overshoot():
     the output channel has to be released in that case too. `limit(0)` is the
     other no-contributor path.
     """
-    import daft
-
     df = daft.range(0, 100, partitions=8).into_partitions(3).offset(10).limit(20)
     assert len(_materialize_with_deadline(df)["id"]) == 20
 


### PR DESCRIPTION
## Changes Made

> **Stacked on #7415.** That PR is the first two commits here; this one adds the third
> (`fix(distributed): keep task tokens alive when combining task builders`). Please merge
> #7415 first, or review only the top commit. The fix below needs #7415's change to be
> present: the drain path added here waits for the tasks derived from a forwarded builder,
> and those tasks only get submitted once `LimitNode` has released its output channel.

A `LIMIT` on either side of a cross join hangs forever on the Ray runner. No error, no
timeout — same external symptom as #7415, but a different bug: applying #7415 alone does not
fix it (verified 3/3 on an isolated build).

### Repro

```python
import daft
from daft import col

daft.set_runner_ray()

left = daft.range(0, 400, partitions=4).limit(100)
right = daft.range(0, 5, partitions=1).select(col("id").alias("rid"))

print(len(left.join(right, how="cross").to_pydict()["rid"]))  # never reached
```

Hangs with the limit on either side, with one partition or four, and whether or not the
limit can be pushed into the scan. Cross join without a limit, broadcast join with a limit,
and `concat` with a limit are all fine.

### Root cause

`CrossJoinNode` is the one production caller that fans out. It keeps both sides' builders as
templates and crosses each new arrival with every builder already seen
(`cross_join.rs:83`/`:103`), so a builder `LimitNode` forwarded becomes *n* tasks — and none
of them is the builder the token was registered on.

`SwordfishTaskBuilder::combine_with` reset both token fields to empty:

```rust
notify_tokens: vec![],   // task.rs:429
cancel_token: None,      // task.rs:430
```

`LimitNode::limit_execution_loop` registers a notify token per forwarded builder and waits
for `contributors.is_subset(completed_ids)`. The tasks that actually ran reported to nobody,
that condition was never satisfied, and the loop never exited. `cancel_token: None` was the
same drop's second consequence: `parent_cancel.cancel()` could not reach the combined tasks,
so early-stop could not cancel them either.

There is a second half. `limit_loop_done`'s natural-drain path assumed "no tokens being
tracked ⇒ no tasks in flight". Fan-out breaks that too: a template can still derive a task
after everything forwarded so far has finished. With #7415 applied but tokens still dropped,
the loop exits *before any task runs*, tears down the counter actor, and the tasks that
follow fail against a dead actor and are retried on new workers forever — a hang again, by a
different route.

`broadcast_join` (`map_plan`) and `hash_join` (1:1 `zip`) never duplicate a builder, which is
why only cross join hangs today; `hash_join` uses the same `combine_with` and was
structurally exposed.

### Fix

A notify token is now a clonable handle onto one channel (`TaskNotifyToken`) instead of a
oneshot. It carries into every derived task, so each one reports its own `TaskID` back, and
the channel closes only once every derived task has finished **and** no builder that could
derive another one survives. `LimitNode` uses that as its drain condition, which closes the
second half: the counter actor is torn down only when nothing can still be talking to it.

`combine_with` derives the combined task's cancel token from both sides — a child of each, so
cancelling one derived task never reaches its siblings or the templates it came from, and
either side's `cancel()` reaches the task it was fused into.

Three other nodes register tokens the same way (actor-pool UDF, vLLM, key-filtering join) and
would have torn their actors down early under a cross join; they now wait for the whole
fan-out. This also removes the `if let Ok(Ok(task_id))` swallow in `LimitNode` — there is no
longer an error case to lose, only "next completion" or "channel closed".

### Tests

Three regression tests in `tests/dataframe/test_distributed_limit.py`: the limit on the left
and on the right (early-stop path), and `limit > total rows` (natural-drain path, which is
where the premature-teardown half shows up). They reuse #7415's thread watchdog — the
deadlock blocks inside the Rust runtime holding the GIL, so pytest-timeout's SIGALRM handler
hangs along with the query.

Verified against a build with the Rust change stashed out: all three fail cleanly at the
deadline. Two Rust unit tests cover `combine_with` directly (both sides' notify tokens
survive and fire; the derived cancel token responds to either parent and to neither in
reverse).

| | before | after |
|---|---|---|
| cross join + `limit` (left, 4 partitions) | hang | 500 rows |
| cross join + `limit` (right) | hang | 500 rows |
| cross join + `limit > total rows` | hang | full product |
| `into_partitions(8) + limit(10)` (#7415's case) | 10 rows | 10 rows |

- `tests/dataframe/test_distributed_limit.py` on Ray: 17 passed, 1 xfailed
- `test_joins.py` + `test_limit_offset.py` + `test_key_filtering_join.py` on Ray: 3824
  passed, 730 skipped
- `cargo test -p daft-distributed`: 70 passed
- fmt / clippy clean

### Follow-up (not in this PR)

Fixing the hang exposes a separate defect that was previously invisible because these queries
never returned: a distributed `LIMIT` under a cross join **drops rows** when the other side
has more than one partition. The limited side is duplicated into one task per builder on the
other side, and every copy claims from the same counter actor, so each row survives in only
one of the tasks it should appear in.

| `range(0, 400, partitions=4).limit(L)` × `range(0, 50, partitions=P)` | expected | ray | native |
|---|---|---|---|
| `L=100, P=1` | 5000 | 5000 | 5000 |
| `L=100, P=2` | 5000 | 2500 | — |
| `L=100, P=5` | 5000 | 1000 | 5000 |
| `L=500, P=2` (limit exceeds the 400 rows — a no-op) | 20000 | 12500 | — |

With a `LIMIT` on both sides the two budgets can be claimed by different tasks, and the query
returns 0 rows. Measured behaviour fits `min(L, rows × P) × (other_rows / P)`.

This is not a one-line fix: making the claim per source partition is not enough, because the
duplicates would still each pick a different set of rows. The real invariant is that the
limited side must be finalized before it enters the cross join. Pinned by
`test_limit_under_cross_join_pairs_with_every_partition_of_the_other_side`, marked
`xfail(strict=True)` so it flags itself when fixed. Happy to open a separate PR if there is
interest in a direction.

## Related Issues

No existing issue. Depends on #7415.