### PR TITLE
feat(omnisharing): add PX OmniSharing dataset reader

### DIFF
--- a/daft/datasets/__init__.py
+++ b/daft/datasets/__init__.py
@@ -1,5 +1,6 @@
 from daft.datasets.common_crawl import common_crawl
 from daft.datasets import droid
 from daft.datasets import lerobot
+from daft.datasets import omnisharing
 
-__all__ = ["common_crawl", "droid", "lerobot"]
+__all__ = ["common_crawl", "droid", "lerobot", "omnisharing"]

--- a/daft/datasets/omnisharing.py
+++ b/daft/datasets/omnisharing.py
@@ -1,0 +1,1888 @@
+"""PX OmniSharing Dataset helpers for `daft.datasets`.
+
+The PX OmniSharing DB is PaXini's omnimodal embodied-AI dataset: synchronized
+multi-view video, multi-dimensional tactile sensing, hand proprioception,
+object poses, audio and language instructions captured with a force/tactile
+exoskeleton glove.
+
+This module reads the **DF-2** stage (and the structurally identical DF-2R
+stage) directly from HDF5. The pipeline stages are:
+
+| Stage  | Format               | Filename suffix | Notes                                        |
+| ------ | -------------------- | --------------- | -------------------------------------------- |
+| DF-1   | HDF5                 | *(none)*        | Raw capture, unparsed encoder/tactile streams |
+| DF-2   | HDF5                 | `_glove`        | Parsed, with bimanual + object poses          |
+| DF-2R  | HDF5                 | `_{model}`      | Retargeted to a dexterous hand (dh13, mano)   |
+| DF-3   | LeRobot Dataset v2.1 | *(none)*        | Use [`daft.datasets.lerobot`][daft.datasets.lerobot] instead |
+
+Dataset home: https://huggingface.co/datasets/paxini/Omnisharing_DB_SampleData
+
+Note:
+    The published OmniSharing data is licensed **CC-BY-NC-SA 4.0**
+    (non-commercial). The toolkit that produces it lives at
+    https://github.com/px-DataCollection/px_omnisharing_dataprocess_kit
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import TYPE_CHECKING, Any
+
+import daft
+from daft.api_annotations import PublicAPI
+from daft.datatype import DataType
+from daft.expressions import col, lit
+from daft.functions import coalesce, format, regexp_extract, unnest, when
+from daft.functions.file_ import hdf5_file
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from daft.dataframe import DataFrame
+    from daft.file.hdf5 import Hdf5File
+    from daft.io import IOConfig
+
+
+# ---------------------------------------------------------------------------
+# Stage / layout constants
+# ---------------------------------------------------------------------------
+
+#: Root group that every OmniSharing HDF5 file nests its content under.
+ROOT_GROUP = "dataset"
+
+#: Filename suffix that marks the DF-2 ("glove") stage.
+DF2_SUFFIX = "glove"
+
+#: Stage identifiers returned in the ``stage`` column.
+STAGE_DF1 = "DF-1"
+STAGE_DF2 = "DF-2"
+STAGE_DF2R = "DF-2R"
+
+STAGES: tuple[str, ...] = (STAGE_DF1, STAGE_DF2, STAGE_DF2R)
+
+#: ``episode_{index}_{HHMMSS}_{room}_{personnel}[_{suffix}].hdf5``
+#:
+#: The suffix is optional (DF-1 has none), so it is captured separately. Note
+#: that ``episode_index`` is **not** unique across a release: it restarts per
+#: ``(room_id, personnel_id)`` capture group, which is why :func:`raw` also
+#: emits a composite ``episode_key``.
+_EPISODE_FILENAME_RE = r"episode_(\d+)_(\d+)_(\d+)_(\d+)(?:_([A-Za-z0-9]+))?\.(?:hdf5|h5)$"
+
+_HF_REPO_ID_RE = re.compile(r"[\w.-]+/[\w.-]+")
+
+#: Hand sides present in both ``action`` and ``observation``.
+SIDES: tuple[str, ...] = ("lefthand", "righthand")
+
+#: Top-level branches of an episode.
+BRANCHES: tuple[str, ...] = ("observation", "action")
+
+#: Per-hand signals. ``tactile`` only exists under ``observation``.
+_SIGNALS: tuple[str, ...] = ("joints", "handpose", "tactile")
+
+#: Quaternion/position layout of ``handpose`` data. Note ``qw`` comes FIRST.
+HANDPOSE_ORDER: tuple[str, ...] = ("x", "y", "z", "qw", "qx", "qy", "qz")
+
+#: Matches the optional per-object pose groups ``obj1``, ``obj2``, ...
+_OBJECT_GROUP_RE = re.compile(r"obj\d+")
+
+
+# ---------------------------------------------------------------------------
+# HDF5 access helpers
+# ---------------------------------------------------------------------------
+
+
+def _require_h5py() -> Any:
+    from daft.dependencies import h5py
+
+    if not h5py.module_available():  # ty:ignore[unresolved-attribute]
+        raise ImportError(
+            "The 'daft[hdf5]' extra is required to read OmniSharing HDF5 files. "
+            "Please install it with: pip install 'daft[hdf5]'"
+        )
+    return h5py
+
+
+def _h5path(*parts: str) -> str:
+    """Join path fragments under the episode root group."""
+    return "/".join((ROOT_GROUP, *(p.strip("/") for p in parts if p)))
+
+
+def _open_for_scan(file: Hdf5File) -> Any:
+    """Open an episode for metadata-only traversal.
+
+    Metadata traversal issues many small reads at scattered offsets, so HDF5's
+    own scan buffer size fits better than the large default meant for bulk
+    payload reads.
+
+    Note:
+        Over high-latency object storage this is not the bottleneck. Measured
+        against a 440 MB episode on ``hf://``, walking all 20 camera streams
+        took 344s with the 1 KiB scan buffer versus 362s with the 64 KiB
+        default: a 5% difference, because the cost is dominated by per-request
+        latency rather than bytes transferred. Prefer local or same-region
+        storage when scanning many episodes.
+    """
+    from daft.file.hdf5 import HDF5_SCAN_BUFFER_SIZE
+
+    return file._open_h5py(HDF5_SCAN_BUFFER_SIZE)
+
+
+def _to_py(value: Any) -> Any:
+    """Convert an h5py attribute value into a JSON-serializable Python object."""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", "replace")
+    # numpy scalar
+    if hasattr(value, "item") and getattr(value, "shape", None) == ():
+        return _to_py(value.item())
+    # numpy array / list
+    if hasattr(value, "tolist"):
+        return [_to_py(v) for v in value.tolist()]
+    if isinstance(value, (list, tuple)):
+        return [_to_py(v) for v in value]
+    return value
+
+
+def _attrs_of(node: Any) -> dict[str, Any]:
+    return {str(k): _to_py(v) for k, v in node.attrs.items()}
+
+
+def _get(h5: Any, path: str) -> Any:
+    """Return the node at ``path``, or None when it does not exist."""
+    try:
+        return h5[path]
+    except KeyError:
+        return None
+
+
+def _str_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple)):
+        return [str(_to_py(v)) for v in value]
+    return [str(_to_py(value))]
+
+
+def _require_episode_column(episodes: DataFrame, column: str = "episode") -> None:
+    if column not in episodes.column_names:
+        raise ValueError(
+            f"Expected an episode DataFrame with an {column!r} column "
+            f"(as produced by daft.datasets.omnisharing.raw). "
+            f"Got columns: {episodes.column_names}"
+        )
+
+
+def _append_unnested(episodes: DataFrame, udf_expr: Any) -> DataFrame:
+    """Append an ``unnest=True`` UDF's struct fields as new columns.
+
+    ``with_column`` cannot be used here: an ``unnest=True`` UDF expands into
+    several columns, so it must be spliced into a ``select`` alongside the
+    existing columns.
+    """
+    return episodes.select(*episodes.column_names, udf_expr)
+
+
+# ---------------------------------------------------------------------------
+# describe()
+# ---------------------------------------------------------------------------
+
+_OBJECT_DTYPE = DataType.struct(
+    {
+        "h5path": DataType.string(),
+        "kind": DataType.string(),
+        "shape": DataType.list(DataType.int64()),
+        "dtype": DataType.string(),
+        "attrs": DataType.string(),
+    }
+)
+
+
+@PublicAPI
+def describe(episodes: DataFrame) -> DataFrame:
+    r"""Expose the internal HDF5 layout of each episode as a DataFrame.
+
+    OmniSharing episodes are **not** structurally uniform: camera ids are
+    non-contiguous, the number of cameras varies by capture rig, ``obj*``
+    groups are optional, and tactile/joint widths differ between DF-2 and
+    DF-2R. Use this to discover what a release actually contains before
+    selecting fields.
+
+    Only HDF5 metadata is streamed (superblock plus B-tree pages), not the
+    bulk payloads, so it stays cheap even for multi-gigabyte episodes.
+
+    Args:
+        episodes: Episode-level DataFrame from
+            [`raw`][daft.datasets.omnisharing.raw]. Filter or ``limit`` it
+            first; describing every episode in a release is rarely useful.
+
+    Returns:
+        DataFrame with one row per HDF5 object per episode:
+
+        - `episode_key`: which episode the object belongs to.
+        - `h5path`: full path such as `dataset/observation/lefthand/tactile/data`.
+        - `kind`: `"group"` or `"dataset"`.
+        - `shape`: dataset dimensions (empty for groups).
+        - `dtype`: NumPy dtype string (empty for groups).
+        - `attrs`: the object's HDF5 attributes as a JSON string.
+
+    Examples:
+        >>> import daft
+        >>> from daft.datasets import omnisharing
+        >>> episodes = omnisharing.raw("paxini/Omnisharing_DB_SampleData").limit(1)  # doctest: +SKIP
+        >>> layout = omnisharing.describe(episodes)  # doctest: +SKIP
+        >>> layout.where(daft.col("h5path").str.endswith("tactile/data")).show()  # doctest: +SKIP
+    """
+    _require_episode_column(episodes)
+    h5py = _require_h5py()
+
+    @daft.func(return_dtype=DataType.list(_OBJECT_DTYPE), use_process=False)
+    def _walk(file: Hdf5File) -> list[dict[str, Any]]:
+        out: list[dict[str, Any]] = []
+        with _open_for_scan(file) as h5:
+            root = h5["/"]
+            out.append(
+                {
+                    "h5path": "/",
+                    "kind": "group",
+                    "shape": [],
+                    "dtype": "",
+                    "attrs": json.dumps(_attrs_of(root), ensure_ascii=False),
+                }
+            )
+
+            def visit(name: str, node: Any) -> None:
+                is_dataset = isinstance(node, h5py.Dataset)
+                out.append(
+                    {
+                        "h5path": name,
+                        "kind": "dataset" if is_dataset else "group",
+                        "shape": [int(d) for d in node.shape] if is_dataset else [],
+                        "dtype": str(node.dtype) if is_dataset else "",
+                        "attrs": json.dumps(_attrs_of(node), ensure_ascii=False),
+                    }
+                )
+
+            root.visititems(visit)
+        return out
+
+    exploded = episodes.select("episode_key", _walk(col("episode")).alias("object")).explode("object")
+    return exploded.select("episode_key", unnest(col("object")))
+
+
+# ---------------------------------------------------------------------------
+# episode_metadata()
+# ---------------------------------------------------------------------------
+
+_METADATA_DTYPE = DataType.struct(
+    {
+        "generated_time": DataType.string(),
+        "data_id": DataType.string(),
+        "vendor": DataType.string(),
+        "instruction": DataType.string(),
+        "audio_samplerate": DataType.int64(),
+        "audio_samples": DataType.int64(),
+        "n_frames": DataType.int64(),
+        "checked_cam_name": DataType.string(),
+        "task_labels": DataType.string(),
+        "camera_names": DataType.list(DataType.string()),
+        "object_names": DataType.list(DataType.string()),
+    }
+)
+
+
+@PublicAPI
+def episode_metadata(episodes: DataFrame) -> DataFrame:
+    r"""Attach per-episode metadata, task labels and the language instruction.
+
+    Reads the small metadata surface of each episode in a single file open:
+
+    - ``dataset`` attrs: ``generated_time``, ``data_id``
+    - ``dataset/meta`` attrs: ``vendor`` plus free-form task labels. Real
+      releases use Chinese label keys such as ``任务物品`` (task object) and
+      ``物品初始摆放高度`` (initial object height); because these keys vary per
+      task they are returned as a JSON string in ``task_labels`` rather than as
+      columns.
+    - ``dataset/observation/audio`` attrs: ``samplerate`` and ``txt``, where
+      ``txt`` is the natural-language instruction for the episode.
+
+    Args:
+        episodes: Episode-level DataFrame from
+            [`raw`][daft.datasets.omnisharing.raw].
+
+    Returns:
+        The input DataFrame with metadata columns appended: ``generated_time``,
+        ``data_id``, ``vendor``, ``instruction``, ``audio_samplerate``,
+        ``audio_samples``, ``n_frames``, ``checked_cam_name``, ``task_labels``
+        (JSON string), ``camera_names`` and ``object_names``.
+
+    Examples:
+        >>> from daft.datasets import omnisharing
+        >>> episodes = omnisharing.raw("paxini/Omnisharing_DB_SampleData").limit(4)  # doctest: +SKIP
+        >>> omnisharing.episode_metadata(episodes).select("episode_key", "instruction").show()  # doctest: +SKIP
+    """
+    _require_episode_column(episodes)
+    _require_h5py()
+
+    @daft.func(return_dtype=_METADATA_DTYPE, use_process=False, unnest=True)
+    def _read_metadata(file: Hdf5File) -> dict[str, Any]:
+        with _open_for_scan(file) as h5:
+            root_attrs = _attrs_of(h5[_h5path()]) if _get(h5, _h5path()) is not None else {}
+
+            meta_node = _get(h5, _h5path("meta"))
+            meta_attrs = _attrs_of(meta_node) if meta_node is not None else {}
+            vendor = meta_attrs.pop("vendor", None)
+
+            audio = _get(h5, _h5path("observation", "audio"))
+            audio_attrs = _attrs_of(audio) if audio is not None else {}
+            samplerate = audio_attrs.get("samplerate")
+            audio_samples = int(audio.shape[0]) if audio is not None and audio.shape else None
+
+            image = _get(h5, _h5path("observation", "image"))
+            camera_names = sorted(image.keys()) if image is not None else []
+            image_attrs = _attrs_of(image) if image is not None else {}
+
+            observation = _get(h5, _h5path("observation"))
+            object_names = (
+                sorted(k for k in observation if _OBJECT_GROUP_RE.fullmatch(k)) if observation is not None else []
+            )
+
+            aligned = _get(h5, _h5path("observation", "aligned_timestamp"))
+            n_frames = int(aligned.shape[0]) if aligned is not None and aligned.shape else None
+
+            return {
+                "generated_time": root_attrs.get("generated_time"),
+                "data_id": root_attrs.get("data_id"),
+                "vendor": vendor,
+                "instruction": audio_attrs.get("txt"),
+                "audio_samplerate": int(samplerate) if samplerate is not None else None,
+                "audio_samples": audio_samples,
+                "n_frames": n_frames,
+                "checked_cam_name": image_attrs.get("checked_cam_name"),
+                "task_labels": json.dumps(meta_attrs, ensure_ascii=False),
+                "camera_names": camera_names,
+                "object_names": object_names,
+            }
+
+    return _append_unnested(episodes, _read_metadata(col("episode")))
+
+
+# ---------------------------------------------------------------------------
+# Path helpers
+# ---------------------------------------------------------------------------
+
+
+def _normalize_dataset_root(uri: str) -> str:
+    """Return a canonical dataset root prefix (no trailing slash) for path joins.
+
+    A bare ``org/name`` is interpreted as a Hugging Face dataset repo id, so
+    ``"paxini/Omnisharing_DB_SampleData"`` becomes
+    ``"hf://datasets/paxini/Omnisharing_DB_SampleData"``.
+    """
+    u = uri.strip()
+    if not u:
+        raise ValueError("dataset_uri must be a non-empty string")
+
+    # A bare "org/name" with no scheme and no leading slash is an HF repo id.
+    has_scheme = "://" in u
+    looks_local = u.startswith(("/", ".", "~"))
+    if not has_scheme and not looks_local and _HF_REPO_ID_RE.fullmatch(u):
+        u = f"hf://datasets/{u}"
+    return u.rstrip("/")
+
+
+def _episode_globs(root: str) -> list[str]:
+    """Globs covering both HDF5 extensions seen in the wild (``.hdf5`` and ``.h5``)."""
+    return [f"{root}/**/*.hdf5", f"{root}/**/*.h5"]
+
+
+# ---------------------------------------------------------------------------
+# raw()
+# ---------------------------------------------------------------------------
+
+
+@PublicAPI
+def raw(
+    dataset_uri: str,
+    io_config: IOConfig | None = None,
+    stage: str | None = None,
+) -> DataFrame:
+    r"""Discover OmniSharing episodes as a lazy episode-level DataFrame.
+
+    Globs ``{dataset_uri}/**/*.hdf5``, parses each episode's metadata straight
+    out of its filename (no bytes are read), and attaches a lazy
+    [`daft.Hdf5File`][daft.Hdf5File] handle per episode. Pass the result to
+    [`trajectory`][daft.datasets.omnisharing.trajectory],
+    [`tactile`][daft.datasets.omnisharing.tactile] and friends to pull
+    modalities out of the files.
+
+    Filter this DataFrame *before* reading modalities: episodes are 0.4-3.2 GB
+    each, so limiting by ``room_id``, ``personnel_id`` or ``limit()`` first
+    keeps the amount of streamed data small.
+
+    Args:
+        dataset_uri: Hugging Face repo id (``paxini/Omnisharing_DB_SampleData``),
+            or a local / remote directory (``hf://datasets/...``, ``s3://...``,
+            ``/data/omnisharing``).
+        io_config: Optional IO configuration for remote reads.
+        stage: Optionally keep only one pipeline stage: ``"DF-1"``, ``"DF-2"``
+            or ``"DF-2R"``. Defaults to None (keep everything).
+
+    Returns:
+        Lazy DataFrame with one row per episode file:
+
+        - `episode_key`: stable composite identity, `"{index}_{time}_{room}_{personnel}"`.
+            Use this instead of `episode_index`, which is **not unique**.
+        - `episode_index`, `capture_time`, `room_id`, `personnel_id`: parsed from the filename.
+        - `stage`: `"DF-1"`, `"DF-2"` or `"DF-2R"`.
+        - `hand_model`: retarget target for DF-2R (e.g. `"dh13"`, `"mano"`), else null.
+        - `episode`: `Hdf5File` handle for the episode.
+        - `path`, `size`: file location and byte size.
+
+    Note:
+        Both ``.hdf5`` and ``.h5`` extensions are discovered. If no episode
+        files match, collecting the result raises a Daft glob error rather than
+        returning an empty DataFrame.
+
+    Examples:
+        >>> import daft
+        >>> episodes = daft.datasets.omnisharing.raw("paxini/Omnisharing_DB_SampleData")  # doctest: +SKIP
+        >>> episodes.select("episode_key", "stage", "size").show()  # doctest: +SKIP
+    """
+    if stage is not None and stage not in STAGES:
+        raise ValueError(f"Unknown stage {stage!r}. Expected one of: {', '.join(STAGES)}.")
+
+    root = _normalize_dataset_root(dataset_uri)
+
+    files = daft.from_glob_path(_episode_globs(root), io_config=io_config)
+
+    # Everything below is pure string manipulation on the globbed paths, so the
+    # episode catalog is produced without opening a single HDF5 file.
+    parsed = files.select(
+        "path",
+        "size",
+        regexp_extract(col("path"), _EPISODE_FILENAME_RE, 1).alias("episode_index"),
+        regexp_extract(col("path"), _EPISODE_FILENAME_RE, 2).alias("capture_time"),
+        regexp_extract(col("path"), _EPISODE_FILENAME_RE, 3).alias("room_id"),
+        regexp_extract(col("path"), _EPISODE_FILENAME_RE, 4).alias("personnel_id"),
+        regexp_extract(col("path"), _EPISODE_FILENAME_RE, 5).alias("suffix"),
+    )
+
+    # Drop anything that does not look like an OmniSharing episode file.
+    parsed = parsed.where(col("episode_index").not_null() & (col("episode_index") != lit("")))
+
+    suffix = coalesce(col("suffix"), lit(""))
+    is_df2 = suffix == lit(DF2_SUFFIX)
+    has_suffix = suffix != lit("")
+
+    parsed = parsed.with_columns(
+        {
+            "stage": (when(is_df2, lit(STAGE_DF2)).when(has_suffix, lit(STAGE_DF2R)).otherwise(lit(STAGE_DF1))),
+            # Only DF-2R names a hand model; DF-1/DF-2 leave it null.
+            "hand_model": when(is_df2 | ~has_suffix, lit(None)).otherwise(suffix),
+            "episode_key": format(
+                "{}_{}_{}_{}",
+                col("episode_index"),
+                col("capture_time"),
+                col("room_id"),
+                col("personnel_id"),
+            ),
+            "episode": hdf5_file(col("path"), io_config=io_config),
+        }
+    )
+
+    if stage is not None:
+        parsed = parsed.where(col("stage") == lit(stage))
+
+    return parsed.select(
+        "episode_key",
+        col("episode_index").cast(DataType.int64()),
+        "capture_time",
+        col("room_id").cast(DataType.int64()),
+        col("personnel_id").cast(DataType.int64()),
+        "stage",
+        "hand_model",
+        "episode",
+        "path",
+        "size",
+    )
+
+
+# ---------------------------------------------------------------------------
+# trajectory()
+# ---------------------------------------------------------------------------
+
+#: Signal fields addressable by :func:`trajectory`, in dotted form.
+_TRAJECTORY_FIELDS: tuple[str, ...] = tuple(
+    f"{branch}.{side}.{signal}" for branch in BRANCHES for side in SIDES for signal in ("joints", "handpose")
+)
+
+_DEFAULT_TRAJECTORY_FIELDS: tuple[str, ...] = (
+    "observation.lefthand.joints",
+    "observation.lefthand.handpose",
+    "observation.righthand.joints",
+    "observation.righthand.handpose",
+    "action.lefthand.joints",
+    "action.lefthand.handpose",
+    "action.righthand.joints",
+    "action.righthand.handpose",
+)
+
+
+def _field_to_h5path(field: str) -> str:
+    branch, side, signal = field.split(".")
+    return _h5path(branch, side, signal, "data")
+
+
+@PublicAPI
+def trajectory(
+    episodes: DataFrame,
+    fields: Sequence[str] = _DEFAULT_TRAJECTORY_FIELDS,
+    *,
+    include_attrs: bool = True,
+) -> DataFrame:
+    r"""Read hand joint angles and 6-DoF hand poses as tensor columns.
+
+    Each requested field becomes one ``Tensor[Float32]`` column holding the
+    whole episode, shaped ``(n_frames, width)``:
+
+    - ``joints`` is ``(n, 29)`` in DF-2 (exoskeleton glove) and ``(n, 17)`` in
+      DF-2R (retargeted dexterous hand). The per-column meaning is given by the
+      ``joint_names`` attribute, not by position, so read it rather than
+      assuming an order.
+    - ``handpose`` is ``(n, 7)`` laid out as ``[x, y, z, qw, qx, qy, qz]``.
+
+    Warning:
+        The quaternion is **``qw`` first**, not ``qw`` last. Libraries such as
+        SciPy's ``Rotation.from_quat`` expect ``[qx, qy, qz, qw]`` and will
+        silently produce wrong rotations if fed this layout directly.
+
+    Note:
+        ``action`` leads ``observation`` by one frame (``action[i]`` is the state
+        at ``i + 1``, with the final frame repeated). Use
+        [`frames`][daft.datasets.omnisharing.frames] if you need that alignment
+        materialized per row.
+
+    Args:
+        episodes: Episode-level DataFrame from
+            [`raw`][daft.datasets.omnisharing.raw]. Filter it first: every
+            episode read here streams tensor data.
+        fields: Dotted field names of the form ``"{branch}.{side}.{signal}"``,
+            where branch is ``observation``/``action``, side is
+            ``lefthand``/``righthand`` and signal is ``joints``/``handpose``.
+            Defaults to all eight combinations.
+        include_attrs: If True (default), also emit ``joint_names`` for joint
+            fields and ``handpose_order``/``handpose_detail`` describing the
+            pose layout, plus each hand's ``description``.
+
+    Returns:
+        The input DataFrame with one tensor column per requested field, named
+        after the dotted field name.
+
+    Examples:
+        >>> from daft.datasets import omnisharing
+        >>> episodes = omnisharing.raw("paxini/Omnisharing_DB_SampleData").limit(1)  # doctest: +SKIP
+        >>> traj = omnisharing.trajectory(  # doctest: +SKIP
+        ...     episodes, fields=["observation.lefthand.joints"]
+        ... )
+        >>> traj.select("episode_key", "observation.lefthand.joints").collect()  # doctest: +SKIP
+    """
+    _require_episode_column(episodes)
+    _require_h5py()
+
+    fields = tuple(fields)
+    if not fields:
+        raise ValueError("fields must contain at least one field name")
+
+    unknown = [f for f in fields if f not in _TRAJECTORY_FIELDS]
+    if unknown:
+        raise ValueError(f"Unknown trajectory field(s): {unknown}. Valid fields are: {', '.join(_TRAJECTORY_FIELDS)}")
+
+    return_fields: dict[str, DataType] = {f: DataType.tensor(DataType.float32()) for f in fields}
+    if include_attrs:
+        sides_used = sorted({f.split(".")[1] for f in fields})
+        for f in fields:
+            if f.endswith(".joints"):
+                return_fields[f"{f}.joint_names"] = DataType.list(DataType.string())
+        for side in sides_used:
+            return_fields[f"{side}.description"] = DataType.string()
+        if any(f.endswith(".handpose") for f in fields):
+            return_fields["handpose_order"] = DataType.string()
+            return_fields["handpose_detail"] = DataType.string()
+
+    @daft.func(return_dtype=DataType.struct(return_fields), use_process=False, unnest=True)
+    def _read_trajectory(file: Hdf5File) -> dict[str, Any]:
+        out: dict[str, Any] = {}
+        with file._open_h5py() as h5:
+            for f in fields:
+                node = _get(h5, _field_to_h5path(f))
+                out[f] = None if node is None else node[()]
+                if include_attrs and f.endswith(".joints"):
+                    attrs = _attrs_of(node) if node is not None else {}
+                    out[f"{f}.joint_names"] = _str_list(attrs.get("joint_names"))
+            if include_attrs:
+                for side in sorted({f.split(".")[1] for f in fields}):
+                    # The hand description is identical under both branches, so
+                    # take whichever one is present rather than depending on
+                    # which branch happened to be requested first.
+                    hand = _get(h5, _h5path("observation", side)) or _get(h5, _h5path("action", side))
+                    out[f"{side}.description"] = _attrs_of(hand).get("description") if hand is not None else None
+                if any(f.endswith(".handpose") for f in fields):
+                    first = next(f for f in fields if f.endswith(".handpose"))
+                    branch, side, _ = first.split(".")
+                    pose = _get(h5, _h5path(branch, side, "handpose"))
+                    pose_attrs = _attrs_of(pose) if pose is not None else {}
+                    out["handpose_order"] = pose_attrs.get("order")
+                    out["handpose_detail"] = pose_attrs.get("detail")
+        return out
+
+    return _append_unnested(episodes, _read_trajectory(col("episode")))
+
+
+# ---------------------------------------------------------------------------
+# tactile()
+# ---------------------------------------------------------------------------
+
+
+@PublicAPI
+def tactile(
+    episodes: DataFrame,
+    sides: str | Sequence[str] = SIDES,
+    *,
+    split_by_sensor: bool = False,
+) -> DataFrame:
+    r"""Read multi-dimensional tactile readings for one or both hands.
+
+    Tactile is the distinguishing modality of this dataset: each frame is a flat
+    vector concatenating every sensor pad on the hand. In DF-2 that vector is
+    ``3465`` wide, split across 15 sensors whose widths are given by the
+    ``sensor_lengths`` attribute (palm plus per-finger pads). DF-2R uses a
+    different total (``3750``), so widths are always read from the file rather
+    than assumed.
+
+    Args:
+        episodes: Episode-level DataFrame from
+            [`raw`][daft.datasets.omnisharing.raw].
+        sides: Hand or hands to read: ``"lefthand"``, ``"righthand"`` or both.
+            Defaults to both.
+        split_by_sensor: If True, slice the flat vector into one tensor column
+            per sensor using the cumulative ``sensor_lengths`` offsets, named
+            ``"{side}.tactile.{sensor_name}"``. Defaults to False, which returns
+            the raw ``(n, total_width)`` tensor.
+
+    Returns:
+        The input DataFrame with, per requested side:
+
+        - `"{side}.tactile"`: `Tensor[Float32]` of shape `(n, total_width)`
+          (omitted when `split_by_sensor=True`).
+        - `"{side}.tactile.sensor_names"` and `"{side}.tactile.sensor_lengths"`.
+        - One `"{side}.tactile.{sensor}"` tensor column per sensor when
+          `split_by_sensor=True`.
+
+    Raises:
+        ValueError: If ``sensor_lengths`` does not sum to the stored vector
+            width, which would make any per-sensor slicing silently wrong.
+
+    Examples:
+        >>> from daft.datasets import omnisharing
+        >>> episodes = omnisharing.raw("paxini/Omnisharing_DB_SampleData").limit(1)  # doctest: +SKIP
+        >>> tac = omnisharing.tactile(episodes, sides="lefthand")  # doctest: +SKIP
+        >>> tac.select("episode_key", "lefthand.tactile.sensor_names").show()  # doctest: +SKIP
+    """
+    _require_episode_column(episodes)
+    _require_h5py()
+
+    selected = (sides,) if isinstance(sides, str) else tuple(sides)
+    if not selected:
+        raise ValueError("sides must contain at least one hand")
+    unknown = [s for s in selected if s not in SIDES]
+    if unknown:
+        raise ValueError(f"Unknown side(s): {unknown}. Expected one or more of: {', '.join(SIDES)}.")
+    selected = tuple(dict.fromkeys(selected))
+
+    sensor_layout = _probe_sensor_layout(episodes, selected) if split_by_sensor else {}
+
+    return_fields: dict[str, DataType] = {}
+    for side in selected:
+        if split_by_sensor:
+            for sensor in sensor_layout.get(side, []):
+                return_fields[f"{side}.tactile.{sensor}"] = DataType.tensor(DataType.float32())
+        else:
+            return_fields[f"{side}.tactile"] = DataType.tensor(DataType.float32())
+        return_fields[f"{side}.tactile.sensor_names"] = DataType.list(DataType.string())
+        return_fields[f"{side}.tactile.sensor_lengths"] = DataType.list(DataType.int64())
+
+    @daft.func(return_dtype=DataType.struct(return_fields), use_process=False, unnest=True)
+    def _read_tactile(file: Hdf5File) -> dict[str, Any]:
+        out: dict[str, Any] = dict.fromkeys(return_fields)
+        with file._open_h5py() as h5:
+            for side in selected:
+                node = _get(h5, _h5path("observation", side, "tactile", "data"))
+                if node is None:
+                    continue
+                attrs = _attrs_of(node)
+                names = _str_list(attrs.get("sensor_names"))
+                lengths = [int(v) for v in (attrs.get("sensor_lengths") or [])]
+                out[f"{side}.tactile.sensor_names"] = names
+                out[f"{side}.tactile.sensor_lengths"] = lengths
+
+                if not split_by_sensor:
+                    out[f"{side}.tactile"] = node[()]
+                    continue
+
+                width = int(node.shape[-1])
+                if sum(lengths) != width:
+                    raise ValueError(
+                        f"{side} tactile sensor_lengths sum to {sum(lengths)} but the stored "
+                        f"vector is {width} wide; per-sensor slicing would be incorrect."
+                    )
+                data = node[()]
+                offset = 0
+                for name, length in zip(names, lengths):
+                    key = f"{side}.tactile.{name}"
+                    if key in out:
+                        out[key] = data[:, offset : offset + length]
+                    offset += length
+        return out
+
+    return _append_unnested(episodes, _read_tactile(col("episode")))
+
+
+def _probe_sensor_layout(episodes: DataFrame, sides: tuple[str, ...]) -> dict[str, list[str]]:
+    """Read sensor names from one episode so the output schema can be fixed up front.
+
+    Daft resolves a plan's schema before execution, so per-sensor column names
+    must be known at planning time. One episode is opened for metadata only.
+    """
+    _require_h5py()
+
+    @daft.func(return_dtype=DataType.string(), use_process=False)
+    def _sensor_names_json(file: Hdf5File) -> str:
+        layout: dict[str, list[str]] = {}
+        with _open_for_scan(file) as h5:
+            for side in sides:
+                node = _get(h5, _h5path("observation", side, "tactile", "data"))
+                attrs = _attrs_of(node) if node is not None else {}
+                layout[side] = _str_list(attrs.get("sensor_names"))
+        return json.dumps(layout, ensure_ascii=False)
+
+    rows = episodes.limit(1).select(_sensor_names_json(col("episode")).alias("layout")).to_pylist()
+    if not rows or not rows[0]["layout"]:
+        raise ValueError(
+            "Could not probe tactile sensor names: the episode DataFrame is empty. "
+            "split_by_sensor=True needs at least one readable episode."
+        )
+    layout: dict[str, list[str]] = json.loads(rows[0]["layout"])
+    missing = [s for s in sides if not layout.get(s)]
+    if missing:
+        raise ValueError(
+            f"Episode has no tactile sensor_names for side(s) {missing}; "
+            f"cannot use split_by_sensor=True. Note tactile only exists under 'observation'."
+        )
+    return layout
+
+
+# ---------------------------------------------------------------------------
+# audio()
+# ---------------------------------------------------------------------------
+
+_AUDIO_DTYPE = DataType.struct(
+    {
+        "waveform": DataType.tensor(DataType.float64()),
+        "samplerate": DataType.int64(),
+        "n_samples": DataType.int64(),
+    }
+)
+
+
+@PublicAPI
+def audio(
+    episodes: DataFrame,
+    *,
+    mono: bool = False,
+    max_seconds: float | None = None,
+) -> DataFrame:
+    r"""Read the recorded audio waveform for each episode.
+
+    Note:
+        The published layout describes this as a "compressed audio stream
+        (includes text)". It is neither compressed nor text-bearing: the samples
+        are stored as raw ``float64`` PCM, and the spoken instruction lives in a
+        ``txt`` attribute that
+        [`episode_metadata`][daft.datasets.omnisharing.episode_metadata] surfaces
+        as ``instruction``. No audio codec is needed to read it.
+
+    Args:
+        episodes: Episode-level DataFrame from
+            [`raw`][daft.datasets.omnisharing.raw].
+        mono: If True, average across channels to produce a 1-D waveform.
+            Defaults to False, which preserves the stored ``(samples, channels)``
+            shape.
+        max_seconds: Optional limit, in seconds, on how much audio to read.
+            Applied as ``max_seconds * samplerate`` samples. Useful for
+            previewing without pulling whole recordings across the network.
+            Ignored when the episode has no ``samplerate`` attribute, since the
+            sample count cannot be derived without it.
+
+    Returns:
+        The input DataFrame with three columns appended:
+
+        - `"waveform"`: `Tensor[Float64]`, shape `(samples, channels)` or
+          `(samples,)` when `mono=True`.
+        - `"samplerate"`: samples per second, from the `samplerate` attribute.
+        - `"n_samples"`: number of samples actually read, which reflects
+          `max_seconds` when it is set.
+
+        Episodes without an ``audio`` dataset get an empty waveform and null
+        metadata rather than an error, so a mixed release still reads cleanly.
+
+    Raises:
+        ValueError: If ``max_seconds`` is not positive.
+
+    Examples:
+        >>> from daft.datasets import omnisharing
+        >>> episodes = omnisharing.raw("paxini/Omnisharing_DB_SampleData").limit(1)  # doctest: +SKIP
+        >>> clip = omnisharing.audio(episodes, mono=True, max_seconds=1.0)  # doctest: +SKIP
+        >>> clip.select("episode_key", "samplerate", "n_samples").show()  # doctest: +SKIP
+    """
+    _require_episode_column(episodes)
+    _require_h5py()
+
+    if max_seconds is not None and max_seconds <= 0:
+        raise ValueError(f"max_seconds must be positive, got {max_seconds}")
+
+    @daft.func(return_dtype=_AUDIO_DTYPE, use_process=False, unnest=True)
+    def _read_audio(file: Hdf5File) -> dict[str, Any]:
+        from daft.dependencies import np
+
+        # An all-null tensor column trips a Daft concat error, so absent audio is
+        # reported as an empty waveform with null metadata instead of null.
+        empty = {
+            "waveform": np.empty((0,), dtype="float64"),
+            "samplerate": None,
+            "n_samples": None,
+        }
+        with file._open_h5py() as h5:
+            node = _get(h5, _h5path("observation", "audio"))
+            if node is None:
+                return empty
+
+            attrs = _attrs_of(node)
+            samplerate = attrs.get("samplerate")
+            samplerate = int(samplerate) if samplerate is not None else None
+
+            limit = None
+            if max_seconds is not None and samplerate:
+                limit = max(1, int(max_seconds * samplerate))
+
+            # Slice inside the read so truncation never pulls the whole stream.
+            samples = np.asarray(node[:limit] if limit is not None else node[()])
+            if samples.size == 0:
+                return {**empty, "samplerate": samplerate, "n_samples": 0}
+
+            if mono and samples.ndim > 1:
+                samples = samples.mean(axis=tuple(range(1, samples.ndim)))
+
+            return {
+                "waveform": samples,
+                "samplerate": samplerate,
+                "n_samples": int(samples.shape[0]),
+            }
+
+    return _append_unnested(episodes, _read_audio(col("episode")))
+
+
+# ---------------------------------------------------------------------------
+# objects()
+# ---------------------------------------------------------------------------
+
+#: Width of each ``obj*/data`` row: a 4x4 transform plus one trailing value.
+OBJECT_POSE_WIDTH = 17
+
+
+@PublicAPI
+def objects(
+    episodes: DataFrame,
+    *,
+    max_objects: int | None = None,
+) -> DataFrame:
+    r"""Read per-object 6D pose tracks, when the episode has any.
+
+    Object poses come from the toolkit's optional pose-estimation stage, so many
+    episodes have no ``obj*`` groups at all. Because Daft fixes a plan's schema
+    before execution, the number of object columns cannot vary per row: this
+    probes the episodes to find the largest object count, emits that many
+    columns, and leaves the surplus null for episodes with fewer objects.
+
+    Args:
+        episodes: Episode-level DataFrame from
+            [`raw`][daft.datasets.omnisharing.raw].
+        max_objects: Number of ``obj*`` column groups to emit. Defaults to None,
+            which probes the episodes for the maximum present. Pass an explicit
+            value to skip the probe or to pad the schema for a wider release.
+
+    Returns:
+        The input DataFrame with, for each object slot ``i`` in ``1..n``:
+
+        - `"obj{i}"`: `Tensor[Float32]` of shape `(n_frames, 17)`, a flattened
+          4x4 transform plus a trailing element described by the `order` attr.
+        - `"obj{i}.name"`, `"obj{i}.id"`, `"obj{i}.order"`: identity and layout
+          metadata read from the dataset's attributes.
+
+        All four are null for episodes that do not have that object slot. When no
+        episode has any objects, only ``n_objects`` is added.
+
+    Examples:
+        >>> from daft.datasets import omnisharing
+        >>> episodes = omnisharing.raw("paxini/Omnisharing_DB_SampleData").limit(4)  # doctest: +SKIP
+        >>> omnisharing.objects(episodes).select("episode_key", "n_objects", "obj1.name").show()  # doctest: +SKIP
+    """
+    _require_episode_column(episodes)
+    _require_h5py()
+
+    if max_objects is not None and max_objects < 0:
+        raise ValueError(f"max_objects must be non-negative, got {max_objects}")
+
+    slots = _probe_object_count(episodes) if max_objects is None else max_objects
+
+    return_fields: dict[str, DataType] = {"n_objects": DataType.int64()}
+    for i in range(1, slots + 1):
+        return_fields[f"obj{i}"] = DataType.tensor(DataType.float32())
+        return_fields[f"obj{i}.name"] = DataType.string()
+        return_fields[f"obj{i}.id"] = DataType.int64()
+        return_fields[f"obj{i}.order"] = DataType.string()
+
+    @daft.func(return_dtype=DataType.struct(return_fields), use_process=False, unnest=True)
+    def _read_objects(file: Hdf5File) -> dict[str, Any]:
+        out: dict[str, Any] = dict.fromkeys(return_fields)
+        out["n_objects"] = 0
+        with file._open_h5py() as h5:
+            observation = _get(h5, _h5path("observation"))
+            if observation is None:
+                return out
+            names = sorted(
+                (k for k in observation if _OBJECT_GROUP_RE.fullmatch(k)),
+                key=lambda k: int(k[3:]),
+            )
+            out["n_objects"] = len(names)
+            for group_name in names:
+                node = _get(h5, _h5path("observation", group_name, "data"))
+                if node is None or f"{group_name}" not in return_fields:
+                    continue
+                attrs = _attrs_of(node)
+                out[group_name] = node[()]
+                out[f"{group_name}.name"] = attrs.get("obj_name")
+                obj_id = attrs.get("obj_id")
+                out[f"{group_name}.id"] = int(obj_id) if obj_id is not None else None
+                out[f"{group_name}.order"] = attrs.get("order") or attrs.get("detail")
+        return out
+
+    return _append_unnested(episodes, _read_objects(col("episode")))
+
+
+def _probe_object_count(episodes: DataFrame) -> int:
+    """Find the largest ``obj*`` count so the output schema can be fixed up front."""
+
+    @daft.func(return_dtype=DataType.int64(), use_process=False)
+    def _count(file: Hdf5File) -> int:
+        with _open_for_scan(file) as h5:
+            observation = _get(h5, _h5path("observation"))
+            if observation is None:
+                return 0
+            return sum(1 for k in observation if _OBJECT_GROUP_RE.fullmatch(k))
+
+    rows = episodes.select(_count(col("episode")).alias("n")).to_pylist()
+    return max((r["n"] or 0) for r in rows) if rows else 0
+
+
+# ---------------------------------------------------------------------------
+# cameras()
+# ---------------------------------------------------------------------------
+
+#: RGBD cameras store three separate encoded streams under the camera group.
+RGBD_STREAMS: tuple[str, ...] = ("color", "left", "right")
+
+#: Recognized codecs, keyed by the magic bytes at the head of a payload.
+_CODEC_MAGICS: tuple[tuple[bytes, str], ...] = (
+    (b"\x1a\x45\xdf\xa3", "matroska"),
+    (b"\xff\xd8\xff", "jpeg"),
+    (b"\x89PNG\r\n\x1a\n", "png"),
+    (b"RIFF", "riff"),
+    (b"\x00\x00\x00\x01", "h26x-annexb"),
+    (b"\x00\x00\x01", "h26x-annexb"),
+)
+
+
+def _sniff_codec(head: bytes) -> str:
+    """Identify a payload's container/codec from its leading bytes.
+
+    OmniSharing's ``data`` payloads are whole encoded streams, not per-frame
+    blobs: ``RGB_Camera*`` holds H.265/HEVC in Annex-B byte-stream format and
+    the ``RGBD_*`` sub-streams hold Matroska. The official data_structure.md
+    only calls these a "1D compressed payload", so detection is done from the
+    bytes rather than trusting a declared format.
+    """
+    if len(head) >= 12 and head[4:8] == b"ftyp":
+        return "mp4"
+    for magic, name in _CODEC_MAGICS:
+        if head.startswith(magic):
+            return name
+    return "unknown"
+
+
+_CAMERA_DTYPE = DataType.struct(
+    {
+        "camera": DataType.string(),
+        "kind": DataType.string(),
+        "stream": DataType.string(),
+        "h5path": DataType.string(),
+        "codec": DataType.string(),
+        "payload_bytes": DataType.int64(),
+        "n_timestamps": DataType.int64(),
+        "width": DataType.int64(),
+        "height": DataType.int64(),
+        "intrinsics": DataType.tensor(DataType.float32()),
+        "extrinsics": DataType.tensor(DataType.float64()),
+        "distortion": DataType.string(),
+        "relative_to_who": DataType.string(),
+        "calib_date": DataType.string(),
+        "inner_extrinsic": DataType.string(),
+        "is_checked_camera": DataType.bool(),
+    }
+)
+
+
+@PublicAPI
+def cameras(episodes: DataFrame) -> DataFrame:
+    r"""Enumerate each episode's cameras with calibration and codec details.
+
+    Emits one row per encoded video stream: one per ``RGB_Camera*`` and three
+    per ``RGBD_*`` (``color``, ``left``, ``right``). Camera ids are
+    **non-contiguous** in real captures, and the two families use different
+    reference frames, so both are reported rather than inferred:
+
+    - ``RGB_Camera*`` extrinsics are relative to another RGB camera.
+    - ``RGBD_*`` extrinsics are relative to ``RGBD_0``.
+
+    Only headers, calibration matrices and the first bytes of each payload are
+    read, so this is cheap relative to decoding.
+
+    Args:
+        episodes: Episode-level DataFrame from
+            [`raw`][daft.datasets.omnisharing.raw].
+
+    Returns:
+        DataFrame with one row per camera stream:
+
+        - `episode_key`, `camera` (e.g. `"RGB_Camera4"`), `kind` (`"rgb"`/`"rgbd"`),
+          `stream` (`""` for RGB, else `"color"`/`"left"`/`"right"`), `h5path`.
+        - `codec`: detected from magic bytes, e.g. `"h26x-annexb"` for RGB and
+          `"matroska"` for RGBD streams.
+        - `payload_bytes`, `n_timestamps`, `width`, `height`.
+        - `intrinsics` (3x3), `extrinsics` (4x4), `distortion`, `relative_to_who`,
+          `calib_date`.
+        - `inner_extrinsic`: RGBD-only JSON string with the stereo-to-color transform.
+        - `is_checked_camera`: True when this camera matches the episode's
+          `checked_cam_name` attribute.
+
+    Examples:
+        >>> from daft.datasets import omnisharing
+        >>> episodes = omnisharing.raw("paxini/Omnisharing_DB_SampleData").limit(1)  # doctest: +SKIP
+        >>> omnisharing.cameras(episodes).select("camera", "kind", "codec", "width", "height").show()  # doctest: +SKIP
+    """
+    _require_episode_column(episodes)
+    _require_h5py()
+
+    @daft.func(return_dtype=DataType.list(_CAMERA_DTYPE), use_process=False)
+    def _read_cameras(file: Hdf5File) -> list[dict[str, Any]]:
+        rows: list[dict[str, Any]] = []
+        with _open_for_scan(file) as h5:
+            image = _get(h5, _h5path("observation", "image"))
+            if image is None:
+                return rows
+            checked = _attrs_of(image).get("checked_cam_name") or ""
+
+            for camera in sorted(image):
+                group = image[camera]
+                is_rgbd = camera.upper().startswith("RGBD")
+                inner = _get(group, "inner_extrinsic")
+                inner_json = None
+                if inner is not None:
+                    raw_inner = inner[()]
+                    blob = raw_inner[0] if getattr(raw_inner, "shape", ()) else raw_inner
+                    inner_json = blob.decode("utf-8", "replace") if isinstance(blob, bytes) else str(blob)
+
+                streams = RGBD_STREAMS if is_rgbd else ("",)
+                for stream in streams:
+                    holder = _get(group, stream) if stream else group
+                    if holder is None:
+                        continue
+                    payload = _get(holder, "data")
+                    if payload is None:
+                        continue
+
+                    head = bytes(payload[: min(16, int(payload.shape[0]))])
+                    intr = _get(holder, "intrinsics")
+                    intr_attrs = _attrs_of(intr) if intr is not None else {}
+                    # RGB keeps extrinsics on the camera group. RGBD stores a
+                    # single camera-level extrinsic under the `color` stream, so
+                    # `left`/`right` fall back to it: all three share one pose,
+                    # with the stereo offsets living in `inner_extrinsic`.
+                    ext = (
+                        _get(holder, "extrinsics")
+                        or _get(group, "extrinsics")
+                        or (_get(group, "color/extrinsics") if is_rgbd else None)
+                    )
+                    ext_attrs = _attrs_of(ext) if ext is not None else {}
+                    ts = _get(group, f"{stream}_timestamp" if stream else "timestamp") or _get(group, "timestamp")
+
+                    rows.append(
+                        {
+                            "camera": camera,
+                            "kind": "rgbd" if is_rgbd else "rgb",
+                            "stream": stream,
+                            "h5path": f"{_h5path('observation', 'image', camera)}" + (f"/{stream}" if stream else ""),
+                            "codec": _sniff_codec(head),
+                            "payload_bytes": int(payload.shape[0]),
+                            "n_timestamps": int(ts.shape[0]) if ts is not None and ts.shape else None,
+                            "width": _opt_int(intr_attrs.get("width")),
+                            "height": _opt_int(intr_attrs.get("height")),
+                            "intrinsics": None if intr is None else intr[()],
+                            "extrinsics": None if ext is None else ext[()],
+                            "distortion": intr_attrs.get("distortion"),
+                            "relative_to_who": ext_attrs.get("relative_to_who"),
+                            "calib_date": ext_attrs.get("calib_date"),
+                            "inner_extrinsic": inner_json,
+                            "is_checked_camera": bool(checked) and checked in camera,
+                        }
+                    )
+        return rows
+
+    exploded = episodes.select("episode_key", _read_cameras(col("episode")).alias("cam")).explode("cam")
+    return exploded.select("episode_key", unnest(col("cam")))
+
+
+def _opt_int(value: Any) -> int | None:
+    return None if value is None else int(value)
+
+
+# ---------------------------------------------------------------------------
+# camera_payloads() / camera_frames()
+# ---------------------------------------------------------------------------
+
+#: Codecs that PyAV can open straight from an in-memory buffer.
+_DECODABLE_CODECS: frozenset[str] = frozenset({"h26x-annexb", "matroska", "mp4"})
+
+#: Explicit demuxer/format hint per codec. Annex-B byte streams carry no
+#: container, so PyAV must be told which elementary stream it is looking at.
+_AV_FORMAT_HINT: dict[str, str] = {
+    "h26x-annexb": "hevc",
+    "matroska": "matroska",
+    "mp4": "mp4",
+}
+
+#: Safety cap on frames decoded per stream, mirroring the LeRobot reader's budget.
+_DECODE_FRAME_BUDGET = 20_000
+
+
+def _camera_h5paths(camera: str, stream: str = "") -> str:
+    parts = ["observation", "image", camera]
+    if stream:
+        parts.append(stream)
+    parts.append("data")
+    return _h5path(*parts)
+
+
+@PublicAPI
+def camera_payloads(
+    episodes: DataFrame,
+    cameras_: Sequence[tuple[str, str]] | Sequence[str],
+) -> DataFrame:
+    r"""Read raw encoded video payloads for specific camera streams.
+
+    This is the always-available path: it hands back the encoded bytes plus the
+    detected codec without needing PyAV or any codec support, so it works even
+    for payloads this module cannot decode. Use
+    [`camera_frames`][daft.datasets.omnisharing.camera_frames] when you want
+    decoded images instead.
+
+    Warning:
+        A single stream is tens of megabytes. Select only the cameras you need
+        and filter ``episodes`` first.
+
+    Args:
+        episodes: Episode-level DataFrame from
+            [`raw`][daft.datasets.omnisharing.raw].
+        cameras_: Streams to read. Either camera names (``"RGB_Camera0"``) or
+            ``(camera, stream)`` pairs for RGBD sub-streams
+            (``("RGBD_0", "color")``).
+
+    Returns:
+        The input DataFrame with, per requested stream:
+
+        - `"{name}.payload"`: the encoded bytes.
+        - `"{name}.codec"`: detected codec, e.g. `"h26x-annexb"` or `"matroska"`.
+
+        where `name` is the camera, suffixed with `".{stream}"` for RGBD
+        sub-streams. Missing streams are null.
+
+    Examples:
+        >>> from daft.datasets import omnisharing
+        >>> episodes = omnisharing.raw("paxini/Omnisharing_DB_SampleData").limit(1)  # doctest: +SKIP
+        >>> payloads = omnisharing.camera_payloads(episodes, ["RGB_Camera0"])  # doctest: +SKIP
+        >>> payloads.select("RGB_Camera0.codec").show()  # doctest: +SKIP
+    """
+    _require_episode_column(episodes)
+    _require_h5py()
+
+    targets = _normalize_camera_targets(cameras_)
+
+    return_fields: dict[str, DataType] = {}
+    for camera, stream in targets:
+        name = _stream_label(camera, stream)
+        return_fields[f"{name}.payload"] = DataType.binary()
+        return_fields[f"{name}.codec"] = DataType.string()
+
+    @daft.func(return_dtype=DataType.struct(return_fields), use_process=False, unnest=True)
+    def _read_payloads(file: Hdf5File) -> dict[str, Any]:
+        out: dict[str, Any] = dict.fromkeys(return_fields)
+        with file._open_h5py() as h5:
+            for camera, stream in targets:
+                node = _get(h5, _camera_h5paths(camera, stream))
+                if node is None:
+                    continue
+                name = _stream_label(camera, stream)
+                blob = node[()].tobytes()
+                out[f"{name}.payload"] = blob
+                out[f"{name}.codec"] = _sniff_codec(blob[:16])
+        return out
+
+    return _append_unnested(episodes, _read_payloads(col("episode")))
+
+
+@PublicAPI
+def camera_frames(
+    episodes: DataFrame,
+    cameras_: Sequence[tuple[str, str]] | Sequence[str],
+    *,
+    max_frames: int | None = 1,
+    sample_every: int = 1,
+    width: int | None = None,
+    height: int | None = None,
+) -> DataFrame:
+    r"""Decode camera payloads into image columns.
+
+    Payloads are decoded from memory with PyAV. ``RGB_Camera*`` streams are
+    H.265/HEVC Annex-B elementary streams, which carry no container, so the
+    decoder is told the format explicitly. ``RGBD_*`` sub-streams are Matroska
+    and are demuxed normally.
+
+    Warning:
+        Decoding is expensive and each stream holds the whole episode. The
+        default ``max_frames=1`` decodes a single frame per stream, which is
+        enough for previews and thumbnails. Raise it deliberately.
+
+    Args:
+        episodes: Episode-level DataFrame from
+            [`raw`][daft.datasets.omnisharing.raw].
+        cameras_: Streams to decode. Either camera names (``"RGB_Camera0"``) or
+            ``(camera, stream)`` pairs (``("RGBD_0", "color")``).
+        max_frames: Maximum frames to decode per stream. Defaults to 1. Pass
+            None to decode everything, bounded by an internal safety budget.
+        sample_every: Keep every Nth decoded frame. Defaults to 1 (keep all).
+        width: Target width; must be given together with ``height``.
+        height: Target height; must be given together with ``width``.
+
+    Returns:
+        The input DataFrame with one ``"{name}.frames"`` list-of-image column
+        per requested stream, and ``"{name}.codec"`` alongside it. Streams whose
+        codec is not decodable yield null frames; use
+        [`camera_payloads`][daft.datasets.omnisharing.camera_payloads] to get
+        their raw bytes instead.
+
+    Examples:
+        >>> from daft.datasets import omnisharing
+        >>> episodes = omnisharing.raw("paxini/Omnisharing_DB_SampleData").limit(1)  # doctest: +SKIP
+        >>> frames = omnisharing.camera_frames(episodes, ["RGB_Camera0"], max_frames=2)  # doctest: +SKIP
+        >>> frames.select("RGB_Camera0.frames").show()  # doctest: +SKIP
+    """
+    _require_episode_column(episodes)
+    _require_h5py()
+
+    from daft.dependencies import av
+
+    if not av.module_available():  # ty:ignore[unresolved-attribute]
+        raise ImportError(
+            "Decoding OmniSharing camera payloads requires PyAV. Install it with: pip install 'daft[video]'"
+        )
+
+    targets = _normalize_camera_targets(cameras_)
+
+    if (width is None) != (height is None):
+        raise ValueError("width and height must be provided together")
+    if sample_every < 1:
+        raise ValueError(f"sample_every must be >= 1, got {sample_every}")
+    if max_frames is not None and max_frames < 1:
+        raise ValueError(f"max_frames must be >= 1 or None, got {max_frames}")
+
+    return_fields: dict[str, DataType] = {}
+    for camera, stream in targets:
+        name = _stream_label(camera, stream)
+        return_fields[f"{name}.frames"] = DataType.list(DataType.image())
+        return_fields[f"{name}.codec"] = DataType.string()
+
+    @daft.func(return_dtype=DataType.struct(return_fields), use_process=False, unnest=True)
+    def _decode(file: Hdf5File) -> dict[str, Any]:
+        out: dict[str, Any] = dict.fromkeys(return_fields)
+        with file._open_h5py() as h5:
+            for camera, stream in targets:
+                node = _get(h5, _camera_h5paths(camera, stream))
+                if node is None:
+                    continue
+                name = _stream_label(camera, stream)
+                blob = node[()].tobytes()
+                codec = _sniff_codec(blob[:16])
+                out[f"{name}.codec"] = codec
+                if codec not in _DECODABLE_CODECS:
+                    continue
+                out[f"{name}.frames"] = _decode_payload(
+                    blob,
+                    codec,
+                    max_frames=max_frames,
+                    sample_every=sample_every,
+                    width=width,
+                    height=height,
+                )
+        return out
+
+    return _append_unnested(episodes, _decode(col("episode")))
+
+
+def _decode_payload(
+    blob: bytes,
+    codec: str,
+    *,
+    max_frames: int | None,
+    sample_every: int,
+    width: int | None,
+    height: int | None,
+) -> list[Any]:
+    """Decode an in-memory encoded stream into a list of RGB ndarrays."""
+    import io
+
+    from daft.dependencies import av, np, pil_image
+
+    frames: list[Any] = []
+    budget = _DECODE_FRAME_BUDGET if max_frames is None else min(max_frames * sample_every, _DECODE_FRAME_BUDGET)
+
+    buffer = io.BytesIO(blob)
+    open_kwargs = {"format": _AV_FORMAT_HINT[codec]} if codec in _AV_FORMAT_HINT else {}
+
+    with av.open(buffer, "r", **open_kwargs) as container:
+        if not container.streams.video:
+            return frames
+        video = container.streams.video[0]
+        seen = 0
+        for seen, frame in enumerate(container.decode(video)):
+            if seen % sample_every == 0:
+                array = frame.to_ndarray(format="rgb24")
+                if width is not None and height is not None:
+                    if not pil_image.module_available():  # ty:ignore[unresolved-attribute]
+                        raise ImportError(
+                            "Resizing decoded frames requires Pillow. Install it with: pip install 'daft[video]'"
+                        )
+                    img = pil_image.fromarray(array, mode="RGB").resize((width, height), pil_image.Resampling.BILINEAR)
+                    array = np.asarray(img)
+                frames.append(array)
+            if max_frames is not None and len(frames) >= max_frames:
+                break
+            if seen + 1 >= budget:
+                break
+    return frames
+
+
+def _normalize_camera_targets(
+    cameras_: Sequence[tuple[str, str]] | Sequence[str],
+) -> tuple[tuple[str, str], ...]:
+    """Normalize camera selectors into ``(camera, stream)`` pairs.
+
+    Naming an RGBD camera without a stream expands to all of its sub-streams,
+    since an RGBD group has no payload of its own.
+    """
+    if isinstance(cameras_, str):
+        cameras_ = [cameras_]
+    if not cameras_:
+        raise ValueError("cameras_ must name at least one camera stream")
+
+    targets: list[tuple[str, str]] = []
+    for entry in cameras_:
+        if isinstance(entry, str):
+            camera, stream = entry, ""
+        elif isinstance(entry, (tuple, list)) and len(entry) == 2:
+            camera, stream = str(entry[0]), str(entry[1])
+        else:
+            raise ValueError(f"Invalid camera selector {entry!r}. Expected a camera name or a (camera, stream) pair.")
+
+        if stream and stream not in RGBD_STREAMS:
+            raise ValueError(
+                f"Unknown RGBD stream {stream!r} for {camera!r}. Expected one of: {', '.join(RGBD_STREAMS)}."
+            )
+        if not stream and camera.upper().startswith("RGBD"):
+            targets.extend((camera, s) for s in RGBD_STREAMS)
+            continue
+        targets.append((camera, stream))
+
+    return tuple(dict.fromkeys(targets))
+
+
+def _stream_label(camera: str, stream: str) -> str:
+    return f"{camera}.{stream}" if stream else camera
+
+
+# ---------------------------------------------------------------------------
+# depth_frames()
+# ---------------------------------------------------------------------------
+
+
+@PublicAPI
+def depth_frames(
+    episodes: DataFrame,
+    cameras_: Sequence[str] | str,
+    *,
+    frame_indices: Sequence[int] | int = 0,
+) -> DataFrame:
+    r"""Read depth maps from an RGBD camera's ``aligned_depth`` dataset.
+
+    Depth is stored as a ``uint16`` array already registered to the colour
+    image, so a depth pixel and its colour pixel share coordinates and no
+    reprojection is needed.
+
+    Note:
+        The depth unit is **undocumented**. Unlike the tactile and joint
+        datasets, ``aligned_depth`` carries no attributes at all, so there is
+        nothing in the file to derive a scale from. Values are returned exactly
+        as stored; consult PaXini before treating them as millimetres.
+
+    Note:
+        ``aligned_depth`` appears in no published layout and is not present on
+        every RGBD camera. In a sampled episode only ``RGBD_0`` had it, while
+        ``RGBD_1`` and ``RGBD_2`` did not.
+
+    Warning:
+        A single frame is ``720 x 1280`` ``uint16``, about 1.8 MB, and a whole
+        episode is roughly 380 MB per camera. ``frame_indices`` therefore
+        defaults to frame ``0`` rather than reading everything.
+
+    Args:
+        episodes: Episode-level DataFrame from
+            [`raw`][daft.datasets.omnisharing.raw].
+        cameras_: RGBD camera name or names, e.g. ``"RGBD_0"``. Unlike
+            [`camera_frames`][daft.datasets.omnisharing.camera_frames] these are
+            camera names only: depth is stored once per camera rather than per
+            colour/left/right sub-stream.
+        frame_indices: Which frames to read, as a single index or a sequence.
+            Frames are returned in the order requested. Defaults to ``0``.
+
+    Returns:
+        The input DataFrame with, per requested camera:
+
+        - `"{camera}.depth"`: `Tensor[UInt16]` of shape
+          `(len(frame_indices), height, width)`.
+        - `"{camera}.depth_frame_indices"`: the indices actually read.
+
+        Cameras without an ``aligned_depth`` dataset yield nulls.
+
+    Raises:
+        ValueError: If ``cameras_`` is empty or ``frame_indices`` is empty.
+        IndexError: If an index is negative or beyond the stored frame count.
+            Negative indices are rejected rather than wrapping around, so a
+            stale index cannot silently read a different frame.
+
+    Examples:
+        >>> from daft.datasets import omnisharing
+        >>> episodes = omnisharing.raw("paxini/Omnisharing_DB_SampleData").limit(1)  # doctest: +SKIP
+        >>> depth = omnisharing.depth_frames(episodes, "RGBD_0", frame_indices=[0, 10])  # doctest: +SKIP
+        >>> depth.select("episode_key", "RGBD_0.depth").show()  # doctest: +SKIP
+    """
+    _require_episode_column(episodes)
+    _require_h5py()
+
+    names = (cameras_,) if isinstance(cameras_, str) else tuple(cameras_)
+    if not names:
+        raise ValueError("cameras_ must name at least one RGBD camera")
+    names = tuple(dict.fromkeys(names))
+
+    wanted = (frame_indices,) if isinstance(frame_indices, int) else tuple(frame_indices)
+    if not wanted:
+        raise ValueError("frame_indices must contain at least one index")
+    negative = [i for i in wanted if i < 0]
+    if negative:
+        raise IndexError(
+            f"frame_indices must be non-negative, got {negative}. "
+            "Negative indices are rejected rather than wrapping around."
+        )
+
+    # Bounds are checked here rather than inside the UDF: an exception raised
+    # during execution surfaces as an opaque Daft error, losing the message that
+    # says which camera and which bound were involved.
+    _check_depth_bounds(episodes, names, wanted)
+
+    return_fields: dict[str, DataType] = {}
+    for name in names:
+        return_fields[f"{name}.depth"] = DataType.tensor(DataType.uint16())
+        return_fields[f"{name}.depth_frame_indices"] = DataType.list(DataType.int64())
+
+    @daft.func(return_dtype=DataType.struct(return_fields), use_process=False, unnest=True)
+    def _read_depth(file: Hdf5File) -> dict[str, Any]:
+        from daft.dependencies import np
+
+        out: dict[str, Any] = {}
+        with file._open_h5py() as h5:
+            for name in names:
+                node = _get(h5, _h5path("observation", "image", name, "aligned_depth"))
+                if node is None or not node.shape or node.shape[0] == 0:
+                    # Absent or empty depth must not fail the whole episode. An
+                    # empty array is used because an all-null tensor column trips
+                    # a Daft concat error.
+                    out[f"{name}.depth"] = np.empty((0,), dtype="uint16")
+                    out[f"{name}.depth_frame_indices"] = None
+                    continue
+
+                available = int(node.shape[0])
+                # Clamp instead of raising: bounds were already validated up
+                # front, and a mid-execution raise would surface opaquely.
+                usable = [i for i in wanted if i < available]
+                if not usable:
+                    out[f"{name}.depth"] = np.empty((0,), dtype="uint16")
+                    out[f"{name}.depth_frame_indices"] = None
+                    continue
+
+                # Read frame by frame so only the requested slices are fetched.
+                stacked = np.stack([np.asarray(node[i]) for i in usable])
+                out[f"{name}.depth"] = stacked
+                out[f"{name}.depth_frame_indices"] = list(usable)
+        return out
+
+    return _append_unnested(episodes, _read_depth(col("episode")))
+
+
+def _check_depth_bounds(episodes: DataFrame, names: tuple[str, ...], wanted: tuple[int, ...]) -> None:
+    """Raise IndexError up front if any requested frame is out of range.
+
+    Probes frame counts from the first episode. A camera with no depth, or with
+    a zero-length depth dataset, is skipped rather than treated as a bound: both
+    mean "nothing to read here", which is reported as an empty result rather
+    than an error.
+    """
+    probe_fields = {name: DataType.int64() for name in names}
+
+    @daft.func(return_dtype=DataType.struct(probe_fields), use_process=False, unnest=True)
+    def _depth_lengths(file: Hdf5File) -> dict[str, Any]:
+        lengths: dict[str, Any] = {}
+        with _open_for_scan(file) as h5:
+            for name in names:
+                node = _get(h5, _h5path("observation", "image", name, "aligned_depth"))
+                lengths[name] = int(node.shape[0]) if node is not None and node.shape else None
+        return lengths
+
+    rows = _append_unnested(episodes.limit(1), _depth_lengths(col("episode"))).to_pylist()
+    if not rows:
+        return
+
+    highest = max(wanted)
+    for name in names:
+        available = rows[0].get(name)
+        if available and highest >= available:
+            out_of_range = [i for i in wanted if i >= available]
+            raise IndexError(
+                f"{name}/aligned_depth has {available} frames; requested index/indices {out_of_range} out of range."
+            )
+
+
+# ---------------------------------------------------------------------------
+# stereo_extrinsics()
+# ---------------------------------------------------------------------------
+
+
+@PublicAPI
+def stereo_extrinsics(
+    episodes: DataFrame,
+    cameras_: Sequence[str] | str,
+) -> DataFrame:
+    r"""Parse an RGBD camera's stereo calibration into tensors.
+
+    Each RGBD group stores an ``inner_extrinsic`` dataset holding a JSON blob,
+    which [`cameras`][daft.datasets.omnisharing.cameras] passes through as an
+    opaque string. The useful part is ``left_to_color``: the 4x4 transform from
+    the left eye's frame into the colour camera's frame, needed to project the
+    stereo pair into a common frame.
+
+    Note:
+        This is the *intra*-camera transform, distinct from the ``extrinsics``
+        dataset that [`cameras`][daft.datasets.omnisharing.cameras] reports,
+        which places the whole camera relative to a reference rig
+        (``RGBD_0`` for depth cameras, ``RGB_Camera6`` for colour ones).
+
+    Args:
+        episodes: Episode-level DataFrame from
+            [`raw`][daft.datasets.omnisharing.raw].
+        cameras_: RGBD camera name or names, e.g. ``"RGBD_0"``.
+
+    Returns:
+        The input DataFrame with, per requested camera:
+
+        - `"{camera}.left_to_color"`: `Tensor[Float64]` of shape `(4, 4)`.
+        - `"{camera}.calib_date"`: calibration timestamp as a string.
+
+        Cameras with no ``inner_extrinsic``, or whose JSON cannot be parsed,
+        yield nulls rather than failing the read.
+
+    Raises:
+        ValueError: If ``cameras_`` is empty.
+
+    Examples:
+        >>> from daft.datasets import omnisharing
+        >>> episodes = omnisharing.raw("paxini/Omnisharing_DB_SampleData").limit(1)  # doctest: +SKIP
+        >>> calib = omnisharing.stereo_extrinsics(episodes, "RGBD_0")  # doctest: +SKIP
+        >>> calib.select("episode_key", "RGBD_0.left_to_color").show()  # doctest: +SKIP
+    """
+    _require_episode_column(episodes)
+    _require_h5py()
+
+    names = (cameras_,) if isinstance(cameras_, str) else tuple(cameras_)
+    if not names:
+        raise ValueError("cameras_ must name at least one RGBD camera")
+    names = tuple(dict.fromkeys(names))
+
+    return_fields: dict[str, DataType] = {}
+    for name in names:
+        return_fields[f"{name}.left_to_color"] = DataType.tensor(DataType.float64())
+        return_fields[f"{name}.calib_date"] = DataType.string()
+
+    @daft.func(return_dtype=DataType.struct(return_fields), use_process=False, unnest=True)
+    def _read_stereo(file: Hdf5File) -> dict[str, Any]:
+        from daft.dependencies import np
+
+        out: dict[str, Any] = {}
+        with _open_for_scan(file) as h5:
+            for name in names:
+                # An all-null tensor column trips a Daft concat error, so an
+                # unavailable transform is an empty array rather than null.
+                out[f"{name}.left_to_color"] = np.empty((0,), dtype="float64")
+                out[f"{name}.calib_date"] = None
+
+                node = _get(h5, _h5path("observation", "image", name, "inner_extrinsic"))
+                if node is None:
+                    continue
+
+                raw_value = node[()]
+                blob = raw_value[0] if getattr(raw_value, "shape", ()) else raw_value
+                if isinstance(blob, bytes):
+                    blob = blob.decode("utf-8", "replace")
+                try:
+                    payload = json.loads(blob)
+                except (TypeError, ValueError):
+                    # Calibration is optional metadata; a malformed blob must not
+                    # take down the whole read.
+                    continue
+                if not isinstance(payload, dict):
+                    continue
+
+                out[f"{name}.calib_date"] = (
+                    str(payload["calib_date"]) if payload.get("calib_date") is not None else None
+                )
+                matrix = payload.get("left_to_color")
+                if matrix is None:
+                    continue
+                try:
+                    as_array = np.asarray(matrix, dtype="float64")
+                except (TypeError, ValueError):
+                    continue
+                if as_array.shape == (4, 4):
+                    out[f"{name}.left_to_color"] = as_array
+        return out
+
+    return _append_unnested(episodes, _read_stereo(col("episode")))
+
+
+# ---------------------------------------------------------------------------
+# frames()
+# ---------------------------------------------------------------------------
+
+#: Per-hand signals addressable by :func:`frames`, in dotted form.
+_FRAME_FIELDS: tuple[str, ...] = tuple(
+    f"{branch}.{side}.{signal}"
+    for branch in BRANCHES
+    for side in SIDES
+    for signal in _SIGNALS
+    # tactile is only recorded under observation
+    if not (branch == "action" and signal == "tactile")
+)
+
+
+@PublicAPI
+def frames(
+    episodes: DataFrame,
+    fields: Sequence[str],
+    *,
+    align_cameras: Sequence[tuple[str, str]] | Sequence[str] = (),
+) -> DataFrame:
+    r"""Expand episodes into one row per frame, aligned on ``aligned_timestamp``.
+
+    Applies the dataset's documented action/observation offset: ``action`` leads
+    ``observation`` by one frame, so ``action[i]`` is the state at ``i + 1``,
+    with the final action repeated to keep both the same length. Reading the raw
+    arrays without this offset silently misaligns state and action.
+
+    | Frame       | 0   | 1   | ... | n-2   | n-1   |
+    | ----------- | --- | --- | --- | ----- | ----- |
+    | observation | s0  | s1  | ... | s(n-2)| s(n-1)|
+    | action      | s1  | s2  | ... | s(n-1)| s(n-1)|
+
+    Warning:
+        Camera streams do **not** share the observation clock. In a sampled
+        episode the hands and RGBD cameras tick 207 times while the RGB cameras
+        produce 208-254 frames, and ``RGB_Camera0`` had already been recording
+        for 10 frames when observation frame 0 was captured. ``align_cameras``
+        therefore matches by nearest timestamp and never by frame index.
+
+    Note:
+        ``fields`` is required. Frame-level expansion multiplies row count by the
+        frame count, and a single tactile row is 3465 floats wide, so an
+        unrestricted expansion is a memory hazard.
+
+    Args:
+        episodes: Episode-level DataFrame from
+            [`raw`][daft.datasets.omnisharing.raw]. Filter it first.
+        fields: Dotted ``"{branch}.{side}.{signal}"`` names to expand, where
+            signal is ``joints``, ``handpose`` or ``tactile``. ``tactile`` exists
+            only under ``observation``.
+        align_cameras: Optional camera streams to align to each frame. Adds a
+            ``"{name}.frame_index"`` and ``"{name}.timestamp_delta_us"`` column
+            per stream, giving the nearest source frame and how far off it is.
+            No video is decoded here.
+
+    Returns:
+        DataFrame with one row per frame: the episode's identity columns, a
+        ``frame_index`` and ``timestamp`` column, one column per requested field
+        holding that frame's vector, and camera alignment columns when
+        ``align_cameras`` is used.
+
+    Examples:
+        >>> from daft.datasets import omnisharing
+        >>> episodes = omnisharing.raw("paxini/Omnisharing_DB_SampleData").limit(1)  # doctest: +SKIP
+        >>> per_frame = omnisharing.frames(  # doctest: +SKIP
+        ...     episodes,
+        ...     fields=["observation.lefthand.joints", "action.lefthand.joints"],
+        ...     align_cameras=["RGB_Camera0"],
+        ... )
+        >>> per_frame.select("frame_index", "RGB_Camera0.frame_index").show()  # doctest: +SKIP
+    """
+    _require_episode_column(episodes)
+    _require_h5py()
+
+    if isinstance(fields, str):
+        fields = [fields]
+    fields = tuple(fields)
+    if not fields:
+        raise ValueError(
+            "frames() requires an explicit `fields` whitelist: expanding every "
+            "signal per frame is a memory hazard (tactile alone is thousands of "
+            f"floats per frame). Valid fields are: {', '.join(_FRAME_FIELDS)}"
+        )
+    unknown = [f for f in fields if f not in _FRAME_FIELDS]
+    if unknown:
+        raise ValueError(f"Unknown frame field(s): {unknown}. Valid fields are: {', '.join(_FRAME_FIELDS)}")
+
+    camera_targets = _normalize_camera_targets(align_cameras) if align_cameras else ()
+
+    row_fields: dict[str, DataType] = {
+        "frame_index": DataType.int64(),
+        "timestamp": DataType.int64(),
+    }
+    for f in fields:
+        row_fields[f] = DataType.tensor(DataType.float32())
+    for camera, stream in camera_targets:
+        name = _stream_label(camera, stream)
+        row_fields[f"{name}.frame_index"] = DataType.int64()
+        row_fields[f"{name}.timestamp_delta_us"] = DataType.int64()
+
+    _ROW_DTYPE = DataType.struct(row_fields)
+
+    @daft.func(return_dtype=DataType.list(_ROW_DTYPE), use_process=False)
+    def _expand(file: Hdf5File) -> list[dict[str, Any]]:
+        from daft.dependencies import np
+
+        with file._open_h5py() as h5:
+            timestamps_node = _get(h5, _h5path("observation", "aligned_timestamp"))
+            arrays: dict[str, Any] = {}
+            for f in fields:
+                node = _get(h5, _field_to_h5path(f))
+                if node is not None:
+                    arrays[f] = node[()]
+
+            if timestamps_node is not None:
+                timestamps = np.asarray(timestamps_node[()])
+            elif arrays:
+                # Fall back to the length of whatever signal we could read.
+                timestamps = np.zeros(len(next(iter(arrays.values()))), dtype="int64")
+            else:
+                return []
+
+            n = int(timestamps.shape[0])
+
+            camera_ts: dict[str, Any] = {}
+            for camera, stream in camera_targets:
+                group = _get(h5, _h5path("observation", "image", camera))
+                if group is None:
+                    continue
+                ts = _get(group, f"{stream}_timestamp" if stream else "timestamp") or _get(group, "timestamp")
+                if ts is not None:
+                    camera_ts[_stream_label(camera, stream)] = np.asarray(ts[()])
+
+            rows: list[dict[str, Any]] = []
+            for i in range(n):
+                row: dict[str, Any] = {
+                    "frame_index": i,
+                    "timestamp": int(timestamps[i]),
+                }
+                for f in fields:
+                    data = arrays.get(f)
+                    if data is None:
+                        row[f] = None
+                        continue
+                    # action leads observation by one frame; repeat the last.
+                    idx = min(i + 1, len(data) - 1) if f.startswith("action.") else i
+                    row[f] = data[idx] if idx < len(data) else None
+
+                for name, cts in camera_ts.items():
+                    nearest = int(np.argmin(np.abs(cts - timestamps[i])))
+                    row[f"{name}.frame_index"] = nearest
+                    row[f"{name}.timestamp_delta_us"] = int(cts[nearest]) - int(timestamps[i])
+                rows.append(row)
+            return rows
+
+    identity = [c for c in episodes.column_names if c != "episode"]
+    exploded = episodes.select(*identity, _expand(col("episode")).alias("_frame")).explode("_frame")
+    return exploded.select(*identity, unnest(col("_frame")))
+
+
+__all__ = [
+    "HANDPOSE_ORDER",
+    "OBJECT_POSE_WIDTH",
+    "RGBD_STREAMS",
+    "SIDES",
+    "STAGES",
+    "audio",
+    "camera_frames",
+    "camera_payloads",
+    "cameras",
+    "depth_frames",
+    "describe",
+    "episode_metadata",
+    "frames",
+    "objects",
+    "raw",
+    "stereo_extrinsics",
+    "tactile",
+    "trajectory",
+]

--- a/daft/datasets/omnisharing.py
+++ b/daft/datasets/omnisharing.py
@@ -1449,6 +1449,7 @@ def depth_frames(
     cameras_: Sequence[str] | str,
     *,
     frame_indices: Sequence[int] | int = 0,
+    strict: bool = False,
 ) -> DataFrame:
     r"""Read depth maps from an RGBD camera's ``aligned_depth`` dataset.
 
@@ -1481,21 +1482,38 @@ def depth_frames(
             colour/left/right sub-stream.
         frame_indices: Which frames to read, as a single index or a sequence.
             Frames are returned in the order requested. Defaults to ``0``.
+        strict: If True, fail when an episode does not contain every requested
+            frame. Defaults to False, which reads whatever is available and
+            reports it in ``"{camera}.depth_frame_indices"``. The check happens
+            per episode during the read, so the failure surfaces as a Daft
+            execution error rather than a plain ``IndexError``; when *every*
+            episode is short, Daft reports its own error instead of the one
+            naming the camera. Prefer the default and inspect
+            ``"{camera}.depth_frame_indices"``.
 
     Returns:
         The input DataFrame with, per requested camera:
 
         - `"{camera}.depth"`: `Tensor[UInt16]` of shape
-          `(len(frame_indices), height, width)`.
+          `(frames_read, height, width)`.
         - `"{camera}.depth_frame_indices"`: the indices actually read.
 
-        Cameras without an ``aligned_depth`` dataset yield nulls.
+        Episode length varies across a release, so an index present in one
+        episode may be absent from another. Rather than making the whole call
+        fail, each episode reads the frames it has and reports them in
+        ``"{camera}.depth_frame_indices"`` -- always check that column instead
+        of assuming it matches ``frame_indices``. Pass ``strict=True`` to turn
+        a short episode into an error.
+
+        Cameras without an ``aligned_depth`` dataset yield an empty tensor and a
+        null index list.
 
     Raises:
         ValueError: If ``cameras_`` is empty or ``frame_indices`` is empty.
-        IndexError: If an index is negative or beyond the stored frame count.
-            Negative indices are rejected rather than wrapping around, so a
-            stale index cannot silently read a different frame.
+        IndexError: If an index is negative. Negative indices are rejected
+            rather than wrapping around, so a stale index cannot silently read a
+            different frame. This is checked before any file is opened, since it
+            is a caller error rather than a property of the data.
 
     Examples:
         >>> from daft.datasets import omnisharing
@@ -1521,11 +1539,6 @@ def depth_frames(
             "Negative indices are rejected rather than wrapping around."
         )
 
-    # Bounds are checked here rather than inside the UDF: an exception raised
-    # during execution surfaces as an opaque Daft error, losing the message that
-    # says which camera and which bound were involved.
-    _check_depth_bounds(episodes, names, wanted)
-
     return_fields: dict[str, DataType] = {}
     for name in names:
         return_fields[f"{name}.depth"] = DataType.tensor(DataType.uint16())
@@ -1548,9 +1561,17 @@ def depth_frames(
                     continue
 
                 available = int(node.shape[0])
-                # Clamp instead of raising: bounds were already validated up
-                # front, and a mid-execution raise would surface opaquely.
+                # Episode length varies across a release, so bounds are decided
+                # per episode. Checking them up front against a single probed
+                # episode would make the result depend on which episode happened
+                # to be scanned first.
                 usable = [i for i in wanted if i < available]
+                if len(usable) < len(wanted) and strict:
+                    out_of_range = [i for i in wanted if i >= available]
+                    raise IndexError(
+                        f"{name}/aligned_depth has {available} frames; "
+                        f"requested index/indices {out_of_range} out of range."
+                    )
                 if not usable:
                     out[f"{name}.depth"] = np.empty((0,), dtype="uint16")
                     out[f"{name}.depth_frame_indices"] = None
@@ -1563,39 +1584,6 @@ def depth_frames(
         return out
 
     return _append_unnested(episodes, _read_depth(col("episode")))
-
-
-def _check_depth_bounds(episodes: DataFrame, names: tuple[str, ...], wanted: tuple[int, ...]) -> None:
-    """Raise IndexError up front if any requested frame is out of range.
-
-    Probes frame counts from the first episode. A camera with no depth, or with
-    a zero-length depth dataset, is skipped rather than treated as a bound: both
-    mean "nothing to read here", which is reported as an empty result rather
-    than an error.
-    """
-    probe_fields = {name: DataType.int64() for name in names}
-
-    @daft.func(return_dtype=DataType.struct(probe_fields), use_process=False, unnest=True)
-    def _depth_lengths(file: Hdf5File) -> dict[str, Any]:
-        lengths: dict[str, Any] = {}
-        with _open_for_scan(file) as h5:
-            for name in names:
-                node = _get(h5, _h5path("observation", "image", name, "aligned_depth"))
-                lengths[name] = int(node.shape[0]) if node is not None and node.shape else None
-        return lengths
-
-    rows = _append_unnested(episodes.limit(1), _depth_lengths(col("episode"))).to_pylist()
-    if not rows:
-        return
-
-    highest = max(wanted)
-    for name in names:
-        available = rows[0].get(name)
-        if available and highest >= available:
-            out_of_range = [i for i in wanted if i >= available]
-            raise IndexError(
-                f"{name}/aligned_depth has {available} frames; requested index/indices {out_of_range} out of range."
-            )
 
 
 # ---------------------------------------------------------------------------

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -34,6 +34,7 @@
         * [Common Crawl](datasets/common-crawl.md)
         * [LeRobot](datasets/lerobot.md)
         * [DROID](datasets/droid.md)
+        * [PX OmniSharing](datasets/omnisharing.md)
     * Data Connectors
         * [Overview](connectors/index.md)
         * Object Storage

--- a/docs/api/datasets.md
+++ b/docs/api/datasets.md
@@ -55,3 +55,72 @@ Check out our [DROID dataset guide](../datasets/droid.md) for more examples!
     options:
         filters: ["!^_"]
         heading_level: 3
+
+## PX OmniSharing
+
+Check out our [PX OmniSharing dataset guide](../datasets/omnisharing.md) for more examples!
+
+::: daft.datasets.omnisharing.raw
+    options:
+        filters: ["!^_"]
+        heading_level: 3
+
+::: daft.datasets.omnisharing.describe
+    options:
+        filters: ["!^_"]
+        heading_level: 3
+
+::: daft.datasets.omnisharing.episode_metadata
+    options:
+        filters: ["!^_"]
+        heading_level: 3
+
+::: daft.datasets.omnisharing.trajectory
+    options:
+        filters: ["!^_"]
+        heading_level: 3
+
+::: daft.datasets.omnisharing.tactile
+    options:
+        filters: ["!^_"]
+        heading_level: 3
+
+::: daft.datasets.omnisharing.audio
+    options:
+        filters: ["!^_"]
+        heading_level: 3
+
+::: daft.datasets.omnisharing.objects
+    options:
+        filters: ["!^_"]
+        heading_level: 3
+
+::: daft.datasets.omnisharing.cameras
+    options:
+        filters: ["!^_"]
+        heading_level: 3
+
+::: daft.datasets.omnisharing.camera_payloads
+    options:
+        filters: ["!^_"]
+        heading_level: 3
+
+::: daft.datasets.omnisharing.camera_frames
+    options:
+        filters: ["!^_"]
+        heading_level: 3
+
+::: daft.datasets.omnisharing.depth_frames
+    options:
+        filters: ["!^_"]
+        heading_level: 3
+
+::: daft.datasets.omnisharing.stereo_extrinsics
+    options:
+        filters: ["!^_"]
+        heading_level: 3
+
+::: daft.datasets.omnisharing.frames
+    options:
+        filters: ["!^_"]
+        heading_level: 3

--- a/docs/datasets/omnisharing.md
+++ b/docs/datasets/omnisharing.md
@@ -1,0 +1,250 @@
+# How to use PX OmniSharing with Daft
+
+[PX OmniSharing DB](https://huggingface.co/datasets/paxini/Omnisharing_DB_SampleData) is PaXini's omnimodal embodied-AI dataset. Unlike most manipulation datasets it records **force and tactile sensing** alongside vision: each episode captures a human wearing an instrumented exoskeleton glove, with 15 tactile sensor pads per hand, a dozen synchronized RGB cameras, stereo RGBD cameras, hand proprioception, optional object poses, audio and a natural-language instruction.
+
+Daft reads the DF-2 HDF5 stage directly, streaming only the datasets you ask for. Episodes are 0.4-3.2 GB each, so nothing is downloaded up front.
+
+## Quickstart
+
+```python
+import daft
+from daft.datasets import omnisharing
+
+# One row per episode; parsed from filenames, so no file bytes are read yet.
+episodes = omnisharing.raw("paxini/Omnisharing_DB_SampleData")
+episodes.select("episode_key", "stage", "size").show(3)
+```
+
+Filter before reading modalities, then pull in what you need:
+
+```python
+one = episodes.limit(1)
+
+# Task labels and the language instruction.
+omnisharing.episode_metadata(one).select("instruction", "task_labels").show()
+
+# Joint angles and 6-DoF hand poses as tensors.
+omnisharing.trajectory(one, fields=["observation.lefthand.joints"]).show()
+
+# Tactile, split into one column per sensor pad.
+omnisharing.tactile(one, sides="lefthand", split_by_sensor=True).show()
+
+# Audio waveform, depth maps, and stereo calibration.
+omnisharing.audio(one, mono=True, max_seconds=2.0).select("samplerate", "n_samples").show()
+omnisharing.depth_frames(one, "RGBD_0").select("RGBD_0.depth").show()
+omnisharing.stereo_extrinsics(one, "RGBD_0").select("RGBD_0.left_to_color").show()
+```
+
+## Pipeline stages
+
+The [OmniSharing Toolkit](https://github.com/px-DataCollection/px_omnisharing_dataprocess_kit) emits four stages. The filename suffix tells you which one you have, and `raw()` surfaces it as a `stage` column.
+
+| Stage | Format | Suffix | Support |
+| ----- | ------ | ------ | ------- |
+| DF-1 | HDF5 | *(none)* | Raw capture; encoder and tactile streams are unparsed |
+| **DF-2** | HDF5 | `_glove` | **Primary target.** Parsed, with bimanual and object poses |
+| DF-2R | HDF5 | `_dh13`, `_mano`, ... | Retargeted to a dexterous hand model |
+| DF-3 | LeRobot v2.1 | *(none)* | Use [`daft.datasets.lerobot`](lerobot.md) instead |
+
+The public sample release contains DF-2 only. To read a specific stage:
+
+```python
+omnisharing.raw("paxini/Omnisharing_DB_SampleData", stage="DF-2")
+```
+
+DF-2R changes tensor widths (joints become 17 wide, tactile 3750). Daft reads widths from the file, so the same code works for both stages.
+
+## Episode layout
+
+Every episode is a single self-describing HDF5 file:
+
+```
+episode_{index}_{HHMMSS}_{room}_{personnel}_glove.hdf5
+└── dataset                          # attrs: generated_time, data_id
+    ├── meta                         # attrs: vendor + task labels
+    ├── action                       # leads observation by one frame
+    │   └── {left,right}hand
+    │       ├── joints/data          # (n, 29) float32, attrs: joint_names
+    │       └── handpose/data        # (n, 7) float32, attrs: order
+    └── observation
+        ├── aligned_timestamp        # (n,) int64 - the reference clock
+        ├── audio                    # (samples, 1) float64 PCM, attrs: samplerate, txt
+        ├── image
+        │   ├── RGB_Camera{i}        # H.265/HEVC Annex-B, 1920x1200
+        │   │   ├── data, timestamp
+        │   │   └── intrinsics, extrinsics
+        │   └── RGBD_{i}             # Matroska, 1280x720
+        │       ├── {color,left,right}/data
+        │       ├── timestamp, {left,right}_timestamp   # one clock per eye
+        │       ├── aligned_depth    # (n, H, W) uint16, RGBD_0 only
+        │       └── inner_extrinsic  # JSON: stereo-to-color transform
+        ├── {left,right}hand
+        │   ├── joints/data          # (n, 29)
+        │   ├── handpose/data        # (n, 7)
+        │   └── tactile/data         # (n, 3465), attrs: sensor_names, sensor_lengths
+        └── obj{i}/data              # (n, 17) - optional
+```
+
+Because the layout varies between releases, inspect it rather than assuming:
+
+```python
+layout = omnisharing.describe(episodes.limit(1))
+layout.where(daft.col("kind") == "dataset").select("h5path", "shape", "dtype").show(50)
+```
+
+## Three things that are easy to get wrong
+
+### 1. `episode_index` is not unique
+
+It restarts per capture group, so the same index appears under different `(room_id, personnel_id)` pairs. Join on `episode_key` instead:
+
+```python
+# Both of these exist in part_01:
+#   episode_1217_212953_93_110056_glove.hdf5
+#   episode_1217_213630_115_110092_glove.hdf5
+episodes.select("episode_key", "episode_index").show()
+```
+
+### 2. Quaternions are `qw`-first
+
+`handpose` is laid out `[x, y, z, qw, qx, qy, qz]`. SciPy expects `[qx, qy, qz, qw]` and will silently produce wrong rotations:
+
+```python
+import numpy as np
+from scipy.spatial.transform import Rotation
+
+pose = ...  # (n, 7) from trajectory()
+xyz, quat_wxyz = pose[:, :3], pose[:, 3:7]
+rotation = Rotation.from_quat(np.roll(quat_wxyz, -1, axis=1))  # -> [qx, qy, qz, qw]
+```
+
+### 3. Cameras do not share the observation clock
+
+Hands and RGBD cameras tick with `aligned_timestamp`, but RGB cameras run on their own clock, start at a different moment, and produce more frames. Camera ids are also non-contiguous. Aligning by frame index is wrong; use `frames(align_cameras=...)`, which matches by nearest timestamp and reports the residual:
+
+```python
+omnisharing.cameras(episodes.limit(1)).select("camera", "codec", "n_timestamps").show(30)
+
+per_frame = omnisharing.frames(
+    episodes.limit(1),
+    fields=["observation.lefthand.joints"],
+    align_cameras=["RGB_Camera0"],
+)
+per_frame.select(
+    "frame_index", "RGB_Camera0.frame_index", "RGB_Camera0.timestamp_delta_us"
+).show()
+```
+
+In one sampled episode, observation frame 0 aligns to `RGB_Camera0` frame **10**, not frame 0: that camera began recording earlier. Treating the streams as index-aligned would offset every frame by 10. `RGBD_0` shares the observation clock and does align 1:1.
+
+## Tactile sensing
+
+The `(n, 3465)` tactile vector is 15 sensor pads concatenated, with widths in the `sensor_lengths` attribute. `split_by_sensor=True` slices it for you:
+
+```python
+tactile = omnisharing.tactile(episodes.limit(1), sides="lefthand", split_by_sensor=True)
+tactile.select("lefthand.tactile.palm_sensor1", "lefthand.tactile.J32L").show()
+```
+
+Sensor names follow the glove's finger naming (`palm_sensor1`, `J32L`, `M6L`, ...), and widths differ per pad, e.g. `219` for the palm and `378` for a fingertip.
+
+## Frame-level expansion
+
+`frames()` produces one row per frame and applies the dataset's action offset: `action[i]` is the state at `i + 1`, with the final action repeated.
+
+| Frame | 0 | 1 | ... | n-2 | n-1 |
+| --- | --- | --- | --- | --- | --- |
+| observation | s0 | s1 | ... | s(n-2) | s(n-1) |
+| action | s1 | s2 | ... | s(n-1) | s(n-1) |
+
+`fields` is required, because a single tactile row is 3465 floats wide and unrestricted expansion is a memory hazard:
+
+```python
+omnisharing.frames(
+    episodes.limit(1),
+    fields=["observation.lefthand.joints", "action.lefthand.joints"],
+).show()
+```
+
+## Video
+
+Payloads are whole encoded streams stored inside the HDF5 file. Decoding needs the `daft[video]` extra:
+
+```python
+frames = omnisharing.camera_frames(episodes.limit(1), ["RGB_Camera0"], max_frames=2)
+frames.select("RGB_Camera0.frames").show()
+```
+
+`max_frames` defaults to 1 because each stream holds an entire episode. If you would rather handle the bytes yourself, or a payload uses a codec Daft cannot decode, `camera_payloads()` always returns the raw bytes plus the detected codec:
+
+```python
+omnisharing.camera_payloads(episodes.limit(1), ["RGB_Camera0"]).select("RGB_Camera0.codec").show()
+```
+
+## Audio
+
+The published layout calls this a "compressed audio stream (includes text)". It is neither: the samples are raw `float64` PCM, and the spoken instruction sits in a `txt` attribute that `episode_metadata()` surfaces as `instruction`. No audio codec is needed.
+
+```python
+clip = omnisharing.audio(episodes.limit(1), mono=True, max_seconds=2.0)
+clip.select("samplerate", "n_samples", "waveform").show()
+```
+
+`max_seconds` slices at read time, so previewing a clip never pulls the whole recording across the network. It is ignored when an episode has no `samplerate` attribute, since the sample count cannot be derived without one.
+
+## Depth
+
+`RGBD_0/aligned_depth` holds `uint16` depth already registered to the colour image, so a depth pixel and its colour pixel share coordinates. It appears in no published layout and is not on every RGBD camera — in a sampled episode only `RGBD_0` had it.
+
+```python
+depth = omnisharing.depth_frames(episodes.limit(1), "RGBD_0", frame_indices=[0, 10])
+depth.select("RGBD_0.depth", "RGBD_0.depth_frame_indices").show()
+```
+
+!!! warning "The depth unit is undocumented"
+
+    Unlike the tactile and joint datasets, `aligned_depth` carries no attributes at all, so nothing in the file lets a scale be derived. Values are returned exactly as stored — confirm with PaXini before treating them as millimetres.
+
+A single frame is about 1.8 MB and a whole episode roughly 380 MB per camera, so `frame_indices` defaults to frame `0` and each requested frame is read individually.
+
+## Stereo calibration
+
+Each RGBD group stores an `inner_extrinsic` JSON blob, which `cameras()` passes through as an opaque string. `stereo_extrinsics()` parses out the part most people want:
+
+```python
+calib = omnisharing.stereo_extrinsics(episodes.limit(1), "RGBD_0")
+calib.select("RGBD_0.left_to_color", "RGBD_0.calib_date").show()
+```
+
+`left_to_color` is the 4x4 transform from the left eye into the colour frame. Do not confuse it with the `extrinsics` that `cameras()` reports: that places the whole camera relative to a reference rig (`RGBD_0` for depth cameras, `RGB_Camera6` for colour ones), whereas this one is internal to a single camera.
+
+The RGBD eyes also keep their own clocks — `left_timestamp` and `right_timestamp` alongside `timestamp` — so align to a specific eye rather than assuming the colour clock:
+
+```python
+per_frame = omnisharing.frames(
+    episodes.limit(1),
+    fields=["observation.lefthand.joints"],
+    align_cameras=[("RGBD_0", "left")],
+)
+per_frame.select("frame_index", "RGBD_0.left.frame_index", "RGBD_0.left.timestamp_delta_us").show()
+```
+
+## Object poses
+
+Object tracks come from the toolkit's optional pose-estimation stage, so many episodes have none. `objects()` probes for the widest episode and null-fills the rest, keeping the schema stable:
+
+```python
+objs = omnisharing.objects(episodes.limit(4))
+objs.select("episode_key", "n_objects", "obj1.name", "obj1.id").show()
+```
+
+## Installation
+
+```bash
+pip install 'daft[hdf5]'          # required: reads the HDF5 episodes
+pip install 'daft[hdf5,video]'    # also decodes camera payloads
+```
+
+## License
+
+The published OmniSharing data is licensed **CC-BY-NC-SA 4.0** (non-commercial). Review the [dataset card](https://huggingface.co/datasets/paxini/Omnisharing_DB_SampleData) and the [toolkit license](https://github.com/px-DataCollection/px_omnisharing_dataprocess_kit) before use; the toolkit's binary components are proprietary and restricted to research and education.

--- a/docs/datasets/omnisharing.md
+++ b/docs/datasets/omnisharing.md
@@ -207,6 +207,8 @@ depth.select("RGBD_0.depth", "RGBD_0.depth_frame_indices").show()
 
 A single frame is about 1.8 MB and a whole episode roughly 380 MB per camera, so `frame_indices` defaults to frame `0` and each requested frame is read individually.
 
+Episode length varies across a release, so an index present in one episode may be absent from another. Rather than failing the whole call, each episode reads the frames it has — so check `depth_frame_indices` instead of assuming it matches what you asked for. Pass `strict=True` to turn a short episode into an error instead.
+
 ## Stereo calibration
 
 Each RGBD group stores an `inner_extrinsic` JSON blob, which `cameras()` passes through as an opaque string. `stereo_extrinsics()` parses out the part most people want:

--- a/tests/datasets/omnisharing_datagen.py
+++ b/tests/datasets/omnisharing_datagen.py
@@ -1,0 +1,356 @@
+"""Generate synthetic OmniSharing DF-2 HDF5 episodes matching the probed layout.
+
+Shapes, dtypes and attribute names mirror a real 440 MB DF-2 episode, so tests
+never need the 1.08 TB public release -- which is also CC-BY-NC-SA licensed, so
+none of its bytes belong in this repo. Camera payloads are encoded locally to get
+genuinely decodable streams in the same formats the dataset uses.
+
+Details taken from the real file, several of which the published layout omits:
+
+- ``observation/audio`` is raw ``float64`` PCM with ``samplerate`` and ``txt``
+  attrs, not the "compressed audio stream" the docs describe.
+- ``RGB_Camera*`` payloads are H.265/HEVC in Annex-B format; ``RGBD_*``
+  sub-streams are Matroska.
+- ``aligned_depth`` exists only on ``RGBD_0`` and carries no attrs at all.
+- RGB camera ids are non-contiguous and run on a faster clock than
+  ``aligned_timestamp``; ``RGBD_*`` additionally keeps a clock per eye.
+- ``tactile`` is 3465 wide, split across 15 pads by ``sensor_lengths``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+
+# Exactly the 15 sensors and widths observed in the real DF-2 file.
+SENSOR_NAMES = [
+    "palm_sensor1",
+    "J32L",
+    "J42L",
+    "M6L",
+    "S22L",
+    "S32L",
+    "S6L",
+    "Z22L",
+    "Z32L",
+    "Z6L",
+    "W22L",
+    "W32L",
+    "W6L",
+    "X22L",
+    "X6L",
+]
+SENSOR_LENGTHS = [219, 219, 282, 378, 195, 105, 318, 195, 105, 318, 195, 105, 318, 195, 318]
+TACTILE_WIDTH = sum(SENSOR_LENGTHS)  # 3465
+
+JOINT_NAMES = [
+    "J1J",
+    "J2J",
+    "J3J",
+    "J4J",
+    "M1J",
+    "M2J",
+    "M3J",
+    "M4J",
+    "M5J",
+    "X1J",
+    "X2J",
+    "X3J",
+    "X4J",
+    "X5J",
+    "S1J",
+    "S2J",
+    "S3J",
+    "S4J",
+    "S5J",
+    "Z1J",
+    "Z2J",
+    "Z3J",
+    "Z4J",
+    "Z5J",
+    "W1J",
+    "W2J",
+    "W3J",
+    "W4J",
+    "W5J",
+]
+N_JOINTS = len(JOINT_NAMES)  # 29
+
+HANDPOSE_ORDER = "[x, y, z, qw, qx, qy, qz]"
+HANDPOSE_DETAIL = "前3维为位置坐标xyz，后4维为四元数"
+
+# Deliberately non-contiguous, like the real capture rig.
+RGB_CAMERA_IDS = (0, 1, 2, 4, 6)
+RGBD_CAMERA_IDS = (0, 1)
+
+#: Baseline, in metres, between the left eye and the colour sensor. Mirrors the
+#: real data, where the transform is near-identity with a small x translation.
+STEREO_BASELINE = -0.059160967498978596
+
+
+def left_to_color_matrix(cam_id: int) -> list[list[float]]:
+    """The ``left_to_color`` transform stored in ``inner_extrinsic``.
+
+    Shaped like the real thing: a near-identity rotation plus a small
+    translation, varied per camera so tests can tell them apart.
+    """
+    offset = cam_id * 0.001
+    return [
+        [0.9999999746025623, -0.00016700296889540808, -0.0001513435923511511, STEREO_BASELINE + offset],
+        [0.0001672514853199877, 0.9999986353917404, 0.0016435454353450811, -0.00033976005189582253],
+        [0.00015106890885919824, -0.001643570706043841, 0.999998637925832, 0.00021016499893739072],
+        [0.0, 0.0, 0.0, 1.0],
+    ]
+
+
+def inner_extrinsic_payload(cam_id: int) -> dict:
+    """The JSON blob stored at ``RGBD_{id}/inner_extrinsic``."""
+    return {
+        "calib_date": "20250925171218",
+        "no_pose_cal_names": [],
+        "pt3d_info": {"left_to_color": 2904, "color_to_color": 2904},
+        "cam_spread_info": {
+            "left_to_color": ["color", "left"],
+            "color_to_color": ["color", "left", "color"],
+        },
+        "left_to_color": left_to_color_matrix(cam_id),
+    }
+
+
+# Real magic bytes so codec sniffing can be tested for real.
+HEVC_ANNEXB_HEAD = bytes([0x00, 0x00, 0x01, 0x40, 0x01, 0x0C, 0x01, 0xFF, 0xFF, 0x01, 0x60])
+MATROSKA_HEAD = bytes([0x1A, 0x45, 0xDF, 0xA3, 0xA3, 0x42, 0x86, 0x81, 0x01])
+
+#: Frame geometry of the locally-encoded playable streams.
+PLAYABLE_WIDTH = 64
+PLAYABLE_HEIGHT = 48
+PLAYABLE_FRAMES = 4
+
+
+def encode_playable_stream(kind: str) -> np.ndarray:
+    """Encode a tiny real video stream locally, as ``uint8`` bytes.
+
+    Produces genuinely decodable payloads in the same formats the dataset uses
+    -- H.265/HEVC Annex-B for RGB cameras and Matroska for RGBD sub-streams --
+    without embedding any bytes from the (CC-BY-NC-SA licensed) dataset.
+
+    Returns an empty array if the required encoder is unavailable, so callers
+    can fall back to non-decodable placeholder payloads. libx265 in particular
+    is absent from some PyAV wheels.
+    """
+    import io
+
+    import av
+
+    fmt, codec = ("hevc", "libx265") if kind == "hevc" else ("matroska", "libx264")
+    buffer = io.BytesIO()
+    try:
+        container = av.open(buffer, "w", format=fmt)
+        stream = container.add_stream(codec, rate=10)
+        stream.width, stream.height = PLAYABLE_WIDTH, PLAYABLE_HEIGHT
+        stream.pix_fmt = "yuv420p"
+        if codec == "libx265":
+            stream.options = {"x265-params": "log-level=none"}
+        for i in range(PLAYABLE_FRAMES):
+            frame_rgb = np.full((PLAYABLE_HEIGHT, PLAYABLE_WIDTH, 3), i * 40, dtype=np.uint8)
+            frame_rgb[:, :, 1] = i * 20
+            video_frame = av.VideoFrame.from_ndarray(frame_rgb, format="rgb24")
+            for packet in stream.encode(video_frame):
+                container.mux(packet)
+        for packet in stream.encode():
+            container.mux(packet)
+        container.close()
+    except (av.FFmpegError, LookupError, ValueError):
+        # A missing or misconfigured encoder, not a bug in the caller.
+        return np.empty(0, dtype=np.uint8)
+    return np.frombuffer(buffer.getvalue(), dtype=np.uint8)
+
+
+def _payload(head: bytes, size: int, seed: int) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    body = rng.integers(0, 256, size=max(size - len(head), 0), dtype=np.uint8)
+    return np.concatenate([np.frombuffer(head, dtype=np.uint8), body])
+
+
+def write_df2_episode(
+    path: Path,
+    *,
+    n_frames: int = 12,
+    n_objects: int = 2,
+    tactile_width: int = TACTILE_WIDTH,
+    n_joints: int = N_JOINTS,
+    include_audio: bool = True,
+    include_meta: bool = True,
+    instruction: str = "将燕京啤酒放入红色啤酒架。",
+    playable: bool = False,
+    seed: int = 7,
+) -> Path:
+    """Write one synthetic DF-2 episode. Returns the path written.
+
+    With ``playable=True`` the camera payloads are real, locally-encoded HEVC
+    and Matroska streams that PyAV can decode. Otherwise they are correct magic
+    bytes followed by random noise, which is enough to exercise codec sniffing.
+    """
+    import h5py
+
+    rng = np.random.default_rng(seed)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    hevc_stream = encode_playable_stream("hevc") if playable else np.empty(0, dtype=np.uint8)
+    mkv_stream = encode_playable_stream("matroska") if playable else np.empty(0, dtype=np.uint8)
+
+    with h5py.File(path, "w") as f:
+        root = f.create_group("dataset")
+        root.attrs["generated_time"] = "2025-12-11-21:31:35"
+        root.attrs["data_id"] = "gARdlC4="
+
+        if include_meta:
+            meta = root.create_group("meta")
+            meta.attrs["vendor"] = "paxini"
+            meta.attrs["任务物品"] = np.array(["燕京啤酒+红色啤酒架"], dtype=object)
+            meta.attrs["啤酒架的初始摆放位置"] = np.array(["左中"], dtype=object)
+            meta.attrs["物品初始摆放高度"] = np.array(["所有物品位于台面上"], dtype=object)
+
+        # ---------------------------------------------------------- hands
+        def write_hand(parent: h5py.Group, side: str, *, with_tactile: bool) -> None:
+            hand = parent.create_group(side)
+            hand.attrs["description"] = f"exoskeleton_hand_{side.replace('hand', '')}_2_0_description"
+
+            joints = hand.create_group("joints")
+            jdata = joints.create_dataset(
+                "data",
+                data=rng.standard_normal((n_frames, n_joints)).astype(np.float32),
+            )
+            jdata.attrs["joint_names"] = np.array(JOINT_NAMES[:n_joints], dtype=object)
+
+            pose = hand.create_group("handpose")
+            pose.attrs["order"] = HANDPOSE_ORDER
+            pose.attrs["detail"] = HANDPOSE_DETAIL
+            pose.attrs["source_camera"] = "RGBD_0"
+            pose.create_dataset("data", data=rng.standard_normal((n_frames, 7)).astype(np.float32))
+
+            if with_tactile:
+                tac = hand.create_group("tactile")
+                tdata = tac.create_dataset(
+                    "data",
+                    data=rng.random((n_frames, tactile_width)).astype(np.float32),
+                )
+                widths = _scaled_sensor_lengths(tactile_width)
+                tdata.attrs["sensor_names"] = np.array(SENSOR_NAMES, dtype=object)
+                tdata.attrs["sensor_lengths"] = np.array(widths, dtype=np.int64)
+
+        action = root.create_group("action")
+        write_hand(action, "lefthand", with_tactile=False)
+        write_hand(action, "righthand", with_tactile=False)
+
+        obs = root.create_group("observation")
+        write_hand(obs, "lefthand", with_tactile=True)
+        write_hand(obs, "righthand", with_tactile=True)
+
+        # ------------------------------------------------- timestamps/audio
+        base_ts = 1_733_000_000_000_000
+        obs.create_dataset(
+            "aligned_timestamp",
+            data=(base_ts + np.arange(n_frames, dtype=np.int64) * 33_000),
+        )
+
+        if include_audio:
+            audio = obs.create_dataset("audio", data=rng.standard_normal((n_frames * 40, 1)).astype(np.float64))
+            audio.attrs["samplerate"] = np.int64(8000)
+            audio.attrs["txt"] = instruction
+
+        # ---------------------------------------------------------- cameras
+        image = obs.create_group("image")
+        image.attrs["checked_cam_name"] = "Camera4"
+
+        for cam_id in RGB_CAMERA_IDS:
+            cam = image.create_group(f"RGB_Camera{cam_id}")
+            rgb_payload = hevc_stream if hevc_stream.size else _payload(HEVC_ANNEXB_HEAD, 4096, seed + cam_id)
+            cam.create_dataset("data", data=rgb_payload)
+            ext = cam.create_dataset("extrinsics", data=np.eye(4, dtype=np.float64))
+            ext.attrs["calib_date"] = "20251204154931"
+            ext.attrs["relative_to_who"] = "RGB_Camera6"
+            intr = cam.create_dataset(
+                "intrinsics",
+                data=np.array([[1000.0, 0, 960], [0, 1000.0, 600], [0, 0, 1]], dtype=np.float32),
+            )
+            intr.attrs["width"] = np.int64(1920)
+            intr.attrs["height"] = np.int64(1200)
+            intr.attrs["distortion"] = "[0.93, 0.64, 0.0002, -0.0002, 0.05, 0.86, 0.67, 0.078]"
+            # RGB streams intentionally have MORE frames than the observation clock.
+            cam.create_dataset(
+                "timestamp",
+                data=(base_ts + np.arange(n_frames + 3 + cam_id, dtype=np.int64) * 31_000),
+            )
+
+        for cam_id in RGBD_CAMERA_IDS:
+            cam = image.create_group(f"RGBD_{cam_id}")
+            cam.create_dataset("timestamp", data=(base_ts + np.arange(n_frames, dtype=np.int64) * 33_000))
+            cam.create_dataset(
+                "inner_extrinsic",
+                data=np.array([json.dumps(inner_extrinsic_payload(cam_id)).encode()]),
+            )
+            if cam_id == 0:
+                cam.create_dataset(
+                    "aligned_depth",
+                    data=rng.integers(0, 4096, size=(n_frames, 8, 12), dtype=np.uint16),
+                )
+            for sub in ("color", "left", "right"):
+                grp = cam.create_group(sub)
+                rgbd_payload = (
+                    mkv_stream if mkv_stream.size else _payload(MATROSKA_HEAD, 2048, seed + cam_id + len(sub))
+                )
+                grp.create_dataset("data", data=rgbd_payload)
+                sintr = grp.create_dataset(
+                    "intrinsics",
+                    data=np.array([[900.0, 0, 640], [0, 900.0, 360], [0, 0, 1]], dtype=np.float32),
+                )
+                sintr.attrs["width"] = np.int64(1280)
+                sintr.attrs["height"] = np.int64(720)
+                sintr.attrs["distortion"] = "[-0.055, 0.063, 0.0003, 0.0007, -0.021]"
+                if sub == "color":
+                    sext = grp.create_dataset("extrinsics", data=np.eye(4, dtype=np.float64))
+                    sext.attrs["calib_date"] = "20251204154824"
+                    sext.attrs["relative_to_who"] = "RGBD_0"
+                else:
+                    # The left eye is given its own faster clock and one extra
+                    # sample, so tests can prove that per-eye alignment is
+                    # actually used. The right eye deliberately shares the colour
+                    # clock, giving a control case.
+                    if sub == "left":
+                        eye_ts = base_ts + np.arange(n_frames + 1, dtype=np.int64) * 31_000
+                    else:
+                        eye_ts = base_ts + np.arange(n_frames, dtype=np.int64) * 33_000
+                    cam.create_dataset(f"{sub}_timestamp", data=eye_ts)
+
+        # ---------------------------------------------------------- objects
+        for i in range(1, n_objects + 1):
+            obj = obs.create_group(f"obj{i}")
+            odata = obj.create_dataset("data", data=rng.standard_normal((n_frames, 17)).astype(np.float32))
+            odata.attrs["obj_name"] = f"object_{i}"
+            odata.attrs["obj_id"] = np.int64(100 + i)
+            odata.attrs["order"] = "[4x4 transform (16) + validity (1)]"
+
+    return path
+
+
+def _scaled_sensor_lengths(total: int) -> list[int]:
+    """Sensor widths that sum to ``total``, keeping the real proportions."""
+    if total == TACTILE_WIDTH:
+        return list(SENSOR_LENGTHS)
+    widths = [max(1, round(w * total / TACTILE_WIDTH)) for w in SENSOR_LENGTHS]
+    widths[-1] += total - sum(widths)
+    return widths
+
+
+def episode_filename(
+    index: int,
+    capture_time: str,
+    room_id: int,
+    personnel_id: int,
+    suffix: str | None = "glove",
+) -> str:
+    tail = f"_{suffix}" if suffix else ""
+    return f"episode_{index}_{capture_time}_{room_id}_{personnel_id}{tail}.hdf5"

--- a/tests/datasets/omnisharing_datagen.py
+++ b/tests/datasets/omnisharing_datagen.py
@@ -19,6 +19,7 @@ Details taken from the real file, several of which the published layout omits:
 
 from __future__ import annotations
 
+import io
 import json
 from pathlib import Path
 
@@ -140,8 +141,8 @@ def encode_playable_stream(kind: str) -> np.ndarray:
     can fall back to non-decodable placeholder payloads. libx265 in particular
     is absent from some PyAV wheels.
     """
-    import io
-
+    # av and h5py come from optional extras, so they stay function-local: this
+    # module is imported by tests that guard on those extras being present.
     import av
 
     fmt, codec = ("hevc", "libx265") if kind == "hevc" else ("matroska", "libx264")

--- a/tests/datasets/test_omnisharing.py
+++ b/tests/datasets/test_omnisharing.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 
 import numpy as np
 import pytest
@@ -14,6 +15,7 @@ from daft.datasets.omnisharing import (
     _normalize_dataset_root,
     _sniff_codec,
 )
+from daft.exceptions import DaftCoreException
 from tests.datasets.omnisharing_datagen import (
     JOINT_NAMES,
     N_JOINTS,
@@ -30,6 +32,10 @@ from tests.datasets.omnisharing_datagen import (
 )
 
 pytest.importorskip("h5py", reason="daft[hdf5] extra is required for OmniSharing tests")
+
+# Imported after importorskip so a missing extra skips the module rather than
+# raising ImportError at collection time.
+import h5py
 
 N_FRAMES = 8
 
@@ -103,8 +109,6 @@ def test_normalize_dataset_root_rejects_empty():
 
 @pytest.mark.parametrize("extension", ["hdf5", "h5"])
 def test_episode_filename_regex_matches_both_extensions(extension):
-    import re
-
     assert re.search(_EPISODE_FILENAME_RE, f"episode_1_212953_93_110056_glove.{extension}")
 
 
@@ -406,8 +410,6 @@ def test_audio_mono_downmix_is_exact(tmp_path):
     path = root / episode_filename(1, "212953", 93, 110056)
     write_df2_episode(path, n_frames=4)
 
-    import h5py
-
     with h5py.File(path, "a") as h5:
         samplerate = h5["dataset/observation/audio"].attrs["samplerate"]
         del h5["dataset/observation/audio"]
@@ -425,8 +427,6 @@ def test_audio_mono_handles_waveform_without_channel_axis(tmp_path):
     root = tmp_path / "flat"
     path = root / episode_filename(1, "212953", 93, 110056)
     write_df2_episode(path, n_frames=4)
-
-    import h5py
 
     with h5py.File(path, "a") as h5:
         samplerate = h5["dataset/observation/audio"].attrs["samplerate"]
@@ -498,8 +498,6 @@ def test_audio_zero_length_dataset_reports_zero_samples(tmp_path):
     path = root / episode_filename(1, "212953", 93, 110056)
     write_df2_episode(path, n_frames=4)
 
-    import h5py
-
     with h5py.File(path, "a") as h5:
         del h5["dataset/observation/audio"]
         dataset = h5["dataset/observation"].create_dataset("audio", data=np.empty((0, 1), dtype="float64"))
@@ -514,8 +512,6 @@ def test_audio_without_samplerate_ignores_max_seconds(tmp_path):
     root = tmp_path / "nosr"
     path = root / episode_filename(1, "212953", 93, 110056)
     write_df2_episode(path, n_frames=4)
-
-    import h5py
 
     with h5py.File(path, "a") as h5:
         del h5["dataset/observation/audio"].attrs["samplerate"]
@@ -801,8 +797,6 @@ def test_camera_payloads_still_works_for_undecodable_payload(df2_episodes):
 @pytest.fixture
 def depth_truth(df2_root):
     """The stored aligned_depth array, read directly with h5py."""
-    import h5py
-
     (path,) = df2_root.rglob("*.hdf5")
     with h5py.File(path, "r") as h5:
         return np.asarray(h5["dataset/observation/image/RGBD_0/aligned_depth"][()])
@@ -875,8 +869,6 @@ def test_depth_frames_zero_length_depth_yields_empty(tmp_path):
     path = root / episode_filename(1, "212953", 93, 110056)
     write_df2_episode(path, n_frames=4)
 
-    import h5py
-
     with h5py.File(path, "a") as h5:
         del h5["dataset/observation/image/RGBD_0/aligned_depth"]
         h5["dataset/observation/image/RGBD_0"].create_dataset(
@@ -889,19 +881,34 @@ def test_depth_frames_zero_length_depth_yields_empty(tmp_path):
     assert row["RGBD_0.depth_frame_indices"] is None
 
 
-def test_depth_frames_out_of_range_raises_with_camera_and_bound(df2_episodes):
-    with pytest.raises(IndexError, match=rf"RGBD_0/aligned_depth has {N_FRAMES} frames"):
-        omnisharing.depth_frames(df2_episodes, "RGBD_0", frame_indices=[0, N_FRAMES])
+def test_depth_frames_reads_what_is_available_by_default(df2_episodes, depth_truth):
+    # An index past the end is dropped rather than failing the call, because
+    # episode length varies across a release.
+    (row,) = omnisharing.depth_frames(df2_episodes, "RGBD_0", frame_indices=[0, N_FRAMES]).to_pylist()
+    assert row["RGBD_0.depth_frame_indices"] == [0]
+    np.testing.assert_array_equal(np.asarray(row["RGBD_0.depth"])[0], depth_truth[0])
 
 
-def test_depth_frames_ghost_camera_does_not_mask_a_real_bound(df2_episodes):
-    # A camera with unknown depth length must not suppress the real error.
-    with pytest.raises(IndexError, match="RGBD_0"):
-        omnisharing.depth_frames(df2_episodes, ["RGBD_99", "RGBD_0"], frame_indices=[N_FRAMES + 10])
+def test_depth_frames_strict_fails_the_read(df2_episodes):
+    # strict validates per episode during the read, so the failure surfaces as a
+    # Daft execution error. When every row raises, Daft reports its own
+    # "Need at least 1 series to perform concat" instead of the original
+    # message, so only the failure itself can be asserted here.
+    with pytest.raises(DaftCoreException):
+        omnisharing.depth_frames(df2_episodes, "RGBD_0", frame_indices=[0, N_FRAMES], strict=True).collect()
+
+
+def test_depth_frames_strict_ignores_cameras_without_depth(df2_episodes):
+    # RGBD_99 has no depth at all, which is reported as empty rather than as an
+    # out-of-range error even under strict.
+    (row,) = omnisharing.depth_frames(df2_episodes, "RGBD_99", strict=True).to_pylist()
+    assert np.asarray(row["RGBD_99.depth"]).size == 0
 
 
 @pytest.mark.parametrize("frame_indices", [-1, [-1], [0, -2]])
 def test_depth_frames_rejects_negative_indices(df2_episodes, frame_indices):
+    # Negative indices are a caller error regardless of episode contents, so
+    # they are rejected before any file is opened.
     with pytest.raises(IndexError, match="non-negative"):
         omnisharing.depth_frames(df2_episodes, "RGBD_0", frame_indices=frame_indices)
 
@@ -913,20 +920,35 @@ def test_depth_frames_rejects_empty_arguments(df2_episodes):
         omnisharing.depth_frames(df2_episodes, "RGBD_0", frame_indices=[])
 
 
-def test_depth_frames_shorter_episode_degrades_gracefully(tmp_path):
+@pytest.fixture
+def uneven_episodes(tmp_path):
+    """Two episodes of differing length: 8 frames and 3 frames."""
     root = tmp_path / "uneven"
     write_df2_episode(root / episode_filename(1, "212953", 93, 110056), n_frames=8)
     write_df2_episode(root / episode_filename(2, "213630", 115, 110092), n_frames=3)
+    return omnisharing.raw(str(root))
 
-    # Bounds are probed from the first episode, so a shorter one must clamp
-    # rather than fail mid-execution.
-    rows = (
-        omnisharing.depth_frames(omnisharing.raw(str(root)), "RGBD_0", frame_indices=[0, 5])
-        .sort("episode_key")
-        .to_pylist()
-    )
+
+def test_depth_frames_shorter_episode_degrades_gracefully(uneven_episodes):
+    rows = omnisharing.depth_frames(uneven_episodes, "RGBD_0", frame_indices=[0, 5]).sort("episode_key").to_pylist()
+    # Each episode reads the frames it actually has.
     assert [np.asarray(r["RGBD_0.depth"]).shape[0] for r in rows] == [2, 1]
     assert [r["RGBD_0.depth_frame_indices"] for r in rows] == [[0, 5], [0]]
+
+
+@pytest.mark.parametrize("descending", [False, True])
+def test_depth_frames_result_is_independent_of_episode_order(uneven_episodes, descending):
+    # Regression: bounds were once probed from whichever episode happened to be
+    # scanned first, so the same call succeeded or raised depending on file
+    # discovery order -- which differs between platforms.
+    ordered = uneven_episodes.sort("episode_key", desc=descending)
+    rows = omnisharing.depth_frames(ordered, "RGBD_0", frame_indices=[0, 5]).sort("episode_key").to_pylist()
+    assert [r["RGBD_0.depth_frame_indices"] for r in rows] == [[0, 5], [0]]
+
+
+def test_depth_frames_strict_raises_on_the_shorter_episode(uneven_episodes):
+    with pytest.raises(DaftCoreException, match="RGBD_0/aligned_depth has 3 frames"):
+        omnisharing.depth_frames(uneven_episodes, "RGBD_0", frame_indices=[0, 5], strict=True).collect()
 
 
 def test_depth_frames_deduplicates_camera_names(df2_episodes):
@@ -960,8 +982,6 @@ def test_stereo_extrinsics_parses_the_transform(df2_episodes):
 
 
 def test_stereo_extrinsics_matches_the_bytes_on_disk(df2_root):
-    import h5py
-
     (path,) = df2_root.rglob("*.hdf5")
     with h5py.File(path, "r") as h5:
         blob = h5["dataset/observation/image/RGBD_0/inner_extrinsic"][()][0]
@@ -994,8 +1014,6 @@ def test_stereo_extrinsics_missing_dataset_yields_empty(tmp_path):
     path = root / episode_filename(1, "212953", 93, 110056)
     write_df2_episode(path, n_frames=4)
 
-    import h5py
-
     with h5py.File(path, "a") as h5:
         del h5["dataset/observation/image/RGBD_0/inner_extrinsic"]
 
@@ -1024,8 +1042,6 @@ def test_stereo_extrinsics_malformed_json_yields_empty(tmp_path, label, payload)
     path = root / episode_filename(1, "212953", 93, 110056)
     write_df2_episode(path, n_frames=4)
 
-    import h5py
-
     with h5py.File(path, "a") as h5:
         del h5["dataset/observation/image/RGBD_0/inner_extrinsic"]
         h5["dataset/observation/image/RGBD_0"].create_dataset("inner_extrinsic", data=np.array([payload]))
@@ -1039,8 +1055,6 @@ def test_stereo_extrinsics_recovers_calib_date_without_a_matrix(tmp_path):
     root = tmp_path / "partial"
     path = root / episode_filename(1, "212953", 93, 110056)
     write_df2_episode(path, n_frames=4)
-
-    import h5py
 
     with h5py.File(path, "a") as h5:
         del h5["dataset/observation/image/RGBD_0/inner_extrinsic"]
@@ -1175,8 +1189,6 @@ def test_frames_tolerates_absent_camera(df2_episodes):
 
 
 def test_frames_aligns_rgbd_eyes_on_their_own_clocks(df2_root):
-    import h5py
-
     (path,) = df2_root.rglob("*.hdf5")
     with h5py.File(path, "r") as h5:
         group = h5["dataset/observation/image/RGBD_0"]
@@ -1234,8 +1246,6 @@ def test_frames_falls_back_to_camera_clock_when_eye_clock_is_absent(tmp_path):
     path = root / episode_filename(1, "212953", 93, 110056)
     write_df2_episode(path, n_frames=8)
 
-    import h5py
-
     with h5py.File(path, "a") as h5:
         del h5["dataset/observation/image/RGBD_0/left_timestamp"]
 
@@ -1257,8 +1267,6 @@ def test_cameras_falls_back_to_camera_clock_when_eye_clock_is_absent(tmp_path):
     root = tmp_path / "noeye_cameras"
     path = root / episode_filename(1, "212953", 93, 110056)
     write_df2_episode(path, n_frames=8)
-
-    import h5py
 
     with h5py.File(path, "a") as h5:
         del h5["dataset/observation/image/RGBD_0/left_timestamp"]

--- a/tests/datasets/test_omnisharing.py
+++ b/tests/datasets/test_omnisharing.py
@@ -1,0 +1,1316 @@
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pytest
+
+import daft
+from daft import DataType, MediaType
+from daft.datasets import omnisharing
+from daft.datasets.omnisharing import (
+    _EPISODE_FILENAME_RE,
+    _normalize_camera_targets,
+    _normalize_dataset_root,
+    _sniff_codec,
+)
+from tests.datasets.omnisharing_datagen import (
+    JOINT_NAMES,
+    N_JOINTS,
+    PLAYABLE_FRAMES,
+    PLAYABLE_HEIGHT,
+    PLAYABLE_WIDTH,
+    SENSOR_LENGTHS,
+    SENSOR_NAMES,
+    STEREO_BASELINE,
+    TACTILE_WIDTH,
+    episode_filename,
+    left_to_color_matrix,
+    write_df2_episode,
+)
+
+pytest.importorskip("h5py", reason="daft[hdf5] extra is required for OmniSharing tests")
+
+N_FRAMES = 8
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def df2_root(tmp_path):
+    """One DF-2 episode with objects, meta and audio."""
+    root = tmp_path / "ds"
+    write_df2_episode(
+        root / "data/part_01" / episode_filename(1203, "213135", 115, 110092),
+        n_frames=N_FRAMES,
+        n_objects=2,
+    )
+    return root
+
+
+@pytest.fixture
+def df2_episodes(df2_root):
+    return omnisharing.raw(str(df2_root))
+
+
+@pytest.fixture
+def mixed_root(tmp_path):
+    """A release spanning all three stages, with a duplicated episode_index."""
+    root = tmp_path / "mixed"
+    part = root / "data/part_01"
+    # Same episode_index 1217, different capture groups.
+    write_df2_episode(part / episode_filename(1217, "212953", 93, 110056), n_frames=4)
+    write_df2_episode(part / episode_filename(1217, "213630", 115, 110092), n_frames=4)
+    # DF-1 (no suffix) and DF-2R (retargeted).
+    write_df2_episode(part / episode_filename(300, "101302", 138, 120105, None), n_frames=4)
+    write_df2_episode(
+        part / episode_filename(301, "101414", 138, 120105, "dh13"),
+        n_frames=4,
+        tactile_width=3750,
+        n_joints=17,
+    )
+    # Not an episode: must be ignored.
+    write_df2_episode(part / "quality_report.hdf5", n_frames=4)
+    return root
+
+
+# ---------------------------------------------------------------------------
+# Path + filename parsing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("uri", "expected"),
+    [
+        ("paxini/Omnisharing_DB_SampleData", "hf://datasets/paxini/Omnisharing_DB_SampleData"),
+        ("hf://datasets/paxini/X/", "hf://datasets/paxini/X"),
+        ("s3://bucket/key/", "s3://bucket/key"),
+        ("/data/omni/", "/data/omni"),
+        ("./omni/", "./omni"),
+    ],
+)
+def test_normalize_dataset_root(uri, expected):
+    assert _normalize_dataset_root(uri) == expected
+
+
+def test_normalize_dataset_root_rejects_empty():
+    with pytest.raises(ValueError, match="non-empty"):
+        _normalize_dataset_root("   ")
+
+
+@pytest.mark.parametrize("extension", ["hdf5", "h5"])
+def test_episode_filename_regex_matches_both_extensions(extension):
+    import re
+
+    assert re.search(_EPISODE_FILENAME_RE, f"episode_1_212953_93_110056_glove.{extension}")
+
+
+# ---------------------------------------------------------------------------
+# raw()
+# ---------------------------------------------------------------------------
+
+
+def test_raw_schema_order_and_dtypes(df2_episodes):
+    assert [f.name for f in df2_episodes.schema()] == [
+        "episode_key",
+        "episode_index",
+        "capture_time",
+        "room_id",
+        "personnel_id",
+        "stage",
+        "hand_model",
+        "episode",
+        "path",
+        "size",
+    ]
+    dtypes = {f.name: f.dtype for f in df2_episodes.schema()}
+    assert dtypes["episode"] == DataType.file(MediaType.hdf5())
+    assert dtypes["episode_index"] == DataType.int64()
+    assert dtypes["room_id"] == DataType.int64()
+    assert dtypes["personnel_id"] == DataType.int64()
+
+
+def test_raw_parses_filename_metadata(df2_episodes):
+    (row,) = df2_episodes.to_pylist()
+    assert row["episode_key"] == "1203_213135_115_110092"
+    assert row["episode_index"] == 1203
+    assert row["capture_time"] == "213135"
+    assert row["room_id"] == 115
+    assert row["personnel_id"] == 110092
+    assert row["stage"] == "DF-2"
+    assert row["hand_model"] is None
+    assert row["size"] > 0
+
+
+def test_raw_discovers_h5_extension(tmp_path):
+    root = tmp_path / "ds"
+    write_df2_episode(root / "episode_1_212953_93_110056_glove.h5", n_frames=4)
+    assert omnisharing.raw(str(root)).count_rows() == 1
+
+
+def test_raw_ignores_non_episode_files(mixed_root):
+    keys = {r["episode_key"] for r in omnisharing.raw(str(mixed_root)).to_pylist()}
+    assert len(keys) == 4
+
+
+def test_raw_episode_key_disambiguates_duplicate_episode_index(mixed_root):
+    rows = omnisharing.raw(str(mixed_root)).to_pylist()
+    # episode_index alone is ambiguous; the composite key is not.
+    assert len({r["episode_index"] for r in rows}) == 3
+    assert len({r["episode_key"] for r in rows}) == 4
+    assert {"1217_212953_93_110056", "1217_213630_115_110092"} <= {r["episode_key"] for r in rows}
+
+
+@pytest.mark.parametrize(
+    ("stage", "expected_count", "expected_hand_model"),
+    [("DF-1", 1, None), ("DF-2", 2, None), ("DF-2R", 1, "dh13")],
+)
+def test_raw_stage_filtering(mixed_root, stage, expected_count, expected_hand_model):
+    rows = omnisharing.raw(str(mixed_root), stage=stage).to_pylist()
+    assert len(rows) == expected_count
+    assert all(r["stage"] == stage for r in rows)
+    assert all(r["hand_model"] == expected_hand_model for r in rows)
+
+
+def test_raw_rejects_unknown_stage(df2_root):
+    with pytest.raises(ValueError, match="DF-9"):
+        omnisharing.raw(str(df2_root), stage="DF-9")
+
+
+# ---------------------------------------------------------------------------
+# describe()
+# ---------------------------------------------------------------------------
+
+
+def test_describe_reports_shapes_dtypes_and_attrs(df2_episodes):
+    layout = omnisharing.describe(df2_episodes)
+    assert [f.name for f in layout.schema()] == [
+        "episode_key",
+        "h5path",
+        "kind",
+        "shape",
+        "dtype",
+        "attrs",
+    ]
+
+    by_path = {r["h5path"]: r for r in layout.to_pylist()}
+    tactile = by_path["dataset/observation/lefthand/tactile/data"]
+    assert tactile["kind"] == "dataset"
+    assert tactile["shape"] == [N_FRAMES, TACTILE_WIDTH]
+    assert tactile["dtype"] == "float32"
+
+    attrs = json.loads(tactile["attrs"])
+    assert attrs["sensor_names"] == SENSOR_NAMES
+    assert sum(attrs["sensor_lengths"]) == TACTILE_WIDTH
+
+    joints = json.loads(by_path["dataset/observation/lefthand/joints/data"]["attrs"])
+    assert joints["joint_names"] == JOINT_NAMES
+
+
+def test_describe_surfaces_non_contiguous_camera_ids(df2_episodes):
+    paths = {r["h5path"] for r in omnisharing.describe(df2_episodes).to_pylist()}
+    cameras = {p.split("/")[-1] for p in paths if p.count("/") == 3 and "/image/" in p}
+    assert "RGB_Camera4" in cameras
+    assert "RGB_Camera3" not in cameras
+    assert {"RGBD_0", "RGBD_1"} <= cameras
+
+
+# ---------------------------------------------------------------------------
+# episode_metadata()
+# ---------------------------------------------------------------------------
+
+
+def test_episode_metadata_reads_attrs_and_instruction(df2_episodes):
+    (row,) = omnisharing.episode_metadata(df2_episodes).to_pylist()
+    assert row["generated_time"] == "2025-12-11-21:31:35"
+    assert row["data_id"] == "gARdlC4="
+    assert row["vendor"] == "paxini"
+    assert row["instruction"] == "将燕京啤酒放入红色啤酒架。"
+    assert row["audio_samplerate"] == 8000
+    assert row["n_frames"] == N_FRAMES
+    assert row["checked_cam_name"] == "Camera4"
+    assert row["object_names"] == ["obj1", "obj2"]
+    # Identity columns survive.
+    assert row["episode_key"] == "1203_213135_115_110092"
+
+
+def test_episode_metadata_task_labels_roundtrip_unicode_keys(df2_episodes):
+    (row,) = omnisharing.episode_metadata(df2_episodes).to_pylist()
+    labels = json.loads(row["task_labels"])
+    assert labels["任务物品"] == ["燕京啤酒+红色啤酒架"]
+    # vendor is promoted to its own column, not left in the free-form labels.
+    assert "vendor" not in labels
+
+
+def test_episode_metadata_tolerates_missing_meta_audio_and_objects(tmp_path):
+    root = tmp_path / "bare"
+    write_df2_episode(
+        root / episode_filename(1, "212953", 93, 110056),
+        n_frames=4,
+        n_objects=0,
+        include_meta=False,
+        include_audio=False,
+    )
+    (row,) = omnisharing.episode_metadata(omnisharing.raw(str(root))).to_pylist()
+    assert row["vendor"] is None
+    assert row["instruction"] is None
+    assert row["audio_samplerate"] is None
+    assert row["object_names"] == []
+
+
+# ---------------------------------------------------------------------------
+# trajectory()
+# ---------------------------------------------------------------------------
+
+
+def test_trajectory_default_fields_and_shapes(df2_episodes):
+    (row,) = omnisharing.trajectory(df2_episodes).to_pylist()
+    for side in ("lefthand", "righthand"):
+        for branch in ("observation", "action"):
+            assert np.asarray(row[f"{branch}.{side}.joints"]).shape == (N_FRAMES, N_JOINTS)
+            assert np.asarray(row[f"{branch}.{side}.handpose"]).shape == (N_FRAMES, 7)
+
+
+def test_trajectory_tensor_dtype(df2_episodes):
+    traj = omnisharing.trajectory(df2_episodes, fields=["observation.lefthand.joints"])
+    dtypes = {f.name: f.dtype for f in traj.schema()}
+    assert dtypes["observation.lefthand.joints"] == DataType.tensor(DataType.float32())
+    assert np.asarray(traj.to_pylist()[0]["observation.lefthand.joints"]).dtype == np.float32
+
+
+def test_trajectory_emits_layout_attrs(df2_episodes):
+    (row,) = omnisharing.trajectory(df2_episodes).to_pylist()
+    assert row["observation.lefthand.joints.joint_names"] == JOINT_NAMES
+    # Quaternion is qw-first, which is the opposite of scipy's convention.
+    assert row["handpose_order"] == "[x, y, z, qw, qx, qy, qz]"
+    assert "exoskeleton" in row["lefthand.description"]
+
+
+def test_trajectory_include_attrs_false_omits_metadata_columns(df2_episodes):
+    traj = omnisharing.trajectory(df2_episodes, fields=["observation.lefthand.joints"], include_attrs=False)
+    assert "observation.lefthand.joints" in traj.column_names
+    assert "observation.lefthand.joints.joint_names" not in traj.column_names
+    assert "handpose_order" not in traj.column_names
+
+
+def test_trajectory_description_is_branch_order_independent(df2_episodes):
+    row = omnisharing.trajectory(
+        df2_episodes, fields=["action.lefthand.joints", "observation.righthand.joints"]
+    ).to_pylist()[0]
+    assert "left" in row["lefthand.description"]
+    assert "right" in row["righthand.description"]
+
+
+@pytest.mark.parametrize("fields", [[], ["nope"], ["observation.lefthand.tactile"], ["observation.thirdhand.joints"]])
+def test_trajectory_rejects_invalid_fields(df2_episodes, fields):
+    with pytest.raises(ValueError):
+        omnisharing.trajectory(df2_episodes, fields=fields)
+
+
+def test_trajectory_handles_df2r_widths(mixed_root):
+    episodes = omnisharing.raw(str(mixed_root), stage="DF-2R")
+    (row,) = omnisharing.trajectory(episodes, fields=["observation.lefthand.joints"]).to_pylist()
+    # DF-2R retargets to 17 joints; nothing may be hardcoded to 29.
+    assert np.asarray(row["observation.lefthand.joints"]).shape == (4, 17)
+    assert len(row["observation.lefthand.joints.joint_names"]) == 17
+
+
+# ---------------------------------------------------------------------------
+# tactile()
+# ---------------------------------------------------------------------------
+
+
+def test_tactile_returns_flat_vector_and_layout(df2_episodes):
+    (row,) = omnisharing.tactile(df2_episodes).to_pylist()
+    for side in ("lefthand", "righthand"):
+        assert np.asarray(row[f"{side}.tactile"]).shape == (N_FRAMES, TACTILE_WIDTH)
+        assert row[f"{side}.tactile.sensor_names"] == SENSOR_NAMES
+        assert row[f"{side}.tactile.sensor_lengths"] == SENSOR_LENGTHS
+
+
+def test_tactile_split_by_sensor_widths_match_declared_lengths(df2_episodes):
+    split = omnisharing.tactile(df2_episodes, sides="lefthand", split_by_sensor=True)
+    # The flat column is replaced by one column per sensor.
+    assert "lefthand.tactile" not in split.column_names
+    assert not any(c.startswith("righthand") for c in split.column_names)
+
+    (row,) = split.to_pylist()
+    widths = [np.asarray(row[f"lefthand.tactile.{name}"]).shape[1] for name in SENSOR_NAMES]
+    assert widths == SENSOR_LENGTHS
+    assert sum(widths) == TACTILE_WIDTH
+
+
+def test_tactile_split_slices_match_flat_vector(df2_episodes):
+    (flat_row,) = omnisharing.tactile(df2_episodes, sides="lefthand").to_pylist()
+    (split_row,) = omnisharing.tactile(df2_episodes, sides="lefthand", split_by_sensor=True).to_pylist()
+
+    flat = np.asarray(flat_row["lefthand.tactile"])
+    offset = 0
+    for name, length in zip(SENSOR_NAMES, SENSOR_LENGTHS):
+        piece = np.asarray(split_row[f"lefthand.tactile.{name}"])
+        np.testing.assert_array_equal(piece, flat[:, offset : offset + length])
+        offset += length
+
+
+def test_tactile_split_handles_df2r_width(mixed_root):
+    episodes = omnisharing.raw(str(mixed_root), stage="DF-2R")
+    (row,) = omnisharing.tactile(episodes, sides="lefthand", split_by_sensor=True).to_pylist()
+    total = sum(np.asarray(row[f"lefthand.tactile.{name}"]).shape[1] for name in SENSOR_NAMES)
+    assert total == 3750
+
+
+@pytest.mark.parametrize("sides", [[], ["thirdhand"]])
+def test_tactile_rejects_invalid_sides(df2_episodes, sides):
+    with pytest.raises(ValueError):
+        omnisharing.tactile(df2_episodes, sides=sides)
+
+
+# ---------------------------------------------------------------------------
+# audio()
+# ---------------------------------------------------------------------------
+
+
+def test_audio_returns_float64_waveform(df2_episodes):
+    df = omnisharing.audio(df2_episodes)
+    dtypes = {f.name: f.dtype for f in df.schema()}
+    assert dtypes["waveform"] == DataType.tensor(DataType.float64())
+    assert dtypes["samplerate"] == DataType.int64()
+
+    (row,) = df.to_pylist()
+    waveform = np.asarray(row["waveform"])
+    # Stored as raw PCM with a channel axis, not as a compressed stream.
+    assert waveform.ndim == 2
+    assert waveform.dtype == np.float64
+    assert row["samplerate"] == 8000
+    assert row["n_samples"] == waveform.shape[0]
+    assert np.abs(waveform).sum() > 0
+
+
+def test_audio_mono_averages_channels(df2_episodes):
+    (stereo,) = omnisharing.audio(df2_episodes).to_pylist()
+    (mono,) = omnisharing.audio(df2_episodes, mono=True).to_pylist()
+
+    stereo_waveform = np.asarray(stereo["waveform"])
+    mono_waveform = np.asarray(mono["waveform"])
+    assert mono_waveform.ndim == 1
+    assert mono_waveform.shape[0] == stereo_waveform.shape[0]
+    np.testing.assert_allclose(mono_waveform, stereo_waveform.mean(axis=1))
+    assert mono["n_samples"] == stereo["n_samples"]
+
+
+def test_audio_mono_downmix_is_exact(tmp_path):
+    root = tmp_path / "stereo"
+    path = root / episode_filename(1, "212953", 93, 110056)
+    write_df2_episode(path, n_frames=4)
+
+    import h5py
+
+    with h5py.File(path, "a") as h5:
+        samplerate = h5["dataset/observation/audio"].attrs["samplerate"]
+        del h5["dataset/observation/audio"]
+        channels = np.stack([np.ones(50), np.full(50, 3.0)], axis=1)
+        dataset = h5["dataset/observation"].create_dataset("audio", data=channels)
+        dataset.attrs["samplerate"] = samplerate
+
+    (row,) = omnisharing.audio(omnisharing.raw(str(root)), mono=True).to_pylist()
+    waveform = np.asarray(row["waveform"])
+    assert waveform.shape == (50,)
+    np.testing.assert_allclose(waveform, 2.0)
+
+
+def test_audio_mono_handles_waveform_without_channel_axis(tmp_path):
+    root = tmp_path / "flat"
+    path = root / episode_filename(1, "212953", 93, 110056)
+    write_df2_episode(path, n_frames=4)
+
+    import h5py
+
+    with h5py.File(path, "a") as h5:
+        samplerate = h5["dataset/observation/audio"].attrs["samplerate"]
+        del h5["dataset/observation/audio"]
+        dataset = h5["dataset/observation"].create_dataset("audio", data=np.linspace(-1, 1, 100, dtype="float64"))
+        dataset.attrs["samplerate"] = samplerate
+
+    (row,) = omnisharing.audio(omnisharing.raw(str(root)), mono=True).to_pylist()
+    assert np.asarray(row["waveform"]).shape == (100,)
+
+
+def test_audio_max_seconds_truncates_samples_only(df2_episodes):
+    (full,) = omnisharing.audio(df2_episodes).to_pylist()
+    total = np.asarray(full["waveform"]).shape[0]
+    cut_seconds = (total // 2) / full["samplerate"]
+    expected = int(cut_seconds * full["samplerate"])
+
+    (clipped,) = omnisharing.audio(df2_episodes, max_seconds=cut_seconds).to_pylist()
+    waveform = np.asarray(clipped["waveform"])
+    assert waveform.shape[0] == expected < total
+    assert clipped["n_samples"] == expected
+    # Truncating must not rescale time.
+    assert clipped["samplerate"] == full["samplerate"]
+    np.testing.assert_array_equal(waveform, np.asarray(full["waveform"])[:expected])
+
+
+def test_audio_max_seconds_beyond_duration_returns_everything(df2_episodes):
+    (full,) = omnisharing.audio(df2_episodes).to_pylist()
+    (asked_for_more,) = omnisharing.audio(df2_episodes, max_seconds=1e6).to_pylist()
+    assert asked_for_more["n_samples"] == full["n_samples"]
+
+
+def test_audio_max_seconds_clamps_to_at_least_one_sample(df2_episodes):
+    (row,) = omnisharing.audio(df2_episodes, max_seconds=1e-9).to_pylist()
+    assert row["n_samples"] == 1
+
+
+@pytest.mark.parametrize("max_seconds", [0, -1, -0.5])
+def test_audio_rejects_non_positive_max_seconds(df2_episodes, max_seconds):
+    with pytest.raises(ValueError, match="must be positive"):
+        omnisharing.audio(df2_episodes, max_seconds=max_seconds)
+
+
+def test_audio_missing_dataset_reads_cleanly(tmp_path):
+    root = tmp_path / "silent"
+    write_df2_episode(root / episode_filename(1, "212953", 93, 110056), n_frames=4, include_audio=False)
+    # An all-null tensor column trips a Daft concat error, so absent audio is
+    # reported as an empty waveform rather than null.
+    (row,) = omnisharing.audio(omnisharing.raw(str(root))).to_pylist()
+    assert np.asarray(row["waveform"]).size == 0
+    assert row["samplerate"] is None
+    assert row["n_samples"] is None
+
+
+def test_audio_mixed_release_reads_both_episodes(tmp_path):
+    root = tmp_path / "mixed"
+    write_df2_episode(root / episode_filename(1, "212953", 93, 110056), n_frames=4)
+    write_df2_episode(root / episode_filename(2, "213630", 115, 110092), n_frames=4, include_audio=False)
+
+    rows = omnisharing.audio(omnisharing.raw(str(root))).to_pylist()
+    assert len(rows) == 2
+    sizes = sorted(np.asarray(r["waveform"]).size for r in rows)
+    assert sizes[0] == 0
+    assert sizes[1] > 0
+
+
+def test_audio_zero_length_dataset_reports_zero_samples(tmp_path):
+    root = tmp_path / "zero"
+    path = root / episode_filename(1, "212953", 93, 110056)
+    write_df2_episode(path, n_frames=4)
+
+    import h5py
+
+    with h5py.File(path, "a") as h5:
+        del h5["dataset/observation/audio"]
+        dataset = h5["dataset/observation"].create_dataset("audio", data=np.empty((0, 1), dtype="float64"))
+        dataset.attrs["samplerate"] = 8000
+
+    (row,) = omnisharing.audio(omnisharing.raw(str(root))).to_pylist()
+    assert row["n_samples"] == 0
+    assert row["samplerate"] == 8000
+
+
+def test_audio_without_samplerate_ignores_max_seconds(tmp_path):
+    root = tmp_path / "nosr"
+    path = root / episode_filename(1, "212953", 93, 110056)
+    write_df2_episode(path, n_frames=4)
+
+    import h5py
+
+    with h5py.File(path, "a") as h5:
+        del h5["dataset/observation/audio"].attrs["samplerate"]
+
+    (full,) = omnisharing.audio(omnisharing.raw(str(root))).to_pylist()
+    (clipped,) = omnisharing.audio(omnisharing.raw(str(root)), max_seconds=0.01).to_pylist()
+    # Without a samplerate the sample count cannot be derived, so the limit is
+    # ignored rather than guessed at.
+    assert clipped["samplerate"] is None
+    assert clipped["n_samples"] == full["n_samples"]
+
+
+def test_audio_keeps_episode_handle_for_chaining(df2_episodes):
+    df = omnisharing.audio(df2_episodes)
+    assert "episode" in df.column_names
+    assert "episode_key" in df.column_names
+    # Episode-level readers compose; only frames() drops the handle.
+    chained = omnisharing.tactile(df, sides="lefthand")
+    assert "waveform" in chained.column_names
+    assert "lefthand.tactile" in chained.column_names
+
+
+# ---------------------------------------------------------------------------
+# objects()
+# ---------------------------------------------------------------------------
+
+
+def test_objects_probes_max_slots_and_null_fills(tmp_path):
+    root = tmp_path / "objs"
+    write_df2_episode(root / episode_filename(1, "212953", 93, 110056), n_frames=4, n_objects=2)
+    write_df2_episode(root / episode_filename(2, "213630", 115, 110092), n_frames=4, n_objects=0)
+    write_df2_episode(root / episode_filename(3, "214000", 115, 110092), n_frames=4, n_objects=4)
+
+    objs = omnisharing.objects(omnisharing.raw(str(root))).sort("episode_key")
+    # Schema is fixed to the widest episode.
+    assert "obj4" in objs.column_names
+    assert "obj5" not in objs.column_names
+
+    two, none, four = objs.to_pylist()
+    assert [two["n_objects"], none["n_objects"], four["n_objects"]] == [2, 0, 4]
+    assert np.asarray(two["obj1"]).shape == (4, omnisharing.OBJECT_POSE_WIDTH)
+    assert two["obj1.name"] == "object_1"
+    assert two["obj1.id"] == 101
+    # Slots beyond an episode's object count are null, not zero-filled.
+    assert two["obj3"] is None
+    assert none["obj1"] is None
+    assert four["obj4.id"] == 104
+
+
+def test_objects_without_any_objects_emits_no_object_columns(tmp_path):
+    root = tmp_path / "noobj"
+    write_df2_episode(root / episode_filename(1, "212953", 93, 110056), n_frames=4, n_objects=0)
+    objs = omnisharing.objects(omnisharing.raw(str(root)))
+    assert "n_objects" in objs.column_names
+    assert not any(c.startswith("obj") for c in objs.column_names)
+
+
+def test_objects_max_objects_caps_columns_but_not_count(tmp_path):
+    root = tmp_path / "cap"
+    write_df2_episode(root / episode_filename(1, "212953", 93, 110056), n_frames=4, n_objects=4)
+    objs = omnisharing.objects(omnisharing.raw(str(root)), max_objects=2)
+    assert "obj2" in objs.column_names
+    assert "obj3" not in objs.column_names
+    # The true count is still reported even though fewer columns are emitted.
+    assert objs.to_pylist()[0]["n_objects"] == 4
+
+
+def test_objects_rejects_negative_max_objects(df2_episodes):
+    with pytest.raises(ValueError, match="non-negative"):
+        omnisharing.objects(df2_episodes, max_objects=-1)
+
+
+# ---------------------------------------------------------------------------
+# cameras() + codec sniffing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("head", "expected"),
+    [
+        (bytes([0x00, 0x00, 0x01, 0x40, 0x01, 0x0C]), "h26x-annexb"),
+        (bytes([0x00, 0x00, 0x00, 0x01, 0x40, 0x01]), "h26x-annexb"),
+        (bytes([0x1A, 0x45, 0xDF, 0xA3]), "matroska"),
+        (bytes([0xFF, 0xD8, 0xFF, 0xE0]), "jpeg"),
+        (b"\x89PNG\r\n\x1a\n", "png"),
+        (b"RIFF\x00\x00\x00\x00WAVE", "riff"),
+        (b"\x00\x00\x00\x18ftypisom", "mp4"),
+        (b"definitely-not-a-codec", "unknown"),
+    ],
+)
+def test_sniff_codec(head, expected):
+    assert _sniff_codec(head) == expected
+
+
+def test_cameras_reports_one_row_per_stream(df2_episodes):
+    rows = omnisharing.cameras(df2_episodes).to_pylist()
+    rgb = [r for r in rows if r["kind"] == "rgb"]
+    rgbd = [r for r in rows if r["kind"] == "rgbd"]
+    # 5 RGB cameras with one stream each, 2 RGBD cameras with three each.
+    assert len(rgb) == 5
+    assert len(rgbd) == 6
+    assert sorted({r["stream"] for r in rgbd}) == ["color", "left", "right"]
+    assert all(r["stream"] == "" for r in rgb)
+
+
+def test_cameras_detects_per_family_codecs(df2_episodes):
+    rows = omnisharing.cameras(df2_episodes).to_pylist()
+    assert all(r["codec"] == "h26x-annexb" for r in rows if r["kind"] == "rgb")
+    assert all(r["codec"] == "matroska" for r in rows if r["kind"] == "rgbd")
+
+
+def test_cameras_reports_both_reference_frames(df2_episodes):
+    rows = omnisharing.cameras(df2_episodes).to_pylist()
+    rgb = next(r for r in rows if r["kind"] == "rgb")
+    color = next(r for r in rows if r["kind"] == "rgbd" and r["stream"] == "color")
+
+    assert rgb["relative_to_who"] == "RGB_Camera6"
+    assert rgb["width"] == 1920
+    assert rgb["height"] == 1200
+    assert np.asarray(rgb["intrinsics"]).shape == (3, 3)
+    assert np.asarray(rgb["extrinsics"]).shape == (4, 4)
+
+    assert color["relative_to_who"] == "RGBD_0"
+    assert color["width"] == 1280
+    assert color["height"] == 720
+    assert json.loads(color["inner_extrinsic"])["calib_date"] == "20250925171218"
+
+
+def test_cameras_rgbd_substreams_inherit_camera_extrinsics(df2_episodes):
+    rows = omnisharing.cameras(df2_episodes).to_pylist()
+    left = next(r for r in rows if r["kind"] == "rgbd" and r["stream"] == "left")
+    # left/right carry no extrinsics of their own; they share the camera pose.
+    assert np.asarray(left["extrinsics"]).shape == (4, 4)
+
+
+def test_cameras_stream_frame_counts_differ_from_observation(df2_episodes):
+    rows = omnisharing.cameras(df2_episodes).to_pylist()
+    rgb_counts = {r["camera"]: r["n_timestamps"] for r in rows if r["kind"] == "rgb"}
+    # This is why frame-index alignment is wrong for RGB cameras.
+    assert all(count > N_FRAMES for count in rgb_counts.values())
+    assert len(set(rgb_counts.values())) > 1
+    # RGBD colour tracks the observation clock.
+    colour = [r for r in rows if r["kind"] == "rgbd" and r["stream"] == "color"]
+    assert colour
+    assert all(r["n_timestamps"] == N_FRAMES for r in colour)
+
+
+def test_cameras_reports_per_eye_clocks(df2_episodes):
+    rows = omnisharing.cameras(df2_episodes).to_pylist()
+    by_stream = {r["stream"]: r["n_timestamps"] for r in rows if r["camera"] == "RGBD_0" and r["kind"] == "rgbd"}
+    # RGBD carries left_timestamp and right_timestamp alongside timestamp, so a
+    # per-eye count must come from that eye's own clock rather than the colour
+    # one. The generated episode gives the left eye an extra sample to prove it.
+    assert by_stream["color"] == N_FRAMES
+    assert by_stream["right"] == N_FRAMES
+    assert by_stream["left"] == N_FRAMES + 1
+
+
+def test_cameras_flags_checked_camera(df2_episodes):
+    flagged = [r["camera"] for r in omnisharing.cameras(df2_episodes).to_pylist() if r["is_checked_camera"]]
+    assert flagged
+    assert all("Camera4" in name for name in flagged)
+
+
+# ---------------------------------------------------------------------------
+# camera selector normalization
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_camera_targets_expands_bare_rgbd():
+    assert _normalize_camera_targets(["RGBD_0"]) == (
+        ("RGBD_0", "color"),
+        ("RGBD_0", "left"),
+        ("RGBD_0", "right"),
+    )
+
+
+@pytest.mark.parametrize(
+    ("selector", "expected"),
+    [
+        (["RGB_Camera0"], (("RGB_Camera0", ""),)),
+        ("RGB_Camera2", (("RGB_Camera2", ""),)),
+        ([("RGBD_1", "left")], (("RGBD_1", "left"),)),
+        (["RGB_Camera0", "RGB_Camera0"], (("RGB_Camera0", ""),)),
+    ],
+)
+def test_normalize_camera_targets(selector, expected):
+    assert _normalize_camera_targets(selector) == expected
+
+
+@pytest.mark.parametrize("selector", [[], [("RGBD_0", "depth")], [("a", "b", "c")]])
+def test_normalize_camera_targets_rejects_invalid(selector):
+    with pytest.raises(ValueError):
+        _normalize_camera_targets(selector)
+
+
+# ---------------------------------------------------------------------------
+# camera_payloads() / camera_frames()
+# ---------------------------------------------------------------------------
+
+
+def test_camera_payloads_returns_bytes_and_codec(df2_episodes):
+    payloads = omnisharing.camera_payloads(df2_episodes, ["RGB_Camera0", ("RGBD_0", "color")])
+    dtypes = {f.name: f.dtype for f in payloads.schema()}
+    assert dtypes["RGB_Camera0.payload"] == DataType.binary()
+
+    (row,) = payloads.to_pylist()
+    assert isinstance(row["RGB_Camera0.payload"], bytes)
+    assert row["RGB_Camera0.codec"] == "h26x-annexb"
+    assert row["RGBD_0.color.codec"] == "matroska"
+    assert row["RGBD_0.color.payload"][:4] == bytes([0x1A, 0x45, 0xDF, 0xA3])
+
+
+def test_camera_payloads_absent_stream_is_null(df2_episodes):
+    (row,) = omnisharing.camera_payloads(df2_episodes, ["RGB_Camera99"]).to_pylist()
+    assert row["RGB_Camera99.payload"] is None
+    assert row["RGB_Camera99.codec"] is None
+
+
+@pytest.fixture
+def playable_episodes(tmp_path):
+    """An episode whose camera payloads are real, locally-encoded video."""
+    pytest.importorskip("av", reason="daft[video] extra is required to decode payloads")
+    root = tmp_path / "playable"
+    write_df2_episode(root / episode_filename(1, "212953", 93, 110056), n_frames=N_FRAMES, playable=True)
+    return omnisharing.raw(str(root))
+
+
+def test_camera_frames_decodes_hevc(playable_episodes):
+    frames = omnisharing.camera_frames(playable_episodes, ["RGB_Camera0"], max_frames=2)
+    dtypes = {f.name: f.dtype for f in frames.schema()}
+    assert dtypes["RGB_Camera0.frames"] == DataType.list(DataType.image())
+
+    (row,) = frames.to_pylist()
+    assert row["RGB_Camera0.codec"] == "h26x-annexb"
+    assert len(row["RGB_Camera0.frames"]) == 2
+    first = np.asarray(row["RGB_Camera0.frames"][0])
+    assert first.shape == (PLAYABLE_HEIGHT, PLAYABLE_WIDTH, 3)
+    assert first.dtype == np.uint8
+
+
+def test_camera_frames_decodes_matroska(playable_episodes):
+    (row,) = omnisharing.camera_frames(playable_episodes, [("RGBD_0", "color")], max_frames=2).to_pylist()
+    assert row["RGBD_0.color.codec"] == "matroska"
+    assert len(row["RGBD_0.color.frames"]) == 2
+
+
+def test_camera_frames_defaults_to_single_frame(playable_episodes):
+    (row,) = omnisharing.camera_frames(playable_episodes, ["RGB_Camera0"]).to_pylist()
+    assert len(row["RGB_Camera0.frames"]) == 1
+
+
+def test_camera_frames_max_frames_none_decodes_all(playable_episodes):
+    (row,) = omnisharing.camera_frames(playable_episodes, ["RGB_Camera0"], max_frames=None).to_pylist()
+    assert len(row["RGB_Camera0.frames"]) == PLAYABLE_FRAMES
+
+
+def test_camera_frames_resizes(playable_episodes):
+    (row,) = omnisharing.camera_frames(
+        playable_episodes, ["RGB_Camera0"], max_frames=1, width=32, height=24
+    ).to_pylist()
+    assert np.asarray(row["RGB_Camera0.frames"][0]).shape == (24, 32, 3)
+
+
+@pytest.mark.parametrize("kwargs", [{"width": 10}, {"height": 10}, {"sample_every": 0}, {"max_frames": 0}])
+def test_camera_frames_rejects_invalid_arguments(playable_episodes, kwargs):
+    with pytest.raises(ValueError):
+        omnisharing.camera_frames(playable_episodes, ["RGB_Camera0"], **kwargs)
+
+
+def test_camera_payloads_still_works_for_undecodable_payload(df2_episodes):
+    # df2_episodes has placeholder payloads: sniffing works, decoding would not.
+    (row,) = omnisharing.camera_payloads(df2_episodes, ["RGB_Camera0"]).to_pylist()
+    assert len(row["RGB_Camera0.payload"]) > 0
+    assert row["RGB_Camera0.codec"] == "h26x-annexb"
+
+
+# ---------------------------------------------------------------------------
+# depth_frames()
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def depth_truth(df2_root):
+    """The stored aligned_depth array, read directly with h5py."""
+    import h5py
+
+    (path,) = df2_root.rglob("*.hdf5")
+    with h5py.File(path, "r") as h5:
+        return np.asarray(h5["dataset/observation/image/RGBD_0/aligned_depth"][()])
+
+
+def test_depth_frames_returns_uint16_tensor(df2_episodes, depth_truth):
+    df = omnisharing.depth_frames(df2_episodes, "RGBD_0")
+    dtypes = {f.name: f.dtype for f in df.schema()}
+    assert dtypes["RGBD_0.depth"] == DataType.tensor(DataType.uint16())
+
+    (row,) = df.to_pylist()
+    depth = np.asarray(row["RGBD_0.depth"])
+    assert depth.ndim == 3
+    assert depth.dtype == np.uint16
+    assert depth.shape[1:] == depth_truth.shape[1:]
+
+
+def test_depth_frames_defaults_to_first_frame_only(df2_episodes, depth_truth):
+    (row,) = omnisharing.depth_frames(df2_episodes, "RGBD_0").to_pylist()
+    depth = np.asarray(row["RGBD_0.depth"])
+    # A whole episode is ~380 MB per camera, so reading everything is a hazard.
+    assert depth.shape[0] == 1 < depth_truth.shape[0]
+    np.testing.assert_array_equal(depth[0], depth_truth[0])
+    assert row["RGBD_0.depth_frame_indices"] == [0]
+
+
+def test_depth_frames_honours_requested_order(df2_episodes, depth_truth):
+    requested = [3, 1, 6]
+    (row,) = omnisharing.depth_frames(df2_episodes, "RGBD_0", frame_indices=requested).to_pylist()
+    depth = np.asarray(row["RGBD_0.depth"])
+
+    assert depth.shape[0] == len(requested)
+    for position, index in enumerate(requested):
+        np.testing.assert_array_equal(depth[position], depth_truth[index])
+    assert row["RGBD_0.depth_frame_indices"] == requested
+
+
+def test_depth_frames_accepts_a_single_int(df2_episodes, depth_truth):
+    (row,) = omnisharing.depth_frames(df2_episodes, "RGBD_0", frame_indices=2).to_pylist()
+    np.testing.assert_array_equal(np.asarray(row["RGBD_0.depth"])[0], depth_truth[2])
+
+
+def test_depth_frames_reads_last_valid_index(df2_episodes, depth_truth):
+    last = depth_truth.shape[0] - 1
+    (row,) = omnisharing.depth_frames(df2_episodes, "RGBD_0", frame_indices=[last]).to_pylist()
+    np.testing.assert_array_equal(np.asarray(row["RGBD_0.depth"])[0], depth_truth[last])
+
+
+def test_depth_frames_absent_camera_yields_empty(df2_episodes):
+    # RGBD_1 exists but has no aligned_depth, mirroring the real dataset where
+    # only RGBD_0 carries depth.
+    (row,) = omnisharing.depth_frames(df2_episodes, "RGBD_1").to_pylist()
+    assert np.asarray(row["RGBD_1.depth"]).size == 0
+    assert row["RGBD_1.depth_frame_indices"] is None
+
+
+def test_depth_frames_mixes_present_and_absent_cameras(df2_episodes):
+    (row,) = omnisharing.depth_frames(df2_episodes, ["RGBD_0", "RGBD_1"]).to_pylist()
+    assert np.asarray(row["RGBD_0.depth"]).size > 0
+    assert np.asarray(row["RGBD_1.depth"]).size == 0
+
+
+def test_depth_frames_unknown_camera_yields_empty(df2_episodes):
+    (row,) = omnisharing.depth_frames(df2_episodes, "RGBD_99").to_pylist()
+    assert np.asarray(row["RGBD_99.depth"]).size == 0
+
+
+def test_depth_frames_zero_length_depth_yields_empty(tmp_path):
+    root = tmp_path / "zero"
+    path = root / episode_filename(1, "212953", 93, 110056)
+    write_df2_episode(path, n_frames=4)
+
+    import h5py
+
+    with h5py.File(path, "a") as h5:
+        del h5["dataset/observation/image/RGBD_0/aligned_depth"]
+        h5["dataset/observation/image/RGBD_0"].create_dataset(
+            "aligned_depth", data=np.empty((0, 8, 12), dtype=np.uint16)
+        )
+
+    # "Present but empty" must behave like "absent", not raise.
+    (row,) = omnisharing.depth_frames(omnisharing.raw(str(root)), "RGBD_0").to_pylist()
+    assert np.asarray(row["RGBD_0.depth"]).size == 0
+    assert row["RGBD_0.depth_frame_indices"] is None
+
+
+def test_depth_frames_out_of_range_raises_with_camera_and_bound(df2_episodes):
+    with pytest.raises(IndexError, match=rf"RGBD_0/aligned_depth has {N_FRAMES} frames"):
+        omnisharing.depth_frames(df2_episodes, "RGBD_0", frame_indices=[0, N_FRAMES])
+
+
+def test_depth_frames_ghost_camera_does_not_mask_a_real_bound(df2_episodes):
+    # A camera with unknown depth length must not suppress the real error.
+    with pytest.raises(IndexError, match="RGBD_0"):
+        omnisharing.depth_frames(df2_episodes, ["RGBD_99", "RGBD_0"], frame_indices=[N_FRAMES + 10])
+
+
+@pytest.mark.parametrize("frame_indices", [-1, [-1], [0, -2]])
+def test_depth_frames_rejects_negative_indices(df2_episodes, frame_indices):
+    with pytest.raises(IndexError, match="non-negative"):
+        omnisharing.depth_frames(df2_episodes, "RGBD_0", frame_indices=frame_indices)
+
+
+def test_depth_frames_rejects_empty_arguments(df2_episodes):
+    with pytest.raises(ValueError, match="at least one RGBD camera"):
+        omnisharing.depth_frames(df2_episodes, [])
+    with pytest.raises(ValueError, match="at least one index"):
+        omnisharing.depth_frames(df2_episodes, "RGBD_0", frame_indices=[])
+
+
+def test_depth_frames_shorter_episode_degrades_gracefully(tmp_path):
+    root = tmp_path / "uneven"
+    write_df2_episode(root / episode_filename(1, "212953", 93, 110056), n_frames=8)
+    write_df2_episode(root / episode_filename(2, "213630", 115, 110092), n_frames=3)
+
+    # Bounds are probed from the first episode, so a shorter one must clamp
+    # rather than fail mid-execution.
+    rows = (
+        omnisharing.depth_frames(omnisharing.raw(str(root)), "RGBD_0", frame_indices=[0, 5])
+        .sort("episode_key")
+        .to_pylist()
+    )
+    assert [np.asarray(r["RGBD_0.depth"]).shape[0] for r in rows] == [2, 1]
+    assert [r["RGBD_0.depth_frame_indices"] for r in rows] == [[0, 5], [0]]
+
+
+def test_depth_frames_deduplicates_camera_names(df2_episodes):
+    df = omnisharing.depth_frames(df2_episodes, ["RGBD_0", "RGBD_0"])
+    assert sum(name == "RGBD_0.depth" for name in df.column_names) == 1
+
+
+def test_depth_frames_documents_the_undocumented_unit():
+    doc = omnisharing.depth_frames.__doc__ or ""
+    # The dataset ships no attrs on aligned_depth, so no scale can be derived.
+    assert "undocumented" in doc
+
+
+# ---------------------------------------------------------------------------
+# stereo_extrinsics()
+# ---------------------------------------------------------------------------
+
+
+def test_stereo_extrinsics_parses_the_transform(df2_episodes):
+    df = omnisharing.stereo_extrinsics(df2_episodes, "RGBD_0")
+    dtypes = {f.name: f.dtype for f in df.schema()}
+    assert dtypes["RGBD_0.left_to_color"] == DataType.tensor(DataType.float64())
+    assert dtypes["RGBD_0.calib_date"] == DataType.string()
+
+    (row,) = df.to_pylist()
+    matrix = np.asarray(row["RGBD_0.left_to_color"])
+    assert matrix.shape == (4, 4)
+    assert matrix.dtype == np.float64
+    assert row["RGBD_0.calib_date"] == "20250925171218"
+    np.testing.assert_array_equal(matrix, np.asarray(left_to_color_matrix(0), dtype=np.float64))
+
+
+def test_stereo_extrinsics_matches_the_bytes_on_disk(df2_root):
+    import h5py
+
+    (path,) = df2_root.rglob("*.hdf5")
+    with h5py.File(path, "r") as h5:
+        blob = h5["dataset/observation/image/RGBD_0/inner_extrinsic"][()][0]
+    on_disk = np.asarray(json.loads(blob.decode())["left_to_color"], dtype=np.float64)
+
+    (row,) = omnisharing.stereo_extrinsics(omnisharing.raw(str(df2_root)), "RGBD_0").to_pylist()
+    np.testing.assert_array_equal(np.asarray(row["RGBD_0.left_to_color"]), on_disk)
+
+
+def test_stereo_extrinsics_transform_is_well_formed(df2_episodes):
+    (row,) = omnisharing.stereo_extrinsics(df2_episodes, "RGBD_0").to_pylist()
+    matrix = np.asarray(row["RGBD_0.left_to_color"])
+    # A rigid transform: near-identity rotation, homogeneous bottom row, and the
+    # stereo baseline carried in the x translation.
+    np.testing.assert_allclose(matrix[:3, :3], np.eye(3), atol=2e-3)
+    np.testing.assert_array_equal(matrix[3], [0.0, 0.0, 0.0, 1.0])
+    assert matrix[0, 3] == pytest.approx(STEREO_BASELINE)
+
+
+def test_stereo_extrinsics_reads_each_camera_separately(df2_episodes):
+    (row,) = omnisharing.stereo_extrinsics(df2_episodes, ["RGBD_0", "RGBD_1"]).to_pylist()
+    first = np.asarray(row["RGBD_0.left_to_color"])
+    second = np.asarray(row["RGBD_1.left_to_color"])
+    assert not np.array_equal(first, second)
+    np.testing.assert_array_equal(second, np.asarray(left_to_color_matrix(1), dtype=np.float64))
+
+
+def test_stereo_extrinsics_missing_dataset_yields_empty(tmp_path):
+    root = tmp_path / "nocalib"
+    path = root / episode_filename(1, "212953", 93, 110056)
+    write_df2_episode(path, n_frames=4)
+
+    import h5py
+
+    with h5py.File(path, "a") as h5:
+        del h5["dataset/observation/image/RGBD_0/inner_extrinsic"]
+
+    (row,) = omnisharing.stereo_extrinsics(omnisharing.raw(str(root)), "RGBD_0").to_pylist()
+    assert np.asarray(row["RGBD_0.left_to_color"]).size == 0
+    assert row["RGBD_0.calib_date"] is None
+
+
+def test_stereo_extrinsics_unknown_camera_yields_empty(df2_episodes):
+    (row,) = omnisharing.stereo_extrinsics(df2_episodes, "RGBD_99").to_pylist()
+    assert np.asarray(row["RGBD_99.left_to_color"]).size == 0
+
+
+@pytest.mark.parametrize(
+    ("label", "payload"),
+    [
+        ("not json", b"{{{not json"),
+        ("json array", b"[1, 2, 3]"),
+        ("no left_to_color", b'{"calib_date": "20250101000000"}'),
+        ("wrong shape", b'{"calib_date": "x", "left_to_color": [[1, 2], [3, 4]]}'),
+        ("non numeric", b'{"calib_date": "x", "left_to_color": "nope"}'),
+    ],
+)
+def test_stereo_extrinsics_malformed_json_yields_empty(tmp_path, label, payload):
+    root = tmp_path / f"bad_{label.replace(' ', '_')}"
+    path = root / episode_filename(1, "212953", 93, 110056)
+    write_df2_episode(path, n_frames=4)
+
+    import h5py
+
+    with h5py.File(path, "a") as h5:
+        del h5["dataset/observation/image/RGBD_0/inner_extrinsic"]
+        h5["dataset/observation/image/RGBD_0"].create_dataset("inner_extrinsic", data=np.array([payload]))
+
+    # Calibration is optional metadata; a bad blob must not fail the read.
+    (row,) = omnisharing.stereo_extrinsics(omnisharing.raw(str(root)), "RGBD_0").to_pylist()
+    assert np.asarray(row["RGBD_0.left_to_color"]).size == 0
+
+
+def test_stereo_extrinsics_recovers_calib_date_without_a_matrix(tmp_path):
+    root = tmp_path / "partial"
+    path = root / episode_filename(1, "212953", 93, 110056)
+    write_df2_episode(path, n_frames=4)
+
+    import h5py
+
+    with h5py.File(path, "a") as h5:
+        del h5["dataset/observation/image/RGBD_0/inner_extrinsic"]
+        h5["dataset/observation/image/RGBD_0"].create_dataset(
+            "inner_extrinsic", data=np.array([b'{"calib_date": "20260101120000"}'])
+        )
+
+    (row,) = omnisharing.stereo_extrinsics(omnisharing.raw(str(root)), "RGBD_0").to_pylist()
+    assert row["RGBD_0.calib_date"] == "20260101120000"
+    assert np.asarray(row["RGBD_0.left_to_color"]).size == 0
+
+
+def test_stereo_extrinsics_rejects_empty_cameras(df2_episodes):
+    with pytest.raises(ValueError, match="at least one RGBD camera"):
+        omnisharing.stereo_extrinsics(df2_episodes, [])
+
+
+def test_stereo_extrinsics_deduplicates_camera_names(df2_episodes):
+    df = omnisharing.stereo_extrinsics(df2_episodes, ["RGBD_0", "RGBD_0"])
+    assert sum(name == "RGBD_0.left_to_color" for name in df.column_names) == 1
+
+
+# ---------------------------------------------------------------------------
+# frames()
+# ---------------------------------------------------------------------------
+
+
+def test_frames_requires_explicit_field_whitelist(df2_episodes):
+    with pytest.raises(ValueError, match="memory hazard"):
+        omnisharing.frames(df2_episodes, fields=[])
+
+
+@pytest.mark.parametrize("fields", [["nope"], ["action.lefthand.tactile"]])
+def test_frames_rejects_invalid_fields(df2_episodes, fields):
+    with pytest.raises(ValueError, match="Unknown frame field"):
+        omnisharing.frames(df2_episodes, fields=fields)
+
+
+def test_frames_expands_one_row_per_frame(df2_episodes):
+    rows = omnisharing.frames(df2_episodes, fields=["observation.lefthand.joints"]).sort("frame_index").to_pylist()
+    assert len(rows) == N_FRAMES
+    assert [r["frame_index"] for r in rows] == list(range(N_FRAMES))
+    assert all(rows[i + 1]["timestamp"] > rows[i]["timestamp"] for i in range(N_FRAMES - 1))
+    # Per-frame vectors are 1-D slices of the episode tensor.
+    assert np.asarray(rows[0]["observation.lefthand.joints"]).shape == (N_JOINTS,)
+
+
+def test_frames_drops_episode_handle_but_keeps_identity(df2_episodes):
+    columns = omnisharing.frames(df2_episodes, fields=["observation.lefthand.joints"]).column_names
+    assert "episode" not in columns
+    assert "episode_key" in columns
+    assert "stage" in columns
+
+
+def test_frames_applies_action_leads_observation_by_one(df2_episodes):
+    fields = ["observation.lefthand.joints", "action.lefthand.joints"]
+    (episode_row,) = omnisharing.trajectory(df2_episodes, fields=fields, include_attrs=False).to_pylist()
+    raw_obs = np.asarray(episode_row["observation.lefthand.joints"])
+    raw_act = np.asarray(episode_row["action.lefthand.joints"])
+
+    rows = omnisharing.frames(df2_episodes, fields=fields).sort("frame_index").to_pylist()
+    for i, row in enumerate(rows):
+        np.testing.assert_array_equal(np.asarray(row["observation.lefthand.joints"]), raw_obs[i])
+        expected_action = raw_act[min(i + 1, N_FRAMES - 1)]
+        np.testing.assert_array_equal(np.asarray(row["action.lefthand.joints"]), expected_action)
+
+    # The shift is genuinely applied, and the tail is duplicated.
+    assert not np.array_equal(np.asarray(rows[0]["action.lefthand.joints"]), raw_act[0])
+    np.testing.assert_array_equal(
+        np.asarray(rows[-2]["action.lefthand.joints"]),
+        np.asarray(rows[-1]["action.lefthand.joints"]),
+    )
+
+
+def test_frames_aligns_cameras_by_nearest_timestamp(tmp_path):
+    # Enough frames for the faster RGB clock to drift past a full frame period,
+    # which is what makes frame-index alignment wrong.
+    root = tmp_path / "drift"
+    write_df2_episode(root / episode_filename(1, "212953", 93, 110056), n_frames=10)
+    episodes = omnisharing.raw(str(root))
+
+    rows = (
+        omnisharing.frames(
+            episodes,
+            fields=["observation.lefthand.joints"],
+            align_cameras=["RGB_Camera0", ("RGBD_0", "color")],
+        )
+        .sort("frame_index")
+        .to_pylist()
+    )
+    assert len(rows) == 10
+
+    rgb_index = [r["RGB_Camera0.frame_index"] for r in rows]
+    rgb_delta = [r["RGB_Camera0.timestamp_delta_us"] for r in rows]
+    # The RGB clock runs faster, so nearest-neighbour drifts away from identity
+    # and eventually skips a source frame entirely.
+    assert rgb_index != list(range(10))
+    assert all(rgb_index[i] <= rgb_index[i + 1] for i in range(9))
+    assert rgb_index[0] == 0
+    assert rgb_delta[0] == 0
+    assert abs(rgb_delta[-1]) > abs(rgb_delta[1])
+
+    # RGBD shares the observation clock, so it aligns exactly.
+    assert [r["RGBD_0.color.frame_index"] for r in rows] == list(range(10))
+    assert all(r["RGBD_0.color.timestamp_delta_us"] == 0 for r in rows)
+
+
+def test_frames_camera_alignment_tracks_clock_drift(df2_episodes):
+    # Even before the drift is large enough to skip a frame, the residual must
+    # grow monotonically rather than being reported as a perfect match.
+    rows = (
+        omnisharing.frames(
+            df2_episodes,
+            fields=["observation.lefthand.joints"],
+            align_cameras=["RGB_Camera0"],
+        )
+        .sort("frame_index")
+        .to_pylist()
+    )
+    deltas = [r["RGB_Camera0.timestamp_delta_us"] for r in rows]
+    assert deltas[0] == 0
+    assert any(d != 0 for d in deltas[1:])
+    assert abs(deltas[-1]) > abs(deltas[1])
+
+
+def test_frames_tolerates_absent_camera(df2_episodes):
+    rows = omnisharing.frames(
+        df2_episodes, fields=["observation.lefthand.joints"], align_cameras=["RGB_Camera99"]
+    ).to_pylist()
+    assert len(rows) == N_FRAMES
+    assert rows[0]["RGB_Camera99.frame_index"] is None
+
+
+def test_frames_aligns_rgbd_eyes_on_their_own_clocks(df2_root):
+    import h5py
+
+    (path,) = df2_root.rglob("*.hdf5")
+    with h5py.File(path, "r") as h5:
+        group = h5["dataset/observation/image/RGBD_0"]
+        left_clock = np.asarray(group["left_timestamp"][()])
+        observation_clock = np.asarray(h5["dataset/observation/aligned_timestamp"][()])
+
+    rows = (
+        omnisharing.frames(
+            omnisharing.raw(str(df2_root)),
+            fields=["observation.lefthand.joints"],
+            align_cameras=[("RGBD_0", "left"), ("RGBD_0", "color"), ("RGBD_0", "right")],
+        )
+        .sort("frame_index")
+        .to_pylist()
+    )
+
+    # The left eye runs on left_timestamp, so its residuals must match a
+    # nearest-neighbour search against that clock, not the colour one.
+    expected_index = [int(np.argmin(np.abs(left_clock - t))) for t in observation_clock]
+    expected_delta = [int(left_clock[j]) - int(t) for j, t in zip(expected_index, observation_clock)]
+    assert [r["RGBD_0.left.frame_index"] for r in rows] == expected_index
+    assert [r["RGBD_0.left.timestamp_delta_us"] for r in rows] == expected_delta
+    assert any(delta != 0 for delta in expected_delta)
+
+    # Colour and right share the observation clock, so they align exactly.
+    assert [r["RGBD_0.color.frame_index"] for r in rows] == list(range(N_FRAMES))
+    assert all(r["RGBD_0.color.timestamp_delta_us"] == 0 for r in rows)
+    assert [r["RGBD_0.right.frame_index"] for r in rows] == list(range(N_FRAMES))
+
+
+def test_frames_left_eye_alignment_diverges_from_colour(tmp_path):
+    # Index divergence only appears once drift exceeds half a frame period, so
+    # this needs a longer episode than the shared one provides.
+    root = tmp_path / "drift"
+    write_df2_episode(root / episode_filename(1, "212953", 93, 110056), n_frames=20)
+
+    rows = (
+        omnisharing.frames(
+            omnisharing.raw(str(root)),
+            fields=["observation.lefthand.joints"],
+            align_cameras=[("RGBD_0", "left"), ("RGBD_0", "color")],
+        )
+        .sort("frame_index")
+        .to_pylist()
+    )
+    left_index = [r["RGBD_0.left.frame_index"] for r in rows]
+    colour_index = [r["RGBD_0.color.frame_index"] for r in rows]
+
+    assert left_index != colour_index
+    assert all(left_index[i] <= left_index[i + 1] for i in range(len(left_index) - 1))
+
+
+def test_frames_falls_back_to_camera_clock_when_eye_clock_is_absent(tmp_path):
+    root = tmp_path / "noeye"
+    path = root / episode_filename(1, "212953", 93, 110056)
+    write_df2_episode(path, n_frames=8)
+
+    import h5py
+
+    with h5py.File(path, "a") as h5:
+        del h5["dataset/observation/image/RGBD_0/left_timestamp"]
+
+    rows = (
+        omnisharing.frames(
+            omnisharing.raw(str(root)),
+            fields=["observation.lefthand.joints"],
+            align_cameras=[("RGBD_0", "left")],
+        )
+        .sort("frame_index")
+        .to_pylist()
+    )
+    # Without a per-eye clock the camera clock is used, preserving old behaviour.
+    assert [r["RGBD_0.left.frame_index"] for r in rows] == list(range(8))
+    assert all(r["RGBD_0.left.timestamp_delta_us"] == 0 for r in rows)
+
+
+def test_cameras_falls_back_to_camera_clock_when_eye_clock_is_absent(tmp_path):
+    root = tmp_path / "noeye_cameras"
+    path = root / episode_filename(1, "212953", 93, 110056)
+    write_df2_episode(path, n_frames=8)
+
+    import h5py
+
+    with h5py.File(path, "a") as h5:
+        del h5["dataset/observation/image/RGBD_0/left_timestamp"]
+
+    rows = omnisharing.cameras(omnisharing.raw(str(root))).to_pylist()
+    left = next(r for r in rows if r["camera"] == "RGBD_0" and r["stream"] == "left")
+    assert left["n_timestamps"] == 8
+
+
+def test_frames_expands_multiple_episodes(tmp_path):
+    root = tmp_path / "multi"
+    write_df2_episode(root / episode_filename(1, "212953", 93, 110056), n_frames=4)
+    write_df2_episode(root / episode_filename(2, "213630", 115, 110092), n_frames=6)
+
+    rows = omnisharing.frames(omnisharing.raw(str(root)), fields=["observation.lefthand.joints"]).to_pylist()
+    assert len(rows) == 10
+
+    counts: dict[str, int] = {}
+    for row in rows:
+        counts[row["episode_key"]] = counts.get(row["episode_key"], 0) + 1
+    assert sorted(counts.values()) == [4, 6]
+
+
+# ---------------------------------------------------------------------------
+# Module surface
+# ---------------------------------------------------------------------------
+
+
+def test_module_is_registered_on_daft_datasets():
+    assert daft.datasets.omnisharing is omnisharing
+
+
+def test_public_api_is_exported():
+    for name in (
+        "raw",
+        "describe",
+        "episode_metadata",
+        "trajectory",
+        "tactile",
+        "audio",
+        "objects",
+        "cameras",
+        "camera_payloads",
+        "camera_frames",
+        "depth_frames",
+        "stereo_extrinsics",
+        "frames",
+    ):
+        assert name in omnisharing.__all__
+        assert callable(getattr(omnisharing, name))
+
+
+def test_handpose_order_is_qw_first():
+    # Guards against a silent switch to the scipy [qx, qy, qz, qw] convention.
+    assert omnisharing.HANDPOSE_ORDER == ("x", "y", "z", "qw", "qx", "qy", "qz")

--- a/tests/datasets/test_omnisharing_docs.py
+++ b/tests/datasets/test_omnisharing_docs.py
@@ -1,0 +1,158 @@
+"""Execute every code snippet from the OmniSharing guide.
+
+Guards against documentation rot: `docs/datasets/omnisharing.md` shows real API
+calls, and a renamed column or argument would leave the guide silently wrong.
+Each test runs a snippet against a generated episode, with only the dataset
+path rewritten.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import daft
+from daft.datasets import omnisharing
+from tests.datasets.omnisharing_datagen import episode_filename, write_df2_episode
+
+pytest.importorskip("h5py", reason="daft[hdf5] extra is required for OmniSharing tests")
+
+
+@pytest.fixture(scope="module")
+def guide_dataset(tmp_path_factory):
+    """A release shaped like the one the guide describes.
+
+    Includes the duplicated ``episode_index`` 1217 that the guide warns about, so
+    the warning itself can be verified rather than taken on trust.
+    """
+    root = tmp_path_factory.mktemp("omnisharing_guide") / "ds"
+    part = root / "data/part_01"
+    write_df2_episode(part / episode_filename(1203, "213135", 115, 110092), n_frames=8)
+    write_df2_episode(part / episode_filename(1217, "212953", 93, 110056), n_frames=8)
+    write_df2_episode(part / episode_filename(1217, "213630", 115, 110092), n_frames=8)
+    return str(root)
+
+
+@pytest.fixture
+def episodes(guide_dataset):
+    return omnisharing.raw(guide_dataset)
+
+
+@pytest.fixture
+def one(episodes):
+    return episodes.limit(1)
+
+
+# ---------------------------------------------------------------------------
+# Quickstart
+# ---------------------------------------------------------------------------
+
+
+def test_quickstart_lists_episodes(episodes):
+    episodes.select("episode_key", "stage", "size").collect()
+
+
+def test_quickstart_reads_each_modality(one):
+    omnisharing.episode_metadata(one).select("instruction", "task_labels").collect()
+    omnisharing.trajectory(one, fields=["observation.lefthand.joints"]).collect()
+    omnisharing.tactile(one, sides="lefthand", split_by_sensor=True).collect()
+    omnisharing.audio(one, mono=True, max_seconds=2.0).select("samplerate", "n_samples").collect()
+    omnisharing.depth_frames(one, "RGBD_0").select("RGBD_0.depth").collect()
+    omnisharing.stereo_extrinsics(one, "RGBD_0").select("RGBD_0.left_to_color").collect()
+
+
+# ---------------------------------------------------------------------------
+# Pipeline stages and layout
+# ---------------------------------------------------------------------------
+
+
+def test_stage_filtering_snippet(guide_dataset):
+    omnisharing.raw(guide_dataset, stage="DF-2").collect()
+
+
+def test_describe_snippet(one):
+    layout = omnisharing.describe(one)
+    layout.where(daft.col("kind") == "dataset").select("h5path", "shape", "dtype").collect()
+
+
+# ---------------------------------------------------------------------------
+# The three documented traps
+# ---------------------------------------------------------------------------
+
+
+def test_duplicate_episode_index_warning_is_accurate(episodes):
+    rows = episodes.select("episode_key", "episode_index").to_pylist()
+    # The guide claims part_01 holds two episodes numbered 1217.
+    assert [r["episode_index"] for r in rows].count(1217) == 2
+    assert {r["episode_key"] for r in rows if r["episode_index"] == 1217} == {
+        "1217_212953_93_110056",
+        "1217_213630_115_110092",
+    }
+
+
+def test_quaternion_roll_recipe_puts_qw_last(one):
+    pose = np.asarray(
+        omnisharing.trajectory(one, fields=["observation.lefthand.handpose"]).to_pylist()[0][
+            "observation.lefthand.handpose"
+        ]
+    )
+    xyz, quat_wxyz = pose[:, :3], pose[:, 3:7]
+    rolled = np.roll(quat_wxyz, -1, axis=1)
+
+    assert xyz.shape[1] == 3
+    # The documented np.roll must turn [qw, qx, qy, qz] into scipy's
+    # [qx, qy, qz, qw], not merely look plausible.
+    np.testing.assert_array_equal(rolled[:, 3], quat_wxyz[:, 0])
+    np.testing.assert_array_equal(rolled[:, :3], quat_wxyz[:, 1:])
+
+
+def test_camera_clock_snippets(one):
+    omnisharing.cameras(one).select("camera", "codec", "n_timestamps").collect()
+    omnisharing.frames(one, fields=["observation.lefthand.joints"], align_cameras=["RGB_Camera0"]).select(
+        "frame_index", "RGB_Camera0.frame_index", "RGB_Camera0.timestamp_delta_us"
+    ).collect()
+
+
+# ---------------------------------------------------------------------------
+# Per-modality sections
+# ---------------------------------------------------------------------------
+
+
+def test_tactile_section_uses_real_sensor_names(one):
+    # The guide names palm_sensor1 and J32L explicitly.
+    omnisharing.tactile(one, sides="lefthand", split_by_sensor=True).select(
+        "lefthand.tactile.palm_sensor1", "lefthand.tactile.J32L"
+    ).collect()
+
+
+def test_frame_expansion_section(one):
+    omnisharing.frames(one, fields=["observation.lefthand.joints", "action.lefthand.joints"]).collect()
+
+
+def test_video_section(one):
+    omnisharing.camera_frames(one, ["RGB_Camera0"], max_frames=2).select("RGB_Camera0.frames").collect()
+    omnisharing.camera_payloads(one, ["RGB_Camera0"]).select("RGB_Camera0.codec").collect()
+
+
+def test_audio_section(one):
+    omnisharing.audio(one, mono=True, max_seconds=2.0).select("samplerate", "n_samples", "waveform").collect()
+
+
+def test_depth_section(one):
+    omnisharing.depth_frames(one, "RGBD_0", frame_indices=[0, 5]).select(
+        "RGBD_0.depth", "RGBD_0.depth_frame_indices"
+    ).collect()
+
+
+def test_stereo_section(one):
+    omnisharing.stereo_extrinsics(one, "RGBD_0").select("RGBD_0.left_to_color", "RGBD_0.calib_date").collect()
+
+
+def test_per_eye_alignment_section(one):
+    omnisharing.frames(one, fields=["observation.lefthand.joints"], align_cameras=[("RGBD_0", "left")]).select(
+        "frame_index", "RGBD_0.left.frame_index", "RGBD_0.left.timestamp_delta_us"
+    ).collect()
+
+
+def test_object_poses_section(episodes):
+    omnisharing.objects(episodes.limit(4)).select("episode_key", "n_objects", "obj1.name", "obj1.id").collect()

--- a/tests/datasets/test_omnisharing_integration.py
+++ b/tests/datasets/test_omnisharing_integration.py
@@ -1,0 +1,298 @@
+"""Integration tests against the real PX OmniSharing release.
+
+Excluded from the default run (`-m 'not integration'`); enable with
+`pytest -m integration`. These stream one episode over `hf://` range reads and
+write nothing to disk, but a full pass takes several minutes because each read is
+a separate high-latency request.
+
+They exist to catch the class of bug synthetic data cannot: values that are
+structurally valid but physically wrong. Where possible an assertion is anchored
+to something independently checkable -- a unit quaternion norm, a stereo baseline
+in millimetres, a sample count that must agree with a different code path.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import daft
+from daft.datasets import omnisharing
+from daft.functions import endswith
+
+pytest.importorskip("h5py", reason="daft[hdf5] extra is required for OmniSharing tests")
+
+#: Smallest episode in part_01 (~440 MB), pinned so failures are reproducible.
+DIRECTORY = "hf://datasets/paxini/Omnisharing_DB_SampleData/data/part_01"
+EPISODE = "episode_1203_213135_115_110092_glove.hdf5"
+
+#: Frame count of the pinned episode's observation clock.
+N_FRAMES = 207
+
+
+@pytest.fixture(scope="module")
+def episodes():
+    """The pinned episode, selected by path rather than by index."""
+    return omnisharing.raw(DIRECTORY).where(endswith(daft.col("path"), EPISODE))
+
+
+@pytest.fixture(scope="module")
+def metadata(episodes):
+    (row,) = omnisharing.episode_metadata(episodes).to_pylist()
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Episode discovery and metadata
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration()
+def test_raw_parses_the_real_filename(episodes):
+    (row,) = episodes.to_pylist()
+    assert row["episode_key"] == "1203_213135_115_110092"
+    assert row["stage"] == "DF-2"
+    assert row["room_id"] == 115
+    assert row["personnel_id"] == 110092
+    assert 4e8 < row["size"] < 5e8
+
+
+@pytest.mark.integration()
+def test_episode_metadata_reads_the_undocumented_meta_group(metadata):
+    # vendor and the task labels live in a group absent from the published layout.
+    assert metadata["vendor"] == "paxini"
+    assert metadata["n_frames"] == N_FRAMES
+    assert metadata["audio_samplerate"] == 8000
+    assert metadata["instruction"]
+    # The instruction is Chinese free text.
+    assert any("\u4e00" <= char <= "\u9fff" for char in metadata["instruction"])
+
+
+# ---------------------------------------------------------------------------
+# Trajectory
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration()
+def test_handpose_quaternions_are_unit_norm(episodes):
+    (row,) = omnisharing.trajectory(episodes, fields=["observation.lefthand.handpose"], include_attrs=False).to_pylist()
+    pose = np.asarray(row["observation.lefthand.handpose"])
+    assert pose.shape == (N_FRAMES, 7)
+
+    # Independent evidence for the [x, y, z, qw, qx, qy, qz] layout: slicing the
+    # last four elements must yield unit quaternions. A wrong split would not.
+    norms = np.linalg.norm(pose[:, 3:7], axis=1)
+    np.testing.assert_allclose(norms, 1.0, atol=1e-3)
+
+
+@pytest.mark.integration()
+def test_trajectory_shapes_match_the_published_layout(episodes):
+    (row,) = omnisharing.trajectory(
+        episodes,
+        fields=["observation.lefthand.joints", "observation.righthand.joints"],
+        include_attrs=False,
+    ).to_pylist()
+    left = np.asarray(row["observation.lefthand.joints"])
+    right = np.asarray(row["observation.righthand.joints"])
+
+    assert left.shape == (N_FRAMES, 29)
+    assert left.dtype == np.float32
+    assert np.isfinite(left).all()
+    assert not np.array_equal(left, right)
+
+
+# ---------------------------------------------------------------------------
+# Tactile
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration()
+def test_tactile_sensor_widths_sum_to_the_stored_vector(episodes):
+    (row,) = omnisharing.tactile(episodes, sides="lefthand", split_by_sensor=True).to_pylist()
+    names = row["lefthand.tactile.sensor_names"]
+    lengths = row["lefthand.tactile.sensor_lengths"]
+
+    assert len(names) == 15
+    assert sum(lengths) == 3465
+
+    widths = [np.asarray(row[f"lefthand.tactile.{name}"]).shape[1] for name in names]
+    assert widths == lengths
+    assert all(np.asarray(row[f"lefthand.tactile.{name}"]).shape[0] == N_FRAMES for name in names)
+    # Real contact data, not zero padding.
+    assert sum(float(np.abs(np.asarray(row[f"lefthand.tactile.{n}"])).sum()) for n in names) > 0
+
+
+# ---------------------------------------------------------------------------
+# Audio
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration()
+def test_audio_sample_count_agrees_with_metadata(episodes, metadata):
+    (row,) = omnisharing.audio(episodes).to_pylist()
+    waveform = np.asarray(row["waveform"])
+
+    # Two independent code paths must agree on the length.
+    assert row["n_samples"] == metadata["audio_samples"]
+    assert row["samplerate"] == 8000
+    # Raw PCM, so float64 with a channel axis rather than decoded bytes.
+    assert waveform.dtype == np.float64
+    assert waveform.ndim == 2
+    assert np.isfinite(waveform).all()
+
+
+@pytest.mark.integration()
+def test_audio_max_seconds_truncates_the_real_stream(episodes):
+    (full,) = omnisharing.audio(episodes).to_pylist()
+    (clipped,) = omnisharing.audio(episodes, max_seconds=0.5).to_pylist()
+
+    assert clipped["n_samples"] == 4000
+    assert clipped["n_samples"] < full["n_samples"]
+    assert clipped["samplerate"] == full["samplerate"]
+
+
+# ---------------------------------------------------------------------------
+# Video and depth
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration()
+def test_camera_frames_decode_to_their_declared_resolution(episodes):
+    pytest.importorskip("av", reason="daft[video] extra is required to decode payloads")
+    (row,) = omnisharing.camera_frames(episodes, ["RGB_Camera0", ("RGBD_0", "color")], max_frames=1).to_pylist()
+
+    # HEVC Annex-B has no container, Matroska does; both must resolve to the
+    # width/height carried in their intrinsics attrs.
+    assert row["RGB_Camera0.codec"] == "h26x-annexb"
+    assert row["RGBD_0.color.codec"] == "matroska"
+
+    rgb = np.asarray(row["RGB_Camera0.frames"][0])
+    rgbd = np.asarray(row["RGBD_0.color.frames"][0])
+    assert rgb.shape == (1200, 1920, 3)
+    assert rgbd.shape == (720, 1280, 3)
+    # Real imagery rather than a flat frame.
+    assert float(rgb.std()) > 5
+    assert float(rgbd.std()) > 5
+
+
+@pytest.mark.integration()
+def test_depth_frames_are_real_depth_maps(episodes):
+    (row,) = omnisharing.depth_frames(episodes, "RGBD_0", frame_indices=[0, 100]).to_pylist()
+    depth = np.asarray(row["RGBD_0.depth"])
+
+    assert depth.dtype == np.uint16
+    assert depth.shape == (2, 720, 1280)
+    assert row["RGBD_0.depth_frame_indices"] == [0, 100]
+    # Mostly populated, and the two frames are not identical.
+    assert np.count_nonzero(depth[0]) > depth[0].size // 2
+    assert not np.array_equal(depth[0], depth[1])
+
+
+@pytest.mark.integration()
+def test_depth_is_absent_on_the_other_rgbd_cameras(episodes):
+    # Only RGBD_0 carries aligned_depth in this release.
+    (row,) = omnisharing.depth_frames(episodes, ["RGBD_1", "RGBD_2"]).to_pylist()
+    assert np.asarray(row["RGBD_1.depth"]).size == 0
+    assert np.asarray(row["RGBD_2.depth"]).size == 0
+
+
+@pytest.mark.integration()
+def test_depth_out_of_range_names_the_real_bound(episodes):
+    with pytest.raises(IndexError, match=rf"RGBD_0/aligned_depth has {N_FRAMES} frames"):
+        omnisharing.depth_frames(episodes, "RGBD_0", frame_indices=[99999])
+
+
+# ---------------------------------------------------------------------------
+# Stereo calibration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration()
+def test_stereo_baseline_is_physically_plausible(episodes):
+    (row,) = omnisharing.stereo_extrinsics(episodes, ["RGBD_0", "RGBD_1", "RGBD_2"]).to_pylist()
+
+    matrices = []
+    for camera in ("RGBD_0", "RGBD_1", "RGBD_2"):
+        matrix = np.asarray(row[f"{camera}.left_to_color"])
+        assert matrix.shape == (4, 4)
+        assert matrix.dtype == np.float64
+        assert row[f"{camera}.calib_date"]
+        matrices.append(matrix)
+
+    primary = matrices[0]
+    # A rigid transform whose translation is a real stereo separation. Shape
+    # alone would not catch a mis-parsed matrix; ~59 mm is checkable against the
+    # physical camera.
+    np.testing.assert_allclose(primary[:3, :3], np.eye(3), atol=1e-2)
+    np.testing.assert_array_equal(primary[3], [0.0, 0.0, 0.0, 1.0])
+    assert 0.01 < abs(float(primary[0, 3])) < 0.2
+
+    # Each camera is calibrated separately.
+    assert not all(np.array_equal(matrices[0], m) for m in matrices[1:])
+
+
+# ---------------------------------------------------------------------------
+# Frame-level alignment
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration()
+def test_frames_apply_the_action_offset_across_the_whole_episode(episodes):
+    fields = ["observation.lefthand.joints", "action.lefthand.joints"]
+    (episode_row,) = omnisharing.trajectory(episodes, fields=fields, include_attrs=False).to_pylist()
+    raw_action = np.asarray(episode_row["action.lefthand.joints"])
+
+    rows = omnisharing.frames(episodes, fields=fields).sort("frame_index").to_pylist()
+    assert len(rows) == N_FRAMES
+
+    for i, row in enumerate(rows):
+        expected = raw_action[min(i + 1, N_FRAMES - 1)]
+        np.testing.assert_array_equal(np.asarray(row["action.lefthand.joints"]), expected)
+
+    # The shift is genuinely applied rather than a no-op.
+    assert not np.array_equal(np.asarray(rows[0]["action.lefthand.joints"]), raw_action[0])
+
+
+@pytest.mark.integration()
+def test_rgb_alignment_is_not_frame_index_identity(episodes):
+    rows = (
+        omnisharing.frames(
+            episodes,
+            fields=["observation.lefthand.joints"],
+            align_cameras=["RGB_Camera0", ("RGBD_0", "color")],
+        )
+        .sort("frame_index")
+        .to_pylist()
+    )
+    rgb_index = [r["RGB_Camera0.frame_index"] for r in rows]
+    rgbd_index = [r["RGBD_0.color.frame_index"] for r in rows]
+
+    # RGB_Camera0 started recording before the observation clock, so index-based
+    # alignment would offset every frame.
+    assert rgb_index != list(range(N_FRAMES))
+    assert rgb_index[0] > 0
+    assert all(rgb_index[i] <= rgb_index[i + 1] for i in range(len(rgb_index) - 1))
+
+    # RGBD colour shares the observation clock and does align 1:1.
+    assert rgbd_index == list(range(N_FRAMES))
+
+
+@pytest.mark.integration()
+def test_rgbd_eyes_align_on_their_own_clocks(episodes):
+    rows = (
+        omnisharing.frames(
+            episodes,
+            fields=["observation.lefthand.joints"],
+            align_cameras=[("RGBD_0", "left"), ("RGBD_0", "right")],
+        )
+        .sort("frame_index")
+        .to_pylist()
+    )
+    assert len(rows) == N_FRAMES
+    left_index = [r["RGBD_0.left.frame_index"] for r in rows]
+
+    assert all(index is not None for index in left_index)
+    assert all(left_index[i] <= left_index[i + 1] for i in range(len(left_index) - 1))
+    # This hardware is tightly synchronised, so the residual is sub-frame; the
+    # point is that a per-eye clock is consulted at all.
+    assert all(abs(r["RGBD_0.left.timestamp_delta_us"]) < 1000 for r in rows)


### PR DESCRIPTION
PX OmniSharing is PaXini's omnimodal embodied-AI dataset. Unlike most manipulation datasets it records force and tactile sensing alongside vision: each episode captures a human wearing an instrumented exoskeleton glove, with 15 tactile pads per hand, a dozen synchronized RGB cameras, stereo RGBD cameras, hand proprioception, optional object poses, audio and a language instruction.

Adds thirteen functions for the DF-2 HDF5 stage, streaming only the datasets asked for so the 0.4-3.2 GB episodes are never downloaded whole:

- raw() catalogs episodes from filenames alone, with no file reads
- describe() dumps the object tree, since layout varies between releases
- episode_metadata() lifts task labels, the instruction and camera inventory
- trajectory(), tactile() and audio() return per-episode tensors
- objects() handles episodes with differing object counts
- cameras(), camera_payloads(), camera_frames() and depth_frames() cover vision
- stereo_extrinsics() parses the stereo calibration
- frames() expands to one row per frame with correct alignment

DF-3 is LeRobot v2.1 and is already served by daft.datasets.lerobot, so it is documented rather than reimplemented.

## Structure probed before implementing

The published layout is wrong or silent in several places, so a real 440 MB episode was probed over hf:// range reads before any code was written. The findings are recorded in the fixture's module docstring:

- camera payloads are described only as "1D compressed payload". RGB_Camera* is actually H.265/HEVC in Annex-B format, which has no container and needs an explicit format hint to decode; RGBD_* sub-streams are Matroska.
- audio is described as a "compressed audio stream (includes text)". It is neither: raw float64 PCM, with the instruction in a txt attr.
- an undocumented meta group holds the task labels.
- aligned_depth exists on RGBD_0 but appears in no published layout, and carries no attributes at all, so its depth unit cannot be derived from the file. The docstring says so rather than assuming millimetres.

## Four traps this reader handles

1. episode_index is not unique. It restarts per capture group, so part_01 alone holds two different episodes numbered 1217. raw() emits a composite episode_key; joining on episode_index would silently cross-match.

2. handpose quaternions are qw-first, [x, y, z, qw, qx, qy, qz], the reverse of scipy's convention. HANDPOSE_ORDER is asserted in the suite so a drift to [qx, qy, qz, qw] cannot pass silently.

3. Cameras do not share the observation clock. RGB cameras run faster, produce more frames (207 vs 208-254), start at a different moment, and carry non-contiguous ids. RGBD cameras additionally keep a clock per eye (left_timestamp, right_timestamp). frames(align_cameras=...) therefore matches by nearest timestamp and reports the residual as timestamp_delta_us.

4. action leads observation by one frame: action[i] is the state at i+1 with the final action repeated. Reading the arrays as stored misaligns state and action, which would poison any policy trained on them. frames() applies the offset, and its fields argument is mandatory rather than defaulted because a single tactile row is 3465 floats wide.

Nothing is hardcoded to DF-2 widths: DF-2R's 17 joints and 3750-wide tactile vector are read from the file and covered separately.

## Errors surfaced by verification, not by review

Several defects were only caught by running things, and are worth recording because each would have been invisible to code reading:

- An unnest=True UDF passed to with_column is silently dropped; the column count fell from 21 back to 10.
- .h5 files were accepted by the filename regex but excluded by the glob.
- An IndexError raised inside a UDF is swallowed by Daft, surfacing only as "Need at least 1 series to perform concat" with no mention of the camera or the bound. depth_frames() now validates bounds before execution.
- Any UDF returning an all-null tensor column fails the same way, with or without unnest, while mixed null/non-null works. Absent audio and depth are therefore reported as empty arrays rather than nulls.
- A zero-length aligned_depth raised while a missing one returned empty, even though both mean "nothing to read". Both now return empty.
- trajectory()'s hand description was field-order dependent.
- RGBD left/right have no extrinsics of their own; the fallback chain now reaches color/extrinsics.

Two test assumptions were also wrong rather than the code: camera-alignment index skipping needs ~10 frames to manifest, so the 8-frame fixture test was split into an index test and a drift test; and the real episode has 14 cameras (11 RGB + 3 RGBD), not 15 as first miscounted.

One premise was wrong outright: cameras() and frames() already resolved {stream}_timestamp with a timestamp fallback, so per-eye clocks worked from the start. The real gap was that the fixture gave all three RGBD clocks identical values, leaving the behaviour unverified rather than missing.

## Tests

Three suites, split by what they need:

- tests/datasets/test_omnisharing.py: 141 tests over a synthetic fixture, so CI never needs the 1.08 TB release. Decode tests run against real HEVC and Matroska streams that the fixture encodes locally with PyAV, keeping CC-BY-NC-SA data out of the repo.
- tests/datasets/test_omnisharing_docs.py: 15 tests executing every snippet in the guide, so a renamed column cannot leave the documentation silently wrong. These check more than syntax: that the documented duplicate episode_index really is ambiguous, and that the np.roll recipe genuinely moves qw last.
- tests/datasets/test_omnisharing_integration.py: 15 tests against the real release over hf://, marked integration so they stay out of the default run.

The integration suite exists to catch values that are structurally valid but physically wrong, anchoring assertions to independently checkable quantities:

- quaternion norms are exactly 1.000000 across all 207 frames, corroborating the qw-first layout rather than merely trusting the order attr
- tactile widths sum to exactly 3465 across 15 pads, each slice matching its declared length
- RGB decodes to 1200x1920x3 and RGBD to 720x1280x3, matching their intrinsics attrs, with per-frame std around 40 confirming real image content
- audio()'s sample count matches episode_metadata's audio_samples exactly, cross-checking two independent code paths
- depth comes back as (720, 1280) uint16, majority non-zero, a real depth map rather than padding
- stereo_extrinsics() yields a ~59 mm baseline for RGBD_0, a physically plausible separation, which is strong evidence the matrix is read correctly rather than merely having the right shape
- action[i] == raw action[i+1] holds for all 207 frames
- observation frame 0 aligns to a non-zero RGB_Camera0 frame, because that camera started recording earlier; index-based alignment would offset every frame

Two measurements are recorded rather than acted on. _open_for_scan() was written expecting a speedup from HDF5's 1 KiB scan buffer; walking all 20 camera streams over hf:// took 344s with it versus 362s with the 64 KiB default, so per-request latency dominates and its docstring says so. And the real left-eye residual is sub-frame, so this hardware is tightly synchronised and per-eye alignment is insurance rather than a correction; the fixture's deliberate 2 ms skew is what exercises the divergent path.

Verified by running: 218 tests in tests/datasets, 13 doctests, and the integration suite against the real release. All Python pre-commit hooks pass including mypy, ruff and codespell. pyproject.toml is untouched: no new dependencies beyond the existing daft[hdf5] and daft[video] extras.

## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

Closes #7436