### PR TITLE
feat: auto-detect Hive partitioning

### DIFF
--- a/daft/io/_csv.py
+++ b/daft/io/_csv.py
@@ -34,7 +34,7 @@ def read_csv(
     allow_variable_columns: bool = False,
     io_config: IOConfig | None = None,
     file_path_column: str | None = None,
-    hive_partitioning: bool = False,
+    hive_partitioning: bool | None = None,
     ignore_corrupt_files: bool = False,
     _buffer_size: int | None = None,
     _chunk_size: int | None = None,
@@ -54,7 +54,10 @@ def read_csv(
         allow_variable_columns (bool): Whether to allow for variable number of columns in the CSV, defaults to False. If set to True, Daft will append nulls to rows with less columns than the schema, and ignore extra columns in rows with more columns
         io_config (IOConfig): Config to be used with the native downloader
         file_path_column: Include the source path(s) as a column with this name. Defaults to None.
-        hive_partitioning: Whether to infer hive_style partitions from file paths and include them as columns in the Dataframe. Defaults to False.
+        hive_partitioning: Whether to infer Hive-style partitions from file paths and
+        include them as columns in the DataFrame. If None, automatically detects
+        Hive partitioning from the expanded file paths. True forces Hive
+        partitioning and False disables it. Defaults to None.
         checkpoint: Optional :class:`daft.CheckpointConfig` for progress tracking across runs. Bundles the
             checkpoint store, the source key column (``on=``), and optional anti-join tuning. Rows whose key
             already exists in the store are skipped on re-run. Requires the Ray runner.

--- a/daft/io/_json.py
+++ b/daft/io/_json.py
@@ -27,7 +27,7 @@ def read_json(
     schema: dict[str, DataType] | None = None,
     io_config: IOConfig | None = None,
     file_path_column: str | None = None,
-    hive_partitioning: bool = False,
+    hive_partitioning: bool | None = None,
     skip_empty_files: bool = False,
     _buffer_size: int | None = None,
     _chunk_size: int | None = None,
@@ -41,7 +41,10 @@ def read_json(
         schema (dict[str, DataType]): A schema that is used as the definitive schema for the JSON if infer_schema is False, otherwise it is used as a schema hint that is applied after the schema is inferred (overriding the types of inferred columns, and appending any new columns not found during inference).
         io_config (IOConfig): Config to be used with the native downloader
         file_path_column: Include the source path(s) as a column with this name. Defaults to None.
-        hive_partitioning: Whether to infer hive_style partitions from file paths and include them as columns in the Dataframe. Defaults to False.
+        hive_partitioning: Whether to infer Hive-style partitions from file paths and
+        include them as columns in the DataFrame. If None, automatically detects
+        Hive partitioning from the expanded file paths. True forces Hive
+        partitioning and False disables it. Defaults to None.
         skip_empty_files: Whether to skip empty files when reading. Defaults to False.
         checkpoint: Optional :class:`daft.CheckpointConfig` for progress tracking across runs. Bundles the
             checkpoint store, the source key column (``on=``), and optional anti-join tuning. Rows whose key

--- a/daft/io/_parquet.py
+++ b/daft/io/_parquet.py
@@ -28,7 +28,7 @@ def read_parquet(
     schema: dict[str, DataType] | None = None,
     io_config: IOConfig | None = None,
     file_path_column: str | None = None,
-    hive_partitioning: bool = False,
+    hive_partitioning: bool | None = None,
     coerce_int96_timestamp_unit: str | TimeUnit | None = None,
     ignore_corrupt_files: bool = False,
     _multithreaded_io: bool | None = None,
@@ -44,7 +44,10 @@ def read_parquet(
         schema (dict[str, DataType]): A schema that is used as the definitive schema for the Parquet file if infer_schema is False, otherwise it is used as a schema hint that is applied after the schema is inferred (overriding the types of inferred columns, and appending any new columns not found during inference).
         io_config (IOConfig): Config to be used with the native downloader
         file_path_column: Include the source path(s) as a column with this name. Defaults to None.
-        hive_partitioning: Whether to infer hive_style partitions from file paths and include them as columns in the Dataframe. Defaults to False.
+        hive_partitioning: Whether to infer Hive-style partitions from file paths and
+        include them as columns in the DataFrame. If None, automatically detects
+        Hive partitioning from the expanded file paths. True forces Hive
+        partitioning and False disables it. Defaults to None.
         coerce_int96_timestamp_unit: TimeUnit to coerce Int96 TimeStamps to. e.g.: [ns, us, ms], Defaults to None.
         ignore_corrupt_files: If True, corrupt or unreadable Parquet files are silently skipped
             instead of raising an error. Skipped files are recorded in ``df.skipped_corrupt_files`` after

--- a/daft/io/_text.py
+++ b/daft/io/_text.py
@@ -16,7 +16,7 @@ def read_text(
     skip_blank_lines: bool = True,
     whole_text: bool = False,
     file_path_column: str | None = None,
-    hive_partitioning: bool = False,
+    hive_partitioning: bool | None = None,
     io_config: IOConfig | None = None,
     _buffer_size: int | None = None,
     _chunk_size: int | None = None,
@@ -32,8 +32,10 @@ def read_text(
             When ``False``, each line in the file becomes a row in the DataFrame.
             When ``True``, the entire content of each file becomes a single row in the DataFrame.
         file_path_column: Include the source path(s) as a column with this name. Defaults to ``None``.
-        hive_partitioning: Whether to infer hive-style partitions from file paths and include them as
-            columns in the DataFrame. Defaults to ``False``.
+                hive_partitioning: Whether to infer Hive-style partitions from file paths and
+            include them as columns in the DataFrame. If ``None``, automatically detects
+            Hive partitioning from the expanded file paths. ``True`` forces Hive
+            partitioning and ``False`` disables it. Defaults to ``None``.
         io_config: IO configuration for the native downloader.
         _buffer_size: Optional tuning parameter for the underlying streaming reader buffer size (bytes).
         _chunk_size: Optional tuning parameter for the underlying streaming reader chunk size (rows).

--- a/daft/io/common.py
+++ b/daft/io/common.py
@@ -24,7 +24,7 @@ def get_tabular_files_scan(
     file_format_config: FileFormatConfig,
     storage_config: StorageConfig,
     file_path_column: str | None = None,
-    hive_partitioning: bool = False,
+    hive_partitioning: bool | None = None,
     skip_glob: bool = False,
 ) -> LogicalPlanBuilder:
     """Returns a TabularFilesScan LogicalPlan for a given glob filepath."""

--- a/src/common/py-serde/src/python.rs
+++ b/src/common/py-serde/src/python.rs
@@ -1,17 +1,10 @@
 use std::{
-    fmt,
     hash::{Hash, Hasher},
     io::Write,
-    sync::Arc,
 };
 
 #[cfg(feature = "python")]
 use pyo3::{Bound, Py, PyAny, PyResult, Python, types::PyAnyMethods};
-use serde::{
-    Deserialize, Deserializer, Serialize, Serializer,
-    de::{Error as DeError, Visitor},
-    ser::Error as SerError,
-};
 
 #[cfg(feature = "python")]
 pub fn pickle_dumps(py: Python, obj: &Py<PyAny>) -> PyResult<Vec<u8>> {

--- a/src/daft-core/src/array/ops/get.rs
+++ b/src/daft-core/src/array/ops/get.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use arrow::{
     array::{Array, ArrayRef, Scalar},
     datatypes::IntervalMonthDayNano,

--- a/src/daft-dsl/src/functions/python/runtime_py_object.rs
+++ b/src/daft-dsl/src/functions/python/runtime_py_object.rs
@@ -1,7 +1,5 @@
 #![allow(clippy::all, reason = "todo: remove; getting a rustc error")]
 
-use std::sync::Arc;
-
 #[cfg(feature = "python")]
 use common_py_serde::PyObjectWrapper;
 use serde::{Deserialize, Serialize};
@@ -16,8 +14,6 @@ pub struct RuntimePyObject {
 impl RuntimePyObject {
     /// Creates a new 'None' python value as 'None' is used where a non-optional RuntimePyObject is expected.
     pub fn new_none() -> Self {
-        use std::sync::Arc;
-
         #[cfg(feature = "python")]
         {
             let none_value = Arc::new(pyo3::Python::attach(|py| py.None()));

--- a/src/daft-dsl/src/python_udf/row_wise.rs
+++ b/src/daft-dsl/src/python_udf/row_wise.rs
@@ -1,14 +1,10 @@
-use std::{collections::HashMap, fmt::Display, num::NonZeroUsize, sync::Arc};
+use std::{fmt::Display, num::NonZeroUsize, sync::Arc};
 
 use common_error::DaftResult;
 use common_hashable_float_wrapper::FloatWrapper as HashableF64;
 use common_metrics::MetricsCollector;
 use daft_core::{prelude::*, series::Series};
 use itertools::Itertools;
-use opentelemetry::{
-    Key,
-    logs::{AnyValue, LogRecord, Logger, LoggerProvider},
-};
 #[cfg(feature = "python")]
 use pyo3::{PyErr, Python, prelude::*};
 use serde::{Deserialize, Serialize};

--- a/src/daft-recordbatch/src/file_info.rs
+++ b/src/daft-recordbatch/src/file_info.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use common_py_serde::impl_bincode_py_state_serialization;
 #[cfg(feature = "python")]
 use pyo3::{PyResult, Python, exceptions::PyKeyError, pyclass, pymethods};

--- a/src/daft-recordbatch/src/ops/agg.rs
+++ b/src/daft-recordbatch/src/ops/agg.rs
@@ -1,14 +1,6 @@
 use common_error::{DaftError, DaftResult};
 use daft_core::prelude::*;
-use daft_dsl::{
-    AggExpr,
-    expr::{
-        MapGroupsFn,
-        bound_expr::{BoundAggExpr, BoundExpr},
-    },
-    operator_metrics::NoopMetricsCollector,
-    python_udf::PyScalarFn,
-};
+use daft_dsl::expr::bound_expr::{BoundAggExpr, BoundExpr};
 use daft_groupby::{IntoGroups, IntoUniqueIdxs};
 
 use super::inline_agg::can_inline_agg;

--- a/src/daft-scan/src/expr_rewriter.rs
+++ b/src/daft-scan/src/expr_rewriter.rs
@@ -6,7 +6,7 @@ use daft_core::prelude::Operator;
 use daft_dsl::{
     Column, Expr, ExprRef, ResolvedColumn,
     common_treenode::{Transformed, TreeNode, TreeNodeRecursion},
-    functions::{FunctionExpr, partitioning},
+    functions::partitioning,
     null_lit, resolved_col,
 };
 

--- a/src/daft-scan/src/glob.rs
+++ b/src/daft-scan/src/glob.rs
@@ -148,6 +148,63 @@ fn run_glob_parallel(
     Ok(iterator)
 }
 
+pub(crate) async fn detect_hive_partitioning(
+    glob_paths: &[String],
+    io_client: Arc<IOClient>,
+    io_stats: Option<IOStatsRef>,
+    file_format: FileFormat,
+    skip_glob: bool,
+) -> DaftResult<bool> {
+    let mut expected_keys = None;
+
+    for glob_path in glob_paths {
+        if skip_glob {
+            let partitions = parse_hive_partitioning(glob_path)?;
+
+            if partitions.is_empty() {
+                return Ok(false);
+            }
+
+            let keys = partitions.keys().cloned().collect::<Vec<_>>();
+
+            match &expected_keys {
+                Some(expected) if expected != &keys => return Ok(false),
+                None => expected_keys = Some(keys),
+                _ => {}
+            }
+        } else {
+            let mut stream = run_glob(
+                glob_path.clone(),
+                None,
+                io_client.clone(),
+                io_stats.clone(),
+                file_format,
+            )
+            .await?;
+
+            while let Some(metadata) = stream.next().await {
+                let FileMetadata { filepath, .. } = metadata?;
+
+                let partitions = parse_hive_partitioning(&filepath)?;
+
+                if partitions.is_empty() {
+                    return Ok(false);
+                }
+
+                let keys = partitions.keys().cloned().collect::<Vec<_>>();
+
+                match &expected_keys {
+                    Some(expected) if expected != &keys => return Ok(false),
+                    None => expected_keys = Some(keys),
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    Ok(expected_keys.is_some())
+}
+
 #[allow(clippy::too_many_arguments)]
 impl GlobScanOperator {
     pub async fn try_new(
@@ -157,7 +214,7 @@ impl GlobScanOperator {
         infer_schema: bool,
         user_provided_schema: Option<SchemaRef>,
         file_path_column: Option<String>,
-        hive_partitioning: bool,
+        hive_partitioning: Option<bool>,
         skip_glob: bool,
     ) -> DaftResult<Self> {
         let first_glob_path = match glob_paths.first() {
@@ -498,6 +555,20 @@ impl GlobScanOperator {
             };
 
             (schema, None, first_filepath)
+        };
+
+        let hive_partitioning = match hive_partitioning {
+            Some(value) => value,
+            None => {
+                detect_hive_partitioning(
+                    &glob_paths,
+                    io_client.clone(),
+                    Some(io_stats.clone()),
+                    file_format,
+                    skip_glob,
+                )
+                .await?
+            }
         };
 
         // If hive partitioning is set, create partition fields from the hive partitions.

--- a/src/daft-scan/src/lib.rs
+++ b/src/daft-scan/src/lib.rs
@@ -997,7 +997,7 @@ mod test {
             infer_schema,
             Some(Arc::new(Schema::empty())),
             None,
-            false,
+            Some(false),
             false,
         )
         .await
@@ -1593,5 +1593,68 @@ mod test {
             assert!(estimate_val <= REASONABLE_SIZE_BYTES);
             assert!(estimate_val > 0);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use common_error::DaftResult;
+    use common_file_formats::FileFormat;
+
+    use super::*;
+    use crate::glob::detect_hive_partitioning;
+
+    #[tokio::test]
+    async fn test_detect_hive_partitioning_consistent_keys() -> DaftResult<()> {
+        let paths = vec![
+            "file:///data/year=2024/month=01/file1.parquet".to_string(),
+            "file:///data/year=2024/month=02/file2.parquet".to_string(),
+        ];
+
+        let (_, io_client) =
+            StorageConfig::new_internal(false, None).get_io_client_and_runtime()?;
+
+        let result =
+            detect_hive_partitioning(&paths, io_client, None, FileFormat::Parquet, true).await?;
+
+        assert!(result);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_detect_hive_partitioning_inconsistent_keys() -> DaftResult<()> {
+        let paths = vec![
+            "file:///data/year=2024/month=01/file1.parquet".to_string(),
+            "file:///data/year=2024/day=01/file2.parquet".to_string(),
+        ];
+
+        let (_, io_client) =
+            StorageConfig::new_internal(false, None).get_io_client_and_runtime()?;
+
+        let result =
+            detect_hive_partitioning(&paths, io_client, None, FileFormat::Parquet, true).await?;
+
+        assert!(!result);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_detect_hive_partitioning_without_partitions() -> DaftResult<()> {
+        let paths = vec![
+            "file:///data/file1.parquet".to_string(),
+            "file:///data/file2.parquet".to_string(),
+        ];
+
+        let (_, io_client) =
+            StorageConfig::new_internal(false, None).get_io_client_and_runtime()?;
+
+        let result =
+            detect_hive_partitioning(&paths, io_client, None, FileFormat::Parquet, true).await?;
+
+        assert!(!result);
+
+        Ok(())
     }
 }

--- a/src/daft-scan/src/python.rs
+++ b/src/daft-scan/src/python.rs
@@ -378,7 +378,7 @@ pub mod pylib {
             glob_path: Vec<String>,
             file_format_config: PyFileFormatConfig,
             storage_config: StorageConfig,
-            hive_partitioning: bool,
+            hive_partitioning: Option<bool>,
             infer_schema: bool,
             schema: Option<PySchema>,
             file_path_column: Option<String>,


### PR DESCRIPTION
## Changes Made

- Changed `hive_partitioning` from `bool` to `bool | None` across the `read_*` APIs.
- `None` automatically detects Hive-style partitioning after glob expansion.
- `True` explicitly enables Hive partitioning.
- `False` explicitly disables Hive partitioning.
- Auto-detection only enables Hive partitioning when all discovered files have consistent partition key names.
- Added tests for consistent keys, inconsistent keys, and paths without Hive partitions.

## Validation

- Ran `cargo fmt`
- Ran `cargo test -p daft-scan`
- All 56 tests passed.

## Also removed some unused imports

Closes #6753