### PR TITLE
perf(file): avoid opening files for file_size

### DIFF
--- a/src/daft-file/src/functions.rs
+++ b/src/daft-file/src/functions.rs
@@ -484,9 +484,17 @@ impl ScalarUDF for FilePath {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Size;
 
+impl Size {
+    const DEFAULT_BATCH_SIZE: usize = 64;
+}
+
 #[typetag::serde]
 #[async_trait::async_trait]
 impl AsyncScalarUDF for Size {
+    fn preferred_batch_size(&self, _inputs: FunctionArgs<ExprRef>) -> DaftResult<Option<usize>> {
+        Ok(Some(Self::DEFAULT_BATCH_SIZE))
+    }
+
     fn name(&self) -> &'static str {
         "file_size"
     }

--- a/src/daft-file/src/functions.rs
+++ b/src/daft-file/src/functions.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     file::{BUFFER_SIZE_SNIFF, DaftFile, HDF5_MIME},
-    meta::file_exists,
+    meta::{file_exists, file_size},
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
@@ -485,12 +485,13 @@ impl ScalarUDF for FilePath {
 pub struct Size;
 
 #[typetag::serde]
-impl ScalarUDF for Size {
+#[async_trait::async_trait]
+impl AsyncScalarUDF for Size {
     fn name(&self) -> &'static str {
         "file_size"
     }
 
-    fn call(
+    async fn call(
         &self,
         args: FunctionArgs<Series>,
         _ctx: &daft_dsl::functions::scalar::EvalContext,
@@ -499,20 +500,16 @@ impl ScalarUDF for Size {
 
         with_match_file_types!(input.data_type(), |$P| {
             let s = input.file::<$P>()?;
-            let len = s.len();
-            let mut out = Vec::with_capacity(len);
-            // TODO(cory): can likely optimize this a lot more than a naive for loop.
-            for i in 0..len {
-                let opt: Option<u64> = s
-                    .get(i)
-                    .map(|f| {
-                        let f = DaftFile::load_blocking(f, false, Some(BUFFER_SIZE_SNIFF))?;
-                        let size = f.size()?;
-                        DaftResult::Ok(size as _)
-                    })
-                    .transpose()?;
-                out.push(opt);
-            }
+
+            let out = futures::future::try_join_all(s.into_iter().map(|f| async {
+                if let Some(f) = f {
+                    file_size(f).await.map(|size| Some(size as u64))
+                } else {
+                    Ok(None)
+                }
+            }))
+            .await?;
+
             Ok(
                 daft_core::prelude::UInt64Array::from_iter(Field::new(s.name(), DataType::UInt64), out.into_iter())
                     .into_series(),

--- a/src/daft-file/src/meta.rs
+++ b/src/daft-file/src/meta.rs
@@ -1,6 +1,8 @@
 use common_error::{DaftError, DaftResult};
 use daft_core::file::FileReference;
 
+use crate::{DaftFile, file::BUFFER_SIZE_SNIFF};
+
 /// Checks whether the file at the given reference exists.
 pub async fn file_exists(file_ref: FileReference) -> DaftResult<bool> {
     let io_config = file_ref.io_config.unwrap_or_default();
@@ -16,6 +18,28 @@ pub async fn file_exists(file_ref: FileReference) -> DaftResult<bool> {
         Err(daft_io::Error::NotFound { .. } | daft_io::Error::NotAFile { .. }) => Ok(false),
         Err(e) => Err(DaftError::from(e)),
     }
+}
+
+/// Returns the size of the file at the given reference.
+///
+/// For whole-file references this only performs a metadata request. Byte-range references retain
+/// the existing `DaftFile` behavior, where the returned size is the size of the loaded range.
+pub async fn file_size(file_ref: FileReference) -> DaftResult<usize> {
+    if file_ref.position.is_some() || file_ref.size.is_some() {
+        return DaftFile::load(file_ref, false, Some(BUFFER_SIZE_SNIFF))
+            .await?
+            .size();
+    }
+
+    let io_config = file_ref.io_config.unwrap_or_default();
+    let io_client = daft_io::get_io_client(true, io_config)?;
+
+    let (source, path) = io_client
+        .get_source_and_path(&file_ref.url)
+        .await
+        .map_err(DaftError::from)?;
+
+    source.get_size(&path, None).await.map_err(DaftError::from)
 }
 
 /// Blocking version of `file_exists`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,7 +179,7 @@ pub mod pylib {
         functions_registry.add_fn(daft_file::File);
         functions_registry.add_fn(daft_file::FilePath);
         functions_registry.add_async_fn(daft_file::FileExists);
-        functions_registry.add_fn(daft_file::Size);
+        functions_registry.add_async_fn(daft_file::Size);
         functions_registry.add_fn(daft_file::VideoFile);
         functions_registry.add_fn(daft_file::AudioFile);
         functions_registry.add_fn(daft_file::ImageFile);

--- a/tests/file/test_file_basics.py
+++ b/tests/file/test_file_basics.py
@@ -4,6 +4,9 @@ import importlib
 import io
 import random
 import struct
+import threading
+from functools import partial
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
 import pytest
@@ -209,6 +212,52 @@ def test_filesize_expr_multiple_files_and_nulls(tmp_path: Path):
 
     result = df.select(file_size(file(df["file"]))).to_pydict()["file"]
     assert result == [3, None, 5]
+
+
+@pytest.mark.skipif(get_tests_daft_runner_name() == "ray", reason="local HTTP server is unavailable to Ray workers")
+def test_filesize_expr_uses_http_metadata_only(tmp_path: Path):
+    file_path = tmp_path / "test_file.bin"
+    file_path.write_bytes(b"metadata-only")
+    requests: list[str] = []
+
+    class RequestRecordingHandler(SimpleHTTPRequestHandler):
+        def do_GET(self):
+            requests.append("GET")
+            super().do_GET()
+
+        def do_HEAD(self):
+            requests.append("HEAD")
+            super().do_HEAD()
+
+        def log_message(self, format, *args):
+            pass
+
+    handler = partial(RequestRecordingHandler, directory=str(tmp_path))
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    try:
+        url = f"http://127.0.0.1:{server.server_port}/{file_path.name}"
+        df = daft.from_pydict({"file": [url]})
+        result = df.select(file_size(file(df["file"]))).to_pydict()["file"]
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert result == [len(b"metadata-only")]
+    assert requests == ["HEAD"]
+
+
+def test_filesize_expr_preserves_byte_range_size(tmp_path: Path):
+    file_path = tmp_path / "test_file.bin"
+    file_path.write_bytes(b"abcdef")
+
+    df = daft.from_pydict({"file": [daft.File(str(file_path), position=2, size=3)]})
+
+    result = df.select(file_size(df["file"])).to_pydict()["file"]
+    assert result == [3]
 
 
 def test_file_exists(tmp_path: Path):

--- a/tests/file/test_file_basics.py
+++ b/tests/file/test_file_basics.py
@@ -191,6 +191,26 @@ def test_filesize_expr(tmp_path: Path):
     assert res == 2048
 
 
+def test_filesize_expr_multiple_files_and_nulls(tmp_path: Path):
+    first_file = tmp_path / "first.bin"
+    first_file.write_bytes(b"abc")
+    second_file = tmp_path / "second.bin"
+    second_file.write_bytes(b"12345")
+
+    df = daft.from_pydict(
+        {
+            "file": [
+                str(first_file.absolute()),
+                None,
+                str(second_file.absolute()),
+            ]
+        }
+    )
+
+    result = df.select(file_size(file(df["file"]))).to_pydict()["file"]
+    assert result == [3, None, 5]
+
+
 def test_file_exists(tmp_path: Path):
     existing_file = tmp_path / "exists.bin"
     existing_file.write_bytes(b"data")


### PR DESCRIPTION
`file_size()` now retrieves the size of whole-file references directly from object metadata instead of loading each file through `DaftFile::load()`.

This avoids the unnecessary `supports_range()` probe and reader construction that previously happened after the file size had already been fetched. The function is now an async scalar UDF, allowing independent size lookups in a batch to run concurrently.

Byte-range file references retain the existing load behavior so their returned size semantics are unchanged.

Added coverage for multiple file inputs and null propagation.

Fixes #7480 

- `cargo check -p daft-file`
- `make build`
- `DAFT_RUNNER=native make test EXTRA_ARGS='-v tests/file/test_file_basics.py -k filesize'`
