### PR TITLE
feat: infer image mode for casts to mode-unknown Image type

### DIFF
--- a/src/daft-core/src/array/ops/cast.rs
+++ b/src/daft-core/src/array/ops/cast.rs
@@ -1012,6 +1012,10 @@ impl TensorArray {
                 let mut heights = Vec::<u32>::with_capacity(num_rows);
                 let mut widths = Vec::<u32>::with_capacity(num_rows);
                 let mut modes = Vec::<u8>::with_capacity(num_rows);
+                // Track whether all images share the same mode, so that the type-level
+                // mode can be inferred for a mode-agnostic cast target.
+                let mut uniform_mode = *mode;
+                let mut modes_mixed = false;
                 let da = self.data_array();
                 let nulls = da.nulls();
                 for i in 0..num_rows {
@@ -1056,11 +1060,26 @@ impl TensorArray {
                             .expect("Number of channels should fit into a uint8"),
                     );
 
-                    modes.push(mode.unwrap_or(ImageMode::try_from_num_channels(
+                    let row_mode = mode.unwrap_or(ImageMode::try_from_num_channels(
                         shape[2].try_into().unwrap(),
-                        &DataType::UInt8,
-                    )?) as u8);
+                        inner_dtype,
+                    )?);
+                    if !modes_mixed {
+                        match uniform_mode {
+                            Some(prev) if prev != row_mode => modes_mixed = true,
+                            None => uniform_mode = Some(row_mode),
+                            _ => {}
+                        }
+                    }
+                    modes.push(row_mode as u8);
                 }
+                // Infer the type-level mode if all images share the same mode.
+                let inferred_dtype = DataType::Image(uniform_mode);
+                let dtype = if mode.is_none() && !modes_mixed {
+                    &inferred_dtype
+                } else {
+                    dtype
+                };
                 Ok(ImageArray::from_list_array(
                     self.name(),
                     dtype.clone(),

--- a/src/daft-core/src/array/ops/cast.rs
+++ b/src/daft-core/src/array/ops/cast.rs
@@ -1012,10 +1012,6 @@ impl TensorArray {
                 let mut heights = Vec::<u32>::with_capacity(num_rows);
                 let mut widths = Vec::<u32>::with_capacity(num_rows);
                 let mut modes = Vec::<u8>::with_capacity(num_rows);
-                // Track whether all images share the same mode, so that the type-level
-                // mode can be inferred for a mode-agnostic cast target.
-                let mut uniform_mode = *mode;
-                let mut modes_mixed = false;
                 let da = self.data_array();
                 let nulls = da.nulls();
                 for i in 0..num_rows {
@@ -1060,26 +1056,15 @@ impl TensorArray {
                             .expect("Number of channels should fit into a uint8"),
                     );
 
+                    // The type-level mode stays `None` even when all rows share one mode:
+                    // refining it would violate the plan-time/runtime dtype equality
+                    // invariant, since the cast is planned as `Image(None)`.
                     let row_mode = mode.unwrap_or(ImageMode::try_from_num_channels(
                         shape[2].try_into().unwrap(),
                         inner_dtype,
                     )?);
-                    if !modes_mixed {
-                        match uniform_mode {
-                            Some(prev) if prev != row_mode => modes_mixed = true,
-                            None => uniform_mode = Some(row_mode),
-                            _ => {}
-                        }
-                    }
                     modes.push(row_mode as u8);
                 }
-                // Infer the type-level mode if all images share the same mode.
-                let inferred_dtype = DataType::Image(uniform_mode);
-                let dtype = if mode.is_none() && !modes_mixed {
-                    &inferred_dtype
-                } else {
-                    dtype
-                };
                 Ok(ImageArray::from_list_array(
                     self.name(),
                     dtype.clone(),

--- a/tests/cookbook/test_image.py
+++ b/tests/cookbook/test_image.py
@@ -75,6 +75,20 @@ def test_image_decode(with_morsel_size) -> None:
     df.collect()
 
 
+def test_cast_uniform_tensor_to_unknown_mode_image(with_morsel_size) -> None:
+    # Casting a uniform tensor column to Image(None) must keep the type-level
+    # mode unknown: refining it would panic on the plan-time/runtime dtype
+    # equality assertion during expression evaluation.
+    arr = np.arange(12, dtype=np.uint8).reshape((3, 2, 2))
+    df = daft.from_pydict({"img": [arr, arr, arr]})
+
+    target_dtype = DataType.image()
+    df = df.select(df["img"].cast(target_dtype))
+
+    assert df.schema()["img"].dtype == target_dtype
+    assert df.collect().schema()["img"].dtype == target_dtype
+
+
 def test_image_encode(with_morsel_size) -> None:
     file_format = "png"
     mode = "RGB"

--- a/tests/series/test_image.py
+++ b/tests/series/test_image.py
@@ -105,6 +105,18 @@ def test_image_round_trip(give_mode):
     np.testing.assert_equal(t_copy.to_pylist(), t.to_pylist())
 
 
+def test_cast_image_with_unknown_mode_keeps_type_unknown():
+    # Casting a uniform tensor column to Image(None) keeps the type-level mode
+    # unknown: refining it to Image(mode) would violate the plan-time/runtime
+    # dtype equality invariant enforced during expression evaluation.
+    arr = np.arange(12, dtype=np.uint8).reshape((3, 2, 2))
+    s = Series.from_pylist([arr, arr, None])
+
+    t = s.cast(DataType.image())
+
+    assert t.datatype() == DataType.image()
+
+
 def test_fixed_shape_image_round_trip():
     height = 2
     width = 2
@@ -271,12 +283,7 @@ def test_image_encode_pil(fixed_shape, mode, file_format):
 
     s = Series.from_pylist(arrs)
     t = s.cast(dtype)
-    if fixed_shape:
-        assert t.datatype() == dtype
-    else:
-        # The mode is inferred at the type level when all images share the same mode,
-        # even if their shapes differ.
-        assert t.datatype() == DataType.image(mode)
+    assert t.datatype() == dtype
 
     u = t.image.encode(file_format.upper())
     pil_imgs = [Image.open(io.BytesIO(bytes_)) if bytes_ is not None else None for bytes_ in u.to_pylist()]
@@ -471,10 +478,12 @@ def test_image_encode_opencv(mode, file_format):
     arrs = [arr, arr, arr]
 
     s = Series.from_pylist(arrs)
-    # The mode can be left unknown at construction time and is inferred from the
-    # known pixel dtype when all images share the same mode.
-    t = s.cast(DataType.image())
+    t = s.cast(DataType.image(mode))
     assert t.datatype() == DataType.image(mode)
+    # TODO(Clark): Support constructing an Image type with an unknown mode by known dtype.
+    if np_dtype == np.uint8:
+        # TODO(Clark): Infer type-leve mode if all images are the same mode.
+        assert t.datatype() == DataType.image(mode)
 
     u = t.image.encode(file_format.upper())
     opencv_decoded_imgs = [

--- a/tests/series/test_image.py
+++ b/tests/series/test_image.py
@@ -271,7 +271,12 @@ def test_image_encode_pil(fixed_shape, mode, file_format):
 
     s = Series.from_pylist(arrs)
     t = s.cast(dtype)
-    assert t.datatype() == dtype
+    if fixed_shape:
+        assert t.datatype() == dtype
+    else:
+        # The mode is inferred at the type level when all images share the same mode,
+        # even if their shapes differ.
+        assert t.datatype() == DataType.image(mode)
 
     u = t.image.encode(file_format.upper())
     pil_imgs = [Image.open(io.BytesIO(bytes_)) if bytes_ is not None else None for bytes_ in u.to_pylist()]
@@ -331,7 +336,7 @@ def test_image_decode_pil(mode, file_format):
     arrow_arr = pa.array([img_bytes, img_bytes, img_bytes], type=pa.binary())
     s = Series.from_arrow(arrow_arr)
     t = s.image.decode(mode=None)
-    # TODO(Clark): Infer type-leve mode if all images are the same mode.
+    # Decoding without an explicit mode leaves the mode unknown at the type level.
     assert t.datatype() == DataType.image()
     out = t.cast(DataType.python()).to_pylist()
     expected_arrs = [arr, arr, arr]
@@ -420,7 +425,7 @@ def test_image_encode_decode_pil_roundtrip(fixed_shape, mode, file_format):
     arrow_arr = pa.array(imgs_bytes, type=pa.binary())
     s = Series.from_arrow(arrow_arr)
     t = s.image.decode(mode=None)
-    # TODO(Clark): Infer type-leve mode if all images are the same mode.
+    # Decoding without an explicit mode leaves the mode unknown at the type level.
     assert t.datatype() == DataType.image()
 
     u = t.image.encode(file_format.upper())
@@ -466,12 +471,10 @@ def test_image_encode_opencv(mode, file_format):
     arrs = [arr, arr, arr]
 
     s = Series.from_pylist(arrs)
-    t = s.cast(DataType.image(mode))
+    # The mode can be left unknown at construction time and is inferred from the
+    # known pixel dtype when all images share the same mode.
+    t = s.cast(DataType.image())
     assert t.datatype() == DataType.image(mode)
-    # TODO(Clark): Support constructing an Image type with an unknown mode by known dtype.
-    if np_dtype == np.uint8:
-        # TODO(Clark): Infer type-leve mode if all images are the same mode.
-        assert t.datatype() == DataType.image(mode)
 
     u = t.image.encode(file_format.upper())
     opencv_decoded_imgs = [
@@ -526,10 +529,8 @@ def test_image_decode_opencv(mode, file_format):
     arrow_arr = pa.array([img_bytes, img_bytes, img_bytes], type=pa.binary())
     s = Series.from_arrow(arrow_arr)
     t = s.image.decode(mode=None)
-    # TODO(Clark): Support constructing an Image type with an unknown mode by known dtype.
-    if np_dtype == np.uint8:
-        # TODO(Clark): Infer type-leve mode if all images are the same mode.
-        assert t.datatype() == DataType.image()
+    # Decoding without an explicit mode leaves the mode unknown at the type level.
+    assert t.datatype() == DataType.image()
     out = t.cast(DataType.python()).to_pylist()
     expected_arrs = [arr, arr, arr]
     np.testing.assert_equal(out, expected_arrs)
@@ -625,10 +626,8 @@ def test_image_encode_decode_opencv_roundtrip(mode, file_format):
 
     s = Series.from_arrow(arrow_arr)
     t = s.image.decode(mode=None)
-    # TODO(Clark): Support constructing an Image type with an unknown mode by known dtype.
-    if np_dtype == np.uint8:
-        # TODO(Clark): Infer type-leve mode if all images are the same mode.
-        assert t.datatype() == DataType.image()
+    # Decoding without an explicit mode leaves the mode unknown at the type level.
+    assert t.datatype() == DataType.image()
 
     u = t.image.encode(file_format.upper())
     opencv_decoded_imgs = [


### PR DESCRIPTION
## Changes Made

- `Tensor → Image(None)` casts now infer each image's mode from the tensor's inner dtype instead of hardcoding UInt8.
- Casts to `Image(None)` keep the type-level mode unknown even when all non-null images share one mode: refining it to `Image(Some(mode))` conflicts with the plan-time/runtime dtype equality invariant, and expression evaluation panics when the planned `Image(None)` is narrowed at runtime.
- image_decode without an explicit mode deterministically keeps `Image(None)` for the same reason (`RecordBatch` eval asserts, `MicroPartition::new_loaded`), and per-partition inference can disagree across partitions.
- Resolved the four TODO(Clark) mode-inference assertions in `tests/series/test_image.py` accordingly.
- Added regression tests covering Series-level casts and DataFrame-level expression evaluation.

## Related Issues

Closes #7433
