### PR TITLE
fix(sql): make the io_config argument work in SQL readers

### DIFF
--- a/src/daft-sql/src/functions.rs
+++ b/src/daft-sql/src/functions.rs
@@ -406,10 +406,15 @@ impl SQLFunctions {
     }
 
     /// Add a [FunctionExpr] to the [SQLFunctions] instance.
+    ///
+    /// The name is lowercased on the way in. Lookup lowercases the parsed function
+    /// name (SQL function names are case-insensitive), so a mixed-case key would be
+    /// unreachable — normalizing here makes that class of bug unrepresentable.
     pub fn add_fn<F: SQLFunction + 'static>(&mut self, name: &str, func: F) {
+        let key = name.to_lowercase();
         self.docsmap
-            .insert(name.to_string(), (func.docstrings(name), func.arg_names()));
-        self.map.insert(name.to_string(), Arc::new(func));
+            .insert(key.clone(), (func.docstrings(name), func.arg_names()));
+        self.map.insert(key, Arc::new(func));
     }
 
     /// Get a function by name from the [SQLFunctions] instance.

--- a/src/daft-sql/src/modules/config.rs
+++ b/src/daft-sql/src/modules/config.rs
@@ -13,11 +13,13 @@ pub struct SQLModuleConfig;
 
 impl SQLModule for SQLModuleConfig {
     fn register(parent: &mut SQLFunctions) {
-        parent.add_fn("S3Config", S3ConfigFunction);
-        parent.add_fn("HTTPConfig", HTTPConfigFunction);
-        parent.add_fn("AzureConfig", AzureConfigFunction);
-        parent.add_fn("GCSConfig", GCSConfigFunction);
-        parent.add_fn("TosConfig", TosConfigFunction);
+        // Names must be registered lowercase: lookup lowercases the parsed function name
+        // before hitting the registry, so a mixed-case key can never be found.
+        parent.add_fn("s3config", S3ConfigFunction);
+        parent.add_fn("httpconfig", HTTPConfigFunction);
+        parent.add_fn("azureconfig", AzureConfigFunction);
+        parent.add_fn("gcsconfig", GCSConfigFunction);
+        parent.add_fn("tosconfig", TosConfigFunction);
     }
 }
 

--- a/src/daft-sql/src/modules/config.rs
+++ b/src/daft-sql/src/modules/config.rs
@@ -13,13 +13,11 @@ pub struct SQLModuleConfig;
 
 impl SQLModule for SQLModuleConfig {
     fn register(parent: &mut SQLFunctions) {
-        // Names must be registered lowercase: lookup lowercases the parsed function name
-        // before hitting the registry, so a mixed-case key can never be found.
-        parent.add_fn("s3config", S3ConfigFunction);
-        parent.add_fn("httpconfig", HTTPConfigFunction);
-        parent.add_fn("azureconfig", AzureConfigFunction);
-        parent.add_fn("gcsconfig", GCSConfigFunction);
-        parent.add_fn("tosconfig", TosConfigFunction);
+        parent.add_fn("S3Config", S3ConfigFunction);
+        parent.add_fn("HTTPConfig", HTTPConfigFunction);
+        parent.add_fn("AzureConfig", AzureConfigFunction);
+        parent.add_fn("GCSConfig", GCSConfigFunction);
+        parent.add_fn("TosConfig", TosConfigFunction);
     }
 }
 

--- a/src/daft-sql/src/table_provider/mod.rs
+++ b/src/daft-sql/src/table_provider/mod.rs
@@ -11,6 +11,7 @@ use std::{
 };
 
 use common_error::DaftResult;
+use common_io_config::IOConfig;
 use daft_dsl::{Expr, ExprRef};
 use daft_logical_plan::LogicalPlanBuilder;
 use read_csv::ReadCsvFunction;
@@ -22,7 +23,7 @@ use sqlparser::ast::TableFunctionArgs;
 
 use crate::{
     error::{PlannerError, SQLPlannerResult},
-    functions::SQLLiteral,
+    functions::{SQLFunctionArguments, SQLLiteral},
     invalid_operation_err,
     modules::config::expr_to_iocfg,
     planner::SQLPlanner,
@@ -118,5 +119,21 @@ where
     #[cfg(not(feature = "python"))]
     {
         runtime.block_within_async_context(future)
+    }
+}
+
+/// Resolve a reader's `io_config` argument, falling back to the context default.
+///
+/// Mirrors the Python readers, which do
+/// `io_config = get_context().daft_planning_config.default_io_config if io_config is None`:
+/// an explicit argument wins, otherwise the globally-configured default applies. Without
+/// this fallback `daft.sql("... read_parquet('s3://...')")` silently ignores credentials
+/// that the equivalent `daft.read_parquet` call would pick up.
+pub(crate) fn resolve_io_config(
+    args: &SQLFunctionArguments,
+) -> Result<Option<IOConfig>, PlannerError> {
+    match args.get_named("io_config") {
+        Some(expr) => Ok(Some(expr_to_iocfg(expr)?)),
+        None => Ok(Some(daft_context::get_context().io_config())),
     }
 }

--- a/src/daft-sql/src/table_provider/mod.rs
+++ b/src/daft-sql/src/table_provider/mod.rs
@@ -129,11 +129,16 @@ where
 /// an explicit argument wins, otherwise the globally-configured default applies. Without
 /// this fallback `daft.sql("... read_parquet('s3://...')")` silently ignores credentials
 /// that the equivalent `daft.read_parquet` call would pick up.
-pub(crate) fn resolve_io_config(
-    args: &SQLFunctionArguments,
-) -> Result<Option<IOConfig>, PlannerError> {
+///
+/// `read_iceberg` deliberately does not use this: it passes `None` so the scan can apply
+/// the table's own FileIO properties before falling back to the context default (see
+/// `resolve_iceberg_io_config` in `daft/io/iceberg/_iceberg.py`).
+///
+/// This has to live in `daft-sql` rather than in the scan builders, because
+/// `daft-context` depends on `daft-logical-plan` and the reverse dependency would cycle.
+pub(crate) fn resolve_io_config(args: &SQLFunctionArguments) -> Result<IOConfig, PlannerError> {
     match args.get_named("io_config") {
-        Some(expr) => Ok(Some(expr_to_iocfg(expr)?)),
-        None => Ok(Some(daft_context::get_context().io_config())),
+        Some(expr) => expr_to_iocfg(expr),
+        None => Ok(daft_context::get_context().io_config()),
     }
 }

--- a/src/daft-sql/src/table_provider/read_csv.rs
+++ b/src/daft-sql/src/table_provider/read_csv.rs
@@ -8,7 +8,6 @@ use crate::{
     error::{PlannerError, SQLPlannerResult},
     functions::SQLFunctionArguments,
     invalid_operation_err,
-    modules::config::expr_to_iocfg,
     planner::SQLPlanner,
     schema::try_parse_schema,
 };
@@ -50,7 +49,7 @@ impl TryFrom<SQLFunctionArguments> for CsvScanBuilder {
             .map(try_parse_schema)
             .transpose()?
             .map(Arc::new);
-        let io_config = args.get_named("io_config").map(expr_to_iocfg).transpose()?;
+        let io_config = super::resolve_io_config(&args)?;
 
         Ok(Self {
             glob_paths,

--- a/src/daft-sql/src/table_provider/read_csv.rs
+++ b/src/daft-sql/src/table_provider/read_csv.rs
@@ -49,7 +49,7 @@ impl TryFrom<SQLFunctionArguments> for CsvScanBuilder {
             .map(try_parse_schema)
             .transpose()?
             .map(Arc::new);
-        let io_config = super::resolve_io_config(&args)?;
+        let io_config = Some(super::resolve_io_config(&args)?);
 
         Ok(Self {
             glob_paths,

--- a/src/daft-sql/src/table_provider/read_deltalake.rs
+++ b/src/daft-sql/src/table_provider/read_deltalake.rs
@@ -1,7 +1,7 @@
 use daft_logical_plan::LogicalPlanBuilder;
 use sqlparser::ast::TableFunctionArgs;
 
-use super::{SQLTableFunction, expr_to_iocfg};
+use super::SQLTableFunction;
 use crate::{SQLPlanner, error::SQLPlannerResult, unsupported_sql_err};
 
 pub(super) struct ReadDeltalakeFunction;
@@ -14,14 +14,14 @@ impl SQLTableFunction for ReadDeltalakeFunction {
         args: &TableFunctionArgs,
     ) -> SQLPlannerResult<LogicalPlanBuilder> {
         let (uri, io_config) = match args.args.as_slice() {
-            [uri] => (uri, None),
+            [uri] => (uri, Some(daft_context::get_context().io_config())),
             [uri, io_config] => {
                 let args = planner.parse_function_args(
                     std::slice::from_ref(io_config),
                     &["io_config"],
                     0,
                 )?;
-                let io_config = args.get_named("io_config").map(expr_to_iocfg).transpose()?;
+                let io_config = super::resolve_io_config(&args)?;
                 (uri, io_config)
             }
             _ => unsupported_sql_err!("Expected one or two arguments"),

--- a/src/daft-sql/src/table_provider/read_deltalake.rs
+++ b/src/daft-sql/src/table_provider/read_deltalake.rs
@@ -22,7 +22,7 @@ impl SQLTableFunction for ReadDeltalakeFunction {
                     0,
                 )?;
                 let io_config = super::resolve_io_config(&args)?;
-                (uri, io_config)
+                (uri, Some(io_config))
             }
             _ => unsupported_sql_err!("Expected one or two arguments"),
         };

--- a/src/daft-sql/src/table_provider/read_json.rs
+++ b/src/daft-sql/src/table_provider/read_json.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use daft_logical_plan::scan_builder::JsonScanBuilder;
 
-use super::{SQLTableFunction, expr_to_iocfg, try_coerce_list};
+use super::{SQLTableFunction, try_coerce_list};
 use crate::{
     error::PlannerError, functions::SQLFunctionArguments, invalid_operation_err,
     schema::try_parse_schema,
@@ -61,7 +61,7 @@ impl TryFrom<SQLFunctionArguments> for JsonScanBuilder {
             .map(try_parse_schema)
             .transpose()?
             .map(Arc::new);
-        let io_config = args.get_named("io_config").map(expr_to_iocfg).transpose()?;
+        let io_config = super::resolve_io_config(&args)?;
         let skip_empty_files = args.try_get_named("skip_empty_files")?.unwrap_or(false);
 
         Ok(Self {

--- a/src/daft-sql/src/table_provider/read_json.rs
+++ b/src/daft-sql/src/table_provider/read_json.rs
@@ -61,7 +61,7 @@ impl TryFrom<SQLFunctionArguments> for JsonScanBuilder {
             .map(try_parse_schema)
             .transpose()?
             .map(Arc::new);
-        let io_config = super::resolve_io_config(&args)?;
+        let io_config = Some(super::resolve_io_config(&args)?);
         let skip_empty_files = args.try_get_named("skip_empty_files")?.unwrap_or(false);
 
         Ok(Self {

--- a/src/daft-sql/src/table_provider/read_parquet.rs
+++ b/src/daft-sql/src/table_provider/read_parquet.rs
@@ -9,7 +9,6 @@ use crate::{
     error::{PlannerError, SQLPlannerResult},
     functions::SQLFunctionArguments,
     invalid_operation_err,
-    modules::config::expr_to_iocfg,
     planner::SQLPlanner,
     schema::try_parse_schema,
 };
@@ -51,7 +50,7 @@ impl TryFrom<SQLFunctionArguments> for ParquetScanBuilder {
             .map(try_parse_schema)
             .transpose()?
             .map(Arc::new);
-        let io_config = args.get_named("io_config").map(expr_to_iocfg).transpose()?;
+        let io_config = super::resolve_io_config(&args)?;
 
         Ok(Self {
             glob_paths,

--- a/src/daft-sql/src/table_provider/read_parquet.rs
+++ b/src/daft-sql/src/table_provider/read_parquet.rs
@@ -50,7 +50,7 @@ impl TryFrom<SQLFunctionArguments> for ParquetScanBuilder {
             .map(try_parse_schema)
             .transpose()?
             .map(Arc::new);
-        let io_config = super::resolve_io_config(&args)?;
+        let io_config = Some(super::resolve_io_config(&args)?);
 
         Ok(Self {
             glob_paths,

--- a/tests/sql/test_sql_table_functions.py
+++ b/tests/sql/test_sql_table_functions.py
@@ -262,3 +262,61 @@ def test_sql_read_csv_ignore_corrupt_files(tmp_path):
     path, reason, _partial = skipped[0]
     assert path.endswith("zzz_bad.csv")
     assert reason
+
+
+def _plan_io_config_line(df) -> str | None:
+    """Return the plan's ``IO config`` line, or None when the plan carries none."""
+    import contextlib
+    import io as _io
+
+    buf = _io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        df.explain(show_all=False)
+    for line in buf.getvalue().splitlines():
+        if "IO config" in line:
+            return line.strip()
+    return None
+
+
+@pytest.fixture
+def default_io_config():
+    """Set a recognizable context default_io_config for the duration of a test."""
+    from daft.io import IOConfig, S3Config
+
+    previous = daft.context.get_context().daft_planning_config.default_io_config
+    daft.context.set_planning_config(default_io_config=IOConfig(s3=S3Config(region_name="us-west-2")))
+    try:
+        yield
+    finally:
+        daft.context.set_planning_config(default_io_config=previous)
+
+
+@pytest.fixture
+def io_config_sample_files(tmp_path):
+    parquet_path = tmp_path / "a.parquet"
+    papq.write_table(pa.table({"x": [1, 2, 3]}), parquet_path)
+    csv_path = tmp_path / "a.csv"
+    csv_path.write_text("x\n1\n2\n")
+    json_path = tmp_path / "a.jsonl"
+    json_path.write_text('{"x": 1}\n{"x": 2}\n')
+    return {
+        "read_parquet": parquet_path.as_posix(),
+        "read_csv": csv_path.as_posix(),
+        "read_json": json_path.as_posix(),
+    }
+
+
+@pytest.mark.parametrize("function", ["read_parquet", "read_csv", "read_json"])
+def test_sql_reader_uses_default_io_config(default_io_config, io_config_sample_files, function):
+    """Without an explicit io_config, SQL readers fall back to the context default.
+
+    The Python readers already do this, so a globally-set ``default_io_config`` used to apply
+    to ``daft.read_parquet`` but be silently dropped by ``read_parquet`` in SQL.
+    """
+    path = io_config_sample_files[function]
+    sql_line = _plan_io_config_line(daft.sql(f"SELECT * FROM {function}('{path}')"))
+    python_line = _plan_io_config_line(getattr(daft, function)(path))
+
+    assert sql_line is not None
+    assert "us-west-2" in sql_line
+    assert sql_line == python_line

--- a/tests/sql/test_sql_table_functions.py
+++ b/tests/sql/test_sql_table_functions.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import contextlib
+import io
 import os
 
 import pyarrow as pa
@@ -8,6 +10,7 @@ import pytest
 
 import daft
 from daft import DataType as dt
+from daft.io import IOConfig, S3Config
 
 # TODO chore: make an asset fixture for all tests (beyond just sql).
 
@@ -266,10 +269,7 @@ def test_sql_read_csv_ignore_corrupt_files(tmp_path):
 
 def _plan_io_config_line(df) -> str | None:
     """Return the plan's ``IO config`` line, or None when the plan carries none."""
-    import contextlib
-    import io as _io
-
-    buf = _io.StringIO()
+    buf = io.StringIO()
     with contextlib.redirect_stdout(buf):
         df.explain(show_all=False)
     for line in buf.getvalue().splitlines():
@@ -281,8 +281,6 @@ def _plan_io_config_line(df) -> str | None:
 @pytest.fixture
 def default_io_config():
     """Set a recognizable context default_io_config for the duration of a test."""
-    from daft.io import IOConfig, S3Config
-
     previous = daft.context.get_context().daft_planning_config.default_io_config
     daft.context.set_planning_config(default_io_config=IOConfig(s3=S3Config(region_name="us-west-2")))
     try:
@@ -320,3 +318,29 @@ def test_sql_reader_uses_default_io_config(default_io_config, io_config_sample_f
     assert sql_line is not None
     assert "us-west-2" in sql_line
     assert sql_line == python_line
+
+
+@pytest.mark.parametrize("function", ["read_parquet", "read_csv", "read_json"])
+def test_sql_reader_explicit_io_config_wins(default_io_config, io_config_sample_files, function):
+    """An explicit io_config argument overrides the context default."""
+    path = io_config_sample_files[function]
+    query = f"SELECT * FROM {function}('{path}', io_config := S3Config(region_name => 'eu-central-1'))"
+
+    sql_line = _plan_io_config_line(daft.sql(query))
+
+    assert sql_line is not None
+    assert "eu-central-1" in sql_line
+
+
+@pytest.mark.parametrize(
+    "spelling", ["S3Config", "s3config", "S3CONFIG"], ids=["mixed_case", "lower_case", "upper_case"]
+)
+def test_sql_config_constructors_are_case_insensitive(io_config_sample_files, spelling):
+    """Config constructors resolve under any casing, like every other SQL function."""
+    path = io_config_sample_files["read_parquet"]
+    query = f"SELECT * FROM read_parquet('{path}', io_config := {spelling}(region_name => 'eu-central-1'))"
+
+    sql_line = _plan_io_config_line(daft.sql(query))
+
+    assert sql_line is not None
+    assert "eu-central-1" in sql_line


### PR DESCRIPTION
## Changes Made

Two defects make `io_config` unusable in SQL readers.

**The context default is dropped.** Providers read only the named argument, so an absent
argument became `None`:

```python
daft.set_planning_config(default_io_config=IOConfig(s3=S3Config(region_name="us-west-2")))
daft.read_parquet(path)                       # IO config = { Region name = us-west-2 }
daft.sql(f"SELECT * FROM read_parquet(...)")  # none at all
```

`resolve_io_config` now falls back to it. `read_iceberg` keeps `None` so the scan can apply
the table's own FileIO properties first.

**The explicit argument could not be constructed.** `add_fn` stored names verbatim while
lookup lowercases them, so the five config constructors were unreachable under any casing.
Normalizing in `add_fn` makes that unrepresentable instead of patching five call sites.

Two visible effects: `list_sql_functions` reports `s3config` not `S3Config` (all other
functions were already lowercase), and a plan with no `default_io_config` now prints
`IO config = <default>` where it printed nothing.

## Testing

New tests: the default fallback matches the Python reader, an explicit `io_config` wins, and
constructors resolve under three casings — all fail on `main`. native `tests/sql` 416 passed,
ray 33, `make precommit` clean.

## AI usage disclosure

Written with an AI coding assistant. I reviewed the full diff, reproduced both failures on
unpatched builds, and reverted each fix to confirm its tests fail.

## Related Issues
Closes #7448
Closes #7447
