### PR TITLE
fix(sql): reject negative literals for unsigned table function options

### DIFF
--- a/src/daft-sql/src/functions.rs
+++ b/src/daft-sql/src/functions.rs
@@ -335,9 +335,21 @@ impl SQLLiteral for usize {
     where
         Self: Sized,
     {
-        expr.as_literal()
-            .and_then(|lit| lit.as_i64().map(|v| v as Self))
-            .ok_or_else(|| PlannerError::invalid_operation("Expected an integer literal"))
+        // Reuse daft-core's conversion policy rather than keeping a second one here:
+        // it accepts every integer width, where `as_i64` silently rejects unsigned
+        // literals. The message is ours because the core error mentions `usize`.
+        let lit = expr
+            .as_literal()
+            .ok_or_else(|| PlannerError::invalid_operation("Expected an integer literal"))?;
+        match lit.try_as_usize() {
+            Ok(Some(value)) => Ok(value),
+            Ok(None) => Err(PlannerError::invalid_operation(
+                "Expected an integer literal",
+            )),
+            Err(_) => Err(PlannerError::invalid_operation(format!(
+                "Expected a non-negative integer literal, got {lit}"
+            ))),
+        }
     }
 }
 

--- a/tests/sql/test_sql_table_functions.py
+++ b/tests/sql/test_sql_table_functions.py
@@ -262,3 +262,26 @@ def test_sql_read_csv_ignore_corrupt_files(tmp_path):
     path, reason, _partial = skipped[0]
     assert path.endswith("zzz_bad.csv")
     assert reason
+
+
+@pytest.mark.parametrize(
+    ("function", "path", "option"),
+    [
+        ("read_parquet", "tests/assets/parquet-data/mvp.parquet", "chunk_size"),
+        ("read_csv", "tests/assets/mvp.csv", "buffer_size"),
+        ("read_csv", "tests/assets/mvp.csv", "chunk_size"),
+        ("read_json", "tests/assets/json-data/sample1.jsonl", "buffer_size"),
+        ("read_json", "tests/assets/json-data/sample1.jsonl", "chunk_size"),
+    ],
+)
+def test_sql_read_negative_size_option_rejected(function, path, option):
+    """Negative literals for unsigned options are rejected instead of wrapping around.
+
+    These options are parsed as `usize`, so a negative value used to be cast into a huge
+    positive one (e.g. -1 became 18446744073709551615) rather than reported to the user.
+    """
+    # `InvalidSQLException` is created by pyo3 at runtime and is not importable from
+    # `daft.exceptions`, so match on the name the way the other SQL tests do.
+    with pytest.raises(Exception, match="Expected a non-negative integer literal") as exc_info:
+        daft.sql(f"SELECT * FROM {function}('{path}', {option} => -1)")
+    assert exc_info.type.__name__ == "InvalidSQLException"


### PR DESCRIPTION
## Changes Made

Negative literals for unsigned table function options wrapped around instead of erroring:

```python
daft.sql("SELECT * FROM read_parquet('f.parquet', chunk_size => -1)")   # accepted silently
daft.sql("SELECT * FROM read_iceberg('...', snapshot_id => -1)")
# ValueError: Snapshot not found: 18446744073709551615
```

`impl SQLLiteral for usize` used `lit.as_i64().map(|v| v as usize)`, a wrapping cast. It now
delegates to `daft_core::lit::Literal::try_as_usize`, the crate's existing policy, which also
accepts integer widths `as_i64` rejected outright. The message stays ours, since the core
error mentions `usize`.

Scope is the options actually parsed as `usize` — `chunk_size`, `buffer_size`, `snapshot_id`,
and the `HTTPConfig`/`TosConfig` numerics. `S3Config` and `AzureConfig` read theirs as `i64`
and cast to `u32`, so those still wrap; that is a separate fix.

## Testing

Parametrized rejection of negative `chunk_size`/`buffer_size` across `read_parquet`,
`read_csv` and `read_json` — all five fail on `main`. native `tests/sql` 412 passed, ray 29,
`make precommit` clean.

## AI usage disclosure

Written with an AI coding assistant. I reviewed the full diff, reproduced the wraparound on an
unpatched build, and reverted the fix to confirm the new tests fail without it.

## Related Issues

Closes #7478. Split out of #7354; the `snapshot_id` typing is #7477.
