### PR TITLE
fix(expr): stable var/stddev via Chan parallel merge

### DIFF
--- a/src/daft-core/src/array/ops/mod.rs
+++ b/src/daft-core/src/array/ops/mod.rs
@@ -226,6 +226,18 @@ pub trait DaftVarianceAggable {
     fn grouped_var(&self, groups: &GroupIndices, ddof: usize) -> Self::Output;
 }
 
+pub trait DaftVarPartialAggable {
+    type Output;
+    fn var_partial(&self) -> Self::Output;
+    fn grouped_var_partial(&self, groups: &GroupIndices) -> Self::Output;
+}
+
+pub trait DaftMergeVarPartialAggable {
+    type Output;
+    fn merge_var_partial(&self) -> Self::Output;
+    fn grouped_merge_var_partial(&self, groups: &GroupIndices) -> Self::Output;
+}
+
 pub trait DaftCompareAggable {
     type Output;
     fn min(&self) -> Self::Output;

--- a/src/daft-core/src/array/ops/variance.rs
+++ b/src/daft-core/src/array/ops/variance.rs
@@ -95,16 +95,17 @@ impl DaftVarPartialAggable for DataArray<Float64Type> {
     type Output = DaftResult<StructArray>;
 
     fn var_partial(&self) -> Self::Output {
-        let state = stats::calculate_var_partial(self.into_iter().flatten());
+        let stats = stats::calculate_stats(self)?;
+        let values = self.into_iter().flatten();
+        let state = stats::calculate_var_partial(stats, values);
         build_var_partial_struct(self.name(), vec![state])
     }
 
     fn grouped_var_partial(&self, groups: &GroupIndices) -> Self::Output {
-        let states = groups
-            .iter()
-            .map(|group| {
+        let states = stats::grouped_stats(self, groups)?
+            .map(|(stats, group)| {
                 let values = group.iter().filter_map(|&index| self.get(index as _));
-                stats::calculate_var_partial(values)
+                stats::calculate_var_partial(stats, values)
             })
             .collect();
         build_var_partial_struct(self.name(), states)

--- a/src/daft-core/src/array/ops/variance.rs
+++ b/src/daft-core/src/array/ops/variance.rs
@@ -9,7 +9,7 @@ use crate::{
             DaftMergeVarPartialAggable, DaftVarPartialAggable, DaftVarianceAggable, GroupIndices,
         },
     },
-    datatypes::{Field, Float64Type},
+    datatypes::{DataType, Field, Float64Type, UInt64Type},
     prelude::IntoSeries,
     utils::stats::{self, VarPartialState},
 };
@@ -18,8 +18,6 @@ fn build_var_partial_struct(
     parent_name: &str,
     states: Vec<VarPartialState>,
 ) -> DaftResult<StructArray> {
-    use crate::datatypes::{DataType, UInt64Type};
-
     let counts: Vec<Option<u64>> = states.iter().map(|s| Some(s.count)).collect();
     let means: Vec<Option<f64>> = states.iter().map(|s| s.mean).collect();
     let m2s: Vec<Option<f64>> = states.iter().map(|s| s.m2).collect();

--- a/src/daft-core/src/array/ops/variance.rs
+++ b/src/daft-core/src/array/ops/variance.rs
@@ -1,13 +1,72 @@
+use std::sync::Arc;
+
 use common_error::DaftResult;
 
 use crate::{
     array::{
-        DataArray,
-        ops::{DaftVarianceAggable, GroupIndices},
+        DataArray, StructArray,
+        ops::{
+            DaftMergeVarPartialAggable, DaftVarPartialAggable, DaftVarianceAggable, GroupIndices,
+        },
     },
-    datatypes::Float64Type,
-    utils::stats,
+    datatypes::{Field, Float64Type},
+    prelude::IntoSeries,
+    utils::stats::{self, VarPartialState},
 };
+
+fn build_var_partial_struct(
+    parent_name: &str,
+    states: Vec<VarPartialState>,
+) -> DaftResult<StructArray> {
+    use crate::datatypes::{DataType, UInt64Type};
+
+    let counts: Vec<Option<u64>> = states.iter().map(|s| Some(s.count)).collect();
+    let means: Vec<Option<f64>> = states.iter().map(|s| s.mean).collect();
+    let m2s: Vec<Option<f64>> = states.iter().map(|s| s.m2).collect();
+
+    let count_field = Arc::new(Field::new(stats::VAR_PARTIAL_COUNT_FIELD, DataType::UInt64));
+    let mean_field = Arc::new(Field::new(stats::VAR_PARTIAL_MEAN_FIELD, DataType::Float64));
+    let m2_field = Arc::new(Field::new(stats::VAR_PARTIAL_M2_FIELD, DataType::Float64));
+
+    let count_arr = DataArray::<UInt64Type>::from_iter(count_field, counts);
+    let mean_arr = DataArray::<Float64Type>::from_iter(mean_field, means);
+    let m2_arr = DataArray::<Float64Type>::from_iter(m2_field, m2s);
+
+    let parent_field = Arc::new(Field::new(parent_name, stats::var_partial_dtype()));
+    Ok(StructArray::new(
+        parent_field,
+        vec![
+            count_arr.into_series(),
+            mean_arr.into_series(),
+            m2_arr.into_series(),
+        ],
+        None,
+    ))
+}
+
+fn struct_row_to_state(count: Option<u64>, mean: Option<f64>, m2: Option<f64>) -> VarPartialState {
+    match count {
+        None | Some(0) => VarPartialState {
+            count: 0,
+            mean: None,
+            m2: None,
+        },
+        Some(n) => match (mean, m2) {
+            (Some(mean), Some(m2)) => VarPartialState {
+                count: n,
+                mean: Some(mean),
+                m2: Some(m2),
+            },
+            // A partial with a positive count must carry a mean and m2; treat
+            // malformed rows as identity rather than corrupting the merge.
+            _ => VarPartialState {
+                count: 0,
+                mean: None,
+                m2: None,
+            },
+        },
+    }
+}
 
 impl DaftVarianceAggable for DataArray<Float64Type> {
     type Output = DaftResult<Self>;
@@ -31,5 +90,56 @@ impl DaftVarianceAggable for DataArray<Float64Type> {
             self.field().clone(),
             grouped_variances_iter,
         ))
+    }
+}
+
+impl DaftVarPartialAggable for DataArray<Float64Type> {
+    type Output = DaftResult<StructArray>;
+
+    fn var_partial(&self) -> Self::Output {
+        let state = stats::calculate_var_partial(self.into_iter().flatten());
+        build_var_partial_struct(self.name(), vec![state])
+    }
+
+    fn grouped_var_partial(&self, groups: &GroupIndices) -> Self::Output {
+        let states = groups
+            .iter()
+            .map(|group| {
+                let values = group.iter().filter_map(|&index| self.get(index as _));
+                stats::calculate_var_partial(values)
+            })
+            .collect();
+        build_var_partial_struct(self.name(), states)
+    }
+}
+
+impl DaftMergeVarPartialAggable for StructArray {
+    type Output = DaftResult<Self>;
+
+    fn merge_var_partial(&self) -> Self::Output {
+        let counts = self.get(stats::VAR_PARTIAL_COUNT_FIELD)?.u64()?.clone();
+        let means = self.get(stats::VAR_PARTIAL_MEAN_FIELD)?.f64()?.clone();
+        let m2s = self.get(stats::VAR_PARTIAL_M2_FIELD)?.f64()?.clone();
+        let partials =
+            (0..self.len()).map(|i| struct_row_to_state(counts.get(i), means.get(i), m2s.get(i)));
+        let merged = stats::merge_var_partials(partials);
+        build_var_partial_struct(self.name(), vec![merged])
+    }
+
+    fn grouped_merge_var_partial(&self, groups: &GroupIndices) -> Self::Output {
+        let counts = self.get(stats::VAR_PARTIAL_COUNT_FIELD)?.u64()?.clone();
+        let means = self.get(stats::VAR_PARTIAL_MEAN_FIELD)?.f64()?.clone();
+        let m2s = self.get(stats::VAR_PARTIAL_M2_FIELD)?.f64()?.clone();
+        let states = groups
+            .iter()
+            .map(|group| {
+                let partials = group.iter().map(|&index| {
+                    let i = index as usize;
+                    struct_row_to_state(counts.get(i), means.get(i), m2s.get(i))
+                });
+                stats::merge_var_partials(partials)
+            })
+            .collect();
+        build_var_partial_struct(self.name(), states)
     }
 }

--- a/src/daft-core/src/series/ops/agg.rs
+++ b/src/daft-core/src/series/ops/agg.rs
@@ -8,8 +8,9 @@ use crate::{
         growable::make_growable,
         ops::{
             DaftApproxSketchAggable, DaftBoolAggable, DaftConcatAggable, DaftCountAggable,
-            DaftHllMergeAggable, DaftMeanAggable, DaftMergeSketchAggable, DaftPercentileAggable,
-            DaftProductAggable, DaftSetAggable, DaftSkewAggable, DaftStddevAggable, DaftSumAggable,
+            DaftHllMergeAggable, DaftMeanAggable, DaftMergeSketchAggable,
+            DaftMergeVarPartialAggable, DaftPercentileAggable, DaftProductAggable, DaftSetAggable,
+            DaftSkewAggable, DaftStddevAggable, DaftSumAggable, DaftVarPartialAggable,
             DaftVarianceAggable, GroupIndices,
         },
     },
@@ -510,6 +511,43 @@ impl Series {
         Ok(groups
             .map_or_else(|| casted.skew(), |groups| casted.grouped_skew(groups))?
             .into_series())
+    }
+
+    pub fn var_partial(&self, groups: Option<&GroupIndices>) -> DaftResult<Self> {
+        let target_type = try_variance_aggregation_supertype(self.data_type())?;
+        match target_type {
+            DataType::Float64 => {
+                let casted = self.cast(&DataType::Float64)?;
+                let casted = casted.f64()?;
+                let result = match groups {
+                    Some(groups) => casted.grouped_var_partial(groups)?,
+                    None => casted.var_partial()?,
+                }
+                .into_series();
+                Ok(result)
+            }
+            _ => Err(DaftError::not_implemented(format!(
+                "Variance partial not implemented for {target_type}, source type: {}",
+                self.data_type()
+            ))),
+        }
+    }
+
+    pub fn merge_var_partial(&self, groups: Option<&GroupIndices>) -> DaftResult<Self> {
+        match self.data_type() {
+            DataType::Struct(_) => {
+                let struct_array = self.struct_()?;
+                let result = match groups {
+                    Some(groups) => struct_array.grouped_merge_var_partial(groups)?,
+                    None => struct_array.merge_var_partial()?,
+                }
+                .into_series();
+                Ok(result)
+            }
+            other => Err(DaftError::TypeError(format!(
+                "Merge variance partial is not implemented for type {other}"
+            ))),
+        }
     }
 }
 

--- a/src/daft-core/src/utils/stats.rs
+++ b/src/daft-core/src/utils/stats.rs
@@ -32,9 +32,10 @@ pub struct Stats {
     pub mean: Option<f64>,
 }
 
-/// Per-partition variance state: `count` valid values with mean `mean` and
-/// `m2 = sum((x - mean)^2)`, so the variance is `m2 / (count - ddof)`. `mean` and `m2` are
-/// `None` when `count == 0`.
+/// Per-partition variance state.
+///
+/// `count` valid values with mean `mean` and `m2 = sum((x - mean)^2)`, so the variance is
+/// `m2 / (count - ddof)`. `mean` and `m2` are `None` when `count == 0`.
 #[derive(Clone, Copy, Default, Debug)]
 pub struct VarPartialState {
     pub count: u64,
@@ -42,11 +43,12 @@ pub struct VarPartialState {
     pub m2: Option<f64>,
 }
 
-/// Corrected two-pass `(count, mean, m2)` over non-null values, per Chan et al. eq. (1.7):
-/// with `s1 = sum(x - mean0)` and `s2 = sum((x - mean0)^2)`, `mean = mean0 + s1 / n` and
+/// Corrected two-pass `(count, mean, m2)` over non-null values, per Chan et al. eq. (1.7).
+///
+/// With `s1 = sum(x - mean0)` and `s2 = sum((x - mean0)^2)`: `mean = mean0 + s1 / n`,
 /// `m2 = s2 - s1^2 / n`. The `s1` correction removes the error in the provisional
-/// `mean0 = sum / count`, which a plain two-pass inherits as a spurious `n * error^2` term
-/// and a Welford update cannot fix once `delta / count` falls below `ulp(mean)`.
+/// `mean0 = sum / count`, which a plain two-pass inherits as a spurious `n * error^2`
+/// term and a Welford update cannot fix once `delta / count` falls below `ulp(mean)`.
 pub fn calculate_var_partial(stats: Stats, values: impl Iterator<Item = f64>) -> VarPartialState {
     let Some(mean0) = stats.mean else {
         // `mean` is `None` exactly when there were no valid values.
@@ -72,8 +74,10 @@ pub fn calculate_var_partial(stats: Stats, values: impl Iterator<Item = f64>) ->
     }
 }
 
-/// Chan et al. parallel merge of per-partition states. Inputs with `count == 0` (or a missing
-/// `mean`/`m2`) are the identity. Only combines deviations, so it stays accurate for large means.
+/// Chan et al. parallel merge of per-partition states.
+///
+/// Inputs with `count == 0` (or a missing `mean`/`m2`) are the identity. Only combines
+/// deviations, so it stays accurate for large means.
 pub fn merge_var_partials(partials: impl Iterator<Item = VarPartialState>) -> VarPartialState {
     let mut count: u64 = 0;
     let mut mean = 0.0;
@@ -218,8 +222,10 @@ pub fn calculate_stddev(
     calculate_variance(stats, values, ddof).map(f64::sqrt)
 }
 
-/// Variance of `values` with `ddof` degrees of freedom, or `None` when `count <= ddof`. Shares
-/// [`calculate_var_partial`] with the two-stage lowering so the two cannot diverge numerically.
+/// Variance of `values` with `ddof` degrees of freedom, or `None` when `count <= ddof`.
+///
+/// Shares [`calculate_var_partial`] with the two-stage lowering so the two cannot diverge
+/// numerically.
 pub fn calculate_variance(
     stats: Stats,
     values: impl Iterator<Item = f64>,

--- a/src/daft-core/src/utils/stats.rs
+++ b/src/daft-core/src/utils/stats.rs
@@ -6,13 +6,125 @@ use crate::{
         prelude::{Float64Array, UInt64Array},
     },
     count_mode::CountMode,
+    datatypes::{DataType, Field},
 };
+
+pub const VAR_PARTIAL_COUNT_FIELD: &str = "count";
+pub const VAR_PARTIAL_MEAN_FIELD: &str = "mean";
+pub const VAR_PARTIAL_M2_FIELD: &str = "m2";
+
+pub fn var_partial_fields() -> Vec<Field> {
+    vec![
+        Field::new(VAR_PARTIAL_COUNT_FIELD, DataType::UInt64),
+        Field::new(VAR_PARTIAL_MEAN_FIELD, DataType::Float64),
+        Field::new(VAR_PARTIAL_M2_FIELD, DataType::Float64),
+    ]
+}
+
+pub fn var_partial_dtype() -> DataType {
+    DataType::Struct(var_partial_fields())
+}
 
 #[derive(Clone, Copy, Default, Debug)]
 pub struct Stats {
     pub sum: f64,
     pub count: f64,
     pub mean: Option<f64>,
+}
+
+/// Numerically stable partial variance state, per Chan et al. parallel variance update.
+///
+/// `count` is the number of valid (non-null) values observed, `mean` is their mean and
+/// `m2` is the sum of squared deviations from the mean, i.e. `sum((x - mean)^2)`.
+/// The finalized (population) variance is `m2 / count` and the sample variance with
+/// `ddof` degrees of freedom is `m2 / (count - ddof)`.
+///
+/// `mean` and `m2` are `None` when `count == 0`.
+#[derive(Clone, Copy, Default, Debug)]
+pub struct VarPartialState {
+    pub count: u64,
+    pub mean: Option<f64>,
+    pub m2: Option<f64>,
+}
+
+/// Single-pass Welford computation of `(count, mean, m2)` over non-null values.
+///
+/// This is the per-partition step of the parallel variance algorithm: it never forms
+/// `sum(x^2)`, so unlike `E(x^2) - E(x)^2` it does not catastrophically cancel when
+/// the mean is large relative to the variance (e.g. `[1e9 + 1, 1e9 + 2, 1e9 + 3]`).
+pub fn calculate_var_partial(values: impl Iterator<Item = f64>) -> VarPartialState {
+    let mut count: u64 = 0;
+    let mut mean = 0.0;
+    let mut m2 = 0.0;
+    for x in values {
+        count += 1;
+        let delta = x - mean;
+        mean += delta / count as f64;
+        let delta2 = x - mean;
+        m2 += delta * delta2;
+    }
+    if count == 0 {
+        VarPartialState {
+            count: 0,
+            mean: None,
+            m2: None,
+        }
+    } else {
+        VarPartialState {
+            count,
+            mean: Some(mean),
+            m2: Some(m2),
+        }
+    }
+}
+
+/// Chan et al. parallel merge of per-partition `(count, mean, m2)` states.
+///
+/// Each input with `count == 0` (or missing `mean`/`m2`) is an identity and is skipped.
+/// The merge is associative up to floating-point rounding and only ever combines
+/// deviations (`delta = mean_b - mean_a`), so it stays accurate when the global mean
+/// is large and the variance is small.
+pub fn merge_var_partials(partials: impl Iterator<Item = VarPartialState>) -> VarPartialState {
+    let mut count: u64 = 0;
+    let mut mean = 0.0;
+    let mut m2 = 0.0;
+    for partial in partials {
+        if partial.count == 0 {
+            continue;
+        }
+        let (other_n, other_mean, other_m2) = match (partial.mean, partial.m2) {
+            (Some(other_mean), Some(other_m2)) => (partial.count, other_mean, other_m2),
+            _ => continue,
+        };
+        if count == 0 {
+            count = other_n;
+            mean = other_mean;
+            m2 = other_m2;
+        } else {
+            let delta = other_mean - mean;
+            let new_count = count + other_n;
+            let new_mean = mean + delta * (other_n as f64) / (new_count as f64);
+            let new_m2 = m2
+                + other_m2
+                + delta * delta * (count as f64) * (other_n as f64) / (new_count as f64);
+            count = new_count;
+            mean = new_mean;
+            m2 = new_m2;
+        }
+    }
+    if count == 0 {
+        VarPartialState {
+            count: 0,
+            mean: None,
+            m2: None,
+        }
+    } else {
+        VarPartialState {
+            count,
+            mean: Some(mean),
+            m2: Some(m2),
+        }
+    }
 }
 
 pub fn calculate_stats(array: &Float64Array) -> DaftResult<Stats> {
@@ -144,4 +256,53 @@ pub fn calculate_skew(stats: Stats, values: impl Iterator<Item = f64>) -> Option
 
         (m3 / count) / (m2 / count).powi(3).sqrt()
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{VarPartialState, calculate_var_partial, merge_var_partials};
+
+    fn var_from_state(state: VarPartialState, ddof: usize) -> Option<f64> {
+        if (state.count as usize) <= ddof {
+            return None;
+        }
+        state.m2.map(|m2| m2 / (state.count as f64 - ddof as f64))
+    }
+
+    #[test]
+    fn test_var_partial_large_mean() {
+        // Regression test for https://github.com/Eventual-Inc/Daft/issues/7468:
+        // `E(x^2) - E(x)^2` collapses to 0 for `[1e9 + 1, 1e9 + 2, 1e9 + 3]`.
+        let values = [1e9 + 1.0, 1e9 + 2.0, 1e9 + 3.0];
+        let state = calculate_var_partial(values.into_iter());
+        assert_eq!(state.count, 3);
+        assert_eq!(var_from_state(state, 1), Some(1.0));
+        assert_eq!(var_from_state(state, 0), Some(2.0 / 3.0));
+    }
+
+    #[test]
+    fn test_merge_var_partials_singletons() {
+        // Merging single-row partials must recover the joint variance, including
+        // the `n == 1` case where a per-partition sample variance would be null.
+        let partials = [1e9 + 1.0, 1e9 + 2.0, 1e9 + 3.0]
+            .into_iter()
+            .map(|v| calculate_var_partial(std::iter::once(v)));
+        let merged = merge_var_partials(partials);
+        assert_eq!(merged.count, 3);
+        assert_eq!(var_from_state(merged, 1), Some(1.0));
+    }
+
+    #[test]
+    fn test_merge_var_partials_empty_is_identity() {
+        let empty = VarPartialState {
+            count: 0,
+            mean: None,
+            m2: None,
+        };
+        let state = calculate_var_partial([1.0, 2.0, 3.0].into_iter());
+        let merged = merge_var_partials([empty, state, empty].into_iter());
+        assert_eq!(merged.count, 3);
+        assert_eq!(var_from_state(merged, 1), Some(1.0));
+        assert_eq!(merge_var_partials([empty, empty].into_iter()).count, 0);
+    }
 }

--- a/src/daft-core/src/utils/stats.rs
+++ b/src/daft-core/src/utils/stats.rs
@@ -47,34 +47,49 @@ pub struct VarPartialState {
     pub m2: Option<f64>,
 }
 
-/// Single-pass Welford computation of `(count, mean, m2)` over non-null values.
+/// Corrected two-pass computation of `(count, mean, m2)` over non-null values.
 ///
-/// This is the per-partition step of the parallel variance algorithm: it never forms
-/// `sum(x^2)`, so unlike `E(x^2) - E(x)^2` it does not catastrophically cancel when
-/// the mean is large relative to the variance (e.g. `[1e9 + 1, 1e9 + 2, 1e9 + 3]`).
-pub fn calculate_var_partial(values: impl Iterator<Item = f64>) -> VarPartialState {
-    let mut count: u64 = 0;
-    let mut mean = 0.0;
-    let mut m2 = 0.0;
-    for x in values {
-        count += 1;
-        let delta = x - mean;
-        mean += delta / count as f64;
-        let delta2 = x - mean;
-        m2 += delta * delta2;
-    }
-    if count == 0 {
-        VarPartialState {
+/// This is the per-partition step of the parallel variance algorithm. It starts from the
+/// provisional mean already in `stats` (`sum / count`) and then corrects both the mean and
+/// the second moment with the residual `s1`, per Chan et al. eq. (1.7):
+///
+/// ```text
+/// s1   = sum(x - mean0)            s2 = sum((x - mean0)^2)
+/// mean = mean0 + s1 / n            m2 = s2 - s1^2 / n
+/// ```
+///
+/// It never forms `sum(x^2)`, so unlike `E(x^2) - E(x)^2` it does not catastrophically
+/// cancel when the mean is large relative to the variance (e.g. `[1e9 + 1, 1e9 + 2,
+/// 1e9 + 3]`, which collapsed to `0.0` before this was introduced).
+///
+/// The `s1` correction is what makes this robust where the two obvious alternatives are
+/// not. A plain two-pass `sum((x - mean0)^2)` inherits the error in `mean0` from the
+/// summation kernel as a spurious `n * error^2` term, which matters because the grouped
+/// path sums with a sequential fold. A Welford update (`mean += delta / count`) instead
+/// stops moving the mean entirely once `delta / count` drops below `ulp(mean)` -- around
+/// `1e15` with a spread of ~1 the running mean freezes near its first few values and the
+/// result is off by tens of percent. Correcting an explicit `mean0` avoids both.
+pub fn calculate_var_partial(stats: Stats, values: impl Iterator<Item = f64>) -> VarPartialState {
+    let Some(mean0) = stats.mean else {
+        // `mean` is `None` exactly when there were no valid values.
+        return VarPartialState {
             count: 0,
             mean: None,
             m2: None,
-        }
-    } else {
-        VarPartialState {
-            count,
-            mean: Some(mean),
-            m2: Some(m2),
-        }
+        };
+    };
+
+    let count = stats.count as u64;
+    let n = stats.count;
+    let (s1, s2) = values.fold((0.0, 0.0), |(s1, s2), value| {
+        let delta = value - mean0;
+        (s1 + delta, s2 + delta * delta)
+    });
+
+    VarPartialState {
+        count,
+        mean: Some(mean0 + s1 / n),
+        m2: Some(s2 - s1 * s1 / n),
     }
 }
 
@@ -228,19 +243,21 @@ pub fn calculate_stddev(
     calculate_variance(stats, values, ddof).map(f64::sqrt)
 }
 
+/// Variance of `values` with `ddof` degrees of freedom, or `None` when `count <= ddof`.
+///
+/// This goes through [`calculate_var_partial`], the same kernel the two-stage `VarPartial`
+/// lowering uses, so `Series::var` and `df.agg(col(..).var())` cannot diverge numerically.
 pub fn calculate_variance(
     stats: Stats,
     values: impl Iterator<Item = f64>,
     ddof: usize,
 ) -> Option<f64> {
-    stats.mean.and_then(|mean| {
-        let n = stats.count as usize;
-        if n <= ddof {
-            return None; // Not enough data points for the requested ddof
-        }
-        let sum_of_squares = values.map(|value| (value - mean).powi(2)).sum::<f64>();
-        Some(sum_of_squares / (n - ddof) as f64)
-    })
+    let state = calculate_var_partial(stats, values);
+    let n = state.count as usize;
+    if n <= ddof {
+        return None; // Not enough data points for the requested ddof
+    }
+    state.m2.map(|m2| m2 / (n - ddof) as f64)
 }
 
 pub fn calculate_skew(stats: Stats, values: impl Iterator<Item = f64>) -> Option<f64> {
@@ -260,7 +277,25 @@ pub fn calculate_skew(stats: Stats, values: impl Iterator<Item = f64>) -> Option
 
 #[cfg(test)]
 mod tests {
-    use super::{VarPartialState, calculate_var_partial, merge_var_partials};
+    use super::{
+        Stats, VarPartialState, calculate_mean, calculate_var_partial, calculate_variance,
+        merge_var_partials,
+    };
+
+    /// Mirrors `calculate_stats`, which derives the provisional mean from the sum kernel.
+    fn stats_of(values: &[f64]) -> Stats {
+        let sum = values.iter().sum::<f64>();
+        let count = values.len() as u64;
+        Stats {
+            sum,
+            count: count as f64,
+            mean: calculate_mean(sum, count),
+        }
+    }
+
+    fn partial_of(values: &[f64]) -> VarPartialState {
+        calculate_var_partial(stats_of(values), values.iter().copied())
+    }
 
     fn var_from_state(state: VarPartialState, ddof: usize) -> Option<f64> {
         if (state.count as usize) <= ddof {
@@ -269,15 +304,47 @@ mod tests {
         state.m2.map(|m2| m2 / (state.count as f64 - ddof as f64))
     }
 
+    fn assert_close(actual: f64, expected: f64, rel: f64) {
+        assert!(
+            (actual - expected).abs() <= rel * expected.abs(),
+            "expected {expected}, got {actual} (relative tolerance {rel})"
+        );
+    }
+
     #[test]
     fn test_var_partial_large_mean() {
         // Regression test for https://github.com/Eventual-Inc/Daft/issues/7468:
         // `E(x^2) - E(x)^2` collapses to 0 for `[1e9 + 1, 1e9 + 2, 1e9 + 3]`.
         let values = [1e9 + 1.0, 1e9 + 2.0, 1e9 + 3.0];
-        let state = calculate_var_partial(values.into_iter());
+        let state = partial_of(&values);
         assert_eq!(state.count, 3);
         assert_eq!(var_from_state(state, 1), Some(1.0));
         assert_eq!(var_from_state(state, 0), Some(2.0 / 3.0));
+    }
+
+    #[test]
+    fn test_var_partial_large_mean_large_partition() {
+        // The other large-mean tests use three values, so they only exercise the merge.
+        // Here a single partition holds 20k values, which is where the *per-partition*
+        // kernel decides the answer -- and where a Welford running mean silently stops
+        // updating, because `delta / count` falls below `ulp(1e15)`.
+        //
+        // Every value is a multiple of 1/8, and 1e9, 1e12 and 1e15 all have an ulp of at
+        // most 1/8, so `base + x` is exact and the variance is *exactly* shift invariant.
+        // Any deviation from the unshifted variance is therefore pure algorithm error.
+        const N: usize = 20_000;
+        let unshifted: Vec<f64> = (0..N).map(|i| ((i * 7919) % 1000) as f64 / 8.0).collect();
+        let expected = var_from_state(partial_of(&unshifted), 1).unwrap();
+
+        for base in [1e9, 1e12, 1e15] {
+            let shifted: Vec<f64> = unshifted.iter().map(|x| base + x).collect();
+            assert!(
+                shifted.iter().zip(&unshifted).all(|(s, x)| s - base == *x),
+                "shift by {base} must not quantise the data"
+            );
+            let actual = var_from_state(partial_of(&shifted), 1).unwrap();
+            assert_close(actual, expected, 1e-12);
+        }
     }
 
     #[test]
@@ -286,7 +353,7 @@ mod tests {
         // the `n == 1` case where a per-partition sample variance would be null.
         let partials = [1e9 + 1.0, 1e9 + 2.0, 1e9 + 3.0]
             .into_iter()
-            .map(|v| calculate_var_partial(std::iter::once(v)));
+            .map(|v| partial_of(&[v]));
         let merged = merge_var_partials(partials);
         assert_eq!(merged.count, 3);
         assert_eq!(var_from_state(merged, 1), Some(1.0));
@@ -299,10 +366,56 @@ mod tests {
             mean: None,
             m2: None,
         };
-        let state = calculate_var_partial([1.0, 2.0, 3.0].into_iter());
+        let state = partial_of(&[1.0, 2.0, 3.0]);
         let merged = merge_var_partials([empty, state, empty].into_iter());
         assert_eq!(merged.count, 3);
         assert_eq!(var_from_state(merged, 1), Some(1.0));
         assert_eq!(merge_var_partials([empty, empty].into_iter()).count, 0);
+    }
+
+    #[test]
+    fn test_merge_var_partials_partition_shape_invariance() {
+        // How the rows happen to be split across morsels/partitions must not change the
+        // answer: the merge is what makes the two-stage lowering agree with a single pass.
+        for base in [0.0, 1e9] {
+            let values: Vec<f64> = (1..=8).map(|i| base + f64::from(i)).collect();
+            let whole = partial_of(&values);
+            let halves = merge_var_partials(
+                [partial_of(&values[..4]), partial_of(&values[4..])].into_iter(),
+            );
+            let uneven = merge_var_partials(
+                [partial_of(&values[..1]), partial_of(&values[1..])].into_iter(),
+            );
+            let singletons =
+                merge_var_partials(values.iter().map(|v| partial_of(std::slice::from_ref(v))));
+
+            let expected = var_from_state(whole, 1).unwrap();
+            assert_close(expected, 6.0, 1e-12);
+            for shape in [halves, uneven, singletons] {
+                assert_eq!(shape.count, 8);
+                assert_close(var_from_state(shape, 1).unwrap(), expected, 1e-9);
+            }
+        }
+    }
+
+    #[test]
+    fn test_calculate_variance_matches_var_partial() {
+        // `Series::var` goes through `calculate_variance` while the query engine goes
+        // through `calculate_var_partial`; they must not be able to disagree.
+        for values in [
+            vec![1.0, 2.0, 3.0, 4.0, 5.0],
+            vec![1e9 + 1.0, 1e9 + 2.0, 1e9 + 3.0],
+            vec![5.0],
+            vec![],
+        ] {
+            let stats = stats_of(&values);
+            for ddof in [0, 1] {
+                assert_eq!(
+                    calculate_variance(stats, values.iter().copied(), ddof),
+                    var_from_state(calculate_var_partial(stats, values.iter().copied()), ddof),
+                    "values={values:?} ddof={ddof}"
+                );
+            }
+        }
     }
 }

--- a/src/daft-core/src/utils/stats.rs
+++ b/src/daft-core/src/utils/stats.rs
@@ -32,14 +32,9 @@ pub struct Stats {
     pub mean: Option<f64>,
 }
 
-/// Numerically stable partial variance state, per Chan et al. parallel variance update.
-///
-/// `count` is the number of valid (non-null) values observed, `mean` is their mean and
-/// `m2` is the sum of squared deviations from the mean, i.e. `sum((x - mean)^2)`.
-/// The finalized (population) variance is `m2 / count` and the sample variance with
-/// `ddof` degrees of freedom is `m2 / (count - ddof)`.
-///
-/// `mean` and `m2` are `None` when `count == 0`.
+/// Per-partition variance state: `count` valid values with mean `mean` and
+/// `m2 = sum((x - mean)^2)`, so the variance is `m2 / (count - ddof)`. `mean` and `m2` are
+/// `None` when `count == 0`.
 #[derive(Clone, Copy, Default, Debug)]
 pub struct VarPartialState {
     pub count: u64,
@@ -47,28 +42,11 @@ pub struct VarPartialState {
     pub m2: Option<f64>,
 }
 
-/// Corrected two-pass computation of `(count, mean, m2)` over non-null values.
-///
-/// This is the per-partition step of the parallel variance algorithm. It starts from the
-/// provisional mean already in `stats` (`sum / count`) and then corrects both the mean and
-/// the second moment with the residual `s1`, per Chan et al. eq. (1.7):
-///
-/// ```text
-/// s1   = sum(x - mean0)            s2 = sum((x - mean0)^2)
-/// mean = mean0 + s1 / n            m2 = s2 - s1^2 / n
-/// ```
-///
-/// It never forms `sum(x^2)`, so unlike `E(x^2) - E(x)^2` it does not catastrophically
-/// cancel when the mean is large relative to the variance (e.g. `[1e9 + 1, 1e9 + 2,
-/// 1e9 + 3]`, which collapsed to `0.0` before this was introduced).
-///
-/// The `s1` correction is what makes this robust where the two obvious alternatives are
-/// not. A plain two-pass `sum((x - mean0)^2)` inherits the error in `mean0` from the
-/// summation kernel as a spurious `n * error^2` term, which matters because the grouped
-/// path sums with a sequential fold. A Welford update (`mean += delta / count`) instead
-/// stops moving the mean entirely once `delta / count` drops below `ulp(mean)` -- around
-/// `1e15` with a spread of ~1 the running mean freezes near its first few values and the
-/// result is off by tens of percent. Correcting an explicit `mean0` avoids both.
+/// Corrected two-pass `(count, mean, m2)` over non-null values, per Chan et al. eq. (1.7):
+/// with `s1 = sum(x - mean0)` and `s2 = sum((x - mean0)^2)`, `mean = mean0 + s1 / n` and
+/// `m2 = s2 - s1^2 / n`. The `s1` correction removes the error in the provisional
+/// `mean0 = sum / count`, which a plain two-pass inherits as a spurious `n * error^2` term
+/// and a Welford update cannot fix once `delta / count` falls below `ulp(mean)`.
 pub fn calculate_var_partial(stats: Stats, values: impl Iterator<Item = f64>) -> VarPartialState {
     let Some(mean0) = stats.mean else {
         // `mean` is `None` exactly when there were no valid values.
@@ -81,9 +59,10 @@ pub fn calculate_var_partial(stats: Stats, values: impl Iterator<Item = f64>) ->
 
     let count = stats.count as u64;
     let n = stats.count;
+    // `mul_add` rounds `delta * delta + s2` once instead of twice.
     let (s1, s2) = values.fold((0.0, 0.0), |(s1, s2), value| {
         let delta = value - mean0;
-        (s1 + delta, s2 + delta * delta)
+        (s1 + delta, delta.mul_add(delta, s2))
     });
 
     VarPartialState {
@@ -93,12 +72,8 @@ pub fn calculate_var_partial(stats: Stats, values: impl Iterator<Item = f64>) ->
     }
 }
 
-/// Chan et al. parallel merge of per-partition `(count, mean, m2)` states.
-///
-/// Each input with `count == 0` (or missing `mean`/`m2`) is an identity and is skipped.
-/// The merge is associative up to floating-point rounding and only ever combines
-/// deviations (`delta = mean_b - mean_a`), so it stays accurate when the global mean
-/// is large and the variance is small.
+/// Chan et al. parallel merge of per-partition states. Inputs with `count == 0` (or a missing
+/// `mean`/`m2`) are the identity. Only combines deviations, so it stays accurate for large means.
 pub fn merge_var_partials(partials: impl Iterator<Item = VarPartialState>) -> VarPartialState {
     let mut count: u64 = 0;
     let mut mean = 0.0;
@@ -243,10 +218,8 @@ pub fn calculate_stddev(
     calculate_variance(stats, values, ddof).map(f64::sqrt)
 }
 
-/// Variance of `values` with `ddof` degrees of freedom, or `None` when `count <= ddof`.
-///
-/// This goes through [`calculate_var_partial`], the same kernel the two-stage `VarPartial`
-/// lowering uses, so `Series::var` and `df.agg(col(..).var())` cannot diverge numerically.
+/// Variance of `values` with `ddof` degrees of freedom, or `None` when `count <= ddof`. Shares
+/// [`calculate_var_partial`] with the two-stage lowering so the two cannot diverge numerically.
 pub fn calculate_variance(
     stats: Stats,
     values: impl Iterator<Item = f64>,
@@ -324,14 +297,10 @@ mod tests {
 
     #[test]
     fn test_var_partial_large_mean_large_partition() {
-        // The other large-mean tests use three values, so they only exercise the merge.
-        // Here a single partition holds 20k values, which is where the *per-partition*
-        // kernel decides the answer -- and where a Welford running mean silently stops
-        // updating, because `delta / count` falls below `ulp(1e15)`.
-        //
-        // Every value is a multiple of 1/8, and 1e9, 1e12 and 1e15 all have an ulp of at
-        // most 1/8, so `base + x` is exact and the variance is *exactly* shift invariant.
-        // Any deviation from the unshifted variance is therefore pure algorithm error.
+        // Exercises the per-partition kernel at scale rather than just the merge.
+        // Values are multiples of 1/8 and every base has an ulp of at most 1/8, so the shift
+        // is exact and the variance is exactly shift invariant; any deviation is algorithm
+        // error. Do not change the divisor without rechecking that.
         const N: usize = 20_000;
         let unshifted: Vec<f64> = (0..N).map(|i| ((i * 7919) % 1000) as f64 / 8.0).collect();
         let expected = var_from_state(partial_of(&unshifted), 1).unwrap();
@@ -349,8 +318,8 @@ mod tests {
 
     #[test]
     fn test_merge_var_partials_singletons() {
-        // Merging single-row partials must recover the joint variance, including
-        // the `n == 1` case where a per-partition sample variance would be null.
+        // Single-row partials must still recover the joint variance, even though a
+        // per-partition sample variance would be null at `n == 1`.
         let partials = [1e9 + 1.0, 1e9 + 2.0, 1e9 + 3.0]
             .into_iter()
             .map(|v| partial_of(&[v]));
@@ -375,8 +344,7 @@ mod tests {
 
     #[test]
     fn test_merge_var_partials_partition_shape_invariance() {
-        // How the rows happen to be split across morsels/partitions must not change the
-        // answer: the merge is what makes the two-stage lowering agree with a single pass.
+        // How rows split across morsels/partitions must not change the answer.
         for base in [0.0, 1e9] {
             let values: Vec<f64> = (1..=8).map(|i| base + f64::from(i)).collect();
             let whole = partial_of(&values);
@@ -400,8 +368,7 @@ mod tests {
 
     #[test]
     fn test_calculate_variance_matches_var_partial() {
-        // `Series::var` goes through `calculate_variance` while the query engine goes
-        // through `calculate_var_partial`; they must not be able to disagree.
+        // `Series::var` uses `calculate_variance`, the engine uses `calculate_var_partial`.
         for values in [
             vec![1.0, 2.0, 3.0, 4.0, 5.0],
             vec![1e9 + 1.0, 1e9 + 2.0, 1e9 + 3.0],

--- a/src/daft-dsl/src/expr/agg.rs
+++ b/src/daft-dsl/src/expr/agg.rs
@@ -42,6 +42,10 @@ pub fn extract_agg_expr(expr: &ExprRef) -> DaftResult<AggExpr> {
                     AggExpr::Stddev(Expr::Alias(e, name.clone()).into(), ddof)
                 }
                 AggExpr::Var(e, ddof) => AggExpr::Var(Expr::Alias(e, name.clone()).into(), ddof),
+                AggExpr::VarPartial(e) => AggExpr::VarPartial(Expr::Alias(e, name.clone()).into()),
+                AggExpr::MergeVarPartial(e) => {
+                    AggExpr::MergeVarPartial(Expr::Alias(e, name.clone()).into())
+                }
                 AggExpr::Min(e) => AggExpr::Min(Expr::Alias(e, name.clone()).into()),
                 AggExpr::Max(e) => AggExpr::Max(Expr::Alias(e, name.clone()).into()),
                 AggExpr::BoolAnd(e) => AggExpr::BoolAnd(Expr::Alias(e, name.clone()).into()),

--- a/src/daft-dsl/src/expr/mod.rs
+++ b/src/daft-dsl/src/expr/mod.rs
@@ -429,9 +429,23 @@ pub enum AggExpr {
     #[display("var({_0}, ddof={_1})")]
     Var(ExprRef, usize),
 
+    /// Internal: per-partition `(count, mean, m2)` summary for `Var`/`Stddev`.
+    ///
+    /// Not user-constructible and never produced by the frontends -- it is introduced
+    /// only by `populate_aggregation_stages`, which lowers `Var`/`Stddev` into
+    /// `VarPartial` followed by [`Self::MergeVarPartial`]. Both stages reduce many rows
+    /// to one row per group, so both have to be aggregations rather than a scalar
+    /// function over a `List` aggregate; this mirrors the existing
+    /// [`Self::ApproxSketch`] / [`Self::MergeSketch`] pair, and keeps the partial state
+    /// bounded instead of growing with the number of partitions.
     #[display("var_partial({_0})")]
     VarPartial(ExprRef),
 
+    /// Internal: Chan et al. parallel merge of [`Self::VarPartial`] summaries.
+    ///
+    /// See [`Self::VarPartial`]. Merging is associative, so this lowers to itself the
+    /// same way [`Self::MergeSketch`] does, which is what lets Flotilla re-lower the
+    /// aggregations it hands to each Swordfish task.
     #[display("merge_var_partial({_0})")]
     MergeVarPartial(ExprRef),
 

--- a/src/daft-dsl/src/expr/mod.rs
+++ b/src/daft-dsl/src/expr/mod.rs
@@ -429,6 +429,12 @@ pub enum AggExpr {
     #[display("var({_0}, ddof={_1})")]
     Var(ExprRef, usize),
 
+    #[display("var_partial({_0})")]
+    VarPartial(ExprRef),
+
+    #[display("merge_var_partial({_0})")]
+    MergeVarPartial(ExprRef),
+
     #[display("min({_0})")]
     Min(ExprRef),
 
@@ -593,6 +599,8 @@ impl AggExpr {
             Self::Percentile(_, _) => "Percentile",
             Self::Stddev(_, _) => "Stddev",
             Self::Var(_, _) => "Var",
+            Self::VarPartial(_) => "Var Partial",
+            Self::MergeVarPartial(_) => "Merge Var Partial",
             Self::Min(_) => "Min",
             Self::Max(_) => "Max",
             Self::BoolAnd(_) => "Bool And",
@@ -625,6 +633,8 @@ impl AggExpr {
             | Self::Percentile(expr, _)
             | Self::Stddev(expr, _)
             | Self::Var(expr, _)
+            | Self::VarPartial(expr)
+            | Self::MergeVarPartial(expr)
             | Self::Min(expr)
             | Self::Max(expr)
             | Self::BoolAnd(expr)
@@ -706,6 +716,14 @@ impl AggExpr {
             Self::Var(expr, ddof) => {
                 let child_id = expr.semantic_id(schema);
                 FieldID::new(format!("{child_id}.local_var(ddof={ddof})"))
+            }
+            Self::VarPartial(expr) => {
+                let child_id = expr.semantic_id(schema);
+                FieldID::new(format!("{child_id}.local_var_partial()"))
+            }
+            Self::MergeVarPartial(expr) => {
+                let child_id = expr.semantic_id(schema);
+                FieldID::new(format!("{child_id}.local_merge_var_partial()"))
             }
             Self::Min(expr) => {
                 let child_id = expr.semantic_id(schema);
@@ -795,6 +813,8 @@ impl AggExpr {
             | Self::Percentile(expr, _)
             | Self::Stddev(expr, _)
             | Self::Var(expr, _)
+            | Self::VarPartial(expr)
+            | Self::MergeVarPartial(expr)
             | Self::Min(expr)
             | Self::Max(expr)
             | Self::BoolAnd(expr)
@@ -832,6 +852,8 @@ impl AggExpr {
             Self::Percentile(_, percentile) => Self::Percentile(first_child(), percentile.clone()),
             &Self::Stddev(_, ddof) => Self::Stddev(first_child(), ddof),
             &Self::Var(_, ddof) => Self::Var(first_child(), ddof),
+            Self::VarPartial(_) => Self::VarPartial(first_child()),
+            Self::MergeVarPartial(_) => Self::MergeVarPartial(first_child()),
             Self::Min(_) => Self::Min(first_child()),
             Self::Max(_) => Self::Max(first_child()),
             Self::BoolAnd(_) => Self::BoolAnd(first_child()),
@@ -1006,6 +1028,26 @@ impl AggExpr {
                     field.name.as_ref(),
                     try_variance_aggregation_supertype(&field.dtype)?,
                 ))
+            }
+            Self::VarPartial(expr) => {
+                let field = expr.to_field(schema)?;
+                // Validate the input type eagerly so misuse fails with the same
+                // error as `var` instead of a downstream struct error.
+                try_variance_aggregation_supertype(&field.dtype)?;
+                Ok(Field::new(
+                    field.name.as_ref(),
+                    daft_core::utils::stats::var_partial_dtype(),
+                ))
+            }
+            Self::MergeVarPartial(expr) => {
+                let field = expr.to_field(schema)?;
+                match field.dtype {
+                    DataType::Struct(_) => Ok(Field::new(field.name.as_ref(), field.dtype)),
+                    _ => Err(DaftError::TypeError(format!(
+                        "Expected input to merge_var_partial() to be struct but received dtype {} for column \"{}\"",
+                        field.dtype, field.name,
+                    ))),
+                }
             }
 
             Self::Min(expr) | Self::Max(expr) | Self::AnyValue(expr, _) => {

--- a/src/daft-dsl/src/expr/mod.rs
+++ b/src/daft-dsl/src/expr/mod.rs
@@ -429,23 +429,14 @@ pub enum AggExpr {
     #[display("var({_0}, ddof={_1})")]
     Var(ExprRef, usize),
 
-    /// Internal: per-partition `(count, mean, m2)` summary for `Var`/`Stddev`.
-    ///
-    /// Not user-constructible and never produced by the frontends -- it is introduced
-    /// only by `populate_aggregation_stages`, which lowers `Var`/`Stddev` into
-    /// `VarPartial` followed by [`Self::MergeVarPartial`]. Both stages reduce many rows
-    /// to one row per group, so both have to be aggregations rather than a scalar
-    /// function over a `List` aggregate; this mirrors the existing
-    /// [`Self::ApproxSketch`] / [`Self::MergeSketch`] pair, and keeps the partial state
-    /// bounded instead of growing with the number of partitions.
+    /// Internal per-partition `(count, mean, m2)` summary for `Var`/`Stddev`, introduced only
+    /// by `populate_aggregation_stages`. Not user-constructible; mirrors the
+    /// [`Self::ApproxSketch`] / [`Self::MergeSketch`] pair.
     #[display("var_partial({_0})")]
     VarPartial(ExprRef),
 
-    /// Internal: Chan et al. parallel merge of [`Self::VarPartial`] summaries.
-    ///
-    /// See [`Self::VarPartial`]. Merging is associative, so this lowers to itself the
-    /// same way [`Self::MergeSketch`] does, which is what lets Flotilla re-lower the
-    /// aggregations it hands to each Swordfish task.
+    /// Internal Chan et al. merge of [`Self::VarPartial`] summaries. Associative, so it lowers
+    /// to itself like [`Self::MergeSketch`].
     #[display("merge_var_partial({_0})")]
     MergeVarPartial(ExprRef),
 

--- a/src/daft-dsl/src/expr/mod.rs
+++ b/src/daft-dsl/src/expr/mod.rs
@@ -429,14 +429,16 @@ pub enum AggExpr {
     #[display("var({_0}, ddof={_1})")]
     Var(ExprRef, usize),
 
-    /// Internal per-partition `(count, mean, m2)` summary for `Var`/`Stddev`, introduced only
-    /// by `populate_aggregation_stages`. Not user-constructible; mirrors the
-    /// [`Self::ApproxSketch`] / [`Self::MergeSketch`] pair.
+    /// Internal per-partition `(count, mean, m2)` summary for `Var`/`Stddev`.
+    ///
+    /// Introduced only by `populate_aggregation_stages`, so it is not user-constructible.
+    /// Mirrors the [`Self::ApproxSketch`] / [`Self::MergeSketch`] pair.
     #[display("var_partial({_0})")]
     VarPartial(ExprRef),
 
-    /// Internal Chan et al. merge of [`Self::VarPartial`] summaries. Associative, so it lowers
-    /// to itself like [`Self::MergeSketch`].
+    /// Internal Chan et al. merge of [`Self::VarPartial`] summaries.
+    ///
+    /// Associative, so it lowers to itself like [`Self::MergeSketch`].
     #[display("merge_var_partial({_0})")]
     MergeVarPartial(ExprRef),
 

--- a/src/daft-local-plan/src/agg.rs
+++ b/src/daft-local-plan/src/agg.rs
@@ -1,9 +1,12 @@
 use common_error::DaftResult;
-use daft_core::prelude::{CountMode, DataType, Field, Schema};
+use daft_core::{
+    prelude::{CountMode, DataType, Field, Schema},
+    utils::stats::{VAR_PARTIAL_COUNT_FIELD, VAR_PARTIAL_M2_FIELD},
+};
 use daft_dsl::{
     AggExpr, ApproxPercentileParams, ExprRef, SketchType, bound_col,
     expr::bound_expr::{BoundAggExpr, BoundExpr},
-    functions::agg::merge_mean,
+    functions::{agg::merge_mean, struct_::get as struct_get},
     lit, null_lit,
 };
 use daft_functions::numeric::sqrt;
@@ -188,75 +191,64 @@ pub fn populate_aggregation_stages_bound_with_schema(
                 final_stage(global_percentile_col);
             }
             AggExpr::Stddev(expr, ddof) => {
-                // The stddev calculation we're performing here is:
-                // stddev(X, ddof) = sqrt((E(X^2) - E(X)^2) * n / (n - ddof))
-                // where X is the sub_expr.
+                // Numerically stable two-stage stddev via Chan et al. parallel variance.
                 //
-                // First stage, we compute `sum(X^2)`, `sum(X)` and `count(X)`.
-                // Second stage, we `global_sqsum := sum(sum(X^2))`, `global_sum := sum(sum(X))` and `global_count := sum(count(X))` in order to get the global versions of the first stage.
-                // In the final projection, we then compute:
-                // `sqrt(((global_sqsum / global_count) - (global_sum / global_count) ^ 2) * global_count / (global_count - ddof))`.
-
-                // This is a workaround since we have different code paths for single stage and two stage aggregations.
+                // Each partition computes `(count, mean, m2)` with Welford's single-pass
+                // update (`VarPartial`), where `m2 = sum((x - mean)^2)`. Partitions are
+                // merged with the parallel update
+                // `m2 = m2_a + m2_b + delta^2 * n_a * n_b / (n_a + n_b)`
+                // (`MergeVarPartial`), which only ever combines deviations and therefore
+                // stays accurate when the mean is large relative to the variance.
+                // This replaces the previous `E(x^2) - E(x)^2` rewrite, which
+                // catastrophically cancels (e.g. `[1e9 + 1, 1e9 + 2, 1e9 + 3]`
+                // collapsed to `0.0`).
+                //
                 // Currently all Std Dev types will be computed using floats.
                 let expr = expr.clone().cast(&DataType::Float64);
 
-                let sum_col = first_stage!(AggExpr::Sum(expr.clone()));
-                let sq_sum_col = first_stage!(AggExpr::Sum(expr.clone().mul(expr.clone())));
-                let count_col = first_stage!(AggExpr::Count(expr, CountMode::Valid));
+                let partial_col = first_stage!(AggExpr::VarPartial(expr));
+                let merged_col = second_stage!(AggExpr::MergeVarPartial(partial_col));
 
-                let global_sum_col = second_stage!(AggExpr::Sum(sum_col));
-                let global_sq_sum_col = second_stage!(AggExpr::Sum(sq_sum_col));
-                let global_count_col = second_stage!(AggExpr::Sum(count_col));
-
-                let n = global_count_col.clone().cast(&DataType::Float64);
-                let sq_mean = global_sq_sum_col.div(n.clone());
-                let mean = global_sum_col.clone().div(n.clone());
-                let mean_sq = mean.clone().mul(mean);
-                let pop_var = sq_mean.sub(mean_sq);
+                let n = struct_get(merged_col.clone(), VAR_PARTIAL_COUNT_FIELD)
+                    .cast(&DataType::Float64);
+                let m2 = struct_get(merged_col, VAR_PARTIAL_M2_FIELD);
 
                 let ddof_expr = lit(*ddof as f64);
-                let adjusted = pop_var.mul(n.clone()).div(n.clone().sub(ddof_expr.clone()));
+                let var = m2.div(n.clone().sub(ddof_expr.clone()));
                 let result = n
                     .clone()
                     .lt_eq(ddof_expr)
-                    .if_else(null_lit(), sqrt::sqrt(adjusted));
+                    .if_else(null_lit(), sqrt::sqrt(var));
 
                 final_stage(result);
             }
             AggExpr::Var(expr, ddof) => {
-                // The variance calculation we're performing here is:
-                // var(X, ddof) = (E(X^2) - E(X)^2) * n / (n - ddof)
-                // where X is the sub_expr.
-                //
-                // First stage, we compute `sum(X^2)`, `sum(X)` and `count(X)`.
-                // Second stage, we get global versions: `global_sqsum`, `global_sum`, `global_count`.
-                // In the final projection, we compute:
-                // ((global_sqsum / global_count) - (global_sum / global_count) ^ 2) * global_count / (global_count - ddof)
-
+                // Numerically stable two-stage variance via Chan et al. parallel variance.
+                // See `Stddev` above for the derivation. Finalizes `m2 / (n - ddof)`.
                 let expr = expr.clone().cast(&DataType::Float64);
 
-                let sum_col = first_stage!(AggExpr::Sum(expr.clone()));
-                let sq_sum_col = first_stage!(AggExpr::Sum(expr.clone().mul(expr.clone())));
-                let count_col = first_stage!(AggExpr::Count(expr, CountMode::Valid));
+                let partial_col = first_stage!(AggExpr::VarPartial(expr));
+                let merged_col = second_stage!(AggExpr::MergeVarPartial(partial_col));
 
-                let global_sum_col = second_stage!(AggExpr::Sum(sum_col));
-                let global_sq_sum_col = second_stage!(AggExpr::Sum(sq_sum_col));
-                let global_count_col = second_stage!(AggExpr::Sum(count_col));
+                let n = struct_get(merged_col.clone(), VAR_PARTIAL_COUNT_FIELD)
+                    .cast(&DataType::Float64);
+                let m2 = struct_get(merged_col, VAR_PARTIAL_M2_FIELD);
 
-                // Population variance = (sqsum/n - (sum/n)^2)
-                let n = global_count_col.clone().cast(&DataType::Float64);
-                let sq_mean = global_sq_sum_col.div(n.clone());
-                let mean = global_sum_col.clone().div(n.clone());
-                let mean_sq = mean.clone().mul(mean);
-                let pop_var = sq_mean.sub(mean_sq);
-
-                // Adjust for ddof: sample_var = pop_var * n / (n - ddof)
                 let ddof_expr = lit(*ddof as f64);
-                let adjusted = pop_var.mul(n.clone()).div(n.clone().sub(ddof_expr.clone()));
-                let result = n.clone().lt_eq(ddof_expr).if_else(null_lit(), adjusted);
+                let var = m2.div(n.clone().sub(ddof_expr.clone()));
+                let result = n.clone().lt_eq(ddof_expr).if_else(null_lit(), var);
 
                 final_stage(result);
+            }
+            AggExpr::VarPartial(expr) => {
+                let partial_col = first_stage!(AggExpr::VarPartial(expr.clone()));
+                let merged_col = second_stage!(AggExpr::MergeVarPartial(partial_col));
+                final_stage(merged_col);
+            }
+            AggExpr::MergeVarPartial(expr) => {
+                let merged_col = first_stage!(AggExpr::MergeVarPartial(expr.clone()));
+                let global_merged_col = second_stage!(AggExpr::MergeVarPartial(merged_col));
+                final_stage(global_merged_col);
             }
             AggExpr::Min(expr) => {
                 let min_col = first_stage!(AggExpr::Min(expr.clone()));

--- a/src/daft-local-plan/src/agg.rs
+++ b/src/daft-local-plan/src/agg.rs
@@ -432,3 +432,60 @@ pub fn populate_aggregation_stages_bound_with_schema(
         final_exprs,
     ))
 }
+
+#[cfg(test)]
+mod tests {
+    use daft_core::{
+        prelude::{DataType, Field, Schema},
+        utils::stats::var_partial_dtype,
+    };
+    use daft_dsl::{AggExpr, expr::bound_expr::BoundAggExpr, resolved_col};
+
+    use super::populate_aggregation_stages_bound;
+
+    fn lower(agg: AggExpr, schema: &Schema) -> (Vec<BoundAggExpr>, Vec<BoundAggExpr>, usize) {
+        let bound = BoundAggExpr::try_new(agg, schema).unwrap();
+        let (first, second, finals) =
+            populate_aggregation_stages_bound(&[bound], schema, &[]).unwrap();
+        (first, second, finals.len())
+    }
+
+    #[test]
+    fn test_var_lowers_to_var_partial_stages() {
+        let schema = Schema::new(vec![Field::new("a", DataType::Float64)]);
+
+        for agg in [
+            AggExpr::Var(resolved_col("a"), 1),
+            AggExpr::Stddev(resolved_col("a"), 1),
+        ] {
+            let (first, second, num_finals) = lower(agg, &schema);
+            assert_eq!(first.len(), 1);
+            assert!(matches!(first[0].as_ref(), AggExpr::VarPartial(_)));
+            assert_eq!(second.len(), 1);
+            assert!(matches!(second[0].as_ref(), AggExpr::MergeVarPartial(_)));
+            assert_eq!(num_finals, 1);
+        }
+    }
+
+    #[test]
+    fn test_var_partial_stages_are_self_lowering() {
+        // Flotilla re-lowers the aggregations it hands to each Swordfish task, so the
+        // internal partial variants the `Var`/`Stddev` arms emit have to be lowerable
+        // themselves -- exactly like the `ApproxSketch`/`MergeSketch` pair. Without these
+        // arms a distributed var/stddev fails at plan time with a confusing schema error.
+        let value_schema = Schema::new(vec![Field::new("a", DataType::Float64)]);
+        let (first, second, num_finals) =
+            lower(AggExpr::VarPartial(resolved_col("a")), &value_schema);
+        assert!(matches!(first[0].as_ref(), AggExpr::VarPartial(_)));
+        assert!(matches!(second[0].as_ref(), AggExpr::MergeVarPartial(_)));
+        assert_eq!(num_finals, 1);
+
+        // Merging is associative, so `MergeVarPartial` lowers to itself on both stages.
+        let partial_schema = Schema::new(vec![Field::new("a", var_partial_dtype())]);
+        let (first, second, num_finals) =
+            lower(AggExpr::MergeVarPartial(resolved_col("a")), &partial_schema);
+        assert!(matches!(first[0].as_ref(), AggExpr::MergeVarPartial(_)));
+        assert!(matches!(second[0].as_ref(), AggExpr::MergeVarPartial(_)));
+        assert_eq!(num_finals, 1);
+    }
+}

--- a/src/daft-local-plan/src/agg.rs
+++ b/src/daft-local-plan/src/agg.rs
@@ -469,10 +469,8 @@ mod tests {
 
     #[test]
     fn test_var_partial_stages_are_self_lowering() {
-        // Flotilla re-lowers the aggregations it hands to each Swordfish task, so the
-        // internal partial variants the `Var`/`Stddev` arms emit have to be lowerable
-        // themselves -- exactly like the `ApproxSketch`/`MergeSketch` pair. Without these
-        // arms a distributed var/stddev fails at plan time with a confusing schema error.
+        // Flotilla re-lowers the aggs it hands to each Swordfish task, so the partial
+        // variants must be lowerable themselves, like `ApproxSketch`/`MergeSketch`.
         let value_schema = Schema::new(vec![Field::new("a", DataType::Float64)]);
         let (first, second, num_finals) =
             lower(AggExpr::VarPartial(resolved_col("a")), &value_schema);

--- a/src/daft-logical-plan/src/ops/project.rs
+++ b/src/daft-logical-plan/src/ops/project.rs
@@ -632,6 +632,14 @@ fn replace_column_with_semantic_id_aggexpr(
                 |_| e,
             )
         }
+        AggExpr::VarPartial(ref child) => {
+            replace_column_with_semantic_id(child.clone(), subexprs_to_replace, schema)
+                .map_yes_no(AggExpr::VarPartial, |_| e)
+        }
+        AggExpr::MergeVarPartial(ref child) => {
+            replace_column_with_semantic_id(child.clone(), subexprs_to_replace, schema)
+                .map_yes_no(AggExpr::MergeVarPartial, |_| e)
+        }
         AggExpr::Min(ref child) => {
             replace_column_with_semantic_id(child.clone(), subexprs_to_replace, schema)
                 .map_yes_no(AggExpr::Min, |_| e)

--- a/src/daft-recordbatch/src/lib.rs
+++ b/src/daft-recordbatch/src/lib.rs
@@ -769,6 +769,8 @@ impl RecordBatch {
             }
             AggExpr::Stddev(expr, ddof) => self.eval_agg_child(expr)?.stddev(groups, *ddof),
             AggExpr::Var(expr, ddof) => self.eval_agg_child(expr)?.var(groups, *ddof),
+            AggExpr::VarPartial(expr) => self.eval_agg_child(expr)?.var_partial(groups),
+            AggExpr::MergeVarPartial(expr) => self.eval_agg_child(expr)?.merge_var_partial(groups),
             AggExpr::Min(expr) => self.eval_agg_child(expr)?.min(groups),
             AggExpr::Max(expr) => self.eval_agg_child(expr)?.max(groups),
             AggExpr::BoolAnd(expr) => self.eval_agg_child(expr)?.bool_and(groups),

--- a/src/daft-recordbatch/src/ops/inline_agg.rs
+++ b/src/daft-recordbatch/src/ops/inline_agg.rs
@@ -862,6 +862,17 @@ fn try_create_accumulator(
 ///
 /// Uses schema-level type inference (`to_field`) instead of expression evaluation
 /// to avoid materializing computed columns just for a dtype check.
+///
+/// Note that `Var`/`Stddev` lower to a `VarPartial` first stage, which is deliberately
+/// *not* on this list, so a batch such as `agg(sum(a), var(b))` falls off the inline path
+/// entirely. `AggAccumulator`s consume rows in a single streaming `update_batch` pass,
+/// which for variance means a Welford online update -- and that is precisely the
+/// algorithm `calculate_var_partial` avoids, because its running mean stops updating once
+/// `delta / count` falls below `ulp(mean)` (see the note there). Inlining `VarPartial`
+/// would make the result depend on which path the planner picked; giving it a two-pass
+/// accumulator instead would mean reworking the accumulator contract, and `MergeVarPartial`
+/// additionally consumes and produces structs, which this module's typed dispatch does not
+/// model. Both are bigger changes than they are worth here.
 pub(super) fn can_inline_agg(to_agg: &[BoundAggExpr], source: &RecordBatch) -> bool {
     // Quick check: bail immediately if any agg type isn't supported.
     if !to_agg.iter().all(|e| {

--- a/src/daft-recordbatch/src/ops/inline_agg.rs
+++ b/src/daft-recordbatch/src/ops/inline_agg.rs
@@ -863,16 +863,9 @@ fn try_create_accumulator(
 /// Uses schema-level type inference (`to_field`) instead of expression evaluation
 /// to avoid materializing computed columns just for a dtype check.
 ///
-/// Note that `Var`/`Stddev` lower to a `VarPartial` first stage, which is deliberately
-/// *not* on this list, so a batch such as `agg(sum(a), var(b))` falls off the inline path
-/// entirely. `AggAccumulator`s consume rows in a single streaming `update_batch` pass,
-/// which for variance means a Welford online update -- and that is precisely the
-/// algorithm `calculate_var_partial` avoids, because its running mean stops updating once
-/// `delta / count` falls below `ulp(mean)` (see the note there). Inlining `VarPartial`
-/// would make the result depend on which path the planner picked; giving it a two-pass
-/// accumulator instead would mean reworking the accumulator contract, and `MergeVarPartial`
-/// additionally consumes and produces structs, which this module's typed dispatch does not
-/// model. Both are bigger changes than they are worth here.
+/// `VarPartial` (the first stage of `Var`/`Stddev`) is deliberately absent: accumulators are
+/// single-pass streaming, variance needs two passes, so inlining it would make the result
+/// depend on which path the planner picked.
 pub(super) fn can_inline_agg(to_agg: &[BoundAggExpr], source: &RecordBatch) -> bool {
     // Quick check: bail immediately if any agg type isn't supported.
     if !to_agg.iter().all(|e| {

--- a/src/daft-sql/src/modules/aggs.rs
+++ b/src/daft-sql/src/modules/aggs.rs
@@ -237,6 +237,8 @@ fn to_expr(expr: &AggExpr, args: &[ExprRef]) -> SQLPlannerResult<ExprRef> {
         AggExpr::Set(_) => unsupported_sql_err!("set"),
         AggExpr::Skew(_) => unsupported_sql_err!("skew"),
         AggExpr::AggFn { .. } => unsupported_sql_err!("agg_fn"),
+        AggExpr::VarPartial(_) => unsupported_sql_err!("var_partial"),
+        AggExpr::MergeVarPartial(_) => unsupported_sql_err!("merge_var_partial"),
         AggExpr::AggFnMap { .. } => unsupported_sql_err!("agg_fn_map"),
         AggExpr::AggFnCombine { .. } => unsupported_sql_err!("agg_fn_combine"),
         AggExpr::AggFnReduce { .. } => unsupported_sql_err!("agg_fn_reduce"),

--- a/tests/dataframe/test_stddev.py
+++ b/tests/dataframe/test_stddev.py
@@ -149,3 +149,16 @@ def test_grouped_stddev_with_multiple_partitions(nums, ddof, with_morsel_size):
         pd.Series(expected["data"]).sort_values(),
         check_index=False,
     )
+
+
+@pytest.mark.parametrize("ddof,expected", [(1, 1.0), (0, 2.0 / 3.0)])
+def test_stddev_large_mean_matches_shifted_data(ddof, expected, with_morsel_size):
+    """Regression test for https://github.com/Eventual-Inc/Daft/issues/7468."""
+    df = daft.from_pydict({"a": [1e9 + 1, 1e9 + 2, 1e9 + 3], "g": [1, 1, 1]})
+    row = next(df.select(daft.col("a").stddev(ddof=ddof)).collect().iter_rows())
+    assert abs(row["a"] - math.sqrt(expected)) < 1e-12
+
+    grouped = next(
+        df.groupby("g").agg(daft.col("a").stddev(ddof=ddof)).collect().iter_rows()
+    )
+    assert abs(grouped["a"] - math.sqrt(expected)) < 1e-12

--- a/tests/dataframe/test_stddev.py
+++ b/tests/dataframe/test_stddev.py
@@ -158,7 +158,5 @@ def test_stddev_large_mean_matches_shifted_data(ddof, expected, with_morsel_size
     row = next(df.select(daft.col("a").stddev(ddof=ddof)).collect().iter_rows())
     assert abs(row["a"] - math.sqrt(expected)) < 1e-12
 
-    grouped = next(
-        df.groupby("g").agg(daft.col("a").stddev(ddof=ddof)).collect().iter_rows()
-    )
+    grouped = next(df.groupby("g").agg(daft.col("a").stddev(ddof=ddof)).collect().iter_rows())
     assert abs(grouped["a"] - math.sqrt(expected)) < 1e-12

--- a/tests/dataframe/test_stddev.py
+++ b/tests/dataframe/test_stddev.py
@@ -48,6 +48,9 @@ TESTS = [
     [100, 100, 100],
     [None, 100, None],
     [None] * 10 + [100],
+    # Large mean, tiny spread: E(x^2) - E(x)^2 collapses to 0 here (see #7468).
+    [1e9 + 1, 1e9 + 2, 1e9 + 3],
+    [1e12, 1e12 + 1, 1e12 + 2],
 ]
 
 
@@ -91,6 +94,8 @@ GROUPED_TESTS = [
     [("k0", 100), ("k0", 100), ("k0", 100)],
     [("k0", 0), ("k0", 1), ("k0", 2)],
     [("k0", None), ("k0", None), ("k0", 100)],
+    # Large mean, plus a single-row group that must stay NULL at ddof=1 (see #7468).
+    [("k0", 1e9 + 1), ("k0", 1e9 + 2), ("k1", 1e9 + 3)],
 ]
 
 

--- a/tests/dataframe/test_variance.py
+++ b/tests/dataframe/test_variance.py
@@ -243,3 +243,34 @@ def test_var_stddev_relationship(with_morsel_size):
     ).collect()
     row = next(result.iter_rows())
     assert abs(row["var"] - row["stddev"] ** 2) < 1e-10
+
+
+def test_var_large_mean_matches_shifted_data(with_morsel_size):
+    """Regression test for https://github.com/Eventual-Inc/Daft/issues/7468.
+
+    The old `E(x^2) - E(x)^2` rewrite collapsed to 0.0 for data with a large
+    mean; the Chan parallel merge must match the shifted (small-mean) result.
+    """
+    data = [1e9 + 1, 1e9 + 2, 1e9 + 3]
+    for ddof, expected in [(1, 1.0), (0, 2.0 / 3.0)]:
+        df = daft.from_pydict({"a": data, "g": [1, 1, 1]})
+        row = next(
+            df.select(
+                daft.col("a").var(ddof=ddof).alias("var"),
+                daft.col("a").stddev(ddof=ddof).alias("std"),
+            ).collect().iter_rows()
+        )
+        assert row["var"] == expected
+        assert abs(row["std"] - expected**0.5) < 1e-12
+
+        grouped = next(
+            df.groupby("g")
+            .agg(
+                daft.col("a").var(ddof=ddof).alias("var"),
+                daft.col("a").stddev(ddof=ddof).alias("std"),
+            )
+            .collect()
+            .iter_rows()
+        )
+        assert grouped["var"] == expected
+        assert abs(grouped["std"] - expected**0.5) < 1e-12

--- a/tests/dataframe/test_variance.py
+++ b/tests/dataframe/test_variance.py
@@ -288,16 +288,9 @@ def test_var_large_mean_matches_shifted_data(with_morsel_size):
 def test_var_large_mean_large_partition(base, with_default_morsel_size):
     """Large mean *and* a large partition (see #7468).
 
-    Every other large-mean test here uses three values, so whatever the morsel
-    size, the per-partition summary is computed over a handful of rows and only
-    the cross-partition merge is really exercised. With the default morsel size
-    these 20k rows land in a single partial aggregate, so this is the only test
-    that exercises the per-partition variance kernel at scale -- which is where
-    `E(x^2) - E(x)^2`, a mean reconstructed from a naive sum, and a Welford
-    running mean each lose the rest of their accuracy.
-
-    `statistics.variance` is the reference because it is computed in exact
-    rational arithmetic, unlike the float `var()` helper above.
+    The other large-mean tests use three values, so they only exercise the merge; these
+    20k rows land in one partial aggregate. `statistics.variance` is the reference
+    because it is exact, unlike the float `var()` helper above.
     """
     n = 20_000
     data = [base + ((i * 7919) % 1000) / 1000.0 for i in range(n)]

--- a/tests/dataframe/test_variance.py
+++ b/tests/dataframe/test_variance.py
@@ -258,7 +258,9 @@ def test_var_large_mean_matches_shifted_data(with_morsel_size):
             df.select(
                 daft.col("a").var(ddof=ddof).alias("var"),
                 daft.col("a").stddev(ddof=ddof).alias("std"),
-            ).collect().iter_rows()
+            )
+            .collect()
+            .iter_rows()
         )
         assert row["var"] == expected
         assert abs(row["std"] - expected**0.5) < 1e-12

--- a/tests/dataframe/test_variance.py
+++ b/tests/dataframe/test_variance.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import functools
+import statistics
 from typing import Any
 
 import pandas as pd
@@ -44,6 +45,9 @@ TESTS = [
     [nums := [None, 100, None], var(nums, ddof=0), var(nums, ddof=1)],
     [nums := [1, 2, 3, 4, 5], var(nums, ddof=0), var(nums, ddof=1)],
     [nums := [None] * 10 + [100], var(nums, ddof=0), var(nums, ddof=1)],
+    # Large mean, tiny spread: E(x^2) - E(x)^2 collapses to 0 here (see #7468).
+    [nums := [1e9 + 1, 1e9 + 2, 1e9 + 3], var(nums, ddof=0), var(nums, ddof=1)],
+    [nums := [1e12, 1e12 + 1, 1e12 + 2], var(nums, ddof=0), var(nums, ddof=1)],
 ]
 
 
@@ -176,6 +180,8 @@ GROUPED_TESTS = [
     [rows := [("k0", 100), ("k0", 100), ("k0", 100)], *grouped_var(rows)],
     [rows := [("k0", 0), ("k0", 1), ("k0", 2)], *grouped_var(rows)],
     [rows := [("k0", None), ("k0", None), ("k0", 100)], *grouped_var(rows)],
+    # Large mean, plus a single-row group that must stay NULL at ddof=1 (see #7468).
+    [rows := [("k0", 1e9 + 1), ("k0", 1e9 + 2), ("k1", 1e9 + 3)], *grouped_var(rows)],
 ]
 
 
@@ -276,3 +282,32 @@ def test_var_large_mean_matches_shifted_data(with_morsel_size):
         )
         assert grouped["var"] == expected
         assert abs(grouped["std"] - expected**0.5) < 1e-12
+
+
+@pytest.mark.parametrize("base", [1e9, 1e12, 1e15])
+def test_var_large_mean_large_partition(base, with_default_morsel_size):
+    """Large mean *and* a large partition (see #7468).
+
+    Every other large-mean test here uses three values, so whatever the morsel
+    size, the per-partition summary is computed over a handful of rows and only
+    the cross-partition merge is really exercised. With the default morsel size
+    these 20k rows land in a single partial aggregate, so this is the only test
+    that exercises the per-partition variance kernel at scale -- which is where
+    `E(x^2) - E(x)^2`, a mean reconstructed from a naive sum, and a Welford
+    running mean each lose the rest of their accuracy.
+
+    `statistics.variance` is the reference because it is computed in exact
+    rational arithmetic, unlike the float `var()` helper above.
+    """
+    n = 20_000
+    data = [base + ((i * 7919) % 1000) / 1000.0 for i in range(n)]
+    expected = statistics.variance(data)
+
+    df = daft.from_pydict({"a": data, "g": [1] * n})
+
+    row = next(df.agg(daft.col("a").var().alias("var"), daft.col("a").stddev().alias("std")).collect().iter_rows())
+    assert row["var"] == pytest.approx(expected, rel=1e-9)
+    assert row["std"] == pytest.approx(expected**0.5, rel=1e-9)
+
+    grouped = next(df.groupby("g").agg(daft.col("a").var().alias("var")).collect().iter_rows())
+    assert grouped["var"] == pytest.approx(expected, rel=1e-9)


### PR DESCRIPTION
## Changes Made

Replace the E(x²) − E(x)² two-stage rewrite for var/stddev with per-partition `(count, mean, M2)` summaries merged by the Chan et al. parallel update. Adds internal `AggExpr::VarPartial` / `MergeVarPartial` struct state and finalizes `m2 / (n - ddof)`.

The per-partition summary is computed with the **corrected two-pass** algorithm (Chan et al. eq. 1.7): starting from the provisional mean `mean0 = sum / count`, it accumulates `s1 = Σ(x − mean0)` and `s2 = Σ(x − mean0)²`, then reports `mean = mean0 + s1/n` and `m2 = s2 − s1²/n`. The `s1` correction is what keeps this accurate for large-magnitude data:

- a plain two-pass `Σ(x − mean0)²` inherits the error in `mean0` from the summation kernel as a spurious `n · error²` term, which matters because the grouped path sums with a sequential fold;
- a Welford update (`mean += delta / count`) stops moving the mean entirely once `delta / count` drops below `ulp(mean)` — at ~1e15 with a spread of ~1 the running mean freezes near its first few values and the result is off by tens of percent.

`calculate_variance` (which backs `Series.var()` / `Series.stddev()` and the window path) now routes through the same kernel, so the single-array API and `df.agg(col(..).var())` cannot diverge numerically.

## Notes for reviewers

**`can_inline_agg` interaction.** `Var`/`Stddev` previously lowered to `Sum`/`Sum`/`Count`, all of which are on the inline fast path in `daft-recordbatch/src/ops/inline_agg.rs`. They now lower to a `VarPartial` first stage, which is not, so a batch such as `agg(sum(a), var(b))` falls off the inline path for *every* agg in the batch. This is deliberate and documented at `can_inline_agg`: `AggAccumulator`s consume rows in a single streaming `update_batch` pass, which for variance means a Welford online update — exactly the algorithm this PR avoids. Inlining `VarPartial` would make the result depend on which path the planner picked; giving it a two-pass accumulator instead would mean reworking the accumulator contract, and `MergeVarPartial` additionally consumes and produces structs, which that module's typed dispatch does not model. Both are bigger changes than belong here.

**Follow-up: `AggExpr::Skew`.** The `Skew` arm in `daft-local-plan/src/agg.rs` still computes `S2 − S²/N` and has exactly the same catastrophic cancellation for large-mean data. It is left alone here to keep this change focused, but it wants the same treatment (per-partition central moments plus a stable merge).

## Related Issues

Closes #7468
