### PR TITLE
fix(distributed): tolerate shuffle outputs with no partitions

### DIFF
--- a/src/daft-distributed/src/utils/transpose.rs
+++ b/src/daft-distributed/src/utils/transpose.rs
@@ -36,8 +36,10 @@ pub(crate) fn transpose_materialized_outputs_from_vec(
 /// from all input materialized outputs.
 ///
 /// # Arguments
-/// * `materialized_partitions` - A vector of materialized outputs, each containing `num_partitions` partitions
-/// * `num_partitions` - The number of partitions each materialized output should contain
+/// * `materialized_partitions` - A vector of materialized outputs, each containing `num_partitions`
+///   partitions, or no partitions at all when the producing task emitted no output (e.g. its input
+///   was cut to zero rows by a limit sitting below the shuffle).
+/// * `num_partitions` - The number of partitions each non-empty materialized output should contain
 ///
 /// # Returns
 /// * A vector of partition groups, where each group contains all materialized outputs for that partition
@@ -48,8 +50,8 @@ fn transpose_materialized_outputs(
     debug_assert!(
         materialized_partitions
             .iter()
-            .all(|mat| mat.len() == num_partitions),
-        "Expected all outputs to have {} partitions, got {}",
+            .all(|mat| mat.len() == num_partitions || mat.is_empty()),
+        "Expected all outputs to have {} partitions or none at all, got {}",
         num_partitions,
         materialized_partitions
             .iter()
@@ -61,7 +63,11 @@ fn transpose_materialized_outputs(
     for idx in 0..num_partitions {
         let mut partition_group = vec![];
         for materialized_partition in &materialized_partitions {
-            let part = &materialized_partition[idx];
+            // An output with no partitions carries no rows for any partition index,
+            // so it contributes nothing to any partition group.
+            let Some(part) = materialized_partition.get(idx) else {
+                continue;
+            };
             if part.num_rows() > 0 {
                 partition_group.push(part.clone());
             }

--- a/tests/dataframe/test_limit_offset.py
+++ b/tests/dataframe/test_limit_offset.py
@@ -718,4 +718,9 @@ def test_limit_below_and_above_multipartition_join():
     right = daft.range(0, 100, partitions=8).select(col("id").alias("k"))
     joined = left.limit(20).join(right, on="k", how="left").limit(20)
     result = joined.to_pydict()
-    assert len(next(iter(result.values()))) == 20
+    # Each left row (id 0..19, k = id % 100) matches exactly one right row with
+    # the same key, so the join must pair every id i with key i. Asserting the
+    # exact set of (id, key) pairs -- rather than only the row count -- catches
+    # mis-routed, duplicated, or null-extended rows leaking through the shuffle.
+    # Sorting keeps the check independent of distributed row ordering.
+    assert sorted(zip(result["id"], result["k"])) == [(i, i) for i in range(20)]

--- a/tests/dataframe/test_limit_offset.py
+++ b/tests/dataframe/test_limit_offset.py
@@ -718,9 +718,15 @@ def test_limit_below_and_above_multipartition_join():
     right = daft.range(0, 100, partitions=8).select(col("id").alias("k"))
     joined = left.limit(20).join(right, on="k", how="left").limit(20)
     result = joined.to_pydict()
-    # Each left row (id 0..19, k = id % 100) matches exactly one right row with
-    # the same key, so the join must pair every id i with key i. Asserting the
-    # exact set of (id, key) pairs -- rather than only the row count -- catches
-    # mis-routed, duplicated, or null-extended rows leaking through the shuffle.
-    # Sorting keeps the check independent of distributed row ordering.
-    assert sorted(zip(result["id"], result["k"])) == [(i, i) for i in range(20)]
+    # Daft's LIMIT is unordered: which 20 rows survive depends on partition
+    # scheduling, so the surviving ids are not deterministic across runners.
+    # What must hold regardless is that the shuffle neither lost, duplicated,
+    # mis-routed, nor null-extended a row: exactly 20 distinct ids come back and
+    # each keeps the key it was assigned (k == id % 100), proving the join paired
+    # every surviving left row with its one matching right row.
+    ids = result["id"]
+    keys = result["k"]
+    assert len(ids) == 20, "shuffle dropped rows produced by the limit"
+    assert len(set(ids)) == 20, "limit/join duplicated or fanned out rows"
+    assert all(k is not None for k in keys), "left join null-extended a matched row"
+    assert all(k == i % 100 for i, k in zip(ids, keys)), "shuffle mis-routed join keys"

--- a/tests/dataframe/test_limit_offset.py
+++ b/tests/dataframe/test_limit_offset.py
@@ -705,3 +705,17 @@ def test_multiple_limits():
 
     df = df.to_pydict()
     assert df["id"] == [i for i in range(901, 1000)]
+
+
+def test_limit_below_and_above_multipartition_join():
+    # Regression test for a panic in the distributed shuffle: a Limit below a
+    # join cuts some upstream tasks down to zero rows, so those tasks emit a
+    # materialized output with no partitions at all. Transposing the shuffle
+    # outputs used to require every output to carry exactly `num_partitions`
+    # partitions and indexed into them unconditionally, which panicked with
+    # "Expected all outputs to have 8 partitions, got 0, 8, 0, ...".
+    left = daft.range(0, 1000, partitions=8).with_column("k", col("id") % 100)
+    right = daft.range(0, 100, partitions=8).select(col("id").alias("k"))
+    joined = left.limit(20).join(right, on="k", how="left").limit(20)
+    result = joined.to_pydict()
+    assert len(next(iter(result.values()))) == 20


### PR DESCRIPTION
## Changes Made

`transpose_materialized_outputs` asserted that every materialized output carries exactly `num_partitions` partitions and then indexed into each one unconditionally. A task whose input was cut to zero rows - e.g. by a `Limit` sitting below a join's shuffle, where the coordinated distributed limit lets only the first tasks emit rows - produces a materialized output with **no partitions at all**, so the `debug_assert!` fires in debug builds and the indexing would run out of bounds in release builds.

Such an output carries no rows for any partition index, so it contributes nothing to any partition group. This skips missing indices and relaxes the assert to allow an output to be either fully partitioned or empty. For well-formed outputs the code path is unchanged.

## Reproducer

Plain user code on `main`, no optimizer changes involved:

```python
import daft
from daft import col

left = daft.range(0, 1000, partitions=8).with_column("k", col("id") % 100)
right = daft.range(0, 100, partitions=8).select(col("id").alias("k"))
left.limit(20).join(right, on="k", how="left").limit(20).to_pydict()
```

```
DAFT_RUNNER=ray
daft.exceptions.DaftCoreException: task 4 panicked with message
  "Expected all outputs to have 8 partitions, got 0, 8, 0, 0, 0, 0, 0, 8"
```

The same query succeeds on the native runner, and succeeds on both runners with this fix. Added as a regression test in `tests/dataframe/test_limit_offset.py`.

## Notes

This also unblocks limit pushdown through joins (#7439): that rule produces exactly this plan shape - a limit directly below the join's shuffle - for every `join` + `limit` query, so it turns a rare user pattern into an always-on one.
