### PR TITLE
fix(optimizer): match aliased count aggregations in count pushdown

### DIFF
--- a/src/daft-logical-plan/src/optimization/rules/push_down_aggregation.rs
+++ b/src/daft-logical-plan/src/optimization/rules/push_down_aggregation.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
 
-use common_error::{DaftError, DaftResult};
+use common_error::DaftResult;
 use common_treenode::{Transformed, TreeNode};
 use daft_core::{count_mode::CountMode, prelude::Schema};
-use daft_dsl::{AggExpr, Expr, ExprRef};
+use daft_dsl::{AggExpr, Expr, ExprRef, resolved_col};
 
 use crate::{
     LogicalPlan, logical_plan::Aggregate, optimization::rules::OptimizerRule,
@@ -72,6 +72,7 @@ impl OptimizerRule for PushDownAggregation {
                                             .with_aggregation(Some(agg_expr.clone()));
 
                                         let field = agg_expr.to_field(&input.schema())?;
+                                        let count_field_name = field.name.clone();
                                         let new_schema = Arc::new(Schema::new(vec![field]));
 
                                         let new_external_info =
@@ -83,8 +84,14 @@ impl OptimizerRule for PushDownAggregation {
                                         let new_source =
                                             LogicalPlan::Source(new_source_node).into();
                                         // Scan operators may produce partial counts over multiple scan tasks (e.g., distributed parquet reads), so we still need to sum them.
+                                        //
+                                        // Sum the single column the scan emits, not the count's own argument.
+                                        // They coincide only when the argument is a bare column; for anything
+                                        // else the argument would be evaluated against the post-pushdown
+                                        // schema, e.g. `count(lit(1))` would sum the literal once per scan
+                                        // task and return the scan task count instead of the row count.
                                         let mut sum_expr: ExprRef = Arc::new(Expr::Agg(
-                                            AggExpr::Sum(count_expr(&agg_expr)?),
+                                            AggExpr::Sum(resolved_col(count_field_name)),
                                         ));
                                         // Preserve the original output name so the rewrite is schema-preserving.
                                         if let Some(name) = agg_alias {
@@ -131,15 +138,6 @@ fn as_count_agg(expr: &ExprRef) -> Option<(ExprRef, Option<Arc<str>>, CountMode)
     }
 }
 
-fn count_expr(expr: &ExprRef) -> DaftResult<ExprRef> {
-    match expr.as_ref() {
-        Expr::Agg(AggExpr::Count(expr, _)) => Ok(expr.clone()),
-        _ => Err(DaftError::InternalError(
-            "Tried to get count expression from non-count expression".to_string(),
-        )),
-    }
-}
-
 // Check if the count mode is supported for pushdown
 // Currently only CountMode::All is fully supported
 fn is_count_mode_supported(count_mode: &CountMode) -> bool {
@@ -160,7 +158,7 @@ mod tests {
         optimization::{
             optimizer::{RuleBatch, RuleExecutionStrategy},
             rules::PushDownAggregation,
-            test::assert_optimized_plan_with_rules_eq,
+            test::{assert_optimized_plan_with_rules_eq, optimize_with_rules},
         },
         test::{
             dummy_scan_node, dummy_scan_node_with_pushdowns, dummy_scan_operator_for_aggregation,
@@ -234,6 +232,43 @@ mod tests {
 
         assert_eq!(plan.schema(), expected.schema());
         assert_optimized_plan_eq(plan, expected)?;
+        Ok(())
+    }
+
+    /// The rewritten `Sum` must read the column the scan emits, not the count's own
+    /// argument. Those differ whenever the argument is not a bare column: summing
+    /// `lit(1)` over one partial-count row per scan task yields the scan task count,
+    /// not the row count.
+    #[test]
+    fn agg_count_literal_sums_scan_count_column() -> DaftResult<()> {
+        let scan_op =
+            dummy_scan_operator_for_aggregation(vec![Field::new("a", DataType::UInt64)], true);
+        let count = Arc::new(Expr::Agg(AggExpr::Count(lit(1), CountMode::All)));
+        let plan = dummy_scan_node(scan_op)
+            .aggregate(vec![count.clone()], vec![])?
+            .build();
+
+        let optimized = optimize_with_rules(
+            plan,
+            vec![RuleBatch::new(
+                vec![Box::new(PushDownAggregation::new(true))],
+                RuleExecutionStrategy::Once,
+            )],
+        )?;
+
+        let LogicalPlan::Aggregate(agg) = optimized.as_ref() else {
+            panic!(
+                "expected the count to be pushed down, got:\n{}",
+                optimized.repr_ascii(false)
+            );
+        };
+        // The scan emits one column, named after the pushed-down aggregate; the outer
+        // Sum has to reference that column rather than re-evaluating `lit(1)`.
+        let scan_col = agg.input.schema()[0].name.clone();
+        assert_eq!(
+            agg.aggregations,
+            vec![Arc::new(Expr::Agg(AggExpr::Sum(resolved_col(scan_col))))]
+        );
         Ok(())
     }
 

--- a/src/daft-logical-plan/src/optimization/rules/push_down_aggregation.rs
+++ b/src/daft-logical-plan/src/optimization/rules/push_down_aggregation.rs
@@ -34,7 +34,7 @@ impl OptimizerRule for PushDownAggregation {
             {
                 if groupby.is_empty()
                     && aggregations.len() == 1
-                    && let Some(count_mode) = is_count_expr(&aggregations[0])
+                    && let Some((agg_expr, agg_alias, count_mode)) = as_count_agg(&aggregations[0])
                 {
                     // Only handle global aggregation with no GROUP BY and a single aggregation expression
                     match input.as_ref() {
@@ -61,7 +61,7 @@ impl OptimizerRule for PushDownAggregation {
                                         external_info.pushdowns.filters.is_none()
                                     };
                                     let can_pushdown = scan_op.supports_count_pushdown()
-                                        && is_count_mode_supported(count_mode)
+                                        && is_count_mode_supported(&count_mode)
                                         && is_remaining_filters
                                         && external_info.pushdowns.limit.is_none();
 
@@ -69,9 +69,9 @@ impl OptimizerRule for PushDownAggregation {
                                         // Create new pushdown info with count aggregation
                                         let new_pushdowns = external_info
                                             .pushdowns
-                                            .with_aggregation(Some(aggregations[0].clone()));
+                                            .with_aggregation(Some(agg_expr.clone()));
 
-                                        let field = aggregations[0].to_field(&input.schema())?;
+                                        let field = agg_expr.to_field(&input.schema())?;
                                         let new_schema = Arc::new(Schema::new(vec![field]));
 
                                         let new_external_info =
@@ -83,11 +83,16 @@ impl OptimizerRule for PushDownAggregation {
                                         let new_source =
                                             LogicalPlan::Source(new_source_node).into();
                                         // Scan operators may produce partial counts over multiple scan tasks (e.g., distributed parquet reads), so we still need to sum them.
+                                        let mut sum_expr: ExprRef = Arc::new(Expr::Agg(
+                                            AggExpr::Sum(count_expr(&agg_expr)?),
+                                        ));
+                                        // Preserve the original output name so the rewrite is schema-preserving.
+                                        if let Some(name) = agg_alias {
+                                            sum_expr = sum_expr.alias(name);
+                                        }
                                         let new_aggregate = Aggregate::try_new(
                                             new_source,
-                                            vec![Arc::new(Expr::Agg(AggExpr::Sum(count_expr(
-                                                &aggregations[0],
-                                            )?)))],
+                                            vec![sum_expr],
                                             groupby.clone(),
                                         )?
                                         .into();
@@ -111,10 +116,17 @@ impl OptimizerRule for PushDownAggregation {
     }
 }
 
-// Check if expression is count aggregation
-fn is_count_expr(expr: &ExprRef) -> Option<&CountMode> {
-    match expr.as_ref() {
-        Expr::Agg(AggExpr::Count(_, count_mode)) => Some(count_mode),
+/// Match a (possibly aliased) count aggregation.
+///
+/// Returns the count expression with any alias stripped, the alias name if there was
+/// one, and the count mode. The alias has to be peeled off here because the SQL
+/// frontend always emits `count(*)` as `count(<narrowest col>, All) as "count"`, and
+/// `df.agg(col("x").count("all").alias("n"))` produces the same shape; matching only
+/// the bare `Expr::Agg` would skip pushdown for all of them.
+fn as_count_agg(expr: &ExprRef) -> Option<(ExprRef, Option<Arc<str>>, CountMode)> {
+    let (unaliased, alias) = expr.unwrap_alias();
+    match unaliased.as_ref() {
+        Expr::Agg(AggExpr::Count(_, count_mode)) => Some((unaliased.clone(), alias, *count_mode)),
         _ => None,
     }
 }
@@ -188,6 +200,39 @@ mod tests {
         .aggregate(vec![unresolved_col("a").sum()], vec![])?
         .build();
 
+        assert_optimized_plan_eq(plan, expected)?;
+        Ok(())
+    }
+
+    /// `count(*)` from the SQL frontend, and `df.agg(col("a").count("all").alias(..))`,
+    /// arrive as an aliased count. The alias must not block pushdown, and the rewritten
+    /// plan has to keep the original output name.
+    #[test]
+    fn agg_count_all_aliased() -> DaftResult<()> {
+        let scan_op =
+            dummy_scan_operator_for_aggregation(vec![Field::new("a", DataType::UInt64)], true);
+
+        let plan = dummy_scan_node(scan_op.clone())
+            .aggregate(
+                vec![unresolved_col("a").count(CountMode::All).alias("n")],
+                vec![],
+            )?
+            .build();
+
+        let expected = dummy_scan_node_with_pushdowns(
+            scan_op,
+            // The pushed-down expression is the bare count: the scan readers match on
+            // `Expr::Agg(AggExpr::Count(..))` and would silently fall back to a full
+            // column read if handed an alias.
+            Pushdowns::default().with_aggregation(Some(Arc::new(Expr::Agg(AggExpr::Count(
+                resolved_col("a"),
+                CountMode::All,
+            ))))),
+        )
+        .aggregate(vec![unresolved_col("a").sum().alias("n")], vec![])?
+        .build();
+
+        assert_eq!(plan.schema(), expected.schema());
         assert_optimized_plan_eq(plan, expected)?;
         Ok(())
     }

--- a/tests/io/test_parquet.py
+++ b/tests/io/test_parquet.py
@@ -639,6 +639,22 @@ def test_parquet_count(tmp_path_factory):
     assert result == {"count": [10]}
 
 
+@pytest.mark.parametrize("query", ["select count(*) as n from tbl", "select count(1) as n from tbl"])
+def test_parquet_count_sql_reaches_pushdown(tmp_path_factory, query):
+    # Regression: the SQL frontend emits count(*) as an aliased aggregate
+    # (`count(<narrowest col>, All) as "count"`), and the pushdown rule only matched the
+    # bare Expr::Agg shape, so every SQL count read a full column instead of the footer.
+    path = str(tmp_path_factory.mktemp("parquet_count_sql"))
+    daft.from_pydict({"string_content": ["a"] * 10, "int_id": [1] * 10}).write_parquet(path, write_mode="overwrite")
+
+    df = daft.sql(query, tbl=daft.read_parquet(path))
+    plan = io.StringIO()
+    df.explain(True, file=plan)
+    assert "aggregation: count(col(int_id), All)" in plan.getvalue()
+
+    assert df.to_pydict() == {"n": [10]}
+
+
 def test_write_and_read_empty_parquet(tmp_path_factory):
     empty_parquet_files = str(tmp_path_factory.mktemp("empty_parquet"))
     df = daft.from_pydict({"a": []})

--- a/tests/io/test_parquet.py
+++ b/tests/io/test_parquet.py
@@ -655,6 +655,19 @@ def test_parquet_count_sql_reaches_pushdown(tmp_path_factory, query):
     assert df.to_pydict() == {"n": [10]}
 
 
+def test_parquet_count_literal_arg_counts_rows(tmp_path_factory):
+    # Regression: the pushdown rewrote `count(<expr>)` into `sum(<expr>)`, which only
+    # happens to be right when <expr> is a bare column matching the scan's output name.
+    # With a literal it summed lit(1) over one partial-count row per scan task and
+    # returned the scan task count instead of the row count.
+    path = str(tmp_path_factory.mktemp("parquet_count_literal"))
+    daft.from_pydict({"a": list(range(10))}).write_parquet(path, write_mode="overwrite")
+
+    df = daft.read_parquet(path)
+    assert df.agg(daft.lit(1).count("all").alias("n")).to_pydict() == {"n": [10]}
+    assert df.agg(daft.lit(1).count("all")).to_pydict()["literal"] == [10]
+
+
 def test_write_and_read_empty_parquet(tmp_path_factory):
     empty_parquet_files = str(tmp_path_factory.mktemp("empty_parquet"))
     df = daft.from_pydict({"a": []})


### PR DESCRIPTION
## Changes Made

`PushDownAggregation` matched only a bare `Expr::Agg(AggExpr::Count(..))`, so any
count wrapped in an alias silently missed the parquet count pushdown added in #5038
and fell back to reading a full column.

The SQL frontend always emits `count(*)` that way — `handle_count` in
`src/daft-sql/src/modules/aggs.rs` rewrites it to
`count(<narrowest col>, All).alias("count")` — so **no SQL count has ever reached the
pushdown**. This is not SQL-specific; the DataFrame API misses it too whenever the
aggregate carries a name:

```python
src = lambda: daft.read_parquet("<parquet glob>")

src().count("*").explain(show_all=True)
# Pushdowns: {projection: [id], aggregation: count(col(id), All)}   <- pushed down

src().agg(col("id").count("all").alias("n")).explain(show_all=True)
# Pushdowns: {projection: [id]}                                     <- not pushed down

daft.sql("select count(*) as n from t", t=src()).explain(show_all=True)
# Pushdowns: {projection: [id]}                                     <- not pushed down
```

`df.count("*")` only works because it puts the rename in a separate `Project` node
above the aggregate, leaving the aggregate expression bare.

### Implementation

- Replace `is_count_expr` with `as_count_agg`, which peels the alias via the existing
  `ExprRef::unwrap_alias()` and returns `(unaliased count, alias name, count mode)`.
- **Push the bare `Count` into the scan, not the aliased expression.** This matters for
  correctness, not just style: `scan_task_reader.rs` matches on
  `Expr::Agg(AggExpr::Count(_, count_mode))` to select the metadata path. Handing it an
  alias makes it fall through to a normal row-level read, while the post-pushdown schema
  has already been narrowed to a single count field — the result would be wrong, not
  merely slow.
- Re-apply the alias to the rewritten `Sum` so the rewrite stays schema-preserving.
- Drive-by: the rule indexed `aggregations[0]` before the `len() == 1` guard; that is now
  ordered by `&&` short-circuit.

Everything that was previously skipped is still skipped: `CountMode::Valid`/`Null`,
grouped counts, and counts with a filter or limit are unchanged.

### Measurements

128 parquet files in S3 (~32 rows and 43 columns each, ~1.2 MiB/file), 7 runs,
min/median seconds:

| | before | after |
|---|---|---|
| native `SQL count(*)` | 1.41 / 1.48 | **0.77 / 0.87** |
| native `df.count_rows()` | 0.78 / 0.86 | 0.73 / 0.77 |
| ray `SQL count(*)` | 1.49 / 1.63 | **0.94 / 1.00** |
| ray `df.count_rows()` | 0.88 / 0.93 | 0.89 / 0.95 |

`df.count_rows()` is the control and does not move; SQL converges to it, which is the
point — both now take the same path.

### Tests

- `agg_count_all_aliased` in `push_down_aggregation.rs`: asserts the alias does not block
  pushdown, that the expression handed to the scan is the bare `Count`, and that the
  rewrite preserves the output schema.
- `test_parquet_count_sql_reaches_pushdown` in `tests/io/test_parquet.py`: end-to-end over
  parquet for both `count(*)` and `count(1)`.

Full suites green on both runners (`tests/sql`, `tests/io/test_pushdowns.py`,
`tests/io/test_parquet.py`, `tests/dataframe/test_aggregations.py`,
`tests/dataframe/test_explain.py`, `tests/cookbook/test_aggregations.py`).

## Related Issues
