### PR TITLE
chore!: remove deprecated min_cpu_per_task from ExecutionContext

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1834,7 +1834,6 @@ version = "0.3.0-dev0"
 dependencies = [
  "common-io-config",
  "common-py-serde",
- "log",
  "pyo3",
  "serde",
 ]

--- a/daft/context.py
+++ b/daft/context.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import contextlib
 import logging
 import threading
-import warnings
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, ClassVar
 
@@ -237,7 +236,6 @@ def set_execution_config(
     pre_shuffle_merge_partition_threshold: int | None = None,
     scantask_max_parallel: int | None = None,
     native_parquet_writer: bool | None = None,
-    min_cpu_per_task: float | None = None,
     actor_udf_ready_timeout: int | None = None,
     maintain_order: bool | None = None,
     enable_dynamic_batching: bool | None = None,
@@ -286,8 +284,6 @@ def set_execution_config(
         pre_shuffle_merge_partition_threshold: Number of partitions threshold to enable pre-shuffle merge when shuffle_algorithm is "auto". Defaults to 200.
         scantask_max_parallel: Set the max parallelism for running scan tasks simultaneously. Currently, this only works for Native Runner. If set to 0, all available CPUs will be used. Defaults to 8.
         native_parquet_writer: Whether to use the native parquet writer vs the pyarrow parquet writer. Defaults to `True`.
-        min_cpu_per_task: Deprecated. This was used by the old Ray runner and has no effect on
-            distributed scheduling. It will be removed in v0.8.0.
         actor_udf_ready_timeout: Timeout for UDF actors to be ready. Defaults to 120 seconds.
         maintain_order: Whether to maintain order during execution. Defaults to True. Some blocking sink operators (e.g. write_parquet) won't respect this flag and will always keep maintain_order as false, and propagate to child operators. It's useful to set this to False for running df.collect() when no ordering is required.
         enable_dynamic_batching: Whether to enable dynamic batching. Defaults to False.
@@ -297,14 +293,6 @@ def set_execution_config(
         enable_multi_glob_path_tasks: Whether to create multiple glob path tasks in Ray Runner to achieve parallel glob. Defaults to False.
     """
     # Replace values in the DaftExecutionConfig with user-specified overrides
-    if min_cpu_per_task is not None:
-        warnings.warn(
-            "`min_cpu_per_task` is deprecated as of v0.7.0 and has no effect on distributed scheduling. "
-            "It will be removed from v0.8.0 onwards.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
     ctx = get_context()
     with ctx._lock:
         old_daft_execution_config = ctx._ctx._daft_execution_config if config is None else config
@@ -337,7 +325,6 @@ def set_execution_config(
             pre_shuffle_merge_partition_threshold=pre_shuffle_merge_partition_threshold,
             scantask_max_parallel=scantask_max_parallel,
             native_parquet_writer=native_parquet_writer,
-            min_cpu_per_task=min_cpu_per_task,
             actor_udf_ready_timeout=actor_udf_ready_timeout,
             maintain_order=maintain_order,
             enable_dynamic_batching=enable_dynamic_batching,

--- a/daft/daft/__init__.pyi
+++ b/daft/daft/__init__.pyi
@@ -2638,7 +2638,6 @@ class PyDaftExecutionConfig:
         pre_shuffle_merge_partition_threshold: int | None = None,
         scantask_max_parallel: int | None = None,
         native_parquet_writer: bool | None = None,
-        min_cpu_per_task: float | None = None,
         actor_udf_ready_timeout: int | None = None,
         maintain_order: bool | None = None,
         enable_dynamic_batching: bool | None = None,
@@ -2697,8 +2696,6 @@ class PyDaftExecutionConfig:
     def pre_shuffle_merge_threshold(self) -> int: ...
     @property
     def pre_shuffle_merge_partition_threshold(self) -> int: ...
-    @property
-    def min_cpu_per_task(self) -> float: ...
     @property
     def actor_udf_ready_timeout(self) -> int: ...
     @property

--- a/src/common/daft-config/Cargo.toml
+++ b/src/common/daft-config/Cargo.toml
@@ -3,7 +3,6 @@ common-io-config = {path = "../io-config", default-features = false}
 common-py-serde = {path = "../py-serde", default-features = false, optional = true}
 pyo3 = {workspace = true, optional = true}
 serde = {workspace = true}
-log = {workspace = true}
 
 [features]
 python = ["dep:pyo3", "common-io-config/python", "dep:common-py-serde"]

--- a/src/common/daft-config/src/lib.rs
+++ b/src/common/daft-config/src/lib.rs
@@ -145,7 +145,6 @@ pub struct DaftExecutionConfig {
     pub pre_shuffle_merge_partition_threshold: usize,
     pub scantask_max_parallel: usize,
     pub native_parquet_writer: bool,
-    pub min_cpu_per_task: f64,
     pub actor_udf_ready_timeout: usize,
     pub maintain_order: bool,
     pub enable_dynamic_batching: bool,
@@ -192,7 +191,6 @@ impl Default for DaftExecutionConfig {
             pre_shuffle_merge_partition_threshold: 200,
             scantask_max_parallel: 8,
             native_parquet_writer: true,
-            min_cpu_per_task: 0.5,
             actor_udf_ready_timeout: 120,
             maintain_order: true,
             enable_dynamic_batching: false,
@@ -208,7 +206,6 @@ impl DaftExecutionConfig {
     const ENV_DAFT_SHUFFLE_ALGORITHM: &'static str = "DAFT_SHUFFLE_ALGORITHM";
     const ENV_DAFT_SCANTASK_MAX_PARALLEL: &'static str = "DAFT_SCANTASK_MAX_PARALLEL";
     const ENV_DAFT_NATIVE_PARQUET_WRITER: &'static str = "DAFT_NATIVE_PARQUET_WRITER";
-    const ENV_DAFT_MIN_CPU_PER_TASK: &'static str = "DAFT_MIN_CPU_PER_TASK";
     const ENV_DAFT_ACTOR_UDF_READY_TIMEOUT: &'static str = "DAFT_ACTOR_UDF_READY_TIMEOUT";
     const ENV_PARQUET_INFLATION_FACTOR: &'static str = "DAFT_PARQUET_INFLATION_FACTOR";
     const ENV_CSV_INFLATION_FACTOR: &'static str = "DAFT_CSV_INFLATION_FACTOR";
@@ -236,16 +233,6 @@ impl DaftExecutionConfig {
 
         if let Some(val) = parse_bool_from_env(Self::ENV_DAFT_NATIVE_PARQUET_WRITER) {
             cfg.native_parquet_writer = val;
-        }
-
-        if let Some(val) =
-            parse_number_from_env(Self::ENV_DAFT_MIN_CPU_PER_TASK, cfg.min_cpu_per_task)
-        {
-            log::warn!(
-                "{} is deprecated as of v0.7.0 and has no effect on distributed scheduling. It will be removed from v0.8.0 onwards.",
-                Self::ENV_DAFT_MIN_CPU_PER_TASK
-            );
-            cfg.min_cpu_per_task = val;
         }
 
         if let Some(val) = parse_number_from_env(
@@ -511,28 +498,6 @@ mod tests {
 
             unsafe {
                 std::env::remove_var(DaftExecutionConfig::ENV_DAFT_NATIVE_PARQUET_WRITER);
-            }
-        }
-
-        // ENV_DAFT_MIN_CPU_PER_TASK
-        {
-            let cfg = DaftExecutionConfig::from_env();
-            assert_eq!(cfg.min_cpu_per_task, 0.5);
-
-            unsafe {
-                std::env::set_var(DaftExecutionConfig::ENV_DAFT_MIN_CPU_PER_TASK, "0.1");
-            }
-            let cfg = DaftExecutionConfig::from_env();
-            assert_eq!(cfg.min_cpu_per_task, 0.1);
-
-            unsafe {
-                std::env::set_var(DaftExecutionConfig::ENV_DAFT_MIN_CPU_PER_TASK, "invalid");
-            }
-            let cfg = DaftExecutionConfig::from_env();
-            assert_eq!(cfg.min_cpu_per_task, 0.5);
-
-            unsafe {
-                std::env::remove_var(DaftExecutionConfig::ENV_DAFT_MIN_CPU_PER_TASK);
             }
         }
 

--- a/src/common/daft-config/src/python.rs
+++ b/src/common/daft-config/src/python.rs
@@ -116,7 +116,6 @@ impl PyDaftExecutionConfig {
         pre_shuffle_merge_partition_threshold=None,
         scantask_max_parallel=None,
         native_parquet_writer=None,
-        min_cpu_per_task=None,
         actor_udf_ready_timeout=None,
         maintain_order=None,
         enable_dynamic_batching=None,
@@ -154,7 +153,6 @@ impl PyDaftExecutionConfig {
         pre_shuffle_merge_partition_threshold: Option<usize>,
         scantask_max_parallel: Option<usize>,
         native_parquet_writer: Option<bool>,
-        min_cpu_per_task: Option<f64>,
         actor_udf_ready_timeout: Option<usize>,
         maintain_order: Option<bool>,
         enable_dynamic_batching: Option<bool>,
@@ -266,10 +264,6 @@ impl PyDaftExecutionConfig {
 
         if let Some(native_parquet_writer) = native_parquet_writer {
             config.native_parquet_writer = native_parquet_writer;
-        }
-
-        if let Some(min_cpu_per_task) = min_cpu_per_task {
-            config.min_cpu_per_task = min_cpu_per_task;
         }
 
         if let Some(actor_udf_ready_timeout) = actor_udf_ready_timeout {
@@ -449,11 +443,6 @@ impl PyDaftExecutionConfig {
     #[getter]
     fn scantask_max_parallel(&self) -> PyResult<usize> {
         Ok(self.config.scantask_max_parallel)
-    }
-
-    #[getter]
-    fn min_cpu_per_task(&self) -> PyResult<f64> {
-        Ok(self.config.min_cpu_per_task)
     }
 
     #[getter]

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -376,8 +376,3 @@ def test_set_scantask_max_parallelism_greater_than_partition_num():
         df.explain(show_all=True, file=str_io)
         assert "Num Parallel Scan Tasks = 17" in str_io.getvalue().strip()
 
-
-def test_min_cpu_per_task_is_deprecated():
-    with pytest.warns(DeprecationWarning, match="min_cpu_per_task"):
-        with daft.execution_config_ctx(min_cpu_per_task=0.1):
-            assert daft.context.get_context().daft_execution_config.min_cpu_per_task == 0.1

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -375,4 +375,3 @@ def test_set_scantask_max_parallelism_greater_than_partition_num():
         df = daft.range(start=0, end=1024, partitions=10)
         df.explain(show_all=True, file=str_io)
         assert "Num Parallel Scan Tasks = 17" in str_io.getvalue().strip()
-


### PR DESCRIPTION

## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

- Remove min_cpu_per_task field, default value, and DAFT_MIN_CPU_PER_TASK env var parsing from DaftExecutionConfig (Rust)
- Remove min_cpu_per_task parameter and getter from PyDaftExecutionConfig Python bindings
- Remove min_cpu_per_task parameter and deprecation warning from daft_execution_config() in daft/context.py
- Remove min_cpu_per_task from PyDaftExecutionConfig type stubs
- Remove test_min_cpu_per_task_is_deprecated test## Related Issues
- 

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

Closes #7407