### PR TITLE
fix(parquet): error instead of nulling columns when field ids are absent

### DIFF
--- a/src/daft-parquet/src/lib.rs
+++ b/src/daft-parquet/src/lib.rs
@@ -97,6 +97,13 @@ pub enum Error {
     #[snafu(display("Parquet reader invariant violated for {path}: {message}"))]
     ReaderInternal { path: String, message: String },
 
+    #[snafu(display(
+        "{path} carries no parquet field IDs, but a field ID mapping was supplied, so every \
+         mapped column would read as null. Tables registered with `add_files` rely on the \
+         `schema.name-mapping.default` property, which Daft does not apply yet"
+    ))]
+    MissingParquetFieldIds { path: String },
+
     /// Remote fetch tasks store their results in a `Shared` future whose error
     /// type must be `Clone`, so we keep `Arc<Error>` internally and surface the
     /// typed source to every consumer.

--- a/src/daft-parquet/src/metadata.rs
+++ b/src/daft-parquet/src/metadata.rs
@@ -141,6 +141,20 @@ pub(crate) fn apply_field_ids_to_arrowrs_parquet_metadata(
     let old_schema = metadata.file_metadata().schema_descr();
     let old_root = old_schema.root_schema();
 
+    // A file with no field IDs at all cannot be matched against the mapping, so every
+    // mapped column would silently read as null. Fail instead — a partially-annotated
+    // file is still handled below, where unmapped children are dropped on purpose.
+    if !old_root.get_fields().is_empty()
+        && !old_root
+            .get_fields()
+            .iter()
+            .any(|field| get_field_id(field.get_basic_info()).is_some())
+    {
+        return Err(Error::MissingParquetFieldIds {
+            path: path.to_string(),
+        });
+    }
+
     // 1. Rewrite the schema type tree: rename + filter by field_id_mapping
     let new_fields: Vec<_> = old_root
         .get_fields()

--- a/tests/io/test_native_tasks.py
+++ b/tests/io/test_native_tasks.py
@@ -11,6 +11,7 @@ import pytest
 
 import daft
 from daft import DataType
+from daft.daft import ParquetSourceConfig
 from daft.io.source import DataSource, DataSourceTask
 from daft.recordbatch import RecordBatch
 from daft.schema import Schema
@@ -174,3 +175,61 @@ def test_parquet_factory_always_returns_task():
         partition_values=pv,
     )
     assert isinstance(task, DataSourceTask)
+
+
+def _write_parquet_with_field_ids(path: str, field_ids: dict[str, int]) -> None:
+    """Write a parquet file whose columns carry ``PARQUET:field_id`` metadata."""
+    table = pa.table({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+    schema = pa.schema(
+        [
+            table.schema.field(name).with_metadata({b"PARQUET:field_id": str(field_ids[name]).encode()})
+            for name in table.schema.names
+        ]
+    )
+    pq.write_table(pa.Table.from_arrays(table.columns, schema=schema), path)
+
+
+class FieldIdMappingSource(DataSource):
+    """Reads one parquet file with a field ID mapping applied."""
+
+    def __init__(self, path: str, schema: Schema) -> None:
+        self._path = path
+        self._schema = schema
+
+    @property
+    def name(self) -> str:
+        return "FieldIdMappingSource"
+
+    @property
+    def schema(self) -> Schema:
+        return self._schema
+
+    async def get_tasks(self, pushdowns) -> AsyncIterator[DataSourceTask]:
+        mapping = {1: self._schema["a"]._field, 2: self._schema["b"]._field}
+        yield DataSourceTask.parquet(
+            path=self._path,
+            schema=self._schema,
+            pushdowns=pushdowns,
+            parquet_config=ParquetSourceConfig(field_id_mapping=mapping),
+        )
+
+
+def test_field_id_mapping_without_field_ids_raises(tmp_path: Path):
+    """A field ID mapping against a file with no field IDs is an error, not all-null columns."""
+    path = str(tmp_path / "no_field_ids.parquet")
+    pq.write_table(pa.table({"a": [1, 2, 3], "b": ["x", "y", "z"]}), path)
+    schema = Schema.from_pydict({"a": DataType.int64(), "b": DataType.string()})
+
+    with pytest.raises(Exception, match="carries no parquet field IDs"):
+        FieldIdMappingSource(path, schema).read().to_pydict()
+
+
+def test_field_id_mapping_with_field_ids_reads_values(tmp_path: Path):
+    """A file that does carry field IDs still reads through the mapping."""
+    path = str(tmp_path / "with_field_ids.parquet")
+    _write_parquet_with_field_ids(path, {"a": 1, "b": 2})
+    schema = Schema.from_pydict({"a": DataType.int64(), "b": DataType.string()})
+
+    result = FieldIdMappingSource(path, schema).read().sort("a").to_pydict()
+
+    assert result == {"a": [1, 2, 3], "b": ["x", "y", "z"]}


### PR DESCRIPTION
## Changes Made

A parquet file with no field IDs read through a field ID mapping produces all-null columns:

```python
daft.read_iceberg(table).to_pydict()  # {'a': [None, None, None], 'b': [None, None, None]}
pyiceberg_table.scan().to_arrow()     # {'a': [1, 2, 3], 'b': ['x', 'y', 'z']}
```

`apply_field_ids_to_arrowrs_parquet_metadata` drops any field whose ID is absent from the
mapping, along with its column chunks. With zero field IDs in the file every column is
dropped and the reader nulls them. This raises `MissingParquetFieldIds` instead. Partially
annotated files keep the existing drop-unmapped behavior that nested structs rely on.

This covers pyiceberg's third case only (no IDs, no name mapping → raise); supporting
`schema.name-mapping.default` is left out on purpose.

## Testing

- New test asserting the error, plus a positive test that a file carrying
  `PARQUET:field_id` still reads its values. The error test fails on `main`.
- `cargo test -p daft-parquet --release`: 15 passed. `DAFT_RUNNER=native pytest
  tests/io/test_native_tasks.py tests/io/test_parquet.py`: 48 passed. `DAFT_RUNNER=ray` on
  the new file: 11 passed. `make precommit` clean.

## AI usage disclosure

Written with an AI coding assistant. I reviewed the full diff, reproduced the all-null read
and the new error locally, read pyiceberg's dispatch to confirm which case this covers, and
verified by reverting the guard that the new test fails without it.

## Related Issues

Closes #7445
