### PR TITLE
fix(functions): preserve literal backslashes in regexp_replace replacement

### DIFF
--- a/src/daft-functions-utf8/src/replace.rs
+++ b/src/daft-functions-utf8/src/replace.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Borrow, sync::LazyLock};
+use std::borrow::Borrow;
 
 use common_error::{DaftError, DaftResult, ensure};
 use daft_core::{
@@ -163,14 +163,48 @@ fn replace_impl(
     Ok(result)
 }
 
-/// replace POSIX capture groups (like \1) with Rust Regex group (like ${1})
-/// used by regexp_replace
+/// Rewrites a `regexp_replace` replacement template into the syntax the `regex` crate expects.
+///
+/// The `regex` crate understands only `$name` / `${name}` group references and treats a backslash
+/// literally, whereas POSIX-style replacements use `\1` for groups and `\\` for a literal
+/// backslash. This translates `\<digits>` into `${digits}` and `\\` into a single `\`; any other
+/// `\x` (including a trailing `\`) keeps its backslash so a backslash can appear in the output.
+///
+/// The previous regex-based rewrite used `(\\)(\d*)` -> `${$2}`. Because `\d*` also matches zero
+/// digits, a backslash not followed by a digit became `${}` — an empty group name that expands to
+/// nothing — silently dropping every literal backslash.
 fn regex_replace_posix_groups(replacement: &str) -> String {
-    static CAPTURE_GROUPS_RE_LOCK: LazyLock<regex::Regex> =
-        LazyLock::new(|| regex::Regex::new(r"(\\)(\d*)").unwrap());
-    CAPTURE_GROUPS_RE_LOCK
-        .replace_all(replacement, "$${$2}")
-        .into_owned()
+    let mut result = String::with_capacity(replacement.len());
+    let mut chars = replacement.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c != '\\' {
+            result.push(c);
+            continue;
+        }
+        match chars.peek() {
+            // `\\` is an escaped backslash: emit one literal backslash.
+            Some('\\') => {
+                chars.next();
+                result.push('\\');
+            }
+            // `\<digits>` is a POSIX group reference: emit Rust's `${digits}`.
+            Some(digit) if digit.is_ascii_digit() => {
+                result.push_str("${");
+                while let Some(digit) = chars.peek() {
+                    if digit.is_ascii_digit() {
+                        result.push(*digit);
+                        chars.next();
+                    } else {
+                        break;
+                    }
+                }
+                result.push('}');
+            }
+            // Any other `\x` (or a trailing `\`) keeps the backslash literally.
+            _ => result.push('\\'),
+        }
+    }
+    result
 }
 
 fn regex_replace<'a, R: Borrow<regex::Regex>>(
@@ -305,5 +339,38 @@ mod tests {
         let result = replace_impl(&arr, &pattern, &replacement, true).unwrap();
 
         assert_eq!(result.get(0), Some("world hello"));
+    }
+
+    #[test]
+    fn test_regexp_replace_preserves_literal_backslashes() {
+        // From #7471: a backslash in the replacement that is neither a `\1`-style group reference
+        // nor an escaped `\\` must survive into the output instead of being silently dropped.
+        let arr = Utf8Array::from_iter("a", vec![Some("abc")].into_iter());
+        let pattern = Utf8Array::from_iter("p", vec![Some("(b)")].into_iter());
+
+        let cases = [
+            ("[$1]", "a[b]c"),  // `$1`: Rust group reference
+            ("[\\1]", "a[b]c"), // `\1`: POSIX group reference
+            ("a\\b", "aa\\bc"), // `\b`: not a group, backslash stays literal
+            ("\\\\", "a\\c"),   // `\\`: escaped backslash -> one literal `\`
+            ("x\\", "ax\\c"),   // trailing backslash stays literal
+        ];
+        for (replacement, expected) in cases {
+            let replacement_arr = Utf8Array::from_iter("r", vec![Some(replacement)].into_iter());
+            let result = replace_impl(&arr, &pattern, &replacement_arr, true).unwrap();
+            assert_eq!(result.get(0), Some(expected), "replacement={replacement:?}");
+        }
+    }
+
+    #[test]
+    fn test_regex_replace_posix_groups_translation() {
+        assert_eq!(regex_replace_posix_groups("[$1]"), "[$1]");
+        assert_eq!(regex_replace_posix_groups("[\\1]"), "[${1}]");
+        assert_eq!(regex_replace_posix_groups("a\\b"), "a\\b");
+        assert_eq!(regex_replace_posix_groups("\\\\"), "\\");
+        assert_eq!(regex_replace_posix_groups("x\\"), "x\\");
+        assert_eq!(regex_replace_posix_groups("\\2 \\1"), "${2} ${1}");
+        // Group references are greedy over digits, matching the previous behaviour.
+        assert_eq!(regex_replace_posix_groups("\\12"), "${12}");
     }
 }

--- a/tests/series/test_utf8_ops.py
+++ b/tests/series/test_utf8_ops.py
@@ -816,6 +816,26 @@ def test_series_utf8_replace_regex(data, pattern, replacement, expected) -> None
 
 
 @pytest.mark.parametrize(
+    ["replacement", "expected"],
+    [
+        ("[$1]", "a[b]c"),  # `$1`: Rust group reference
+        ("[\\1]", "a[b]c"),  # `\1`: POSIX group reference
+        ("a\\b", "aa\\bc"),  # `\b`: not a group reference, backslash stays literal
+        ("\\\\", "a\\c"),  # `\\`: escaped backslash -> one literal `\`
+        ("x\\", "ax\\c"),  # trailing backslash stays literal
+    ],
+)
+def test_series_utf8_regexp_replace_backslashes(replacement, expected) -> None:
+    # From #7471: a backslash in the replacement that is not a group reference must be preserved
+    # rather than silently dropped.
+    s = Series.from_arrow(pa.array(["abc"], type=pa.string()))
+    pattern = Series.from_arrow(pa.array(["(b)"], type=pa.string()))
+    replacements = Series.from_arrow(pa.array([replacement], type=pa.string()))
+    result = s.str.replace(pattern, replacements, regex=True)
+    assert result.to_pylist() == [expected]
+
+
+@pytest.mark.parametrize(
     ["data", "pattern", "replacement", "expected"],
     [
         # Broadcast null data


### PR DESCRIPTION
## Problem

`regexp_replace` drops every literal backslash from the replacement, so there is no way to emit one at all. From #7471:

```python
import daft
import daft.functions as F
from daft import col

df = daft.from_pydict({"s": ["abc"]})
for replacement in ["[$1]", "[\\1]", "a\\b", "\\\\", "x\\"]:
    print(f"{replacement!r:10} -> {df.select(F.regexp_replace(col('s'), '(b)', replacement)).to_pydict()['s'][0]!r}")
```

| replacement (actual string) | before | expected |
| --- | --- | --- |
| `[$1]`  | `a[b]c` | `a[b]c` |
| `[\1]`  | `a[b]c` | `a[b]c` |
| `a\b`   | `aabc`  | `aa\bc` |
| `\\`    | `ac`    | `a\c`   |
| `x\`    | `axc`   | `ax\c`  |

`$1` / `\1` group references were fine, but any other backslash was silently swallowed — including replacements that come from user data or another column.

## Root cause

`regex_replace_posix_groups` rewrote the replacement with the regex `(\\)(\d*)` → `${$2}` to translate POSIX `\1` into Rust's `${1}`. Because `\d*` also matches **zero** digits, a backslash not followed by a digit became `${}` — an empty group name that the `regex` crate expands to nothing — dropping the backslash. (This was copied from DataFusion, which has the same regex.)

## Fix

Replaced the regex with an explicit character scan in `src/daft-functions-utf8/src/replace.rs`:

- `\<digits>` → `${digits}` (POSIX group reference → Rust syntax), unchanged and still greedy over digits;
- `\\` → a single literal `\`;
- any other `\x`, including a trailing `\` → the backslash is kept literally.

`$1` handling is untouched (the `regex` crate already understands `$`). This also removes the now-unused `LazyLock` import.

## Tests

- Rust: added `test_regexp_replace_preserves_literal_backslashes` (end-to-end through `replace_impl`, all five issue cases) and `test_regex_replace_posix_groups_translation` (template translation, incl. `\12` → `${12}`); the existing `test_regexp_replace_with_capture_groups` (`\2 \1` → `world hello`) still passes.
- Python: added `test_series_utf8_regexp_replace_backslashes` covering the same five cases via `str.replace(regex=True)`.
- `cargo test -p daft-functions-utf8 replace` → 8 passed; the replace suites in `tests/series/test_utf8_ops.py`, `tests/recordbatch/utf8/test_replace.py` and `tests/sql/test_utf8_exprs.py` pass.

Closes #7471
