### PR TITLE
feat(io): serve additional OpenDAL filesystems through the opendal Python package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,16 @@ python = [
   "daft-recordbatch/python",
   "daft-writers/python"
 ]
-hdfs = ["daft-io/hdfs"]
+# Native OpenDAL service backends (opt-in; install `daft[extra-fs]` for the
+# Python-based fallback instead). HDFS is native-only since the `opendal`
+# Python wheel does not ship the JNI-based service.
+native-oss = ["daft-io/native-oss"]
+native-cos = ["daft-io/native-cos"]
+native-obs = ["daft-io/native-obs"]
+native-tos = ["daft-io/native-tos"]
+native-goosefs = ["daft-io/native-goosefs"]
+native-github = ["daft-io/native-github"]
+native-hdfs = ["daft-io/native-hdfs"]
 
 [lib]
 crate-type = ["cdylib"]

--- a/daft/filesystem.py
+++ b/daft/filesystem.py
@@ -130,6 +130,26 @@ def canonicalize_protocol(protocol: str) -> str:
     return _CANONICAL_PROTOCOLS.get(protocol, protocol)
 
 
+# Protocols handled by the `opendal` Python package (see daft/io/opendal_filesystem.py).
+# The scheme names mirror the schemes actually shipped in the OpenDAL Python wheel;
+# goosefs, github, hdfs, sftp and ftps are intentionally absent because the wheel
+# does not ship them (verified against opendal 0.47.5). Keep this list in sync with
+# the wheel's scheme set when bumping the opendal dependency.
+_OPEN_DAL_PROTOCOLS = frozenset(
+    {
+        "oss",
+        "cos",
+        "obs",
+        "tos",
+        "webhdfs",
+        "webdav",
+        "ftp",
+        "dropbox",
+        "gdrive",
+    }
+)
+
+
 def _apply_protocol_alias(path: str, aliases: dict[str, str]) -> str:
     """Rewrite the URI scheme of *path* if it matches an entry in *aliases*."""
     sep = path.find("://")
@@ -308,6 +328,16 @@ def _build_filesystem(
         from daft.io.gravitino_filesystem import GravitinoFileSystem
 
         return GravitinoFileSystem(io_config=io_config), None
+
+    ###
+    # OpenDAL-backed protocols (e.g. oss, cos, obs, tos): PyArrow and fsspec
+    # have no native implementation, so fall back to the `opendal` Python
+    # package (installed via `daft[extra-fs]`).
+    ###
+    if protocol in _OPEN_DAL_PROTOCOLS:
+        from daft.io.opendal_filesystem import OpenDALFileSystem
+
+        return OpenDALFileSystem(protocol=protocol, io_config=io_config), None
 
     raise NotImplementedError(f"Cannot infer PyArrow filesystem for protocol {protocol}: please file an issue!")
 

--- a/daft/io/opendal_bridge.py
+++ b/daft/io/opendal_bridge.py
@@ -1,0 +1,49 @@
+"""Bridge helpers for driving the `opendal` Python package from Rust.
+
+The Rust `PythonOpenDALSource` backend (see `src/daft-io/src/opendal_python.rs`)
+calls into this module to run `opendal.AsyncOperator` coroutines on a fresh
+asyncio event loop. The pyo3-async-runtimes machinery requires a running event
+loop at coroutine-creation time, so coroutines must be created *inside*
+`run_until_complete` — hence every operation is wrapped in a small `async def`
+here.
+
+Each function is synchronous: it creates an event loop owned by the calling
+(spawn-blocking) thread, runs the coroutine to completion, and closes the loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+
+def _run(awaitable_factory):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(awaitable_factory())
+    finally:
+        loop.close()
+
+
+def call(operator: Any, method: str, args: tuple, kwargs: dict) -> Any:
+    """Run `await getattr(operator, method)(*args, **kwargs)` and return the result."""
+
+    async def _inner():
+        return await getattr(operator, method)(*args, **kwargs)
+
+    return _run(_inner)
+
+
+def list_entries(operator: Any, path: str, recursive: bool) -> list:
+    """Fully drain `operator.list(...)` into a list of (path, is_dir, size)."""
+
+    async def _inner():
+        entries = []
+        async for entry in await operator.list(path, recursive=recursive):
+            meta = entry.metadata
+            is_dir = meta.mode.is_dir()
+            size = None if is_dir else meta.content_length
+            entries.append((entry.path, is_dir, size))
+        return entries
+
+    return _run(_inner)

--- a/daft/io/opendal_bridge.py
+++ b/daft/io/opendal_bridge.py
@@ -14,10 +14,11 @@ Each function is synchronous: it creates an event loop owned by the calling
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 
-def _run(awaitable_factory):
+def _run(awaitable_factory: Callable[[], Awaitable[Any]]) -> Any:
     loop = asyncio.new_event_loop()
     try:
         return loop.run_until_complete(awaitable_factory())
@@ -25,20 +26,20 @@ def _run(awaitable_factory):
         loop.close()
 
 
-def call(operator: Any, method: str, args: tuple, kwargs: dict) -> Any:
+def call(operator: Any, method: str, args: tuple[Any, ...], kwargs: dict[str, Any]) -> Any:
     """Run `await getattr(operator, method)(*args, **kwargs)` and return the result."""
 
-    async def _inner():
+    async def _inner() -> Any:
         return await getattr(operator, method)(*args, **kwargs)
 
     return _run(_inner)
 
 
-def list_entries(operator: Any, path: str, recursive: bool) -> list:
+def list_entries(operator: Any, path: str, recursive: bool) -> list[tuple[str, bool, int | None]]:
     """Fully drain `operator.list(...)` into a list of (path, is_dir, size)."""
 
-    async def _inner():
-        entries = []
+    async def _inner() -> list[tuple[str, bool, int | None]]:
+        entries: list[tuple[str, bool, int | None]] = []
         async for entry in await operator.list(path, recursive=recursive):
             meta = entry.metadata
             is_dir = meta.mode.is_dir()

--- a/daft/io/opendal_filesystem.py
+++ b/daft/io/opendal_filesystem.py
@@ -1,0 +1,142 @@
+"""PyArrow filesystem backed by the `opendal` Python package.
+
+Protocols that neither PyArrow nor fsspec handle natively (e.g. ``oss``,
+``cos``, ``obs``, ``tos``) are routed here when the ``opendal`` Python package
+is installed via ``daft[extra-fs]``. The handler speaks the fsspec-like
+protocol expected by :class:`pyarrow.fs.FSSpecHandler`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from daft.dependencies import pafs
+from daft.io import IOConfig
+
+
+class OpenDALFileSystemHandler:
+    """FSSpec-like handler delegating to a blocking ``opendal.Operator``."""
+
+    def __init__(self, protocol: str, io_config: IOConfig | None = None) -> None:
+        try:
+            import opendal
+        except ImportError:
+            raise ImportError(
+                f"Accessing '{protocol}://' paths through PyArrow requires the `opendal` "
+                f"Python package, which is not installed. Install it with "
+                f"`pip install 'daft[extra-fs]'` (https://docs.daft.ai/en/latest/install)."
+            ) from None
+
+        from opendal import exceptions as opendal_exceptions
+
+        self._exceptions = opendal_exceptions
+
+        # fsspec introspection attribute used by FSSpecHandler.get_type_name.
+        self.protocol = protocol
+
+        backend_kwargs: dict[str, str] = {}
+        if io_config is not None and io_config.opendal_backends is not None:
+            backend_kwargs = dict(io_config.opendal_backends.get(protocol, {}))
+        self.operator = opendal.Operator(protocol, **backend_kwargs)
+
+    def _metadata_to_info(self, path: str, metadata: Any) -> dict[str, Any]:
+        is_dir = metadata.mode.is_dir()
+        return {
+            "name": path,
+            "type": "directory" if is_dir else "file",
+            "size": 0 if is_dir else metadata.content_length,
+        }
+
+    def _entry_to_info(self, entry: Any) -> dict[str, Any]:
+        return self._metadata_to_info(entry.path, entry.metadata)
+
+    def info(self, path: str) -> dict[str, Any]:
+        return self._metadata_to_info(path, self.operator.stat(path))
+
+    def exists(self, path: str) -> bool:
+        return self.operator.exists(path)
+
+    def isdir(self, path: str) -> bool:
+        try:
+            return self.operator.stat(path).is_dir
+        except self._exceptions.NotFound:
+            return False
+
+    def isfile(self, path: str) -> bool:
+        try:
+            return self.operator.stat(path).is_file
+        except self._exceptions.NotFound:
+            return False
+
+    def mkdir(self, path: str, create_parents: bool = True) -> None:
+        # opendal's create_dir is always recursive (mkdir -p semantics).
+        self.operator.create_dir(path)
+
+    def rm(self, path: str, recursive: bool = False) -> None:
+        if recursive:
+            self.operator.remove_all(path)
+        else:
+            self.operator.delete(path)
+
+    def listdir(self, path: str, detail: bool = False) -> list[Any]:
+        entries = self.operator.list(path)
+        if detail:
+            return [self._entry_to_info(entry) for entry in entries]
+        return [entry.path for entry in entries]
+
+    def find(
+        self,
+        path: str,
+        maxdepth: int | None = None,
+        withdirs: bool = False,
+        detail: bool = False,
+    ) -> list[Any] | dict[str, dict[str, Any]]:
+        # opendal's list is either single-level or fully recursive; approximate
+        # fsspec's maxdepth semantics with those two modes.
+        recursive = maxdepth is None or maxdepth > 1
+        entries = self.operator.list(path, recursive=recursive)
+        if not withdirs:
+            entries = [e for e in entries if not e.metadata.mode.is_dir()]
+        if detail:
+            return {e.path: self._entry_to_info(e) for e in entries}
+        return [e.path for e in entries]
+
+    def mv(self, src: str, dest: str, recursive: bool = True) -> None:
+        self.operator.rename(src, dest)
+
+    def copy(self, src: str, dest: str) -> None:
+        self.operator.copy(src, dest)
+
+    def open(self, path: str, mode: str = "rb") -> Any:
+        # opendal's sync File implements the full file protocol
+        # (read/readinto/write/seek/tell/close), which is all PythonFile needs.
+        # Its write() requires true `bytes`, so adapt pyarrow Buffers here.
+        return _OpenDALFileWrapper(self.operator.open(path, mode))
+
+
+class _OpenDALFileWrapper:
+    """Adapt an `opendal.File` for pyarrow consumption.
+
+    pyarrow passes `pyarrow.Buffer` objects to ``write``, while opendal's
+    ``File.write`` only accepts true ``bytes``. All other file operations are
+    delegated transparently.
+    """
+
+    def __init__(self, file: Any) -> None:
+        self._file = file
+
+    def write(self, data: Any) -> int:
+        if not isinstance(data, (bytes, bytearray, memoryview)):
+            data = bytes(data)
+        return self._file.write(data)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._file, name)
+
+
+class OpenDALFileSystem(pafs.PyFileSystem):  # type: ignore[misc]
+    """PyArrow filesystem for protocols handled by the `opendal` Python package."""
+
+    def __init__(self, protocol: str, io_config: IOConfig | None = None) -> None:
+        handler = OpenDALFileSystemHandler(protocol=protocol, io_config=io_config)
+        super().__init__(pafs.FSSpecHandler(handler))

--- a/docs/connectors/index.md
+++ b/docs/connectors/index.md
@@ -14,6 +14,16 @@ Daft natively supports reading and writing data to major cloud object storage pr
 | [Tencent Cloud COS](cos.md) | `cos://`, `cosn://` | [`CosConfig`][daft.io.CosConfig] |
 | [GooseFS](goosefs.md) | `goosefs://` | [`GooseFSConfig`][daft.io.GooseFSConfig] |
 
+!!! note "Additional OpenDAL-backed filesystems"
+
+    Daft also supports a wide range of additional object storage protocols — such as `oss://`, `obs://`, `tos://`, `webdav://`, `ftp://` and more — through the [OpenDAL](https://opendal.apache.org/) Python library. Install the `extra-fs` extra to enable them:
+
+    ```bash
+    pip install -U "daft[extra-fs]"
+    ```
+
+    These backends use the Python OpenDAL bindings at runtime, so no special Daft build is required. Writes are buffered in memory, up to 1GB per file. The `goosefs://`, `github://`, `hdfs://`, `sftp://` and `ftps://` protocols are not shipped in the Python wheel — use Daft's native HDFS support for `hdfs://` instead. See [Installation](../install.md) for details.
+
 ## Table Formats
 
 Daft reads and writes the major open table formats.

--- a/docs/install.md
+++ b/docs/install.md
@@ -208,6 +208,14 @@ Depending on your use case, you may need to install Daft with additional depende
           <strong>MCAP</strong> <code>mcap</code>
         </div>
       </label>
+
+      <label class="checkbox-item">
+        <input type="checkbox" id="extra-fs" data-extra="extra-fs">
+        <span class="checkmark"></span>
+        <div class="checkbox-content">
+          <strong>Additional Filesystems</strong> <code>extra-fs</code>
+        </div>
+      </label>
     </div>
 
   </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,12 +29,13 @@ homepage = "https://www.daft.ai"
 repository = "https://github.com/Eventual-Inc/Daft"
 
 [project.optional-dependencies]
-all = ["daft[audio, aws, azure, clickhouse, deltalake, google, gravitino, hdf5, http, huggingface, iceberg, kafka, lance, mcap, numpy, openai, pandas, postgres, ray, sql, transformers, turbopuffer, unity, video]"]
+all = ["daft[audio, aws, azure, clickhouse, deltalake, extra-fs, google, gravitino, hdf5, http, huggingface, iceberg, kafka, lance, mcap, numpy, openai, pandas, postgres, ray, sql, transformers, turbopuffer, unity, video]"]
 audio = ["soundfile >= 0.13.0,<0.14.0", "librosa >= 0.11.0,<0.12.0"]
 aws = ["boto3<1.44.0", "mypy-boto3-glue"]
 azure = ["fsspec<2026.8.0", "adlfs<2026.5.0"]
 clickhouse = ["clickhouse_connect<1.1.0"]
 deltalake = ["deltalake >= 1.6.0,< 1.7.0"]
+extra-fs = ["opendal>=0.47.5,<1"]
 gcp = []
 google = ["google-genai<2.7.0", "numpy<2.4.0", "pillow==12.2.0"]
 gravitino = ["requests>=2.28.0,<3.0.0"]

--- a/src/daft-io/Cargo.toml
+++ b/src/daft-io/Cargo.toml
@@ -27,14 +27,8 @@ log = {workspace = true}
 opendal = {version = "0.58", default-features = false, features = [
   "executors-tokio",  # Use tokio for async execution
   "http-transport-reqwest",  # Reqwest HTTP transport (required for cloud services in 0.58+)
-  "services-oss",  # Alibaba Cloud Object Storage Service
-  "services-cos",  # Tencent Cloud Object Storage
-  "services-obs",  # Huawei Cloud Object Storage
-  "services-tos",  # Volcengine TOS (Torch Object Storage)
-  "services-goosefs",  # Tencent Cloud GooseFS distributed cache
   "services-memory",  # In-memory backend (used for testing)
-  "services-fs",  # Local filesystem (used for integration testing)
-  "services-github"  # GitHub repository contents
+  "services-fs"  # Local filesystem (used for integration testing)
 ]}
 pyo3 = {workspace = true, optional = true}
 rand = {workspace = true}
@@ -60,7 +54,17 @@ md5 = "0.8.0"
 tempfile = "3.23.0"
 
 [features]
-hdfs = ["opendal/services-hdfs"]
+# Native OpenDAL services. Deprecated as default-builtins: install `daft[extra-fs]`
+# (the `opendal` Python package) to use these backends at runtime instead.
+native-oss = ["opendal/services-oss"]  # Alibaba Cloud Object Storage Service
+native-cos = ["opendal/services-cos"]  # Tencent Cloud Object Storage
+native-obs = ["opendal/services-obs"]  # Huawei Cloud Object Storage
+native-tos = ["opendal/services-tos"]  # Volcengine TOS (Torch Object Storage)
+native-goosefs = ["opendal/services-goosefs"]  # Tencent Cloud GooseFS distributed cache
+native-github = ["opendal/services-github"]  # GitHub repository contents
+# HDFS is JNI-based and not shipped in the `opendal` Python wheel (which only
+# has `hdfs-native`), so it stays native-only and is not deprecated.
+native-hdfs = ["opendal/services-hdfs"]
 python = [
   "dep:pyo3",
   "common-error/python",

--- a/src/daft-io/src/lib.rs
+++ b/src/daft-io/src/lib.rs
@@ -10,6 +10,8 @@ mod local;
 pub mod multipart;
 mod object_io;
 mod object_store_glob;
+#[cfg(feature = "python")]
+mod opendal_python;
 mod opendal_source;
 mod range_expansion;
 mod retry;
@@ -130,6 +132,12 @@ pub enum Error {
 
     #[snafu(display("Failed to load credentials for IO backend `{store}`"))]
     UnableToCreateClient { store: SourceType, source: DynError },
+
+    #[snafu(display("OpenDAL service '{scheme}' is not compiled into this build"))]
+    UnsupportedOpenDALService { scheme: String },
+
+    #[snafu(display("The `opendal` Python package is not installed"))]
+    OpenDALPythonPackageMissing,
 
     #[snafu(display(
         "Unauthorized to access store: {store} for file: {path}\nYou may need to set valid Credentials\n{source}"
@@ -314,7 +322,7 @@ impl IOClient {
                         };
                         self.config.goosefs.to_opendal_config(&authority)
                     }
-                    #[cfg(feature = "hdfs")]
+                    #[cfg(feature = "native-hdfs")]
                     "hdfs" => {
                         // Extract name_node (scheme + authority) from URL,
                         // e.g. "hdfs://namenode:9000" from "hdfs://namenode:9000/path".
@@ -324,11 +332,11 @@ impl IOClient {
                             format!("{}://{}", parsed_url.scheme(), parsed_url.authority());
                         self.config.hdfs.to_opendal_config(&name_node)
                     }
-                    #[cfg(not(feature = "hdfs"))]
+                    #[cfg(not(feature = "native-hdfs"))]
                     "hdfs" => {
                         log::warn!(
                             "HDFS support is not compiled in. \
-                             Rebuild with `--features hdfs` to enable it."
+                             Rebuild with `--features native-hdfs` to enable it."
                         );
                         self.config
                             .opendal_backends
@@ -348,7 +356,64 @@ impl IOClient {
                         backend_config.insert(k.clone(), v.clone());
                     }
                 }
-                OpenDALSource::get_client(scheme, &backend_config).await? as Arc<dyn ObjectSource>
+
+                // Test/dev hook: prefer the Python OpenDAL backend over the
+                // native one, when the `opendal` package is importable. This
+                // lets the fallback path be exercised without cloud
+                // credentials.
+                #[cfg(feature = "python")]
+                let python_source = {
+                    let force_python = std::env::var("DAFT_FORCE_PYTHON_OPENDAL")
+                        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+                        .unwrap_or(false);
+                    if force_python {
+                        opendal_python::PythonOpenDALSource::get_client(scheme, &backend_config)
+                            .await
+                            .ok()
+                    } else {
+                        None
+                    }
+                };
+                #[cfg(not(feature = "python"))]
+                let python_source = None::<Arc<dyn ObjectSource>>;
+
+                if let Some(source) = python_source {
+                    source
+                } else {
+                    match OpenDALSource::get_client(scheme, &backend_config).await {
+                        Ok(source) => source as Arc<dyn ObjectSource>,
+                        // Service is not compiled into this build: fall back to
+                        // the Python OpenDAL backend (`daft[extra-fs]`).
+                        Err(Error::UnsupportedOpenDALService { scheme: s }) => {
+                            #[cfg(feature = "python")]
+                            {
+                                match opendal_python::PythonOpenDALSource::get_client(
+                                    &s,
+                                    &backend_config,
+                                )
+                                .await
+                                {
+                                    Ok(source) => source as Arc<dyn ObjectSource>,
+                                    Err(py_err) => {
+                                        return Err(python_fallback_error(&s, py_err));
+                                    }
+                                }
+                            }
+                            #[cfg(not(feature = "python"))]
+                            {
+                                return Err(Error::UnableToCreateClient {
+                                    store: SourceType::OpenDAL { scheme: s.clone() },
+                                    source: format!(
+                                        "OpenDAL service '{s}' is not compiled into this build. \
+                                         Rebuild with `--features {s}` to enable it."
+                                    )
+                                    .into(),
+                                });
+                            }
+                        }
+                        Err(e) => return Err(e),
+                    }
+                }
             }
         };
 
@@ -698,6 +763,72 @@ pub fn resolve_url_alias<'a>(input: &'a str, config: &IOConfig) -> Cow<'a, str> 
         }
     }
     Cow::Borrowed(input)
+}
+
+/// Rebuild hint suffix for schemes that have a corresponding `native-*`
+/// feature; empty for schemes that are Python-wheel-only.
+#[cfg(feature = "python")]
+fn native_rebuild_hint(scheme: &str) -> String {
+    // Only suggest a rebuild when a corresponding `native-*` feature exists.
+    match scheme {
+        "oss" | "cos" | "obs" | "tos" | "goosefs" | "github" | "hdfs" => {
+            format!(", or rebuild with `--features native-{scheme}`")
+        }
+        _ => String::new(),
+    }
+}
+
+/// Build the error reported when the Python OpenDAL fallback itself fails.
+///
+/// The hint depends on why the fallback failed: the `opendal` wheel does not
+/// ship every service (goosefs, github, hdfs), the package may be missing
+/// entirely, or the operator may simply be unconfigured.
+#[cfg(feature = "python")]
+fn python_fallback_error(s: &str, py_err: Error) -> Error {
+    // snafu's display omits `source`, so extract the root Python error text
+    // to keep the cause visible.
+    let detail = match &py_err {
+        Error::UnableToCreateClient { source, .. } | Error::Generic { source, .. } => {
+            source.to_string()
+        }
+        other => other.to_string(),
+    };
+    let hint = if matches!(s, "goosefs" | "github" | "hdfs") {
+        format!(
+            "OpenDAL service '{s}' is not compiled into this build, \
+             and the `opendal` Python package does not ship it. \
+             Rebuild with `--features native-{s}` to enable it."
+        )
+    } else if matches!(py_err, Error::OpenDALPythonPackageMissing) {
+        format!(
+            "OpenDAL service '{s}' is not compiled into this build. \
+             Install the Python backend with `pip install \"daft[extra-fs]\"`{}.",
+            native_rebuild_hint(s)
+        )
+    } else if detail.contains("scheme is not registered") {
+        // The package is installed but does not know this scheme (e.g. sftp,
+        // ftps), and no native feature provides it.
+        format!(
+            "OpenDAL service '{s}' is not compiled into this build, \
+             and the `opendal` Python package does not ship it either. \
+             It is not supported by this Daft build."
+        )
+    } else {
+        // The package is installed but the operator could not be created
+        // (typically missing credentials/config).
+        format!(
+            "OpenDAL service '{s}' is not compiled into this build and the \
+             Python backend (`daft[extra-fs]`) could not create a client. \
+             Configure it via IOConfig(opendal_backends={{\"{s}\": {{...}}}}){}.",
+            native_rebuild_hint(s)
+        )
+    };
+    Error::UnableToCreateClient {
+        store: SourceType::OpenDAL {
+            scheme: s.to_string(),
+        },
+        source: format!("{hint} Error: {detail}").into(),
+    }
 }
 
 type CacheKey = (bool, Arc<IOConfig>);

--- a/src/daft-io/src/opendal_python.rs
+++ b/src/daft-io/src/opendal_python.rs
@@ -175,7 +175,7 @@ impl PythonOpenDALSource {
         .await
     }
 
-    async fn stat_content_length(&self, uri: &str, path: &str) -> super::Result<u64> {
+    async fn stat_metadata(&self, uri: &str, path: &str) -> super::Result<(bool, u64)> {
         let path_owned = path.to_string();
         self.run_op(
             uri,
@@ -184,7 +184,11 @@ impl PythonOpenDALSource {
                 let args = PyTuple::new(py, [path_owned.as_str()])?;
                 Ok((args.unbind(), PyDict::new(py).unbind()))
             },
-            |_py, result| result.getattr("content_length")?.extract(),
+            |_py, result| {
+                let is_dir = result.getattr("mode")?.call_method0("is_dir")?.extract()?;
+                let content_length = result.getattr("content_length")?.extract()?;
+                Ok((is_dir, content_length))
+            },
         )
         .await
     }
@@ -311,7 +315,7 @@ impl ObjectSource for PythonOpenDALSource {
             Some(GetRange::Bounded(r)) => (Some(r.start as u64), Some((r.end - r.start) as u64)),
             Some(GetRange::Offset(offset)) => (Some(offset as u64), None),
             Some(GetRange::Suffix(n)) => {
-                let file_size = self.stat_content_length(uri, &path).await?;
+                let file_size = self.stat_metadata(uri, &path).await?.1;
                 let start = file_size.saturating_sub(n as u64);
                 (Some(start), Some(file_size - start))
             }
@@ -370,7 +374,12 @@ impl ObjectSource for PythonOpenDALSource {
 
     async fn get_size(&self, uri: &str, _io_stats: Option<IOStatsRef>) -> super::Result<usize> {
         let path = url_to_opendal_path(uri)?;
-        let size = self.stat_content_length(uri, &path).await?;
+        let (is_dir, size) = self.stat_metadata(uri, &path).await?;
+        if is_dir {
+            return Err(super::Error::NotAFile {
+                path: uri.to_string(),
+            });
+        }
         Ok(size as usize)
     }
 

--- a/src/daft-io/src/opendal_python.rs
+++ b/src/daft-io/src/opendal_python.rs
@@ -1,0 +1,475 @@
+//! Python-based OpenDAL backend.
+//!
+//! This module provides an [`ObjectSource`] implementation that drives the
+//! `opendal` Python package (installed via `pip install "daft[extra-fs]"`)
+//! through its `AsyncOperator` API. It is used as a runtime fallback for
+//! OpenDAL services that are not compiled into the native build, so the
+//! default wheel stays small while still supporting all services that the
+//! Python binding ships.
+//!
+//! Coroutines are driven with a fresh `asyncio` event loop per call, inside a
+//! `spawn_blocking` thread: event loops are thread-affine and each blocking
+//! call may land on a different thread, so a loop is never shared.
+
+use std::{any::Any, collections::BTreeMap, sync::Arc};
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::{stream, stream::BoxStream};
+use pyo3::{
+    prelude::*,
+    types::{PyBool, PyBytes, PyDict, PyString, PyTuple},
+};
+
+use crate::{
+    FileFormat, GetRange,
+    multipart::MultipartWriter,
+    object_io::{FileMetadata, FileType, GetResult, LSResult, ObjectSource},
+    object_store_glob,
+    opendal_source::{url_prefix, url_to_opendal_path},
+    stats::IOStatsRef,
+    stream_utils::io_stats_on_bytestream,
+};
+
+/// Upper bound on buffered data for the multipart-writer emulation. The
+/// `opendal` Python binding has no multipart/append API, so parts are buffered
+/// in memory and flushed as a single write on `complete`. This cap prevents
+/// unbounded memory usage on very large uploads.
+const MAX_BUFFERED_WRITE_BYTES: usize = 1024 * 1024 * 1024; // 1GB
+
+pub(crate) struct PythonOpenDALSource {
+    /// The `opendal.AsyncOperator` instance.
+    operator: Py<PyAny>,
+    /// The `daft.io.opendal_bridge` helper module.
+    bridge: Py<PyAny>,
+    scheme: String,
+}
+
+impl PythonOpenDALSource {
+    pub async fn get_client(
+        scheme: &str,
+        config: &BTreeMap<String, String>,
+    ) -> super::Result<Arc<dyn ObjectSource>> {
+        let scheme = scheme.to_string();
+        let config = config.clone();
+        let (operator, bridge) = tokio::task::spawn_blocking({
+            let scheme = scheme.clone();
+            move || {
+                Python::attach(|py| -> super::Result<(Py<PyAny>, Py<PyAny>)> {
+                    let pyerr = |e: PyErr| super::Error::UnableToCreateClient {
+                        store: super::SourceType::OpenDAL {
+                            scheme: scheme.clone(),
+                        },
+                        // Embed the PyErr text: the error display omits `source`,
+                        // so a bare PyErr would lose the failure message.
+                        source: format!("{e}").into(),
+                    };
+                    let opendal_mod = py
+                        .import("opendal")
+                        .map_err(|_| super::Error::OpenDALPythonPackageMissing)?;
+                    let bridge = py
+                        .import("daft.io.opendal_bridge")
+                        .map_err(|_| pyerr(PyErr::new::<pyo3::exceptions::PyImportError, _>(
+                            "The `daft.io.opendal_bridge` helper module could not be imported. Reinstall Daft to restore it.",
+                        )))?;
+                    let kwargs = PyDict::new(py);
+                    for (k, v) in &config {
+                        kwargs.set_item(k.as_str(), v.as_str()).map_err(&pyerr)?;
+                    }
+                    let operator = opendal_mod
+                        .getattr("AsyncOperator")
+                        .map_err(&pyerr)?
+                        .call((scheme.as_str(),), Some(&kwargs))
+                        .map_err(pyerr)?;
+                    Ok((operator.unbind(), bridge.unbind().into_any()))
+                })
+            }
+        })
+        .await
+        .map_err(|e| super::Error::Generic {
+            store: super::SourceType::OpenDAL {
+                scheme: scheme.clone(),
+            },
+            source: e.into(),
+        })??;
+
+        Ok(Arc::new(Self {
+            operator,
+            bridge,
+            scheme,
+        }))
+    }
+
+    /// Run `bridge.<fn_name>(...)` on a fresh event loop in a blocking
+    /// thread, then post-process the result while the GIL is still held.
+    /// `make_payload` builds the full positional-argument tuple (the
+    /// operator is passed in as its first element) under the GIL.
+    async fn run_bridge<M, P, R>(
+        &self,
+        uri: &str,
+        fn_name: &'static str,
+        make_payload: M,
+        process: P,
+    ) -> super::Result<R>
+    where
+        M: FnOnce(Python<'_>, &Bound<'_, PyAny>) -> PyResult<Py<PyTuple>> + Send + 'static,
+        P: FnOnce(Python<'_>, &Bound<'_, PyAny>) -> PyResult<R> + Send + 'static,
+        R: Send + 'static,
+    {
+        let (operator, bridge) =
+            Python::attach(|py| (self.operator.clone_ref(py), self.bridge.clone_ref(py)));
+        let uri_owned = uri.to_string();
+        let scheme = self.scheme.clone();
+        tokio::task::spawn_blocking(move || {
+            Python::attach(|py| {
+                let translate = |e: PyErr| translate_py_err(py, e, &uri_owned, &scheme);
+                let args = make_payload(py, operator.bind(py)).map_err(&translate)?;
+                let result = bridge
+                    .bind(py)
+                    .call_method1(fn_name, args.bind(py))
+                    .map_err(&translate)?;
+                process(py, &result).map_err(&translate)
+            })
+        })
+        .await
+        .map_err(|e| super::Error::Generic {
+            store: super::SourceType::OpenDAL {
+                scheme: self.scheme.clone(),
+            },
+            source: e.into(),
+        })?
+    }
+
+    /// Run `bridge.call(operator, method, args, kwargs)`; `make_payload`
+    /// builds the positional/keyword arguments under the GIL.
+    async fn run_op<M, P, R>(
+        &self,
+        uri: &str,
+        method: &'static str,
+        make_payload: M,
+        process: P,
+    ) -> super::Result<R>
+    where
+        M: FnOnce(Python<'_>) -> PyResult<(Py<PyTuple>, Py<PyDict>)> + Send + 'static,
+        P: FnOnce(Python<'_>, &Bound<'_, PyAny>) -> PyResult<R> + Send + 'static,
+        R: Send + 'static,
+    {
+        self.run_bridge(
+            uri,
+            "call",
+            move |py, operator| {
+                let (args, kwargs) = make_payload(py)?;
+                PyTuple::new(
+                    py,
+                    [
+                        operator.clone().into_any().unbind(),
+                        PyString::new(py, method).into_any().unbind(),
+                        args.into_any(),
+                        kwargs.into_any(),
+                    ],
+                )
+                .map(|t| t.unbind())
+            },
+            process,
+        )
+        .await
+    }
+
+    async fn stat_content_length(&self, uri: &str, path: &str) -> super::Result<u64> {
+        let path_owned = path.to_string();
+        self.run_op(
+            uri,
+            "stat",
+            move |py| {
+                let args = PyTuple::new(py, [path_owned.as_str()])?;
+                Ok((args.unbind(), PyDict::new(py).unbind()))
+            },
+            |_py, result| result.getattr("content_length")?.extract(),
+        )
+        .await
+    }
+}
+
+/// Translate known `opendal` Python exceptions into their `daft-io` error
+/// equivalents so upstream handling (retries, not-found semantics) keeps
+/// working across the Python fallback.
+fn translate_py_err(py: Python<'_>, err: PyErr, uri: &str, scheme: &str) -> super::Error {
+    let store = super::SourceType::OpenDAL {
+        scheme: scheme.to_string(),
+    };
+    if let Ok(exceptions) = py.import("opendal.exceptions") {
+        let class_of = |name: &str| exceptions.getattr(name).ok();
+        if let Some(cls) = class_of("NotFound")
+            && err.is_instance(py, &cls)
+        {
+            return super::Error::NotFound {
+                path: uri.to_string(),
+                source: Box::new(err),
+            };
+        }
+        if let Some(cls) = class_of("PermissionDenied")
+            && err.is_instance(py, &cls)
+        {
+            return super::Error::Unauthorized {
+                store,
+                path: uri.to_string(),
+                source: Box::new(err),
+            };
+        }
+        if let Some(cls) = class_of("RateLimited")
+            && err.is_instance(py, &cls)
+        {
+            return super::Error::Throttled {
+                path: uri.to_string(),
+                source: Box::new(err),
+            };
+        }
+        if let Some(cls) = class_of("IsADirectory")
+            && err.is_instance(py, &cls)
+        {
+            return super::Error::NotAFile {
+                path: uri.to_string(),
+            };
+        }
+    }
+    super::Error::Generic {
+        store,
+        source: if let Some(tb) = err.traceback(py) {
+            format!("{err}\n{tb}").into()
+        } else {
+            Box::new(err)
+        },
+    }
+}
+
+struct PythonOpenDALMultipartWriter {
+    source: Arc<PythonOpenDALSource>,
+    uri: String,
+    parts: Vec<Bytes>,
+    total_len: usize,
+}
+
+#[async_trait]
+impl MultipartWriter for PythonOpenDALMultipartWriter {
+    fn part_size(&self) -> usize {
+        5 * 1024 * 1024 // 5MB
+    }
+
+    async fn put_part(&mut self, data: Bytes) -> super::Result<()> {
+        self.total_len += data.len();
+        if self.total_len > MAX_BUFFERED_WRITE_BYTES {
+            return Err(super::Error::InvalidArgument {
+                msg: format!(
+                    "Buffered write to '{}' exceeds the {}GB limit of the Python OpenDAL backend. \
+                     The `opendal` Python package has no multipart API, so writes are buffered \
+                     in memory and flushed as a single write on completion.",
+                    self.uri,
+                    MAX_BUFFERED_WRITE_BYTES / 1024 / 1024 / 1024,
+                ),
+            });
+        }
+        self.parts.push(data);
+        Ok(())
+    }
+
+    async fn complete(&mut self) -> super::Result<()> {
+        let mut all = Vec::with_capacity(self.total_len);
+        for part in self.parts.drain(..) {
+            all.extend_from_slice(&part);
+        }
+        self.source.put(&self.uri, Bytes::from(all), None).await
+    }
+}
+
+#[async_trait]
+impl ObjectSource for PythonOpenDALSource {
+    async fn supports_range(&self, _uri: &str) -> super::Result<bool> {
+        Ok(true)
+    }
+
+    async fn create_multipart_writer(
+        self: Arc<Self>,
+        uri: &str,
+    ) -> super::Result<Option<Box<dyn MultipartWriter>>> {
+        Ok(Some(Box::new(PythonOpenDALMultipartWriter {
+            source: self,
+            uri: uri.to_string(),
+            parts: Vec::new(),
+            total_len: 0,
+        })))
+    }
+
+    async fn get(
+        &self,
+        uri: &str,
+        range: Option<GetRange>,
+        io_stats: Option<IOStatsRef>,
+    ) -> super::Result<GetResult> {
+        let path = url_to_opendal_path(uri)?;
+
+        let (offset, size) = match range {
+            Some(GetRange::Bounded(r)) => (Some(r.start as u64), Some((r.end - r.start) as u64)),
+            Some(GetRange::Offset(offset)) => (Some(offset as u64), None),
+            Some(GetRange::Suffix(n)) => {
+                let file_size = self.stat_content_length(uri, &path).await?;
+                let start = file_size.saturating_sub(n as u64);
+                (Some(start), Some(file_size - start))
+            }
+            None => (None, None),
+        };
+
+        let bytes = self
+            .run_op(
+                uri,
+                "read",
+                move |py| {
+                    let args = PyTuple::new(py, [path.as_str()])?;
+                    let kwargs = PyDict::new(py);
+                    if let Some(offset) = offset {
+                        kwargs.set_item("offset", offset)?;
+                    }
+                    if let Some(size) = size {
+                        kwargs.set_item("size", size)?;
+                    }
+                    Ok((args.unbind(), kwargs.unbind()))
+                },
+                |_py, result| result.extract::<Vec<u8>>().map(Bytes::from),
+            )
+            .await?;
+
+        let stream = Box::pin(stream::iter([Ok(bytes)]));
+        let stream_with_stats = io_stats_on_bytestream(stream, io_stats);
+        Ok(GetResult::Stream(
+            stream_with_stats,
+            size.map(|s| s as usize),
+            None,
+            None,
+        ))
+    }
+
+    async fn put(
+        &self,
+        uri: &str,
+        data: Bytes,
+        _io_stats: Option<IOStatsRef>,
+    ) -> super::Result<()> {
+        let path = url_to_opendal_path(uri)?;
+        self.run_op(
+            uri,
+            "write",
+            move |py| {
+                let path_arg = path.as_str().into_pyobject(py)?.into_any().unbind();
+                let data_arg = PyBytes::new(py, data.as_ref()).into_any().unbind();
+                let args = PyTuple::new(py, [path_arg, data_arg])?;
+                Ok((args.unbind(), PyDict::new(py).unbind()))
+            },
+            |_py, _result| Ok(()),
+        )
+        .await
+    }
+
+    async fn get_size(&self, uri: &str, _io_stats: Option<IOStatsRef>) -> super::Result<usize> {
+        let path = url_to_opendal_path(uri)?;
+        let size = self.stat_content_length(uri, &path).await?;
+        Ok(size as usize)
+    }
+
+    async fn glob(
+        self: Arc<Self>,
+        glob_path: &str,
+        fanout_limit: Option<usize>,
+        page_size: Option<i32>,
+        limit: Option<usize>,
+        io_stats: Option<IOStatsRef>,
+        _file_format: Option<FileFormat>,
+    ) -> super::Result<BoxStream<'static, super::Result<FileMetadata>>> {
+        object_store_glob::glob(self, glob_path, fanout_limit, page_size, limit, io_stats).await
+    }
+
+    async fn ls(
+        &self,
+        path: &str,
+        posix: bool,
+        continuation_token: Option<&str>,
+        _page_size: Option<i32>,
+        _io_stats: Option<IOStatsRef>,
+    ) -> super::Result<LSResult> {
+        let opendal_path = url_to_opendal_path(path)?;
+
+        let dir_path = if opendal_path.is_empty() || opendal_path.ends_with('/') {
+            opendal_path
+        } else {
+            format!("{}/", opendal_path)
+        };
+
+        // Same semantics as the native backend: everything is listed in one go,
+        // so a continuation token means we are already done.
+        if continuation_token.is_some() {
+            return Ok(LSResult {
+                files: vec![],
+                continuation_token: None,
+                not_found_if_empty: false,
+            });
+        }
+
+        let prefix = url_prefix(path)?;
+        let dir_path_owned = dir_path.clone();
+        let entries: Vec<(String, bool, Option<u64>)> = self
+            .run_bridge(
+                path,
+                "list_entries",
+                move |py, operator| {
+                    PyTuple::new(
+                        py,
+                        [
+                            operator.clone().into_any().unbind(),
+                            PyString::new(py, &dir_path_owned).into_any().unbind(),
+                            PyBool::new(py, !posix).to_owned().into_any().unbind(),
+                        ],
+                    )
+                    .map(|t| t.unbind())
+                },
+                |_py, result| result.extract(),
+            )
+            .await?;
+
+        // Skip the directory itself (OpenDAL lists it as an entry).
+        let files = entries
+            .into_iter()
+            .filter(|(entry_path, _, _)| entry_path != &dir_path && !entry_path.is_empty())
+            .map(|(entry_path, is_dir, size)| FileMetadata {
+                filepath: format!("{prefix}/{entry_path}"),
+                size,
+                filetype: if is_dir {
+                    FileType::Directory
+                } else {
+                    FileType::File
+                },
+            })
+            .collect();
+
+        Ok(LSResult {
+            files,
+            continuation_token: None,
+            not_found_if_empty: false,
+        })
+    }
+
+    async fn delete(&self, uri: &str, _io_stats: Option<IOStatsRef>) -> super::Result<()> {
+        let path = url_to_opendal_path(uri)?;
+        self.run_op(
+            uri,
+            "delete",
+            move |py| {
+                let args = PyTuple::new(py, [path.as_str()])?;
+                Ok((args.unbind(), PyDict::new(py).unbind()))
+            },
+            |_py, _result| Ok(()),
+        )
+        .await
+    }
+
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
+        self
+    }
+}

--- a/src/daft-io/src/opendal_source.rs
+++ b/src/daft-io/src/opendal_source.rs
@@ -23,9 +23,11 @@ pub(crate) struct OpenDALSource {
 impl OpenDALSource {
     /// List the OpenDAL service schemes that are compiled into this build.
     fn available_schemes() -> Vec<&'static str> {
+        // Pushing the always-compiled schemes first keeps `schemes` mutated
+        // under every feature combination, so no `unused_mut` allow is needed.
+        let mut schemes = Vec::with_capacity(2);
         // `memory` and `fs` are always compiled (used by tests and local IO).
-        #[allow(unused_mut)] // No `native-*` feature enabled => no pushes below.
-        let mut schemes = vec!["memory", "fs"];
+        schemes.extend(["memory", "fs"]);
         // Cloud service schemes are opt-in via `native-*` features; they are
         // also available at runtime through the Python OpenDAL backend
         // (`daft[extra-fs]`), which is the preferred path.

--- a/src/daft-io/src/opendal_source.rs
+++ b/src/daft-io/src/opendal_source.rs
@@ -23,11 +23,25 @@ pub(crate) struct OpenDALSource {
 impl OpenDALSource {
     /// List the OpenDAL service schemes that are compiled into this build.
     fn available_schemes() -> Vec<&'static str> {
-        #[cfg_attr(not(feature = "hdfs"), allow(unused_mut))]
-        let mut schemes = vec![
-            "oss", "cos", "obs", "tos", "goosefs", "memory", "fs", "github",
-        ];
-        #[cfg(feature = "hdfs")]
+        // `memory` and `fs` are always compiled (used by tests and local IO).
+        #[allow(unused_mut)] // No `native-*` feature enabled => no pushes below.
+        let mut schemes = vec!["memory", "fs"];
+        // Cloud service schemes are opt-in via `native-*` features; they are
+        // also available at runtime through the Python OpenDAL backend
+        // (`daft[extra-fs]`), which is the preferred path.
+        #[cfg(feature = "native-oss")]
+        schemes.push("oss");
+        #[cfg(feature = "native-cos")]
+        schemes.push("cos");
+        #[cfg(feature = "native-obs")]
+        schemes.push("obs");
+        #[cfg(feature = "native-tos")]
+        schemes.push("tos");
+        #[cfg(feature = "native-goosefs")]
+        schemes.push("goosefs");
+        #[cfg(feature = "native-github")]
+        schemes.push("github");
+        #[cfg(feature = "native-hdfs")]
         schemes.push("hdfs");
         schemes
     }
@@ -44,20 +58,38 @@ impl OpenDALSource {
 
         let operator =
             Operator::via_iter(scheme, config.clone()).map_err(|e: opendal::Error| {
-                super::Error::UnableToCreateClient {
-                    store: super::SourceType::OpenDAL {
+                if e.kind() == opendal::ErrorKind::Unsupported {
+                    // Service not compiled into this build; the caller may fall
+                    // back to the Python OpenDAL backend.
+                    super::Error::UnsupportedOpenDALService {
                         scheme: scheme.to_string(),
-                    },
-                    source: format!(
-                        "Failed to create OpenDAL operator for '{}'. \
-                         You may need to configure it via IOConfig(opendal_backends={{\"{}\": {{...}}}}). \
-                         Available OpenDAL schemes: [{}]. \
-                         Error: {}",
-                        scheme, scheme, Self::available_schemes().join(", "), e
-                    )
-                    .into(),
+                    }
+                } else {
+                    super::Error::UnableToCreateClient {
+                        store: super::SourceType::OpenDAL {
+                            scheme: scheme.to_string(),
+                        },
+                        source: format!(
+                            "Failed to create OpenDAL operator for '{}'. \
+                             You may need to configure it via IOConfig(opendal_backends={{\"{}\": {{...}}}}). \
+                             Available OpenDAL schemes: [{}]. \
+                             Error: {}",
+                            scheme, scheme, Self::available_schemes().join(", "), e
+                        )
+                        .into(),
+                    }
                 }
             })?;
+
+        // Deprecated as a built-in backend: cloud services should go through
+        // the Python OpenDAL backend (daft[extra-fs]) instead.
+        if matches!(scheme, "oss" | "cos" | "obs" | "tos" | "goosefs" | "github") {
+            log::warn!(
+                "Built-in '{scheme}' OpenDAL support is deprecated and will be removed \
+                 in a future release. Install `daft[extra-fs]` to use the Python-based \
+                 OpenDAL backend instead."
+            );
+        }
 
         Ok(Arc::new(Self {
             operator,
@@ -69,13 +101,26 @@ impl OpenDALSource {
 /// Extract the path component from a URL like `oss://bucket/path/to/file`.
 /// OpenDAL operators are already configured with the root/bucket, so we only
 /// need the path portion.
-fn url_to_opendal_path(uri: &str) -> super::Result<String> {
+pub(crate) fn url_to_opendal_path(uri: &str) -> super::Result<String> {
     let parsed = url::Url::parse(uri).context(super::InvalidUrlSnafu { path: uri })?;
     // url::Url::path() returns the path component, e.g. "/path/to/file"
     // We strip the leading "/" since OpenDAL paths are relative to the operator root.
     let path = parsed.path();
     let path = path.strip_prefix('/').unwrap_or(path);
     Ok(path.to_string())
+}
+
+/// Reconstruct the URL prefix (scheme + authority) for a given path.
+/// Use authority (host:port) rather than host_str so schemes like HDFS
+/// (hdfs://host:port) generate correct URLs.
+pub(crate) fn url_prefix(path: &str) -> super::Result<String> {
+    let parsed = url::Url::parse(path).context(super::InvalidUrlSnafu { path })?;
+    let base_url = if !parsed.authority().is_empty() {
+        format!("{}://{}", parsed.scheme(), parsed.authority())
+    } else {
+        format!("{}://", parsed.scheme())
+    };
+    Ok(base_url)
 }
 
 pub struct OpenDALMultipartWriter {
@@ -308,14 +353,7 @@ impl ObjectSource for OpenDALSource {
             .map_err(|e| opendal_err_to_daft_err(e, path, &self.scheme))?;
 
         // Reconstruct the URL prefix for file paths.
-        // Use authority (host:port) rather than host_str so schemes like HDFS
-        // (hdfs://host:port) generate correct URLs.
-        let parsed = url::Url::parse(path).context(super::InvalidUrlSnafu { path })?;
-        let base_url = if !parsed.authority().is_empty() {
-            format!("{}://{}", parsed.scheme(), parsed.authority())
-        } else {
-            format!("{}://", parsed.scheme())
-        };
+        let base_url = url_prefix(path)?;
 
         let files = entries
             .into_iter()

--- a/tests/io/test_opendal.py
+++ b/tests/io/test_opendal.py
@@ -73,8 +73,13 @@ def test_opendal_fs_glob_parquet(tmp_path):
 
 
 def test_opendal_unknown_scheme_error():
-    """Test that an unknown scheme gives a helpful error message."""
-    with pytest.raises(Exception, match="does not ship it"):
+    """Test that an unknown scheme gives a helpful error message.
+
+    The exact hint depends on whether the `opendal` package is installed
+    ("does not ship it" vs. "Install the Python backend"), so match the part
+    that is present in both branches.
+    """
+    with pytest.raises(Exception, match="is not compiled into this build"):
         daft.read_parquet("unknownscheme://bucket/data.parquet").collect()
 
 

--- a/tests/io/test_opendal.py
+++ b/tests/io/test_opendal.py
@@ -72,9 +72,9 @@ def test_opendal_fs_glob_parquet(tmp_path):
     assert result.to_pydict() == {"val": [0, 1, 2]}
 
 
-def test_opendal_unconfigured_scheme_error():
-    """Test that an unconfigured scheme gives a helpful error message."""
-    with pytest.raises(Exception, match="IOConfig\\(opendal_backends="):
+def test_opendal_unknown_scheme_error():
+    """Test that an unknown scheme gives a helpful error message."""
+    with pytest.raises(Exception, match="does not ship it"):
         daft.read_parquet("unknownscheme://bucket/data.parquet").collect()
 
 

--- a/tests/io/test_opendal_python.py
+++ b/tests/io/test_opendal_python.py
@@ -1,0 +1,162 @@
+"""Tests for the Python-based OpenDAL fallback backend (daft[extra-fs]).
+
+These tests exercise the `PythonOpenDALSource` Rust backend, which drives the
+`opendal` Python package through its `AsyncOperator` API. They require the
+`opendal` package to be installed (`pip install "daft[extra-fs]"`).
+"""
+
+from __future__ import annotations
+
+import csv as csv_mod
+
+import pyarrow as pa
+import pyarrow.parquet as papq
+import pytest
+
+pytest.importorskip("opendal")
+
+from opendal import exceptions as opendal_exceptions
+
+import daft
+from daft.daft import IOConfig
+
+
+def _fs_io_config(root_dir) -> IOConfig:
+    """Create an IOConfig using OpenDAL's 'fs' (filesystem) backend."""
+    return IOConfig(
+        opendal_backends={
+            "fs": {
+                "root": str(root_dir),
+            }
+        }
+    )
+
+
+@pytest.fixture
+def forced_python_fallback(monkeypatch):
+    """Route OpenDAL schemes through the Python backend for this test.
+
+    Counts calls into the Python bridge and asserts at teardown that the
+    Python backend was actually exercised. This guards against
+    DAFT_FORCE_PYTHON_OPENDAL silently failing to create the Python client
+    (e.g. when the `opendal` package misbehaves) and the test degrading to
+    the native path without anyone noticing.
+    """
+    monkeypatch.setenv("DAFT_FORCE_PYTHON_OPENDAL", "1")
+
+    import daft.io.opendal_bridge as bridge
+
+    calls = {"count": 0}
+    real_call = bridge.call
+
+    def counting_call(*args, **kwargs):
+        calls["count"] += 1
+        return real_call(*args, **kwargs)
+
+    monkeypatch.setattr(bridge, "call", counting_call)
+    yield calls
+    assert calls["count"] > 0, "no bridge.call recorded: the Python OpenDAL backend was not exercised"
+
+
+def test_python_fallback_read_parquet(tmp_path, forced_python_fallback):
+    """Read a parquet file through the Python OpenDAL fallback."""
+    table = pa.table({"x": [1, 2, 3], "y": ["a", "b", "c"]})
+    papq.write_table(table, str(tmp_path / "data.parquet"))
+
+    io_config = _fs_io_config(tmp_path)
+    df = daft.read_parquet("fs://localhost/data.parquet", io_config=io_config)
+    assert df.collect().to_pydict() == {"x": [1, 2, 3], "y": ["a", "b", "c"]}
+
+
+def test_python_fallback_read_csv(tmp_path, forced_python_fallback):
+    """Read a CSV file through the Python OpenDAL fallback."""
+    path = tmp_path / "data.csv"
+    with open(path, "w", newline="") as f:
+        writer = csv_mod.writer(f)
+        writer.writerow(["x", "y"])
+        writer.writerows([[1, "a"], [2, "b"], [3, "c"]])
+
+    io_config = _fs_io_config(tmp_path)
+    df = daft.read_csv("fs://localhost/data.csv", io_config=io_config)
+    assert df.collect().to_pydict() == {"x": [1, 2, 3], "y": ["a", "b", "c"]}
+
+
+def test_python_fallback_write_parquet(tmp_path, forced_python_fallback):
+    """Write parquet through the Python fallback (buffered multipart emulation)."""
+    io_config = _fs_io_config(tmp_path)
+    df = daft.from_pydict({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+    df.write_parquet("fs://localhost/out", io_config=io_config)
+
+    result = daft.read_parquet("fs://localhost/out/*.parquet", io_config=io_config).sort("a").collect()
+    assert result.to_pydict() == {"a": [1, 2, 3], "b": ["x", "y", "z"]}
+
+
+def test_python_fallback_ls(tmp_path, forced_python_fallback):
+    """List files through the Python OpenDAL fallback."""
+    for i in range(3):
+        table = pa.table({"val": [i]})
+        papq.write_table(table, str(tmp_path / f"part_{i}.parquet"))
+
+    io_config = _fs_io_config(tmp_path)
+    df = daft.read_parquet("fs://localhost/*.parquet", io_config=io_config)
+    assert df.sort("val").collect().to_pydict() == {"val": [0, 1, 2]}
+
+
+def test_python_fallback_get_range(tmp_path, forced_python_fallback):
+    """Exercise ranged reads (parquet footers) through the Python fallback."""
+    io_config = _fs_io_config(tmp_path)
+    table = pa.table({"x": [42]})
+    papq.write_table(table, str(tmp_path / "r.parquet"))
+
+    df = daft.read_parquet("fs://localhost/r.parquet", io_config=io_config)
+    assert df.collect().to_pydict() == {"x": [42]}
+
+
+def test_opendal_pyarrow_filesystem_memory_roundtrip():
+    """The pyarrow wrapper (OpenDALFileSystem) works against the memory backend."""
+    from daft.io.opendal_filesystem import OpenDALFileSystem
+
+    fs = OpenDALFileSystem(protocol="memory")
+
+    with fs.open_output_stream("data.txt") as out:
+        out.write(b"hello opendal")
+
+    info = fs.get_file_info("data.txt")
+    assert info.size == 13
+
+    with fs.open_input_stream("data.txt") as inp:
+        assert inp.read() == b"hello opendal"
+
+    fs.delete_file("data.txt")
+    with pytest.raises(opendal_exceptions.NotFound):
+        fs.get_file_info("data.txt")
+
+
+def test_opendal_pyarrow_filesystem_missing_package(monkeypatch):
+    """A helpful error is raised when the opendal package is not installed."""
+    import builtins
+
+    from daft.io.opendal_filesystem import OpenDALFileSystem
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "opendal":
+            raise ImportError("No module named 'opendal'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    with pytest.raises(ImportError, match="extra-fs"):
+        OpenDALFileSystem(protocol="oss")
+
+
+def test_python_fallback_unconfigured_service_error_message():
+    """Installed-but-unconfigured services point at IOConfig, not installation."""
+    with pytest.raises(Exception, match="IOConfig\\(opendal_backends"):
+        daft.read_parquet("oss://some-bucket/key.parquet").collect()
+
+
+def test_hdfs_not_shipped_in_wheel_error_message():
+    """`hdfs` is absent from the opendal wheel; point at the native feature."""
+    with pytest.raises(Exception, match="--features native-hdfs"):
+        daft.read_parquet("hdfs://namenode:9000/data.parquet").collect()

--- a/tests/io/test_opendal_python.py
+++ b/tests/io/test_opendal_python.py
@@ -112,6 +112,23 @@ def test_python_fallback_get_range(tmp_path, forced_python_fallback):
     assert df.collect().to_pydict() == {"x": [42]}
 
 
+def test_python_fallback_concrete_dir_read(tmp_path, forced_python_fallback):
+    """A concrete directory path is expanded, not read as a file.
+
+    Glob discovery probes a patternless path with `get_size` first; a
+    directory must surface `NotAFile` so the path is retried as a directory,
+    matching the native backend.
+    """
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    for i in range(2):
+        papq.write_table(pa.table({"val": [i]}), str(sub / f"part_{i}.parquet"))
+
+    io_config = _fs_io_config(tmp_path)
+    df = daft.read_parquet("fs://localhost/sub", io_config=io_config)
+    assert df.sort("val").collect().to_pydict() == {"val": [0, 1]}
+
+
 def test_opendal_pyarrow_filesystem_memory_roundtrip():
     """The pyarrow wrapper (OpenDALFileSystem) works against the memory backend."""
     from daft.io.opendal_filesystem import OpenDALFileSystem

--- a/uv.lock
+++ b/uv.lock
@@ -1552,6 +1552,7 @@ all = [
     { name = "mypy-boto3-glue" },
     { name = "numpy" },
     { name = "openai" },
+    { name = "opendal" },
     { name = "pandas", version = "2.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
     { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
     { name = "pgvector" },
@@ -1587,6 +1588,9 @@ clickhouse = [
 ]
 deltalake = [
     { name = "deltalake" },
+]
+extra-fs = [
+    { name = "opendal" },
 ]
 google = [
     { name = "google-genai" },
@@ -1768,7 +1772,7 @@ requires-dist = [
     { name = "confluent-kafka", marker = "extra == 'kafka'" },
     { name = "connectorx", marker = "extra == 'postgres'", specifier = ">=0.4.4,<0.5.0" },
     { name = "connectorx", marker = "extra == 'sql'", specifier = ">=0.4.4,<0.5.0" },
-    { name = "daft", extras = ["audio", "aws", "azure", "clickhouse", "deltalake", "google", "gravitino", "hdf5", "http", "huggingface", "iceberg", "kafka", "lance", "mcap", "numpy", "openai", "pandas", "postgres", "ray", "sql", "transformers", "turbopuffer", "unity", "video"], marker = "extra == 'all'" },
+    { name = "daft", extras = ["audio", "aws", "azure", "clickhouse", "deltalake", "extra-fs", "google", "gravitino", "hdf5", "http", "huggingface", "iceberg", "kafka", "lance", "mcap", "numpy", "openai", "pandas", "postgres", "ray", "sql", "transformers", "turbopuffer", "unity", "video"], marker = "extra == 'all'" },
     { name = "daft-lance", marker = "extra == 'lance'" },
     { name = "datasets", marker = "extra == 'huggingface'", specifier = "<4.9.0" },
     { name = "deltalake", marker = "extra == 'deltalake'", specifier = ">=1.6.0,<1.7.0" },
@@ -1788,6 +1792,7 @@ requires-dist = [
     { name = "numpy", marker = "extra == 'numpy'", specifier = "<2.4.0" },
     { name = "numpy", marker = "extra == 'openai'", specifier = "<2.4.0" },
     { name = "openai", marker = "extra == 'openai'", specifier = "<2.39.0" },
+    { name = "opendal", marker = "extra == 'extra-fs'", specifier = ">=0.47.5,<1" },
     { name = "packaging" },
     { name = "pandas", marker = "extra == 'pandas'", specifier = "<2.4.0" },
     { name = "pgvector", marker = "extra == 'postgres'", specifier = "<0.5.0" },
@@ -1813,7 +1818,7 @@ requires-dist = [
     { name = "typing-extensions", marker = "python_full_version < '3.12'", specifier = ">=4.0.0" },
     { name = "unitycatalog", marker = "extra == 'unity'", specifier = "<0.2.0" },
 ]
-provides-extras = ["all", "audio", "aws", "azure", "clickhouse", "deltalake", "gcp", "google", "gravitino", "hdf5", "http", "hudi", "huggingface", "iceberg", "kafka", "lance", "mcap", "numpy", "openai", "pandas", "postgres", "ray", "sql", "transformers", "turbopuffer", "unity", "video", "viz"]
+provides-extras = ["all", "audio", "aws", "azure", "clickhouse", "deltalake", "extra-fs", "gcp", "google", "gravitino", "hdf5", "http", "hudi", "huggingface", "iceberg", "kafka", "lance", "mcap", "numpy", "openai", "pandas", "postgres", "ray", "sql", "transformers", "turbopuffer", "unity", "video", "viz"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -6116,6 +6121,41 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/92/ce/bd17ff5772938267fd49716e94ca24f616ff4cb1ff4c6be13085108037be/opencv_python_headless-4.13.0.92-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0525a3d2c0b46c611e2130b5fdebc94cf404845d8fa64d2f3a3b679572a5bd22", size = 56016764, upload-time = "2026-02-05T10:26:48.904Z" },
     { url = "https://files.pythonhosted.org/packages/8f/b4/b7bcbf7c874665825a8c8e1097e93ea25d1f1d210a3e20d4451d01da30aa/opencv_python_headless-4.13.0.92-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:eb60e36b237b1ebd40a912da5384b348df8ed534f6f644d8e0b4f103e272ba7d", size = 35010236, upload-time = "2026-02-05T10:28:11.031Z" },
     { url = "https://files.pythonhosted.org/packages/4b/33/b5db29a6c00eb8f50708110d8d453747ca125c8b805bc437b289dbdcc057/opencv_python_headless-4.13.0.92-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0bd48544f77c68b2941392fcdf9bcd2b9cdf00e98cb8c29b2455d194763cf99e", size = 60391106, upload-time = "2026-02-05T10:30:14.236Z" },
+]
+
+[[package]]
+name = "opendal"
+version = "0.47.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/97/a3/898b9097795c4015a3329dc3f99a96350570769367ddea7a9d087ffb1a05/opendal-0.47.6.tar.gz", hash = "sha256:297b876ab44162490d4e38041ecb712800ad14814ee35c4c3c196af4b26ffd61", size = 1801677, upload-time = "2026-08-20T17:32:58.452Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/d9/5b26e703e2a8e602efe100fde39239e2dccde8b78bc1c0a89bd4987d2a0b/opendal-0.47.6-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:2c798ef757e25932f524119bb146b736149b3c70400ad92ac41de193a9be64f2", size = 17697575, upload-time = "2026-08-20T17:31:57.67Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/17/91dfbf1a7bd14437ea026a5d7ce4f59d8096182ae735631c63c0685c234d/opendal-0.47.6-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:6b7d609aa2f3d60952f8d9961dd9fad8aa1416ea684e518b20a3df6f8eb4a35f", size = 16322602, upload-time = "2026-08-20T17:32:00.322Z" },
+    { url = "https://files.pythonhosted.org/packages/70/1d/914eebb4d921af6e7296e2f70efcb4a5c53de50d2ae6ce27eb3d9422d075/opendal-0.47.6-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:07c250b998170b572721154ec1cf4f3ef6ddd772c1487298b34463b654b91ab9", size = 16921727, upload-time = "2026-08-20T17:32:02.455Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f6/a4194c4ad7bcd350c618dd2baa61eb5e145b7d79116d70235091418432f0/opendal-0.47.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c512e08f9ced310ae73f7b6edac3c1e6c3eab2350997d1f51a4df9df9c486be", size = 18137784, upload-time = "2026-08-20T17:32:04.774Z" },
+    { url = "https://files.pythonhosted.org/packages/16/81/61bfac6016adb58db1ede6ad8477d377b1d2e9a84c52549eac0a70ea88a9/opendal-0.47.6-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:e625ce40ee8b463d932caa71318bc641e79cf09374cbb304da9836fb9ccd5cc9", size = 17212538, upload-time = "2026-08-20T17:32:07.027Z" },
+    { url = "https://files.pythonhosted.org/packages/60/e3/5c4f8e38a31b79666bdf1485fd436dcaeedd34d9d0b832dd772c829ab1a7/opendal-0.47.6-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:28ea74e9233203f7981d35c5679b2b4f365fb18109e1e8f1b3f98c6970022f80", size = 17558949, upload-time = "2026-08-20T17:32:09.368Z" },
+    { url = "https://files.pythonhosted.org/packages/02/00/28604d46b2b7a5c35876ca435d7ac2d1e64693bc5de423f75a25d5d73381/opendal-0.47.6-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:e723e2032846ea14f498bbcbd8ef6e60074e1aab9dcaf2a77558a96a51bf0650", size = 17223031, upload-time = "2026-08-20T17:32:11.609Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d0/f85f0268cb7434ed41e119a7d8e2e5ec73df8308ff3ddf7e28068fa766f9/opendal-0.47.6-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:0b0d699f9d5f68c32f501aa6e578ce5f6d33ca2091dfba3ab14effd483884445", size = 18368886, upload-time = "2026-08-20T17:32:14.372Z" },
+    { url = "https://files.pythonhosted.org/packages/18/25/3bf0c190c7de610f6d43b112f4fa4f29e75e0e2a52598c1bca4423cd2c16/opendal-0.47.6-cp310-cp310-win_amd64.whl", hash = "sha256:71c04f0657e0c6f4273d8da08f0e415ea5dcd667128f93c6ba5b8ba6067384bb", size = 19414540, upload-time = "2026-08-20T17:32:16.828Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/8e/51d2c1cfabb4052cf7bbf3aef80a49a699f3e5d55f7ebd67b9de3830ad15/opendal-0.47.6-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:ce28bee2ef19c04d16033b602604d4d26eedb295c7868ced2c55ef1255aa695b", size = 17705330, upload-time = "2026-08-20T17:32:19.061Z" },
+    { url = "https://files.pythonhosted.org/packages/24/fa/84e3bb3e2ff046fd9b55c870badf929a51cf6e399843c125aa7da9f958f5/opendal-0.47.6-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:94a481ba0931df63e361347efb02bb4e715c63b12ac5f3cb3bfb8f2f6bbed527", size = 16330575, upload-time = "2026-08-20T17:32:20.956Z" },
+    { url = "https://files.pythonhosted.org/packages/28/d9/315ce33d51500222ad5e47769d423d9eff51b2b67275872b3afc03bf6a86/opendal-0.47.6-cp311-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:586dd31f6b0e337f5037d6f80035a5b8c615ed56fe0a13b72ece68c6675ed749", size = 16923201, upload-time = "2026-08-20T17:32:23.465Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/04/ddb50902fef4ac5f9a201f16cf1041ba7b4cf351bdce5fcf3dd26cb91012/opendal-0.47.6-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ee1443cbab2e95fd55ad35c890284693ced5132e74ab63e9953ecabb15efe4f5", size = 18146763, upload-time = "2026-08-20T17:32:25.583Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/0b/b0a993271eb0745e428c1358401af52d1293dddc7d758e5b3bde64ea2fac/opendal-0.47.6-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a9c457824b161f8351801c03632c9b617f32dd597b2a6fd9c88083c8c9428a1a", size = 17220213, upload-time = "2026-08-20T17:32:27.878Z" },
+    { url = "https://files.pythonhosted.org/packages/40/4b/cd2cd193a6cb250699cc4b816baebac9cf389d34bbaaac4dba9d21dedca2/opendal-0.47.6-cp311-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:8be0535b4cbd28115458a9bc194030fde49ce9a626f0c225b6f900203a942cfc", size = 17561196, upload-time = "2026-08-20T17:32:30.343Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/e6/d2061fdef84f173e580dd42fedfc99e7c43b7bbe9bea4d0f271464cdbdb1/opendal-0.47.6-cp311-abi3-musllinux_1_1_armv7l.whl", hash = "sha256:4e815a0120f95d9ae37312f5c6b2e8da2010314c0c55b18cfb4c90384bcf2743", size = 17227288, upload-time = "2026-08-20T17:32:32.469Z" },
+    { url = "https://files.pythonhosted.org/packages/57/09/51f24e3540f0777d0433f2559e8158e2297eb120265544b4be2d831f280a/opendal-0.47.6-cp311-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:ac3519eb30648d5f8d159dd29e1c54dac1a5730c8fe656ccfd1664fd042e8b8a", size = 18373732, upload-time = "2026-08-20T17:32:34.66Z" },
+    { url = "https://files.pythonhosted.org/packages/85/cd/45e8484b5b141e9605b49a8fe3b92c747d486d59a04da868dc5ae62ebb9a/opendal-0.47.6-cp311-abi3-win_amd64.whl", hash = "sha256:81d52f5919b0845f747eeef16bf41a968ad11a16ede3a686556c75b1d0903298", size = 19421219, upload-time = "2026-08-20T17:32:36.991Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c9/ce51d2f5cda6f961d77dd376c3a7db9c74fac8769a36a2d91f3a09c1f03e/opendal-0.47.6-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8142f90419334550cc42ea655184e3a5744909d8cf8a53462cf22849b5448a06", size = 17713841, upload-time = "2026-08-20T17:32:39.279Z" },
+    { url = "https://files.pythonhosted.org/packages/25/c2/8daa8ff57682104992fce97e3f776e3289516538e1267b8fcbc94eb79939/opendal-0.47.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:19ca7f2c9751fc1279d4803b65cf27c0ea55d035e29601e263cfcc4b31c6435f", size = 16314577, upload-time = "2026-08-20T17:32:41.397Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/0d/bc5a06ddca9d8d30bc5ca2fd1c5fd16c411ecf15e3523376760a93d9a972/opendal-0.47.6-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:dfa9b490c327745032ea865dd28cc5b2282b1a5e1ed6fe03e2e3320a74677479", size = 16917195, upload-time = "2026-08-20T17:32:43.532Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/61/c70cec20351311caf33c2a261e4e615798f0e733c68f84b81983b329bb46/opendal-0.47.6-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:43a0a12144066fff5246a8e34116724e8248bc5c3c34c6998fcea5d01586bfa1", size = 18136350, upload-time = "2026-08-20T17:32:45.701Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/57/15358c7e9455f34a5abe6dc156024d7681b78d64c4e2f2db9300e3a1ca18/opendal-0.47.6-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:71e99848b40787e9505f5423473488bc818499c92707dc168037a047d297be1b", size = 17208049, upload-time = "2026-08-20T17:32:47.801Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/f5/72cea960b30c643cd3b216d2ad4af3c14ce503c21045b75a7ea23905d1de/opendal-0.47.6-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:64ee2b40a4f457f60ddfb822a5263962ff1bc07399403ceff0e90a175defafef", size = 17558165, upload-time = "2026-08-20T17:32:49.903Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/6f/ae82bedcc1acc2d1047931c4aefd750afecc2f66b2e7967a3afdbffdbe48/opendal-0.47.6-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:0e3532a848e3473e1787ed29a745b85b699938a1e01eeea390ace833405fd545", size = 17221105, upload-time = "2026-08-20T17:32:52.026Z" },
+    { url = "https://files.pythonhosted.org/packages/24/5b/de96032981f74e0e473c4e81efd4357657aacf4673c3e09b8c3cd665d5d5/opendal-0.47.6-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:0ab143680d79a189deae5cb9ed2dbd7adbe967bfd82947317f09f02709553a21", size = 18367917, upload-time = "2026-08-20T17:32:54.371Z" },
+    { url = "https://files.pythonhosted.org/packages/57/c3/da0429e7da22bbddd2708259e134f24d228e862404f8c430fa4bdcd4f4b9/opendal-0.47.6-cp314-cp314t-win_amd64.whl", hash = "sha256:60673bbf72aad5f1b1be37be5c25014a852349b1e395671731cd49c6792aae04", size = 19402260, upload-time = "2026-08-20T17:32:56.707Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Changes Made

Compiling the additional OpenDAL backends (OSS, COS, OBS, TOS, GooseFS, GitHub) into the default build costs compile time and wheel size, while the `opendal` Python package already ships them prebuilt. This PR uses that package as a runtime backend instead: when a scheme is not compiled in, Daft falls back to `opendal`, installed via a new `daft[extra-fs]` extra.

- `src/daft-io/src/opendal_python.rs` (new): an `ObjectSource` driving the Python package's `AsyncOperator`; `src/daft-io/src/lib.rs` wires the fallback and produces per-cause error messages
- `daft/io/opendal_bridge.py`, `daft/io/opendal_filesystem.py` (new): bridge + PyArrow `FSSpecHandler`-compatible filesystem; `daft/filesystem.py` routes `oss/cos/obs/tos/webhdfs/webdav/ftp/dropbox/gdrive` to it
- `Cargo.toml`: OSS/COS/OBS/TOS/GooseFS/GitHub/HDFS become opt-in `native-*` features; `memory`/`fs` stay unconditional
- `pyproject.toml`: `extra-fs = ["opendal>=0.47.5,<1"]`, included in `all`; docs updated
- `tests/io/test_opendal_python.py` (new), guarded by `importorskip("opendal")`

Implementation notes:

- The Python binding has no multipart API, so writes buffer in memory and flush as a single write, capped at 1 GB per file.
- Python exceptions are translated to Daft's `NotFound`/`Unauthorized`/`Throttled`, preserving retry and not-found semantics.

### User-facing behavior

The API is unchanged; additional filesystems are enabled with `pip install "daft[extra-fs]"`. Without it, errors state the required action:

```text
# opendal not installed
OpenDAL service 'oss' is not compiled into this build. Install the Python backend with `pip install "daft[extra-fs]"`, or rebuild with `--features native-oss`.

# installed but unconfigured
... Configure it via IOConfig(opendal_backends={"oss": {...}}), or rebuild with `--features native-oss`.

# not shipped in the opendal wheel (goosefs / github / hdfs)
... the `opendal` Python package does not ship it. Rebuild with `--features native-hdfs` to enable it.
```

Native builds (`--features native-oss`, etc.) still work but log a deprecation warning — HDFS excepted, see below. The wheel also provides `webhdfs`, `webdav`, `ftp`, `dropbox` and `gdrive`, which Daft did not previously support.

### HDFS

The wheel ships `hdfs-native` but not the JNI-based `services-hdfs` that Daft uses, and the two behave differently. HDFS therefore stays native-only behind `--features native-hdfs` and is not deprecated, per the issue's proposal. `goosefs`/`github` are likewise absent from the wheel but available via their `native-*` features; `sftp`/`ftps` are unsupported.

### Verification

Local wheel on macOS arm64, `opendal==0.47.5`:

- Without `extra-fs` (import blocked): the install hint is reported instead of a bare ImportError
- With `extra-fs`: `DAFT_FORCE_PYTHON_OPENDAL=1` plus a bridge call counter confirms the Python path is exercised — parquet/csv reads, a `write_parquet` + glob roundtrip, and multi-part glob listing all pass
- Error matrix (`hdfs://`, unconfigured `oss://`, unknown scheme) produces the matching hint
- `tests/io/test_opendal.py` passes (one test updated for the new error semantics), plus 9 new tests; `cargo check` clean with `--no-default-features` and `--all-features`, clippy/fmt clean

## Related Issues

Closes #7309