### PR TITLE
fix(utf8): decide to_datetime output timezone from format, not data

### DIFF
--- a/src/daft-functions-utf8/src/to_datetime.rs
+++ b/src/daft-functions-utf8/src/to_datetime.rs
@@ -105,7 +105,7 @@ fn to_datetime_impl(
     let len = arr.len();
     let arr_iter = arr.into_iter();
     let timeunit = infer_timeunit_from_format_string(format);
-    let mut timezone = timezone.map(|tz| tz.to_string());
+    let timezone = timezone.map(|tz| tz.to_string());
     let result = arr_iter
             .map(|val| match val {
                 Some(val) => {
@@ -136,11 +136,6 @@ fn to_datetime_impl(
                                     ))
                                 })?.0.to_utc();
 
-                                // if it has an offset, we coerce it to UTC. This is consistent with other engines (duckdb, polars, datafusion)
-                                if timezone.is_none() {
-                                    timezone = Some("UTC".to_string());
-                                }
-
                                 match timeunit {
                                     TimeUnit::Seconds => datetime.timestamp(),
                                     TimeUnit::Milliseconds => datetime.timestamp_millis(),
@@ -167,6 +162,12 @@ fn to_datetime_impl(
                 _ => Ok(None),
             })
             .collect::<DaftResult<Int64Array>>()?;
+
+    // The output timezone must be decided from the format alone, exactly as `get_return_field`
+    // does: an offset directive coerces the result to UTC even when no value carries an offset
+    // (e.g. an all-null column). Otherwise the runtime array would be built as `Timestamp[us]`
+    // and mismatch the planned `Timestamp[us; UTC]`, panicking at execution.
+    let timezone = timezone.or_else(|| format_string_has_offset(format).then(|| "UTC".to_string()));
 
     let result = TimestampArray::new(
         Field::new(arr.name(), DataType::Timestamp(timeunit, timezone)),

--- a/tests/recordbatch/utf8/test_to_datetime.py
+++ b/tests/recordbatch/utf8/test_to_datetime.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import datetime
 
+import pyarrow as pa
+
+from daft import DataType
 from daft.expressions import col
 from daft.recordbatch import MicroPartition
 
@@ -16,3 +19,12 @@ def test_utf8_to_datetime():
             datetime.datetime(2021, 1, 2, 0, 0),
         ]
     }
+
+
+def test_utf8_to_datetime_all_null_with_offset():
+    # An all-null column with an offset directive must still resolve to Timestamp[us; UTC],
+    # matching get_return_field. Otherwise eval_expression panics with a data type mismatch.
+    table = MicroPartition.from_arrow(pa.table({"col": pa.array([None, None], type=pa.string())}))
+    result = table.eval_expression_list([col("col").to_datetime("%Y-%m-%d %H:%M:%S %z")])
+    assert result.to_pydict() == {"col": [None, None]}
+    assert result.schema()["col"].dtype == DataType.timestamp("us", "UTC")


### PR DESCRIPTION
## Problem

`to_datetime` panics at execution when a column contains no value carrying an
offset but the format string has an offset directive (`%z`) -- the simplest case
being an all-null string column.

```python
import daft, daft.functions as F
from daft import DataType, col

fmt = "%Y-%m-%dT%H:%M:%S%z"
nulls = daft.from_pydict({"s": [None]}).with_column("s", col("s").cast(DataType.string()))
nulls.select(F.to_datetime(col("s"), fmt)).collect()
```

Before this fix the `collect()` panics:

```
Data type mismatch in expression evaluation:
    Expected type: Timestamp[us; UTC]
    Computed type: Timestamp[us]
```

After the fix it returns `{'s': [None]}` with dtype `Timestamp[us; UTC]`.

## Root cause

`ToDatetime::get_return_field` decides the output type from the format string
alone: an offset directive coerces the result to `Timestamp[tu; UTC]`
(`src/daft-functions-utf8/src/to_datetime.rs`, the `format_string_has_offset`
branch).

But `to_datetime_impl` set its output timezone to UTC only *inside* the parse
loop, and only when it actually parsed a value carrying an offset (the removed
`if timezone.is_none() { timezone = Some("UTC".to_string()); }`). For a column
where no value has an offset -- e.g. all-null -- that branch never ran, so the
array was built as naive `Timestamp[tu]`, mismatching the planned
`Timestamp[tu; UTC]` and tripping the data-type assertion in
`RecordBatch::eval_expression` (`src/daft-recordbatch/src/lib.rs`).

## Fix

Decide the output timezone purely from the explicit `timezone` argument and
`format_string_has_offset(format)`, exactly mirroring `get_return_field`, and
drop the data-driven in-loop mutation. The runtime array type now always matches
the planned type, for all-null, mixed, explicit-timezone and offset-format
columns alike.

## Tests

- New regression test `test_utf8_to_datetime_all_null_with_offset`
  (`tests/recordbatch/utf8/test_to_datetime.py`): an all-null string column with
  a `%z` format resolves to `Timestamp[us; UTC]` with values `[None, None]`, and
  `eval_expression_list` no longer panics.
- Existing suites pass: `tests/series/test_utf8_ops.py -k to_datetime`
  (incl. "Unspecified timezone returns datetime in utc"),
  `tests/recordbatch/utf8/test_to_datetime.py`,
  `tests/expressions/typing/test_str.py`.
- `cargo clippy --workspace --all-features --all-targets -- -D warnings` is clean.

Closes #7470
