### PR TITLE
feat(io): add compression_level to write_parquet

### DIFF
--- a/daft/daft/__init__.pyi
+++ b/daft/daft/__init__.pyi
@@ -2254,7 +2254,11 @@ class PyFormatSinkOption:
         timestamp_format: str | None = None,
     ) -> PyFormatSinkOption: ...
     @classmethod
-    def parquet(cls, column_compression: list[tuple[str, str]] | None = None) -> PyFormatSinkOption: ...
+    def parquet(
+        cls,
+        column_compression: list[tuple[str, str]] | None = None,
+        compression_level: int | None = None,
+    ) -> PyFormatSinkOption: ...
 
 class CheckpointStoreConfig:
     @staticmethod

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -1025,6 +1025,7 @@ class DataFrame:
         io_config: IOConfig | None = None,
         column_compression: dict[str, str] | None = None,
         single_file: bool = False,
+        compression_level: int | None = None,
     ) -> "DataFrame":
         """Writes the DataFrame as parquet files, returning a new DataFrame with paths to the files that were written.
 
@@ -1039,6 +1040,7 @@ class DataFrame:
             io_config (Optional[IOConfig], optional): configurations to use when interacting with remote storage.
             column_compression (Optional[Dict[str, str]], optional): per-column compression overrides. Keys are dot-separated column paths (e.g. `"user.name"` for a nested struct field); values are codec names accepted by `compression`. Columns not listed fall back to `compression`. Defaults to None.
             single_file (bool, optional): If True, coalesce all data into a single parquet file at `root_dir` (treated as the exact file path). Cannot be combined with `partition_cols` or `overwrite-partitions`. Only supported on the native runner. Defaults to False.
+            compression_level (Optional[int], optional): compression level for codecs that support one: "zstd" (1-22, default 1), "gzip" (0-9, default 6) and "brotli" (0-11, default 1). The level applies to every such codec in use, whether it comes from `compression` or from a `column_compression` override; codecs without levels ("snappy", "lz4", "lz4_raw", "none") are unaffected. Raises if no codec in use supports a level. Defaults to None, which uses each codec's default level.
 
         Returns:
             DataFrame: The filenames that were written out as strings.
@@ -1051,6 +1053,7 @@ class DataFrame:
             >>> df = daft.from_pydict({"x": [1, 2, 3], "y": ["a", "b", "c"]})
             >>> df.write_parquet("output_dir", write_mode="overwrite")  # doctest: +SKIP
             >>> df.write_parquet("output.parquet", single_file=True)  # doctest: +SKIP
+            >>> df.write_parquet("output_dir", compression="zstd", compression_level=6)  # doctest: +SKIP
 
         Tip:
             See also [`df.write_csv()`][daft.DataFrame.write_csv] and [`df.write_json()`][daft.DataFrame.write_json]
@@ -1078,9 +1081,10 @@ class DataFrame:
             cols = column_inputs_to_expressions(tuple(partition_cols))
 
         file_format_option: PyFormatSinkOption | None = None
-        if column_compression:
+        if column_compression or compression_level is not None:
             file_format_option = PyFormatSinkOption.parquet(
-                column_compression=list(column_compression.items()),
+                column_compression=list(column_compression.items()) if column_compression else None,
+                compression_level=compression_level,
             )
 
         builder = self._builder.write_tabular(

--- a/daft/io/writer.py
+++ b/daft/io/writer.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import uuid
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from daft.datatype import DataType
 from daft.dependencies import pa, pacsv, pafs, pq
@@ -113,6 +113,11 @@ class FileWriterBase(ABC):
         pass
 
 
+# Parquet codecs that accept a compression level in PyArrow. PyArrow raises if a level is
+# supplied for any other codec, so levels are only ever attached to these.
+_LEVELED_CODECS = frozenset({"zstd", "gzip", "brotli"})
+
+
 class ParquetFileWriter(FileWriterBase):
     def __init__(
         self,
@@ -125,6 +130,7 @@ class ParquetFileWriter(FileWriterBase):
         default_partition_fallback: str | None = None,
         metadata_collector: list[pq.FileMetaData] | None = None,
         column_compression: dict[str, str] | None = None,
+        compression_level: int | None = None,
     ):
         super().__init__(
             root_dir=root_dir,
@@ -140,9 +146,10 @@ class ParquetFileWriter(FileWriterBase):
         self.current_writer: pq.ParquetWriter | None = None
         self.metadata_collector: list[pq.FileMetaData] | None = metadata_collector
         self.column_compression = column_compression
+        self.compression_level = compression_level
 
     def _create_writer(self, schema: pa.Schema) -> pq.ParquetWriter:
-        opts = {}
+        opts: dict[str, Any] = {}
         if self.metadata_collector is not None:
             opts["metadata_collector"] = self.metadata_collector
         compression: str | dict[str, str]
@@ -150,6 +157,9 @@ class ParquetFileWriter(FileWriterBase):
             compression = self._resolve_column_compression(schema)
         else:
             compression = self.compression
+        compression_level = self._resolve_compression_level(compression)
+        if compression_level is not None:
+            opts["compression_level"] = compression_level
         return pq.ParquetWriter(
             self.full_path,
             schema,
@@ -188,6 +198,27 @@ class ParquetFileWriter(FileWriterBase):
             return RecordBatch.from_pydict(metadata).slice(0, 0)
         self.current_writer.close()
         return RecordBatch.from_pydict(metadata)
+
+    def _resolve_compression_level(
+        self,
+        compression: str | dict[str, str],
+    ) -> int | dict[str, int] | None:
+        """Shape ``compression_level`` the way ``pq.ParquetWriter`` expects it.
+
+        PyArrow rejects a level for codecs that do not take one (e.g. snappy), so
+        with a single codec the level is passed only if that codec supports it,
+        and with per-column codecs it is passed as a leaf-path -> level dict
+        restricted to the leaves whose codec supports it. Returns ``None`` when
+        there is nothing to pass.
+        """
+        if self.compression_level is None:
+            return None
+        if isinstance(compression, str):
+            return self.compression_level if compression.lower() in _LEVELED_CODECS else None
+        levels = {
+            leaf: self.compression_level for leaf, codec in compression.items() if codec.lower() in _LEVELED_CODECS
+        }
+        return levels or None
 
     def _resolve_column_compression(
         self,

--- a/src/daft-logical-plan/src/sink_info.rs
+++ b/src/daft-logical-plan/src/sink_info.rs
@@ -370,6 +370,9 @@ pub struct ParquetFormatOption {
     /// Per-column compression overrides, the type matches the parquet writer builder
     /// method for setting column compression. The writer will parse the codec names.
     pub column_compression: Option<Vec<(String, String)>>,
+    /// Compression level applied to every codec in use that supports one (zstd, gzip, brotli),
+    /// including `column_compression` overrides. `None` keeps each codec's default level.
+    pub compression_level: Option<i32>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -452,13 +455,17 @@ impl PyFormatSinkOption {
     }
 
     #[classmethod]
-    #[pyo3(signature = (column_compression=None))]
+    #[pyo3(signature = (column_compression=None, compression_level=None))]
     pub fn parquet(
         _cls: &pyo3::prelude::Bound<pyo3::types::PyType>,
         column_compression: Option<Vec<(String, String)>>,
+        compression_level: Option<i32>,
     ) -> Self {
         Self {
-            inner: FormatSinkOption::Parquet(ParquetFormatOption { column_compression }),
+            inner: FormatSinkOption::Parquet(ParquetFormatOption {
+                column_compression,
+                compression_level,
+            }),
         }
     }
 }

--- a/src/daft-writers/src/parquet_writer.rs
+++ b/src/daft-writers/src/parquet_writer.rs
@@ -19,7 +19,7 @@ use parquet::{
         ArrowSchemaConverter, add_encoded_arrow_schema_to_metadata,
         arrow_writer::{ArrowColumnChunk, ArrowLeafColumn, compute_leaves, get_column_writers},
     },
-    basic::Compression,
+    basic::{BrotliLevel, Compression, GzipLevel, ZstdLevel},
     file::{
         properties::{WriterProperties, WriterVersion},
         writer::SerializedFileWriter,
@@ -37,22 +37,99 @@ type ColumnWriterFuture = dyn Future<Output = DaftResult<ArrowColumnChunk>> + Se
 
 /// Parse a user-supplied compression name into a `parquet::basic::Compression` codec.
 ///
-/// Codec strings are case-insensitive. Levels (e.g. `zstd:9`) are not yet supported — defaults
-/// are used for codecs that take a level.
-pub(crate) fn parse_compression(s: &str) -> DaftResult<Compression> {
-    match s.to_ascii_lowercase().as_str() {
+/// Codec strings are case-insensitive. `level` is applied to codecs that take one (`zstd`,
+/// `gzip`, `brotli`) and ignored by codecs that do not; `None` selects the codec's default level
+/// (zstd 1, gzip 6, brotli 1). Out-of-range levels are rejected with a `ValueError`.
+pub(crate) fn parse_compression(s: &str, level: Option<i32>) -> DaftResult<Compression> {
+    let codec = s.to_ascii_lowercase();
+    // parquet-rs reports the valid range in its error, so surface that directly. Negative levels
+    // for the unsigned codecs are mapped to `u32::MAX` so they fail the same range check.
+    let level_err = |err: parquet::errors::ParquetError| {
+        DaftError::ValueError(format!(
+            "invalid compression level {} for parquet codec {codec}: {err}",
+            level.unwrap_or_default()
+        ))
+    };
+    let unsigned_level = || level.map(|l| u32::try_from(l).unwrap_or(u32::MAX));
+    match codec.as_str() {
         "none" | "uncompressed" => Ok(Compression::UNCOMPRESSED),
         "snappy" => Ok(Compression::SNAPPY),
-        "gzip" => Ok(Compression::GZIP(Default::default())),
+        "gzip" => Ok(Compression::GZIP(match unsigned_level() {
+            Some(l) => GzipLevel::try_new(l).map_err(level_err)?,
+            None => GzipLevel::default(),
+        })),
         "lzo" => Ok(Compression::LZO),
-        "brotli" => Ok(Compression::BROTLI(Default::default())),
+        "brotli" => Ok(Compression::BROTLI(match unsigned_level() {
+            Some(l) => BrotliLevel::try_new(l).map_err(level_err)?,
+            None => BrotliLevel::default(),
+        })),
         "lz4" => Ok(Compression::LZ4),
         "lz4_raw" => Ok(Compression::LZ4_RAW),
-        "zstd" => Ok(Compression::ZSTD(Default::default())),
+        "zstd" => Ok(Compression::ZSTD(match level {
+            Some(l) => ZstdLevel::try_new(l).map_err(level_err)?,
+            None => ZstdLevel::default(),
+        })),
         other => Err(DaftError::ValueError(format!(
             "unsupported parquet compression codec: {other}"
         ))),
     }
+}
+
+/// Whether a parsed codec carries a compression level.
+fn compression_has_level(compression: Compression) -> bool {
+    matches!(
+        compression,
+        Compression::ZSTD(_) | Compression::GZIP(_) | Compression::BROTLI(_)
+    )
+}
+
+/// Resolve the default codec and the per-column overrides for a Parquet write.
+///
+/// `compression_level` is applied to every codec in use that supports a level (`zstd`, `gzip`,
+/// `brotli`), so it reaches both the default codec and any `column_compression` override. It is
+/// an error to supply a level when none of the requested codecs can honor it, so a
+/// misconfiguration such as `compression="snappy", compression_level=6` is never silently ignored.
+///
+/// Returns `(default_compression, [(dot-separated column path, compression)])`.
+pub(crate) fn resolve_parquet_compression(
+    compression: Option<&str>,
+    column_compression: Option<&[(String, String)]>,
+    compression_level: Option<i32>,
+) -> DaftResult<(Compression, Vec<(String, Compression)>)> {
+    let default_compression = match compression {
+        Some(name) => parse_compression(name, compression_level)?,
+        None => Compression::SNAPPY,
+    };
+    let parsed_column_compression: Vec<(String, Compression)> = column_compression
+        .unwrap_or(&[])
+        .iter()
+        .map(|(path, name)| Ok((path.clone(), parse_compression(name, compression_level)?)))
+        .collect::<DaftResult<_>>()?;
+
+    if let Some(level) = compression_level
+        && !compression_has_level(default_compression)
+        && !parsed_column_compression
+            .iter()
+            .any(|(_, c)| compression_has_level(*c))
+    {
+        let mut codecs: Vec<String> = std::iter::once(compression.unwrap_or("snappy"))
+            .chain(
+                column_compression
+                    .unwrap_or(&[])
+                    .iter()
+                    .map(|(_, name)| name.as_str()),
+            )
+            .map(str::to_ascii_lowercase)
+            .collect();
+        codecs.sort();
+        codecs.dedup();
+        return Err(DaftError::ValueError(format!(
+            "compression_level={level} requires a codec that supports compression levels (zstd, gzip, brotli), but only {} requested",
+            codecs.join(", ")
+        )));
+    }
+
+    Ok((default_compression, parsed_column_compression))
 }
 
 /// Construct writer properties for the native Parquet writer.
@@ -108,6 +185,7 @@ pub(crate) fn create_native_parquet_writer(
     io_config: Option<IOConfig>,
     compression: Option<&str>,
     column_compression: Option<&[(String, String)]>,
+    compression_level: Option<i32>,
     single_file: bool,
     overwrite_single_file_target: bool,
 ) -> DaftResult<Box<dyn AsyncFileWriter<Input = MicroPartition, Result = Option<RecordBatch>>>> {
@@ -125,15 +203,8 @@ pub(crate) fn create_native_parquet_writer(
         )?
     };
 
-    let default_compression = match compression {
-        Some(name) => parse_compression(name)?,
-        None => Compression::SNAPPY,
-    };
-    let parsed_column_compression: Vec<(String, Compression)> = column_compression
-        .unwrap_or(&[])
-        .iter()
-        .map(|(path, name)| Ok((path.clone(), parse_compression(name)?)))
-        .collect::<DaftResult<_>>()?;
+    let (default_compression, parsed_column_compression) =
+        resolve_parquet_compression(compression, column_compression, compression_level)?;
 
     // TODO(desmond): Explore configurations such data page size limit, writer version, etc. Parquet format v2
     // could be interesting but has much less support in the ecosystem (including ourselves).
@@ -507,17 +578,157 @@ mod tests {
             ("lz4", Compression::LZ4),
             ("lz4_raw", Compression::LZ4_RAW),
         ] {
-            assert_eq!(parse_compression(input).unwrap(), expected);
+            assert_eq!(parse_compression(input, None).unwrap(), expected);
         }
         assert!(matches!(
-            parse_compression("zstd").unwrap(),
+            parse_compression("zstd", None).unwrap(),
             Compression::ZSTD(_)
         ));
         assert!(matches!(
-            parse_compression("gzip").unwrap(),
+            parse_compression("gzip", None).unwrap(),
             Compression::GZIP(_)
         ));
-        assert!(parse_compression("bogus").is_err());
+        assert!(parse_compression("bogus", None).is_err());
+    }
+
+    #[test]
+    fn parse_compression_default_levels_match_parquet_rs_defaults() {
+        assert_eq!(
+            parse_compression("zstd", None).unwrap(),
+            Compression::ZSTD(ZstdLevel::default())
+        );
+        assert_eq!(ZstdLevel::default().compression_level(), 1);
+        assert_eq!(
+            parse_compression("gzip", None).unwrap(),
+            Compression::GZIP(GzipLevel::default())
+        );
+        assert_eq!(
+            parse_compression("brotli", None).unwrap(),
+            Compression::BROTLI(BrotliLevel::default())
+        );
+    }
+
+    #[test]
+    fn parse_compression_applies_level_to_leveled_codecs() {
+        assert_eq!(
+            parse_compression("zstd", Some(9)).unwrap(),
+            Compression::ZSTD(ZstdLevel::try_new(9).unwrap())
+        );
+        assert_eq!(
+            parse_compression("ZSTD", Some(22)).unwrap(),
+            Compression::ZSTD(ZstdLevel::try_new(22).unwrap())
+        );
+        assert_eq!(
+            parse_compression("gzip", Some(9)).unwrap(),
+            Compression::GZIP(GzipLevel::try_new(9).unwrap())
+        );
+        assert_eq!(
+            parse_compression("brotli", Some(11)).unwrap(),
+            Compression::BROTLI(BrotliLevel::try_new(11).unwrap())
+        );
+        // Codecs without a level ignore it; `resolve_parquet_compression` decides whether
+        // that is acceptable for the write as a whole.
+        assert_eq!(
+            parse_compression("snappy", Some(9)).unwrap(),
+            Compression::SNAPPY
+        );
+        assert_eq!(
+            parse_compression("none", Some(9)).unwrap(),
+            Compression::UNCOMPRESSED
+        );
+    }
+
+    #[test]
+    fn parse_compression_rejects_out_of_range_levels() {
+        for (codec, level) in [
+            ("zstd", 0),
+            ("zstd", 23),
+            ("zstd", -1),
+            ("gzip", 10),
+            ("gzip", -1),
+            ("brotli", 12),
+            ("brotli", -3),
+        ] {
+            let err = parse_compression(codec, Some(level))
+                .unwrap_err()
+                .to_string();
+            assert!(
+                err.contains(&format!(
+                    "invalid compression level {level} for parquet codec {codec}"
+                )),
+                "unexpected error for {codec}/{level}: {err}"
+            );
+            assert!(
+                err.contains("valid compression range"),
+                "error should carry the valid range: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn resolve_parquet_compression_applies_level_to_default_and_overrides() {
+        let overrides = vec![
+            ("a".to_string(), "snappy".to_string()),
+            ("b".to_string(), "gzip".to_string()),
+        ];
+        let (default, columns) =
+            resolve_parquet_compression(Some("zstd"), Some(&overrides), Some(6)).unwrap();
+        assert_eq!(default, Compression::ZSTD(ZstdLevel::try_new(6).unwrap()));
+        assert_eq!(
+            columns,
+            vec![
+                ("a".to_string(), Compression::SNAPPY),
+                (
+                    "b".to_string(),
+                    Compression::GZIP(GzipLevel::try_new(6).unwrap())
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn resolve_parquet_compression_level_reaches_override_when_default_has_no_level() {
+        let overrides = vec![("text".to_string(), "zstd".to_string())];
+        let (default, columns) =
+            resolve_parquet_compression(Some("snappy"), Some(&overrides), Some(9)).unwrap();
+        assert_eq!(default, Compression::SNAPPY);
+        assert_eq!(
+            columns,
+            vec![(
+                "text".to_string(),
+                Compression::ZSTD(ZstdLevel::try_new(9).unwrap())
+            )]
+        );
+    }
+
+    #[test]
+    fn resolve_parquet_compression_rejects_level_without_leveled_codec() {
+        let err = resolve_parquet_compression(Some("snappy"), None, Some(6))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("compression_level=6"), "{err}");
+        assert!(err.contains("only snappy requested"), "{err}");
+
+        let overrides = vec![("a".to_string(), "lz4_raw".to_string())];
+        let err = resolve_parquet_compression(None, Some(&overrides), Some(6))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("only lz4_raw, snappy requested"), "{err}");
+
+        // No level: nothing to complain about.
+        let (default, _) = resolve_parquet_compression(Some("snappy"), None, None).unwrap();
+        assert_eq!(default, Compression::SNAPPY);
+    }
+
+    #[test]
+    fn resolve_parquet_compression_surfaces_unknown_codec_before_level_check() {
+        let err = resolve_parquet_compression(Some("bogus"), None, Some(6))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("unsupported parquet compression codec: bogus"),
+            "{err}"
+        );
     }
 
     #[test]
@@ -543,6 +754,29 @@ mod tests {
             props.compression(&ColumnPath::from("b")),
             Compression::ZSTD(_),
         ));
+    }
+
+    #[test]
+    fn native_parquet_writer_properties_carries_compression_level() {
+        let daft_schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int64),
+            Field::new("b", DataType::Utf8),
+        ]));
+        let arrow_schema = daft_schema.to_arrow().unwrap();
+
+        let overrides = vec![("a".to_string(), "snappy".to_string())];
+        let (default, columns) =
+            resolve_parquet_compression(Some("zstd"), Some(&overrides), Some(19)).unwrap();
+        let props = native_parquet_writer_properties(&arrow_schema, default, &columns);
+
+        assert_eq!(
+            props.compression(&ColumnPath::from("a")),
+            Compression::SNAPPY,
+        );
+        assert_eq!(
+            props.compression(&ColumnPath::from("b")),
+            Compression::ZSTD(ZstdLevel::try_new(19).unwrap()),
+        );
     }
 
     #[test]

--- a/src/daft-writers/src/physical.rs
+++ b/src/daft-writers/src/physical.rs
@@ -161,6 +161,13 @@ pub fn create_pyarrow_file_writer(
             let parquet_option = format_option
                 .map(|opt| opt.to_parquet())
                 .unwrap_or_default();
+            // Validate codec names and the compression level up front so the PyArrow fallback
+            // rejects the same inputs, with the same errors, as the native writer.
+            crate::parquet_writer::resolve_parquet_compression(
+                compression.map(String::as_str),
+                parquet_option.column_compression.as_deref(),
+                parquet_option.compression_level,
+            )?;
             Ok(Box::new(crate::pyarrow::PyArrowWriter::new_parquet_writer(
                 root_dir,
                 file_idx,
@@ -168,6 +175,7 @@ pub fn create_pyarrow_file_writer(
                 io_config,
                 partition,
                 parquet_option.column_compression.as_deref(),
+                parquet_option.compression_level,
             )?))
         }
         #[cfg(feature = "python")]
@@ -212,6 +220,7 @@ fn create_native_writer(
                 io_config,
                 compression,
                 parquet_option.column_compression.as_deref(),
+                parquet_option.compression_level,
                 single_file,
                 single_file && matches!(write_mode, WriteMode::Overwrite),
             )

--- a/src/daft-writers/src/pyarrow.rs
+++ b/src/daft-writers/src/pyarrow.rs
@@ -24,6 +24,7 @@ impl PyArrowWriter {
         io_config: Option<&daft_io::IOConfig>,
         partition_values: Option<&RecordBatch>,
         column_compression: Option<&[(String, String)]>,
+        compression_level: Option<i32>,
     ) -> DaftResult<Self> {
         Python::attach(|py| {
             let file_writer_module = py.import(pyo3::intern!(py, "daft.io.writer"))?;
@@ -53,6 +54,9 @@ impl PyArrowWriter {
                     dict.set_item(path, codec)?;
                 }
                 kwargs.set_item("column_compression", dict)?;
+            }
+            if let Some(level) = compression_level {
+                kwargs.set_item("compression_level", level)?;
             }
 
             let py_writer = file_writer_class.call(

--- a/tests/io/test_parquet.py
+++ b/tests/io/test_parquet.py
@@ -4,6 +4,7 @@ import contextlib
 import datetime
 import io
 import os
+import random
 import tempfile
 import uuid
 
@@ -858,3 +859,131 @@ def test_resolve_column_compression_unknown_key_raises(tmp_path):
     schema = pa.schema([("a", pa.int64())])
     with pytest.raises(ValueError, match="does_not_exist"):
         writer._resolve_column_compression(schema)
+
+
+###
+# Compression level
+###
+
+
+def _compressible_df(num_rows: int = 20_000) -> daft.DataFrame:
+    # Deterministic word salad: too many distinct values for dictionary encoding to absorb, so
+    # the pages are PLAIN-encoded text and the compression level visibly changes the file size.
+    rng = random.Random(0)
+    words = ["daft", "parquet", "zstd", "compression", "level", "benchmark", "text", "column", "row", "group"]
+    text = [" ".join(rng.choices(words, k=40)) for _ in range(num_rows)]
+    return daft.from_pydict({"id": list(range(num_rows)), "text": text})
+
+
+def _write_and_measure(df: daft.DataFrame, root: str, **kwargs) -> tuple[int, dict[str, str]]:
+    df.write_parquet(root, **kwargs)
+    files = [os.path.join(dp, f) for dp, _, fs in os.walk(root) for f in fs if f.endswith(".parquet")]
+    assert len(files) == 1, files
+    return os.path.getsize(files[0]), _column_codecs(files[0])
+
+
+@pytest.mark.parametrize("native_parquet_writer", [True, False])
+def test_write_parquet_zstd_compression_level_is_honored(tmp_path, native_parquet_writer):
+    df = _compressible_df()
+    with daft.context.execution_config_ctx(native_parquet_writer=native_parquet_writer):
+        default_size, default_codecs = _write_and_measure(df, str(tmp_path / "default"), compression="zstd")
+        level1_size, _ = _write_and_measure(df, str(tmp_path / "l1"), compression="zstd", compression_level=1)
+        level9_size, level9_codecs = _write_and_measure(
+            df, str(tmp_path / "l9"), compression="zstd", compression_level=9
+        )
+
+    assert default_codecs == {"id": "ZSTD", "text": "ZSTD"}
+    assert level9_codecs == {"id": "ZSTD", "text": "ZSTD"}
+    # Both writers default to zstd level 1, so an explicit level 1 is byte-identical.
+    assert level1_size == default_size
+    # A higher level must actually change the encoded output.
+    assert level9_size < default_size * 0.95, (level9_size, default_size)
+
+
+@pytest.mark.parametrize("native_parquet_writer", [True, False])
+@pytest.mark.parametrize("codec", ["gzip", "brotli"])
+def test_write_parquet_compression_level_other_leveled_codecs(tmp_path, native_parquet_writer, codec):
+    df = _compressible_df()
+    with daft.context.execution_config_ctx(native_parquet_writer=native_parquet_writer):
+        low_size, low_codecs = _write_and_measure(df, str(tmp_path / "low"), compression=codec, compression_level=1)
+        high_size, _ = _write_and_measure(df, str(tmp_path / "high"), compression=codec, compression_level=9)
+
+    assert low_codecs == {"id": codec.upper(), "text": codec.upper()}
+    assert high_size < low_size, (high_size, low_size)
+
+
+@pytest.mark.parametrize("native_parquet_writer", [True, False])
+def test_write_parquet_compression_level_applies_to_column_override(tmp_path, native_parquet_writer):
+    # The default codec (snappy) has no level; the level must still reach the zstd override.
+    df = _compressible_df()
+    with daft.context.execution_config_ctx(native_parquet_writer=native_parquet_writer):
+        base_size, base_codecs = _write_and_measure(
+            df, str(tmp_path / "base"), compression="snappy", column_compression={"text": "zstd"}
+        )
+        level9_size, level9_codecs = _write_and_measure(
+            df,
+            str(tmp_path / "l9"),
+            compression="snappy",
+            column_compression={"text": "zstd"},
+            compression_level=9,
+        )
+
+    assert base_codecs == {"id": "SNAPPY", "text": "ZSTD"}
+    assert level9_codecs == {"id": "SNAPPY", "text": "ZSTD"}
+    assert level9_size < base_size * 0.95, (level9_size, base_size)
+
+
+@pytest.mark.parametrize("native_parquet_writer", [True, False])
+def test_write_parquet_compression_level_without_leveled_codec_raises(tmp_path, native_parquet_writer):
+    df = daft.from_pydict({"a": [1, 2, 3]})
+    with (
+        daft.context.execution_config_ctx(native_parquet_writer=native_parquet_writer),
+        pytest.raises(Exception, match="compression_level=6 requires a codec that supports compression levels"),
+    ):
+        df.write_parquet(str(tmp_path), compression="snappy", compression_level=6)
+    assert list(tmp_path.rglob("*.parquet")) == []
+
+
+@pytest.mark.parametrize("native_parquet_writer", [True, False])
+@pytest.mark.parametrize(
+    "codec, level",
+    [("zstd", 0), ("zstd", 23), ("zstd", -1), ("gzip", 10), ("gzip", -1), ("brotli", 12)],
+)
+def test_write_parquet_compression_level_out_of_range_raises(tmp_path, native_parquet_writer, codec, level):
+    df = daft.from_pydict({"a": [1, 2, 3]})
+    with (
+        daft.context.execution_config_ctx(native_parquet_writer=native_parquet_writer),
+        pytest.raises(Exception, match=f"invalid compression level {level} for parquet codec {codec}"),
+    ):
+        df.write_parquet(str(tmp_path), compression=codec, compression_level=level)
+    assert list(tmp_path.rglob("*.parquet")) == []
+
+
+def test_write_parquet_compression_level_is_not_required(tmp_path):
+    # Omitting the level keeps the pre-existing behaviour (no format option is needed at all).
+    df = daft.from_pydict({"a": [1, 2, 3]})
+    df.write_parquet(str(tmp_path), compression="zstd")
+    assert _column_codecs(str(next(tmp_path.glob("*.parquet"))))["a"] == "ZSTD"
+
+
+@pytest.mark.parametrize(
+    "compression, level, expected",
+    [
+        ("zstd", 6, 6),
+        ("ZSTD", 6, 6),
+        ("gzip", 9, 9),
+        ("snappy", 6, None),
+        ("zstd", None, None),
+        ({"a": "snappy", "b": "zstd", "c": "gzip"}, 4, {"b": 4, "c": 4}),
+        ({"a": "snappy", "b": "none"}, 4, None),
+        ({"a": "zstd"}, None, None),
+    ],
+)
+def test_pyarrow_writer_resolve_compression_level(tmp_path, compression, level, expected):
+    writer = ParquetFileWriter(
+        root_dir=str(tmp_path),
+        file_idx=0,
+        compression=compression if isinstance(compression, str) else "snappy",
+        compression_level=level,
+    )
+    assert writer._resolve_compression_level(compression) == expected


### PR DESCRIPTION
## Changes Made

`DataFrame.write_parquet(compression="zstd")` always writes **zstd level 1**, and there is
no way to ask for anything else. The codec parser in `daft-writers` only accepts bare codec
names and falls back to parquet-rs defaults, `ParquetFormatOption` has no field that could
carry a level, and every spelling that embeds one is rejected:

```python
df.write_parquet(out, compression="zstd(3)")   # ValueError: unsupported parquet compression codec: zstd(3)
df.write_parquet(out, compression="zstd:3")    # same
df.write_parquet(out, compression="zstd", compression_level=3)  # TypeError: unexpected keyword
```

Measured on 20k rows of word-salad text (dictionary encoding falls back to PLAIN, so the
codec level is what decides the size), bytes per file:

| zstd level | pyarrow (`compression_level=`) | Daft native writer | Daft PyArrow fallback |
|---|---:|---:|---:|
| before this PR, `compression="zstd"` | 1,005,264 (level 1) | 1,004,611 | 1,005,264 |
| `compression_level=3` | 976,196 | 972,806 | 976,196 |
| `compression_level=6` | 873,081 | 869,754 | 873,081 |
| `compression_level=9` | 813,578 | 810,047 | 813,578 |
| `compression_level=19` | 615,854 | 610,242 | 615,854 |

For text-heavy data the level is a bigger lever than the codec choice (zstd 1 -> 6 is -13%
here, -17% on the corpus that motivated this), and on I/O-bound clusters the extra CPU is
free, so it needs to be reachable from the API.

### Implementation

Same shape as the existing `column_compression` plumbing:

- `DataFrame.write_parquet(..., compression_level: int | None = None)` ->
  `PyFormatSinkOption.parquet(column_compression=..., compression_level=...)` ->
  `ParquetFormatOption.compression_level: Option<i32>` (`sink_info.rs`).
- `parquet_writer.rs`: `parse_compression(name, level)` builds
  `Compression::ZSTD(ZstdLevel::try_new(l))` / `GZIP(GzipLevel)` / `BROTLI(BrotliLevel)`;
  parquet-rs does the range check and its message (`valid compression range 1..=22
  exceeded.`) is surfaced as a `ValueError`. A new `resolve_parquet_compression` resolves
  the default codec and the per-column overrides together and is the single place both
  writer paths validate against.
- `physical.rs` passes the level to `create_native_parquet_writer`, and runs the same
  `resolve_parquet_compression` before constructing the PyArrow fallback so both paths
  accept and reject the same inputs with the same errors.
- `daft/io/writer.py`: the fallback passes `compression_level` to `pq.ParquetWriter`.
  PyArrow raises if a level is given for a codec without one (snappy), so with mixed
  codecs it is passed as a `{leaf: level}` dict restricted to leaves whose codec takes a
  level.

### Semantics

- `compression_level` applies to **every** codec in use that supports one — zstd (1–22,
  default 1), gzip (0–9, default 6), brotli (0–11, default 1) — whether it comes from
  `compression` or from a `column_compression` override. Codecs without levels (snappy,
  lz4, lz4_raw, lzo, none) are unaffected. So
  `compression="snappy", column_compression={"text": "zstd"}, compression_level=9` gives
  snappy everywhere and zstd:9 on `text`.
- A level with no leveled codec in use is an error rather than a silent no-op:
  `compression_level=6 requires a codec that supports compression levels (zstd, gzip,
  brotli), but only snappy requested`.
- Out-of-range levels error on both paths:
  `invalid compression level 23 for parquet codec zstd: Parquet error: valid compression
  range 1..=22 exceeded.`
- `compression_level=None` (default) is byte-for-byte the previous behaviour; no format
  option is created unless a level or a column override is given. Inline syntax such as
  `"zstd(3)"` is intentionally still rejected so there is one way to set a level.

### Tests

- `parquet_writer.rs`: parse with/without level for each codec, default levels match
  parquet-rs, out-of-range and negative levels, level reaching column overrides when the
  default codec has none, level-without-leveled-codec error, unknown codec still reported
  first, `WriterProperties` carrying the level per column.
- `tests/io/test_parquet.py`, parametrized over `native_parquet_writer=True/False`:
  level 1 is byte-identical to the default and level 9 is >5% smaller (zstd), gzip and
  brotli levels change output, level applies to a `column_compression` override under a
  snappy default, snappy + level raises, out-of-range levels raise, and
  `ParquetFileWriter._resolve_compression_level` shaping for str/dict codecs.

`tests/io/test_parquet.py` + `tests/io/test_parquet_roundtrip.py` green on the native
runner (122 passed), the new tests also pass on the Ray runner; `cargo test -p
daft-writers`, `cargo clippy -p daft-writers -p daft-logical-plan --all-features
--all-targets -D warnings`, ruff and mypy hooks clean.

## Related Issues