### PR TITLE
fix(expression): to_datetime handles date-only formats and rejects trailing input

### DIFF
--- a/daft/functions/datetime.py
+++ b/daft/functions/datetime.py
@@ -1098,6 +1098,23 @@ def to_datetime(expr: Expression, format: str, timezone: str | None = None) -> E
     Note:
         The format must be a valid datetime format string. See: https://docs.rs/chrono/latest/chrono/format/strftime/index.html
 
+    Note:
+        Parsing is strict: the format must consume the whole string. A value with trailing text the
+        format does not describe (for example ``"2021-01-01 00:00:00.123"`` under
+        ``"%Y-%m-%d %H:%M:%S"``) raises rather than silently dropping the extra characters.
+
+    Note:
+        A format with no time-of-day fields (for example ``"%Y-%m-%d"``) resolves to midnight on
+        that date, matching DuckDB ``strptime``, Polars and Spark. A partially specified time (for
+        example ``"%Y-%m-%d %H"``) is an error rather than midnight.
+
+    Note:
+        If the format has an offset directive, the offset in the value determines the instant and
+        the result is returned in UTC unless ``timezone`` says otherwise. If the format has no
+        offset directive and ``timezone`` is given, values are read as local times in that
+        timezone; a local time that a daylight-saving transition makes ambiguous or nonexistent
+        raises.
+
     Examples:
         >>> import daft
         >>> from daft.functions import to_datetime

--- a/daft/functions/datetime.py
+++ b/daft/functions/datetime.py
@@ -1099,21 +1099,10 @@ def to_datetime(expr: Expression, format: str, timezone: str | None = None) -> E
         The format must be a valid datetime format string. See: https://docs.rs/chrono/latest/chrono/format/strftime/index.html
 
     Note:
-        Parsing is strict: the format must consume the whole string. A value with trailing text the
-        format does not describe (for example ``"2021-01-01 00:00:00.123"`` under
-        ``"%Y-%m-%d %H:%M:%S"``) raises rather than silently dropping the extra characters.
-
-    Note:
-        A format with no time-of-day fields (for example ``"%Y-%m-%d"``) resolves to midnight on
-        that date, matching DuckDB ``strptime``, Polars and Spark. A partially specified time (for
-        example ``"%Y-%m-%d %H"``) is an error rather than midnight.
-
-    Note:
-        If the format has an offset directive, the offset in the value determines the instant and
-        the result is returned in UTC unless ``timezone`` says otherwise. If the format has no
-        offset directive and ``timezone`` is given, values are read as local times in that
-        timezone; a local time that a daylight-saving transition makes ambiguous or nonexistent
-        raises.
+        Parsing is strict: trailing text the format does not describe raises. A format without
+        time-of-day fields resolves to midnight, but a partial time such as ``"%Y-%m-%d %H"`` is an
+        error. An offset directive determines the instant, otherwise ``timezone`` is the zone the
+        value is read in.
 
     Examples:
         >>> import daft

--- a/src/daft-core/src/datatypes/mod.rs
+++ b/src/daft-core/src/datatypes/mod.rs
@@ -22,7 +22,10 @@ pub use daft_schema::{
     field::{Field, FieldID, FieldRef},
     image_format::ImageFormat,
     image_mode::ImageMode,
-    time_unit::{TimeUnit, format_string_has_offset, infer_timeunit_from_format_string},
+    time_unit::{
+        TimeUnit, format_string_has_offset, format_string_has_time,
+        infer_timeunit_from_format_string,
+    },
 };
 pub use infer_datatype::try_physical_supertype;
 use num_traits::{Bounded, Float, FromPrimitive, Num, NumCast, ToPrimitive, Zero};

--- a/src/daft-functions-utf8/src/to_datetime.rs
+++ b/src/daft-functions-utf8/src/to_datetime.rs
@@ -120,22 +120,12 @@ fn timestamp_from_datetime<Tz: TimeZone>(
     }
 }
 
-/// Parses a single value into an epoch offset expressed in `timeunit`.
+/// Parses one value into an epoch offset in `timeunit`.
 ///
-/// The parse is strict, mirroring `to_date`: input that the format does not consume is rejected
-/// rather than silently dropped, unlike chrono's `parse_and_remainder`.
-///
-/// A format with no time-of-day field at all (e.g. `%Y-%m-%d`) resolves to midnight on that date,
-/// matching DuckDB `strptime`, Polars and Spark. Whether that fallback applies is decided from the
-/// format alone (`has_time`), never from the parsed row, so every value in a column is parsed the
-/// same way. A partially specified time (e.g. `%Y-%m-%d %H`) therefore stays an error instead of
-/// silently discarding the hour and reporting midnight.
-///
-/// The instant is then resolved in one of three ways:
-/// - the format carries an offset directive: the offset in the input defines the instant, and
-///   `timezone` only controls how that instant is displayed;
-/// - the format is naive and a `timezone` was requested: the value is a local time in that zone;
-/// - otherwise the value is read as UTC.
+/// Strict, like `to_date`: input the format does not consume is an error. A format with no
+/// time-of-day field resolves to midnight, matching DuckDB, Polars and Spark; `has_time` comes from
+/// the format alone, so a partial time like `%Y-%m-%d %H` errors rather than dropping the hour.
+/// An offset directive in the format defines the instant, otherwise `timezone` localizes the value.
 fn parse_to_timestamp(
     val: &str,
     format: &str,
@@ -151,12 +141,11 @@ fn parse_to_timestamp(
     };
 
     let mut parsed = Parsed::new();
-    // Unlike `parse_and_remainder`, `chrono::format::parse` errors when trailing input remains.
+    // `chrono::format::parse` errors on trailing input; `parse_and_remainder` drops it.
     chrono::format::parse(&mut parsed, val, StrftimeItems::new(format)).map_err(fail)?;
 
     let naive = if has_time {
-        // Resolving against the parsed offset mirrors `Parsed::to_datetime`, which matters only
-        // when the value is a Unix timestamp (`%s`) that also carries an offset.
+        // Mirrors `Parsed::to_datetime`; the offset only matters for `%s`.
         parsed
             .to_naive_datetime_with_offset(parsed.offset().unwrap_or(0))
             .map_err(fail)?
@@ -169,8 +158,7 @@ fn parse_to_timestamp(
     };
 
     if has_offset {
-        // The input must actually supply an offset. `%Z` only skips a zone name without yielding
-        // one, so it fails here rather than silently assuming some zone.
+        // `%Z` skips a zone name without yielding an offset, so it is rejected here.
         let offset = parsed.to_fixed_offset().map_err(fail)?;
         let datetime = offset
             .from_local_datetime(&naive)
@@ -178,8 +166,7 @@ fn parse_to_timestamp(
             .expect("a fixed offset maps every local datetime to exactly one instant");
         timestamp_from_datetime(datetime, timeunit, val)
     } else if let Some(tz) = timezone.filter(|_| parsed.timestamp().is_none()) {
-        // A naive value with an explicit timezone is a local time in that zone. `%s` is excluded:
-        // it already names an absolute instant and must not be re-read as a local time.
+        // `%s` names an absolute instant, so it is never re-read as a local time.
         match tz.from_local_datetime(&naive) {
             LocalResult::Single(datetime) => timestamp_from_datetime(datetime, timeunit, val),
             LocalResult::Ambiguous(_, _) => Err(DaftError::ComputeError(format!(
@@ -204,15 +191,13 @@ fn to_datetime_impl(
     let timeunit = infer_timeunit_from_format_string(format);
     let has_time = format_string_has_time(format);
     let has_offset = format_string_has_offset(format);
-    // If the input carries an offset, we coerce it to UTC. This is consistent with other engines (duckdb, polars, datafusion).
-    // Decided from the format alone, and once rather than per row, so an all-null column still
-    // reports UTC and matches `get_return_field`.
+    // An offset is coerced to UTC, consistent with other engines (duckdb, polars, datafusion).
+    // Decided from the format alone so an all-null column still matches `get_return_field`.
     let timezone = match timezone {
         Some(tz) => Some(tz.to_string()),
         None if has_offset => Some("UTC".to_string()),
         None => None,
     };
-    // Resolved once instead of once per row.
     let tz = timezone
         .as_deref()
         .map(|tz| {
@@ -244,7 +229,7 @@ mod tests {
     use super::*;
 
     const MICROS_PER_DAY: i64 = 86_400_000_000;
-    // 05:30 expressed in microseconds, the offset of Asia/Kolkata.
+    // Asia/Kolkata is UTC+05:30.
     const IST_OFFSET_MICROS: i64 = (5 * 3_600 + 30 * 60) * 1_000_000;
 
     fn utf8(values: Vec<Option<&str>>) -> Utf8Array {
@@ -265,7 +250,7 @@ mod tests {
 
     #[test]
     fn test_date_only_format_with_offset_coerces_to_utc() {
-        // Midnight at +05:30 is 18:30 UTC on the previous day.
+        // Midnight at +05:30 is 18:30 UTC the previous day.
         let arr = utf8(vec![Some("1970-01-02 +0530")]);
         let result = to_datetime_impl(&arr, "%Y-%m-%d %z", None).unwrap();
         assert_eq!(result.get(0), Some(MICROS_PER_DAY - IST_OFFSET_MICROS));
@@ -277,7 +262,6 @@ mod tests {
 
     #[test]
     fn test_date_only_format_localizes_into_timezone() {
-        // Midnight in Asia/Kolkata is 18:30 UTC on the previous day.
         let arr = utf8(vec![Some("1970-01-02")]);
         let result = to_datetime_impl(&arr, "%Y-%m-%d", Some("Asia/Kolkata")).unwrap();
         assert_eq!(result.get(0), Some(MICROS_PER_DAY - IST_OFFSET_MICROS));
@@ -285,7 +269,7 @@ mod tests {
 
     #[test]
     fn test_nonexistent_midnight_is_rejected() {
-        // Cuba starts DST at 00:00 -> 01:00, so this midnight never happens locally.
+        // Cuba starts DST at 00:00 -> 01:00, so this midnight never happens.
         let arr = utf8(vec![Some("2018-03-11")]);
         let err = to_datetime_impl(&arr, "%Y-%m-%d", Some("America/Havana")).unwrap_err();
         assert!(
@@ -296,7 +280,7 @@ mod tests {
 
     #[test]
     fn test_ambiguous_midnight_is_rejected() {
-        // Cuba ends DST at 01:00 -> 00:00, so this midnight happens twice locally.
+        // Cuba ends DST at 01:00 -> 00:00, so this midnight happens twice.
         let arr = utf8(vec![Some("2018-11-04")]);
         let err = to_datetime_impl(&arr, "%Y-%m-%d", Some("America/Havana")).unwrap_err();
         assert!(
@@ -307,8 +291,6 @@ mod tests {
 
     #[test]
     fn test_naive_datetime_localizes_into_timezone() {
-        // A format with no offset directive is a local time in the requested timezone, rather
-        // than requiring the value to carry an offset of its own.
         let arr = utf8(vec![Some("1970-01-02 00:00:00")]);
         let result = to_datetime_impl(&arr, "%Y-%m-%d %H:%M:%S", Some("Asia/Kolkata")).unwrap();
         assert_eq!(result.get(0), Some(MICROS_PER_DAY - IST_OFFSET_MICROS));
@@ -320,7 +302,6 @@ mod tests {
 
     #[test]
     fn test_offset_in_input_wins_over_timezone_argument() {
-        // With an offset directive the input defines the instant; the timezone only displays it.
         let arr = utf8(vec![Some("1970-01-02 00:00:00 +0000")]);
         let result = to_datetime_impl(&arr, "%Y-%m-%d %H:%M:%S %z", Some("Asia/Kolkata")).unwrap();
         assert_eq!(result.get(0), Some(MICROS_PER_DAY));
@@ -328,7 +309,7 @@ mod tests {
 
     #[test]
     fn test_unix_timestamp_is_not_localized() {
-        // `%s` already names an absolute instant, so an explicit timezone must not shift it.
+        // `%s` is an absolute instant; the timezone must not shift it.
         let arr = utf8(vec![Some("86400")]);
         let naive = to_datetime_impl(&arr, "%s", None).unwrap();
         let localized = to_datetime_impl(&arr, "%s", Some("Asia/Kolkata")).unwrap();
@@ -338,8 +319,7 @@ mod tests {
 
     #[test]
     fn test_all_null_with_offset_format_still_reports_utc() {
-        // Regression guard for the get_return_field / runtime dtype mismatch: the output timezone
-        // comes from the format, so it must not depend on a row carrying an offset.
+        // The output timezone comes from the format, not from a row carrying an offset.
         let arr = utf8(vec![None, None]);
         let result = to_datetime_impl(&arr, "%Y-%m-%d %H:%M:%S %z", None).unwrap();
         assert_eq!(result.get(0), None);
@@ -358,7 +338,6 @@ mod tests {
 
     #[test]
     fn test_partial_time_is_rejected() {
-        // The hour must not be silently dropped in favour of midnight.
         let arr = utf8(vec![Some("2020-01-01 12")]);
         let err = to_datetime_impl(&arr, "%Y-%m-%d %H", None).unwrap_err();
         assert!(err.to_string().contains("not enough"), "{err}");
@@ -366,7 +345,7 @@ mod tests {
 
     #[test]
     fn test_escaped_percent_is_not_an_offset() {
-        // `%%z` is a literal "%z" in the input, so the result stays naive.
+        // `%%z` matches a literal "%z", so the result stays naive.
         let arr = utf8(vec![Some("1970-01-02 %z")]);
         let result = to_datetime_impl(&arr, "%Y-%m-%d %%z", None).unwrap();
         assert_eq!(result.get(0), Some(MICROS_PER_DAY));
@@ -378,8 +357,7 @@ mod tests {
 
     #[test]
     fn test_zone_name_without_offset_is_rejected() {
-        // chrono skips `%Z` without deriving an offset from it, so the value is refused rather
-        // than silently assumed to be in some particular zone.
+        // chrono skips `%Z` without deriving an offset from it.
         let arr = utf8(vec![Some("2020-01-01 00:00:00 UTC")]);
         assert!(to_datetime_impl(&arr, "%Y-%m-%d %H:%M:%S %Z", None).is_err());
     }

--- a/src/daft-functions-utf8/src/to_datetime.rs
+++ b/src/daft-functions-utf8/src/to_datetime.rs
@@ -120,85 +120,77 @@ fn timestamp_from_datetime<Tz: TimeZone>(
     }
 }
 
-fn timestamp_from_naive_datetime(
-    naive: chrono::NaiveDateTime,
-    timeunit: TimeUnit,
-    val: &str,
-) -> DaftResult<i64> {
-    timestamp_from_datetime(naive.and_utc(), timeunit, val)
-}
-
-/// Parses a date-only value (a format without time fields) as midnight.
+/// Parses a single value into an epoch offset expressed in `timeunit`.
 ///
-/// Uses a strict parse so trailing input is rejected, matching `to_date` and other engines.
-/// An offset embedded in the input (e.g. `%z`) is preserved: midnight is resolved with that
-/// offset before coercing to UTC or the explicit timezone.
-fn parse_date_only_to_timestamp(
+/// The parse is strict, mirroring `to_date`: input that the format does not consume is rejected
+/// rather than silently dropped, unlike chrono's `parse_and_remainder`.
+///
+/// A format with no time-of-day field at all (e.g. `%Y-%m-%d`) resolves to midnight on that date,
+/// matching DuckDB `strptime`, Polars and Spark. Whether that fallback applies is decided from the
+/// format alone (`has_time`), never from the parsed row, so every value in a column is parsed the
+/// same way. A partially specified time (e.g. `%Y-%m-%d %H`) therefore stays an error instead of
+/// silently discarding the hour and reporting midnight.
+///
+/// The instant is then resolved in one of three ways:
+/// - the format carries an offset directive: the offset in the input defines the instant, and
+///   `timezone` only controls how that instant is displayed;
+/// - the format is naive and a `timezone` was requested: the value is a local time in that zone;
+/// - otherwise the value is read as UTC.
+fn parse_to_timestamp(
     val: &str,
     format: &str,
-    timezone: Option<&str>,
+    has_time: bool,
+    has_offset: bool,
+    timezone: Option<chrono_tz::Tz>,
     timeunit: TimeUnit,
 ) -> DaftResult<i64> {
+    let fail = |e: chrono::format::ParseError| {
+        DaftError::ComputeError(format!(
+            "Error in to_datetime: failed to parse datetime {val} with format {format} : {e}"
+        ))
+    };
+
     let mut parsed = Parsed::new();
-    chrono::format::parse(&mut parsed, val, StrftimeItems::new(format)).map_err(|e| {
-        DaftError::ComputeError(format!(
-            "Error in to_datetime: failed to parse datetime {val} with format {format} : {e}"
-        ))
-    })?;
-    let date = parsed.to_naive_date().map_err(|e| {
-        DaftError::ComputeError(format!(
-            "Error in to_datetime: failed to parse datetime {val} with format {format} : {e}"
-        ))
-    })?;
-    let midnight = date
-        .and_hms_opt(0, 0, 0)
-        .expect("midnight is always a valid time");
+    // Unlike `parse_and_remainder`, `chrono::format::parse` errors when trailing input remains.
+    chrono::format::parse(&mut parsed, val, StrftimeItems::new(format)).map_err(fail)?;
 
-    let input_offset = parsed.to_fixed_offset().ok();
+    let naive = if has_time {
+        // Resolving against the parsed offset mirrors `Parsed::to_datetime`, which matters only
+        // when the value is a Unix timestamp (`%s`) that also carries an offset.
+        parsed
+            .to_naive_datetime_with_offset(parsed.offset().unwrap_or(0))
+            .map_err(fail)?
+    } else {
+        parsed
+            .to_naive_date()
+            .map_err(fail)?
+            .and_hms_opt(0, 0, 0)
+            .expect("midnight is always a valid time")
+    };
 
-    match (input_offset, timezone) {
-        (Some(offset), Some(tz_str)) => {
-            let tz = tz_str.parse::<chrono_tz::Tz>().map_err(|e| {
-                DaftError::ComputeError(format!(
-                    "Error in to_datetime: failed to parse timezone {tz_str} : {e}"
-                ))
-            })?;
-            let dt_fixed = offset.from_local_datetime(&midnight).single().ok_or_else(|| {
-                DaftError::ComputeError(format!(
-                    "Error in to_datetime: failed to resolve midnight {midnight} with offset {offset} for {val}"
-                ))
-            })?;
-            timestamp_from_datetime(dt_fixed.with_timezone(&tz), timeunit, val)
+    if has_offset {
+        // The input must actually supply an offset. `%Z` only skips a zone name without yielding
+        // one, so it fails here rather than silently assuming some zone.
+        let offset = parsed.to_fixed_offset().map_err(fail)?;
+        let datetime = offset
+            .from_local_datetime(&naive)
+            .single()
+            .expect("a fixed offset maps every local datetime to exactly one instant");
+        timestamp_from_datetime(datetime, timeunit, val)
+    } else if let Some(tz) = timezone.filter(|_| parsed.timestamp().is_none()) {
+        // A naive value with an explicit timezone is a local time in that zone. `%s` is excluded:
+        // it already names an absolute instant and must not be re-read as a local time.
+        match tz.from_local_datetime(&naive) {
+            LocalResult::Single(datetime) => timestamp_from_datetime(datetime, timeunit, val),
+            LocalResult::Ambiguous(_, _) => Err(DaftError::ComputeError(format!(
+                "Error in to_datetime: ambiguous local datetime {naive} in timezone {tz} for {val}"
+            ))),
+            LocalResult::None => Err(DaftError::ComputeError(format!(
+                "Error in to_datetime: nonexistent local datetime {naive} in timezone {tz} for {val}"
+            ))),
         }
-        (Some(offset), None) => {
-            let dt_utc = offset
-                .from_local_datetime(&midnight)
-                .single()
-                .ok_or_else(|| {
-                    DaftError::ComputeError(format!(
-                        "Error in to_datetime: failed to resolve midnight {midnight} with offset {offset} for {val}"
-                    ))
-                })?
-                .with_timezone(&chrono::Utc);
-            timestamp_from_datetime(dt_utc, timeunit, val)
-        }
-        (None, Some(tz_str)) => {
-            let tz = tz_str.parse::<chrono_tz::Tz>().map_err(|e| {
-                DaftError::ComputeError(format!(
-                    "Error in to_datetime: failed to parse timezone {tz_str} : {e}"
-                ))
-            })?;
-            match tz.from_local_datetime(&midnight) {
-                LocalResult::Single(dt) => timestamp_from_datetime(dt, timeunit, val),
-                LocalResult::Ambiguous(_, _) => Err(DaftError::ComputeError(format!(
-                    "Error in to_datetime: ambiguous local datetime {midnight} in timezone {tz_str} for {val}"
-                ))),
-                LocalResult::None => Err(DaftError::ComputeError(format!(
-                    "Error in to_datetime: nonexistent local datetime {midnight} in timezone {tz_str} for {val}"
-                ))),
-            }
-        }
-        (None, None) => timestamp_from_naive_datetime(midnight, timeunit, val),
+    } else {
+        timestamp_from_datetime(naive.and_utc(), timeunit, val)
     }
 }
 
@@ -213,57 +205,31 @@ fn to_datetime_impl(
     let has_time = format_string_has_time(format);
     let has_offset = format_string_has_offset(format);
     // If the input carries an offset, we coerce it to UTC. This is consistent with other engines (duckdb, polars, datafusion).
-    // Resolved once so all-null inputs still report UTC, matching `get_return_field`.
+    // Decided from the format alone, and once rather than per row, so an all-null column still
+    // reports UTC and matches `get_return_field`.
     let timezone = match timezone {
         Some(tz) => Some(tz.to_string()),
         None if has_offset => Some("UTC".to_string()),
         None => None,
     };
-    let result = arr_iter
-            .map(|val| match val {
-                Some(val) => {
-                    let timestamp = match timezone.as_deref() {
-                        Some(tz) => {
-                            if has_time {
-                                // Strict parse: trailing input is an error (unlike `parse_and_remainder`).
-                                let datetime = chrono::DateTime::parse_from_str(val, format).map_err(|e| {
-                                    DaftError::ComputeError(format!(
-                                        "Error in to_datetime: failed to parse datetime {val} with format {format} : {e}"
-                                    ))
-                                })?;
-                                let datetime_with_timezone = datetime.with_timezone(&tz.parse::<chrono_tz::Tz>().map_err(|e| {
-                                    DaftError::ComputeError(format!(
-                                        "Error in to_datetime: failed to parse timezone {tz} : {e}"
-                                    ))
-                                })?);
-                                timestamp_from_datetime(datetime_with_timezone, timeunit, val)?
-                            } else {
-                                // A format without time fields resolves to midnight,
-                                // matching DuckDB `strptime`, Polars and Spark.
-                                parse_date_only_to_timestamp(val, format, Some(tz), timeunit)?
-                            }
-                        }
-                        None => {
-                            if has_time {
-                                // Strict parse: trailing input is an error (unlike `parse_and_remainder`).
-                                let naive_datetime = chrono::NaiveDateTime::parse_from_str(val, format).map_err(|e| {
-                                    DaftError::ComputeError(format!(
-                                        "Error in to_datetime: failed to parse datetime {val} with format {format} : {e}"
-                                    ))
-                                })?;
-                                timestamp_from_naive_datetime(naive_datetime, timeunit, val)?
-                            } else {
-                                // A format without time fields resolves to midnight,
-                                // matching DuckDB `strptime`, Polars and Spark.
-                                parse_date_only_to_timestamp(val, format, None, timeunit)?
-                            }
-                        }
-                    };
-                    Ok(Some(timestamp))
-                }
-                _ => Ok(None),
+    // Resolved once instead of once per row.
+    let tz = timezone
+        .as_deref()
+        .map(|tz| {
+            tz.parse::<chrono_tz::Tz>().map_err(|e| {
+                DaftError::ComputeError(format!(
+                    "Error in to_datetime: failed to parse timezone {tz} : {e}"
+                ))
             })
-            .collect::<DaftResult<Int64Array>>()?;
+        })
+        .transpose()?;
+
+    let result = arr_iter
+        .map(|val| {
+            val.map(|val| parse_to_timestamp(val, format, has_time, has_offset, tz, timeunit))
+                .transpose()
+        })
+        .collect::<DaftResult<Int64Array>>()?;
 
     let result = TimestampArray::new(
         Field::new(arr.name(), DataType::Timestamp(timeunit, timezone)),
@@ -271,4 +237,160 @@ fn to_datetime_impl(
     );
     assert_eq!(result.len(), len);
     Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MICROS_PER_DAY: i64 = 86_400_000_000;
+    // 05:30 expressed in microseconds, the offset of Asia/Kolkata.
+    const IST_OFFSET_MICROS: i64 = (5 * 3_600 + 30 * 60) * 1_000_000;
+
+    fn utf8(values: Vec<Option<&str>>) -> Utf8Array {
+        Utf8Array::from_iter("s", values)
+    }
+
+    #[test]
+    fn test_date_only_format_resolves_to_midnight() {
+        let arr = utf8(vec![Some("1970-01-02"), None]);
+        let result = to_datetime_impl(&arr, "%Y-%m-%d", None).unwrap();
+        assert_eq!(result.get(0), Some(MICROS_PER_DAY));
+        assert_eq!(result.get(1), None);
+        assert_eq!(
+            result.data_type(),
+            &DataType::Timestamp(TimeUnit::Microseconds, None)
+        );
+    }
+
+    #[test]
+    fn test_date_only_format_with_offset_coerces_to_utc() {
+        // Midnight at +05:30 is 18:30 UTC on the previous day.
+        let arr = utf8(vec![Some("1970-01-02 +0530")]);
+        let result = to_datetime_impl(&arr, "%Y-%m-%d %z", None).unwrap();
+        assert_eq!(result.get(0), Some(MICROS_PER_DAY - IST_OFFSET_MICROS));
+        assert_eq!(
+            result.data_type(),
+            &DataType::Timestamp(TimeUnit::Microseconds, Some("UTC".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_date_only_format_localizes_into_timezone() {
+        // Midnight in Asia/Kolkata is 18:30 UTC on the previous day.
+        let arr = utf8(vec![Some("1970-01-02")]);
+        let result = to_datetime_impl(&arr, "%Y-%m-%d", Some("Asia/Kolkata")).unwrap();
+        assert_eq!(result.get(0), Some(MICROS_PER_DAY - IST_OFFSET_MICROS));
+    }
+
+    #[test]
+    fn test_nonexistent_midnight_is_rejected() {
+        // Cuba starts DST at 00:00 -> 01:00, so this midnight never happens locally.
+        let arr = utf8(vec![Some("2018-03-11")]);
+        let err = to_datetime_impl(&arr, "%Y-%m-%d", Some("America/Havana")).unwrap_err();
+        assert!(
+            err.to_string().contains("nonexistent local datetime"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn test_ambiguous_midnight_is_rejected() {
+        // Cuba ends DST at 01:00 -> 00:00, so this midnight happens twice locally.
+        let arr = utf8(vec![Some("2018-11-04")]);
+        let err = to_datetime_impl(&arr, "%Y-%m-%d", Some("America/Havana")).unwrap_err();
+        assert!(
+            err.to_string().contains("ambiguous local datetime"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn test_naive_datetime_localizes_into_timezone() {
+        // A format with no offset directive is a local time in the requested timezone, rather
+        // than requiring the value to carry an offset of its own.
+        let arr = utf8(vec![Some("1970-01-02 00:00:00")]);
+        let result = to_datetime_impl(&arr, "%Y-%m-%d %H:%M:%S", Some("Asia/Kolkata")).unwrap();
+        assert_eq!(result.get(0), Some(MICROS_PER_DAY - IST_OFFSET_MICROS));
+        assert_eq!(
+            result.data_type(),
+            &DataType::Timestamp(TimeUnit::Microseconds, Some("Asia/Kolkata".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_offset_in_input_wins_over_timezone_argument() {
+        // With an offset directive the input defines the instant; the timezone only displays it.
+        let arr = utf8(vec![Some("1970-01-02 00:00:00 +0000")]);
+        let result = to_datetime_impl(&arr, "%Y-%m-%d %H:%M:%S %z", Some("Asia/Kolkata")).unwrap();
+        assert_eq!(result.get(0), Some(MICROS_PER_DAY));
+    }
+
+    #[test]
+    fn test_unix_timestamp_is_not_localized() {
+        // `%s` already names an absolute instant, so an explicit timezone must not shift it.
+        let arr = utf8(vec![Some("86400")]);
+        let naive = to_datetime_impl(&arr, "%s", None).unwrap();
+        let localized = to_datetime_impl(&arr, "%s", Some("Asia/Kolkata")).unwrap();
+        assert_eq!(naive.get(0), Some(MICROS_PER_DAY));
+        assert_eq!(localized.get(0), Some(MICROS_PER_DAY));
+    }
+
+    #[test]
+    fn test_all_null_with_offset_format_still_reports_utc() {
+        // Regression guard for the get_return_field / runtime dtype mismatch: the output timezone
+        // comes from the format, so it must not depend on a row carrying an offset.
+        let arr = utf8(vec![None, None]);
+        let result = to_datetime_impl(&arr, "%Y-%m-%d %H:%M:%S %z", None).unwrap();
+        assert_eq!(result.get(0), None);
+        assert_eq!(
+            result.data_type(),
+            &DataType::Timestamp(TimeUnit::Microseconds, Some("UTC".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_trailing_input_is_rejected() {
+        let arr = utf8(vec![Some("2020-01-01T12:34:56.789")]);
+        let err = to_datetime_impl(&arr, "%Y-%m-%dT%H:%M:%S", None).unwrap_err();
+        assert!(err.to_string().contains("trailing input"), "{err}");
+    }
+
+    #[test]
+    fn test_partial_time_is_rejected() {
+        // The hour must not be silently dropped in favour of midnight.
+        let arr = utf8(vec![Some("2020-01-01 12")]);
+        let err = to_datetime_impl(&arr, "%Y-%m-%d %H", None).unwrap_err();
+        assert!(err.to_string().contains("not enough"), "{err}");
+    }
+
+    #[test]
+    fn test_escaped_percent_is_not_an_offset() {
+        // `%%z` is a literal "%z" in the input, so the result stays naive.
+        let arr = utf8(vec![Some("1970-01-02 %z")]);
+        let result = to_datetime_impl(&arr, "%Y-%m-%d %%z", None).unwrap();
+        assert_eq!(result.get(0), Some(MICROS_PER_DAY));
+        assert_eq!(
+            result.data_type(),
+            &DataType::Timestamp(TimeUnit::Microseconds, None)
+        );
+    }
+
+    #[test]
+    fn test_zone_name_without_offset_is_rejected() {
+        // chrono skips `%Z` without deriving an offset from it, so the value is refused rather
+        // than silently assumed to be in some particular zone.
+        let arr = utf8(vec![Some("2020-01-01 00:00:00 UTC")]);
+        assert!(to_datetime_impl(&arr, "%Y-%m-%d %H:%M:%S %Z", None).is_err());
+    }
+
+    #[test]
+    fn test_bad_timezone_is_rejected_even_when_no_row_parses() {
+        let arr = utf8(vec![None]);
+        let err = to_datetime_impl(&arr, "%Y-%m-%d", Some("not/a/zone")).unwrap_err();
+        assert!(
+            err.to_string().contains("failed to parse timezone"),
+            "{err}"
+        );
+    }
 }

--- a/src/daft-functions-utf8/src/to_datetime.rs
+++ b/src/daft-functions-utf8/src/to_datetime.rs
@@ -1,6 +1,12 @@
+use chrono::{
+    LocalResult, TimeZone,
+    format::{Parsed, strftime::StrftimeItems},
+};
 use common_error::{DaftError, DaftResult, ensure};
 use daft_core::{
-    datatypes::{format_string_has_offset, infer_timeunit_from_format_string},
+    datatypes::{
+        format_string_has_offset, format_string_has_time, infer_timeunit_from_format_string,
+    },
     prelude::*,
     series::IntoSeries,
 };
@@ -97,6 +103,105 @@ pub fn to_datetime<S: Into<String>>(input: ExprRef, format: S, timezone: Option<
     ScalarFn::builtin(ToDatetime, inputs).into()
 }
 
+fn timestamp_from_datetime<Tz: TimeZone>(
+    datetime: chrono::DateTime<Tz>,
+    timeunit: TimeUnit,
+    val: &str,
+) -> DaftResult<i64> {
+    match timeunit {
+        TimeUnit::Seconds => Ok(datetime.timestamp()),
+        TimeUnit::Milliseconds => Ok(datetime.timestamp_millis()),
+        TimeUnit::Microseconds => Ok(datetime.timestamp_micros()),
+        TimeUnit::Nanoseconds => datetime.timestamp_nanos_opt().ok_or_else(|| {
+            DaftError::ComputeError(format!(
+                "Error in to_datetime: failed to get nanoseconds for {val}"
+            ))
+        }),
+    }
+}
+
+fn timestamp_from_naive_datetime(
+    naive: chrono::NaiveDateTime,
+    timeunit: TimeUnit,
+    val: &str,
+) -> DaftResult<i64> {
+    timestamp_from_datetime(naive.and_utc(), timeunit, val)
+}
+
+/// Parses a date-only value (a format without time fields) as midnight.
+///
+/// Uses a strict parse so trailing input is rejected, matching `to_date` and other engines.
+/// An offset embedded in the input (e.g. `%z`) is preserved: midnight is resolved with that
+/// offset before coercing to UTC or the explicit timezone.
+fn parse_date_only_to_timestamp(
+    val: &str,
+    format: &str,
+    timezone: Option<&str>,
+    timeunit: TimeUnit,
+) -> DaftResult<i64> {
+    let mut parsed = Parsed::new();
+    chrono::format::parse(&mut parsed, val, StrftimeItems::new(format)).map_err(|e| {
+        DaftError::ComputeError(format!(
+            "Error in to_datetime: failed to parse datetime {val} with format {format} : {e}"
+        ))
+    })?;
+    let date = parsed.to_naive_date().map_err(|e| {
+        DaftError::ComputeError(format!(
+            "Error in to_datetime: failed to parse datetime {val} with format {format} : {e}"
+        ))
+    })?;
+    let midnight = date
+        .and_hms_opt(0, 0, 0)
+        .expect("midnight is always a valid time");
+
+    let input_offset = parsed.to_fixed_offset().ok();
+
+    match (input_offset, timezone) {
+        (Some(offset), Some(tz_str)) => {
+            let tz = tz_str.parse::<chrono_tz::Tz>().map_err(|e| {
+                DaftError::ComputeError(format!(
+                    "Error in to_datetime: failed to parse timezone {tz_str} : {e}"
+                ))
+            })?;
+            let dt_fixed = offset.from_local_datetime(&midnight).single().ok_or_else(|| {
+                DaftError::ComputeError(format!(
+                    "Error in to_datetime: failed to resolve midnight {midnight} with offset {offset} for {val}"
+                ))
+            })?;
+            timestamp_from_datetime(dt_fixed.with_timezone(&tz), timeunit, val)
+        }
+        (Some(offset), None) => {
+            let dt_utc = offset
+                .from_local_datetime(&midnight)
+                .single()
+                .ok_or_else(|| {
+                    DaftError::ComputeError(format!(
+                        "Error in to_datetime: failed to resolve midnight {midnight} with offset {offset} for {val}"
+                    ))
+                })?
+                .with_timezone(&chrono::Utc);
+            timestamp_from_datetime(dt_utc, timeunit, val)
+        }
+        (None, Some(tz_str)) => {
+            let tz = tz_str.parse::<chrono_tz::Tz>().map_err(|e| {
+                DaftError::ComputeError(format!(
+                    "Error in to_datetime: failed to parse timezone {tz_str} : {e}"
+                ))
+            })?;
+            match tz.from_local_datetime(&midnight) {
+                LocalResult::Single(dt) => timestamp_from_datetime(dt, timeunit, val),
+                LocalResult::Ambiguous(_, _) => Err(DaftError::ComputeError(format!(
+                    "Error in to_datetime: ambiguous local datetime {midnight} in timezone {tz_str} for {val}"
+                ))),
+                LocalResult::None => Err(DaftError::ComputeError(format!(
+                    "Error in to_datetime: nonexistent local datetime {midnight} in timezone {tz_str} for {val}"
+                ))),
+            }
+        }
+        (None, None) => timestamp_from_naive_datetime(midnight, timeunit, val),
+    }
+}
+
 fn to_datetime_impl(
     arr: &Utf8Array,
     format: &str,
@@ -105,60 +210,52 @@ fn to_datetime_impl(
     let len = arr.len();
     let arr_iter = arr.into_iter();
     let timeunit = infer_timeunit_from_format_string(format);
-    let mut timezone = timezone.map(|tz| tz.to_string());
+    let has_time = format_string_has_time(format);
+    let has_offset = format_string_has_offset(format);
+    // If the input carries an offset, we coerce it to UTC. This is consistent with other engines (duckdb, polars, datafusion).
+    // Resolved once so all-null inputs still report UTC, matching `get_return_field`.
+    let timezone = match timezone {
+        Some(tz) => Some(tz.to_string()),
+        None if has_offset => Some("UTC".to_string()),
+        None => None,
+    };
     let result = arr_iter
             .map(|val| match val {
                 Some(val) => {
                     let timestamp = match timezone.as_deref() {
                         Some(tz) => {
-                            let (datetime, _) = chrono::DateTime::parse_and_remainder(val, format).map_err(|e| {
-                                DaftError::ComputeError(format!(
-                                    "Error in to_datetime: failed to parse datetime {val} with format {format} : {e}"
-                                ))
-                            })?;
-                            let datetime_with_timezone = datetime.with_timezone(&tz.parse::<chrono_tz::Tz>().map_err(|e| {
-                                DaftError::ComputeError(format!(
-                                    "Error in to_datetime: failed to parse timezone {tz} : {e}"
-                                ))
-                            })?);
-                            match timeunit {
-                                TimeUnit::Seconds => datetime_with_timezone.timestamp(),
-                                TimeUnit::Milliseconds => datetime_with_timezone.timestamp_millis(),
-                                TimeUnit::Microseconds => datetime_with_timezone.timestamp_micros(),
-                                TimeUnit::Nanoseconds => datetime_with_timezone.timestamp_nanos_opt().ok_or_else(|| DaftError::ComputeError(format!("Error in to_datetime: failed to get nanoseconds for {val}")))?,
+                            if has_time {
+                                // Strict parse: trailing input is an error (unlike `parse_and_remainder`).
+                                let datetime = chrono::DateTime::parse_from_str(val, format).map_err(|e| {
+                                    DaftError::ComputeError(format!(
+                                        "Error in to_datetime: failed to parse datetime {val} with format {format} : {e}"
+                                    ))
+                                })?;
+                                let datetime_with_timezone = datetime.with_timezone(&tz.parse::<chrono_tz::Tz>().map_err(|e| {
+                                    DaftError::ComputeError(format!(
+                                        "Error in to_datetime: failed to parse timezone {tz} : {e}"
+                                    ))
+                                })?);
+                                timestamp_from_datetime(datetime_with_timezone, timeunit, val)?
+                            } else {
+                                // A format without time fields resolves to midnight,
+                                // matching DuckDB `strptime`, Polars and Spark.
+                                parse_date_only_to_timestamp(val, format, Some(tz), timeunit)?
                             }
                         }
                         None => {
-                            if format_string_has_offset(format) {
-                                let datetime = chrono::DateTime::parse_and_remainder(val, format).map_err(|e| {
+                            if has_time {
+                                // Strict parse: trailing input is an error (unlike `parse_and_remainder`).
+                                let naive_datetime = chrono::NaiveDateTime::parse_from_str(val, format).map_err(|e| {
                                     DaftError::ComputeError(format!(
                                         "Error in to_datetime: failed to parse datetime {val} with format {format} : {e}"
                                     ))
-                                })?.0.to_utc();
-
-                                // if it has an offset, we coerce it to UTC. This is consistent with other engines (duckdb, polars, datafusion)
-                                if timezone.is_none() {
-                                    timezone = Some("UTC".to_string());
-                                }
-
-                                match timeunit {
-                                    TimeUnit::Seconds => datetime.timestamp(),
-                                    TimeUnit::Milliseconds => datetime.timestamp_millis(),
-                                    TimeUnit::Microseconds => datetime.timestamp_micros(),
-                                    TimeUnit::Nanoseconds => datetime.timestamp_nanos_opt().ok_or_else(|| DaftError::ComputeError(format!("Error in to_datetime: failed to get nanoseconds for {val}")))?,
-                                }
+                                })?;
+                                timestamp_from_naive_datetime(naive_datetime, timeunit, val)?
                             } else {
-                                let naive_datetime = chrono::NaiveDateTime::parse_and_remainder(val, format).map_err(|e| {
-                                    DaftError::ComputeError(format!(
-                                        "Error in to_datetime: failed to parse datetime {val} with format {format} : {e}"
-                                    ))
-                                })?.0.and_utc();
-                                match timeunit {
-                                    TimeUnit::Seconds => naive_datetime.timestamp(),
-                                    TimeUnit::Milliseconds => naive_datetime.timestamp_millis(),
-                                    TimeUnit::Microseconds => naive_datetime.timestamp_micros(),
-                                    TimeUnit::Nanoseconds => naive_datetime.timestamp_nanos_opt().ok_or_else(|| DaftError::ComputeError(format!("Error in to_datetime: failed to get nanoseconds for {val}")))?,
-                                }
+                                // A format without time fields resolves to midnight,
+                                // matching DuckDB `strptime`, Polars and Spark.
+                                parse_date_only_to_timestamp(val, format, None, timeunit)?
                             }
                         }
                     };

--- a/src/daft-schema/src/time_unit.rs
+++ b/src/daft-schema/src/time_unit.rs
@@ -84,13 +84,8 @@ pub fn infer_timeunit_from_format_string(format: &str) -> TimeUnit {
     }
 }
 
-/// Classifies a strftime format string in a single tokenized pass.
-///
-/// Returns `(has_time, has_offset)`. Tokenizing (instead of substring matching) correctly
-/// handles escaped literals (`%%z` is text, not an offset) and padding modifiers
-/// (`%_H` is an hour). `Fixed::Internal` variants are opaque to chrono's users (`%3f`/`%6f`/`%9f`
-/// fractional seconds vs `%#z` permissive offset), so they are distinguished by comparing against
-/// a tokenized `%#z`.
+/// Returns `(has_time, has_offset)` for a strftime format string. Tokenizing rather than substring
+/// matching keeps escaped literals (`%%z`) and padding modifiers (`%_H`) classified correctly.
 fn format_time_and_offset_flags(format: &str) -> (bool, bool) {
     let mut has_time = false;
     let mut has_offset = false;
@@ -128,10 +123,8 @@ fn format_time_and_offset_flags(format: &str) -> (bool, bool) {
                 | Fixed::TimezoneOffsetZ,
             ) => has_offset = true,
             Item::Fixed(Fixed::Internal(ref inner)) => {
-                // chrono keeps `InternalFixed` opaque but implements `PartialEq` for it, so the
-                // permissive offset directive is identified by tokenizing `%#z` rather than by
-                // scraping `Debug` output, whose shape chrono makes no promise about. Every other
-                // internal item is a fixed-width fractional second (`%3f`/`%6f`/`%9f`).
+                // `InternalFixed` is opaque, so compare against a tokenized `%#z` rather than its
+                // `Debug` output, whose shape chrono does not promise. The rest are `%3f`-style.
                 let is_permissive_offset = matches!(
                     StrftimeItems::new("%#z").next(),
                     Some(Item::Fixed(Fixed::Internal(ref permissive))) if permissive == inner

--- a/src/daft-schema/src/time_unit.rs
+++ b/src/daft-schema/src/time_unit.rs
@@ -1,7 +1,10 @@
 use std::{fmt::Display, str::FromStr};
 
 use arrow_schema::TimeUnit as ArrowTimeUnit;
-use chrono::{LocalResult, TimeZone};
+use chrono::{
+    LocalResult, TimeZone,
+    format::{Fixed, Item, Numeric, strftime::StrftimeItems},
+};
 use common_error::DaftError;
 use serde::{Deserialize, Serialize};
 
@@ -81,50 +84,74 @@ pub fn infer_timeunit_from_format_string(format: &str) -> TimeUnit {
     }
 }
 
-#[must_use]
-pub fn format_string_has_time(format: &str) -> bool {
-    use chrono::format::{Fixed, Item, Numeric};
-
-    chrono::format::strftime::StrftimeItems::new(format).any(|item| match item {
-        Item::Numeric(numeric, _) => matches!(
-            numeric,
-            Numeric::Hour
+/// Classifies a strftime format string in a single tokenized pass.
+///
+/// Returns `(has_time, has_offset)`. Tokenizing (instead of substring matching) correctly
+/// handles escaped literals (`%%z` is text, not an offset) and padding modifiers
+/// (`%_H` is an hour). `Fixed::Internal` variants are private to chrono (`%3f`/`%6f`/`%9f`
+/// fractional seconds vs `%#z` permissive offset), so they are distinguished via their debug
+/// representation.
+fn format_time_and_offset_flags(format: &str) -> (bool, bool) {
+    let mut has_time = false;
+    let mut has_offset = false;
+    for item in StrftimeItems::new(format) {
+        match item {
+            Item::Numeric(
+                Numeric::Hour
                 | Numeric::Hour12
                 | Numeric::Minute
                 | Numeric::Second
                 | Numeric::Nanosecond
-                | Numeric::Timestamp
-        ),
-        Item::Fixed(fixed) => matches!(
-            fixed,
-            Fixed::LowerAmPm
+                | Numeric::Timestamp,
+                _,
+            ) => has_time = true,
+            Item::Fixed(
+                Fixed::LowerAmPm
                 | Fixed::UpperAmPm
                 | Fixed::Nanosecond
                 | Fixed::Nanosecond3
                 | Fixed::Nanosecond6
-                | Fixed::Nanosecond9
-                | Fixed::RFC2822
-                | Fixed::RFC3339
-                // `%3f`, `%6f`, `%9f` (fractional seconds without a leading dot) and `%#z`
-                // (permissive offset) map to `Fixed::Internal`, whose variants are private to
-                // chrono. Treat as time: three of the four internal variants are fractional
-                // seconds. Misclassifying `%#z` (offset) as time only misses a midnight-default
-                // for an extremely rare date-plus-offset format, which still errors as before.
-                | Fixed::Internal(_)
-        ),
-        _ => false,
-    })
+                | Fixed::Nanosecond9,
+            ) => has_time = true,
+            // Full datetime directives carry both a time and an offset.
+            Item::Fixed(Fixed::RFC2822 | Fixed::RFC3339) => {
+                has_time = true;
+                has_offset = true;
+            }
+            Item::Fixed(
+                Fixed::TimezoneName
+                | Fixed::TimezoneOffset
+                | Fixed::TimezoneOffsetColon
+                | Fixed::TimezoneOffsetDoubleColon
+                | Fixed::TimezoneOffsetTripleColon
+                | Fixed::TimezoneOffsetColonZ
+                | Fixed::TimezoneOffsetZ,
+            ) => has_offset = true,
+            Item::Fixed(Fixed::Internal(inner)) => {
+                if format!("{inner:?}").contains("Nanosecond") {
+                    has_time = true;
+                } else {
+                    // `TimezoneOffsetPermissive` (`%#z`).
+                    has_offset = true;
+                }
+            }
+            _ => {}
+        }
+        if has_time && has_offset {
+            break;
+        }
+    }
+    (has_time, has_offset)
+}
+
+#[must_use]
+pub fn format_string_has_time(format: &str) -> bool {
+    format_time_and_offset_flags(format).0
 }
 
 #[must_use]
 pub fn format_string_has_offset(format: &str) -> bool {
-    // These are all valid chrono formats that contain an offset
-    format.contains("%Z")
-        || format.contains("%z")
-        || format.contains("%:z")
-        || format.contains("%::z")
-        || format.contains("%#z")
-        || format == "%+"
+    format_time_and_offset_flags(format).1
 }
 
 /// Converts a timestamp in `time_unit` into [`chrono::NaiveDateTime`].
@@ -326,7 +353,10 @@ mod tests {
             ("%Y-%m-%d %H:%M:%S.%f", false),
             ("", false),
             ("random text", false),
-            ("%%z", true),
+            // Escaped `%%` is a literal percent sign, not a directive.
+            ("%%z", false),
+            ("%Y-%m-%d %%z", false),
+            ("%Y-%m-%d %#z", true),
         ];
 
         for (format, expected) in test_cases {
@@ -351,6 +381,8 @@ mod tests {
             ("%D", false),
             ("%Y-%m-%d %z", false),
             ("%Y-%m-%d %:z", false),
+            ("%Y-%m-%d %#z", false),
+            ("%Y-%m-%d %%z", false),
             ("%Y-%m-%d", false),
             ("", false),
             ("random text", false),

--- a/src/daft-schema/src/time_unit.rs
+++ b/src/daft-schema/src/time_unit.rs
@@ -82,6 +82,41 @@ pub fn infer_timeunit_from_format_string(format: &str) -> TimeUnit {
 }
 
 #[must_use]
+pub fn format_string_has_time(format: &str) -> bool {
+    use chrono::format::{Fixed, Item, Numeric};
+
+    chrono::format::strftime::StrftimeItems::new(format).any(|item| match item {
+        Item::Numeric(numeric, _) => matches!(
+            numeric,
+            Numeric::Hour
+                | Numeric::Hour12
+                | Numeric::Minute
+                | Numeric::Second
+                | Numeric::Nanosecond
+                | Numeric::Timestamp
+        ),
+        Item::Fixed(fixed) => matches!(
+            fixed,
+            Fixed::LowerAmPm
+                | Fixed::UpperAmPm
+                | Fixed::Nanosecond
+                | Fixed::Nanosecond3
+                | Fixed::Nanosecond6
+                | Fixed::Nanosecond9
+                | Fixed::RFC2822
+                | Fixed::RFC3339
+                // `%3f`, `%6f`, `%9f` (fractional seconds without a leading dot) and `%#z`
+                // (permissive offset) map to `Fixed::Internal`, whose variants are private to
+                // chrono. Treat as time: three of the four internal variants are fractional
+                // seconds. Misclassifying `%#z` (offset) as time only misses a midnight-default
+                // for an extremely rare date-plus-offset format, which still errors as before.
+                | Fixed::Internal(_)
+        ),
+        _ => false,
+    })
+}
+
+#[must_use]
 pub fn format_string_has_offset(format: &str) -> bool {
     // These are all valid chrono formats that contain an offset
     format.contains("%Z")
@@ -297,6 +332,54 @@ mod tests {
         for (format, expected) in test_cases {
             assert_eq!(
                 format_string_has_offset(format),
+                expected,
+                "Failed for format: {}",
+                format
+            );
+        }
+    }
+
+    #[test]
+    fn test_format_string_has_time() {
+        let test_cases = vec![
+            ("%Y-%m-%d", false),
+            ("%Y/%m/%d", false),
+            ("%d-%b-%Y", false),
+            ("%F", false),
+            ("%x", false),
+            ("%v", false),
+            ("%D", false),
+            ("%Y-%m-%d %z", false),
+            ("%Y-%m-%d %:z", false),
+            ("%Y-%m-%d", false),
+            ("", false),
+            ("random text", false),
+            ("%%H %%M %%S", false),
+            ("%Y-%m-%d %H:%M:%S", true),
+            ("%Y-%m-%dT%H:%M:%S", true),
+            ("%H:%M:%S", true),
+            ("%H", true),
+            ("%k", true),
+            ("%I:%M %p", true),
+            ("%l:%M %P", true),
+            ("%R", true),
+            ("%T", true),
+            ("%X", true),
+            ("%r", true),
+            ("%c", true),
+            ("%+", true),
+            ("%s", true),
+            ("%Y-%m-%d %H", true),
+            ("%Y-%m-%d %.3f", true),
+            ("%Y-%m-%d %3f", true),
+            ("%Y-%m-%d %H:%M:%S%.3f", true),
+            ("%_H:%M", true),
+            ("%-M", true),
+        ];
+
+        for (format, expected) in test_cases {
+            assert_eq!(
+                format_string_has_time(format),
                 expected,
                 "Failed for format: {}",
                 format

--- a/src/daft-schema/src/time_unit.rs
+++ b/src/daft-schema/src/time_unit.rs
@@ -88,9 +88,9 @@ pub fn infer_timeunit_from_format_string(format: &str) -> TimeUnit {
 ///
 /// Returns `(has_time, has_offset)`. Tokenizing (instead of substring matching) correctly
 /// handles escaped literals (`%%z` is text, not an offset) and padding modifiers
-/// (`%_H` is an hour). `Fixed::Internal` variants are private to chrono (`%3f`/`%6f`/`%9f`
-/// fractional seconds vs `%#z` permissive offset), so they are distinguished via their debug
-/// representation.
+/// (`%_H` is an hour). `Fixed::Internal` variants are opaque to chrono's users (`%3f`/`%6f`/`%9f`
+/// fractional seconds vs `%#z` permissive offset), so they are distinguished by comparing against
+/// a tokenized `%#z`.
 fn format_time_and_offset_flags(format: &str) -> (bool, bool) {
     let mut has_time = false;
     let mut has_offset = false;
@@ -127,12 +127,19 @@ fn format_time_and_offset_flags(format: &str) -> (bool, bool) {
                 | Fixed::TimezoneOffsetColonZ
                 | Fixed::TimezoneOffsetZ,
             ) => has_offset = true,
-            Item::Fixed(Fixed::Internal(inner)) => {
-                if format!("{inner:?}").contains("Nanosecond") {
-                    has_time = true;
-                } else {
-                    // `TimezoneOffsetPermissive` (`%#z`).
+            Item::Fixed(Fixed::Internal(ref inner)) => {
+                // chrono keeps `InternalFixed` opaque but implements `PartialEq` for it, so the
+                // permissive offset directive is identified by tokenizing `%#z` rather than by
+                // scraping `Debug` output, whose shape chrono makes no promise about. Every other
+                // internal item is a fixed-width fractional second (`%3f`/`%6f`/`%9f`).
+                let is_permissive_offset = matches!(
+                    StrftimeItems::new("%#z").next(),
+                    Some(Item::Fixed(Fixed::Internal(ref permissive))) if permissive == inner
+                );
+                if is_permissive_offset {
                     has_offset = true;
+                } else {
+                    has_time = true;
                 }
             }
             _ => {}

--- a/tests/recordbatch/utf8/test_to_datetime.py
+++ b/tests/recordbatch/utf8/test_to_datetime.py
@@ -2,6 +2,10 @@ from __future__ import annotations
 
 import datetime
 
+import pyarrow as pa
+import pytest
+
+from daft import DataType
 from daft.expressions import col
 from daft.recordbatch import MicroPartition
 
@@ -16,3 +20,31 @@ def test_utf8_to_datetime():
             datetime.datetime(2021, 1, 2, 0, 0),
         ]
     }
+
+
+@pytest.mark.parametrize(
+    "format",
+    [
+        pytest.param("%Y-%m-%d %H:%M:%S %z", id="datetime with offset"),
+        pytest.param("%Y-%m-%d %z", id="date-only with offset"),
+    ],
+)
+def test_utf8_to_datetime_all_null_with_offset(format):
+    # An all-null column with an offset directive must still resolve to Timestamp[us; UTC], the
+    # type get_return_field planned. Deciding it from the data instead would build a naive array
+    # here and fail eval_expression with a data type mismatch.
+    table = MicroPartition.from_arrow(pa.table({"col": pa.array([None, None], type=pa.string())}))
+    result = table.eval_expression_list([col("col").to_datetime(format)])
+    assert result.to_pydict() == {"col": [None, None]}
+    assert result.schema()["col"].dtype == DataType.timestamp("us", "UTC")
+
+
+def test_utf8_to_datetime_agrees_with_to_date():
+    # to_date has always accepted date-only formats strictly; to_datetime must accept the same
+    # inputs and land on midnight of the same day.
+    table = MicroPartition.from_pydict({"col": ["2021-01-01", None, "2021-01-02"]})
+    result = table.eval_expression_list(
+        [col("col").to_date("%Y-%m-%d").alias("d"), col("col").to_datetime("%Y-%m-%d").alias("ts")]
+    ).to_pydict()
+    assert [None if ts is None else ts.date() for ts in result["ts"]] == result["d"]
+    assert all(ts is None or ts.time() == datetime.time(0, 0) for ts in result["ts"])

--- a/tests/recordbatch/utf8/test_to_datetime.py
+++ b/tests/recordbatch/utf8/test_to_datetime.py
@@ -30,9 +30,7 @@ def test_utf8_to_datetime():
     ],
 )
 def test_utf8_to_datetime_all_null_with_offset(format):
-    # An all-null column with an offset directive must still resolve to Timestamp[us; UTC], the
-    # type get_return_field planned. Deciding it from the data instead would build a naive array
-    # here and fail eval_expression with a data type mismatch.
+    # The output timezone comes from the format, so it must match the planned type even here.
     table = MicroPartition.from_arrow(pa.table({"col": pa.array([None, None], type=pa.string())}))
     result = table.eval_expression_list([col("col").to_datetime(format)])
     assert result.to_pydict() == {"col": [None, None]}
@@ -40,8 +38,7 @@ def test_utf8_to_datetime_all_null_with_offset(format):
 
 
 def test_utf8_to_datetime_agrees_with_to_date():
-    # to_date has always accepted date-only formats strictly; to_datetime must accept the same
-    # inputs and land on midnight of the same day.
+    # to_datetime must accept the same date-only formats to_date does, at midnight.
     table = MicroPartition.from_pydict({"col": ["2021-01-01", None, "2021-01-02"]})
     result = table.eval_expression_list(
         [col("col").to_date("%Y-%m-%d").alias("d"), col("col").to_datetime("%Y-%m-%d").alias("ts")]

--- a/tests/series/test_utf8_ops.py
+++ b/tests/series/test_utf8_ops.py
@@ -1464,12 +1464,12 @@ def test_series_utf8_to_datetime_different_timezones(data, format, timezone, exp
             id="Microseconds",
         ),
         pytest.param(
-            ["2021-01-01 00:00:45.123", "2021-01-02 01:07:35.123", "2021-01-03 12:30:00.123"],
+            ["2021-01-01 00:00:45.123", "2021-01-02 01:07:35.456", "2021-01-03 12:30:00.789"],
             "%Y-%m-%d %H:%M:%S%.3f",
             [
                 datetime.datetime(2021, 1, 1, 0, 0, 45, 123000),
-                datetime.datetime(2021, 1, 2, 1, 7, 35, 123000),
-                datetime.datetime(2021, 1, 3, 12, 30, 0, 123000),
+                datetime.datetime(2021, 1, 2, 1, 7, 35, 456000),
+                datetime.datetime(2021, 1, 3, 12, 30, 0, 789000),
             ],
             "ms",
             id="Milliseconds",
@@ -1581,12 +1581,132 @@ def test_series_utf8_to_datetime_date_only(data, format, timezone, expected) -> 
         pytest.param(["2020-01-01 extra"], "%Y-%m-%d", id="Trailing text on date-only"),
         pytest.param(["2020-01-01 00:00:00 trailing"], "%Y-%m-%d %H:%M:%S", id="Trailing text on datetime"),
         pytest.param(["2021-01-01 00:00:45.123"], "%Y-%m-%d %H:%M:%S", id="Trailing fraction without format"),
+        pytest.param(["2020-01-01 "], "%Y-%m-%d", id="Trailing whitespace"),
+        pytest.param(["2020-01-01T"], "%Y-%m-%d", id="Trailing separator"),
+        pytest.param(["2020-01-01 00:00:00+00:00"], "%Y-%m-%d %H:%M:%S", id="Trailing offset"),
     ],
 )
 def test_series_utf8_to_datetime_rejects_trailing_input(data, format) -> None:
     s = Series.from_arrow(pa.array(data, type=pa.string()))
+    with pytest.raises(ValueError, match="trailing input"):
+        s.str.to_datetime(format)
+
+
+def test_series_utf8_to_datetime_rejects_trailing_input_with_timezone() -> None:
+    # The explicit-timezone path is strict too: trailing input is an error, not silently dropped.
+    s = Series.from_arrow(pa.array(["2020-01-01 12:34:56 +0000 extra"], type=pa.string()))
+    with pytest.raises(ValueError, match="trailing input"):
+        s.str.to_datetime("%Y-%m-%d %H:%M:%S %z", "UTC")
+
+
+def test_series_utf8_to_datetime_allows_leading_whitespace() -> None:
+    # chrono skips whitespace ahead of a numeric field, so leading whitespace stays accepted even
+    # though trailing whitespace is not. Pinned so the asymmetry is deliberate rather than
+    # accidental.
+    s = Series.from_arrow(pa.array([" 2020-01-01"], type=pa.string()))
+    assert s.str.to_datetime("%Y-%m-%d").to_pylist() == [datetime.datetime(2020, 1, 1)]
+
+
+@pytest.mark.parametrize(
+    ["data", "format"],
+    [
+        pytest.param(["2020-01-01 12"], "%Y-%m-%d %H", id="Hour without minute"),
+        pytest.param(["2020-01-01T12"], "%Y-%m-%dT%H", id="ISO hour without minute"),
+        pytest.param(["2020-01-01 AM"], "%Y-%m-%d %p", id="Meridiem without hour"),
+    ],
+)
+def test_series_utf8_to_datetime_rejects_partial_time(data, format) -> None:
+    # A partially specified time must not fall back to midnight and silently drop the hour.
+    s = Series.from_arrow(pa.array(data, type=pa.string()))
     with pytest.raises(ValueError):
         s.str.to_datetime(format)
+
+
+def test_series_utf8_to_datetime_optional_fraction_present() -> None:
+    # `%.f` is optional, so rows that omit the fraction still parse as long as the format names a
+    # complete time.
+    s = Series.from_arrow(pa.array(["2021-01-01 00:00:45.5", "2021-01-02 01:07:35"], type=pa.string()))
+    assert s.str.to_datetime("%Y-%m-%d %H:%M:%S%.f").to_pylist() == [
+        datetime.datetime(2021, 1, 1, 0, 0, 45, 500000),
+        datetime.datetime(2021, 1, 2, 1, 7, 35),
+    ]
+
+
+def test_series_utf8_to_datetime_optional_fraction_without_time_fields() -> None:
+    # `%Y-%m-%d%.f` names a fractional-seconds field, so it is not a date-only format even when a
+    # value happens to omit the fraction. The date-only fallback is chosen by the format, not by
+    # the row, so every row in a column behaves the same way instead of one becoming midnight and
+    # the next erroring.
+    s = Series.from_arrow(pa.array(["2020-01-01", "2020-01-01.5"], type=pa.string()))
+    with pytest.raises(ValueError):
+        s.str.to_datetime("%Y-%m-%d%.f")
+
+
+IST = datetime.timezone(datetime.timedelta(hours=5, minutes=30))
+
+
+def test_series_utf8_to_datetime_naive_format_with_timezone() -> None:
+    # A format with no offset directive is read as a local time in the requested timezone, instead
+    # of requiring every value to carry an offset of its own.
+    s = Series.from_arrow(pa.array(["2020-01-01 06:00:00", None], type=pa.string()))
+    result = s.str.to_datetime("%Y-%m-%d %H:%M:%S", "Asia/Kolkata")
+    assert result.datatype() == DataType.timestamp("us", "Asia/Kolkata")
+    assert result.to_pylist() == [datetime.datetime(2020, 1, 1, 6, 0, tzinfo=IST), None]
+
+
+def test_series_utf8_to_datetime_date_only_localizes_into_timezone() -> None:
+    # Midnight in Asia/Kolkata (UTC+05:30), i.e. 18:30 UTC on the previous day.
+    s = Series.from_arrow(pa.array(["2020-01-01"], type=pa.string()))
+    result = s.str.to_datetime("%Y-%m-%d", "Asia/Kolkata")
+    assert result.datatype() == DataType.timestamp("us", "Asia/Kolkata")
+    assert result.to_pylist() == [datetime.datetime(2020, 1, 1, 0, 0, tzinfo=IST)]
+
+
+def test_series_utf8_to_datetime_offset_wins_over_timezone_argument() -> None:
+    # When the format carries an offset directive, the offset in the input defines the instant and
+    # the timezone argument only controls how that instant is displayed: midnight UTC is 05:30 IST.
+    s = Series.from_arrow(pa.array(["2020-01-01 00:00:00 +0000"], type=pa.string()))
+    result = s.str.to_datetime("%Y-%m-%d %H:%M:%S %z", "Asia/Kolkata")
+    assert result.to_pylist() == [datetime.datetime(2020, 1, 1, 5, 30, tzinfo=IST)]
+
+
+@pytest.mark.parametrize(
+    ["date", "message"],
+    [
+        # Cuba starts DST at 00:00 -> 01:00, so this midnight never happens locally.
+        pytest.param("2018-03-11", "nonexistent local datetime", id="Nonexistent midnight"),
+        # Cuba ends DST at 01:00 -> 00:00, so this midnight happens twice locally.
+        pytest.param("2018-11-04", "ambiguous local datetime", id="Ambiguous midnight"),
+    ],
+)
+def test_series_utf8_to_datetime_date_only_dst_midnight(date, message) -> None:
+    # Localizing into a timezone can land on a gap or a fold; both are reported rather than being
+    # resolved arbitrarily.
+    s = Series.from_arrow(pa.array([date], type=pa.string()))
+    with pytest.raises(ValueError, match=message):
+        s.str.to_datetime("%Y-%m-%d", "America/Havana")
+
+
+def test_series_utf8_to_datetime_zone_name_without_offset() -> None:
+    # chrono skips `%Z` without deriving an offset from it, so the value is refused rather than
+    # silently assumed to be in some particular zone.
+    s = Series.from_arrow(pa.array(["2020-01-01 00:00:00 UTC"], type=pa.string()))
+    with pytest.raises(ValueError):
+        s.str.to_datetime("%Y-%m-%d %H:%M:%S %Z")
+
+
+def test_series_utf8_to_datetime_all_null_date_only() -> None:
+    s = Series.from_arrow(pa.array([None, None], type=pa.string()))
+    result = s.str.to_datetime("%Y-%m-%d")
+    assert result.to_pylist() == [None, None]
+    assert result.datatype() == DataType.timestamp("us")
+
+
+def test_series_utf8_to_datetime_mixed_valid_and_invalid() -> None:
+    # One bad row fails the whole column; nulls are skipped without being parsed.
+    s = Series.from_arrow(pa.array(["2020-01-01", None, "not a date"], type=pa.string()))
+    with pytest.raises(ValueError, match="not a date"):
+        s.str.to_datetime("%Y-%m-%d")
 
 
 # source: RedPajama

--- a/tests/series/test_utf8_ops.py
+++ b/tests/series/test_utf8_ops.py
@@ -1464,7 +1464,7 @@ def test_series_utf8_to_datetime_different_timezones(data, format, timezone, exp
             id="Microseconds",
         ),
         pytest.param(
-            ["2021-01-01 00:00:45.1234", "2021-01-02 01:07:35.12300", "2021-01-03 12:30:00.123"],
+            ["2021-01-01 00:00:45.123", "2021-01-02 01:07:35.123", "2021-01-03 12:30:00.123"],
             "%Y-%m-%d %H:%M:%S%.3f",
             [
                 datetime.datetime(2021, 1, 1, 0, 0, 45, 123000),
@@ -1519,6 +1519,60 @@ def test_series_utf8_to_bad_datetime() -> None:
     s = Series.from_arrow(pa.array(["2021-100-20"]))
     with pytest.raises(ValueError):
         s.str.to_datetime("%Y-%m-%d %H:%M:%S", "UTC")
+
+
+@pytest.mark.parametrize(
+    ["data", "format", "timezone", "expected"],
+    [
+        pytest.param(
+            ["2020-01-01", "2020-12-31", None],
+            "%Y-%m-%d",
+            None,
+            [datetime.datetime(2020, 1, 1), datetime.datetime(2020, 12, 31), None],
+            id="Date-only resolves to midnight",
+        ),
+        pytest.param(
+            ["01/02/2020"],
+            "%m/%d/%Y",
+            None,
+            [datetime.datetime(2020, 1, 2)],
+            id="Date-only non-ISO format",
+        ),
+        pytest.param(
+            ["2021-01-01 +0000"],
+            "%Y-%m-%d %z",
+            None,
+            [datetime.datetime(2021, 1, 1, tzinfo=datetime.timezone.utc)],
+            id="Date-only with offset coerces to UTC",
+        ),
+        pytest.param(
+            ["2020-01-01"],
+            "%Y-%m-%d",
+            "UTC",
+            [datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc)],
+            id="Date-only with explicit timezone",
+        ),
+    ],
+)
+def test_series_utf8_to_datetime_date_only(data, format, timezone, expected) -> None:
+    s = Series.from_arrow(pa.array(data, type=pa.string()))
+    result = s.str.to_datetime(format, timezone)
+    assert result.to_pylist() == expected
+
+
+@pytest.mark.parametrize(
+    ["data", "format"],
+    [
+        pytest.param(["2020-01-01T12:34:56.789"], "%Y-%m-%dT%H:%M:%S", id="Trailing fractional seconds"),
+        pytest.param(["2020-01-01 extra"], "%Y-%m-%d", id="Trailing text on date-only"),
+        pytest.param(["2020-01-01 00:00:00 trailing"], "%Y-%m-%d %H:%M:%S", id="Trailing text on datetime"),
+        pytest.param(["2021-01-01 00:00:45.123"], "%Y-%m-%d %H:%M:%S", id="Trailing fraction without format"),
+    ],
+)
+def test_series_utf8_to_datetime_rejects_trailing_input(data, format) -> None:
+    s = Series.from_arrow(pa.array(data, type=pa.string()))
+    with pytest.raises(ValueError):
+        s.str.to_datetime(format)
 
 
 # source: RedPajama

--- a/tests/series/test_utf8_ops.py
+++ b/tests/series/test_utf8_ops.py
@@ -1552,6 +1552,20 @@ def test_series_utf8_to_bad_datetime() -> None:
             [datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc)],
             id="Date-only with explicit timezone",
         ),
+        pytest.param(
+            ["2021-01-01 +0000"],
+            "%Y-%m-%d %#z",
+            None,
+            [datetime.datetime(2021, 1, 1, tzinfo=datetime.timezone.utc)],
+            id="Date-only with permissive offset coerces to UTC",
+        ),
+        pytest.param(
+            ["2020-01-01 %z"],
+            "%Y-%m-%d %%z",
+            None,
+            [datetime.datetime(2020, 1, 1)],
+            id="Escaped percent is literal text, not an offset",
+        ),
     ],
 )
 def test_series_utf8_to_datetime_date_only(data, format, timezone, expected) -> None:

--- a/tests/series/test_utf8_ops.py
+++ b/tests/series/test_utf8_ops.py
@@ -1593,16 +1593,13 @@ def test_series_utf8_to_datetime_rejects_trailing_input(data, format) -> None:
 
 
 def test_series_utf8_to_datetime_rejects_trailing_input_with_timezone() -> None:
-    # The explicit-timezone path is strict too: trailing input is an error, not silently dropped.
     s = Series.from_arrow(pa.array(["2020-01-01 12:34:56 +0000 extra"], type=pa.string()))
     with pytest.raises(ValueError, match="trailing input"):
         s.str.to_datetime("%Y-%m-%d %H:%M:%S %z", "UTC")
 
 
 def test_series_utf8_to_datetime_allows_leading_whitespace() -> None:
-    # chrono skips whitespace ahead of a numeric field, so leading whitespace stays accepted even
-    # though trailing whitespace is not. Pinned so the asymmetry is deliberate rather than
-    # accidental.
+    # chrono skips whitespace ahead of a numeric field, unlike trailing whitespace.
     s = Series.from_arrow(pa.array([" 2020-01-01"], type=pa.string()))
     assert s.str.to_datetime("%Y-%m-%d").to_pylist() == [datetime.datetime(2020, 1, 1)]
 
@@ -1616,15 +1613,13 @@ def test_series_utf8_to_datetime_allows_leading_whitespace() -> None:
     ],
 )
 def test_series_utf8_to_datetime_rejects_partial_time(data, format) -> None:
-    # A partially specified time must not fall back to midnight and silently drop the hour.
     s = Series.from_arrow(pa.array(data, type=pa.string()))
     with pytest.raises(ValueError):
         s.str.to_datetime(format)
 
 
 def test_series_utf8_to_datetime_optional_fraction_present() -> None:
-    # `%.f` is optional, so rows that omit the fraction still parse as long as the format names a
-    # complete time.
+    # chrono only consumes `%.f` when the separator is present.
     s = Series.from_arrow(pa.array(["2021-01-01 00:00:45.5", "2021-01-02 01:07:35"], type=pa.string()))
     assert s.str.to_datetime("%Y-%m-%d %H:%M:%S%.f").to_pylist() == [
         datetime.datetime(2021, 1, 1, 0, 0, 45, 500000),
@@ -1633,10 +1628,7 @@ def test_series_utf8_to_datetime_optional_fraction_present() -> None:
 
 
 def test_series_utf8_to_datetime_optional_fraction_without_time_fields() -> None:
-    # `%Y-%m-%d%.f` names a fractional-seconds field, so it is not a date-only format even when a
-    # value happens to omit the fraction. The date-only fallback is chosen by the format, not by
-    # the row, so every row in a column behaves the same way instead of one becoming midnight and
-    # the next erroring.
+    # The date-only fallback is chosen by the format, not the row, so both values behave alike.
     s = Series.from_arrow(pa.array(["2020-01-01", "2020-01-01.5"], type=pa.string()))
     with pytest.raises(ValueError):
         s.str.to_datetime("%Y-%m-%d%.f")
@@ -1646,8 +1638,6 @@ IST = datetime.timezone(datetime.timedelta(hours=5, minutes=30))
 
 
 def test_series_utf8_to_datetime_naive_format_with_timezone() -> None:
-    # A format with no offset directive is read as a local time in the requested timezone, instead
-    # of requiring every value to carry an offset of its own.
     s = Series.from_arrow(pa.array(["2020-01-01 06:00:00", None], type=pa.string()))
     result = s.str.to_datetime("%Y-%m-%d %H:%M:%S", "Asia/Kolkata")
     assert result.datatype() == DataType.timestamp("us", "Asia/Kolkata")
@@ -1655,7 +1645,6 @@ def test_series_utf8_to_datetime_naive_format_with_timezone() -> None:
 
 
 def test_series_utf8_to_datetime_date_only_localizes_into_timezone() -> None:
-    # Midnight in Asia/Kolkata (UTC+05:30), i.e. 18:30 UTC on the previous day.
     s = Series.from_arrow(pa.array(["2020-01-01"], type=pa.string()))
     result = s.str.to_datetime("%Y-%m-%d", "Asia/Kolkata")
     assert result.datatype() == DataType.timestamp("us", "Asia/Kolkata")
@@ -1663,8 +1652,7 @@ def test_series_utf8_to_datetime_date_only_localizes_into_timezone() -> None:
 
 
 def test_series_utf8_to_datetime_offset_wins_over_timezone_argument() -> None:
-    # When the format carries an offset directive, the offset in the input defines the instant and
-    # the timezone argument only controls how that instant is displayed: midnight UTC is 05:30 IST.
+    # The input offset defines the instant; the timezone only displays it.
     s = Series.from_arrow(pa.array(["2020-01-01 00:00:00 +0000"], type=pa.string()))
     result = s.str.to_datetime("%Y-%m-%d %H:%M:%S %z", "Asia/Kolkata")
     assert result.to_pylist() == [datetime.datetime(2020, 1, 1, 5, 30, tzinfo=IST)]
@@ -1673,23 +1661,20 @@ def test_series_utf8_to_datetime_offset_wins_over_timezone_argument() -> None:
 @pytest.mark.parametrize(
     ["date", "message"],
     [
-        # Cuba starts DST at 00:00 -> 01:00, so this midnight never happens locally.
+        # Cuba starts DST at 00:00 -> 01:00, so this midnight never happens.
         pytest.param("2018-03-11", "nonexistent local datetime", id="Nonexistent midnight"),
-        # Cuba ends DST at 01:00 -> 00:00, so this midnight happens twice locally.
+        # Cuba ends DST at 01:00 -> 00:00, so this midnight happens twice.
         pytest.param("2018-11-04", "ambiguous local datetime", id="Ambiguous midnight"),
     ],
 )
 def test_series_utf8_to_datetime_date_only_dst_midnight(date, message) -> None:
-    # Localizing into a timezone can land on a gap or a fold; both are reported rather than being
-    # resolved arbitrarily.
     s = Series.from_arrow(pa.array([date], type=pa.string()))
     with pytest.raises(ValueError, match=message):
         s.str.to_datetime("%Y-%m-%d", "America/Havana")
 
 
 def test_series_utf8_to_datetime_zone_name_without_offset() -> None:
-    # chrono skips `%Z` without deriving an offset from it, so the value is refused rather than
-    # silently assumed to be in some particular zone.
+    # chrono skips `%Z` without deriving an offset from it.
     s = Series.from_arrow(pa.array(["2020-01-01 00:00:00 UTC"], type=pa.string()))
     with pytest.raises(ValueError):
         s.str.to_datetime("%Y-%m-%d %H:%M:%S %Z")
@@ -1703,7 +1688,6 @@ def test_series_utf8_to_datetime_all_null_date_only() -> None:
 
 
 def test_series_utf8_to_datetime_mixed_valid_and_invalid() -> None:
-    # One bad row fails the whole column; nulls are skipped without being parsed.
     s = Series.from_arrow(pa.array(["2020-01-01", None, "not a date"], type=pa.string()))
     with pytest.raises(ValueError, match="not a date"):
         s.str.to_datetime("%Y-%m-%d")


### PR DESCRIPTION
## Changes Made

- Replace `parse_and_remainder` with a strict `chrono::format::parse` in `to_datetime` so trailing input is an error instead of silently dropped, matching the already-strict `to_date`.
- Date-only formats (no time fields) now resolve to midnight, matching DuckDB `strptime`, Polars and Spark. Whether that fallback applies is decided from the format alone, so every row in a column is parsed the same way and a partial time (e.g. `%Y-%m-%d %H`) stays an error rather than silently becoming midnight.
- Collapse the three parse sites into a single strict `Parsed` scan. The instant resolves as: an offset directive means the input's offset defines the instant and `timezone` only controls display; a naive format plus an explicit `timezone` means the value is a local time in that zone; otherwise UTC.
- Add a `format_string_has_time` helper (via `StrftimeItems`, so `%%` escapes, padding modifiers and composites like `%R`/`%T`/`%c`/`%+` are handled) with unit tests. `format_string_has_offset` is now tokenized too, which fixes `%%z` being treated as an offset.
- Hoist the timezone resolution and the `chrono_tz::Tz` parse out of the per-row loop, and deduplicate timestamp conversion.
- Add Rust unit tests for the kernel and regression tests for date-only, strictness, timezone and DST edges.

### Behaviour changes worth flagging

- **Breaking:** input with trailing text that the format does not describe now raises instead of being silently truncated. The `%.3f` test data relied on this and was fixed.
- `to_datetime(s, "%Y-%m-%d %H:%M:%S", "Asia/Kolkata")` previously errored, because the explicit-timezone path required the value to carry its own offset. It now reads the value as a local time in that timezone, which removes an asymmetry against the date-only path. A local time that a DST transition makes ambiguous or nonexistent raises.
- **Tightening:** a format whose only offset directive is `%Z` is now rejected. chrono skips the zone name without deriving an offset from it, so the previous revision of this PR silently assumed the output timezone for such values. Erroring is consistent with `main` and avoids a silent misread.
- `%s` is excluded from timezone localization: it already names an absolute instant, so an explicit `timezone` only changes how it is displayed.

## Related Issues

Closes #7469

Also fixes #7470 as a structural consequence: the output timezone is now decided from the format alone, before the parse loop, so an all-null column with an offset directive still reports `Timestamp[tu; UTC]` and matches `get_return_field` instead of panicking with a data type mismatch. Covered by `test_utf8_to_datetime_all_null_with_offset` and a Rust unit test, so a later refactor cannot reintroduce the panic silently.
