### PR TITLE
chore(logging)!: remove deprecated setup_debug_logger() 

### DIFF
--- a/daft/logging.py
+++ b/daft/logging.py
@@ -22,17 +22,6 @@ LOG_LEVEL_MAP = {
 }
 
 
-def setup_debug_logger() -> None:
-    import warnings
-
-    warnings.warn(
-        "setup_debug_logger() is deprecated. Use setup_logger('debug') instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return setup_logger("debug")
-
-
 def setup_logger(
     level: str = "debug",
     exclude_prefix: typing.Iterable[str] | None = None,

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -32,13 +32,6 @@ def test_logger_initialization() -> None:
     assert rust_level == "WARN"
 
 
-def test_use_deprecated_method() -> None:
-    from daft.logging import setup_debug_logger
-
-    with pytest.warns(DeprecationWarning):
-        setup_debug_logger()
-
-
 def test_invalid_level_raises() -> None:
     from daft.logging import setup_logger
 


### PR DESCRIPTION
## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

- Removed the deprecated `setup_debug_logger()` function from daft/logging.py
- Removed test_use_deprecated_method from tests/test_logger.py
- Verified no remaining references across code, tests, docs, and notebooks

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

Closes #7408