### PR TITLE
fix(utf8): preserve backslashes in regexp_replace replacement

### DIFF
--- a/daft/functions/str.py
+++ b/daft/functions/str.py
@@ -1511,7 +1511,16 @@ def regexp_replace(
     pattern: str | Expression,
     replacement: str | Expression,
 ) -> Expression:
-    """Replaces all occurrences of a regex pattern in a string column with a replacement string.
+    r"""Replaces all occurrences of a regex pattern in a string column with a replacement string.
+
+    The replacement string is a template. Within it:
+
+    - `\1` to `\9` and `$1` to `$9` refer to the corresponding capture group, and `\0`
+      or `$0` to the whole match. Only one digit follows a backslash, so `\10` is group
+      1 followed by a literal `0`; use `${10}` to reach group 10.
+    - `${name}` and `$name` refer to a named capture group.
+    - `\\` produces a literal backslash and `$$` a literal `$`. Any other backslash is
+      literal, so `\n` is a backslash followed by `n`, not a newline.
 
     Args:
         expr: The string expression to be replaced
@@ -1540,6 +1549,13 @@ def regexp_replace(
         ╰────────┴─────────╯
         <BLANKLINE>
         (Showing first 3 of 3 rows)
+
+        Capture groups are referenced as `\1` (or `$1`), and `\\` emits a literal backslash:
+
+        >>> df = daft.from_pydict({"data": ["2024-01-31"]})
+        >>> df = df.select(regexp_replace(df["data"], r"(\d+)-(\d+)-(\d+)", r"\3\\\2\\\1"))
+        >>> df.to_pydict()["data"]
+        ['31\\01\\2024']
 
     """
     return Expression._call_builtin_scalar_fn("regexp_replace", expr, pattern, replacement)

--- a/daft/functions/str.py
+++ b/daft/functions/str.py
@@ -1513,14 +1513,11 @@ def regexp_replace(
 ) -> Expression:
     r"""Replaces all occurrences of a regex pattern in a string column with a replacement string.
 
-    The replacement string is a template. Within it:
-
-    - `\1` to `\9` and `$1` to `$9` refer to the corresponding capture group, and `\0`
-      or `$0` to the whole match. Only one digit follows a backslash, so `\10` is group
-      1 followed by a literal `0`; use `${10}` to reach group 10.
-    - `${name}` and `$name` refer to a named capture group.
-    - `\\` produces a literal backslash and `$$` a literal `$`. Any other backslash is
-      literal, so `\n` is a backslash followed by `n`, not a newline.
+    In the replacement, `\1`-`\9`/`$1`-`$9` reference capture groups and `\0`/`$0` the
+    whole match; `${name}`/`$name` reference a named group. Only one digit follows a
+    backslash, so `\10` is group 1 then a literal `0` and `${10}` reaches group 10.
+    `\\` emits a literal backslash and `$$` a literal `$`; any other backslash is
+    literal, so `\n` is a backslash followed by `n`, not a newline.
 
     Args:
         expr: The string expression to be replaced
@@ -1550,7 +1547,7 @@ def regexp_replace(
         <BLANKLINE>
         (Showing first 3 of 3 rows)
 
-        Capture groups are referenced as `\1` (or `$1`), and `\\` emits a literal backslash:
+        Capture groups and a literal backslash:
 
         >>> df = daft.from_pydict({"data": ["2024-01-31"]})
         >>> df = df.select(regexp_replace(df["data"], r"(\d+)-(\d+)-(\d+)", r"\3\\\2\\\1"))

--- a/src/daft-functions-utf8/src/replace.rs
+++ b/src/daft-functions-utf8/src/replace.rs
@@ -356,7 +356,6 @@ mod tests {
 
     #[test]
     fn test_regex_replace_posix_groups_translation() {
-        use std::borrow::Cow;
 
         // No backslash: borrowed, untouched (also covers `$`-only replacements).
         let translated = regex_replace_posix_groups("[$1]");

--- a/src/daft-functions-utf8/src/replace.rs
+++ b/src/daft-functions-utf8/src/replace.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Borrow, sync::LazyLock};
+use std::borrow::{Borrow, Cow};
 
 use common_error::{DaftError, DaftResult, ensure};
 use daft_core::{
@@ -163,14 +163,61 @@ fn replace_impl(
     Ok(result)
 }
 
-/// replace POSIX capture groups (like \1) with Rust Regex group (like ${1})
-/// used by regexp_replace
-fn regex_replace_posix_groups(replacement: &str) -> String {
-    static CAPTURE_GROUPS_RE_LOCK: LazyLock<regex::Regex> =
-        LazyLock::new(|| regex::Regex::new(r"(\\)(\d*)").unwrap());
-    CAPTURE_GROUPS_RE_LOCK
-        .replace_all(replacement, "$${$2}")
-        .into_owned()
+/// Translates POSIX-style capture-group references (`\1`, `\12`, ...) into the
+/// `regex` crate's `${1}` syntax so both `\n` and `$n`/`${n}` work as group
+/// references in `regexp_replace`.
+///
+/// Rules (single left-to-right pass):
+///
+/// * `\\` (two backslashes) is an escaped backslash and becomes one `\`.
+///   This takes precedence so `\\1` stays a literal `\1` instead of being
+///   misread as a group reference starting at the second backslash.
+/// * `\` followed by one or more ASCII digits is a group reference (`\1` ->
+///   `${1}`, `\12` -> `${12}`, `\0` -> `${0}`).
+/// * A `\` followed by anything else (or a trailing `\`) is preserved
+///   literally, so e.g. `a\b` stays `a\b`. The `regex` crate treats
+///   backslashes in replacements literally, so this yields a literal backslash
+///   in the output instead of silently dropping it.
+/// * Everything else, including `$`-style references (`$1`, `${1}`, `$$`),
+///   passes through untouched so `$` keeps exactly the `regex` crate's semantics.
+///
+/// Returns a borrowed `str` when no backslash is present to avoid allocating
+/// in the common case.
+fn regex_replace_posix_groups(replacement: &str) -> Cow<'_, str> {
+    if !replacement.contains('\\') {
+        return Cow::Borrowed(replacement);
+    }
+    let mut translated = String::with_capacity(replacement.len());
+    let mut chars = replacement.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c != '\\' {
+            translated.push(c);
+            continue;
+        }
+        match chars.peek() {
+            // Escaped backslash: `\\` -> `\`.
+            Some('\\') => {
+                translated.push('\\');
+                chars.next();
+            }
+            // POSIX group reference: `\` + digits -> `${digits}`.
+            Some(d) if d.is_ascii_digit() => {
+                translated.push_str("${");
+                while let Some(d) = chars.peek() {
+                    if d.is_ascii_digit() {
+                        translated.push(*d);
+                        chars.next();
+                    } else {
+                        break;
+                    }
+                }
+                translated.push('}');
+            }
+            // Lone backslash: preserve literally.
+            _ => translated.push('\\'),
+        }
+    }
+    Cow::Owned(translated)
 }
 
 fn regex_replace<'a, R: Borrow<regex::Regex>>(
@@ -185,7 +232,7 @@ fn regex_replace<'a, R: Borrow<regex::Regex>>(
         .map(|((val, re), replacement)| match (val, re, replacement) {
             (Some(val), Some(re), Some(replacement)) => {
                 let replacement = regex_replace_posix_groups(replacement);
-                Ok(Some(re?.borrow().replace_all(val, replacement.as_str())))
+                Ok(Some(re?.borrow().replace_all(val, replacement.as_ref())))
             }
             _ => Ok(None),
         })
@@ -305,5 +352,69 @@ mod tests {
         let result = replace_impl(&arr, &pattern, &replacement, true).unwrap();
 
         assert_eq!(result.get(0), Some("world hello"));
+    }
+
+    #[test]
+    fn test_regex_replace_posix_groups_translation() {
+        use std::borrow::Cow;
+
+        // No backslash: borrowed, untouched (also covers `$`-only replacements).
+        let translated = regex_replace_posix_groups("[$1]");
+        assert!(matches!(translated, Cow::Borrowed(_)));
+        assert_eq!(translated, "[$1]");
+
+        // `\n` becomes `${n}`; `$n` passes through for the regex crate.
+        assert_eq!(regex_replace_posix_groups("[\\1]"), "[${1}]");
+        assert_eq!(regex_replace_posix_groups("\\12"), "${12}");
+        assert_eq!(regex_replace_posix_groups("\\0"), "${0}");
+        assert_eq!(regex_replace_posix_groups("$1"), "$1");
+        assert_eq!(regex_replace_posix_groups("$$"), "$$");
+
+        // `\\` is an escaped backslash and collapses to one.
+        assert_eq!(regex_replace_posix_groups("\\\\"), "\\");
+        // Escaped backslash wins over group parsing: `\\1` is literal `\1`.
+        assert_eq!(regex_replace_posix_groups("\\\\1"), "\\1");
+        // `\\` + `\1` is a literal backslash followed by a group reference.
+        assert_eq!(regex_replace_posix_groups("\\\\\\1"), "\\${1}");
+
+        // Lone backslashes are preserved literally.
+        assert_eq!(regex_replace_posix_groups("a\\b"), "a\\b");
+        assert_eq!(regex_replace_posix_groups("x\\"), "x\\");
+        assert_eq!(regex_replace_posix_groups("\\"), "\\");
+        assert_eq!(regex_replace_posix_groups("\\$1"), "\\$1");
+    }
+
+    #[test]
+    fn test_regexp_replace_preserves_backslashes() {
+        // Regression test for https://github.com/Eventual-Inc/Daft/issues/7471:
+        // backslashes in the replacement must not be silently dropped.
+        let cases = vec![
+            // (replacement, expected output for input "abc" with pattern "(b)")
+            ("[$1]".to_string(), "a[b]c".to_string()),
+            ("[\\1]".to_string(), "a[b]c".to_string()),
+            ("a\\b".to_string(), "aa\\bc".to_string()),
+            // `\\` (two backslashes) is an escaped backslash -> one backslash.
+            ("\\\\".to_string(), "a\\c".to_string()),
+            ("x\\".to_string(), "ax\\c".to_string()),
+            ("\\1".to_string(), "abc".to_string()),
+            // Escaped backslash + literal `1`, not a group reference.
+            ("\\\\1".to_string(), "a\\1c".to_string()),
+            // Escaped backslash + group reference.
+            ("\\\\\\1".to_string(), "a\\bc".to_string()),
+            ("$1".to_string(), "abc".to_string()),
+            ("$$".to_string(), "a$c".to_string()),
+        ];
+        for (replacement, expected) in cases {
+            let arr = Utf8Array::from_iter("a", vec![Some("abc")].into_iter());
+            let pattern = Utf8Array::from_iter("p", vec![Some("(b)")].into_iter());
+            let replacement_arr =
+                Utf8Array::from_iter("r", vec![Some(replacement.as_str())].into_iter());
+            let result = replace_impl(&arr, &pattern, &replacement_arr, true).unwrap();
+            assert_eq!(
+                result.get(0),
+                Some(expected.as_str()),
+                "replacement {replacement:?}"
+            );
+        }
     }
 }

--- a/src/daft-functions-utf8/src/replace.rs
+++ b/src/daft-functions-utf8/src/replace.rs
@@ -143,9 +143,7 @@ fn replace_impl(
     let arr_iter = create_broadcasted_str_iter(arr, expected_size);
     let replacement_iter = create_broadcasted_str_iter(replacement, expected_size);
 
-    // A scalar replacement is broadcast to every row, so translate its template
-    // once here instead of re-scanning the same string inside the row loop.
-    // A genuinely element-wise replacement column is translated per row.
+    // Translate a broadcast scalar replacement once rather than per row.
     let broadcast_template = if replacement.len() == 1 {
         replacement.get(0).map(regex_replace_posix_groups)
     } else {
@@ -182,20 +180,11 @@ fn replace_impl(
     Ok(result)
 }
 
-/// Length in bytes of the `$` construct at the start of `s`, if the `regex`
-/// crate would read a capture reference (or a `$$` escape) there.
+/// Byte length of the `$$` escape or capture reference at the start of `s`,
+/// per the `regex` crate's interpolation rules; `None` if the `$` is literal.
 ///
-/// This mirrors `regex`'s own interpolation rules so that we can copy such
-/// constructs through untouched:
-///
-/// * `$$` is the escape for a literal `$`.
-/// * `${name}` is a braced reference; the name is everything up to the first
-///   `}`, and an unclosed `${` is not a reference at all.
-/// * `$name` is an unbraced reference whose name is the longest run of
-///   `[0-9A-Za-z_]`; a `$` followed by none of those is not a reference.
-///
-/// Returns `None` when the `$` is just a literal dollar sign (a trailing `$`,
-/// a `$` before a non-name character, or an unclosed `${`).
+/// A braced name runs to the first `}` (unclosed `${` is not a reference); an
+/// unbraced one is the longest run of `[0-9A-Za-z_]`.
 fn dollar_construct_len(s: &str) -> Option<usize> {
     debug_assert!(s.starts_with('$'));
     let bytes = s.as_bytes();
@@ -212,33 +201,17 @@ fn dollar_construct_len(s: &str) -> Option<usize> {
     }
 }
 
-/// Translates a `regexp_replace` replacement template into the syntax the
-/// `regex` crate expects, so that POSIX-style `\1` references, `$`-style
-/// references and literal backslashes can all coexist.
+/// Translates a `regexp_replace` replacement template into `regex` crate syntax.
 ///
-/// Rules (single left-to-right pass):
+/// * `\\` -> `\`, matched before the digit arm so `\\1` is a literal `\1`.
+/// * `\` + one digit -> `${digit}`; only one digit, so `\10` is group 1 then a
+///   literal `0` (POSIX/sed/Java). Groups past 9 need `${10}`.
+/// * Any other `\`, including a trailing one, stays literal.
+/// * `$$` and valid references (`$1`, `$name`, `${10}`) are copied through.
+/// * Any other `$` becomes `$$`, so it stays literal and cannot merge with a
+///   `${` emitted for a following `\1`.
 ///
-/// * `\\` (two backslashes) is an escaped backslash and becomes one `\`.
-///   This takes precedence so `\\1` stays a literal `\1` instead of being
-///   misread as a group reference starting at the second backslash.
-/// * `\` followed by a single ASCII digit is a group reference (`\1` ->
-///   `${1}`, `\0` -> `${0}` for the whole match). Only one digit is consumed,
-///   matching POSIX/sed/Java: `\10` is group 1 followed by a literal `0`, not
-///   the usually-nonexistent group 10. Groups past 9 are reachable as `${10}`.
-/// * A `\` followed by anything else (or a trailing `\`) is preserved
-///   literally, so e.g. `a\b` stays `a\b`. The `regex` crate treats
-///   backslashes in replacements literally, so this yields a literal backslash
-///   in the output instead of silently dropping it.
-/// * `$$` and valid `$`-style references (`$1`, `$name`, `${10}`) are the
-///   `regex` crate's own syntax and are copied through untouched.
-/// * Any other `$` is a literal dollar sign and is escaped to `$$`. This keeps
-///   its meaning unchanged on its own, and stops it from merging with a `${`
-///   emitted for a following POSIX reference: without it `$\1` would produce
-///   the template `$${1}`, which the crate reads as an escaped `$` followed by
-///   the literal text `{1}`.
-///
-/// Returns a borrowed `str` when there is nothing to translate, to avoid
-/// allocating in the common case.
+/// Borrows when there is nothing to translate.
 fn regex_replace_posix_groups(replacement: &str) -> Cow<'_, str> {
     if !replacement.contains(['\\', '$']) {
         return Cow::Borrowed(replacement);
@@ -250,19 +223,16 @@ fn regex_replace_posix_groups(replacement: &str) -> Cow<'_, str> {
             '\\' => {
                 let after = &rest[1..];
                 match after.as_bytes().first() {
-                    // Escaped backslash: `\\` -> `\`.
                     Some(b'\\') => {
                         translated.push('\\');
                         rest = &after[1..];
                     }
-                    // POSIX group reference: `\` + one digit -> `${digit}`.
                     Some(&d) if d.is_ascii_digit() => {
                         translated.push_str("${");
                         translated.push(d as char);
                         translated.push('}');
                         rest = &after[1..];
                     }
-                    // Lone or trailing backslash: preserve literally.
                     _ => {
                         translated.push('\\');
                         rest = after;
@@ -270,13 +240,10 @@ fn regex_replace_posix_groups(replacement: &str) -> Cow<'_, str> {
                 }
             }
             '$' => match dollar_construct_len(rest) {
-                // The regex crate's own syntax: copy it through untouched.
                 Some(len) => {
                     translated.push_str(&rest[..len]);
                     rest = &rest[len..];
                 }
-                // A literal `$`: escape it so it stays literal and cannot
-                // merge with a `${` we emit for a following `\1`.
                 None => {
                     translated.push_str("$$");
                     rest = &rest[1..];
@@ -291,12 +258,8 @@ fn regex_replace_posix_groups(replacement: &str) -> Cow<'_, str> {
     Cow::Owned(translated)
 }
 
-/// Per-row iterator of replacement templates, already translated into the
-/// `regex` crate's syntax.
-///
-/// When `broadcast_template` is set the same pre-translated template is simply
-/// borrowed for every row; otherwise each row's replacement is translated as it
-/// is consumed.
+/// Per-row iterator of already-translated replacement templates: a borrow of
+/// `broadcast_template` when set, otherwise translated as each row is consumed.
 fn translated_replacement_iter<'a>(
     replacement: &'a Utf8Array,
     broadcast_template: Option<&'a str>,
@@ -492,10 +455,8 @@ mod tests {
 
     #[test]
     fn test_regexp_replace_literal_dollar_before_posix_group() {
-        // A literal `$` directly in front of a POSIX group reference must
-        // survive. Emitting a bare `${1}` for `\1` would produce the template
-        // `$${1}`, which the regex crate reads as an escaped `$` followed by
-        // the literal text `{1}`, yielding "a${1}c".
+        // A bare `${1}` for `\1` would make the template `$${1}`: an escaped
+        // `$` plus the literal text `{1}`.
         let arr = Utf8Array::from_iter("a", vec![Some("abc")].into_iter());
         let pattern = Utf8Array::from_iter("p", vec![Some("(b)")].into_iter());
         let replacement = Utf8Array::from_iter("r", vec![Some("$\\1")].into_iter());
@@ -507,10 +468,8 @@ mod tests {
 
     #[test]
     fn test_regexp_replace_multi_digit_group_reference() {
-        // `\10` is group 1 followed by a literal `0`, as in POSIX/sed/Java.
         // Consuming both digits would ask for the nonexistent group 10, which
-        // the regex crate expands to the empty string, silently dropping the
-        // `0` as well.
+        // the regex crate expands to the empty string.
         let arr = Utf8Array::from_iter("a", vec![Some("abc")].into_iter());
         let pattern = Utf8Array::from_iter("p", vec![Some("(b)")].into_iter());
         let replacement = Utf8Array::from_iter("r", vec![Some("\\10")].into_iter());
@@ -537,8 +496,7 @@ mod tests {
 
     #[test]
     fn test_replace_literal_does_not_translate_backslashes() {
-        // `replace()` (regex = false) has no template semantics: every
-        // character of the replacement is emitted verbatim.
+        // `replace()` (regex = false) has no template semantics.
         let arr = Utf8Array::from_iter("a", vec![Some("abc")].into_iter());
         let pattern = Utf8Array::from_iter("p", vec![Some("b")].into_iter());
         let replacement = Utf8Array::from_iter("r", vec![Some("\\1$1\\\\")].into_iter());
@@ -562,8 +520,7 @@ mod tests {
 
     #[test]
     fn test_regexp_replace_elementwise_replacement_column() {
-        // The per-row path (replacement column longer than one) must translate
-        // each row's own template, not reuse a broadcast one.
+        // The per-row path must not reuse a broadcast template.
         let arr = Utf8Array::from_iter("a", vec![Some("abc"), Some("abc")].into_iter());
         let pattern = Utf8Array::from_iter("p", vec![Some("(b)")].into_iter());
         let replacement = Utf8Array::from_iter("r", vec![Some("[\\1]"), Some("x\\")].into_iter());
@@ -576,8 +533,7 @@ mod tests {
 
     #[test]
     fn test_regexp_replace_preserves_backslashes() {
-        // Regression test for https://github.com/Eventual-Inc/Daft/issues/7471:
-        // backslashes in the replacement must not be silently dropped.
+        // Regression test for https://github.com/Eventual-Inc/Daft/issues/7471.
         let cases = vec![
             // (replacement, expected output for input "abc" with pattern "(b)")
             ("[$1]".to_string(), "a[b]c".to_string()),

--- a/src/daft-functions-utf8/src/replace.rs
+++ b/src/daft-functions-utf8/src/replace.rs
@@ -143,16 +143,35 @@ fn replace_impl(
     let arr_iter = create_broadcasted_str_iter(arr, expected_size);
     let replacement_iter = create_broadcasted_str_iter(replacement, expected_size);
 
+    // A scalar replacement is broadcast to every row, so translate its template
+    // once here instead of re-scanning the same string inside the row loop.
+    // A genuinely element-wise replacement column is translated per row.
+    let broadcast_template = if replacement.len() == 1 {
+        replacement.get(0).map(regex_replace_posix_groups)
+    } else {
+        None
+    };
+
     let result = match (regex, pattern.len()) {
         (true, 1) => {
             let regex_val = regex::Regex::new(pattern.get(0).unwrap());
             let regex = regex_val.as_ref().map_err(|e| e.clone());
             let regex_iter = std::iter::repeat_n(Some(regex), expected_size);
-            regex_replace(arr_iter, regex_iter, replacement_iter, arr.name())?
+            let templates = translated_replacement_iter(
+                replacement,
+                broadcast_template.as_deref(),
+                expected_size,
+            );
+            regex_replace(arr_iter, regex_iter, templates, arr.name())?
         }
         (true, _) => {
             let regex_iter = pattern.into_iter().map(|pat| pat.map(regex::Regex::new));
-            regex_replace(arr_iter, regex_iter, replacement_iter, arr.name())?
+            let templates = translated_replacement_iter(
+                replacement,
+                broadcast_template.as_deref(),
+                expected_size,
+            );
+            regex_replace(arr_iter, regex_iter, templates, arr.name())?
         }
         (false, _) => {
             let pattern_iter = create_broadcasted_str_iter(pattern, expected_size);
@@ -163,67 +182,142 @@ fn replace_impl(
     Ok(result)
 }
 
-/// Translates POSIX-style capture-group references (`\1`, `\12`, ...) into the
-/// `regex` crate's `${1}` syntax so both `\n` and `$n`/`${n}` work as group
-/// references in `regexp_replace`.
+/// Length in bytes of the `$` construct at the start of `s`, if the `regex`
+/// crate would read a capture reference (or a `$$` escape) there.
+///
+/// This mirrors `regex`'s own interpolation rules so that we can copy such
+/// constructs through untouched:
+///
+/// * `$$` is the escape for a literal `$`.
+/// * `${name}` is a braced reference; the name is everything up to the first
+///   `}`, and an unclosed `${` is not a reference at all.
+/// * `$name` is an unbraced reference whose name is the longest run of
+///   `[0-9A-Za-z_]`; a `$` followed by none of those is not a reference.
+///
+/// Returns `None` when the `$` is just a literal dollar sign (a trailing `$`,
+/// a `$` before a non-name character, or an unclosed `${`).
+fn dollar_construct_len(s: &str) -> Option<usize> {
+    debug_assert!(s.starts_with('$'));
+    let bytes = s.as_bytes();
+    match bytes.get(1)? {
+        b'$' => Some(2),
+        b'{' => Some(2 + s[2..].find('}')? + 1),
+        _ => {
+            let name_len = bytes[1..]
+                .iter()
+                .take_while(|&&b| b.is_ascii_alphanumeric() || b == b'_')
+                .count();
+            (name_len > 0).then_some(1 + name_len)
+        }
+    }
+}
+
+/// Translates a `regexp_replace` replacement template into the syntax the
+/// `regex` crate expects, so that POSIX-style `\1` references, `$`-style
+/// references and literal backslashes can all coexist.
 ///
 /// Rules (single left-to-right pass):
 ///
 /// * `\\` (two backslashes) is an escaped backslash and becomes one `\`.
 ///   This takes precedence so `\\1` stays a literal `\1` instead of being
 ///   misread as a group reference starting at the second backslash.
-/// * `\` followed by one or more ASCII digits is a group reference (`\1` ->
-///   `${1}`, `\12` -> `${12}`, `\0` -> `${0}`).
+/// * `\` followed by a single ASCII digit is a group reference (`\1` ->
+///   `${1}`, `\0` -> `${0}` for the whole match). Only one digit is consumed,
+///   matching POSIX/sed/Java: `\10` is group 1 followed by a literal `0`, not
+///   the usually-nonexistent group 10. Groups past 9 are reachable as `${10}`.
 /// * A `\` followed by anything else (or a trailing `\`) is preserved
 ///   literally, so e.g. `a\b` stays `a\b`. The `regex` crate treats
 ///   backslashes in replacements literally, so this yields a literal backslash
 ///   in the output instead of silently dropping it.
-/// * Everything else, including `$`-style references (`$1`, `${1}`, `$$`),
-///   passes through untouched so `$` keeps exactly the `regex` crate's semantics.
+/// * `$$` and valid `$`-style references (`$1`, `$name`, `${10}`) are the
+///   `regex` crate's own syntax and are copied through untouched.
+/// * Any other `$` is a literal dollar sign and is escaped to `$$`. This keeps
+///   its meaning unchanged on its own, and stops it from merging with a `${`
+///   emitted for a following POSIX reference: without it `$\1` would produce
+///   the template `$${1}`, which the crate reads as an escaped `$` followed by
+///   the literal text `{1}`.
 ///
-/// Returns a borrowed `str` when no backslash is present to avoid allocating
-/// in the common case.
+/// Returns a borrowed `str` when there is nothing to translate, to avoid
+/// allocating in the common case.
 fn regex_replace_posix_groups(replacement: &str) -> Cow<'_, str> {
-    if !replacement.contains('\\') {
+    if !replacement.contains(['\\', '$']) {
         return Cow::Borrowed(replacement);
     }
     let mut translated = String::with_capacity(replacement.len());
-    let mut chars = replacement.chars().peekable();
-    while let Some(c) = chars.next() {
-        if c != '\\' {
-            translated.push(c);
-            continue;
-        }
-        match chars.peek() {
-            // Escaped backslash: `\\` -> `\`.
-            Some('\\') => {
-                translated.push('\\');
-                chars.next();
-            }
-            // POSIX group reference: `\` + digits -> `${digits}`.
-            Some(d) if d.is_ascii_digit() => {
-                translated.push_str("${");
-                while let Some(d) = chars.peek() {
-                    if d.is_ascii_digit() {
-                        translated.push(*d);
-                        chars.next();
-                    } else {
-                        break;
+    let mut rest = replacement;
+    while let Some(c) = rest.chars().next() {
+        match c {
+            '\\' => {
+                let after = &rest[1..];
+                match after.as_bytes().first() {
+                    // Escaped backslash: `\\` -> `\`.
+                    Some(b'\\') => {
+                        translated.push('\\');
+                        rest = &after[1..];
+                    }
+                    // POSIX group reference: `\` + one digit -> `${digit}`.
+                    Some(&d) if d.is_ascii_digit() => {
+                        translated.push_str("${");
+                        translated.push(d as char);
+                        translated.push('}');
+                        rest = &after[1..];
+                    }
+                    // Lone or trailing backslash: preserve literally.
+                    _ => {
+                        translated.push('\\');
+                        rest = after;
                     }
                 }
-                translated.push('}');
             }
-            // Lone backslash: preserve literally.
-            _ => translated.push('\\'),
+            '$' => match dollar_construct_len(rest) {
+                // The regex crate's own syntax: copy it through untouched.
+                Some(len) => {
+                    translated.push_str(&rest[..len]);
+                    rest = &rest[len..];
+                }
+                // A literal `$`: escape it so it stays literal and cannot
+                // merge with a `${` we emit for a following `\1`.
+                None => {
+                    translated.push_str("$$");
+                    rest = &rest[1..];
+                }
+            },
+            _ => {
+                translated.push(c);
+                rest = &rest[c.len_utf8()..];
+            }
         }
     }
     Cow::Owned(translated)
 }
 
+/// Per-row iterator of replacement templates, already translated into the
+/// `regex` crate's syntax.
+///
+/// When `broadcast_template` is set the same pre-translated template is simply
+/// borrowed for every row; otherwise each row's replacement is translated as it
+/// is consumed.
+fn translated_replacement_iter<'a>(
+    replacement: &'a Utf8Array,
+    broadcast_template: Option<&'a str>,
+    expected_size: usize,
+) -> Box<dyn Iterator<Item = Option<Cow<'a, str>>> + 'a> {
+    match broadcast_template {
+        Some(template) => Box::new(std::iter::repeat_n(
+            Some(Cow::Borrowed(template)),
+            expected_size,
+        )),
+        None => Box::new(
+            create_broadcasted_str_iter(replacement, expected_size)
+                .map(|r| r.map(regex_replace_posix_groups)),
+        ),
+    }
+}
+
 fn regex_replace<'a, R: Borrow<regex::Regex>>(
     arr_iter: impl Iterator<Item = Option<&'a str>>,
     regex_iter: impl Iterator<Item = Option<Result<R, regex::Error>>>,
-    replacement_iter: impl Iterator<Item = Option<&'a str>>,
+    replacement_iter: impl Iterator<Item = Option<Cow<'a, str>>>,
     name: &str,
 ) -> DaftResult<Utf8Array> {
     let result = arr_iter
@@ -231,7 +325,6 @@ fn regex_replace<'a, R: Borrow<regex::Regex>>(
         .zip(replacement_iter)
         .map(|((val, re), replacement)| match (val, re, replacement) {
             (Some(val), Some(re), Some(replacement)) => {
-                let replacement = regex_replace_posix_groups(replacement);
                 Ok(Some(re?.borrow().replace_all(val, replacement.as_ref())))
             }
             _ => Ok(None),
@@ -356,17 +449,24 @@ mod tests {
 
     #[test]
     fn test_regex_replace_posix_groups_translation() {
-        // No backslash: borrowed, untouched (also covers `$`-only replacements).
-        let translated = regex_replace_posix_groups("[$1]");
+        // Neither `\` nor `$`: borrowed, untouched.
+        let translated = regex_replace_posix_groups("[hi]");
         assert!(matches!(translated, Cow::Borrowed(_)));
-        assert_eq!(translated, "[$1]");
+        assert_eq!(translated, "[hi]");
 
         // `\n` becomes `${n}`; `$n` passes through for the regex crate.
+        assert_eq!(regex_replace_posix_groups("[$1]"), "[$1]");
         assert_eq!(regex_replace_posix_groups("[\\1]"), "[${1}]");
-        assert_eq!(regex_replace_posix_groups("\\12"), "${12}");
         assert_eq!(regex_replace_posix_groups("\\0"), "${0}");
         assert_eq!(regex_replace_posix_groups("$1"), "$1");
         assert_eq!(regex_replace_posix_groups("$$"), "$$");
+        assert_eq!(regex_replace_posix_groups("${10}"), "${10}");
+        assert_eq!(regex_replace_posix_groups("$name"), "$name");
+
+        // Only one digit is consumed, so `\12` is group 1 then a literal `2`
+        // (POSIX/sed/Java semantics). Groups past 9 are written `${10}`.
+        assert_eq!(regex_replace_posix_groups("\\12"), "${1}2");
+        assert_eq!(regex_replace_posix_groups("\\10"), "${1}0");
 
         // `\\` is an escaped backslash and collapses to one.
         assert_eq!(regex_replace_posix_groups("\\\\"), "\\");
@@ -380,6 +480,98 @@ mod tests {
         assert_eq!(regex_replace_posix_groups("x\\"), "x\\");
         assert_eq!(regex_replace_posix_groups("\\"), "\\");
         assert_eq!(regex_replace_posix_groups("\\$1"), "\\$1");
+
+        // A `$` the regex crate would not read as a reference is escaped to
+        // `$$` so it stays literal and cannot merge with a following `${`.
+        assert_eq!(regex_replace_posix_groups("$"), "$$");
+        assert_eq!(regex_replace_posix_groups("a$"), "a$$");
+        assert_eq!(regex_replace_posix_groups("$ "), "$$ ");
+        assert_eq!(regex_replace_posix_groups("${"), "$${");
+        assert_eq!(regex_replace_posix_groups("$\\1"), "$$${1}");
+    }
+
+    #[test]
+    fn test_regexp_replace_literal_dollar_before_posix_group() {
+        // A literal `$` directly in front of a POSIX group reference must
+        // survive. Emitting a bare `${1}` for `\1` would produce the template
+        // `$${1}`, which the regex crate reads as an escaped `$` followed by
+        // the literal text `{1}`, yielding "a${1}c".
+        let arr = Utf8Array::from_iter("a", vec![Some("abc")].into_iter());
+        let pattern = Utf8Array::from_iter("p", vec![Some("(b)")].into_iter());
+        let replacement = Utf8Array::from_iter("r", vec![Some("$\\1")].into_iter());
+
+        let result = replace_impl(&arr, &pattern, &replacement, true).unwrap();
+
+        assert_eq!(result.get(0), Some("a$bc"));
+    }
+
+    #[test]
+    fn test_regexp_replace_multi_digit_group_reference() {
+        // `\10` is group 1 followed by a literal `0`, as in POSIX/sed/Java.
+        // Consuming both digits would ask for the nonexistent group 10, which
+        // the regex crate expands to the empty string, silently dropping the
+        // `0` as well.
+        let arr = Utf8Array::from_iter("a", vec![Some("abc")].into_iter());
+        let pattern = Utf8Array::from_iter("p", vec![Some("(b)")].into_iter());
+        let replacement = Utf8Array::from_iter("r", vec![Some("\\10")].into_iter());
+
+        let result = replace_impl(&arr, &pattern, &replacement, true).unwrap();
+
+        assert_eq!(result.get(0), Some("ab0c"));
+    }
+
+    #[test]
+    fn test_regexp_replace_high_group_reference_via_braces() {
+        // Groups past 9 stay reachable through the regex crate's own `${n}`.
+        let arr = Utf8Array::from_iter("a", vec![Some("abcdefghij")].into_iter());
+        let pattern = Utf8Array::from_iter(
+            "p",
+            vec![Some("(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)")].into_iter(),
+        );
+        let replacement = Utf8Array::from_iter("r", vec![Some("${10}")].into_iter());
+
+        let result = replace_impl(&arr, &pattern, &replacement, true).unwrap();
+
+        assert_eq!(result.get(0), Some("j"));
+    }
+
+    #[test]
+    fn test_replace_literal_does_not_translate_backslashes() {
+        // `replace()` (regex = false) has no template semantics: every
+        // character of the replacement is emitted verbatim.
+        let arr = Utf8Array::from_iter("a", vec![Some("abc")].into_iter());
+        let pattern = Utf8Array::from_iter("p", vec![Some("b")].into_iter());
+        let replacement = Utf8Array::from_iter("r", vec![Some("\\1$1\\\\")].into_iter());
+
+        let result = replace_impl(&arr, &pattern, &replacement, false).unwrap();
+
+        assert_eq!(result.get(0), Some("a\\1$1\\\\c"));
+    }
+
+    #[test]
+    fn test_regexp_replace_unicode_replacement_with_backslash() {
+        // Multi-byte characters must survive the scan intact.
+        let arr = Utf8Array::from_iter("a", vec![Some("abc")].into_iter());
+        let pattern = Utf8Array::from_iter("p", vec![Some("(b)")].into_iter());
+        let replacement = Utf8Array::from_iter("r", vec![Some("é\\ü\\1")].into_iter());
+
+        let result = replace_impl(&arr, &pattern, &replacement, true).unwrap();
+
+        assert_eq!(result.get(0), Some("aé\\übc"));
+    }
+
+    #[test]
+    fn test_regexp_replace_elementwise_replacement_column() {
+        // The per-row path (replacement column longer than one) must translate
+        // each row's own template, not reuse a broadcast one.
+        let arr = Utf8Array::from_iter("a", vec![Some("abc"), Some("abc")].into_iter());
+        let pattern = Utf8Array::from_iter("p", vec![Some("(b)")].into_iter());
+        let replacement = Utf8Array::from_iter("r", vec![Some("[\\1]"), Some("x\\")].into_iter());
+
+        let result = replace_impl(&arr, &pattern, &replacement, true).unwrap();
+
+        assert_eq!(result.get(0), Some("a[b]c"));
+        assert_eq!(result.get(1), Some("ax\\c"));
     }
 
     #[test]

--- a/src/daft-functions-utf8/src/replace.rs
+++ b/src/daft-functions-utf8/src/replace.rs
@@ -143,11 +143,24 @@ fn replace_impl(
     let arr_iter = create_broadcasted_str_iter(arr, expected_size);
     let replacement_iter = create_broadcasted_str_iter(replacement, expected_size);
 
-    // Translate a broadcast scalar replacement once rather than per row.
+    // Translate a broadcast scalar replacement once, then repeat a borrow of it.
+    // Repeating `Cow::Borrowed` copies only the fat pointer per row; repeating the
+    // `Option<Cow>` directly would clone the translated `String` per row.
     let broadcast_template = if replacement.len() == 1 {
         replacement.get(0).map(regex_replace_posix_groups)
     } else {
         None
+    };
+    let templates: Box<dyn Iterator<Item = Option<Cow<str>>>> = match broadcast_template.as_deref()
+    {
+        Some(template) => Box::new(std::iter::repeat_n(
+            Some(Cow::Borrowed(template)),
+            expected_size,
+        )),
+        None => Box::new(
+            create_broadcasted_str_iter(replacement, expected_size)
+                .map(|r| r.map(regex_replace_posix_groups)),
+        ),
     };
 
     let result = match (regex, pattern.len()) {
@@ -155,20 +168,10 @@ fn replace_impl(
             let regex_val = regex::Regex::new(pattern.get(0).unwrap());
             let regex = regex_val.as_ref().map_err(|e| e.clone());
             let regex_iter = std::iter::repeat_n(Some(regex), expected_size);
-            let templates = translated_replacement_iter(
-                replacement,
-                broadcast_template.as_deref(),
-                expected_size,
-            );
             regex_replace(arr_iter, regex_iter, templates, arr.name())?
         }
         (true, _) => {
             let regex_iter = pattern.into_iter().map(|pat| pat.map(regex::Regex::new));
-            let templates = translated_replacement_iter(
-                replacement,
-                broadcast_template.as_deref(),
-                expected_size,
-            );
             regex_replace(arr_iter, regex_iter, templates, arr.name())?
         }
         (false, _) => {
@@ -256,25 +259,6 @@ fn regex_replace_posix_groups(replacement: &str) -> Cow<'_, str> {
         }
     }
     Cow::Owned(translated)
-}
-
-/// Per-row iterator of already-translated replacement templates: a borrow of
-/// `broadcast_template` when set, otherwise translated as each row is consumed.
-fn translated_replacement_iter<'a>(
-    replacement: &'a Utf8Array,
-    broadcast_template: Option<&'a str>,
-    expected_size: usize,
-) -> Box<dyn Iterator<Item = Option<Cow<'a, str>>> + 'a> {
-    match broadcast_template {
-        Some(template) => Box::new(std::iter::repeat_n(
-            Some(Cow::Borrowed(template)),
-            expected_size,
-        )),
-        None => Box::new(
-            create_broadcasted_str_iter(replacement, expected_size)
-                .map(|r| r.map(regex_replace_posix_groups)),
-        ),
-    }
 }
 
 fn regex_replace<'a, R: Borrow<regex::Regex>>(

--- a/src/daft-functions-utf8/src/replace.rs
+++ b/src/daft-functions-utf8/src/replace.rs
@@ -356,7 +356,6 @@ mod tests {
 
     #[test]
     fn test_regex_replace_posix_groups_translation() {
-
         // No backslash: borrowed, untouched (also covers `$`-only replacements).
         let translated = regex_replace_posix_groups("[$1]");
         assert!(matches!(translated, Cow::Borrowed(_)));

--- a/tests/recordbatch/utf8/test_replace.py
+++ b/tests/recordbatch/utf8/test_replace.py
@@ -32,3 +32,29 @@ def test_series_utf8_replace(expr, data, expected) -> None:
     table = MicroPartition.from_pydict({"col": data, "emptystrings": [""] * len(data)})
     result = table.eval_expression_list([expr])
     assert result.to_pydict() == {"col": expected}
+
+
+@pytest.mark.parametrize(
+    ["replacement", "expected"],
+    [
+        # `$n` and `\n` are both group references.
+        ("[$1]", "a[b]c"),
+        (r"[\1]", "a[b]c"),
+        ("$1", "abc"),
+        # Lone backslashes are preserved literally (not silently dropped).
+        (r"a\b", r"aa\bc"),
+        ("x\\", r"ax\c"),
+        # `\\` (two backslashes) is an escaped backslash -> one backslash.
+        (r"\\", r"a\c"),
+        # Escaped backslash + literal `1`, not a group reference.
+        (r"\\1", r"a\1c"),
+        # Escaped backslash + group reference.
+        (r"\\\1", r"a\bc"),
+        ("$$", "a$c"),
+    ],
+)
+def test_series_utf8_regexp_replace_backslashes(replacement, expected) -> None:
+    # Regression test for https://github.com/Eventual-Inc/Daft/issues/7471.
+    table = MicroPartition.from_pydict({"col": ["abc"]})
+    result = table.eval_expression_list([col("col").regexp_replace("(b)", replacement)])
+    assert result.to_pydict() == {"col": [expected]}

--- a/tests/recordbatch/utf8/test_replace.py
+++ b/tests/recordbatch/utf8/test_replace.py
@@ -51,6 +51,21 @@ def test_series_utf8_replace(expr, data, expected) -> None:
         # Escaped backslash + group reference.
         (r"\\\1", r"a\bc"),
         ("$$", "a$c"),
+        # `\n`/`\t` are a literal backslash plus a letter, never a newline/tab.
+        (r"\n", r"a\nc"),
+        (r"\t", r"a\tc"),
+        # The regex crate's own braced syntax passes through untouched.
+        ("${1}", "abc"),
+        # A `$` the regex crate would not read as a reference stays literal.
+        ("$", "a$c"),
+        # A literal `$` in front of a group reference must not be swallowed.
+        (r"$\1", "a$bc"),
+        # Only one digit is consumed: `\10` is group 1 then a literal `0`.
+        (r"\10", "ab0c"),
+        # Empty replacement deletes the match.
+        ("", "ac"),
+        # Multi-byte characters survive around a literal backslash.
+        (r"é\ü", r"aé\üc"),
     ],
 )
 def test_series_utf8_regexp_replace_backslashes(replacement, expected) -> None:
@@ -58,3 +73,19 @@ def test_series_utf8_regexp_replace_backslashes(replacement, expected) -> None:
     table = MicroPartition.from_pydict({"col": ["abc"]})
     result = table.eval_expression_list([col("col").regexp_replace("(b)", replacement)])
     assert result.to_pydict() == {"col": [expected]}
+
+
+def test_series_utf8_replace_literal_keeps_template_chars() -> None:
+    # `replace` (non-regex) has no template semantics: backslashes and `$` are
+    # ordinary characters there.
+    table = MicroPartition.from_pydict({"col": ["abc"]})
+    result = table.eval_expression_list([col("col").replace("b", r"\1$1\\")])
+    assert result.to_pydict() == {"col": [r"a\1$1\\c"]}
+
+
+def test_series_utf8_regexp_replace_per_row_replacement() -> None:
+    # Templates are translated per row when the replacement is a real column,
+    # not just broadcast from a single scalar.
+    table = MicroPartition.from_pydict({"col": ["abc", "abc"], "repl": [r"[\1]", "x\\"]})
+    result = table.eval_expression_list([col("col").regexp_replace("(b)", col("repl"))])
+    assert result.to_pydict() == {"col": ["a[b]c", r"ax\c"]}

--- a/tests/recordbatch/utf8/test_replace.py
+++ b/tests/recordbatch/utf8/test_replace.py
@@ -54,17 +54,13 @@ def test_series_utf8_replace(expr, data, expected) -> None:
         # `\n`/`\t` are a literal backslash plus a letter, never a newline/tab.
         (r"\n", r"a\nc"),
         (r"\t", r"a\tc"),
-        # The regex crate's own braced syntax passes through untouched.
         ("${1}", "abc"),
-        # A `$` the regex crate would not read as a reference stays literal.
         ("$", "a$c"),
         # A literal `$` in front of a group reference must not be swallowed.
         (r"$\1", "a$bc"),
         # Only one digit is consumed: `\10` is group 1 then a literal `0`.
         (r"\10", "ab0c"),
-        # Empty replacement deletes the match.
         ("", "ac"),
-        # Multi-byte characters survive around a literal backslash.
         (r"é\ü", r"aé\üc"),
     ],
 )
@@ -76,16 +72,14 @@ def test_series_utf8_regexp_replace_backslashes(replacement, expected) -> None:
 
 
 def test_series_utf8_replace_literal_keeps_template_chars() -> None:
-    # `replace` (non-regex) has no template semantics: backslashes and `$` are
-    # ordinary characters there.
+    # `replace` (non-regex) has no template semantics.
     table = MicroPartition.from_pydict({"col": ["abc"]})
     result = table.eval_expression_list([col("col").replace("b", r"\1$1\\")])
     assert result.to_pydict() == {"col": [r"a\1$1\\c"]}
 
 
 def test_series_utf8_regexp_replace_per_row_replacement() -> None:
-    # Templates are translated per row when the replacement is a real column,
-    # not just broadcast from a single scalar.
+    # The per-row path must not reuse a broadcast template.
     table = MicroPartition.from_pydict({"col": ["abc", "abc"], "repl": [r"[\1]", "x\\"]})
     result = table.eval_expression_list([col("col").regexp_replace("(b)", col("repl"))])
     assert result.to_pydict() == {"col": ["a[b]c", r"ax\c"]}


### PR DESCRIPTION
## Changes Made

Replaces the `regex_replace_posix_groups` rewrite `(|\\)(\\d*)` with a single left-to-right scan that translates POSIX group references (`\\1` -> `${1}`) for the `regex` crate:

- `\\\\` collapses to one backslash (escaped backslash, takes precedence so `\\\\1` stays literal `\\1`)
- `\\` + digits becomes a group reference (`\\1`, `\\12`, `\\0`)
- lone/trailing backslashes are preserved literally (e.g. `a\\b` stays `a\\b`), since the `regex` crate treats backslashes in replacements literally
- `$1`/`${1}`/`$$` pass through untouched, keeping exact `regex`-crate semantics
- returns `Cow<str>` (borrowed when no backslash is present) instead of running a regex engine and always allocating per row

This goes beyond the suggested `\\d+` minimal fix, which would leave `\\\\` as two backslashes and misparse `\\\\1` as a group reference starting at the second backslash.

## Related Issues

Closes #7471

## Verification

- `cargo test -p daft-functions-utf8 --lib replace`: 8 passed (2 new tests)
- Issue repro via `daft.functions.regexp_replace`: `a\\b` -> `aa\\bc`, `\\\\` -> `a\\c`, `x\\` -> `ax\\c` (were `aabc`/`ac`/`axc`)
- `DAFT_RUNNER=native pytest tests/recordbatch/utf8/test_replace.py`: 16 passed (9 new parametrized cases)
- `DAFT_RUNNER=native pytest tests/expressions/test_utf8.py tests/sql/test_utf8_exprs.py`: 23 passed