### PR TITLE
fix(utf8): parse to_datetime strictly and support date-only formats

### DIFF
--- a/src/daft-functions-utf8/src/to_datetime.rs
+++ b/src/daft-functions-utf8/src/to_datetime.rs
@@ -105,7 +105,7 @@ fn to_datetime_impl(
     let len = arr.len();
     let arr_iter = arr.into_iter();
     let timeunit = infer_timeunit_from_format_string(format);
-    let mut timezone = timezone.map(|tz| tz.to_string());
+    let timezone = timezone.map(|tz| tz.to_string());
     let result = arr_iter
             .map(|val| match val {
                 Some(val) => {
@@ -136,11 +136,6 @@ fn to_datetime_impl(
                                     ))
                                 })?.0.to_utc();
 
-                                // if it has an offset, we coerce it to UTC. This is consistent with other engines (duckdb, polars, datafusion)
-                                if timezone.is_none() {
-                                    timezone = Some("UTC".to_string());
-                                }
-
                                 match timeunit {
                                     TimeUnit::Seconds => datetime.timestamp(),
                                     TimeUnit::Milliseconds => datetime.timestamp_millis(),
@@ -167,6 +162,12 @@ fn to_datetime_impl(
                 _ => Ok(None),
             })
             .collect::<DaftResult<Int64Array>>()?;
+
+    // The output timezone must be decided from the format alone, exactly as `get_return_field`
+    // does: an offset directive coerces the result to UTC even when no value carries an offset
+    // (e.g. an all-null column). Otherwise the runtime array would be built as `Timestamp[us]`
+    // and mismatch the planned `Timestamp[us; UTC]`, panicking at execution.
+    let timezone = timezone.or_else(|| format_string_has_offset(format).then(|| "UTC".to_string()));
 
     let result = TimestampArray::new(
         Field::new(arr.name(), DataType::Timestamp(timeunit, timezone)),

--- a/src/daft-functions-utf8/src/to_datetime.rs
+++ b/src/daft-functions-utf8/src/to_datetime.rs
@@ -97,6 +97,47 @@ pub fn to_datetime<S: Into<String>>(input: ExprRef, format: S, timezone: Option<
     ScalarFn::builtin(ToDatetime, inputs).into()
 }
 
+/// Parses a value into a [`chrono::NaiveDateTime`] for a format that carries no UTC offset.
+///
+/// This is strict, mirroring `to_date`: trailing input the format does not consume is rejected
+/// instead of silently dropped (consistent with DuckDB and polars). As a special case, a format
+/// with no time-of-day field at all (e.g. `%Y-%m-%d`) resolves to midnight on that date, matching
+/// DuckDB / polars / Spark. A partially specified time (e.g. `%Y-%m-%d %H`) still errors rather
+/// than silently discarding the fields chrono cannot assemble a time from.
+fn parse_naive_datetime(val: &str, format: &str) -> DaftResult<chrono::NaiveDateTime> {
+    let fail = |e: chrono::format::ParseError| {
+        DaftError::ComputeError(format!(
+            "Error in to_datetime: failed to parse datetime {val} with format {format} : {e}"
+        ))
+    };
+
+    let mut parsed = chrono::format::Parsed::new();
+    // Unlike `parse_and_remainder`, `chrono::format::parse` errors when trailing input remains.
+    chrono::format::parse(&mut parsed, val, chrono::format::StrftimeItems::new(format))
+        .map_err(&fail)?;
+
+    // True when the value+format carry no time-of-day information whatsoever.
+    let date_only = parsed.hour_div_12.is_none()
+        && parsed.hour_mod_12.is_none()
+        && parsed.minute.is_none()
+        && parsed.second.is_none()
+        && parsed.nanosecond.is_none()
+        && parsed.timestamp.is_none();
+
+    match parsed.to_naive_datetime_with_offset(0) {
+        Ok(datetime) => Ok(datetime),
+        // `NaiveDateTime` needs time fields; a bare date reports `NotEnough`. Fall back to midnight
+        // only when nothing time-like was parsed, so partial times keep their error.
+        Err(e) if e.kind() == chrono::format::ParseErrorKind::NotEnough && date_only => {
+            let date = parsed.to_naive_date().map_err(&fail)?;
+            Ok(date
+                .and_hms_opt(0, 0, 0)
+                .expect("midnight is always a valid time"))
+        }
+        Err(e) => Err(fail(e)),
+    }
+}
+
 fn to_datetime_impl(
     arr: &Utf8Array,
     format: &str,
@@ -111,7 +152,7 @@ fn to_datetime_impl(
                 Some(val) => {
                     let timestamp = match timezone.as_deref() {
                         Some(tz) => {
-                            let (datetime, _) = chrono::DateTime::parse_and_remainder(val, format).map_err(|e| {
+                            let datetime = chrono::DateTime::parse_from_str(val, format).map_err(|e| {
                                 DaftError::ComputeError(format!(
                                     "Error in to_datetime: failed to parse datetime {val} with format {format} : {e}"
                                 ))
@@ -130,11 +171,11 @@ fn to_datetime_impl(
                         }
                         None => {
                             if format_string_has_offset(format) {
-                                let datetime = chrono::DateTime::parse_and_remainder(val, format).map_err(|e| {
+                                let datetime = chrono::DateTime::parse_from_str(val, format).map_err(|e| {
                                     DaftError::ComputeError(format!(
                                         "Error in to_datetime: failed to parse datetime {val} with format {format} : {e}"
                                     ))
-                                })?.0.to_utc();
+                                })?.to_utc();
 
                                 match timeunit {
                                     TimeUnit::Seconds => datetime.timestamp(),
@@ -143,11 +184,7 @@ fn to_datetime_impl(
                                     TimeUnit::Nanoseconds => datetime.timestamp_nanos_opt().ok_or_else(|| DaftError::ComputeError(format!("Error in to_datetime: failed to get nanoseconds for {val}")))?,
                                 }
                             } else {
-                                let naive_datetime = chrono::NaiveDateTime::parse_and_remainder(val, format).map_err(|e| {
-                                    DaftError::ComputeError(format!(
-                                        "Error in to_datetime: failed to parse datetime {val} with format {format} : {e}"
-                                    ))
-                                })?.0.and_utc();
+                                let naive_datetime = parse_naive_datetime(val, format)?.and_utc();
                                 match timeunit {
                                     TimeUnit::Seconds => naive_datetime.timestamp(),
                                     TimeUnit::Milliseconds => naive_datetime.timestamp_millis(),

--- a/tests/recordbatch/utf8/test_to_datetime.py
+++ b/tests/recordbatch/utf8/test_to_datetime.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import datetime
 
+import pyarrow as pa
+
+from daft import DataType
 from daft.expressions import col
 from daft.recordbatch import MicroPartition
 
@@ -16,3 +19,12 @@ def test_utf8_to_datetime():
             datetime.datetime(2021, 1, 2, 0, 0),
         ]
     }
+
+
+def test_utf8_to_datetime_all_null_with_offset():
+    # An all-null column with an offset directive must still resolve to Timestamp[us; UTC],
+    # matching get_return_field. Otherwise eval_expression panics with a data type mismatch.
+    table = MicroPartition.from_arrow(pa.table({"col": pa.array([None, None], type=pa.string())}))
+    result = table.eval_expression_list([col("col").to_datetime("%Y-%m-%d %H:%M:%S %z")])
+    assert result.to_pydict() == {"col": [None, None]}
+    assert result.schema()["col"].dtype == DataType.timestamp("us", "UTC")

--- a/tests/series/test_utf8_ops.py
+++ b/tests/series/test_utf8_ops.py
@@ -1464,12 +1464,12 @@ def test_series_utf8_to_datetime_different_timezones(data, format, timezone, exp
             id="Microseconds",
         ),
         pytest.param(
-            ["2021-01-01 00:00:45.1234", "2021-01-02 01:07:35.12300", "2021-01-03 12:30:00.123"],
+            ["2021-01-01 00:00:45.123", "2021-01-02 01:07:35.456", "2021-01-03 12:30:00.789"],
             "%Y-%m-%d %H:%M:%S%.3f",
             [
                 datetime.datetime(2021, 1, 1, 0, 0, 45, 123000),
-                datetime.datetime(2021, 1, 2, 1, 7, 35, 123000),
-                datetime.datetime(2021, 1, 3, 12, 30, 0, 123000),
+                datetime.datetime(2021, 1, 2, 1, 7, 35, 456000),
+                datetime.datetime(2021, 1, 3, 12, 30, 0, 789000),
             ],
             "ms",
             id="Milliseconds",
@@ -1481,6 +1481,32 @@ def test_series_utf8_to_datetime_different_timeunit(data, format, expected, time
     result = s.str.to_datetime(format)
     assert result.to_pylist() == expected
     assert result.datatype() == DataType.timestamp(timeunit)
+
+
+def test_series_utf8_to_datetime_date_only() -> None:
+    # A format with no time-of-day fields resolves to midnight, matching DuckDB / polars / Spark.
+    s = Series.from_arrow(pa.array(["2020-01-01", "2021-12-31"], type=pa.string()))
+    result = s.str.to_datetime("%Y-%m-%d")
+    assert result.to_pylist() == [
+        datetime.datetime(2020, 1, 1, 0, 0, 0),
+        datetime.datetime(2021, 12, 31, 0, 0, 0),
+    ]
+    assert result.datatype() == DataType.timestamp("us")
+
+
+def test_series_utf8_to_datetime_trailing_input_rejected() -> None:
+    # Trailing input the format does not consume is rejected rather than silently dropped.
+    s = Series.from_arrow(pa.array(["2020-01-01T12:34:56.789"], type=pa.string()))
+    with pytest.raises(ValueError, match="trailing input"):
+        s.str.to_datetime("%Y-%m-%dT%H:%M:%S")
+
+
+def test_series_utf8_to_datetime_partial_time_rejected() -> None:
+    # A partially specified time (hour without minute) must not fall back to midnight and silently
+    # drop the hour; it stays an error.
+    s = Series.from_arrow(pa.array(["2020-01-01 12"], type=pa.string()))
+    with pytest.raises(ValueError):
+        s.str.to_datetime("%Y-%m-%d %H")
 
 
 def test_series_utf8_to_datetime_bad_format() -> None:


### PR DESCRIPTION
## Problem

`to_datetime` cannot parse date-only formats, and silently ignores trailing input. From #7469:

```python
import daft
import daft.functions as F
from daft import col

# (1) date-only format errors instead of giving midnight
daft.from_pydict({"s": ["2020-01-01"]}).select(F.to_datetime(col("s"), "%Y-%m-%d")).collect()
# DaftError::ComputeError ... : input is not enough for unique date and time

# (2) trailing input is silently dropped
daft.from_pydict({"s": ["2020-01-01T12:34:56.789"]}).select(F.to_datetime(col("s"), "%Y-%m-%dT%H:%M:%S")).to_pydict()
# {'s': [datetime.datetime(2020, 1, 1, 12, 34, 56)]}   # .789 silently discarded
```

DuckDB's `strptime`, polars' `str.to_datetime` and Spark's `to_timestamp` both (1) return midnight for a format without time fields and (2) reject input with trailing characters.

## Root cause

The kernel parsed every value with `chrono::{NaiveDateTime,DateTime}::parse_and_remainder`, which by design leaves unparsed text behind (so trailing input is dropped), and `NaiveDateTime` requires time fields (so a bare date reports `NotEnough`).

## Fix

In `src/daft-functions-utf8/src/to_datetime.rs`:

- **Reject trailing input**: all three parse sites now use the strict `parse_from_str` / `chrono::format::parse`, which error with `trailing input` when characters remain. This matches the already-strict `to_date`.
- **Date-only → midnight**: the naive (no-offset) path falls back to `NaiveDate` at `00:00:00` when chrono reports `NotEnough`. The fallback fires **only when no time-of-day field was parsed at all**, so a partially specified time (e.g. `%Y-%m-%d %H`, hour without minute) keeps erroring rather than silently dropping the hour and returning midnight.

### Behavior change

`%.3f` means *exactly three* fractional digits. Inputs with more (e.g. `...45.1234`) previously had the extra digits dropped; they are now rejected as trailing input, consistent with part (2) of the issue. The affected parametrized test was updated to use exactly-three-digit fractions.

## Tests

- Added `test_series_utf8_to_datetime_date_only`, `test_series_utf8_to_datetime_trailing_input_rejected`, `test_series_utf8_to_datetime_partial_time_rejected`.
- Updated the `%.3f` "Milliseconds" case in `test_series_utf8_to_datetime_different_timeunit` to valid three-digit fractions.
- Existing suites pass: `tests/series/test_utf8_ops.py`, `tests/recordbatch/utf8/test_to_datetime.py`, `tests/expressions/typing/test_str.py`, `tests/sql/test_temporal_exprs.py`, `tests/sql/test_exprs.py`, `tests/expressions/test_to_arrow_expr.py`.

## Note on stacking

This branch is **stacked on #7483** (the fix for #7470), since both touch `to_datetime_impl`. It therefore includes that one commit; please merge #7483 first, after which this PR's diff reduces to just the changes above. Only the top commit (`fix(utf8): parse to_datetime strictly and support date-only formats`) is new here.

Closes #7469
