### PR TITLE
fix(catalog): avoid shared mutable default for from_postgres extensions

### DIFF
--- a/daft/catalog/__init__.py
+++ b/daft/catalog/__init__.py
@@ -410,14 +410,14 @@ class Catalog(ABC):
             raise ImportError("pypaimon is required: pip install pypaimon")
 
     @staticmethod
-    def from_postgres(connection_string: str, extensions: list[str] | None = ["vector"]) -> Catalog:
+    def from_postgres(connection_string: str, extensions: Sequence[str] | None = ("vector",)) -> Catalog:
         """Create a Daft Catalog from a PostgreSQL connection string.
 
         Args:
             connection_string (str): a PostgreSQL connection string
-            extensions (list[str], optional): List of PostgreSQL extensions to create if they don't exist.
+            extensions (Sequence[str], optional): List of PostgreSQL extensions to create if they don't exist.
                 For each extension, "CREATE EXTENSION IF NOT EXISTS <extension>" will be executed.
-                Defaults to ["vector"] (pgvector extension, if available).
+                Defaults to ("vector",) (pgvector extension, if available).
 
         Returns:
             Catalog: a new Catalog instance to a PostgreSQL database.

--- a/daft/catalog/__postgres.py
+++ b/daft/catalog/__postgres.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Sequence
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any
 
@@ -16,7 +17,7 @@ from daft.logical.schema import Field
 
 
 @contextmanager
-def postgres_connection(connection_string: str, extensions: list[str] | None) -> psycopg.Connection.connect:
+def postgres_connection(connection_string: str, extensions: Sequence[str] | None) -> psycopg.Connection.connect:
     """Context manager that provides a PostgreSQL connection with specified extensions setup.
 
     Args:
@@ -177,7 +178,7 @@ class PostgresCatalog(Catalog):
     # TODO(desmond): For now we can create connections as needed, but in the future we can create lazy connections
     # and connection pools as an optimization.
     _inner: str  # connection string
-    _extensions: list[str] | None  # extensions to create
+    _extensions: Sequence[str] | None  # extensions to create
     _create_table_options = {
         "enable_rls",
     }
@@ -186,7 +187,7 @@ class PostgresCatalog(Catalog):
         raise RuntimeError("PostgresCatalog.__init__ is not supported, please use `Catalog.from_postgres` instead.")
 
     @staticmethod
-    def from_uri(uri: str, extensions: list[str] | None, **options: str | None) -> PostgresCatalog:
+    def from_uri(uri: str, extensions: Sequence[str] | None, **options: str | None) -> PostgresCatalog:
         """Create a PostgresCatalog from a connection string."""
         validate_connection_string(uri)
         c = PostgresCatalog.__new__(PostgresCatalog)
@@ -445,7 +446,7 @@ class PostgresCatalog(Catalog):
 
 class PostgresTable(Table):
     _inner: tuple[str, Identifier]  # (connection_string, identifier)
-    _extensions: list[str] | None
+    _extensions: Sequence[str] | None
     _read_options = {
         "partition_col",
         "num_partitions",
@@ -461,7 +462,7 @@ class PostgresTable(Table):
 
     @classmethod
     def _from_catalog(
-        cls, connection_string: str, identifier: Identifier, extensions: list[str] | None
+        cls, connection_string: str, identifier: Identifier, extensions: Sequence[str] | None
     ) -> PostgresTable:
         """Create a PostgresTable from catalog connection details."""
         t = cls.__new__(cls)

--- a/tests/catalog/test_catalog.py
+++ b/tests/catalog/test_catalog.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import inspect
+from collections.abc import MutableSequence
 from typing import TYPE_CHECKING
 
 import pytest
@@ -16,6 +18,23 @@ if TYPE_CHECKING:
 
 def assert_eq(df1, df2):
     assert df1.to_pydict() == df2.to_pydict()
+
+
+def test_from_postgres_default_extensions_is_immutable():
+    # Regression test for a shared mutable default argument (B006): every catalog
+    # created with the default used to alias the same module-level list object.
+    default = inspect.signature(Catalog.from_postgres).parameters["extensions"].default
+    assert not isinstance(default, MutableSequence)
+    assert tuple(default) == ("vector",)
+
+
+def test_from_postgres_explicit_none_extensions_preserved():
+    pytest.importorskip("psycopg")
+    pytest.importorskip("pgvector")
+    catalog = Catalog.from_postgres("postgresql://user:pass@localhost:5432/db", extensions=None)
+    assert catalog._extensions is None
+    catalog_default = Catalog.from_postgres("postgresql://user:pass@localhost:5432/db")
+    assert tuple(catalog_default._extensions) == ("vector",)
 
 
 def test_try_from_iceberg(tmpdir):


### PR DESCRIPTION
Catalog.from_postgres used a mutable list as the default for extensions. Python evaluates defaults once, so every catalog created with the default aliased the same module-level list, which was stored by reference in PostgresCatalog._extensions and propagated to PostgresTable. Mutating it through any instance silently changed the extensions of all other catalogs, including ones created later.

Use an immutable tuple default instead, preserving the existing semantics of explicit None/empty (no extensions). Type annotations along the path are widened to Sequence[str].

## Changes Made

`Catalog.from_postgres` used a mutable list (`["vector"]`) as the default for
`extensions`. Python evaluates defaults once, so every catalog created with the
default aliased the same module-level list, which was stored by reference in
`PostgresCatalog._extensions` and propagated to `PostgresTable`. Mutating it
through any instance silently changed the extensions of all other catalogs
(including ones created later) and corrupted the module-level default itself.

- Replace the default with an immutable tuple `("vector",)`, which eliminates
  the shared-mutable-state hazard while preserving the existing semantics of
  explicit `None` / empty (no extensions are created)
- Widen the type annotations along the path (`from_postgres`, `from_uri`,
  `postgres_connection`, `PostgresCatalog._extensions`,
  `PostgresTable._extensions`, `PostgresTable._from_catalog`) from
  `list[str] | None` to `Sequence[str] | None`
- Add regression tests: `test_from_postgres_default_extensions_is_immutable`
  (guards against reintroducing a mutable default, no DB or psycopg required)
  and `test_from_postgres_explicit_none_extensions_preserved` (verifies the
  explicit-`None` semantics are unchanged; skipped when psycopg/pgvector are
  not installed)

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
Closes #7425
