### PR TITLE
fix(parquet): account for deleted rows in limit pushdown

### DIFF
--- a/src/daft-parquet/src/helpers.rs
+++ b/src/daft-parquet/src/helpers.rs
@@ -64,6 +64,31 @@ pub fn build_offset_row_selection(offset: usize, total_rows: usize) -> RowSelect
     }
 }
 
+/// Sorted, deduplicated view of positional delete indices.
+///
+/// Callers typically pass sorted data, in which case this borrows.
+fn normalize_deletes(delete_rows: &[i64]) -> Cow<'_, [i64]> {
+    if delete_rows.windows(2).any(|w| w[0] >= w[1]) {
+        let mut sorted = delete_rows.to_vec();
+        sorted.sort_unstable();
+        sorted.dedup();
+        Cow::Owned(sorted)
+    } else {
+        Cow::Borrowed(delete_rows)
+    }
+}
+
+/// Number of deleted rows within the file-global range `[lo, hi)`.
+pub fn count_deletes_in_range(delete_rows: &[i64], lo: usize, hi: usize) -> usize {
+    if delete_rows.is_empty() || hi <= lo {
+        return 0;
+    }
+    let normalized = normalize_deletes(delete_rows);
+    let start = normalized.partition_point(|&r| (r as usize) < lo);
+    let end = normalized.partition_point(|&r| (r as usize) < hi);
+    end - start
+}
+
 /// Build a `RowSelection` for a single row group from Iceberg positional
 /// delete indices.
 pub fn build_single_rg_delete_selection(
@@ -75,15 +100,7 @@ pub fn build_single_rg_delete_selection(
         delete_rows.iter().all(|&r| r >= 0),
         "delete_rows contains negative values"
     );
-    // Normalize: ensure sorted+unique (callers typically pass sorted data).
-    let normalized: Cow<'_, [i64]> = if delete_rows.windows(2).any(|w| w[0] >= w[1]) {
-        let mut sorted = delete_rows.to_vec();
-        sorted.sort_unstable();
-        sorted.dedup();
-        Cow::Owned(sorted)
-    } else {
-        Cow::Borrowed(delete_rows)
-    };
+    let normalized = normalize_deletes(delete_rows);
 
     let rg_end = rg_global_start + rg_rows;
     let lo = normalized.partition_point(|&r| (r as usize) < rg_global_start);
@@ -236,6 +253,11 @@ pub fn validate_requested_row_groups(
 ///   limit only after filtering, so later RGs may still be needed)
 /// - `predicate` stats: drop RGs the min/max stats prove can't match
 ///
+/// `delete_rows` holds Iceberg positional deletes. Those rows never reach the
+/// consumer, so they must not count against the `num_rows` budget — otherwise a
+/// heavily-deleted RG exhausts the budget and later RGs are dropped, returning
+/// fewer rows than requested.
+///
 /// Returns RG indices in original (file) order.
 #[allow(clippy::too_many_arguments)]
 pub fn prune_row_groups(
@@ -243,6 +265,7 @@ pub fn prune_row_groups(
     requested_row_groups: Option<&[i64]>,
     start_offset: usize,
     num_rows: Option<usize>,
+    delete_rows: Option<&[i64]>,
     predicate: Option<&ExprRef>,
     schema: &Schema,
     uri: &str,
@@ -303,12 +326,49 @@ pub fn prune_row_groups(
             }
         }
         result.push(rg_idx);
-        let contrib = if rg_start < start_offset {
-            rg_end - start_offset
-        } else {
-            rg_rows
-        };
+        let visible_start = rg_start.max(start_offset);
+        let contrib = (rg_end - visible_start).saturating_sub(count_deletes_in_range(
+            delete_rows.unwrap_or(&[]),
+            visible_start,
+            rg_end,
+        ));
         rows_remaining = rows_remaining.saturating_sub(contrib as i64);
     }
     Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::count_deletes_in_range;
+
+    #[test]
+    fn counts_deletes_inside_range_only() {
+        let deletes = [0i64, 1, 2, 50, 51, 199];
+        assert_eq!(count_deletes_in_range(&deletes, 0, 50), 3);
+        assert_eq!(count_deletes_in_range(&deletes, 50, 100), 2);
+        assert_eq!(count_deletes_in_range(&deletes, 100, 150), 0);
+        assert_eq!(count_deletes_in_range(&deletes, 150, 200), 1);
+    }
+
+    #[test]
+    fn range_bounds_are_half_open() {
+        let deletes = [10i64];
+        assert_eq!(count_deletes_in_range(&deletes, 10, 11), 1);
+        assert_eq!(count_deletes_in_range(&deletes, 11, 20), 0);
+        assert_eq!(count_deletes_in_range(&deletes, 0, 10), 0);
+    }
+
+    #[test]
+    fn empty_or_inverted_range_counts_nothing() {
+        assert_eq!(count_deletes_in_range(&[], 0, 100), 0);
+        assert_eq!(count_deletes_in_range(&[5i64], 10, 10), 0);
+        assert_eq!(count_deletes_in_range(&[5i64], 10, 5), 0);
+    }
+
+    #[test]
+    fn unsorted_and_duplicate_deletes_are_normalized() {
+        let deletes = [51i64, 0, 50, 0, 2, 1];
+        assert_eq!(count_deletes_in_range(&deletes, 0, 50), 3);
+        assert_eq!(count_deletes_in_range(&deletes, 50, 100), 2);
+    }
 }

--- a/src/daft-parquet/src/helpers.rs
+++ b/src/daft-parquet/src/helpers.rs
@@ -66,8 +66,14 @@ pub fn build_offset_row_selection(offset: usize, total_rows: usize) -> RowSelect
 
 /// Sorted, deduplicated view of positional delete indices.
 ///
-/// Callers typically pass sorted data, in which case this borrows.
-fn normalize_deletes(delete_rows: &[i64]) -> Cow<'_, [i64]> {
+/// Callers typically pass sorted data, in which case this borrows. Hoist this out
+/// of per-row-group loops: the sortedness probe is O(n), so normalizing once per
+/// row group turns row group pruning into O(row groups x deletes).
+pub fn normalize_deletes(delete_rows: &[i64]) -> Cow<'_, [i64]> {
+    debug_assert!(
+        delete_rows.iter().all(|&r| r >= 0),
+        "delete_rows contains negative values"
+    );
     if delete_rows.windows(2).any(|w| w[0] >= w[1]) {
         let mut sorted = delete_rows.to_vec();
         sorted.sort_unstable();
@@ -78,15 +84,57 @@ fn normalize_deletes(delete_rows: &[i64]) -> Cow<'_, [i64]> {
     }
 }
 
-/// Number of deleted rows within the file-global range `[lo, hi)`.
-pub fn count_deletes_in_range(delete_rows: &[i64], lo: usize, hi: usize) -> usize {
-    if delete_rows.is_empty() || hi <= lo {
+/// Number of deletes in the file-global range `[lo, hi)` of an already-normalized
+/// slice. `sorted` must be sorted ascending and non-negative — otherwise the
+/// `(r as usize)` comparison is not monotonic over it and the result is garbage.
+fn count_deletes_in_sorted_range(sorted: &[i64], lo: usize, hi: usize) -> usize {
+    if sorted.is_empty() || hi <= lo {
         return 0;
     }
-    let normalized = normalize_deletes(delete_rows);
-    let start = normalized.partition_point(|&r| (r as usize) < lo);
-    let end = normalized.partition_point(|&r| (r as usize) < hi);
+    let start = sorted.partition_point(|&r| (r as usize) < lo);
+    let end = sorted.partition_point(|&r| (r as usize) < hi);
     end - start
+}
+
+/// File-relative index of the first row of every row group.
+pub fn row_group_file_starts(metadata: &ParquetMetaData) -> Vec<usize> {
+    let mut starts = Vec::with_capacity(metadata.num_row_groups());
+    let mut acc = 0usize;
+    for rg_idx in 0..metadata.num_row_groups() {
+        starts.push(acc);
+        acc += metadata.row_group(rg_idx).num_rows() as usize;
+    }
+    starts
+}
+
+/// Rows in `rg_indices` that actually reach the consumer, i.e. physical rows
+/// minus the positional deletes falling inside those row groups.
+///
+/// This is the same quantity the row-level path derives from
+/// `RowSelection::row_count()`; keep the two in agreement.
+pub fn visible_rows_in_row_groups(
+    metadata: &ParquetMetaData,
+    rg_indices: &[usize],
+    delete_rows: Option<&[i64]>,
+) -> usize {
+    let physical: usize = rg_indices
+        .iter()
+        .map(|&i| metadata.row_group(i).num_rows() as usize)
+        .sum();
+    let Some(deletes) = delete_rows.filter(|d| !d.is_empty()) else {
+        return physical;
+    };
+    let normalized = normalize_deletes(deletes);
+    let starts = row_group_file_starts(metadata);
+    let deleted: usize = rg_indices
+        .iter()
+        .map(|&i| {
+            let start = starts[i];
+            let end = start + metadata.row_group(i).num_rows() as usize;
+            count_deletes_in_sorted_range(&normalized, start, end)
+        })
+        .sum();
+    physical.saturating_sub(deleted)
 }
 
 /// Build a `RowSelection` for a single row group from Iceberg positional
@@ -96,10 +144,6 @@ pub fn build_single_rg_delete_selection(
     rg_global_start: usize,
     rg_rows: usize,
 ) -> RowSelection {
-    debug_assert!(
-        delete_rows.iter().all(|&r| r >= 0),
-        "delete_rows contains negative values"
-    );
     let normalized = normalize_deletes(delete_rows);
 
     let rg_end = rg_global_start + rg_rows;
@@ -278,12 +322,10 @@ pub fn prune_row_groups(
 
     // File-relative row starts for ALL RGs — start_offset is a file-level
     // skip, not relative to `candidates`.
-    let mut rg_file_start = Vec::with_capacity(num_row_groups);
-    let mut acc = 0usize;
-    for rg_idx in 0..num_row_groups {
-        rg_file_start.push(acc);
-        acc += metadata.row_group(rg_idx).num_rows() as usize;
-    }
+    let rg_file_start = row_group_file_starts(metadata);
+
+    // Normalize once, not once per candidate row group.
+    let normalized_deletes = delete_rows.map(normalize_deletes);
 
     let mut rows_remaining: i64 = if predicate.is_none() {
         num_rows.map(|n| n as i64).unwrap_or(i64::MAX)
@@ -327,11 +369,10 @@ pub fn prune_row_groups(
         }
         result.push(rg_idx);
         let visible_start = rg_start.max(start_offset);
-        let contrib = (rg_end - visible_start).saturating_sub(count_deletes_in_range(
-            delete_rows.unwrap_or(&[]),
-            visible_start,
-            rg_end,
-        ));
+        let deleted = normalized_deletes.as_deref().map_or(0, |d| {
+            count_deletes_in_sorted_range(d, visible_start, rg_end)
+        });
+        let contrib = (rg_end - visible_start).saturating_sub(deleted);
         rows_remaining = rows_remaining.saturating_sub(contrib as i64);
     }
     Ok(result)
@@ -339,36 +380,150 @@ pub fn prune_row_groups(
 
 #[cfg(test)]
 mod tests {
-    use super::count_deletes_in_range;
+    use std::sync::Arc;
+
+    use daft_core::prelude::Schema;
+    use parquet::{
+        file::metadata::{FileMetaData, ParquetMetaData, RowGroupMetaData},
+        schema::types::{SchemaDescriptor, Type},
+    };
+
+    use super::{
+        count_deletes_in_sorted_range, normalize_deletes, prune_row_groups,
+        visible_rows_in_row_groups,
+    };
+
+    /// `ParquetMetaData` with `rows_per_group.len()` row groups and no statistics.
+    fn metadata_with_row_groups(rows_per_group: &[i64]) -> ParquetMetaData {
+        let schema = Arc::new(Type::group_type_builder("schema").build().unwrap());
+        let descr = Arc::new(SchemaDescriptor::new(schema));
+        let row_groups = rows_per_group
+            .iter()
+            .map(|&n| {
+                RowGroupMetaData::builder(descr.clone())
+                    .set_num_rows(n)
+                    .build()
+                    .unwrap()
+            })
+            .collect();
+        let file_metadata =
+            FileMetaData::new(2, rows_per_group.iter().sum(), None, None, descr, None);
+        ParquetMetaData::new(file_metadata, row_groups)
+    }
 
     #[test]
     fn counts_deletes_inside_range_only() {
         let deletes = [0i64, 1, 2, 50, 51, 199];
-        assert_eq!(count_deletes_in_range(&deletes, 0, 50), 3);
-        assert_eq!(count_deletes_in_range(&deletes, 50, 100), 2);
-        assert_eq!(count_deletes_in_range(&deletes, 100, 150), 0);
-        assert_eq!(count_deletes_in_range(&deletes, 150, 200), 1);
+        assert_eq!(count_deletes_in_sorted_range(&deletes, 0, 50), 3);
+        assert_eq!(count_deletes_in_sorted_range(&deletes, 50, 100), 2);
+        assert_eq!(count_deletes_in_sorted_range(&deletes, 100, 150), 0);
+        assert_eq!(count_deletes_in_sorted_range(&deletes, 150, 200), 1);
     }
 
     #[test]
     fn range_bounds_are_half_open() {
         let deletes = [10i64];
-        assert_eq!(count_deletes_in_range(&deletes, 10, 11), 1);
-        assert_eq!(count_deletes_in_range(&deletes, 11, 20), 0);
-        assert_eq!(count_deletes_in_range(&deletes, 0, 10), 0);
+        assert_eq!(count_deletes_in_sorted_range(&deletes, 10, 11), 1);
+        assert_eq!(count_deletes_in_sorted_range(&deletes, 11, 20), 0);
+        assert_eq!(count_deletes_in_sorted_range(&deletes, 0, 10), 0);
     }
 
     #[test]
     fn empty_or_inverted_range_counts_nothing() {
-        assert_eq!(count_deletes_in_range(&[], 0, 100), 0);
-        assert_eq!(count_deletes_in_range(&[5i64], 10, 10), 0);
-        assert_eq!(count_deletes_in_range(&[5i64], 10, 5), 0);
+        assert_eq!(count_deletes_in_sorted_range(&[], 0, 100), 0);
+        assert_eq!(count_deletes_in_sorted_range(&[5i64], 10, 10), 0);
+        assert_eq!(count_deletes_in_sorted_range(&[5i64], 10, 5), 0);
     }
 
     #[test]
     fn unsorted_and_duplicate_deletes_are_normalized() {
         let deletes = [51i64, 0, 50, 0, 2, 1];
-        assert_eq!(count_deletes_in_range(&deletes, 0, 50), 3);
-        assert_eq!(count_deletes_in_range(&deletes, 50, 100), 2);
+        let normalized = normalize_deletes(&deletes);
+        assert_eq!(&*normalized, &[0i64, 1, 2, 50, 51]);
+        assert_eq!(count_deletes_in_sorted_range(&normalized, 0, 50), 3);
+        assert_eq!(count_deletes_in_sorted_range(&normalized, 50, 100), 2);
+        // Already-sorted input is borrowed, not copied.
+        assert!(matches!(
+            normalize_deletes(&[0i64, 1, 2]),
+            std::borrow::Cow::Borrowed(_)
+        ));
+    }
+
+    #[test]
+    fn visible_rows_subtracts_deletes_in_selected_row_groups() {
+        let metadata = metadata_with_row_groups(&[50, 50, 50, 50]);
+        // 40 deletes in RG0, 1 in RG2.
+        let deletes: Vec<i64> = (0..40).chain(std::iter::once(120)).collect();
+
+        assert_eq!(visible_rows_in_row_groups(&metadata, &[0], None), 50);
+        assert_eq!(
+            visible_rows_in_row_groups(&metadata, &[0], Some(&deletes)),
+            10
+        );
+        // RG1 has no deletes; RG2 has one.
+        assert_eq!(
+            visible_rows_in_row_groups(&metadata, &[1, 2], Some(&deletes)),
+            99
+        );
+        assert_eq!(
+            visible_rows_in_row_groups(&metadata, &[0, 1, 2, 3], Some(&deletes)),
+            159
+        );
+    }
+
+    #[test]
+    fn limit_budget_counts_only_visible_rows() {
+        let metadata = metadata_with_row_groups(&[50, 50, 50, 50]);
+        let schema = Schema::empty();
+        let deletes: Vec<i64> = (0..40).collect();
+
+        // Without deletes a limit of 20 is satisfied by RG0 alone.
+        let kept =
+            prune_row_groups(&metadata, None, 0, Some(20), None, None, &schema, "t").unwrap();
+        assert_eq!(kept, vec![0]);
+
+        // RG0 only yields 10 visible rows, so RG1 is still needed.
+        let kept = prune_row_groups(
+            &metadata,
+            None,
+            0,
+            Some(20),
+            Some(&deletes),
+            None,
+            &schema,
+            "t",
+        )
+        .unwrap();
+        assert_eq!(kept, vec![0, 1]);
+    }
+
+    #[test]
+    fn start_offset_and_deletes_compose() {
+        let metadata = metadata_with_row_groups(&[50, 50, 50, 50]);
+        let schema = Schema::empty();
+        // Deletes straddle the offset: 20..29 are skipped by the offset anyway,
+        // only 30..49 reduce what RG0 contributes.
+        let deletes: Vec<i64> = (20..50).collect();
+
+        // Offset 30 drops nothing wholesale (RG0 ends at 50 > 30), and RG0's
+        // visible span [30, 50) is entirely deleted, so the budget is untouched
+        // and later row groups must be kept.
+        let kept = prune_row_groups(
+            &metadata,
+            None,
+            30,
+            Some(20),
+            Some(&deletes),
+            None,
+            &schema,
+            "t",
+        )
+        .unwrap();
+        assert_eq!(kept, vec![0, 1]);
+
+        // Same offset without deletes: RG0's 20 visible rows fill the budget.
+        let kept =
+            prune_row_groups(&metadata, None, 30, Some(20), None, None, &schema, "t").unwrap();
+        assert_eq!(kept, vec![0]);
     }
 }

--- a/src/daft-parquet/src/reader/mod.rs
+++ b/src/daft-parquet/src/reader/mod.rs
@@ -595,6 +595,7 @@ pub async fn stream_parquet(
         opts.row_groups.as_deref(),
         opts.start_offset.unwrap_or(0),
         opts.num_rows,
+        opts.delete_rows.as_deref(),
         opts.predicate.as_ref(),
         &plan.read_daft_schema,
         source.label(),

--- a/src/daft-parquet/src/reader/mod.rs
+++ b/src/daft-parquet/src/reader/mod.rs
@@ -529,12 +529,11 @@ fn count_only_stream(
     metadata: &ParquetMetaData,
     rg_indices: &[usize],
     num_rows: Option<usize>,
+    delete_rows: Option<&[i64]>,
     return_schema: Arc<Schema>,
 ) -> DaftResult<(Arc<Schema>, BoxStream<'static, DaftResult<RecordBatch>>)> {
-    let total: usize = rg_indices
-        .iter()
-        .map(|&i| metadata.row_group(i).num_rows() as usize)
-        .sum();
+    // Deleted rows never reach the consumer, so counting them would over-report.
+    let total = crate::helpers::visible_rows_in_row_groups(metadata, rg_indices, delete_rows);
     let n = num_rows.map(|n| n.min(total)).unwrap_or(total);
     let batch = RecordBatch::new_with_size(return_schema.clone(), Vec::new(), n)?;
     Ok((
@@ -615,6 +614,7 @@ pub async fn stream_parquet(
             &prepared.parquet_metadata,
             &rg_indices,
             opts.num_rows,
+            opts.delete_rows.as_deref(),
             plan.return_daft_schema,
         );
     }

--- a/tests/io/test_native_tasks.py
+++ b/tests/io/test_native_tasks.py
@@ -233,3 +233,76 @@ def test_field_id_mapping_with_field_ids_reads_values(tmp_path: Path):
     result = FieldIdMappingSource(path, schema).read().sort("a").to_pydict()
 
     assert result == {"a": [1, 2, 3], "b": ["x", "y", "z"]}
+
+
+@pytest.fixture
+def deleted_rows_parquet(tmp_path: Path) -> tuple[str, str]:
+    """200 rows across 4 row groups, with positional deletes for rows 0..39.
+
+    Row group 0 keeps only 10 of its 50 rows, so a limit budget computed from
+    pre-delete row counts is exhausted before later row groups are considered.
+    """
+    data_path = str(tmp_path / "data.parquet")
+    pq.write_table(pa.table({"x": list(range(200))}), data_path, row_group_size=50)
+
+    delete_path = str(tmp_path / "delete.parquet")
+    pq.write_table(
+        pa.table({"file_path": [data_path] * 40, "pos": list(range(40))}),
+        delete_path,
+    )
+    return data_path, delete_path
+
+
+class DeletedRowsParquetSource(DataSource):
+    """Reads one parquet file with Iceberg positional delete files attached."""
+
+    def __init__(self, data_path: str, delete_path: str, schema: Schema) -> None:
+        self._data_path = data_path
+        self._delete_path = delete_path
+        self._schema = schema
+
+    @property
+    def name(self) -> str:
+        return "DeletedRowsParquetSource"
+
+    @property
+    def schema(self) -> Schema:
+        return self._schema
+
+    async def get_tasks(self, pushdowns) -> AsyncIterator[DataSourceTask]:
+        yield DataSourceTask.parquet(
+            path=self._data_path,
+            schema=self._schema,
+            pushdowns=pushdowns,
+            iceberg_delete_files=[self._delete_path],
+        )
+
+
+@pytest.mark.parametrize("limit", [5, 10, 20, 45, 60, 100, 160, 200])
+def test_parquet_limit_accounts_for_deleted_rows(deleted_rows_parquet: tuple[str, str], limit: int):
+    """Deleted rows must not consume the limit budget.
+
+    Row groups are pruned against `num_rows` before decoding. Counting deleted
+    rows towards that budget drops later row groups, so the read returns fewer
+    rows than the limit even though the file still has matching rows.
+    """
+    data_path, delete_path = deleted_rows_parquet
+    schema = Schema.from_pydict({"x": DataType.int64()})
+    source = DeletedRowsParquetSource(data_path, delete_path, schema)
+
+    result = source.read().limit(limit).to_pydict()
+
+    assert len(result["x"]) == min(limit, 160)
+    # None of the deleted rows (0..39) may be returned.
+    assert all(x >= 40 for x in result["x"])
+
+
+def test_parquet_reads_all_undeleted_rows(deleted_rows_parquet: tuple[str, str]):
+    """Without a limit the read returns exactly the undeleted rows."""
+    data_path, delete_path = deleted_rows_parquet
+    schema = Schema.from_pydict({"x": DataType.int64()})
+    source = DeletedRowsParquetSource(data_path, delete_path, schema)
+
+    result = source.read().sort("x").to_pydict()
+
+    assert result == {"x": list(range(40, 200))}


### PR DESCRIPTION
## Changes Made

With Iceberg positional deletes, `limit(n)` returns fewer than `n` rows:

```python
# 200 rows in 4 row groups of 50; positional deletes remove rows 0..39
source.read().limit(20).to_pydict()    # 10 rows, expected 20
source.read().limit(100).to_pydict()   # 60 rows, expected 100
```

`prune_row_groups` subtracts each row group's `num_rows()` from the limit budget, counting
deleted rows that never reach the consumer. A heavily-deleted row group exhausts the budget
and the loop breaks before reaching row groups that still have matching rows. This subtracts the
deletes falling in each row group's visible range; the row-level accounting downstream was
already correct.

## Testing

- `count_deletes_in_range` unit tests in `helpers.rs`, which had none.
- Parametrized end-to-end test over limits 5/10/20/45/60/100/160/200. The 20/45/100 cases
  fail on `main`.
- `cargo test -p daft-parquet --release`: 19 passed. `DAFT_RUNNER=native pytest` over
  `tests/io/test_native_tasks.py`, `test_parquet.py`, `iceberg/`: 291 passed, 21 skipped.
  `DAFT_RUNNER=ray` on the new file: 18 passed. `make precommit` clean.

## AI usage disclosure

Written with an AI coding assistant. I reviewed the full diff, reproduced the short reads on both
runners, and confirmed by reverting the change that the new tests fail without it.

## Related Issues

None.
