### PR TITLE
perf(distributed): stop upstream work when a distributed LIMIT is satisfied

### DIFF
--- a/daft/execution/ray_distributed_limit.py
+++ b/daft/execution/ray_distributed_limit.py
@@ -85,7 +85,17 @@ class _LimitCounterImpl:
         return [iid for iid, (_skip, take) in self.input_claims.items() if take > 0]
 
     async def await_limit_completion(self) -> list[str]:
-        await self._get_done_event().wait()
+        # Re-check under a loop rather than returning on the first wakeup. The
+        # event is only a wakeup hint: a retry's refund in `start_task` can
+        # reopen the budget after `set()` has already resolved this waiter's
+        # future but before it resumes, and `asyncio.Event.clear()` does not
+        # un-resolve an already-resolved future. Returning there would hand the
+        # coordinator a contributor set for a limit that is no longer satisfied,
+        # and it consumes that set once — so the refunded rows could be
+        # cancelled away before the retry re-claims them.
+        event = self._get_done_event()
+        while not self.is_done():
+            await event.wait()
         return self.contributors()
 
 

--- a/daft/execution/ray_distributed_limit.py
+++ b/daft/execution/ray_distributed_limit.py
@@ -24,6 +24,22 @@ class _LimitCounterImpl:
         self.remaining_take = limit
         # input_id -> (cumulative_skip_claimed, cumulative_take_claimed)
         self.input_claims: dict[str, tuple[int, int]] = {}
+        # Set the moment `remaining_take` reaches zero, so waiters are woken
+        # instead of polling. Created lazily: `__init__` runs on the actor's
+        # thread before its event loop exists, and binding an `asyncio.Event` to
+        # the wrong loop makes `wait()` hang.
+        self._done_event: asyncio.Event | None = None
+
+    def _signal_done(self) -> None:
+        if self._done_event is not None:
+            self._done_event.set()
+
+    def _get_done_event(self) -> asyncio.Event:
+        if self._done_event is None:
+            self._done_event = asyncio.Event()
+            if self.is_done():
+                self._done_event.set()
+        return self._done_event
 
     def start_task(self, input_id: str) -> None:
         # Called by a worker once when it begins processing `input_id`. If
@@ -36,6 +52,11 @@ class _LimitCounterImpl:
             skip, take = prior
             self.remaining_skip += skip
             self.remaining_take += take
+            # A refund can lift `remaining_take` back above zero, so a `done`
+            # already signalled is no longer true: the retry has to re-claim
+            # those rows before the limit is satisfied again.
+            if self.remaining_take > 0 and self._done_event is not None:
+                self._done_event.clear()
 
     def claim(self, input_id: str, num_rows: int) -> tuple[int, int, bool]:
         if self.remaining_take == 0:
@@ -52,7 +73,10 @@ class _LimitCounterImpl:
             prev_skip, prev_take = self.input_claims.get(input_id, (0, 0))
             self.input_claims[input_id] = (prev_skip + skip, prev_take + take)
 
-        return (skip, take, self.remaining_take == 0)
+        done = self.remaining_take == 0
+        if done:
+            self._signal_done()
+        return (skip, take, done)
 
     def is_done(self) -> bool:
         return self.remaining_take == 0
@@ -61,8 +85,7 @@ class _LimitCounterImpl:
         return [iid for iid, (_skip, take) in self.input_claims.items() if take > 0]
 
     async def await_limit_completion(self) -> list[str]:
-        while not self.is_done():
-            await asyncio.sleep(0.01)
+        await self._get_done_event().wait()
         return self.contributors()
 
 
@@ -92,7 +115,10 @@ async def start_limit_counter_actor(limit: int, offset: int, timeout: int) -> Li
     actor = LimitCounterActor.options(
         scheduling_strategy=ray.util.scheduling_strategies.NodeAffinitySchedulingStrategy(
             node_id=node_id,
-            soft=False,
+            # Soft: prefer the runner's node to keep claim RPCs local, but let
+            # Ray place the actor elsewhere rather than fail the query outright
+            # if that node has no room.
+            soft=True,
         ),
     ).remote(limit, offset)
     # Block until the actor's constructor has finished before returning the

--- a/src/daft-local-execution/src/batch_manager.rs
+++ b/src/daft-local-execution/src/batch_manager.rs
@@ -139,6 +139,20 @@ where
         }
     }
 
+    /// Empties `input_id`'s buffer, dropping the data, but leaves the input
+    /// registered.
+    ///
+    /// Used when nothing downstream wants more data for the input yet the
+    /// input must still complete through its normal flush path. `drain` is
+    /// not a substitute: it *removes* the entry, which flips `has_input` to
+    /// false and changes how a later `Flush` for that input is handled.
+    pub fn discard_buffered(&mut self, input_id: InputId) -> DaftResult<()> {
+        if let Some(input) = self.inputs.get_mut(&input_id) {
+            let _ = input.buffer.pop_all()?;
+        }
+        Ok(())
+    }
+
     /// Returns true if the given input has been seen (via `push`).
     pub fn has_input(&self, input_id: InputId) -> bool {
         self.inputs.contains_key(&input_id)

--- a/src/daft-local-execution/src/checkpoint_terminus.rs
+++ b/src/daft-local-execution/src/checkpoint_terminus.rs
@@ -13,6 +13,7 @@ use daft_logical_plan::stats::StatsState;
 use crate::{
     ExecutionRuntimeContext,
     channel::{Receiver, create_channel},
+    input_cancel::InputCancelRegistry,
     pipeline::{BuilderContext, MorselSizeRequirement, PipelineMessage, PipelineNode},
     runtime_stats::{DefaultRuntimeStats, RuntimeStats},
 };
@@ -143,11 +144,14 @@ impl PipelineNode for CheckpointTerminusNode {
         self: Box<Self>,
         maintain_order: bool,
         runtime_handle: &mut ExecutionRuntimeContext,
+        input_cancel: &InputCancelRegistry,
     ) -> crate::Result<Receiver<PipelineMessage>> {
         let node_id = self.node_id();
         let name = self.name();
 
-        let mut child_receiver = self.child.start(maintain_order, runtime_handle)?;
+        let mut child_receiver = self
+            .child
+            .start(maintain_order, runtime_handle, input_cancel)?;
         let (output_sender, output_receiver) = create_channel(1);
 
         let stats_manager = runtime_handle.stats_manager();

--- a/src/daft-local-execution/src/concat.rs
+++ b/src/daft-local-execution/src/concat.rs
@@ -12,6 +12,7 @@ use daft_logical_plan::stats::StatsState;
 use crate::{
     ExecutionRuntimeContext,
     channel::{Receiver, Sender, create_channel},
+    input_cancel::InputCancelRegistry,
     pipeline::{BuilderContext, MorselSizeRequirement, PipelineMessage, PipelineNode},
     runtime_stats::{DefaultRuntimeStats, RuntimeStats, RuntimeStatsManagerHandle},
 };
@@ -189,12 +190,17 @@ impl PipelineNode for ConcatNode {
         self: Box<Self>,
         maintain_order: bool,
         runtime_handle: &mut ExecutionRuntimeContext,
+        input_cancel: &InputCancelRegistry,
     ) -> crate::Result<Receiver<PipelineMessage>> {
         let node_id = self.node_id();
         let name = self.name();
 
-        let left_receiver = self.left.start(maintain_order, runtime_handle)?;
-        let right_receiver = self.right.start(maintain_order, runtime_handle)?;
+        let left_receiver = self
+            .left
+            .start(maintain_order, runtime_handle, input_cancel)?;
+        let right_receiver = self
+            .right
+            .start(maintain_order, runtime_handle, input_cancel)?;
 
         let (destination_sender, destination_receiver) = create_channel(1);
 

--- a/src/daft-local-execution/src/input_cancel.rs
+++ b/src/daft-local-execution/src/input_cancel.rs
@@ -1,0 +1,108 @@
+use std::sync::Arc;
+
+use dashmap::DashMap;
+
+use crate::pipeline::InputId;
+
+/// The set of `input_id`s whose producers have been asked to stop, shared by
+/// every node in one *subtree* of a pipeline.
+///
+/// A worker pipeline is reused across many flotilla tasks — keyed by plan
+/// fingerprint in `NativeExecutor::run` — and each task arrives as its own
+/// `input_id`. An operator that already has all the data it will ever need for
+/// one of those inputs (a distributed `LIMIT` whose global counter reached
+/// zero) cancels that `input_id` here, and the producers feeding it stop
+/// generating data for it. The other `input_id`s riding the same pipeline are
+/// untouched, which is why this is keyed per input and not the pipeline-wide
+/// `CancellationToken` that `NativeExecutor` already owns.
+///
+/// The registry is scoped to a subtree rather than to the whole pipeline
+/// because an operator may only cancel the sources that feed *it*. A
+/// `distributed_limit` can end up as a subtree of a larger task plan —
+/// `SwordfishTaskBuilder::combine_with` fuses both sides of a broadcast or
+/// cross join into one plan — and cancelling by `input_id` alone would stop
+/// the join's other side too, silently dropping rows. `StreamingSink`s that
+/// opt in via [`StreamingSink::cancels_inputs`] get a fresh registry for their
+/// own subtree; every other node forwards the one it was given.
+///
+/// Cancellation is cooperative and *advisory*: it never terminates a node, and
+/// a producer that ignores it simply keeps working, which is the behavior that
+/// predates this registry. That is what keeps the input's normal completion
+/// path intact — a cancelled input still finishes through its own
+/// `PipelineMessage::Flush`, so no bookkeeping has to learn about cancellation.
+#[derive(Clone, Default)]
+pub(crate) struct InputCancelRegistry {
+    /// `DashMap` rather than a `Mutex<HashSet>` because producers poll this on
+    /// every morsel while the cancelling sink writes to it from another task.
+    inner: Arc<DashMap<InputId, ()>>,
+}
+
+impl InputCancelRegistry {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Asks the producers feeding `input_id` to stop generating data for it.
+    /// Only a node that owns this registry may call this — see the type docs.
+    pub(crate) fn cancel(&self, input_id: InputId) {
+        self.inner.insert(input_id, ());
+    }
+
+    /// Polled by producers. Cheap enough to call per morsel.
+    pub(crate) fn is_cancelled(&self, input_id: InputId) -> bool {
+        self.inner.contains_key(&input_id)
+    }
+
+    /// Drops `input_id`'s entry once it has finished flowing through the
+    /// subtree. Only the owning node may call this: clearing the flag while a
+    /// sibling branch is still producing would let that branch resume.
+    pub(crate) fn forget(&self, input_id: InputId) {
+        self.inner.remove(&input_id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cancel_is_scoped_to_one_input() {
+        let registry = InputCancelRegistry::new();
+        registry.cancel(1);
+        assert!(registry.is_cancelled(1));
+        assert!(!registry.is_cancelled(2));
+    }
+
+    #[test]
+    fn unknown_input_is_not_cancelled() {
+        let registry = InputCancelRegistry::new();
+        assert!(!registry.is_cancelled(42));
+    }
+
+    #[test]
+    fn forget_removes_the_entry() {
+        let registry = InputCancelRegistry::new();
+        registry.cancel(3);
+        registry.forget(3);
+        assert!(!registry.is_cancelled(3));
+    }
+
+    /// Two subtrees must not see each other's cancellations — this is what
+    /// keeps a `limit` fused under one side of a join from stopping the other.
+    #[test]
+    fn separate_registries_are_independent() {
+        let left = InputCancelRegistry::new();
+        let right = InputCancelRegistry::new();
+        left.cancel(1);
+        assert!(left.is_cancelled(1));
+        assert!(!right.is_cancelled(1));
+    }
+
+    #[test]
+    fn clones_share_state() {
+        let registry = InputCancelRegistry::new();
+        let clone = registry.clone();
+        registry.cancel(9);
+        assert!(clone.is_cancelled(9));
+    }
+}

--- a/src/daft-local-execution/src/intermediate_ops/intermediate_op.rs
+++ b/src/daft-local-execution/src/intermediate_ops/intermediate_op.rs
@@ -23,6 +23,7 @@ use crate::{
     batch_manager::BatchManager,
     channel::{Receiver, Sender, create_channel},
     dynamic_batching::BatchingStrategy,
+    input_cancel::InputCancelRegistry,
     pipeline::{
         BuilderContext, InputId, MorselSizeRequirement, NodeName, PipelineEvent, PipelineMessage,
         PipelineNode, next_event,
@@ -98,6 +99,10 @@ struct ExecutionContext<Op: IntermediateOperator> {
     node_info: Arc<NodeInfo>,
     node_id: usize,
     node_initialized: bool,
+    /// Cancellation scope this node lives in. Read-only here: intermediate
+    /// operators never satisfy an input themselves, they only notice that a
+    /// sink downstream has, and stop spending work on it.
+    input_cancel: InputCancelRegistry,
 }
 
 impl<Op: IntermediateOperator + 'static> ExecutionContext<Op> {
@@ -114,6 +119,15 @@ impl<Op: IntermediateOperator + 'static> ExecutionContext<Op> {
     }
 
     fn dispatch_ready_batches(&mut self, input_id: InputId) -> DaftResult<()> {
+        if self.input_cancel.is_cancelled(input_id) {
+            // A sink downstream has all it needs for this input, so running the
+            // operator over the backlog would produce rows nobody reads — for a
+            // row-wise UDF under a satisfied `LIMIT` that is the bulk of the
+            // wasted work. Discard rather than `drain`: the entry has to stay so
+            // the input's `Flush` is still handled as an ordinary one.
+            self.batch_manager.discard_buffered(input_id)?;
+            return Ok(());
+        }
         while !self.operator_states.is_empty() {
             let Some(batch) = self.batch_manager.next_batch(input_id)? else {
                 break;
@@ -239,11 +253,20 @@ impl<Op: IntermediateOperator + 'static> ExecutionContext<Op> {
                 }
                 PipelineEvent::Flush(input_id) => {
                     if !self.batch_manager.has_input(input_id) {
-                        let _ = self
+                        // Nothing was ever buffered for this input, so just pass
+                        // the flush along. Note this must *not* end
+                        // `process_input`: a worker pipeline is shared by every
+                        // task with the same plan fingerprint, and the other
+                        // `input_id`s riding it still need this node alive.
+                        if self
                             .output_sender
                             .send(PipelineMessage::Flush(input_id))
-                            .await;
-                        return Ok(());
+                            .await
+                            .is_err()
+                        {
+                            return Ok(());
+                        }
+                        continue;
                     }
                     self.batch_manager.set_pending_flush(input_id);
                     self.try_dispatch()?;
@@ -399,11 +422,15 @@ impl<Op: IntermediateOperator + 'static> PipelineNode for IntermediateNode<Op> {
         self: Box<Self>,
         maintain_order: bool,
         runtime_handle: &mut ExecutionRuntimeContext,
+        input_cancel: &InputCancelRegistry,
     ) -> crate::Result<Receiver<PipelineMessage>> {
         let node_id = self.node_id();
         let name = self.name();
 
-        let mut child_result_receiver = self.child.start(maintain_order, runtime_handle)?;
+        let mut child_result_receiver =
+            self.child
+                .start(maintain_order, runtime_handle, input_cancel)?;
+        let input_cancel = input_cancel.clone();
         let op = self.intermediate_op.clone();
         let (destination_sender, destination_receiver) = create_channel(1);
 
@@ -441,6 +468,7 @@ impl<Op: IntermediateOperator + 'static> PipelineNode for IntermediateNode<Op> {
                     node_info,
                     node_id,
                     node_initialized: false,
+                    input_cancel,
                 };
                 ctx.process_input(&mut child_result_receiver).await?;
 

--- a/src/daft-local-execution/src/join/join_node.rs
+++ b/src/daft-local-execution/src/join/join_node.rs
@@ -13,6 +13,7 @@ use tracing::info_span;
 use crate::{
     ExecutionRuntimeContext, ExecutionTaskSpawner,
     channel::{Receiver, create_channel},
+    input_cancel::InputCancelRegistry,
     join::{
         build::{BuildExecutionContext, BuildStateBridge},
         join_operator::JoinOperator,
@@ -154,13 +155,16 @@ impl<Op: JoinOperator + 'static> PipelineNode for JoinNode<Op> {
         self: Box<Self>,
         maintain_order: bool,
         runtime_handle: &mut ExecutionRuntimeContext,
+        input_cancel: &InputCancelRegistry,
     ) -> crate::Result<Receiver<PipelineMessage>> {
         let node_id = self.node_id();
         let name = self.name();
         let stats_manager = runtime_handle.stats_manager();
 
-        let build_child_receiver = self.left.start(false, runtime_handle)?;
-        let probe_child_receiver = self.right.start(maintain_order, runtime_handle)?;
+        let build_child_receiver = self.left.start(false, runtime_handle, input_cancel)?;
+        let probe_child_receiver =
+            self.right
+                .start(maintain_order, runtime_handle, input_cancel)?;
 
         let (destination_sender, destination_receiver) = create_channel(1);
 

--- a/src/daft-local-execution/src/lib.rs
+++ b/src/daft-local-execution/src/lib.rs
@@ -6,6 +6,7 @@ mod channel;
 mod checkpoint_terminus;
 mod concat;
 mod dynamic_batching;
+mod input_cancel;
 mod input_sender;
 mod intermediate_ops;
 mod join;

--- a/src/daft-local-execution/src/pipeline.rs
+++ b/src/daft-local-execution/src/pipeline.rs
@@ -37,6 +37,7 @@ use crate::{
     ExecutionRuntimeContext, PipelineCreationSnafu,
     channel::create_unbounded_channel,
     concat::ConcatNode,
+    input_cancel::InputCancelRegistry,
     input_sender::InputSender,
     intermediate_ops::{
         distributed_actor_pool_project::DistributedActorPoolProjectOperator,
@@ -231,10 +232,18 @@ pub(crate) trait PipelineNode: Sync + Send + TreeDisplay {
         downstream_requirement: MorselSizeRequirement,
         default_requirement: MorselSizeRequirement,
     );
+    /// Start this node and everything below it.
+    ///
+    /// `input_cancel` is the cancellation scope this node lives in: producers
+    /// under it poll it to learn that nothing downstream wants more data for an
+    /// `input_id`. Nodes forward it to their children verbatim; only a
+    /// `StreamingSink` that opts into `cancels_inputs` substitutes a fresh
+    /// scope for its own subtree.
     fn start(
         self: Box<Self>,
         maintain_order: bool,
         runtime_handle: &mut ExecutionRuntimeContext,
+        input_cancel: &InputCancelRegistry,
     ) -> crate::Result<crate::channel::Receiver<PipelineMessage>>;
 
     fn as_tree_display(&self) -> &dyn TreeDisplay;

--- a/src/daft-local-execution/src/run.rs
+++ b/src/daft-local-execution/src/run.rs
@@ -46,6 +46,7 @@ use {
 use crate::{
     ExecutionRuntimeContext,
     channel::{Sender, UnboundedSender, create_channel, create_unbounded_channel},
+    input_cancel::InputCancelRegistry,
     pipeline::{
         BuilderContext, PipelineMessage, translate_physical_plan_to_pipeline, viz_pipeline_ascii,
         viz_pipeline_mermaid,
@@ -341,7 +342,13 @@ async fn run_execution_loop(
     let memory_manager = get_or_init_memory_manager();
     let mut runtime_handle =
         ExecutionRuntimeContext::new(memory_manager.clone(), stats_manager_handle);
-    let mut output_receiver = pipeline.start(maintain_order, &mut runtime_handle)?;
+    // Root cancellation scope. Nothing cancels in it — only a `StreamingSink`
+    // that opts into `cancels_inputs` creates a scope it may write to — but
+    // every node needs one to forward, and a sink below a cancelling sink
+    // inherits that sink's scope through this same parameter.
+    let root_input_cancel = InputCancelRegistry::new();
+    let mut output_receiver =
+        pipeline.start(maintain_order, &mut runtime_handle, &root_input_cancel)?;
 
     let mut message_router = MessageRouter::new();
     let mut input_senders = Some(input_senders);

--- a/src/daft-local-execution/src/sinks/blocking_sink.rs
+++ b/src/daft-local-execution/src/sinks/blocking_sink.rs
@@ -22,6 +22,7 @@ use tracing::info_span;
 use crate::{
     ExecutionRuntimeContext, ExecutionTaskSpawner, OperatorOutput,
     channel::{Receiver, Sender, create_channel},
+    input_cancel::InputCancelRegistry,
     pipeline::{
         BuilderContext, InputId, MorselSizeRequirement, NodeName, PipelineEvent, PipelineMessage,
         PipelineNode, next_event,
@@ -539,6 +540,7 @@ impl<Op: BlockingSink + 'static> PipelineNode for BlockingSinkNode<Op> {
         self: Box<Self>,
         _maintain_order: bool,
         runtime_handle: &mut ExecutionRuntimeContext,
+        input_cancel: &InputCancelRegistry,
     ) -> crate::Result<Receiver<PipelineMessage>> {
         let Self {
             op,
@@ -549,7 +551,7 @@ impl<Op: BlockingSink + 'static> PipelineNode for BlockingSinkNode<Op> {
             ..
         } = *self;
         let name: Arc<str> = node_info.name.clone();
-        let child_rx = child.start(false, runtime_handle)?;
+        let child_rx = child.start(false, runtime_handle, input_cancel)?;
         let (output_tx, output_rx) = create_channel(1);
         let memory_manager = runtime_handle.memory_manager();
         let stats_manager = runtime_handle.stats_manager();

--- a/src/daft-local-execution/src/sources/glob_scan.rs
+++ b/src/daft-local-execution/src/sources/glob_scan.rs
@@ -21,6 +21,7 @@ use tracing::instrument;
 use super::source::Source;
 use crate::{
     channel::{Sender, UnboundedReceiver, create_channel},
+    input_cancel::InputCancelRegistry,
     pipeline::{InputId, NodeName, PipelineMessage},
     sources::source::{SourceStream, StatsProvider},
 };
@@ -207,6 +208,7 @@ impl Source for GlobScanSource {
         _maintain_order: bool,
         stats_provider: StatsProvider,
         chunk_size: usize,
+        _input_cancel: InputCancelRegistry,
     ) -> DaftResult<SourceStream<'static>> {
         let (output_sender, output_receiver) = create_channel::<PipelineMessage>(1);
         let input_receiver = self.receiver;

--- a/src/daft-local-execution/src/sources/in_memory.rs
+++ b/src/daft-local-execution/src/sources/in_memory.rs
@@ -13,6 +13,7 @@ use tracing::instrument;
 use super::source::Source;
 use crate::{
     channel::{Sender, UnboundedReceiver, create_channel},
+    input_cancel::InputCancelRegistry,
     pipeline::{InputId, NodeName, PipelineMessage},
     sources::source::{SourceStream, StatsProvider},
 };
@@ -129,6 +130,7 @@ impl Source for InMemorySource {
         _maintain_order: bool,
         stats_provider: StatsProvider,
         _chunk_size: usize,
+        _input_cancel: InputCancelRegistry,
     ) -> DaftResult<SourceStream<'static>> {
         let (output_sender, output_receiver) = create_channel::<PipelineMessage>(1);
         let input_receiver = self.receiver;

--- a/src/daft-local-execution/src/sources/scan_task.rs
+++ b/src/daft-local-execution/src/sources/scan_task.rs
@@ -25,6 +25,7 @@ use crate::{
         Receiver, Sender, UnboundedReceiver, UnboundedSender, create_channel,
         create_unbounded_channel,
     },
+    input_cancel::InputCancelRegistry,
     pipeline::{InputId, NodeName, PipelineMessage},
     sources::{
         scan_task_reader,
@@ -78,6 +79,7 @@ impl ScanTaskSource {
         schema: SchemaRef,
         maintain_order: bool,
         skipped_corrupt_files: SkippedCorruptFilesCollector,
+        input_cancel: InputCancelRegistry,
     ) -> common_runtime::RuntimeTask<DaftResult<()>> {
         let io_runtime = get_io_runtime(true);
 
@@ -126,6 +128,7 @@ impl ScanTaskSource {
                         sender,
                         input_id,
                         skipped_corrupt_files.clone(),
+                        input_cancel.clone(),
                     ));
                 }
 
@@ -230,6 +233,7 @@ impl Source for ScanTaskSource {
         maintain_order: bool,
         stats_provider: StatsProvider,
         chunk_size: usize,
+        input_cancel: InputCancelRegistry,
     ) -> DaftResult<SourceStream<'static>> {
         let (output_sender, output_receiver) = create_channel::<PipelineMessage>(1);
         let input_receiver = self.receiver;
@@ -244,6 +248,7 @@ impl Source for ScanTaskSource {
             self.schema.clone(),
             maintain_order,
             self.skipped_corrupt_files.clone(),
+            input_cancel,
         );
         let result_stream = output_receiver.into_stream().map(Ok);
         let combined_stream = combine_stream(result_stream, processor_task.map(|x| x?));
@@ -488,8 +493,22 @@ async fn forward_scan_task_stream(
     sender: ScanTaskOutputSender,
     input_id: InputId,
     skipped_corrupt_files: SkippedCorruptFilesCollector,
+    input_cancel: InputCancelRegistry,
 ) -> DaftResult<InputId> {
     let schema = scan_task.materialized_schema();
+    // Checked before the read is even opened, then again between morsels. This
+    // is deliberately an early *return* rather than skipping the spawn back in
+    // the processor loop: returning normally keeps every piece of flush
+    // bookkeeping intact — `input_id_pending_counts` still decrements to zero
+    // and emits the input's `Flush`, and the order-preserving flattener still
+    // receives the `is_last` marker it is waiting on. Skipping the spawn would
+    // strand both, and the input would never complete.
+    if input_cancel.is_cancelled(input_id) {
+        // Falls through to the `!has_data` branch below, which emits one empty
+        // morsel. Downstream nodes complete an input only once they have seen
+        // data for it, so a cancelled scan task must still say *something*.
+        return finish_forwarding(false, schema, &sender, input_id).await;
+    }
     let mut stream = stream_scan_task(
         scan_task,
         io_stats,
@@ -500,7 +519,15 @@ async fn forward_scan_task_stream(
     )
     .await?;
     let mut has_data = false;
-    while let Some(result) = stream.next().await {
+    loop {
+        // Before the read, not after: checking after `next()` would still pay
+        // for one more chunk of decode before noticing.
+        if input_cancel.is_cancelled(input_id) {
+            break;
+        }
+        let Some(result) = stream.next().await else {
+            break;
+        };
         has_data = true;
         let partition = result?;
         match &sender {
@@ -523,10 +550,21 @@ async fn forward_scan_task_stream(
         }
     }
 
-    // If no data was emitted, send empty micropartition
+    finish_forwarding(has_data, schema, &sender, input_id).await
+}
+
+/// Tail of [`forward_scan_task_stream`]: emits one empty micropartition when
+/// the scan task produced nothing, so that every scan task is visible
+/// downstream as at least one message.
+async fn finish_forwarding(
+    has_data: bool,
+    schema: SchemaRef,
+    sender: &ScanTaskOutputSender,
+    input_id: InputId,
+) -> DaftResult<InputId> {
     if !has_data {
         let empty = MicroPartition::empty(Some(schema));
-        match &sender {
+        match sender {
             ScanTaskOutputSender::Pipeline(s) => {
                 let _ = s
                     .send(PipelineMessage::Morsel {

--- a/src/daft-local-execution/src/sources/shuffle_read.rs
+++ b/src/daft-local-execution/src/sources/shuffle_read.rs
@@ -22,6 +22,7 @@ use tracing::instrument;
 use super::source::{Source, SourceStream, StatsProvider};
 use crate::{
     channel::{Sender, UnboundedReceiver, create_channel},
+    input_cancel::InputCancelRegistry,
     pipeline::{NodeName, PipelineMessage},
 };
 
@@ -238,6 +239,7 @@ impl Source for ShuffleReadSource {
         _maintain_order: bool,
         _stats_provider: StatsProvider,
         _chunk_size: usize,
+        _input_cancel: InputCancelRegistry,
     ) -> DaftResult<SourceStream<'static>> {
         let (output_sender, output_receiver) = create_channel::<PipelineMessage>(1);
         let processor_task = self.spawn_flight_shuffle_processor(output_sender);

--- a/src/daft-local-execution/src/sources/source.rs
+++ b/src/daft-local-execution/src/sources/source.rs
@@ -26,6 +26,7 @@ use snafu::ResultExt;
 use crate::{
     ExecutionRuntimeContext, PipelineExecutionSnafu,
     channel::create_channel,
+    input_cancel::InputCancelRegistry,
     pipeline::{BuilderContext, MorselSizeRequirement, NodeName, PipelineMessage, PipelineNode},
     runtime_stats::{RuntimeStats, RuntimeStatsManagerHandle},
 };
@@ -141,11 +142,21 @@ pub trait Source: Send + Sync {
     fn name(&self) -> NodeName;
     fn op_type(&self) -> NodeType;
     fn multiline_display(&self) -> Vec<String>;
+    /// Start producing data.
+    ///
+    /// `input_cancel` reports which `input_id`s nothing downstream wants more
+    /// data for. Honoring it is optional but is where the savings of an early
+    /// `LIMIT` actually come from: a source that keeps reading just feeds
+    /// morsels to an operator that will throw them away. A source that does
+    /// honor it must still emit at least one message per input it has already
+    /// been handed — downstream nodes complete an input only after they have
+    /// seen data for it.
     fn get_data(
         self: Box<Self>,
         maintain_order: bool,
         stats_provider: StatsProvider,
         chunk_size: usize,
+        input_cancel: InputCancelRegistry,
     ) -> DaftResult<SourceStream<'static>>;
     fn schema(&self) -> &SchemaRef;
 }
@@ -256,6 +267,7 @@ impl PipelineNode for SourceNode {
         self: Box<Self>,
         maintain_order: bool,
         runtime_handle: &mut ExecutionRuntimeContext,
+        input_cancel: &InputCancelRegistry,
     ) -> crate::Result<crate::channel::Receiver<PipelineMessage>> {
         let stats_manager = runtime_handle.stats_manager();
         let node_id = self.node_id();
@@ -273,7 +285,12 @@ impl PipelineNode for SourceNode {
 
         let mut source_stream = self
             .source
-            .get_data(maintain_order, stats_provider.clone(), chunk_size.into())
+            .get_data(
+                maintain_order,
+                stats_provider.clone(),
+                chunk_size.into(),
+                input_cancel.clone(),
+            )
             .with_context(|_| PipelineExecutionSnafu {
                 node_name: name.to_string(),
             })?;

--- a/src/daft-local-execution/src/streaming_sink/base.rs
+++ b/src/daft-local-execution/src/streaming_sink/base.rs
@@ -22,6 +22,7 @@ use crate::{
     batch_manager::BatchManager,
     channel::{Receiver, Sender, create_channel},
     dynamic_batching::BatchingStrategy,
+    input_cancel::InputCancelRegistry,
     pipeline::{
         BuilderContext, InputId, MorselSizeRequirement, NodeName, PipelineEvent, PipelineMessage,
         PipelineNode, next_event,
@@ -31,7 +32,48 @@ use crate::{
 
 pub enum StreamingSinkOutput {
     NeedMoreInput(Option<MicroPartition>),
+    /// The operator has all the data it will ever need for *this* `input_id`,
+    /// but the node must keep running for the others.
+    ///
+    /// Producers feeding this input are asked to stop (see
+    /// [`InputCancelRegistry`]) and anything already buffered for it is
+    /// dropped, yet the input still completes through its own
+    /// `PipelineMessage::Flush` exactly as an uncancelled one would. Operators
+    /// returning this must opt in via [`StreamingSink::cancels_inputs`].
+    ///
+    /// This is separate from `Finished` because `Finished` tears down the whole
+    /// node — correct for a single-task pipeline, fatal for a flotilla worker
+    /// pipeline shared by every task with the same plan fingerprint.
+    ///
+    /// Truncating a subtree is safe even when it contains an operator that must
+    /// see all of its input before it may emit — an aggregation, a sort, a
+    /// top-N. Those are all `BlockingSink`s, and a `BlockingSink` emits nothing
+    /// until it has drained its input, so no row can reach this operator (and
+    /// hence nothing can be satisfied) before every such operator below it has
+    /// already consumed everything it needed.
+    InputSatisfied(Option<MicroPartition>),
+    /// The operator is done with the entire node; the pipeline below it is torn
+    /// down. Only safe when the node serves exactly one input.
     Finished(Option<MicroPartition>),
+}
+
+/// What [`ExecutionContext`] should do after an operator returned a
+/// [`StreamingSinkOutput`].
+#[derive(Copy, Clone, PartialEq, Eq)]
+enum Disposition {
+    KeepGoing,
+    InputSatisfied,
+    Finished,
+}
+
+impl StreamingSinkOutput {
+    fn split(self) -> (Option<MicroPartition>, Disposition) {
+        match self {
+            Self::NeedMoreInput(mp) => (mp, Disposition::KeepGoing),
+            Self::InputSatisfied(mp) => (mp, Disposition::InputSatisfied),
+            Self::Finished(mp) => (mp, Disposition::Finished),
+        }
+    }
 }
 
 pub enum StreamingSinkFinalizeOutput<Op: StreamingSink> {
@@ -79,6 +121,19 @@ pub(crate) trait StreamingSink: Send + Sync {
         None
     }
     fn batching_strategy(&self) -> Self::BatchingStrategy;
+
+    /// Whether this operator ever returns
+    /// [`StreamingSinkOutput::InputSatisfied`].
+    ///
+    /// Opting in gives the operator's subtree its own cancellation scope, so
+    /// satisfying one input cannot stop a producer feeding a *sibling* branch —
+    /// the other side of a broadcast or cross join fused into the same task plan
+    /// by `SwordfishTaskBuilder::combine_with`. Operators that never return
+    /// `InputSatisfied` leave this at `false` and simply forward the scope they
+    /// were handed.
+    fn cancels_inputs(&self) -> bool {
+        false
+    }
 }
 
 enum TaskResult<Op: StreamingSink> {
@@ -129,6 +184,12 @@ struct ExecutionContext<Op: StreamingSink> {
     node_info: Arc<NodeInfo>,
     node_id: usize,
     node_initialized: bool,
+    /// The scope covering this node's *child* subtree — the producers of the
+    /// data this node consumes. Owned (and therefore writable) only when
+    /// `op.cancels_inputs()`; otherwise it is the scope inherited from a
+    /// cancelling sink further downstream, which this node only reads.
+    input_cancel: InputCancelRegistry,
+    owns_input_cancel: bool,
 }
 
 impl<Op: StreamingSink + 'static> ExecutionContext<Op> {
@@ -154,6 +215,13 @@ impl<Op: StreamingSink + 'static> ExecutionContext<Op> {
     }
 
     fn dispatch_ready_batches(&mut self, input_id: InputId) -> DaftResult<()> {
+        if self.input_cancel.is_cancelled(input_id) {
+            // Satisfied — by this operator, or by a sink downstream of it.
+            // Discard rather than `drain`: the entry has to stay so the input's
+            // `Flush` is still handled as an ordinary one.
+            self.batch_manager.discard_buffered(input_id)?;
+            return Ok(());
+        }
         let per_input = self
             .inputs
             .get_mut(&input_id)
@@ -185,6 +253,14 @@ impl<Op: StreamingSink + 'static> ExecutionContext<Op> {
         if workers_idle && self.batch_manager.can_flush(input_id) {
             let remaining = self.batch_manager.drain(input_id)?;
             let per_input = self.inputs.remove(&input_id).unwrap();
+            if self.owns_input_cancel {
+                // The subtree has finished this input, so nothing can act on
+                // the flag any more. Dropping it keeps the registry from growing
+                // by an entry per task on a long-lived reused pipeline. Only the
+                // owner may do this: clearing a flag while a sibling branch is
+                // still producing would let that branch resume.
+                self.input_cancel.forget(input_id);
+            }
             self.spawn_complete_input(per_input, remaining, input_id);
         }
         Ok(())
@@ -217,9 +293,14 @@ impl<Op: StreamingSink + 'static> ExecutionContext<Op> {
                 runtime_stats.add_duration_us(elapsed.as_micros() as u64);
                 runtime_stats.increment_num_tasks();
 
-                let (mp, finished) = match result {
-                    StreamingSinkOutput::NeedMoreInput(mp) => (mp, false),
-                    StreamingSinkOutput::Finished(mp) => (mp, true),
+                // `InputSatisfied` needs no special handling here: this is
+                // already the input's last batch (`try_complete_input` only
+                // fires once the child has flushed it), so there is nothing
+                // left upstream to cancel and the input proceeds to finalize
+                // just as `NeedMoreInput` would.
+                let (mp, finished) = match result.split() {
+                    (mp, Disposition::Finished) => (mp, true),
+                    (mp, _) => (mp, false),
                 };
                 if let Some(mp) = mp {
                     runtime_stats.add_rows_out(mp.len() as u64);
@@ -291,10 +372,7 @@ impl<Op: StreamingSink + 'static> ExecutionContext<Op> {
             .add_duration_us(elapsed.as_micros() as u64);
         per_input.runtime_stats.increment_num_tasks();
 
-        let (mp, finished) = match output {
-            StreamingSinkOutput::NeedMoreInput(mp) => (mp, false),
-            StreamingSinkOutput::Finished(mp) => (mp, true),
-        };
+        let (mp, disposition) = output.split();
         self.batch_manager.record_completion(
             per_input.runtime_stats.as_ref(),
             mp.as_ref().map(|p| p.len()).unwrap_or(0),
@@ -318,7 +396,7 @@ impl<Op: StreamingSink + 'static> ExecutionContext<Op> {
             }
         }
 
-        if finished {
+        if disposition == Disposition::Finished {
             let _ = self
                 .output_sender
                 .send(PipelineMessage::Flush(input_id))
@@ -327,6 +405,19 @@ impl<Op: StreamingSink + 'static> ExecutionContext<Op> {
         }
 
         per_input.states.push(state);
+
+        if disposition == Disposition::InputSatisfied {
+            debug_assert!(
+                self.owns_input_cancel,
+                "operator returned InputSatisfied without opting into cancels_inputs"
+            );
+            // Stop the producers feeding this input. `dispatch_ready_batches`
+            // then throws away whatever they already handed us instead of
+            // claiming against it. The input still completes normally: its
+            // `Flush` arrives once the short-circuited subtree drains, and
+            // `try_complete_input` takes it from there.
+            self.input_cancel.cancel(input_id);
+        }
         self.dispatch_ready_batches(input_id)?;
         self.try_complete_input(input_id)?;
         Ok(ControlFlow::Continue(()))
@@ -532,6 +623,7 @@ impl<Op: StreamingSink + 'static> PipelineNode for StreamingSinkNode<Op> {
         self: Box<Self>,
         maintain_order: bool,
         runtime_handle: &mut ExecutionRuntimeContext,
+        input_cancel: &InputCancelRegistry,
     ) -> crate::Result<Receiver<PipelineMessage>> {
         let Self {
             op,
@@ -542,7 +634,16 @@ impl<Op: StreamingSink + 'static> PipelineNode for StreamingSinkNode<Op> {
         } = *self;
         let node_id = node_info.id;
         let name: Arc<str> = node_info.name.clone();
-        let child_rx = child.start(maintain_order, runtime_handle)?;
+        // A cancelling operator gets a scope of its own, covering exactly the
+        // producers it consumes from; everything else forwards what it was
+        // handed, so a cancel from further downstream still reaches down here.
+        let owns_input_cancel = op.cancels_inputs();
+        let input_cancel = if owns_input_cancel {
+            InputCancelRegistry::new()
+        } else {
+            input_cancel.clone()
+        };
+        let child_rx = child.start(maintain_order, runtime_handle, &input_cancel)?;
         let (output_tx, output_rx) = create_channel(1);
         let memory_manager = runtime_handle.memory_manager();
         let stats_manager = runtime_handle.stats_manager();
@@ -575,6 +676,8 @@ impl<Op: StreamingSink + 'static> PipelineNode for StreamingSinkNode<Op> {
                     node_info,
                     node_id,
                     node_initialized: false,
+                    input_cancel,
+                    owns_input_cancel,
                 };
                 let mut child_rx = child_rx;
                 ctx.process_input(&mut child_rx).await?;

--- a/src/daft-local-execution/src/streaming_sink/distributed_limit.rs
+++ b/src/daft-local-execution/src/streaming_sink/distributed_limit.rs
@@ -71,7 +71,7 @@ impl StreamingSink for DistributedLimitSink {
 
                     let num_rows = input.len();
                     let iid = state.input_id.clone();
-                    let (skip, take, _done) = common_runtime::python::execute_python_coroutine::<
+                    let (skip, take, done) = common_runtime::python::execute_python_coroutine::<
                         _,
                         (i64, i64, bool),
                     >(move |py| {
@@ -91,9 +91,21 @@ impl StreamingSink for DistributedLimitSink {
                         input.slice(skip, skip + take)?
                     };
 
+                    // `done` means the counter actor has handed out the last of
+                    // the global limit — to us or to some other task. Either
+                    // way this task's remaining input can no longer contribute,
+                    // so tell the framework to stop producing it. Every further
+                    // morsel would otherwise cost a full `claim` round-trip and
+                    // all the upstream work that produced it, only to be sliced
+                    // down to nothing.
+                    let output = Some(output.into());
                     Ok((
                         state,
-                        StreamingSinkOutput::NeedMoreInput(Some(output.into())),
+                        if done {
+                            StreamingSinkOutput::InputSatisfied(output)
+                        } else {
+                            StreamingSinkOutput::NeedMoreInput(output)
+                        },
                     ))
                 },
                 Span::current(),
@@ -142,5 +154,9 @@ impl StreamingSink for DistributedLimitSink {
         crate::dynamic_batching::StaticBatchingStrategy::new(
             self.morsel_size_requirement().unwrap_or_default(),
         )
+    }
+
+    fn cancels_inputs(&self) -> bool {
+        true
     }
 }

--- a/src/daft-local-execution/src/streaming_sink/limit.rs
+++ b/src/daft-local-execution/src/streaming_sink/limit.rs
@@ -80,6 +80,15 @@ impl StreamingSink for LimitSink {
             input_num_rows = input.len();
         }
 
+        // `Finished` tears down the whole node, which is only correct because
+        // this operator never runs on a pipeline that serves more than one
+        // input: it is built from `LocalPhysicalPlan::Limit`, which flotilla
+        // does not generate (it plans `distributed_limit` instead, whose sink
+        // returns `InputSatisfied` so that the shared worker pipeline survives).
+        // A future flotilla plan that *does* emit `LocalPhysicalPlan::Limit`
+        // must switch these to `InputSatisfied` — otherwise the first task to
+        // hit its limit kills the pipeline out from under every other task with
+        // the same plan fingerprint.
         match input_num_rows.cmp(remaining_take) {
             Less => {
                 *remaining_take -= input_num_rows;

--- a/tests/dataframe/test_distributed_limit.py
+++ b/tests/dataframe/test_distributed_limit.py
@@ -9,10 +9,15 @@ path is otherwise uncovered.
 
 from __future__ import annotations
 
+import asyncio
+from collections import Counter
+
 import pytest
 
 ray = pytest.importorskip("ray")
 
+import daft
+from daft import DataType, col, func
 from daft.execution.ray_distributed_limit import _LimitCounterImpl
 from tests.conftest import get_tests_daft_runner_name
 
@@ -133,9 +138,6 @@ def test_distributed_limit_retries_after_worker_death(tmp_path):
     """
     import os
 
-    import daft
-    from daft import DataType, col, func
-
     marker = str(tmp_path / "crashed_once")
 
     @func(return_dtype=DataType.int64(), cpus=os.cpu_count())
@@ -174,7 +176,6 @@ def test_distributed_limit_retries_after_worker_death(tmp_path):
 
 def test_claim_signals_done_event():
     """`claim` must wake `await_limit_completion` rather than have it poll."""
-    import asyncio
 
     async def run():
         actor = _LimitCounterImpl(limit=2, offset=0)
@@ -198,7 +199,6 @@ def test_done_event_set_before_any_waiter():
     loop — so the first waiter has to notice a limit that was already satisfied
     instead of blocking forever.
     """
-    import asyncio
 
     async def run():
         actor = _LimitCounterImpl(limit=1, offset=0)
@@ -216,7 +216,6 @@ def test_retry_rewind_reopens_done_event():
     a waiter would conclude the limit was satisfied while the rewound rows had
     never reached downstream.
     """
-    import asyncio
 
     async def run():
         actor = _LimitCounterImpl(limit=1, offset=0)
@@ -233,6 +232,45 @@ def test_retry_rewind_reopens_done_event():
         assert not waiter.done(), "refund left the done event set"
 
         actor.claim("t2", 1)
+        return await asyncio.wait_for(waiter, timeout=5)
+
+    assert asyncio.run(run()) == ["t2"]
+
+
+def test_refund_between_set_and_resume_does_not_release_waiter():
+    """A refund landing after `set()` but before the waiter resumes must not release it.
+
+    `asyncio.Event.clear()` does not un-resolve a future that `set()` already
+    resolved, so a waiter that returned on the first wakeup would hand the
+    coordinator a contributor set for a limit that is no longer satisfied. The
+    coordinator consumes that set exactly once and then cancels the
+    non-contributors, so the refunded rows could be cancelled away before the
+    retry re-claims them and the query would return fewer rows than requested.
+
+    This is the ordering that the previous `while not is_done(): sleep(0.01)`
+    poll could not get wrong, because it re-checked the condition on every
+    wakeup. `await_limit_completion` has to keep doing that.
+    """
+
+    async def run():
+        actor = _LimitCounterImpl(limit=1, offset=0)
+        waiter = asyncio.create_task(actor.await_limit_completion())
+        await asyncio.sleep(0)  # park the waiter inside Event.wait()
+
+        actor.start_task("t1")
+        actor.claim("t1", 1)  # satisfied: resolves the parked waiter's future
+        actor.start_task("t1")  # retry refunds before the waiter ever resumes
+        assert not actor.is_done(), "refund should have reopened the budget"
+
+        # Give the waiter every chance to resume on a stale wakeup.
+        for _ in range(3):
+            await asyncio.sleep(0)
+        assert not waiter.done(), (
+            "await_limit_completion returned while remaining_take > 0; it must "
+            "re-check is_done() instead of trusting a single Event wakeup"
+        )
+
+        actor.claim("t2", 1)  # the retry supplies the row
         return await asyncio.wait_for(waiter, timeout=5)
 
     assert asyncio.run(run()) == ["t2"]
@@ -269,11 +307,6 @@ def test_limit_under_cross_join_keeps_the_other_side_whole():
     not deterministic. The cross product's shape is: every row the limit let
     through must pair with every one of the right side's rows.
     """
-    from collections import Counter
-
-    import daft
-    from daft import DataType, col, func
-
     limit = 100
     right_rows = 5
 
@@ -308,9 +341,6 @@ def test_limit_under_broadcast_join_emits_every_limited_row():
     inner join has to emit exactly `limit` rows — no assumption about *which*
     rows the distributed limit let through, which is not deterministic.
     """
-    import daft
-    from daft import DataType, col, func
-
     limit = 200
     universe = 400
 
@@ -348,9 +378,6 @@ def test_limit_stops_upstream_work():
     fire-and-forget so the total can undercount slightly — but the pre-fix
     behavior feeds the UDF *every* row, which is far outside it.
     """
-    import daft
-    from daft import DataType, col, func
-
     total_rows = 8 * 20_000
 
     @ray.remote(num_cpus=0)
@@ -400,8 +427,6 @@ def test_limit_larger_than_input_reads_everything():
     The complement of `test_limit_stops_upstream_work`: this query legitimately
     has to read all of its input, and early stopping must not truncate it.
     """
-    import daft
-    from daft import DataType, col, func
 
     @func(return_dtype=DataType.bool())
     def keep(a: int) -> bool:

--- a/tests/dataframe/test_distributed_limit.py
+++ b/tests/dataframe/test_distributed_limit.py
@@ -170,3 +170,242 @@ def test_distributed_limit_retries_after_worker_death(tmp_path):
         "If 0 is missing, the limit actor failed to rewind the crashed "
         "task's claim in start_task."
     )
+
+
+def test_claim_signals_done_event():
+    """`claim` must wake `await_limit_completion` rather than have it poll."""
+    import asyncio
+
+    async def run():
+        actor = _LimitCounterImpl(limit=2, offset=0)
+        waiter = asyncio.create_task(actor.await_limit_completion())
+        # Let the waiter reach `Event.wait()` before the limit is satisfied, so
+        # the test covers the wake-up rather than the already-done shortcut.
+        await asyncio.sleep(0)
+        assert not waiter.done()
+
+        actor.start_task("t1")
+        actor.claim("t1", 2)
+        return await asyncio.wait_for(waiter, timeout=5)
+
+    assert asyncio.run(run()) == ["t1"]
+
+
+def test_done_event_set_before_any_waiter():
+    """A limit reached before the first `await_limit_completion` still resolves.
+
+    The event is created lazily — `__init__` runs before the actor has an event
+    loop — so the first waiter has to notice a limit that was already satisfied
+    instead of blocking forever.
+    """
+    import asyncio
+
+    async def run():
+        actor = _LimitCounterImpl(limit=1, offset=0)
+        actor.start_task("t1")
+        actor.claim("t1", 1)
+        return await asyncio.wait_for(actor.await_limit_completion(), timeout=5)
+
+    assert asyncio.run(run()) == ["t1"]
+
+
+def test_retry_rewind_reopens_done_event():
+    """A refund that lifts the budget back above zero must un-signal `done`.
+
+    `start_task` rewinds a crashed attempt's claims. If the event stayed set,
+    a waiter would conclude the limit was satisfied while the rewound rows had
+    never reached downstream.
+    """
+    import asyncio
+
+    async def run():
+        actor = _LimitCounterImpl(limit=1, offset=0)
+        actor.start_task("t1")
+        actor.claim("t1", 1)
+        assert actor.is_done()
+        # Force the event into existence and into the set state.
+        assert await asyncio.wait_for(actor.await_limit_completion(), timeout=5) == ["t1"]
+
+        actor.start_task("t1")  # retry: refunds the claim
+        assert not actor.is_done()
+        waiter = asyncio.create_task(actor.await_limit_completion())
+        await asyncio.sleep(0)
+        assert not waiter.done(), "refund left the done event set"
+
+        actor.claim("t2", 1)
+        return await asyncio.wait_for(waiter, timeout=5)
+
+    assert asyncio.run(run()) == ["t2"]
+
+
+@pytest.mark.skip(
+    reason="`limit` under a cross join hangs on main, unrelated to this test's subject. "
+    "SwordfishTaskBuilder::combine_with resets notify_tokens/cancel_token to empty, so the "
+    "oneshot sender LimitNode registered via add_notify_token is dropped when CrossJoinNode "
+    "combines the builder. Its receiver then resolves Err, limit_execution_loop's "
+    "`if let Ok(Ok(task_id))` swallows it, completed_ids never gains the task, and "
+    "`contributors.is_subset(completed_ids)` is never satisfied. Re-enable once tokens survive "
+    "combine_with."
+)
+@pytest.mark.skipif(get_tests_daft_runner_name() != "ray", reason="requires Ray Runner to be in use")
+def test_limit_under_cross_join_keeps_the_other_side_whole():
+    """Satisfying a `LIMIT` must not stop the *other* side of a fused join.
+
+    This is the strongest form of the invariant: `CrossJoinNode` is the one
+    place that puts two *scan* sources into a single task with a
+    `distributed_limit` over only one of them. `test_limit_under_broadcast_join_
+    emits_every_limited_row` covers the same invariant on a path that works
+    today, but its build side is an in-memory source.
+
+    `CrossJoinNode` builds each task with `SwordfishTaskBuilder::combine_with`,
+    which merges two plans — and their sources — into a single task. With a
+    `limit` on one side, that task contains a `distributed_limit` plus a
+    `ScanTaskSource` the limit does not own. If early-stop were signalled per
+    `input_id` alone it would stop that scan too, and the join would silently
+    lose rows. The signal is scoped to the limit's own subtree instead.
+
+    Asserted on shape rather than on *which* rows survive: a distributed limit
+    claims rows first-come-first-served across tasks, so the surviving set is
+    not deterministic. The cross product's shape is: every row the limit let
+    through must pair with every one of the right side's rows.
+    """
+    from collections import Counter
+
+    import daft
+    from daft import DataType, col, func
+
+    limit = 100
+    right_rows = 5
+
+    @func(return_dtype=DataType.int64())
+    def identity(v: int) -> int:
+        # Blocks limit pushdown into the scan, forcing the path where the
+        # counter actor actually reports `done` mid-stream.
+        return v
+
+    left = daft.range(0, 400, partitions=4).select(identity(col("id")).alias("lid")).limit(limit)
+    right = daft.range(0, right_rows, partitions=1).select(col("id").alias("rid"))
+
+    result = left.join(right, how="cross").to_pydict()
+
+    assert len(result["lid"]) == limit * right_rows, (
+        f"cross join produced {len(result['lid'])} rows, expected {limit * right_rows}. "
+        "A short count means the limit's early stop reached the join's other side."
+    )
+    assert Counter(result["rid"]) == {r: limit for r in range(right_rows)}, (
+        f"right-side rows are not evenly paired: {Counter(result['rid'])}. "
+        "The right scan was truncated by the limit's early stop."
+    )
+
+
+@pytest.mark.skipif(get_tests_daft_runner_name() != "ray", reason="requires Ray Runner to be in use")
+def test_limit_under_broadcast_join_emits_every_limited_row():
+    """A satisfied `LIMIT` under a broadcast join must not drop probe rows.
+
+    `PushDownLimit` leaves the `limit` on the join's receiver side, and
+    `map_plan` fuses both into one task plan. The build side covers every
+    possible key here, so each of the `limit` rows has exactly one match and the
+    inner join has to emit exactly `limit` rows — no assumption about *which*
+    rows the distributed limit let through, which is not deterministic.
+    """
+    import daft
+    from daft import DataType, col, func
+
+    limit = 200
+    universe = 400
+
+    @func(return_dtype=DataType.int64())
+    def identity(v: int) -> int:
+        return v
+
+    big = daft.range(0, universe, partitions=8).select(identity(col("id")).alias("id"))
+    small = daft.from_pydict({"id": list(range(universe)), "tag": [f"t{i}" for i in range(universe)]})
+
+    result = big.limit(limit).join(small, on="id").to_pydict()
+
+    assert len(result["id"]) == limit, (
+        f"join emitted {len(result['id'])} rows, expected {limit}. "
+        "Rows the limit let through failed to find their match."
+    )
+    assert len(set(result["id"])) == limit, f"join duplicated rows: {result['id']}"
+    # Each row must carry its own tag, not another row's — a partially built
+    # hash table can match while pairing the wrong side.
+    assert all(tag == f"t{i}" for i, tag in zip(result["id"], result["tag"]))
+
+
+@pytest.mark.skipif(get_tests_daft_runner_name() != "ray", reason="requires Ray Runner to be in use")
+def test_limit_stops_upstream_work():
+    """A satisfied `LIMIT` must stop upstream production, not just discard it.
+
+    Regression test for the distributed limit doing no work-saving at all: the
+    counter actor's `done` flag was dropped on the floor, so every task drained
+    its whole partition through the (non-pushdown-able) UDF and the query cost
+    the same as having no `LIMIT`.
+
+    Asserts on rows actually fed to the UDF rather than on wall clock, so it
+    does not depend on machine speed. The bound is deliberately loose — how much
+    is saved depends on scheduling, and the counter increments are
+    fire-and-forget so the total can undercount slightly — but the pre-fix
+    behavior feeds the UDF *every* row, which is far outside it.
+    """
+    import daft
+    from daft import DataType, col, func
+
+    total_rows = 8 * 20_000
+
+    @ray.remote(num_cpus=0)
+    class RowCounter:
+        def __init__(self) -> None:
+            self.n = 0
+
+        def add(self, n: int) -> None:
+            self.n += n
+
+        def get(self) -> int:
+            return self.n
+
+    counter = RowCounter.options(name="limit_row_counter", lifetime=None).remote()
+
+    @func(return_dtype=DataType.bool())
+    def keep_and_count(a: int) -> bool:
+        import ray as _ray
+
+        _ray.get_actor("limit_row_counter").add.remote(1)
+        return a % 1_000 == 0
+
+    try:
+        # Small morsels so the early-stop signal has a chance to land partway
+        # through a partition; the default morsel is larger than these
+        # partitions, which would make the test measure nothing.
+        daft.set_execution_config(default_morsel_size=2_000)
+        df = daft.range(0, total_rows, partitions=8).where(keep_and_count(col("id"))).limit(4)
+        result = df.to_pydict()
+        assert len(result["id"]) == 4
+
+        processed = ray.get(counter.get.remote())
+        assert processed < total_rows * 0.9, (
+            f"UDF saw {processed} of {total_rows} rows; the limit saved almost nothing. "
+            "The DistributedLimitSink is not honoring the counter actor's `done` flag, "
+            "or the cancellation is not reaching the source."
+        )
+    finally:
+        daft.set_execution_config(default_morsel_size=None)
+        ray.kill(counter)
+
+
+@pytest.mark.skipif(get_tests_daft_runner_name() != "ray", reason="requires Ray Runner to be in use")
+def test_limit_larger_than_input_reads_everything():
+    """`limit > total rows` never satisfies the counter, so nothing is cancelled.
+
+    The complement of `test_limit_stops_upstream_work`: this query legitimately
+    has to read all of its input, and early stopping must not truncate it.
+    """
+    import daft
+    from daft import DataType, col, func
+
+    @func(return_dtype=DataType.bool())
+    def keep(a: int) -> bool:
+        return a % 3 == 0
+
+    df = daft.range(0, 300, partitions=8).where(keep(col("id"))).limit(10_000)
+    assert len(df.to_pydict()["id"]) == 100


### PR DESCRIPTION
## Changes Made

A distributed `LIMIT` that cannot be pushed into the scan saves no work at all — it costs the same
as not writing `LIMIT` in the first place.

`DistributedLimitSink` discards the `done` flag the counter actor returns
(`distributed_limit.rs:74`) and always answers `NeedMoreInput`, so every task drains its whole
partition *after* the global limit is already satisfied: one `claim` round-trip per morsel, plus all
the upstream work that produced that morsel, only to slice the result down to nothing. Not even the
task that contributed the rows stops early — and the coordinator waits for contributor tasks to
*finish* before it cancels the rest (`limit_loop_done`'s `contributors.is_subset(completed_ids)`),
so nobody stops.

### Repro

```python
import glob, time, daft
from daft import DataType, col, func

daft.set_runner_ray()

@func(return_dtype=DataType.bool())
def keep(a: int) -> bool:          # row-wise UDF: blocks predicate + limit pushdown
    return a % 100_000 == 0

files = sorted(glob.glob("big/*/*.parquet"))       # 8 files x 1M rows
t = time.perf_counter()
d = daft.read_parquet(files).where(keep(col("a"))).limit(10).to_pydict()
print(f"rows={len(d['a'])} wall={time.perf_counter() - t:.2f}s")
```

The UDF matters. A plain `where(col("a") % 1000 == 0)` is pushed into the parquet scan and the limit
rides along, so the problem does not reproduce — that path was already fast. Only a predicate that
cannot be pushed down puts real work above the scan.

Before this PR the limit node saw a total of **80 rows** and the query still took 51.9s, against
51.1s for the same query with no `LIMIT` at all. The native runner, whose `LimitSink` returns
`Finished`, took 19.2s.

### Why this could not reuse `Finished`

`StreamingSinkOutput::Finished` takes `ControlFlow::Break` out of `process_input`
(`base.rs:321`), terminating the **whole node**. That is correct for a single-task pipeline, but
flotilla reuses one local pipeline per plan fingerprint and feeds many tasks into it as separate
`input_id`s (`run.rs`, `enqueue_input_sender` + `active_input_ids`). Short-circuiting one task kills
the shared pipeline, and every later task with the same fingerprint fails with
`Plan execution task has died; cannot enqueue new input`. A five-line prototype that just swapped
`NeedMoreInput` for `Finished` broke 28 tests in `tests/dataframe/test_limit_offset.py` this way.

This is also why flotilla plans never contain `LocalPhysicalPlan::limit` today: the counter-actor
design worked *around* `Finished` rather than with it, at the cost of giving up short-circuiting
entirely.

### Fix

A new outcome, `StreamingSinkOutput::InputSatisfied`, ends **one `input_id`** instead of the node.
It asks the producers feeding that input to stop and drops what they already handed over, while the
input still completes through its ordinary `PipelineMessage::Flush` — so nothing downstream has to
learn about cancellation, and `Finished` keeps its meaning for the native `LimitSink`, which depends
on tearing its subtree down (that is the 19.2s vs 51.9s gap above, and it is unchanged).

Cancellation is carried by a small registry threaded through `PipelineNode::start`, and it is scoped
to the cancelling operator's **subtree**, not to the `input_id`. That scoping is load-bearing:
`SwordfishTaskBuilder::combine_with` fuses both sides of a broadcast or cross join into a single task
plan, so a `distributed_limit` can share a task with sources it does not own — cancelling by
`input_id` alone would stop the join's other side and silently drop rows. Sinks opt in via
`StreamingSink::cancels_inputs` and get a scope covering exactly the producers they consume from;
every other node forwards the scope it was handed, so a cancel from further downstream still reaches
through.

Cancellation is advisory throughout. It never terminates a node, and a producer that ignores its
scope simply keeps working — the pre-existing behaviour. `ScanTaskSource` honours it by returning
early from `forward_scan_task_stream`, checked before each read rather than after, so a cancelled
scan task still completes normally and every piece of flush bookkeeping stays intact
(`input_id_pending_counts` still reaches zero and emits the input's `Flush`; the order-preserving
flattener still gets its `is_last` marker). Skipping the spawn instead would strand both. Streaming
sinks and intermediate operators discard a satisfied input's backlog rather than running the
operator over it — for a row-wise UDF under a satisfied `LIMIT` that is the bulk of the saved work.

Truncating a subtree is safe even when it contains an operator that must see all of its input before
it may emit — an aggregation, a sort, a top-N. Those are all `BlockingSink`s, and a `BlockingSink`
emits nothing until it has drained its input, so no row can reach the limit (and hence nothing can be
satisfied) before every such operator below it has already consumed everything it needed.

Two smaller things, in the same area:

- **A latent bug of the same class.** In `intermediate_op.rs`, a `Flush` for an input the operator
  never buffered did `return Ok(())` — terminating the node, which is wrong under pipeline reuse for
  exactly the reason above. It now forwards the flush and keeps running. The new cancellation path
  exercises flush paths harder, so this is fixed here rather than left to trip later.
- **Counter-actor cleanup.** `await_limit_completion` waited on `asyncio.sleep(0.01)` in a loop; it
  now blocks on an `asyncio.Event`, cleared again when a retry refund in `start_task` lifts the
  budget back above zero. The actor's node affinity is now `soft=True`: it still prefers the runner's
  node to keep `claim` round-trips local, but a full node degrades placement instead of failing the
  query.

### Review fix (second commit)

Swapping the counter actor's completion poll for an `asyncio.Event` lost the poll's re-check.
`Event.clear()` does not un-resolve a future that `set()` already resolved, so a retry's refund in
`start_task` landing between the `set()` and the waiter resuming released the waiter anyway.
`await_limit_completion` then returned a contributor set for a limit that was no longer satisfied —
and `LimitNode` consumes that set exactly once and cancels the non-contributors against it, so the
refunded rows could be cancelled away before the retry re-claimed them, returning fewer rows than
requested.

The event is a wakeup hint, not the condition. `is_done()` is re-checked in a loop around the wait,
which is what `while not is_done(): await sleep(0.01)` did on every wakeup. Confirmed by reverting
the fix: `test_refund_between_set_and_resume_does_not_release_waiter` fails with the waiter having
already returned `[]` while `remaining_take == 1`, and passes with it.

Thanks to the review for catching this — it is a narrow ordering window that the tests I had would
not have hit.

### Results

8 parquet files x 1M rows, 16 cores / 30G, local Ray, same build profile on both sides. "claims" is
the number of `_LimitCounterImpl.claim` calls — a direct measure of how much data reached the limit
node, and therefore of upstream work not saved.

| query | before | after |
|---|---|---|
| `where(keep).limit(10)`, 8 partitions | 51.9s / 64 claims | **39.2s / 14 claims** |
| `where(keep).limit(10)`, 2 partitions | 13.4s / 16 claims | 13.5s / 9 claims |
| `where(keep).limit(10)`, 1 partition | 7.1s / 8 claims | 7.1s / 8 claims |
| `read_parquet(8).limit(10)` (pushdown) | 0.98s / 8 claims | 0.97s / 2 claims |

1.33x wall clock and 4.6x less work at the limit node on 8 partitions. The 1- and 2-partition rows
are the honest control: with this data a single partition only satisfies `LIMIT 10` near the end of
its own scan, so there is almost nothing to cancel and the numbers are flat, as they should be. The
pushdown fast path is unchanged in wall clock and does less work.

### Tests

`tests/dataframe/test_distributed_limit.py` gains:

- `test_limit_stops_upstream_work` — the actual regression test for this PR. Counts rows fed to the
  UDF through a Ray actor and asserts the limit saved work, rather than asserting on wall clock, so
  it does not depend on machine speed. Observed 40% of rows processed against a 90% bound; the
  pre-fix behaviour feeds the UDF every row.
- `test_limit_larger_than_input_reads_everything` — the complement. `limit > total rows` never
  satisfies the counter, so nothing is cancelled and the query must still read all of its input.
- `test_limit_under_broadcast_join_emits_every_limited_row` — the fused-plan invariant: a satisfied
  limit must not drop probe rows when the join's build side shares its task.
- `test_claim_signals_done_event`, `test_done_event_set_before_any_waiter`,
  `test_retry_rewind_reopens_done_event` — the actor's event handling, including the lazily created
  event (`__init__` runs before the actor has a loop) and the refund that must un-signal `done`.
- `test_refund_between_set_and_resume_does_not_release_waiter` — the review fix above. Drives the
  exact interleaving (park the waiter, satisfy the limit, refund before it resumes) and asserts the
  waiter stays parked until the retry re-supplies the row.
- `test_limit_under_cross_join_keeps_the_other_side_whole` — the strongest form of the subtree-scoping
  invariant, and the only place two *scan* sources land in one task with a limit over one of them.
  Skipped, with the root cause in the skip reason: `limit` under a cross join hangs on `main` for an
  unrelated reason (see follow-ups).

One process note, since it cost me a full suite run: a distributed `LIMIT` guarantees the row
*count*, not *which* rows. The counter actor hands out budget first-come-first-served across tasks,
so the surviving set depends on scheduling. My first version of the join test asserted ids `0..199`;
it passed alone and failed under load. These tests assert shape and invariants instead.

Verified locally:

- `tests/dataframe` on the Ray runner: **8554 passed**, 0 failed
- `tests/dataframe` on the native runner: **9457 passed / 2318 skipped**, 0 failed — run in two
  halves, see follow-ups
- `tests/dataframe/test_limit_offset.py` + `test_distributed_limit.py` on Ray: 215 passed, 1 skipped
  (this is the gate the `Finished` prototype failed with 28 errors)
- `tests/dataframe/test_distributed_limit.py` on Ray, after the review fix: 17 passed, 1 skipped
- `cargo test -p daft-local-execution`: 84 passed
- fmt / clippy / ruff clean

### Follow-up (not in this PR)

**1. Morsel granularity, not task fan-out, is what caps the remaining win.** Instrumenting the 8-partition
run gives 14.0s startup-to-first-claim, 13.5s to the limit being hit, then a **14.5s tail**. That tail
is UDF batches already dispatched when cancellation lands; a Python UDF call cannot be interrupted
mid-batch, so the floor on early stopping is one morsel. Re-running at
`default_morsel_size=2000` instead of the default 131072 collapses the tail to 1.8s and the whole
query to 9.6s. Giving the limit a morsel-size requirement is therefore the next real lever — but it
trades latency for per-batch overhead and needs care around `limit > total rows`, so it belongs in
its own PR with its own measurements.

This also explains why this PR lands at 39.2s where the discarded `Finished` prototype appeared to
reach 28.2s: `Finished` aborts the in-flight tokio tasks, so the prototype stopped *waiting* for that
14.5s rather than stopping the work. Better wall clock, same CPU burned, in a configuration that
failed 28 tests.

**2. `LIMIT` under a cross join hangs on `main`.** `SwordfishTaskBuilder::combine_with`
(`task.rs:429`) resets `notify_tokens` to empty and `cancel_token` to `None`, so the oneshot sender
`LimitNode` registered via `add_notify_token` never fires — `completed_ids` never gains the task and
`contributors.is_subset(completed_ids)` is never satisfied. `map_plan` preserves the tokens, which is
why broadcast join is unaffected. Reproduces on plain `main` and with #7415 applied, so it is a
distinct deadlock — now filed as [#7423](https://github.com/Eventual-Inc/Daft/pull/7423), which also
uncovered a silent row-loss bug in the same fan-out point that is still open.

**3. The native full-suite run cannot complete on `main`.** `DAFT_RUNNER=native pytest -q
tests/dataframe` blocks permanently at ~85% inside `tests/dataframe/test_sharding.py` on a
`write_parquet` call, with `--timeout` unable to fire (the block is in Rust holding the GIL).
Reproduced on a clean `bc20b8cb1` with an identical stack, so it predates this PR. Both halves of the
suite pass on their own and the union wedges, so it is cumulative in-process state; splitting the run
is a working workaround and is how the native numbers above were obtained. Ruled out: memory-manager
exhaustion (`DAFT_MEMORY_LIMIT=10^13` still hangs) and a per-query thread/fd leak.

**4. A possible lost-wakeup in the memory manager**, noticed while investigating (3) and *not* its
cause. `MemoryManager::request_bytes` (`resource_manager.rs:79`) does
`loop { if let Some(p) = try_request_bytes(..) { return } ; self.notify.notified().await }`. The
`Notified` future is created *after* the failed try, so a `notify_waiters()` landing in between is
lost and the waiter can sleep with memory available. The usual fix is to build the future before the
check. Untriggered as far as I know — flagging it rather than changing it here.

## Related Issues

No existing issue. The repro, measurements and analysis above are the whole report.