### PR TITLE
perf(optimizer): rewrite starts_with filters into range predicates for pushdown pruning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3597,6 +3597,7 @@ dependencies = [
  "common-error",
  "daft-core",
  "daft-dsl",
+ "daft-functions-utf8",
  "daft-recordbatch",
  "serde",
  "snafu",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3369,6 +3369,7 @@ dependencies = [
  "common-runtime",
  "daft-core",
  "daft-dsl",
+ "daft-functions-utf8",
  "daft-io",
  "daft-recordbatch",
  "daft-stats",

--- a/src/daft-parquet/Cargo.toml
+++ b/src/daft-parquet/Cargo.toml
@@ -25,6 +25,7 @@ tokio-stream = {workspace = true}
 
 [dev-dependencies]
 bincode = {workspace = true}
+daft-functions-utf8 = {path = "../daft-functions-utf8", default-features = false}
 fastrand = "2.1.0"
 parquet = {workspace = true}
 path_macro = {workspace = true}

--- a/src/daft-parquet/src/helpers.rs
+++ b/src/daft-parquet/src/helpers.rs
@@ -312,3 +312,87 @@ pub fn prune_row_groups(
     }
     Ok(result)
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use arrow::{
+        array::{RecordBatch as ArrowRecordBatch, StringArray},
+        datatypes::{DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema},
+    };
+    use daft_core::prelude::{DataType, Field, Schema};
+    use daft_dsl::{lit, resolved_col};
+    use daft_functions_utf8::startswith;
+    use parquet::arrow::{ArrowWriter, arrow_reader::ParquetRecordBatchReaderBuilder};
+
+    use super::prune_row_groups;
+
+    /// End-to-end coverage for `starts_with` row-group pruning: write a real
+    /// parquet file with per-row-group min/max statistics, then confirm
+    /// `prune_row_groups` skips row groups using those stats. This exercises the
+    /// same path production reads use (`row_group_metadata_to_table_stats` ->
+    /// `TableStatistics::eval_expression`), not just the in-memory stats layer.
+    ///
+    /// Layout (two row groups, each flushed separately so each gets its own
+    /// min/max stats):
+    ///   row group 0: ["apple", "avocado"]    -> min="apple",  max="avocado"
+    ///   row group 1: ["banana", "blueberry"] -> min="banana", max="blueberry"
+    ///
+    /// Data is ASCII-only so signed/unsigned byte stat ordering is irrelevant.
+    #[test]
+    fn test_prune_row_groups_startswith_uses_stats() {
+        let dir = std::env::temp_dir().join("daft_test_prune_startswith");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("startswith.parquet");
+
+        let arrow_schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+            "s",
+            ArrowDataType::Utf8,
+            true,
+        )]));
+        let file = std::fs::File::create(&path).unwrap();
+        let mut writer = ArrowWriter::try_new(file, arrow_schema.clone(), None).unwrap();
+        for values in [vec!["apple", "avocado"], vec!["banana", "blueberry"]] {
+            let batch = ArrowRecordBatch::try_new(
+                arrow_schema.clone(),
+                vec![Arc::new(StringArray::from(values))],
+            )
+            .unwrap();
+            writer.write(&batch).unwrap();
+            // Flush after each batch so it becomes its own row group.
+            writer.flush().unwrap();
+        }
+        writer.close().unwrap();
+
+        let file = std::fs::File::open(&path).unwrap();
+        let builder = ParquetRecordBatchReaderBuilder::try_new(file).unwrap();
+        let metadata = builder.metadata();
+        assert_eq!(metadata.num_row_groups(), 2, "expected two row groups");
+
+        let schema = Schema::new(vec![Field::new("s", DataType::Utf8)]);
+        let uri = path.to_str().unwrap();
+
+        // starts_with(s, "b") => "b" <= s < "c": overlaps only row group 1.
+        let pred = startswith(resolved_col("s"), lit("b"));
+        let kept = prune_row_groups(metadata, None, 0, None, Some(&pred), &schema, uri).unwrap();
+        assert_eq!(kept, vec![1], "prefix 'b' must prune row group 0");
+
+        // starts_with(s, "a") => "a" <= s < "b": overlaps only row group 0.
+        let pred = startswith(resolved_col("s"), lit("a"));
+        let kept = prune_row_groups(metadata, None, 0, None, Some(&pred), &schema, uri).unwrap();
+        assert_eq!(kept, vec![0], "prefix 'a' must prune row group 1");
+
+        // starts_with(s, "c") => "c" <= s < "d": overlaps neither row group.
+        let pred = startswith(resolved_col("s"), lit("c"));
+        let kept = prune_row_groups(metadata, None, 0, None, Some(&pred), &schema, uri).unwrap();
+        assert!(kept.is_empty(), "prefix 'c' must prune both row groups");
+
+        // Empty prefix yields no useful bound (Missing), so nothing is pruned.
+        let pred = startswith(resolved_col("s"), lit(""));
+        let kept = prune_row_groups(metadata, None, 0, None, Some(&pred), &schema, uri).unwrap();
+        assert_eq!(kept, vec![0, 1], "empty prefix must not prune anything");
+
+        std::fs::remove_file(&path).ok();
+    }
+}

--- a/src/daft-stats/Cargo.toml
+++ b/src/daft-stats/Cargo.toml
@@ -6,6 +6,9 @@ daft-recordbatch = {path = "../daft-recordbatch", default-features = false}
 serde = {workspace = true}
 snafu = {workspace = true}
 
+[dev-dependencies]
+daft-functions-utf8 = {path = "../daft-functions-utf8", default-features = false}
+
 [features]
 python = ["common-error/python", "daft-core/python", "daft-dsl/python", "daft-recordbatch/python"]
 

--- a/src/daft-stats/src/table_stats.rs
+++ b/src/daft-stats/src/table_stats.rs
@@ -11,6 +11,7 @@ use daft_core::prelude::*;
 use daft_dsl::{
     Column, Expr, ExprRef,
     expr::{BoundColumn, bound_expr::BoundExpr},
+    functions::scalar::ScalarFn,
     null_lit, resolved_col,
 };
 use daft_recordbatch::RecordBatch;
@@ -157,6 +158,45 @@ impl TableStatistics {
                     stats.cast(dtype)
                 }
             }
+            // `starts_with(col, prefix)` is exactly equivalent to the half-open
+            // lexicographic range `prefix <= col < increment(prefix)`, so we can
+            // use min/max column statistics to prune row groups / scan tasks whose
+            // range does not overlap the prefix. This mirrors how mature engines
+            // (e.g. Spark's `StringStartsWith`) push prefix predicates into
+            // column-statistics-based data skipping.
+            Expr::ScalarFn(ScalarFn::Builtin(func)) if func.name() == "starts_with" => {
+                let args: Vec<&ExprRef> = func.inputs.iter().map(|arg| arg.inner()).collect();
+                // Expect exactly `starts_with(input, prefix)`.
+                if args.len() != 2 {
+                    return Ok(ColumnRangeStatistics::Missing);
+                }
+                // The prefix must be a non-empty Utf8 literal; anything else
+                // (column, non-string literal, empty prefix) yields no useful
+                // bound, so we conservatively return Missing (never prune).
+                let prefix = match args[1].as_ref() {
+                    Expr::Literal(Literal::Utf8(s)) if !s.is_empty() => s.clone(),
+                    _ => return Ok(ColumnRangeStatistics::Missing),
+                };
+
+                let col_stats = self.eval_expression(&BoundExpr::new_unchecked(args[0].clone()))?;
+
+                // Lower bound: col >= prefix
+                let lower: ColumnRangeStatistics = Literal::Utf8(prefix.clone()).try_into()?;
+                let ge = col_stats.gte(&lower)?;
+
+                match increment_utf8_prefix(&prefix) {
+                    // Upper bound exists: col < increment(prefix)
+                    Some(upper) => {
+                        let upper: ColumnRangeStatistics = Literal::Utf8(upper).try_into()?;
+                        let lt = col_stats.lt(&upper)?;
+                        ge.bitand(&lt)
+                    }
+                    // Prefix is all max-value characters: no valid exclusive upper
+                    // bound exists, so fall back to the lower-bound-only test. This
+                    // is still sound (it just prunes less).
+                    None => Ok(ge),
+                }
+            }
             _ => Ok(ColumnRangeStatistics::Missing),
         }
     }
@@ -208,6 +248,53 @@ impl TableStatistics {
     }
 }
 
+/// Compute the lexicographically-next string prefix, used as the exclusive upper
+/// bound when pruning with `starts_with(col, prefix)`:
+/// `prefix <= col < increment_utf8_prefix(prefix)`.
+///
+/// It increments the right-most Unicode scalar value that can be incremented
+/// (walking right to left), dropping any trailing characters already at their
+/// maximum. Returns `None` when every character is at the maximum scalar value,
+/// in which case the caller should fall back to a lower-bound-only range.
+///
+/// # UTF-8 / Unicode ordering
+///
+/// This operates on Unicode scalar values (chars), not bytes. Because UTF-8 byte
+/// ordering matches Unicode code point ordering, incrementing a char's code point
+/// produces the correct lexicographic successor for byte-wise string comparison.
+///
+/// Examples:
+/// - `"abc"`  -> `Some("abd")`
+/// - `"café"` -> `Some("cafê")`  (é U+00E9 -> ê U+00EA)
+/// - `"az"` with a max last char is handled by carrying to the previous char.
+fn increment_utf8_prefix(prefix: &str) -> Option<String> {
+    let chars: Vec<char> = prefix.chars().collect();
+    for i in (0..chars.len()).rev() {
+        if let Some(next) = next_unicode_scalar(chars[i]) {
+            let mut result: String = chars[..i].iter().collect();
+            result.push(next);
+            return Some(result);
+        }
+        // chars[i] is at the maximum scalar value; drop it and carry left.
+    }
+    // Every character was at the maximum scalar value.
+    None
+}
+
+/// Return the next valid Unicode scalar value after `c`, skipping the surrogate
+/// range (U+D800..=U+DFFF) which is not valid in UTF-8. Returns `None` when `c`
+/// is already the maximum scalar value (U+10FFFF).
+fn next_unicode_scalar(c: char) -> Option<char> {
+    let next = (c as u32).checked_add(1)?;
+    // Skip the surrogate range, which does not contain valid `char`s.
+    let next = if (0xD800..=0xDFFF).contains(&next) {
+        0xE000
+    } else {
+        next
+    };
+    char::from_u32(next)
+}
+
 impl Display for TableStatistics {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let columns = self
@@ -245,6 +332,7 @@ mod test {
 
     use daft_core::prelude::*;
     use daft_dsl::{Expr, expr::bound_expr::BoundExpr, lit, null_lit, resolved_col};
+    use daft_functions_utf8::{endswith, startswith};
     use daft_recordbatch::RecordBatch;
     use snafu::ResultExt;
 
@@ -391,6 +479,104 @@ mod test {
 
         // col > 12 → Maybe (12 is within [10, 20], some values satisfy, some don't)
         let expr = BoundExpr::try_new(resolved_col("a").gt(lit(12i64)), &table.schema)
+            .context(DaftCoreComputeSnafu)?;
+        let result = table_stats.eval_expression(&expr)?;
+        assert_eq!(result.to_truth_value(), TruthValue::Maybe);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_startswith_prunes_when_prefix_outside_range() -> crate::Result<()> {
+        // Stats: min="apple", max="avocado". Predicate: starts_with(col, "b")
+        // is equivalent to "b" <= col < "c"; the entire [apple, avocado] range
+        // is below "b", so the row group must be pruned (False).
+        let table = RecordBatch::from_nonempty_columns(vec![
+            Utf8Array::from_slice("s", &["apple", "avocado"]).into_series(),
+        ])
+        .unwrap();
+        let table_stats = TableStatistics::from_table(&table);
+
+        let expr = BoundExpr::try_new(startswith(resolved_col("s"), lit("b")), &table.schema)
+            .context(DaftCoreComputeSnafu)?;
+        let result = table_stats.eval_expression(&expr)?;
+        assert_eq!(result.to_truth_value(), TruthValue::False);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_startswith_maybe_when_prefix_in_range() -> crate::Result<()> {
+        // Stats: min="apple", max="cherry". starts_with(col, "b") maps to the
+        // range ["b", "c"), which overlaps [apple, cherry], so we cannot prune
+        // and must return Maybe (some row groups may contain matches).
+        let table = RecordBatch::from_nonempty_columns(vec![
+            Utf8Array::from_slice("s", &["apple", "banana", "cherry"]).into_series(),
+        ])
+        .unwrap();
+        let table_stats = TableStatistics::from_table(&table);
+
+        let expr = BoundExpr::try_new(startswith(resolved_col("s"), lit("b")), &table.schema)
+            .context(DaftCoreComputeSnafu)?;
+        let result = table_stats.eval_expression(&expr)?;
+        assert_eq!(result.to_truth_value(), TruthValue::Maybe);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_startswith_all_max_prefix_falls_back_to_lower_bound() -> crate::Result<()> {
+        // A prefix consisting solely of the maximum Unicode scalar has no valid
+        // exclusive upper bound, so we degrade to the lower-bound-only test
+        // (col >= prefix). Here max="z" < prefix, so the lower-bound test alone
+        // is enough to soundly prune the group (False).
+        let table = RecordBatch::from_nonempty_columns(vec![
+            Utf8Array::from_slice("s", &["a", "z"]).into_series(),
+        ])
+        .unwrap();
+        let table_stats = TableStatistics::from_table(&table);
+
+        let expr = BoundExpr::try_new(
+            startswith(resolved_col("s"), lit("\u{10FFFF}")),
+            &table.schema,
+        )
+        .context(DaftCoreComputeSnafu)?;
+        let result = table_stats.eval_expression(&expr)?;
+        assert_eq!(result.to_truth_value(), TruthValue::False);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_startswith_empty_prefix_never_prunes() -> crate::Result<()> {
+        // An empty prefix matches everything, so it yields no useful bound and
+        // must return Missing (Maybe) rather than pruning anything.
+        let table = RecordBatch::from_nonempty_columns(vec![
+            Utf8Array::from_slice("s", &["apple", "avocado"]).into_series(),
+        ])
+        .unwrap();
+        let table_stats = TableStatistics::from_table(&table);
+
+        let expr = BoundExpr::try_new(startswith(resolved_col("s"), lit("")), &table.schema)
+            .context(DaftCoreComputeSnafu)?;
+        let result = table_stats.eval_expression(&expr)?;
+        assert_eq!(result.to_truth_value(), TruthValue::Maybe);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_endswith_is_not_handled_and_stays_maybe() -> crate::Result<()> {
+        // Only starts_with has a sound range mapping. ends_with (and other
+        // string predicates) must fall through to Missing/Maybe so they never
+        // incorrectly prune a row group.
+        let table = RecordBatch::from_nonempty_columns(vec![
+            Utf8Array::from_slice("s", &["apple", "avocado"]).into_series(),
+        ])
+        .unwrap();
+        let table_stats = TableStatistics::from_table(&table);
+
+        let expr = BoundExpr::try_new(endswith(resolved_col("s"), lit("b")), &table.schema)
             .context(DaftCoreComputeSnafu)?;
         let result = table_stats.eval_expression(&expr)?;
         assert_eq!(result.to_truth_value(), TruthValue::Maybe);

--- a/src/daft-stats/src/table_stats.rs
+++ b/src/daft-stats/src/table_stats.rs
@@ -264,7 +264,7 @@ impl TableStatistics {
 /// produces the correct lexicographic successor for byte-wise string comparison.
 ///
 /// Examples:
-/// - `"abc"`  -> `Some("abd")`
+/// - `"foo"`  -> `Some("fop")`
 /// - `"café"` -> `Some("cafê")`  (é U+00E9 -> ê U+00EA)
 /// - `"az"` with a max last char is handled by carrying to the previous char.
 fn increment_utf8_prefix(prefix: &str) -> Option<String> {

--- a/src/daft-stats/src/table_stats.rs
+++ b/src/daft-stats/src/table_stats.rs
@@ -165,20 +165,28 @@ impl TableStatistics {
             // (e.g. Spark's `StringStartsWith`) push prefix predicates into
             // column-statistics-based data skipping.
             Expr::ScalarFn(ScalarFn::Builtin(func)) if func.name() == "starts_with" => {
-                let args: Vec<&ExprRef> = func.inputs.iter().map(|arg| arg.inner()).collect();
-                // Expect exactly `starts_with(input, prefix)`.
-                if args.len() != 2 {
+                // Bind by name, not position: `starts_with`'s two arguments are
+                // both named (`input`, `pattern`) and a caller may pass them as
+                // keyword args in either order, so positional indexing would be
+                // fragile. This mirrors the binding used by the `starts_with`
+                // kernel itself (see daft-functions-utf8/src/utils.rs). If either
+                // argument is absent we fail safe by returning Missing (no
+                // pruning) rather than propagating an error.
+                let (Ok(input), Ok(pattern)) = (
+                    func.inputs.required((0, "input")),
+                    func.inputs.required((1, "pattern")),
+                ) else {
                     return Ok(ColumnRangeStatistics::Missing);
-                }
+                };
                 // The prefix must be a non-empty Utf8 literal; anything else
                 // (column, non-string literal, empty prefix) yields no useful
                 // bound, so we conservatively return Missing (never prune).
-                let prefix = match args[1].as_ref() {
+                let prefix = match pattern.as_ref() {
                     Expr::Literal(Literal::Utf8(s)) if !s.is_empty() => s.clone(),
                     _ => return Ok(ColumnRangeStatistics::Missing),
                 };
 
-                let col_stats = self.eval_expression(&BoundExpr::new_unchecked(args[0].clone()))?;
+                let col_stats = self.eval_expression(&BoundExpr::new_unchecked(input.clone()))?;
 
                 // Lower bound: col >= prefix
                 let lower: ColumnRangeStatistics = Literal::Utf8(prefix.clone()).try_into()?;
@@ -336,7 +344,7 @@ mod test {
     use daft_recordbatch::RecordBatch;
     use snafu::ResultExt;
 
-    use super::TableStatistics;
+    use super::{TableStatistics, increment_utf8_prefix, next_unicode_scalar};
     use crate::{DaftCoreComputeSnafu, column_stats::TruthValue};
 
     #[test]
@@ -582,5 +590,47 @@ mod test {
         assert_eq!(result.to_truth_value(), TruthValue::Maybe);
 
         Ok(())
+    }
+
+    #[test]
+    fn test_increment_utf8_prefix_basic() {
+        // ASCII: the last scalar advances by one.
+        assert_eq!(increment_utf8_prefix("a"), Some("b".to_string()));
+        assert_eq!(increment_utf8_prefix("foo"), Some("fop".to_string()));
+        // Multibyte: é (U+00E9) -> ê (U+00EA); UTF-8 byte order matches scalar
+        // order, so this is the correct exclusive upper bound.
+        assert_eq!(increment_utf8_prefix("café"), Some("cafê".to_string()));
+    }
+
+    #[test]
+    fn test_increment_utf8_prefix_skips_surrogate_range() {
+        // U+D7FF is the last scalar before the surrogate range; its successor
+        // must skip U+D800..=U+DFFF and land on U+E000.
+        assert_eq!(next_unicode_scalar('\u{D7FF}'), Some('\u{E000}'));
+        assert_eq!(
+            increment_utf8_prefix("\u{D7FF}"),
+            Some("\u{E000}".to_string())
+        );
+    }
+
+    #[test]
+    fn test_increment_utf8_prefix_carries_left_past_max_scalar() {
+        // A trailing U+10FFFF (char::MAX) has no successor, so it is dropped and
+        // the increment carries to the previous char.
+        assert_eq!(increment_utf8_prefix("a\u{10FFFF}"), Some("b".to_string()));
+        // Multiple trailing max scalars collapse into a single carry.
+        assert_eq!(
+            increment_utf8_prefix("ab\u{10FFFF}\u{10FFFF}"),
+            Some("ac".to_string())
+        );
+    }
+
+    #[test]
+    fn test_increment_utf8_prefix_all_max_scalar_is_none() {
+        // When every char is char::MAX there is no valid exclusive upper bound,
+        // so the caller must fall back to the lower-bound-only test.
+        assert_eq!(next_unicode_scalar('\u{10FFFF}'), None);
+        assert_eq!(increment_utf8_prefix("\u{10FFFF}"), None);
+        assert_eq!(increment_utf8_prefix("\u{10FFFF}\u{10FFFF}"), None);
     }
 }


### PR DESCRIPTION
## Changes Made

Implements #7440: enable data skipping for `starts_with(col, prefix)` filters.

Per @srilman's review feedback, this is now implemented as a **planner-level expression rewrite** instead of an extension to `TableStatistics::eval_expression`: a new `RewriteStartsWith` optimizer rule (running right after `SimplifyExpressionsRule`, before `PushDownFilter`) rewrites Filter predicates

    starts_with(c, P)  ->  c >= P AND c < increment(P)

`increment(P)` bumps the right-most incrementable Unicode scalar of the prefix (skipping the U+D800..=U+DFFF surrogate range); if every char is at the maximum scalar value it falls back to a sound lower-bound-only rewrite (`c >= P`). Non-literal / empty patterns are left untouched.

### Why the planner rewrite is the better home
- A lone `starts_with` filter never reached `pushdowns.filters` before: `daft-scan`'s `expr_rewriter.rs` classifies every `Expr::ScalarFn` as a UDF and routes it to a residual Filter op. The rewritten predicate is plain comparisons + conjunction, so it becomes a data predicate and is pushed into the scan natively — for **any** source (Parquet, CSV, Lance, Iceberg, ...), not just the stats layer.
- Once pushed down, the existing Utf8 min/max statistics pruning (`TableStatistics::eval_expression` already handles `>=`/`<`/`AND`) skips row groups and scan tasks for free — no `starts_with` knowledge needed in `daft-stats`. Sources with their own pushdown translation (e.g. Iceberg) now see range bounds instead of an opaque function call.
- Scope: only Filter predicates are rewritten. Projections keep the single `starts_with` kernel call, which is cheaper than two comparisons plus an AND and has no pushdown to gain.

### Safety
- UTF-8 byte order equals Unicode code point order, so char-level increment yields the correct lexicographic successor for byte-wise string comparison.
- The rewrite is pointwise semantically equivalent (including null -> null), so it composes under AND/OR/NOT.
- Arguments are bound **by name** (`input`/`pattern`), so keyword-arg calls in any order rewrite correctly.

### Tests
- Rule plan-shape tests: basic rewrite; nested in AND/OR; empty prefix untouched; non-literal pattern untouched; all-max fallback; carry past trailing max chars; named-argument binding; projection untouched; Unicode helper unit tests (surrogate gap, U+10FFFF).
- Full-optimizer integration test asserting the range predicate lands in the scan's `pushdowns.filters`.
- Parquet e2e tests (`tests/io/test_starts_with_pushdown.py`): rewritten pushdown visible in the optimized/physical plan, correct pruning results across prefixes, empty-prefix and null semantics, SQL path.
- `cargo test -p daft-logical-plan` (298 passed), clippy + fmt clean.

The previous `daft-stats`/`daft-parquet` approach is reverted in this branch.

## Related Issues
Closes #7440.