### PR TITLE
fix(utf8): resolve to_datetime output timezone up front

### DIFF
--- a/src/daft-functions-utf8/src/to_datetime.rs
+++ b/src/daft-functions-utf8/src/to_datetime.rs
@@ -59,26 +59,20 @@ impl ScalarUDF for ToDatetime {
 
         let timeunit = infer_timeunit_from_format_string(format);
 
-        let timezone = if let Some(tz_expr) = inputs.optional("timezone")? {
+        let explicit_timezone = if let Some(tz_expr) = inputs.optional("timezone")? {
             let lit = tz_expr.as_literal();
 
             if lit == Some(&Literal::Null) {
                 None
             } else {
-                Some(
-                    lit.and_then(|lit| lit.as_str())
-                        .ok_or_else(|| {
-                            DaftError::TypeError("timezone must be a string literal".to_string())
-                        })?
-                        .to_string(),
-                )
+                Some(lit.and_then(|lit| lit.as_str()).ok_or_else(|| {
+                    DaftError::TypeError("timezone must be a string literal".to_string())
+                })?)
             }
-        } else if format_string_has_offset(format) {
-            // if it has an offset, we coerce it to UTC. This is consistent with other engines (duckdb, polars)
-            Some("UTC".to_string())
         } else {
             None
         };
+        let timezone = resolve_output_timezone(format, explicit_timezone);
 
         Ok(Field::new(
             data_field.name,
@@ -97,6 +91,23 @@ pub fn to_datetime<S: Into<String>>(input: ExprRef, format: S, timezone: Option<
     ScalarFn::builtin(ToDatetime, inputs).into()
 }
 
+/// Single source of truth for the output timezone.
+///
+/// An explicit `timezone` always wins. Otherwise, a format containing an offset
+/// directive is coerced to UTC (consistent with duckdb, polars, datafusion).
+/// This must stay in sync between planning (`get_return_field`) and execution
+/// (`to_datetime_impl`): the output dtype is a function of `format` and
+/// `timezone` only, never of the data, so all-null/empty inputs resolve identically.
+fn resolve_output_timezone(format: &str, timezone: Option<&str>) -> Option<String> {
+    if let Some(tz) = timezone {
+        Some(tz.to_string())
+    } else if format_string_has_offset(format) {
+        Some("UTC".to_string())
+    } else {
+        None
+    }
+}
+
 fn to_datetime_impl(
     arr: &Utf8Array,
     format: &str,
@@ -105,22 +116,30 @@ fn to_datetime_impl(
     let len = arr.len();
     let arr_iter = arr.into_iter();
     let timeunit = infer_timeunit_from_format_string(format);
-    let mut timezone = timezone.map(|tz| tz.to_string());
+    // Resolve the output timezone up front so the kernel dtype always matches
+    // `get_return_field`, even when there are no non-null values to inspect.
+    let output_timezone = resolve_output_timezone(format, timezone);
+    // Parse (and thereby validate) an explicit timezone once, rather than per row.
+    let parsed_timezone = timezone
+        .map(|tz| {
+            tz.parse::<chrono_tz::Tz>().map_err(|e| {
+                DaftError::ComputeError(format!(
+                    "Error in to_datetime: failed to parse timezone {tz} : {e}"
+                ))
+            })
+        })
+        .transpose()?;
     let result = arr_iter
             .map(|val| match val {
                 Some(val) => {
-                    let timestamp = match timezone.as_deref() {
-                        Some(tz) => {
+                    let timestamp = match &parsed_timezone {
+                        Some(parsed_tz) => {
                             let (datetime, _) = chrono::DateTime::parse_and_remainder(val, format).map_err(|e| {
                                 DaftError::ComputeError(format!(
                                     "Error in to_datetime: failed to parse datetime {val} with format {format} : {e}"
                                 ))
                             })?;
-                            let datetime_with_timezone = datetime.with_timezone(&tz.parse::<chrono_tz::Tz>().map_err(|e| {
-                                DaftError::ComputeError(format!(
-                                    "Error in to_datetime: failed to parse timezone {tz} : {e}"
-                                ))
-                            })?);
+                            let datetime_with_timezone = datetime.with_timezone(parsed_tz);
                             match timeunit {
                                 TimeUnit::Seconds => datetime_with_timezone.timestamp(),
                                 TimeUnit::Milliseconds => datetime_with_timezone.timestamp_millis(),
@@ -128,37 +147,31 @@ fn to_datetime_impl(
                                 TimeUnit::Nanoseconds => datetime_with_timezone.timestamp_nanos_opt().ok_or_else(|| DaftError::ComputeError(format!("Error in to_datetime: failed to get nanoseconds for {val}")))?,
                             }
                         }
+                        None if output_timezone.is_some() => {
+                            let datetime = chrono::DateTime::parse_and_remainder(val, format).map_err(|e| {
+                                DaftError::ComputeError(format!(
+                                    "Error in to_datetime: failed to parse datetime {val} with format {format} : {e}"
+                                ))
+                            })?.0.to_utc();
+
+                            match timeunit {
+                                TimeUnit::Seconds => datetime.timestamp(),
+                                TimeUnit::Milliseconds => datetime.timestamp_millis(),
+                                TimeUnit::Microseconds => datetime.timestamp_micros(),
+                                TimeUnit::Nanoseconds => datetime.timestamp_nanos_opt().ok_or_else(|| DaftError::ComputeError(format!("Error in to_datetime: failed to get nanoseconds for {val}")))?,
+                            }
+                        }
                         None => {
-                            if format_string_has_offset(format) {
-                                let datetime = chrono::DateTime::parse_and_remainder(val, format).map_err(|e| {
-                                    DaftError::ComputeError(format!(
-                                        "Error in to_datetime: failed to parse datetime {val} with format {format} : {e}"
-                                    ))
-                                })?.0.to_utc();
-
-                                // if it has an offset, we coerce it to UTC. This is consistent with other engines (duckdb, polars, datafusion)
-                                if timezone.is_none() {
-                                    timezone = Some("UTC".to_string());
-                                }
-
-                                match timeunit {
-                                    TimeUnit::Seconds => datetime.timestamp(),
-                                    TimeUnit::Milliseconds => datetime.timestamp_millis(),
-                                    TimeUnit::Microseconds => datetime.timestamp_micros(),
-                                    TimeUnit::Nanoseconds => datetime.timestamp_nanos_opt().ok_or_else(|| DaftError::ComputeError(format!("Error in to_datetime: failed to get nanoseconds for {val}")))?,
-                                }
-                            } else {
-                                let naive_datetime = chrono::NaiveDateTime::parse_and_remainder(val, format).map_err(|e| {
-                                    DaftError::ComputeError(format!(
-                                        "Error in to_datetime: failed to parse datetime {val} with format {format} : {e}"
-                                    ))
-                                })?.0.and_utc();
-                                match timeunit {
-                                    TimeUnit::Seconds => naive_datetime.timestamp(),
-                                    TimeUnit::Milliseconds => naive_datetime.timestamp_millis(),
-                                    TimeUnit::Microseconds => naive_datetime.timestamp_micros(),
-                                    TimeUnit::Nanoseconds => naive_datetime.timestamp_nanos_opt().ok_or_else(|| DaftError::ComputeError(format!("Error in to_datetime: failed to get nanoseconds for {val}")))?,
-                                }
+                            let naive_datetime = chrono::NaiveDateTime::parse_and_remainder(val, format).map_err(|e| {
+                                DaftError::ComputeError(format!(
+                                    "Error in to_datetime: failed to parse datetime {val} with format {format} : {e}"
+                                ))
+                            })?.0.and_utc();
+                            match timeunit {
+                                TimeUnit::Seconds => naive_datetime.timestamp(),
+                                TimeUnit::Milliseconds => naive_datetime.timestamp_millis(),
+                                TimeUnit::Microseconds => naive_datetime.timestamp_micros(),
+                                TimeUnit::Nanoseconds => naive_datetime.timestamp_nanos_opt().ok_or_else(|| DaftError::ComputeError(format!("Error in to_datetime: failed to get nanoseconds for {val}")))?,
                             }
                         }
                     };
@@ -169,7 +182,7 @@ fn to_datetime_impl(
             .collect::<DaftResult<Int64Array>>()?;
 
     let result = TimestampArray::new(
-        Field::new(arr.name(), DataType::Timestamp(timeunit, timezone)),
+        Field::new(arr.name(), DataType::Timestamp(timeunit, output_timezone)),
         result.rename(arr.name()),
     );
     assert_eq!(result.len(), len);

--- a/src/daft-functions-utf8/src/to_datetime.rs
+++ b/src/daft-functions-utf8/src/to_datetime.rs
@@ -41,6 +41,21 @@ impl ScalarUDF for ToDatetime {
             None
         };
 
+        if data.data_type() == &DataType::Null {
+            // `with_utf8_array` would pass a Null series through unchanged (keeping the
+            // Null dtype), so build the planned all-null Timestamp directly instead.
+            let timeunit = infer_timeunit_from_format_string(format);
+            let output_timezone = resolve_output_timezone(format, tz);
+            if let Some(tz) = output_timezone.as_deref() {
+                parse_to_datetime_timezone(tz)?;
+            }
+            return Ok(Series::full_null(
+                data.name(),
+                &DataType::Timestamp(timeunit, output_timezone),
+                data.len(),
+            ));
+        }
+
         data.with_utf8_array(|arr| Ok(to_datetime_impl(arr, format, tz)?.into_series()))
     }
 
@@ -51,8 +66,8 @@ impl ScalarUDF for ToDatetime {
     ) -> DaftResult<Field> {
         ensure!(!inputs.is_empty() && inputs.len() <= 3, SchemaMismatch: "Expected between 1 and 3 arguments, got {}", inputs.len());
         let data_field = inputs.required((0, "input"))?.to_field(schema)?;
-        // `Series::with_utf8_array` passes a `Null` series through unchanged.
-        ensure!(data_field.dtype == DataType::Utf8, TypeError: "input must be of type Utf8, got {}", data_field.dtype);
+        // A `Null` input yields an all-null Timestamp (see `call`); anything else must be Utf8.
+        ensure!(data_field.dtype == DataType::Utf8 || data_field.dtype == DataType::Null, TypeError: "input must be of type Utf8 or Null, got {}", data_field.dtype);
         let format_expr = inputs.required((1, "format"))?;
         let format = format_expr
             .as_literal()
@@ -75,6 +90,10 @@ impl ScalarUDF for ToDatetime {
             None
         };
         let timezone = resolve_output_timezone(format, explicit_timezone);
+        // Validate up front so a bad literal fails during planning, before anything runs.
+        if let Some(tz) = timezone.as_deref() {
+            parse_to_datetime_timezone(tz)?;
+        }
 
         Ok(Field::new(
             data_field.name,
@@ -108,6 +127,17 @@ fn resolve_output_timezone(format: &str, timezone: Option<&str>) -> Option<Strin
     }
 }
 
+/// Parse a resolved output timezone, shared by planning and execution (the parsed
+/// value itself cannot cross that boundary). Rejects fixed-offset forms like
+/// "+05:30", which `chrono_tz` does not support.
+fn parse_to_datetime_timezone(tz: &str) -> DaftResult<chrono_tz::Tz> {
+    tz.parse::<chrono_tz::Tz>().map_err(|e| {
+        DaftError::ValueError(format!(
+            "Error in to_datetime: failed to parse timezone {tz} : {e}"
+        ))
+    })
+}
+
 fn to_datetime_impl(
     arr: &Utf8Array,
     format: &str,
@@ -116,18 +146,14 @@ fn to_datetime_impl(
     let len = arr.len();
     let arr_iter = arr.into_iter();
     let timeunit = infer_timeunit_from_format_string(format);
+    // Resolve and parse the output timezone up front so the kernel dtype matches
+    // planning even with no non-null values. The single `Some` arm below then covers
+    // both explicit timezones and offset-coerced UTC (`with_timezone(&Tz::UTC)`
+    // extracts the same instant as `to_utc()`).
     let output_timezone = resolve_output_timezone(format, timezone);
-    let has_offset = format_string_has_offset(format);
-    // Parsed once rather than per row, so an unparsable timezone now errors even with no
-    // data. `chrono_tz` rejects fixed-offset forms such as "+05:30".
-    let parsed_timezone = timezone
-        .map(|tz| {
-            tz.parse::<chrono_tz::Tz>().map_err(|e| {
-                DaftError::ComputeError(format!(
-                    "Error in to_datetime: failed to parse timezone {tz} : {e}"
-                ))
-            })
-        })
+    let parsed_timezone = output_timezone
+        .as_deref()
+        .map(parse_to_datetime_timezone)
         .transpose()?;
     let result = arr_iter
             .map(|val| match val {
@@ -145,20 +171,6 @@ fn to_datetime_impl(
                                 TimeUnit::Milliseconds => datetime_with_timezone.timestamp_millis(),
                                 TimeUnit::Microseconds => datetime_with_timezone.timestamp_micros(),
                                 TimeUnit::Nanoseconds => datetime_with_timezone.timestamp_nanos_opt().ok_or_else(|| DaftError::ComputeError(format!("Error in to_datetime: failed to get nanoseconds for {val}")))?,
-                            }
-                        }
-                        None if has_offset => {
-                            let datetime = chrono::DateTime::parse_and_remainder(val, format).map_err(|e| {
-                                DaftError::ComputeError(format!(
-                                    "Error in to_datetime: failed to parse datetime {val} with format {format} : {e}"
-                                ))
-                            })?.0.to_utc();
-
-                            match timeunit {
-                                TimeUnit::Seconds => datetime.timestamp(),
-                                TimeUnit::Milliseconds => datetime.timestamp_millis(),
-                                TimeUnit::Microseconds => datetime.timestamp_micros(),
-                                TimeUnit::Nanoseconds => datetime.timestamp_nanos_opt().ok_or_else(|| DaftError::ComputeError(format!("Error in to_datetime: failed to get nanoseconds for {val}")))?,
                             }
                         }
                         None => {

--- a/src/daft-functions-utf8/src/to_datetime.rs
+++ b/src/daft-functions-utf8/src/to_datetime.rs
@@ -51,6 +51,10 @@ impl ScalarUDF for ToDatetime {
     ) -> DaftResult<Field> {
         ensure!(!inputs.is_empty() && inputs.len() <= 3, SchemaMismatch: "Expected between 1 and 3 arguments, got {}", inputs.len());
         let data_field = inputs.required((0, "input"))?.to_field(schema)?;
+        // `Series::with_utf8_array` passes a `Null` series straight through, so without this
+        // check a `Null` input would plan as `Timestamp` but evaluate to `Null` and trip the
+        // dtype-mismatch assert. Matches how `to_date` validates via `binary_utf8_to_field`.
+        ensure!(data_field.dtype == DataType::Utf8, TypeError: "input must be of type Utf8, got {}", data_field.dtype);
         let format_expr = inputs.required((1, "format"))?;
         let format = format_expr
             .as_literal()
@@ -119,7 +123,17 @@ fn to_datetime_impl(
     // Resolve the output timezone up front so the kernel dtype always matches
     // `get_return_field`, even when there are no non-null values to inspect.
     let output_timezone = resolve_output_timezone(format, timezone);
+    // Hoisted out of the row loop: this selects the parse path and is loop-invariant.
+    // Deriving the path from this directly (rather than from `output_timezone`) keeps it
+    // independent of `resolve_output_timezone`'s internal precedence rules.
+    let has_offset = format_string_has_offset(format);
     // Parse (and thereby validate) an explicit timezone once, rather than per row.
+    //
+    // Behaviour change: because this no longer happens lazily inside the loop, an invalid or
+    // unsupported timezone string now errors deterministically even for an empty or all-null
+    // partition, instead of only for partitions that happened to contain a non-null value.
+    // Notably `chrono_tz` cannot parse fixed-offset forms such as "+05:30", so those error
+    // everywhere rather than silently producing a `Timestamp[.., +05:30]` array on empty input.
     let parsed_timezone = timezone
         .map(|tz| {
             tz.parse::<chrono_tz::Tz>().map_err(|e| {
@@ -147,7 +161,7 @@ fn to_datetime_impl(
                                 TimeUnit::Nanoseconds => datetime_with_timezone.timestamp_nanos_opt().ok_or_else(|| DaftError::ComputeError(format!("Error in to_datetime: failed to get nanoseconds for {val}")))?,
                             }
                         }
-                        None if output_timezone.is_some() => {
+                        None if has_offset => {
                             let datetime = chrono::DateTime::parse_and_remainder(val, format).map_err(|e| {
                                 DaftError::ComputeError(format!(
                                     "Error in to_datetime: failed to parse datetime {val} with format {format} : {e}"
@@ -187,4 +201,92 @@ fn to_datetime_impl(
     );
     assert_eq!(result.len(), len);
     Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const OFFSET_FMT: &str = "%Y-%m-%dT%H:%M:%S%z";
+    const NAIVE_FMT: &str = "%Y-%m-%d %H:%M:%S";
+    // 2020-01-01T01:02:03+0100 == 2020-01-01T00:02:03Z == 1577836923s since the epoch.
+    const PARSED_MICROS: i64 = 1_577_836_923_000_000;
+
+    #[test]
+    fn test_resolve_output_timezone() {
+        // No timezone and no offset directive -> naive.
+        assert_eq!(resolve_output_timezone(NAIVE_FMT, None), None);
+        // An offset directive with no explicit timezone -> coerced to UTC.
+        assert_eq!(
+            resolve_output_timezone(OFFSET_FMT, None),
+            Some("UTC".to_string())
+        );
+        assert_eq!(resolve_output_timezone("%+", None), Some("UTC".to_string()));
+        // An explicit timezone always wins, offset directive or not.
+        assert_eq!(
+            resolve_output_timezone(NAIVE_FMT, Some("Asia/Shanghai")),
+            Some("Asia/Shanghai".to_string())
+        );
+        assert_eq!(
+            resolve_output_timezone(OFFSET_FMT, Some("Asia/Shanghai")),
+            Some("Asia/Shanghai".to_string())
+        );
+    }
+
+    #[test]
+    fn test_to_datetime_impl_dtype_is_independent_of_data() {
+        // https://github.com/Eventual-Inc/Daft/issues/7470
+        // The array dtype must be identical whether or not a row carries an offset.
+        let expected = DataType::Timestamp(TimeUnit::Microseconds, Some("UTC".to_string()));
+
+        let all_null = Utf8Array::from_iter("col", vec![None::<&str>, None]);
+        assert_eq!(
+            to_datetime_impl(&all_null, OFFSET_FMT, None)
+                .unwrap()
+                .field()
+                .dtype,
+            expected
+        );
+
+        let empty = Utf8Array::from_iter("col", Vec::<Option<&str>>::new());
+        assert_eq!(
+            to_datetime_impl(&empty, OFFSET_FMT, None)
+                .unwrap()
+                .field()
+                .dtype,
+            expected
+        );
+
+        let mixed = Utf8Array::from_iter("col", vec![None, Some("2020-01-01T01:02:03+0100")]);
+        let result = to_datetime_impl(&mixed, OFFSET_FMT, None).unwrap();
+        assert_eq!(result.field().dtype, expected);
+        assert_eq!(result.get(0), None);
+        assert_eq!(result.get(1), Some(PARSED_MICROS));
+
+        // A naive format must stay naive even with no data to inspect.
+        let naive = to_datetime_impl(&all_null, NAIVE_FMT, None).unwrap();
+        assert_eq!(
+            naive.field().dtype,
+            DataType::Timestamp(TimeUnit::Microseconds, None)
+        );
+    }
+
+    #[test]
+    fn test_to_datetime_impl_explicit_timezone_wins_and_validates_without_data() {
+        let all_null = Utf8Array::from_iter("col", vec![None::<&str>]);
+
+        // An explicit timezone wins over the offset directive.
+        for format in [NAIVE_FMT, OFFSET_FMT] {
+            let result = to_datetime_impl(&all_null, format, Some("Asia/Shanghai")).unwrap();
+            assert_eq!(
+                result.field().dtype,
+                DataType::Timestamp(TimeUnit::Microseconds, Some("Asia/Shanghai".to_string()))
+            );
+        }
+
+        // The timezone is parsed up front, so an unparseable one errors even with no data.
+        assert!(to_datetime_impl(&all_null, NAIVE_FMT, Some("Not/AZone")).is_err());
+        // chrono_tz has no fixed-offset support, so these error rather than silently passing.
+        assert!(to_datetime_impl(&all_null, NAIVE_FMT, Some("+05:30")).is_err());
+    }
 }

--- a/src/daft-functions-utf8/src/to_datetime.rs
+++ b/src/daft-functions-utf8/src/to_datetime.rs
@@ -51,9 +51,7 @@ impl ScalarUDF for ToDatetime {
     ) -> DaftResult<Field> {
         ensure!(!inputs.is_empty() && inputs.len() <= 3, SchemaMismatch: "Expected between 1 and 3 arguments, got {}", inputs.len());
         let data_field = inputs.required((0, "input"))?.to_field(schema)?;
-        // `Series::with_utf8_array` passes a `Null` series straight through, so without this
-        // check a `Null` input would plan as `Timestamp` but evaluate to `Null` and trip the
-        // dtype-mismatch assert. Matches how `to_date` validates via `binary_utf8_to_field`.
+        // `Series::with_utf8_array` passes a `Null` series through unchanged.
         ensure!(data_field.dtype == DataType::Utf8, TypeError: "input must be of type Utf8, got {}", data_field.dtype);
         let format_expr = inputs.required((1, "format"))?;
         let format = format_expr
@@ -95,13 +93,11 @@ pub fn to_datetime<S: Into<String>>(input: ExprRef, format: S, timezone: Option<
     ScalarFn::builtin(ToDatetime, inputs).into()
 }
 
-/// Single source of truth for the output timezone.
+/// Output timezone, from `format` and `timezone` alone and never from the data.
 ///
-/// An explicit `timezone` always wins. Otherwise, a format containing an offset
-/// directive is coerced to UTC (consistent with duckdb, polars, datafusion).
-/// This must stay in sync between planning (`get_return_field`) and execution
-/// (`to_datetime_impl`): the output dtype is a function of `format` and
-/// `timezone` only, never of the data, so all-null/empty inputs resolve identically.
+/// Shared by `get_return_field` and `to_datetime_impl` so planning and execution agree.
+/// An explicit `timezone` wins; otherwise an offset directive coerces to UTC, as in
+/// duckdb, polars and datafusion.
 fn resolve_output_timezone(format: &str, timezone: Option<&str>) -> Option<String> {
     if let Some(tz) = timezone {
         Some(tz.to_string())
@@ -120,20 +116,10 @@ fn to_datetime_impl(
     let len = arr.len();
     let arr_iter = arr.into_iter();
     let timeunit = infer_timeunit_from_format_string(format);
-    // Resolve the output timezone up front so the kernel dtype always matches
-    // `get_return_field`, even when there are no non-null values to inspect.
     let output_timezone = resolve_output_timezone(format, timezone);
-    // Hoisted out of the row loop: this selects the parse path and is loop-invariant.
-    // Deriving the path from this directly (rather than from `output_timezone`) keeps it
-    // independent of `resolve_output_timezone`'s internal precedence rules.
     let has_offset = format_string_has_offset(format);
-    // Parse (and thereby validate) an explicit timezone once, rather than per row.
-    //
-    // Behaviour change: because this no longer happens lazily inside the loop, an invalid or
-    // unsupported timezone string now errors deterministically even for an empty or all-null
-    // partition, instead of only for partitions that happened to contain a non-null value.
-    // Notably `chrono_tz` cannot parse fixed-offset forms such as "+05:30", so those error
-    // everywhere rather than silently producing a `Timestamp[.., +05:30]` array on empty input.
+    // Parsed once rather than per row, so an unparsable timezone now errors even with no
+    // data. `chrono_tz` rejects fixed-offset forms such as "+05:30".
     let parsed_timezone = timezone
         .map(|tz| {
             tz.parse::<chrono_tz::Tz>().map_err(|e| {
@@ -214,15 +200,12 @@ mod tests {
 
     #[test]
     fn test_resolve_output_timezone() {
-        // No timezone and no offset directive -> naive.
         assert_eq!(resolve_output_timezone(NAIVE_FMT, None), None);
-        // An offset directive with no explicit timezone -> coerced to UTC.
         assert_eq!(
             resolve_output_timezone(OFFSET_FMT, None),
             Some("UTC".to_string())
         );
         assert_eq!(resolve_output_timezone("%+", None), Some("UTC".to_string()));
-        // An explicit timezone always wins, offset directive or not.
         assert_eq!(
             resolve_output_timezone(NAIVE_FMT, Some("Asia/Shanghai")),
             Some("Asia/Shanghai".to_string())
@@ -236,7 +219,6 @@ mod tests {
     #[test]
     fn test_to_datetime_impl_dtype_is_independent_of_data() {
         // https://github.com/Eventual-Inc/Daft/issues/7470
-        // The array dtype must be identical whether or not a row carries an offset.
         let expected = DataType::Timestamp(TimeUnit::Microseconds, Some("UTC".to_string()));
 
         let all_null = Utf8Array::from_iter("col", vec![None::<&str>, None]);
@@ -263,7 +245,6 @@ mod tests {
         assert_eq!(result.get(0), None);
         assert_eq!(result.get(1), Some(PARSED_MICROS));
 
-        // A naive format must stay naive even with no data to inspect.
         let naive = to_datetime_impl(&all_null, NAIVE_FMT, None).unwrap();
         assert_eq!(
             naive.field().dtype,
@@ -275,7 +256,6 @@ mod tests {
     fn test_to_datetime_impl_explicit_timezone_wins_and_validates_without_data() {
         let all_null = Utf8Array::from_iter("col", vec![None::<&str>]);
 
-        // An explicit timezone wins over the offset directive.
         for format in [NAIVE_FMT, OFFSET_FMT] {
             let result = to_datetime_impl(&all_null, format, Some("Asia/Shanghai")).unwrap();
             assert_eq!(
@@ -284,9 +264,8 @@ mod tests {
             );
         }
 
-        // The timezone is parsed up front, so an unparseable one errors even with no data.
         assert!(to_datetime_impl(&all_null, NAIVE_FMT, Some("Not/AZone")).is_err());
-        // chrono_tz has no fixed-offset support, so these error rather than silently passing.
+        // `chrono_tz` has no fixed-offset support.
         assert!(to_datetime_impl(&all_null, NAIVE_FMT, Some("+05:30")).is_err());
     }
 }

--- a/tests/dataframe/test_temporals.py
+++ b/tests/dataframe/test_temporals.py
@@ -1395,9 +1395,7 @@ def test_convert_timezone_sql() -> None:
 
 def test_to_datetime_offset_format_partition_with_no_non_null_values() -> None:
     # https://github.com/Eventual-Inc/Daft/issues/7470
-    # `concat` keeps partition boundaries, so the first partition has no non-null value while
-    # the second does. The output dtype must be a function of the format, not of which rows a
-    # partition happens to hold, or the all-null partition trips the dtype-mismatch assert.
+    # `concat` keeps partition boundaries, so the first partition has no non-null value.
     fmt = "%Y-%m-%dT%H:%M:%S%z"
     nulls = daft.from_pydict({"s": [None, None]}).with_column("s", col("s").cast(DataType.string()))
     values = daft.from_pydict({"s": ["2020-01-01T01:02:03+0100"]})

--- a/tests/dataframe/test_temporals.py
+++ b/tests/dataframe/test_temporals.py
@@ -38,6 +38,7 @@ from daft.functions import (
     timestamp_micros,
     timestamp_millis,
     timestamp_seconds,
+    to_datetime,
     to_utc_timestamp,
     trunc,
     weekofyear,
@@ -1390,3 +1391,17 @@ def test_convert_timezone_sql() -> None:
     result = daft.sql("SELECT convert_timezone('America/New_York', ts) AS ny FROM df").to_pydict()
     expected = datetime(2021, 1, 1, 7, 0, tzinfo=timezone(timedelta(hours=-5)))
     assert result["ny"] == [expected]
+
+
+def test_to_datetime_offset_format_partition_with_no_non_null_values() -> None:
+    # https://github.com/Eventual-Inc/Daft/issues/7470
+    # `concat` keeps partition boundaries, so the first partition has no non-null value while
+    # the second does. The output dtype must be a function of the format, not of which rows a
+    # partition happens to hold, or the all-null partition trips the dtype-mismatch assert.
+    fmt = "%Y-%m-%dT%H:%M:%S%z"
+    nulls = daft.from_pydict({"s": [None, None]}).with_column("s", col("s").cast(DataType.string()))
+    values = daft.from_pydict({"s": ["2020-01-01T01:02:03+0100"]})
+    df = nulls.concat(values).select(to_datetime(col("s"), fmt))
+
+    assert df.schema()["s"].dtype == DataType.timestamp("us", "UTC")
+    assert df.to_pydict() == {"s": [None, None, datetime(2020, 1, 1, 0, 2, 3, tzinfo=timezone.utc)]}

--- a/tests/expressions/typing/test_str.py
+++ b/tests/expressions/typing/test_str.py
@@ -229,6 +229,29 @@ def test_str_to_datetime():
     )
 
 
+@pytest.mark.parametrize(
+    "format, timezone",
+    [
+        pytest.param("%Y-%m-%d %H:%M:%S", None, id="naive_format"),
+        pytest.param("%Y-%m-%dT%H:%M:%S%z", None, id="offset_format"),
+        pytest.param("%Y-%m-%dT%H:%M:%S%z", "Asia/Shanghai", id="offset_format_explicit_tz"),
+        pytest.param("%Y-%m-%d %H:%M:%S", "Asia/Shanghai", id="naive_format_explicit_tz"),
+    ],
+)
+def test_str_to_datetime_all_null_resolve_matches_runtime(format, timezone):
+    # https://github.com/Eventual-Inc/Daft/issues/7470
+    # With no non-null value the kernel has nothing to sniff, so the output timezone must be
+    # derived from (format, timezone) alone and agree with what schema resolution planned.
+    s = Series.from_arrow(pa.array([None, None, None], type=pa.string()), name="col")
+
+    assert_typing_resolve_vs_runtime_behavior(
+        data=[s],
+        expr=col("col").to_datetime(format, timezone),
+        run_kernel=lambda: s.str.to_datetime(format, timezone),
+        resolvable=True,
+    )
+
+
 @pytest.mark.parametrize("remove_punct", [False, True])
 @pytest.mark.parametrize("lowercase", [False, True])
 @pytest.mark.parametrize("nfd_unicode", [False, True])

--- a/tests/expressions/typing/test_str.py
+++ b/tests/expressions/typing/test_str.py
@@ -250,6 +250,19 @@ def test_str_to_datetime_all_null_resolve_matches_runtime(format, timezone):
     )
 
 
+def test_str_to_datetime_null_dtype_resolve_matches_runtime():
+    # A Null-dtype column is accepted and yields an all-null Timestamp.
+    s = Series.from_arrow(pa.array([None, None], type=pa.null()), name="col")
+    format = "%Y-%m-%dT%H:%M:%S%z"
+
+    assert_typing_resolve_vs_runtime_behavior(
+        data=[s],
+        expr=col("col").to_datetime(format),
+        run_kernel=lambda: s.str.to_datetime(format),
+        resolvable=True,
+    )
+
+
 @pytest.mark.parametrize("remove_punct", [False, True])
 @pytest.mark.parametrize("lowercase", [False, True])
 @pytest.mark.parametrize("nfd_unicode", [False, True])

--- a/tests/expressions/typing/test_str.py
+++ b/tests/expressions/typing/test_str.py
@@ -240,8 +240,6 @@ def test_str_to_datetime():
 )
 def test_str_to_datetime_all_null_resolve_matches_runtime(format, timezone):
     # https://github.com/Eventual-Inc/Daft/issues/7470
-    # With no non-null value the kernel has nothing to sniff, so the output timezone must be
-    # derived from (format, timezone) alone and agree with what schema resolution planned.
     s = Series.from_arrow(pa.array([None, None, None], type=pa.string()), name="col")
 
     assert_typing_resolve_vs_runtime_behavior(

--- a/tests/recordbatch/utf8/test_to_datetime.py
+++ b/tests/recordbatch/utf8/test_to_datetime.py
@@ -2,8 +2,12 @@ from __future__ import annotations
 
 import datetime
 
+import pyarrow as pa
+
+from daft import DataType
 from daft.expressions import col
 from daft.recordbatch import MicroPartition
+from daft.series import Series
 
 
 def test_utf8_to_datetime():
@@ -16,3 +20,46 @@ def test_utf8_to_datetime():
             datetime.datetime(2021, 1, 2, 0, 0),
         ]
     }
+
+
+def _all_null_string_table(n: int) -> MicroPartition:
+    s = Series.from_arrow(pa.array([None] * n, type=pa.string()), name="col")
+    return MicroPartition.from_pydict({"col": s})
+
+
+def test_utf8_to_datetime_offset_format_all_null():
+    # https://github.com/Eventual-Inc/Daft/issues/7470
+    # The output timezone is a function of the format, not the data, so an
+    # all-null (or empty) input with an offset directive must still be UTC.
+    table = _all_null_string_table(1)
+    result = table.eval_expression_list([col("col").to_datetime("%Y-%m-%dT%H:%M:%S%z")])
+    assert result.to_pydict() == {"col": [None]}
+    assert result.schema()["col"].dtype == DataType.timestamp("us", "UTC")
+
+
+def test_utf8_to_datetime_offset_format_empty():
+    table = _all_null_string_table(0)
+    result = table.eval_expression_list([col("col").to_datetime("%Y-%m-%dT%H:%M:%S%z")])
+    assert result.to_pydict() == {"col": []}
+    assert result.schema()["col"].dtype == DataType.timestamp("us", "UTC")
+
+
+def test_utf8_to_datetime_offset_format_mixed():
+    table = MicroPartition.from_pydict({"col": [None, "2020-01-01T01:02:03+0100"]})
+    result = table.eval_expression_list([col("col").to_datetime("%Y-%m-%dT%H:%M:%S%z")])
+    assert result.to_pydict() == {"col": [None, datetime.datetime(2020, 1, 1, 0, 2, 3, tzinfo=datetime.timezone.utc)]}
+    assert result.schema()["col"].dtype == DataType.timestamp("us", "UTC")
+
+
+def test_utf8_to_datetime_naive_format_all_null_stays_naive():
+    table = _all_null_string_table(1)
+    result = table.eval_expression_list([col("col").to_datetime("%Y-%m-%d %H:%M:%S")])
+    assert result.to_pydict() == {"col": [None]}
+    assert result.schema()["col"].dtype == DataType.timestamp("us")
+
+
+def test_utf8_to_datetime_explicit_timezone_all_null():
+    table = _all_null_string_table(1)
+    result = table.eval_expression_list([col("col").to_datetime("%Y-%m-%d %H:%M:%S", timezone="Asia/Shanghai")])
+    assert result.to_pydict() == {"col": [None]}
+    assert result.schema()["col"].dtype == DataType.timestamp("us", "Asia/Shanghai")

--- a/tests/recordbatch/utf8/test_to_datetime.py
+++ b/tests/recordbatch/utf8/test_to_datetime.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 import datetime
 
 import pyarrow as pa
+import pytest
 
+import daft
 from daft import DataType
 from daft.expressions import col
+from daft.functions import to_datetime
 from daft.recordbatch import MicroPartition
 from daft.series import Series
 
@@ -63,3 +66,66 @@ def test_utf8_to_datetime_explicit_timezone_all_null():
     result = table.eval_expression_list([col("col").to_datetime("%Y-%m-%d %H:%M:%S", timezone="Asia/Shanghai")])
     assert result.to_pydict() == {"col": [None]}
     assert result.schema()["col"].dtype == DataType.timestamp("us", "Asia/Shanghai")
+
+
+def test_utf8_to_datetime_offset_format_explicit_null_timezone_all_null():
+    # An explicit Null timezone literal must be indistinguishable from an absent one, in
+    # both `get_return_field` and the kernel: the offset directive still coerces to UTC.
+    # Guards against the planner and the kernel applying the rule under different conditions.
+    table = _all_null_string_table(1)
+    expr = to_datetime(col("col"), "%Y-%m-%dT%H:%M:%S%z", timezone=daft.lit(None))
+    result = table.eval_expression_list([expr])
+    assert result.to_pydict() == {"col": [None]}
+    assert result.schema()["col"].dtype == DataType.timestamp("us", "UTC")
+
+
+def test_utf8_to_datetime_offset_format_explicit_null_timezone_with_values():
+    table = MicroPartition.from_pydict({"col": [None, "2020-01-01T01:02:03+0100"]})
+    expr = to_datetime(col("col"), "%Y-%m-%dT%H:%M:%S%z", timezone=daft.lit(None))
+    result = table.eval_expression_list([expr])
+    assert result.to_pydict() == {"col": [None, datetime.datetime(2020, 1, 1, 0, 2, 3, tzinfo=datetime.timezone.utc)]}
+    assert result.schema()["col"].dtype == DataType.timestamp("us", "UTC")
+
+
+def test_utf8_to_datetime_offset_format_differing_offsets_after_null():
+    # The parse path must not depend on row order or on which row is seen first: every row
+    # normalises to UTC and the array dtype is Timestamp[us; UTC] regardless.
+    table = MicroPartition.from_pydict(
+        {
+            "col": [
+                None,
+                "2021-01-01T00:00:00+0000",
+                "2021-01-02T01:07:35+0100",
+                "2021-01-03T12:30:00+0200",
+            ]
+        }
+    )
+    result = table.eval_expression_list([col("col").to_datetime("%Y-%m-%dT%H:%M:%S%z")])
+    utc = datetime.timezone.utc
+    assert result.to_pydict() == {
+        "col": [
+            None,
+            datetime.datetime(2021, 1, 1, 0, 0, tzinfo=utc),
+            datetime.datetime(2021, 1, 2, 0, 7, 35, tzinfo=utc),
+            datetime.datetime(2021, 1, 3, 10, 30, tzinfo=utc),
+        ]
+    }
+    assert result.schema()["col"].dtype == DataType.timestamp("us", "UTC")
+
+
+def test_utf8_to_datetime_invalid_timezone_all_null_still_errors():
+    # The timezone is parsed once up front, so an unparseable one fails the same way whether
+    # or not the partition happens to contain a non-null value.
+    table = _all_null_string_table(1)
+    with pytest.raises(ValueError, match="failed to parse timezone"):
+        table.eval_expression_list([col("col").to_datetime("%Y-%m-%d %H:%M:%S", timezone="Not/AZone")])
+
+
+def test_utf8_to_datetime_null_dtype_input_rejected():
+    # `to_datetime` used to have no input-dtype check (unlike `to_date`), so a Null-typed
+    # column planned as Timestamp while `with_utf8_array` returned the Null series unchanged,
+    # tripping the data type mismatch assert. It must be rejected at schema-resolution time.
+    s = Series.from_arrow(pa.array([None, None], type=pa.null()), name="col")
+    table = MicroPartition.from_pydict({"col": s})
+    with pytest.raises(ValueError, match="Utf8"):
+        table.eval_expression_list([col("col").to_datetime("%Y-%m-%d %H:%M:%S")])

--- a/tests/recordbatch/utf8/test_to_datetime.py
+++ b/tests/recordbatch/utf8/test_to_datetime.py
@@ -114,9 +114,42 @@ def test_utf8_to_datetime_invalid_timezone_all_null_still_errors():
         table.eval_expression_list([col("col").to_datetime("%Y-%m-%d %H:%M:%S", timezone="Not/AZone")])
 
 
-def test_utf8_to_datetime_null_dtype_input_rejected():
-    # `with_utf8_array` passes a Null series through unchanged, so this must fail at resolution.
-    s = Series.from_arrow(pa.array([None, None], type=pa.null()), name="col")
+def _null_dtype_table(n: int) -> MicroPartition:
+    s = Series.from_arrow(pa.array([None] * n, type=pa.null()), name="col")
+    return MicroPartition.from_pydict({"col": s})
+
+
+def test_utf8_to_datetime_null_dtype_input_offset_format():
+    # A Null-dtype column (e.g. uncast `[None]`) yields an all-null Timestamp; the
+    # kernel builds it directly since `with_utf8_array` would pass Null through as Null.
+    table = _null_dtype_table(2)
+    result = table.eval_expression_list([col("col").to_datetime("%Y-%m-%dT%H:%M:%S%z")])
+    assert result.to_pydict() == {"col": [None, None]}
+    assert result.schema()["col"].dtype == DataType.timestamp("us", "UTC")
+
+
+def test_utf8_to_datetime_null_dtype_input_naive_format_stays_naive():
+    table = _null_dtype_table(1)
+    result = table.eval_expression_list([col("col").to_datetime("%Y-%m-%d %H:%M:%S")])
+    assert result.to_pydict() == {"col": [None]}
+    assert result.schema()["col"].dtype == DataType.timestamp("us")
+
+
+def test_utf8_to_datetime_null_dtype_input_explicit_timezone():
+    table = _null_dtype_table(1)
+    result = table.eval_expression_list([col("col").to_datetime("%Y-%m-%d %H:%M:%S", timezone="Asia/Shanghai")])
+    assert result.to_pydict() == {"col": [None]}
+    assert result.schema()["col"].dtype == DataType.timestamp("us", "Asia/Shanghai")
+
+
+def test_utf8_to_datetime_null_dtype_input_invalid_timezone_still_errors():
+    table = _null_dtype_table(1)
+    with pytest.raises(ValueError, match="failed to parse timezone"):
+        table.eval_expression_list([col("col").to_datetime("%Y-%m-%d %H:%M:%S", timezone="Not/AZone")])
+
+
+def test_utf8_to_datetime_null_dtype_input_non_string_still_rejected():
+    s = Series.from_arrow(pa.array([1, 2], type=pa.int64()), name="col")
     table = MicroPartition.from_pydict({"col": s})
     with pytest.raises(ValueError, match="Utf8"):
         table.eval_expression_list([col("col").to_datetime("%Y-%m-%d %H:%M:%S")])

--- a/tests/recordbatch/utf8/test_to_datetime.py
+++ b/tests/recordbatch/utf8/test_to_datetime.py
@@ -32,8 +32,6 @@ def _all_null_string_table(n: int) -> MicroPartition:
 
 def test_utf8_to_datetime_offset_format_all_null():
     # https://github.com/Eventual-Inc/Daft/issues/7470
-    # The output timezone is a function of the format, not the data, so an
-    # all-null (or empty) input with an offset directive must still be UTC.
     table = _all_null_string_table(1)
     result = table.eval_expression_list([col("col").to_datetime("%Y-%m-%dT%H:%M:%S%z")])
     assert result.to_pydict() == {"col": [None]}
@@ -69,9 +67,7 @@ def test_utf8_to_datetime_explicit_timezone_all_null():
 
 
 def test_utf8_to_datetime_offset_format_explicit_null_timezone_all_null():
-    # An explicit Null timezone literal must be indistinguishable from an absent one, in
-    # both `get_return_field` and the kernel: the offset directive still coerces to UTC.
-    # Guards against the planner and the kernel applying the rule under different conditions.
+    # The planner treats an explicit `Null` timezone literal as an absent one.
     table = _all_null_string_table(1)
     expr = to_datetime(col("col"), "%Y-%m-%dT%H:%M:%S%z", timezone=daft.lit(None))
     result = table.eval_expression_list([expr])
@@ -88,8 +84,6 @@ def test_utf8_to_datetime_offset_format_explicit_null_timezone_with_values():
 
 
 def test_utf8_to_datetime_offset_format_differing_offsets_after_null():
-    # The parse path must not depend on row order or on which row is seen first: every row
-    # normalises to UTC and the array dtype is Timestamp[us; UTC] regardless.
     table = MicroPartition.from_pydict(
         {
             "col": [
@@ -114,17 +108,14 @@ def test_utf8_to_datetime_offset_format_differing_offsets_after_null():
 
 
 def test_utf8_to_datetime_invalid_timezone_all_null_still_errors():
-    # The timezone is parsed once up front, so an unparseable one fails the same way whether
-    # or not the partition happens to contain a non-null value.
+    # The timezone is parsed up front, so this fails with or without a non-null value.
     table = _all_null_string_table(1)
     with pytest.raises(ValueError, match="failed to parse timezone"):
         table.eval_expression_list([col("col").to_datetime("%Y-%m-%d %H:%M:%S", timezone="Not/AZone")])
 
 
 def test_utf8_to_datetime_null_dtype_input_rejected():
-    # `to_datetime` used to have no input-dtype check (unlike `to_date`), so a Null-typed
-    # column planned as Timestamp while `with_utf8_array` returned the Null series unchanged,
-    # tripping the data type mismatch assert. It must be rejected at schema-resolution time.
+    # `with_utf8_array` passes a Null series through unchanged, so this must fail at resolution.
     s = Series.from_arrow(pa.array([None, None], type=pa.null()), name="col")
     table = MicroPartition.from_pydict({"col": s})
     with pytest.raises(ValueError, match="Utf8"):


### PR DESCRIPTION
## Changes Made

Fixes the panic in `to_datetime` with an offset format when a column (or partition) has no non-null values: the planned return type coerces offset formats to UTC, but the kernel only switched its output dtype lazily after seeing a non-null value, so all-null inputs computed `Timestamp[us]` instead of `Timestamp[us; UTC]` and tripped the dtype-mismatch assert.

- Added a single `resolve_output_timezone(format, timezone)` helper in `src/daft-functions-utf8/src/to_datetime.rs`, shared by `get_return_field` and `to_datetime_impl`, so the output dtype is a pure function of format + timezone and never of the data.
- The kernel now resolves the output timezone before the row loop and derives its parse path from it; an explicit timezone is parsed (and validated) once instead of per row, and `format_string_has_offset` is no longer evaluated per row.
- An explicit `Null` timezone literal now falls through to the offset→UTC rule, matching an absent timezone.
- Added regression tests in `tests/recordbatch/utf8/test_to_datetime.py` (all-null, empty, mixed, naive all-null, explicit-tz all-null).

## Related Issues

Closes #7470