### PR TITLE
fix(shuffle): dispatch flight shuffle reads on ref type, not backend config

### DIFF
--- a/src/daft-distributed/src/pipeline_node/into_partitions.rs
+++ b/src/daft-distributed/src/pipeline_node/into_partitions.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use common_error::DaftResult;
 use common_metrics::ops::{NodeCategory, NodeType};
 use common_runtime::OrderedJoinSet;
-use daft_local_plan::{LocalNodeContext, LocalPhysicalPlan, ShuffleBackend};
+use daft_local_plan::{LocalNodeContext, LocalPhysicalPlan, LocalPhysicalPlanRef, ShuffleBackend};
 use daft_logical_plan::stats::StatsState;
 use daft_schema::schema::SchemaRef;
 use futures::StreamExt;
@@ -21,6 +21,28 @@ use crate::{
     },
     utils::channel::{Sender, create_channel},
 };
+
+/// Collapse a task's output into exactly one partition.
+///
+/// This is a local concat, not a shuffle write, so it is always built on the Ray
+/// backend even when the node shuffles over Flight. A Flight-backed local
+/// `into_partitions` is a terminal sink: it spills to disk and emits
+/// `FlightPartitionRef`s instead of morsels, which only the flight read path can
+/// consume. Emitting such a task as this node's output would hand flight refs to
+/// whatever operator the parent node stacks on top, and every local operator
+/// treats an incoming flight ref as unreachable.
+fn local_concat_into_one_partition(
+    plan: LocalPhysicalPlanRef,
+    node_id: NodeID,
+) -> LocalPhysicalPlanRef {
+    LocalPhysicalPlan::into_partitions(
+        plan,
+        1,
+        ShuffleBackend::Ray,
+        StatsState::NotMaterialized,
+        LocalNodeContext::new(Some(node_id as usize)),
+    )
+}
 
 #[derive(Clone)]
 pub(crate) struct IntoPartitionsNode {
@@ -131,20 +153,11 @@ impl IntoPartitionsNode {
                 .collect::<Vec<_>>();
 
             let node_id = self.node_id();
-            let shuffle_backend = self.shuffle_context.backend().clone();
             let builder = self.shuffle_context.build_refs_task_builder(
                 partition_refs,
                 self.as_ref(),
-                move |input| {
-                    LocalPhysicalPlan::into_partitions(
-                        input,
-                        1,
-                        shuffle_backend,
-                        StatsState::NotMaterialized,
-                        LocalNodeContext::new(Some(node_id as usize)),
-                    )
-                },
-            );
+                move |input| local_concat_into_one_partition(input, node_id),
+            )?;
             if result_tx.send(builder).await.is_err() {
                 break;
             }
@@ -216,7 +229,7 @@ impl IntoPartitionsNode {
                         partition_refs,
                         self.as_ref(),
                         |input| input,
-                    );
+                    )?;
                     if result_tx.send(builder).await.is_err() {
                         break;
                     }
@@ -248,13 +261,7 @@ impl IntoPartitionsNode {
                     let node_id = self.node_id();
                     for builder in input_builders {
                         let builder = builder.map_plan(self.as_ref(), |plan| {
-                            LocalPhysicalPlan::into_partitions(
-                                plan,
-                                1,
-                                self.shuffle_context.backend().clone(),
-                                StatsState::NotMaterialized,
-                                LocalNodeContext::new(Some(node_id as usize)),
-                            )
+                            local_concat_into_one_partition(plan, node_id)
                         });
                         let _ = result_tx.send(builder).await;
                     }

--- a/src/daft-distributed/src/pipeline_node/random_shuffle.rs
+++ b/src/daft-distributed/src/pipeline_node/random_shuffle.rs
@@ -93,8 +93,7 @@ impl RandomShuffleNode {
             &self.config.schema,
         )?;
         let node_id = self.node_id();
-        Ok(self
-            .shuffle_context
+        self.shuffle_context
             .build_refs_task_builder(partition_refs, self, |input| {
                 LocalPhysicalPlan::sort(
                     input,
@@ -104,7 +103,7 @@ impl RandomShuffleNode {
                     StatsState::NotMaterialized,
                     LocalNodeContext::new(Some(node_id as usize)),
                 )
-            }))
+            })
     }
 
     async fn execution_loop(

--- a/src/daft-distributed/src/pipeline_node/shuffles/backends/flight.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/backends/flight.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeMap, sync::Arc};
 
-use common_error::DaftResult;
+use common_error::{DaftError, DaftResult};
 use common_partitioning::PartitionRef;
 use daft_local_plan::{
     FlightShuffleReadInput, LocalNodeContext, LocalPhysicalPlan, ShuffleReadBackend,
@@ -27,6 +27,32 @@ pub(crate) fn register_cleanup(
         .map(|base_dir| format!("{}/daft_shuffle/{}", base_dir, shuffle_id))
         .collect();
     plan_context.register_shuffle_dirs(shuffle_dirs_to_register);
+}
+
+/// Whether `partition` came out of a flight write, i.e. whether the flight read
+/// path can address it.
+pub(crate) fn is_flight_ref(partition: &PartitionRef) -> bool {
+    partition.as_any().is::<FlightPartitionRef>()
+}
+
+/// View `partition` as a `FlightPartitionRef`.
+///
+/// Returns an error rather than panicking: the refs reaching the flight read path
+/// come from whatever the upstream stage materialized, and mixing in a plain
+/// in-memory ref is a bug in the calling node, not something to abort the process
+/// over. The panic this replaces surfaced in Python as a bare
+/// `RayTaskError(DaftCoreException)` with no indication of which node was at fault.
+fn as_flight_ref(partition: &PartitionRef) -> DaftResult<&FlightPartitionRef> {
+    partition
+        .as_any()
+        .downcast_ref::<FlightPartitionRef>()
+        .ok_or_else(|| {
+            DaftError::InternalError(
+                "Flight shuffle read expected a flight partition ref, got a partition ref that \
+                 did not come from a flight write."
+                    .to_string(),
+            )
+        })
 }
 
 /// `partition_ref_id` layout: `(input_id << 32) | partition_idx`.
@@ -64,10 +90,7 @@ pub(crate) async fn fold_outputs_from_stream(
         let Some(partition) = output?.into_inner().0.into_iter().next() else {
             continue;
         };
-        let flight_ref = partition
-            .as_any()
-            .downcast_ref::<FlightPartitionRef>()
-            .expect("expected flight partition ref");
+        let flight_ref = as_flight_ref(&partition)?;
         inputs_by_server
             .entry(flight_ref.server_address.clone())
             .or_default()
@@ -88,13 +111,10 @@ pub(crate) async fn fold_outputs_from_stream(
 /// (shuffle, partition idx).
 pub(crate) fn read_inputs_from_refs(
     partition_refs: Vec<PartitionRef>,
-) -> Vec<FlightShuffleReadInput> {
+) -> DaftResult<Vec<FlightShuffleReadInput>> {
     let mut groups: BTreeMap<(u64, u32), BTreeMap<String, Vec<u32>>> = BTreeMap::new();
     for partition in partition_refs {
-        let flight_ref = partition
-            .as_any()
-            .downcast_ref::<FlightPartitionRef>()
-            .expect("expected flight partition ref");
+        let flight_ref = as_flight_ref(&partition)?;
         groups
             .entry((flight_ref.shuffle_id, partition_idx_from_ref(flight_ref)))
             .or_default()
@@ -103,7 +123,7 @@ pub(crate) fn read_inputs_from_refs(
             .push(input_id_from_ref(flight_ref));
     }
 
-    groups
+    Ok(groups
         .into_iter()
         .map(
             |((shuffle_id, partition_idx), inputs_by_server)| FlightShuffleReadInput {
@@ -112,7 +132,7 @@ pub(crate) fn read_inputs_from_refs(
                 inputs_by_server: Arc::new(inputs_by_server),
             },
         )
-        .collect()
+        .collect())
 }
 
 pub(crate) async fn emit_read_tasks(

--- a/src/daft-distributed/src/pipeline_node/shuffles/backends/mod.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/backends/mod.rs
@@ -1,4 +1,4 @@
-use common_error::DaftResult;
+use common_error::{DaftError, DaftResult};
 use common_partitioning::PartitionRef;
 use daft_local_plan::{
     LocalNodeContext, LocalPhysicalPlan, LocalPhysicalPlanRef, ShuffleBackend, ShuffleReadBackend,
@@ -79,47 +79,70 @@ impl ShuffleContext {
     }
 
     /// Build a `SwordfishTaskBuilder` whose plan reads from already-materialized
-    /// partition refs (`in_memory_scan` for Ray, `shuffle_read(Flight)` for Flight)
-    /// and then applies `wrap_plan` on top. The partition refs are attached to
-    /// the task via the backend-appropriate API (`with_psets` /
+    /// partition refs (`in_memory_scan` for plain refs, `shuffle_read(Flight)` for
+    /// flight refs) and then applies `wrap_plan` on top. The partition refs are
+    /// attached to the task via the matching API (`with_psets` /
     /// `with_flight_shuffle_reads`).
+    ///
+    /// The read path is chosen from what the refs *are*, not from what the backend
+    /// is configured to be. A flight-configured node can legitimately hold plain
+    /// in-memory refs: only refs produced by a flight write (`gather_write`,
+    /// `repartition_write`, a Flight-backed local `into_partitions`) are addressable
+    /// over flight, and a node that materializes its child's output directly — as
+    /// `IntoPartitionsNode`'s coalesce branch does — gets ordinary Ray object refs.
+    /// Dispatching on the config instead used to hand those to the flight reader and
+    /// panic on the downcast.
     pub(crate) fn build_refs_task_builder<F>(
         &self,
         partition_refs: Vec<PartitionRef>,
         node: &dyn PipelineNodeImpl,
         wrap_plan: F,
-    ) -> SwordfishTaskBuilder
+    ) -> DaftResult<SwordfishTaskBuilder>
     where
         F: FnOnce(LocalPhysicalPlanRef) -> LocalPhysicalPlanRef,
     {
         let node_id = self.node_id;
-        match &self.backend {
-            ShuffleBackend::Ray => {
-                let total_size_bytes = partition_refs.iter().map(|p| p.size_bytes()).sum::<usize>();
-                let in_memory_scan = LocalPhysicalPlan::in_memory_scan(
-                    node_id,
-                    self.schema.clone(),
-                    total_size_bytes,
-                    StatsState::NotMaterialized,
-                    LocalNodeContext::new(Some(node_id as usize)),
-                );
-                let plan = wrap_plan(in_memory_scan);
+        let num_flight_refs = partition_refs
+            .iter()
+            .filter(|p| flight::is_flight_ref(p))
+            .count();
+        // Empty falls to the in-memory path: there is nothing to read back over
+        // flight, and `in_memory_scan` with no psets yields an empty partition.
+        if num_flight_refs == 0 {
+            let total_size_bytes = partition_refs.iter().map(|p| p.size_bytes()).sum::<usize>();
+            let in_memory_scan = LocalPhysicalPlan::in_memory_scan(
+                node_id,
+                self.schema.clone(),
+                total_size_bytes,
+                StatsState::NotMaterialized,
+                LocalNodeContext::new(Some(node_id as usize)),
+            );
+            let plan = wrap_plan(in_memory_scan);
+            return Ok(
                 SwordfishTaskBuilder::new(plan, node, node_id).with_psets(node_id, partition_refs)
-            }
-            ShuffleBackend::Flight { .. } => {
-                let read_inputs = flight::read_inputs_from_refs(partition_refs);
-                let shuffle_read = LocalPhysicalPlan::shuffle_read(
-                    node_id,
-                    self.schema.clone(),
-                    ShuffleReadBackend::Flight,
-                    StatsState::NotMaterialized,
-                    LocalNodeContext::new(Some(node_id as usize)),
-                );
-                let plan = wrap_plan(shuffle_read);
-                SwordfishTaskBuilder::new(plan, node, node_id)
-                    .with_flight_shuffle_reads(node_id, read_inputs)
-            }
+            );
         }
+        if num_flight_refs != partition_refs.len() {
+            return Err(DaftError::InternalError(format!(
+                "Shuffle read for node {} got a mix of flight and in-memory partition refs \
+                 ({} of {} are flight refs); a stage's outputs must be all one or the other.",
+                node_id,
+                num_flight_refs,
+                partition_refs.len(),
+            )));
+        }
+
+        let read_inputs = flight::read_inputs_from_refs(partition_refs)?;
+        let shuffle_read = LocalPhysicalPlan::shuffle_read(
+            node_id,
+            self.schema.clone(),
+            ShuffleReadBackend::Flight,
+            StatsState::NotMaterialized,
+            LocalNodeContext::new(Some(node_id as usize)),
+        );
+        let plan = wrap_plan(shuffle_read);
+        Ok(SwordfishTaskBuilder::new(plan, node, node_id)
+            .with_flight_shuffle_reads(node_id, read_inputs))
     }
 
     /// Group a stream of map-task outputs into per-partition read tasks.

--- a/src/daft-distributed/src/pipeline_node/shuffles/gather.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/gather.rs
@@ -84,7 +84,7 @@ impl GatherNode {
             .collect();
         let task = self
             .shuffle_context
-            .build_refs_task_builder(refs, self.as_ref(), |plan| plan);
+            .build_refs_task_builder(refs, self.as_ref(), |plan| plan)?;
         let _ = result_tx.send(task).await;
         Ok(())
     }

--- a/tests/dataframe/test_into_partitions.py
+++ b/tests/dataframe/test_into_partitions.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import tempfile
+from contextlib import contextmanager
+
 import pytest
 
 import daft
+from daft import col
 from tests.conftest import get_tests_daft_runner_name
 
 pytestmark = pytest.mark.skipif(
@@ -68,3 +72,54 @@ def test_into_partitions_some_no_split(make_df) -> None:
     df = df.into_partitions(4).collect()
 
     assert df.to_pydict() == data
+
+
+@pytest.fixture(scope="function")
+def flight_shuffle_ctx():
+    """Run the body with the disk-based flight shuffle backend and a temp spill dir."""
+
+    @contextmanager
+    def _ctx():
+        with (
+            tempfile.TemporaryDirectory() as temp_dir,
+            daft.execution_config_ctx(shuffle_algorithm="flight_shuffle", flight_shuffle_dirs=[temp_dir]) as ctx,
+        ):
+            yield ctx
+
+    return _ctx
+
+
+# Covers all three branches of IntoPartitionsNode (coalesce / equal / split) on the
+# flight backend. Coalescing used to panic in the flight read path with
+# "expected flight partition ref": the branch materializes its child's output as
+# plain in-memory refs, which the flight reader cannot address.
+@pytest.mark.parametrize("num_partitions", [1, 3, 7, 8, 9, 16])
+def test_into_partitions_under_flight_shuffle(flight_shuffle_ctx, num_partitions) -> None:
+    with flight_shuffle_ctx():
+        df = daft.range(10_000, partitions=8).into_partitions(num_partitions)
+        parts = list(df.iter_partitions())
+
+        import ray
+
+        values = set(v for p in ray.get(parts) for v in p.to_pydict()["id"])
+        assert values == set(range(10_000))
+
+        if num_partitions <= 8:
+            # Coalescing and the equal case land on exactly `num_partitions`.
+            # Splitting does not, on either backend: the per-task split factor is
+            # not part of the plan fingerprint, so same-fingerprint tasks sharing a
+            # worker pipeline all use whichever factor was built first (8 -> 9 has
+            # been observed as both 16 and 8). Only the row set is checked there.
+            assert len(parts) == num_partitions
+
+
+# The coalesce output must be consumable by whatever the parent node stacks on top,
+# so the read task may not end in a flight write (which emits partition refs instead
+# of rows).
+@pytest.mark.parametrize("num_partitions", [1, 3, 7])
+def test_into_partitions_coalesce_under_flight_shuffle_with_downstream_ops(flight_shuffle_ctx, num_partitions) -> None:
+    with flight_shuffle_ctx():
+        df = daft.range(10_000, partitions=8).into_partitions(num_partitions)
+        assert df.with_column("plus_one", col("id") + 1).count_rows() == 10_000
+        assert df.agg(col("id").count().alias("n")).to_pydict() == {"n": [10_000]}
+        assert df.groupby(col("id") % 4).agg(col("id").count().alias("n")).count_rows() == 4


### PR DESCRIPTION
## Changes Made

`into_partitions(n)` with `n` below the input partition count panics under
`shuffle_algorithm="flight_shuffle"` on the Ray runner. It fails in 0.04s, before any
data moves, and takes the whole query with it (`RayTaskError(DaftCoreException)`,
exit 1):

    thread 'Daft-Scheduler' panicked at
    src/daft-distributed/src/pipeline_node/shuffles/backends/flight.rs:
    expected flight partition ref
       daft_distributed::...::shuffles::backends::flight::read_inputs_from_refs
       daft_distributed::...::into_partitions::IntoPartitionsNode::coalesce_tasks

Minimal repro — no cluster, no data files:

```python
import tempfile, ray, daft
from daft import col

ray.init(num_cpus=8)
daft.set_runner_ray(noop_if_initialized=True)
daft.set_execution_config(
    shuffle_algorithm="flight_shuffle",
    flight_shuffle_dirs=[tempfile.mkdtemp()],
)

# 8 input partitions -> 3: panics. n == 8 and n > 8 are fine.
daft.range(100_000, partitions=8).into_partitions(3).agg(col("id").count()).to_pydict()
```

`repartition` (hash and random, both directions) and `into_batches` are unaffected;
`map_reduce` / `pre_shuffle_merge` / `auto` are correct in every shape. Only
`IntoPartitionsNode`'s coalesce branch on the Flight backend is affected.

### Root cause

`ShuffleContext::build_refs_task_builder` chose its read path from the **configured
backend**, so a Flight-configured node always built a `shuffle_read(Flight)` task and
handed its refs to `flight::read_inputs_from_refs`, which downcast them
unconditionally.

That assumption only holds when the refs came out of a flight write. Of the three
callers, two insert one first — `GatherNode` prepends `gather_write`,
`RandomShuffleNode` prepends `repartition_write` — but `IntoPartitionsNode`'s coalesce
branch submits the child's builders unchanged and materializes them, which yields
ordinary Ray object refs. The downcast then aborts the process.

This is independent of what the child is: a coalescing `into_partitions` on top of a
`repartition` panics too, because a flight reduce stage's output is also plain
in-memory partitions.

Why it stayed hidden: the equal and split directions never reach this helper with
non-flight refs, and small inputs usually make `into_partitions(n)` a *split*. It only
turns into a coalesce once the scan produces more partitions than `n` — i.e. at real
scale.

### Fix

**1. Dispatch on what the refs are, not on what the config says.**
`build_refs_task_builder` now inspects the refs: all-`FlightPartitionRef` takes the
`shuffle_read(Flight)` path, plain refs (and the empty case) take
`in_memory_scan` + `with_psets`, and a mixed set returns a `DaftError` naming the node
and the counts. This closes the class rather than the instance — the next node wired
into the Flight backend cannot repeat it.

**2. The coalesce read task no longer ends in a flight write.**
Its `wrap_plan` was `into_partitions(input, 1, <node backend>)`. A Flight-backed local
`into_partitions` is a *terminal* sink: it spills through `InProgressShuffleCache` and
emits `FlightPartitionRef`s instead of morsels. Emitting such a task as the node's
output hands flight refs to whatever operator the parent node stacks on top, and every
local operator treats an incoming flight ref as `unreachable!`. Collapsing a task to
one partition is a local concat, not a shuffle write, so it now always uses the Ray
sink (`local_concat_into_one_partition`), matching what `sort.rs` already does for its
internal `repartition_write`. The equal branch under
`enable_scan_task_split_and_merge` had the same latent bug and is fixed with it.

No flight write is added on the way in, either. Coalesce is a concatenation, not an
all-to-all: its inputs are already materialized in the Ray object store, so writing
them to local disk and reading them back over flight would be a round trip at
identical peak memory (the output partition has to be assembled in memory either way).
The branch is now backend-independent. **The Ray path is unchanged in all three
directions.**

**3. No more `panic!` in the flight read path.** The three
`.expect("expected flight partition ref")` sites in `flight.rs` return
`DaftError::InternalError`. The panic ran on the `Daft-Scheduler` thread inside a
worker, so Python only ever saw a nested `RayTaskError(DaftCoreException)` and the real
location required `RUST_BACKTRACE=1` plus `log_to_driver=True`.

### Tests

`tests/dataframe/test_into_partitions.py` had no flight-backend coverage at all; only
the Ray backend was exercised.

- `test_into_partitions_under_flight_shuffle[1,3,7,8,9,16]` — all three branches
  (coalesce / equal / split) over 8 input partitions, asserting the full row set.
  Exact partition count is asserted for coalesce and equal; splitting does not land on
  an exact count on **either** backend, for an unrelated reason documented in a comment
  there, so only the row set is checked for `9` and `16`.
- `test_into_partitions_coalesce_under_flight_shuffle_with_downstream_ops[1,3,7]` —
  a projection, an ungrouped agg and a groupby stacked on the coalesce output, which is
  what fix (2) is for.

Green: `tests/dataframe/test_into_partitions.py` (26), `tests/dataframe/test_shuffles.py`
(39), `cargo test -p daft-distributed --lib` (68), and the full `tests/dataframe` under
`DAFT_RUNNER=ray`.