### PR TITLE
refactor(shuffle): migrate distributed sort onto shared shuffle backend

### DIFF
--- a/src/daft-distributed/src/pipeline_node/random_shuffle.rs
+++ b/src/daft-distributed/src/pipeline_node/random_shuffle.rs
@@ -14,18 +14,15 @@ use daft_schema::schema::SchemaRef;
 use super::{PipelineNodeImpl, TaskBuilderStream};
 use crate::{
     pipeline_node::{
-        ClusteringStrategy, DistributedPipelineNode, MaterializedOutput, NodeID,
-        PipelineNodeConfig, PipelineNodeContext, shuffles::backends::ShuffleContext,
+        ClusteringStrategy, DistributedPipelineNode, NodeID, PipelineNodeConfig,
+        PipelineNodeContext, shuffles::backends::ShuffleContext,
     },
     plan::{PlanConfig, PlanExecutionContext, TaskIDCounter},
     scheduling::{
         scheduler::SchedulerHandle,
         task::{SwordfishTask, SwordfishTaskBuilder},
     },
-    utils::{
-        channel::{Sender, create_channel},
-        transpose::transpose_materialized_outputs_from_stream,
-    },
+    utils::channel::{Sender, create_channel},
 };
 
 pub(crate) struct RandomShuffleNode {
@@ -71,42 +68,6 @@ impl RandomShuffleNode {
         }
     }
 
-    fn local_sort_with_random_key(
-        &self,
-        partition_group: Vec<MaterializedOutput>,
-        partition_idx: usize,
-    ) -> DaftResult<SwordfishTaskBuilder> {
-        let partition_refs = partition_group
-            .into_iter()
-            .flat_map(|output| output.into_inner().0)
-            .collect::<Vec<_>>();
-
-        let partition_seed = self.seed.map(|s| {
-            let mut hasher = DefaultHasher::new();
-            s.hash(&mut hasher);
-            partition_idx.hash(&mut hasher);
-            hasher.finish()
-        });
-
-        let sort_by = BoundExpr::bind_all(
-            &[random_int_expr(i64::MIN, i64::MAX, partition_seed)],
-            &self.config.schema,
-        )?;
-        let node_id = self.node_id();
-        Ok(self
-            .shuffle_context
-            .build_refs_task_builder(partition_refs, self, |input| {
-                LocalPhysicalPlan::sort(
-                    input,
-                    sort_by,
-                    vec![false],
-                    vec![false],
-                    StatsState::NotMaterialized,
-                    LocalNodeContext::new(Some(node_id as usize)),
-                )
-            }))
-    }
-
     async fn execution_loop(
         self: Arc<Self>,
         input_node: TaskBuilderStream,
@@ -121,14 +82,37 @@ impl RandomShuffleNode {
             task_id_counter.clone(),
         );
 
-        let partition_groups =
-            transpose_materialized_outputs_from_stream(outputs, num_partitions).await?;
-
-        for (partition_idx, partition_group) in partition_groups.into_iter().enumerate() {
-            let task = self.local_sort_with_random_key(partition_group, partition_idx)?;
-            let _ = result_tx.send(task).await;
-        }
-        Ok(())
+        let seed = self.seed;
+        let schema = self.config.schema.clone();
+        let node_id = self.node_id();
+        self.shuffle_context
+            .emit_read_tasks_from_stream(
+                outputs,
+                num_partitions,
+                self.as_ref(),
+                result_tx,
+                &mut |partition_idx, input| {
+                    let partition_seed = seed.map(|s| {
+                        let mut hasher = DefaultHasher::new();
+                        s.hash(&mut hasher);
+                        partition_idx.hash(&mut hasher);
+                        hasher.finish()
+                    });
+                    let sort_by = BoundExpr::bind_all(
+                        &[random_int_expr(i64::MIN, i64::MAX, partition_seed)],
+                        &schema,
+                    )?;
+                    Ok(LocalPhysicalPlan::sort(
+                        input,
+                        sort_by,
+                        vec![false],
+                        vec![false],
+                        StatsState::NotMaterialized,
+                        LocalNodeContext::new(Some(node_id as usize)),
+                    ))
+                },
+            )
+            .await
     }
 }
 

--- a/src/daft-distributed/src/pipeline_node/shuffles/backends/flight.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/backends/flight.rs
@@ -3,7 +3,8 @@ use std::{collections::BTreeMap, sync::Arc};
 use common_error::DaftResult;
 use common_partitioning::PartitionRef;
 use daft_local_plan::{
-    FlightShuffleReadInput, LocalNodeContext, LocalPhysicalPlan, ShuffleReadBackend,
+    FlightShuffleReadInput, LocalNodeContext, LocalPhysicalPlan, LocalPhysicalPlanRef,
+    ShuffleReadBackend,
 };
 use daft_logical_plan::stats::StatsState;
 use daft_partition_refs::FlightPartitionRef;
@@ -121,6 +122,9 @@ pub(crate) async fn emit_read_tasks(
     read_inputs: Vec<FlightShuffleReadInput>,
     node: &dyn PipelineNodeImpl,
     result_tx: Sender<SwordfishTaskBuilder>,
+    wrap_plan: &mut (
+             dyn FnMut(usize, LocalPhysicalPlanRef) -> DaftResult<LocalPhysicalPlanRef> + Send
+         ),
 ) -> DaftResult<()> {
     for read_input in read_inputs {
         // Fresh plan per task: `SwordfishTaskBuilder::build` mutates the plan in
@@ -132,7 +136,9 @@ pub(crate) async fn emit_read_tasks(
             StatsState::NotMaterialized,
             LocalNodeContext::new(Some(node_id as usize)),
         );
-        let task = SwordfishTaskBuilder::new(shuffle_read_plan, node, node_id)
+        let partition_idx = read_input.partition_idx as usize;
+        let plan = wrap_plan(partition_idx, shuffle_read_plan)?;
+        let task = SwordfishTaskBuilder::new(plan, node, node_id)
             .with_flight_shuffle_reads(node_id, vec![read_input]);
 
         let _ = result_tx.send(task).await;

--- a/src/daft-distributed/src/pipeline_node/shuffles/backends/mod.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/backends/mod.rs
@@ -122,7 +122,8 @@ impl ShuffleContext {
         }
     }
 
-    /// Group a stream of map-task outputs into per-partition read tasks.
+    /// Group a stream of map-task outputs into per-partition read tasks, applying
+    /// `wrap_plan(partition_idx, read_plan)` on top of each partition's read plan.
     ///
     /// The Ray backend transposes the full (tasks x partitions) matrix of object refs.
     /// The flight backend folds the stream into per-server map-input lists shared by
@@ -134,6 +135,9 @@ impl ShuffleContext {
         num_partitions: usize,
         node: &dyn PipelineNodeImpl,
         result_tx: Sender<SwordfishTaskBuilder>,
+        wrap_plan: &mut (
+                 dyn FnMut(usize, LocalPhysicalPlanRef) -> DaftResult<LocalPhysicalPlanRef> + Send
+             ),
     ) -> DaftResult<()> {
         match &self.backend {
             ShuffleBackend::Ray => {
@@ -149,6 +153,7 @@ impl ShuffleContext {
                     partition_groups,
                     node,
                     result_tx,
+                    wrap_plan,
                 )
                 .await
             }
@@ -165,6 +170,7 @@ impl ShuffleContext {
                     read_inputs,
                     node,
                     result_tx,
+                    wrap_plan,
                 )
                 .await
             }

--- a/src/daft-distributed/src/pipeline_node/shuffles/backends/ray.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/backends/ray.rs
@@ -1,5 +1,7 @@
 use common_error::DaftResult;
-use daft_local_plan::{LocalNodeContext, LocalPhysicalPlan, ShuffleReadBackend};
+use daft_local_plan::{
+    LocalNodeContext, LocalPhysicalPlan, LocalPhysicalPlanRef, ShuffleReadBackend,
+};
 use daft_logical_plan::stats::StatsState;
 use daft_schema::schema::SchemaRef;
 
@@ -15,8 +17,11 @@ pub(crate) async fn emit_read_tasks(
     partition_groups: Vec<Vec<MaterializedOutput>>,
     node: &dyn PipelineNodeImpl,
     result_tx: Sender<SwordfishTaskBuilder>,
+    wrap_plan: &mut (
+             dyn FnMut(usize, LocalPhysicalPlanRef) -> DaftResult<LocalPhysicalPlanRef> + Send
+         ),
 ) -> DaftResult<()> {
-    for partition_group in partition_groups {
+    for (partition_idx, partition_group) in partition_groups.into_iter().enumerate() {
         let psets = partition_group
             .into_iter()
             .flat_map(|output| output.into_inner().0)
@@ -29,9 +34,9 @@ pub(crate) async fn emit_read_tasks(
             StatsState::NotMaterialized,
             LocalNodeContext::new(Some(node_id as usize)),
         );
+        let plan = wrap_plan(partition_idx, shuffle_read)?;
 
-        let builder =
-            SwordfishTaskBuilder::new(shuffle_read, node, node_id).with_psets(node_id, psets);
+        let builder = SwordfishTaskBuilder::new(plan, node, node_id).with_psets(node_id, psets);
 
         let _ = result_tx.send(builder).await;
     }

--- a/src/daft-distributed/src/pipeline_node/shuffles/repartition.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/repartition.rs
@@ -87,7 +87,13 @@ impl RepartitionNode {
         );
 
         self.shuffle_context
-            .emit_read_tasks_from_stream(outputs, self.num_partitions, self.as_ref(), result_tx)
+            .emit_read_tasks_from_stream(
+                outputs,
+                self.num_partitions,
+                self.as_ref(),
+                result_tx,
+                &mut |_, plan| Ok(plan),
+            )
             .await
     }
 }

--- a/src/daft-distributed/src/pipeline_node/sort.rs
+++ b/src/daft-distributed/src/pipeline_node/sort.rs
@@ -20,7 +20,7 @@ use super::{PipelineNodeImpl, TaskBuilderStream, clustering::BoundClusteringSpec
 use crate::{
     pipeline_node::{
         ClusteringStrategy, DistributedPipelineNode, MaterializedOutput, NodeID,
-        PipelineNodeConfig, PipelineNodeContext,
+        PipelineNodeConfig, PipelineNodeContext, shuffles::backends::ShuffleContext,
     },
     plan::{PlanConfig, PlanExecutionContext, TaskIDCounter},
     scheduling::{
@@ -31,10 +31,7 @@ use crate::{
         RuntimeStats,
         stats::{BaseCounters, RuntimeStatsRef},
     },
-    utils::{
-        channel::{Sender, create_channel},
-        transpose::transpose_materialized_outputs_from_vec,
-    },
+    utils::channel::{Sender, create_channel},
 };
 
 const SAMPLE_PHASE: &str = "sample";
@@ -256,6 +253,7 @@ pub(crate) fn create_range_repartition_tasks(
     descending: Vec<bool>,
     boundaries: RecordBatch,
     num_partitions: usize,
+    backend: ShuffleBackend,
     pipeline_node: &dyn PipelineNodeImpl,
     task_id_counter: &TaskIDCounter,
     scheduler_handle: &SchedulerHandle<SwordfishTask>,
@@ -277,7 +275,7 @@ pub(crate) fn create_range_repartition_tasks(
                 in_memory_source_plan,
                 num_partitions,
                 input_schema.clone(),
-                ShuffleBackend::Ray,
+                backend.clone(),
                 RepartitionSpec::Range(RangeRepartitionConfig::new(
                     Some(num_partitions),
                     boundaries.clone(),
@@ -375,6 +373,7 @@ pub(crate) async fn range_repartition_two_sides(
         descending.clone(),
         left_boundaries.clone(),
         num_partitions,
+        ShuffleBackend::Ray,
         pipeline_node,
         task_id_counter,
         scheduler_handle,
@@ -402,6 +401,7 @@ pub(crate) async fn range_repartition_two_sides(
         descending,
         right_boundaries,
         num_partitions,
+        ShuffleBackend::Ray,
         pipeline_node,
         task_id_counter,
         scheduler_handle,
@@ -447,6 +447,7 @@ pub(crate) struct SortNode {
     descending: Vec<bool>,
     nulls_first: Vec<bool>,
     needs_range_repartition: bool,
+    shuffle_context: ShuffleContext,
     child: DistributedPipelineNode,
 }
 
@@ -461,6 +462,7 @@ impl SortNode {
         descending: Vec<bool>,
         nulls_first: Vec<bool>,
         output_schema: SchemaRef,
+        backend: ShuffleBackend,
         child: DistributedPipelineNode,
     ) -> Self {
         let context = PipelineNodeContext::new(
@@ -475,7 +477,7 @@ impl SortNode {
         let needs_range_repartition =
             needs_range_repartition(&child, &sort_by, &descending, &nulls_first);
         let config = PipelineNodeConfig::new(
-            output_schema,
+            output_schema.clone(),
             plan_config.config.clone(),
             ClusteringStrategy::Explicit(BoundClusteringSpec::Range(RangeClusteringConfig::new(
                 child.config().clustering_spec.num_partitions(),
@@ -484,6 +486,7 @@ impl SortNode {
                 nulls_first.clone(),
             ))),
         );
+        let shuffle_context = ShuffleContext::new(&context, output_schema, backend);
         Self {
             config,
             context,
@@ -491,6 +494,7 @@ impl SortNode {
             descending,
             nulls_first,
             needs_range_repartition,
+            shuffle_context,
             child,
         }
     }
@@ -602,6 +606,7 @@ impl SortNode {
             self.descending.clone(),
             boundaries,
             num_partitions,
+            self.shuffle_context.backend().clone(),
             self.as_ref(),
             &task_id_counter,
             &scheduler_handle,
@@ -614,30 +619,31 @@ impl SortNode {
             .flatten()
             .collect::<Vec<_>>();
 
-        let transposed_outputs =
-            transpose_materialized_outputs_from_vec(partitioned_outputs, num_partitions);
-
-        for partition_group in transposed_outputs {
-            let (in_memory_source_plan, psets) =
-                MaterializedOutput::into_in_memory_scan_with_psets_and_phase(
-                    partition_group,
-                    self.config.schema.clone(),
-                    self.node_id(),
-                    FINAL_SORT_PHASE,
-                );
-            let plan = LocalPhysicalPlan::sort(
-                in_memory_source_plan,
-                self.sort_by.clone(),
-                self.descending.clone(),
-                self.nulls_first.clone(),
-                StatsState::NotMaterialized,
-                LocalNodeContext::new(Some(self.node_id() as usize)).with_phase(FINAL_SORT_PHASE),
-            );
-            let task = SwordfishTaskBuilder::new(plan, self.as_ref(), self.node_id())
-                .with_psets(self.node_id(), psets);
-            let _ = result_tx.send(task).await;
-        }
-        Ok(())
+        // Final sort phase: one read task per range partition, sorted locally. The
+        // backend decides how the map outputs are grouped and read back (Ray object
+        // refs vs. flight cache).
+        let sort_by = self.sort_by.clone();
+        let descending = self.descending.clone();
+        let nulls_first = self.nulls_first.clone();
+        let node_id = self.node_id();
+        self.shuffle_context
+            .emit_read_tasks_from_stream(
+                futures::stream::iter(partitioned_outputs.into_iter().map(Ok)),
+                num_partitions,
+                self.as_ref(),
+                result_tx,
+                &mut |_, input| {
+                    Ok(LocalPhysicalPlan::sort(
+                        input,
+                        sort_by.clone(),
+                        descending.clone(),
+                        nulls_first.clone(),
+                        StatsState::NotMaterialized,
+                        LocalNodeContext::new(Some(node_id as usize)).with_phase(FINAL_SORT_PHASE),
+                    ))
+                },
+            )
+            .await
     }
 }
 
@@ -660,7 +666,7 @@ impl PipelineNodeImpl for SortNode {
 
     fn multiline_display(&self, _verbose: bool) -> Vec<String> {
         use itertools::Itertools;
-        let mut res = vec!["Sort".to_string()];
+        let mut res = vec![format!("Sort({})", self.shuffle_context.backend().name())];
         res.push(format!(
             "Sort by: {}",
             self.sort_by.iter().map(|e| e.to_string()).join(", ")
@@ -685,6 +691,7 @@ impl PipelineNodeImpl for SortNode {
         plan_context: &mut PlanExecutionContext,
     ) -> TaskBuilderStream {
         let input_node = self.child.clone().produce_tasks(plan_context);
+        self.shuffle_context.register_cleanup(plan_context);
         let (result_tx, result_rx) = create_channel(1);
         plan_context.spawn(self.execution_loop(
             input_node,
@@ -720,6 +727,7 @@ mod tests {
             vec![false],
             vec![false],
             test_schema(),
+            ShuffleBackend::Ray,
             source,
         );
         DistributedPipelineNode::new(Arc::new(sort_node), meter)

--- a/src/daft-distributed/src/pipeline_node/translate.rs
+++ b/src/daft-distributed/src/pipeline_node/translate.rs
@@ -555,6 +555,7 @@ impl TreeNodeVisitor for LogicalPlanToPipelineNodeTranslator {
                         sort.descending.clone(),
                         sort.nulls_first.clone(),
                         sort.input.schema(),
+                        self.select_backend(),
                         self.curr_node.pop().unwrap(),
                     )),
                     &self.meter,

--- a/tests/dataframe/test_shuffles.py
+++ b/tests/dataframe/test_shuffles.py
@@ -204,6 +204,36 @@ def test_flight_random_shuffle(flight_shuffle_ctx):
     get_tests_daft_runner_name() != "ray",
     reason="distributed shuffle tests require the ray runner",
 )
+@pytest.mark.parametrize("descending", [False, True])
+def test_flight_sort(flight_shuffle_ctx, descending):
+    """Exercises the range-repartition path of SortNode under the Flight backend.
+
+    The input is spread over several partitions with no range clustering, so the
+    sort must sample, range-repartition through the flight cache, and sort each
+    partition locally.
+    """
+    rows = 500
+    values = list(range(rows))
+    random.Random(0).shuffle(values)
+    with flight_shuffle_ctx():
+        df = daft.from_pydict({"x": values}).repartition(4, "x").sort("x", desc=descending)
+
+        buf = io.StringIO()
+        df.explain(show_all=True, file=buf)
+        plan = buf.getvalue()
+        assert "Sort(Flight)" in plan, f"expected Sort(Flight) in plan:\n{plan}"
+        assert "Sort(Ray)" not in plan, f"unexpected Sort(Ray) in plan:\n{plan}"
+
+        result = df.to_pydict()["x"]
+
+    expected = sorted(values, reverse=descending)
+    assert result == expected
+
+
+@pytest.mark.skipif(
+    get_tests_daft_runner_name() != "ray",
+    reason="distributed shuffle tests require the ray runner",
+)
 def test_ray_random_shuffle():
     """Ensures `df.shuffle(...)` produces a permutation of the input under the Ray backend."""
     df = daft.from_pydict({"id": list(range(32))}).repartition(4, "id")


### PR DESCRIPTION
## Summary

Stacked on #7412. Migrates `SortNode` onto the shared `ShuffleContext`, so distributed sort runs its range-repartition shuffle on whichever backend the execution config selects. Sort was the last major shuffle-shaped node that hardcoded `ShuffleBackend::Ray`, which meant `shuffle_algorithm="flight_shuffle"` silently fell back to the Ray object store for every sort.

## Why

Large distributed sorts are exactly the workload the Flight shuffle backend exists for: the range-repartition phase materializes one output per (input, partition) slot, and on the Ray backend every one of those lands in the object store and in the head node's ref matrix. With this change the repartition writes go to the flight cache and the final-sort read tasks are built from the folded per-server input lists that `emit_read_tasks_from_stream` already provides, using the `wrap_plan` hook from #7412 to put the per-partition sort on top of each read.

Part of the phase 2 operator list in #6472, following #7402 and #7412.

## Changes Made

- `sort.rs`: `SortNode` gains a `ShuffleContext` (constructed from the plan-level backend like the other shuffle nodes), registers shuffle-dir cleanup in `produce_tasks`, and reports the backend in `multiline_display` as `Sort(Ray)` / `Sort(Flight)`
- `sort.rs`: `create_range_repartition_tasks` takes a `backend: ShuffleBackend` instead of hardcoding `ShuffleBackend::Ray`; `SortNode` passes its stamped backend
- `sort.rs`: the final-sort phase replaces the manual `transpose_materialized_outputs_from_vec` loop with `ShuffleContext::emit_read_tasks_from_stream`, wrapping each partition's read in the local `sort` op tagged with `FINAL_SORT_PHASE`
- `sort.rs`: `range_repartition_two_sides` (the sort-merge and asof join path) passes `ShuffleBackend::Ray` explicitly, keeping join behavior unchanged; migrating joins is a follow-up
- `translate.rs`: passes `select_backend()` into `SortNode::new`
- `tests/dataframe/test_shuffles.py`: adds `test_flight_sort` (ascending and descending) over a multi-partition input, asserting the `Sort(Flight)` plan shape and exact sorted output

## Behavior

- Flight: the sample phase is unchanged (it reads the materialized input via psets and computes boundaries from Ray refs as before); the range-repartition writes now go to the flight cache and the final-sort tasks read via `shuffle_read(Flight)`. Output ordering is identical.
- Ray: the final-sort read plan changes from `in_memory_scan` to `shuffle_read(Ray)` with the same psets attached, matching what `RepartitionNode` and `RandomShuffleNode` build. `SortStats` only counts rows from `Default` snapshots tagged `final-sort`, and both `in_memory_scan` and `shuffle_read` are sources, so row attribution is unchanged; the existing `test_single_partition_stats` and `test_multi_partition_stats` unit tests guard this.
- The two no-shuffle fast paths (input already range-clustered, or a single non-empty input) are unchanged.

## Test Plan

- `cargo check -p daft-distributed --lib --features python`, `cargo fmt`, `cargo clippy --no-deps` clean
- `cargo test -p daft-distributed --lib`: 68 passed (includes the sort stats tests)
- `DAFT_RUNNER=ray pytest tests/dataframe/test_sort.py tests/dataframe/test_sort_shuffle_elision.py tests/dataframe/test_shuffles.py`: 243 passed, 8 skipped, 3 xfailed
- New `test_flight_sort` passes under both sort directions

## Related Issues

Part of #6472.
