### PR TITLE
docs: remove stale TableState references

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -701,11 +701,10 @@ class DataFrame:
             >>>
             >>> daft.set_runner_ray()  # doctest: +SKIP
             >>>
-            >>> df = daft.from_pydict({"foo": [1, 2, 3], "bar": ["a", "b", "c"]}).into_partitions(2)
+            >>> df = daft.from_pydict({"foo": [1, 2, 3], "bar": ["a", "b", "c"]})
             >>> for part in df.iter_partitions():
             ...     print(part)  # doctest: +SKIP
             MicroPartition with 3 rows:
-            TableState: Loaded. 1 tables
             ╭───────┬────────╮
             │ foo   ┆ bar    │
             │ ---   ┆ ---    │

--- a/src/daft-micropartition/src/micropartition.rs
+++ b/src/daft-micropartition/src/micropartition.rs
@@ -737,7 +737,7 @@ pub fn read_parquet_into_micropartition<T: AsRef<str>>(
         ));
     }
 
-    // If no TableStatistics are available, we perform an eager read
+    // No count pushdown to serve from metadata, so read the data eagerly.
     read_parquet_into_loaded_micropartition(
         io_client,
         multithreaded_io,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,7 +72,7 @@ def uuid_ext_type() -> Generator[DaftUuidType, None, None]:
     params=[
         # Convert the data into Arrow and then load as in-memory Arrow data
         "arrow",
-        # Dump the data as Parquet and load it as Parquet (will trigger "Unloaded" MicroPartitions)
+        # Dump the data as Parquet and read it back through the Parquet scan path
         "parquet",
     ],
 )


### PR DESCRIPTION
## Changes Made

Follow-up cleanup to #5710, which removed `TableState` (and with it the `Unloaded` / `Loaded` distinction) from `MicroPartition`. `MicroPartition` now holds `chunks: Arc<Vec<RecordBatch>>` and is always materialized, but three references to the old lazy design survived and are misleading to anyone reading them today.

**1. `DataFrame.iter_partitions` docstring showed a line the code no longer prints.**

The example output contained `TableState: Loaded. 1 tables`. `Display for MicroPartition` (`src/daft-micropartition/src/micropartition.rs:761-779`) emits only the row count, each record batch, and then the statistics — there is no `TableState` line. Removed it.

The same example also called `.into_partitions(2)` while showing a single 3-row partition, so the printed output could not have come from the code above it. Dropped the `.into_partitions(2)` call, which makes the shown output correct for the single partition that `from_pydict` produces.

The output block stays `# doctest: +SKIP` — it has to, because under the Ray runner `iter_partitions` yields `ray.ObjectRef` rather than `MicroPartition`, so the block is not assertable across runners. (That is also why this drifted unnoticed.)

**2. `tests/conftest.py` fixture comment claimed a behavior that no longer exists.**

The `parquet` param was annotated `will trigger "Unloaded" MicroPartitions`. The param is still useful — it exercises the Parquet scan path rather than in-memory Arrow — so this is reworded rather than removed.

**3. Comment in `read_parquet_into_micropartition` described a branch that is no longer there.**

The comment read `// If no TableStatistics are available, we perform an eager read`, implying statistics select between a lazy and an eager path. The eager read at that point is now unconditional; the only early return above it is the count pushdown that answers from Parquet footer metadata. Reworded to say that.

Comments and a docstring only — no behavior change, no public API change.

## Related Issues

No open issue. Follows up on #5710 (`refactor: Remove Unloaded MicroPartitions`), which is where these references went stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
