### PR TITLE
perf(parquet): LM-pipelined predicate evaluation with stats-based group ordering

### DIFF
--- a/src/daft-parquet/src/read.rs
+++ b/src/daft-parquet/src/read.rs
@@ -821,4 +821,303 @@ mod tests {
         );
         let _ = std::fs::remove_dir_all(&dir);
     }
+
+    // ---------------------------------------------------------------------
+    // LM-pipelined predicate evaluation (#6340)
+    //
+    // These tests drive the full read path with real multi-row-group Parquet
+    // files and assert exact output rows/values. The pipelined path
+    // (`a > x AND b < y`, column-disjoint) and the monolithic fallbacks
+    // (single column, or same-column conjunction) must all produce identical,
+    // correctly-ordered results.
+    // ---------------------------------------------------------------------
+
+    /// Deterministic row generator: `a = i` (nullable every 7th row when
+    /// `a_nulls`), `b = i % 50`, `c = i * 10`. Shared by the writer and the
+    /// expected-value computation so they can never drift.
+    fn pipelined_test_rows(n: usize, a_nulls: bool) -> Vec<(Option<i64>, i64, i64)> {
+        (0..n)
+            .map(|i| {
+                let iv = i as i64;
+                let a = if a_nulls && iv % 7 == 0 {
+                    None
+                } else {
+                    Some(iv)
+                };
+                (a, iv % 50, iv * 10)
+            })
+            .collect()
+    }
+
+    fn write_pipelined_test_parquet(
+        path: &std::path::Path,
+        n: usize,
+        rg_size: usize,
+        a_nulls: bool,
+    ) {
+        use arrow::{
+            array::{Int64Array, RecordBatch as ArrowRecordBatch},
+            datatypes::{DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema},
+        };
+        use parquet::{arrow::ArrowWriter, file::properties::WriterProperties};
+
+        let schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new("a", ArrowDataType::Int64, true),
+            ArrowField::new("b", ArrowDataType::Int64, false),
+            ArrowField::new("c", ArrowDataType::Int64, false),
+        ]));
+        let props = WriterProperties::builder()
+            .set_max_row_group_row_count(Some(rg_size))
+            .build();
+        let file = std::fs::File::create(path).unwrap();
+        let mut writer = ArrowWriter::try_new(file, schema.clone(), Some(props)).unwrap();
+
+        let rows = pipelined_test_rows(n, a_nulls);
+        // Write in rg_size-sized batches so each becomes its own row group.
+        for chunk in rows.chunks(rg_size) {
+            let a: Int64Array = chunk.iter().map(|(a, _, _)| *a).collect();
+            let b: Int64Array = chunk.iter().map(|(_, b, _)| *b).collect();
+            let c: Int64Array = chunk.iter().map(|(_, _, c)| *c).collect();
+            let batch = ArrowRecordBatch::try_new(
+                schema.clone(),
+                vec![Arc::new(a), Arc::new(b), Arc::new(c)],
+            )
+            .unwrap();
+            writer.write(&batch).unwrap();
+        }
+        writer.close().unwrap();
+    }
+
+    fn read_pipelined(
+        path: &str,
+        predicate: Option<daft_dsl::ExprRef>,
+        columns: Vec<String>,
+    ) -> daft_recordbatch::RecordBatch {
+        let path = path.to_string();
+        let io_client = Arc::new(IOClient::new(IOConfig::default().into()).unwrap());
+        let runtime = get_io_runtime(true);
+        runtime
+            .block_within_async_context(async move {
+                let opts = ParquetReadOptions {
+                    predicate,
+                    columns: Some(columns),
+                    ..Default::default()
+                };
+                read_parquet_into_recordbatch(&path, io_client, None, opts)
+                    .await
+                    .unwrap()
+            })
+            .unwrap()
+    }
+
+    fn pipelined_col_i64(batch: &daft_recordbatch::RecordBatch, name: &str) -> Vec<Option<i64>> {
+        let idx = batch
+            .schema
+            .get_fields_with_name(name)
+            .into_iter()
+            .next()
+            .unwrap_or_else(|| panic!("column {name} missing from output"))
+            .0;
+        let arr = batch.get_column(idx).i64().unwrap();
+        (0..arr.len()).map(|i| arr.get(i)).collect()
+    }
+
+    #[test]
+    fn test_pipelined_compound_disjoint_predicate() {
+        use daft_dsl::{lit, resolved_col};
+
+        let dir = std::env::temp_dir().join("daft_test_pipelined_compound");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("data.parquet");
+        // 200 rows across ~4 row groups of 64.
+        write_pipelined_test_parquet(&path, 200, 64, false);
+        let uri = path.to_str().unwrap().to_string();
+
+        // a > 100 AND b < 10  →  column-disjoint  →  pipelined path.
+        let pred = resolved_col("a")
+            .gt(lit(100))
+            .and(resolved_col("b").lt(lit(10)));
+        let batch = read_pipelined(&uri, Some(pred), vec!["a".into(), "b".into(), "c".into()]);
+
+        let expected: Vec<(Option<i64>, i64, i64)> = pipelined_test_rows(200, false)
+            .into_iter()
+            .filter(|(a, b, _)| a.is_some_and(|av| av > 100) && *b < 10)
+            .collect();
+        assert!(
+            expected.len() > 1 && expected.len() < 200,
+            "test predicate should be selective but non-empty, got {}",
+            expected.len()
+        );
+
+        assert_eq!(batch.len(), expected.len(), "row count mismatch");
+        assert_eq!(
+            pipelined_col_i64(&batch, "a"),
+            expected.iter().map(|(a, _, _)| *a).collect::<Vec<_>>()
+        );
+        assert_eq!(
+            pipelined_col_i64(&batch, "b"),
+            expected
+                .iter()
+                .map(|(_, b, _)| Some(*b))
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(
+            pipelined_col_i64(&batch, "c"),
+            expected
+                .iter()
+                .map(|(_, _, c)| Some(*c))
+                .collect::<Vec<_>>()
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_pipelined_matches_monolithic_same_data() {
+        use daft_dsl::{lit, resolved_col};
+
+        // Identical data + projection; compare a pipelined predicate against a
+        // monolithic one that selects the same rows, to prove the two strategies
+        // agree. `a > 100 AND b < 10` (pipelined) vs `a > 100 AND a < 1000 AND
+        // b < 10` — the extra same-column conjunct forces grouping but keeps the
+        // surviving set identical.
+        let dir = std::env::temp_dir().join("daft_test_pipelined_vs_mono");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("data.parquet");
+        write_pipelined_test_parquet(&path, 200, 64, false);
+        let uri = path.to_str().unwrap().to_string();
+
+        let pipelined_pred = resolved_col("a")
+            .gt(lit(100))
+            .and(resolved_col("b").lt(lit(10)));
+        let pipelined = read_pipelined(
+            &uri,
+            Some(pipelined_pred),
+            vec!["a".into(), "b".into(), "c".into()],
+        );
+
+        // `a > 100 AND a < 1000` share column a → merged into one group; with
+        // `b < 10` that's still 2 groups, but the point here is the surviving
+        // rows are identical to the pipelined predicate above.
+        let mono_pred = resolved_col("a")
+            .gt(lit(100))
+            .and(resolved_col("a").lt(lit(1000)))
+            .and(resolved_col("b").lt(lit(10)));
+        let mono = read_pipelined(
+            &uri,
+            Some(mono_pred),
+            vec!["a".into(), "b".into(), "c".into()],
+        );
+
+        assert_eq!(pipelined.len(), mono.len());
+        assert_eq!(
+            pipelined_col_i64(&pipelined, "c"),
+            pipelined_col_i64(&mono, "c")
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_monolithic_fallback_single_column() {
+        use daft_dsl::{lit, resolved_col};
+
+        let dir = std::env::temp_dir().join("daft_test_pipelined_mono_single");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("data.parquet");
+        write_pipelined_test_parquet(&path, 200, 64, false);
+        let uri = path.to_str().unwrap().to_string();
+
+        // Single-column predicate → one group → monolithic fallback.
+        let pred = resolved_col("a").gt(lit(100));
+        let batch = read_pipelined(&uri, Some(pred), vec!["a".into(), "c".into()]);
+
+        let expected: Vec<(Option<i64>, i64)> = pipelined_test_rows(200, false)
+            .into_iter()
+            .filter(|(a, _, _)| a.is_some_and(|av| av > 100))
+            .map(|(a, _, c)| (a, c))
+            .collect();
+        assert_eq!(batch.len(), expected.len());
+        assert_eq!(
+            pipelined_col_i64(&batch, "a"),
+            expected.iter().map(|(a, _)| *a).collect::<Vec<_>>()
+        );
+        assert_eq!(
+            pipelined_col_i64(&batch, "c"),
+            expected.iter().map(|(_, c)| Some(*c)).collect::<Vec<_>>()
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_monolithic_fallback_same_column_conjunction() {
+        use daft_dsl::{lit, resolved_col};
+
+        let dir = std::env::temp_dir().join("daft_test_pipelined_mono_samecol");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("data.parquet");
+        write_pipelined_test_parquet(&path, 200, 64, false);
+        let uri = path.to_str().unwrap().to_string();
+
+        // a > 100 AND a < 150 → same column → merged into one group → monolithic.
+        let pred = resolved_col("a")
+            .gt(lit(100))
+            .and(resolved_col("a").lt(lit(150)));
+        let batch = read_pipelined(&uri, Some(pred), vec!["a".into(), "c".into()]);
+
+        let expected: Vec<(Option<i64>, i64)> = pipelined_test_rows(200, false)
+            .into_iter()
+            .filter(|(a, _, _)| a.is_some_and(|av| av > 100 && av < 150))
+            .map(|(a, _, c)| (a, c))
+            .collect();
+        assert_eq!(batch.len(), expected.len());
+        assert_eq!(
+            pipelined_col_i64(&batch, "a"),
+            expected.iter().map(|(a, _)| *a).collect::<Vec<_>>()
+        );
+        assert_eq!(
+            pipelined_col_i64(&batch, "c"),
+            expected.iter().map(|(_, c)| Some(*c)).collect::<Vec<_>>()
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_pipelined_null_handling() {
+        use daft_dsl::{lit, resolved_col};
+
+        let dir = std::env::temp_dir().join("daft_test_pipelined_nulls");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("data.parquet");
+        // `a` is null on every 7th row; those rows must never survive `a > 100`.
+        write_pipelined_test_parquet(&path, 200, 64, true);
+        let uri = path.to_str().unwrap().to_string();
+
+        let pred = resolved_col("a")
+            .gt(lit(100))
+            .and(resolved_col("b").lt(lit(10)));
+        let batch = read_pipelined(&uri, Some(pred), vec!["a".into(), "b".into(), "c".into()]);
+
+        let expected: Vec<(Option<i64>, i64, i64)> = pipelined_test_rows(200, true)
+            .into_iter()
+            .filter(|(a, b, _)| a.is_some_and(|av| av > 100) && *b < 10)
+            .collect();
+        assert_eq!(batch.len(), expected.len());
+        // No null `a` may appear in the output.
+        assert!(
+            pipelined_col_i64(&batch, "a").iter().all(|a| a.is_some()),
+            "null `a` rows must be excluded by `a > 100`"
+        );
+        assert_eq!(
+            pipelined_col_i64(&batch, "c"),
+            expected
+                .iter()
+                .map(|(_, _, c)| Some(*c))
+                .collect::<Vec<_>>()
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 }

--- a/src/daft-parquet/src/read.rs
+++ b/src/daft-parquet/src/read.rs
@@ -1009,7 +1009,7 @@ mod tests {
         let pipelined = read_pipelined(&uri, Some(pred.clone()), columns.clone());
         let mono = read_pipelined_with_limit(&uri, Some(pred), columns, Some(total_fixture_rows));
 
-        assert!(pipelined.len() > 0 && pipelined.len() < total_fixture_rows);
+        assert!(!pipelined.is_empty() && pipelined.len() < total_fixture_rows);
         assert_eq!(pipelined.len(), mono.len());
         for name in ["a", "b", "c"] {
             assert_eq!(

--- a/src/daft-parquet/src/read.rs
+++ b/src/daft-parquet/src/read.rs
@@ -859,31 +859,36 @@ mod tests {
             array::{Int64Array, RecordBatch as ArrowRecordBatch},
             datatypes::{DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema},
         };
-        use parquet::{arrow::ArrowWriter, file::properties::WriterProperties};
-
         let schema = Arc::new(ArrowSchema::new(vec![
             ArrowField::new("a", ArrowDataType::Int64, true),
             ArrowField::new("b", ArrowDataType::Int64, false),
             ArrowField::new("c", ArrowDataType::Int64, false),
         ]));
+        let rows = pipelined_test_rows(n, a_nulls);
+        let a: Int64Array = rows.iter().map(|(a, _, _)| *a).collect();
+        let b: Int64Array = rows.iter().map(|(_, b, _)| *b).collect();
+        let c: Int64Array = rows.iter().map(|(_, _, c)| *c).collect();
+        let batch =
+            ArrowRecordBatch::try_new(schema, vec![Arc::new(a), Arc::new(b), Arc::new(c)]).unwrap();
+        write_pipelined_test_batch(path, &batch, rg_size);
+    }
+
+    fn write_pipelined_test_batch(
+        path: &std::path::Path,
+        batch: &arrow::array::RecordBatch,
+        rg_size: usize,
+    ) {
+        use parquet::{arrow::ArrowWriter, file::properties::WriterProperties};
+
         let props = WriterProperties::builder()
             .set_max_row_group_row_count(Some(rg_size))
             .build();
         let file = std::fs::File::create(path).unwrap();
-        let mut writer = ArrowWriter::try_new(file, schema.clone(), Some(props)).unwrap();
-
-        let rows = pipelined_test_rows(n, a_nulls);
-        // Write in rg_size-sized batches so each becomes its own row group.
-        for chunk in rows.chunks(rg_size) {
-            let a: Int64Array = chunk.iter().map(|(a, _, _)| *a).collect();
-            let b: Int64Array = chunk.iter().map(|(_, b, _)| *b).collect();
-            let c: Int64Array = chunk.iter().map(|(_, _, c)| *c).collect();
-            let batch = ArrowRecordBatch::try_new(
-                schema.clone(),
-                vec![Arc::new(a), Arc::new(b), Arc::new(c)],
-            )
-            .unwrap();
-            writer.write(&batch).unwrap();
+        let mut writer = ArrowWriter::try_new(file, batch.schema(), Some(props)).unwrap();
+        for offset in (0..batch.num_rows()).step_by(rg_size) {
+            writer
+                .write(&batch.slice(offset, rg_size.min(batch.num_rows() - offset)))
+                .unwrap();
         }
         writer.close().unwrap();
     }
@@ -893,6 +898,15 @@ mod tests {
         predicate: Option<daft_dsl::ExprRef>,
         columns: Vec<String>,
     ) -> daft_recordbatch::RecordBatch {
+        read_pipelined_with_limit(path, predicate, columns, None)
+    }
+
+    fn read_pipelined_with_limit(
+        path: &str,
+        predicate: Option<daft_dsl::ExprRef>,
+        columns: Vec<String>,
+        num_rows: Option<usize>,
+    ) -> daft_recordbatch::RecordBatch {
         let path = path.to_string();
         let io_client = Arc::new(IOClient::new(IOConfig::default().into()).unwrap());
         let runtime = get_io_runtime(true);
@@ -901,6 +915,7 @@ mod tests {
                 let opts = ParquetReadOptions {
                     predicate,
                     columns: Some(columns),
+                    num_rows,
                     ..Default::default()
                 };
                 read_parquet_into_recordbatch(&path, io_client, None, opts)
@@ -937,6 +952,7 @@ mod tests {
         let pred = resolved_col("a")
             .gt(lit(100))
             .and(resolved_col("b").lt(lit(10)));
+        crate::reader::assert_prefilter_strategy(&pred, None, true);
         let batch = read_pipelined(&uri, Some(pred), vec!["a".into(), "b".into(), "c".into()]);
 
         let expected: Vec<(Option<i64>, i64, i64)> = pipelined_test_rows(200, false)
@@ -976,44 +992,118 @@ mod tests {
     fn test_pipelined_matches_monolithic_same_data() {
         use daft_dsl::{lit, resolved_col};
 
-        // Identical data + projection; compare a pipelined predicate against a
-        // monolithic one that selects the same rows, to prove the two strategies
-        // agree. `a > 100 AND b < 10` (pipelined) vs `a > 100 AND a < 1000 AND
-        // b < 10` — the extra same-column conjunct forces grouping but keeps the
-        // surviving set identical.
-        let dir = std::env::temp_dir().join("daft_test_pipelined_vs_mono");
+        let dir =
+            std::env::temp_dir().join(format!("daft_test_pipelined_vs_mono_{}", fastrand::u64(..)));
         std::fs::create_dir_all(&dir).unwrap();
         let path = dir.join("data.parquet");
-        write_pipelined_test_parquet(&path, 200, 64, false);
+        let total_fixture_rows = 200;
+        write_pipelined_test_parquet(&path, total_fixture_rows, 64, true);
         let uri = path.to_str().unwrap().to_string();
 
-        let pipelined_pred = resolved_col("a")
+        let pred = resolved_col("a")
             .gt(lit(100))
             .and(resolved_col("b").lt(lit(10)));
-        let pipelined = read_pipelined(
-            &uri,
-            Some(pipelined_pred),
-            vec!["a".into(), "b".into(), "c".into()],
-        );
+        crate::reader::assert_prefilter_strategy(&pred, None, true);
+        crate::reader::assert_prefilter_strategy(&pred, Some(total_fixture_rows), false);
+        let columns = vec!["a".into(), "b".into(), "c".into()];
+        let pipelined = read_pipelined(&uri, Some(pred.clone()), columns.clone());
+        let mono = read_pipelined_with_limit(&uri, Some(pred), columns, Some(total_fixture_rows));
 
-        // `a > 100 AND a < 1000` share column a → merged into one group; with
-        // `b < 10` that's still 2 groups, but the point here is the surviving
-        // rows are identical to the pipelined predicate above.
-        let mono_pred = resolved_col("a")
-            .gt(lit(100))
-            .and(resolved_col("a").lt(lit(1000)))
-            .and(resolved_col("b").lt(lit(10)));
-        let mono = read_pipelined(
-            &uri,
-            Some(mono_pred),
-            vec!["a".into(), "b".into(), "c".into()],
-        );
-
+        assert!(pipelined.len() > 0 && pipelined.len() < total_fixture_rows);
         assert_eq!(pipelined.len(), mono.len());
-        assert_eq!(
-            pipelined_col_i64(&pipelined, "c"),
-            pipelined_col_i64(&mono, "c")
-        );
+        for name in ["a", "b", "c"] {
+            assert_eq!(
+                pipelined_col_i64(&pipelined, name),
+                pipelined_col_i64(&mono, name)
+            );
+        }
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_monolithic_fallback_column_dependent_is_in() {
+        use arrow::{
+            array::{Int64Array, RecordBatch as ArrowRecordBatch},
+            datatypes::{Field as ArrowField, Schema as ArrowSchema},
+        };
+        use daft_dsl::{lit, resolved_col};
+
+        let dir =
+            std::env::temp_dir().join(format!("daft_test_pipelined_is_in_{}", fastrand::u64(..)));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("data.parquet");
+        let schema = Arc::new(ArrowSchema::new(
+            ["a", "b", "c", "d"]
+                .map(|name| ArrowField::new(name, DataType::Int64, false))
+                .to_vec(),
+        ));
+        let batch = ArrowRecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int64Array::from(vec![0, 1])),
+                Arc::new(Int64Array::from(vec![9, 5])),
+                Arc::new(Int64Array::from(vec![5, 9])),
+                Arc::new(Int64Array::from(vec![10, 20])),
+            ],
+        )
+        .unwrap();
+        write_pipelined_test_batch(&path, &batch, 2);
+        let pred = resolved_col("a")
+            .eq(lit(1))
+            .and(resolved_col("b").is_in(vec![resolved_col("c")]));
+        let result = read_pipelined(path.to_str().unwrap(), Some(pred.clone()), vec!["d".into()]);
+
+        assert_eq!(pipelined_col_i64(&result, "d"), vec![Some(20)]);
+        assert_eq!(result.schema.field_names().collect::<Vec<_>>(), vec!["d"]);
+        crate::reader::assert_prefilter_strategy(&pred, None, false);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_monolithic_fallback_constant_conjuncts() {
+        use daft_dsl::{lit, null_lit, resolved_col};
+
+        let dir = std::env::temp_dir().join(format!(
+            "daft_test_pipelined_constants_{}",
+            fastrand::u64(..)
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("data.parquet");
+        write_pipelined_test_parquet(&path, 20, 20, true);
+        let expected: Vec<_> = pipelined_test_rows(20, true)
+            .into_iter()
+            .filter(|(a, b, _)| a.is_some_and(|a| a > 0) && *b < 10)
+            .map(|(_, _, c)| Some(c))
+            .collect();
+        assert!(!expected.is_empty());
+
+        for (constant, keeps_rows) in [
+            (lit(true), true),
+            (lit(false), false),
+            (null_lit(), false),
+            (
+                null_lit().cast(&daft_core::prelude::DataType::Boolean),
+                false,
+            ),
+        ] {
+            let pred = resolved_col("a")
+                .gt(lit(0))
+                .and(resolved_col("b").lt(lit(10)))
+                .and(constant);
+            let result =
+                read_pipelined(path.to_str().unwrap(), Some(pred.clone()), vec!["c".into()]);
+            assert_eq!(
+                pipelined_col_i64(&result, "c"),
+                if keeps_rows {
+                    expected.clone()
+                } else {
+                    Vec::new()
+                },
+                "predicate: {pred}"
+            );
+            crate::reader::assert_prefilter_strategy(&pred, None, false);
+        }
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/src/daft-parquet/src/reader/mod.rs
+++ b/src/daft-parquet/src/reader/mod.rs
@@ -1,5 +1,6 @@
 mod chunk_source;
 mod field_reader;
+mod pred_pipeline;
 mod rg_processor;
 mod util;
 
@@ -22,6 +23,7 @@ use parquet::{
     arrow::arrow_reader::{ArrowReaderMetadata, RowSelection, RowSelector},
     file::metadata::ParquetMetaData,
 };
+use pred_pipeline::{PredGroup, lm_pipeline_enabled, order_groups, plan_pred_groups};
 use rg_processor::{
     process_rg_predicate_only, process_rg_with_data_cols, recv_one_chunk, spawn_col_decoders,
 };
@@ -317,9 +319,19 @@ struct RgInputs {
 /// Build the per-RG input bundles for the streaming decoder.
 ///
 /// Without a pushed predicate prefilter, this just forwards offset/delete/limit
-/// selections. With one, it first decodes predicate columns, evaluates the mask,
-/// and uses that same mask for both filtered predicate arrays and a data-column
-/// `RowSelection`.
+/// selections. With one, it pre-filters: two strategies produce the *same*
+/// `RgInputs` contract (an RG-relative `selection` plus predicate-column arrays
+/// already filtered to the selected rows, in `pred_col_indices` order):
+///
+/// - **Monolithic** ([`prefilter_rg_monolithic`]): decode every predicate column
+///   up-front and evaluate the whole conjunction as one mask.
+/// - **LM-pipelined** ([`prefilter_rg_pipelined`], #6340): split the conjunction
+///   into column-disjoint groups and evaluate them one at a time, progressively
+///   narrowing the selection so each later group decodes fewer rows.
+///
+/// The pipelined path is used only when it can help and is safe for the MVP:
+/// kill-switch on, no `num_rows` limit, and the predicate splits into >= 2
+/// column-disjoint groups. Otherwise it falls back to the monolithic path.
 #[allow(clippy::too_many_arguments)]
 async fn build_rg_inputs(
     chunk_source: &Arc<ChunkSource>,
@@ -348,6 +360,21 @@ async fn build_rg_inputs(
             .collect());
     };
 
+    // Decide the strategy once per file. Pipelining needs >= 2 column-disjoint
+    // groups; the MVP also skips it when a limit is set (limit + progressive
+    // narrowing interacts subtly, deferred to a follow-up).
+    let pred_groups: Option<Vec<PredGroup>> = (lm_pipeline_enabled() && opts.num_rows.is_none())
+        .then(|| plan_pred_groups(prefilter_predicate))
+        .flatten();
+    let group_decodes = match &pred_groups {
+        Some(groups) => Some(prepare_group_decodes(
+            groups,
+            arrow_schema,
+            &plan.pred_col_indices,
+        )?),
+        None => None,
+    };
+
     // Limit set → chunked streaming for early termination. Unbounded → one
     // chunk per col so per-chunk arrow setup costs collapse to per-RG.
     let chunk_size = match opts.num_rows {
@@ -369,90 +396,39 @@ async fn build_rg_inputs(
         if selected_rows_remaining == 0 {
             break;
         }
-        let total_selected = base_sel
-            .as_ref()
-            .map(|s| s.row_count())
-            .unwrap_or_else(|| metadata.row_group(rg_idx).num_rows() as usize);
-
-        let (mut col_receivers, _col_handles) = spawn_col_decoders(
-            &plan.pred_col_indices,
-            chunk_source,
-            metadata,
-            arrow_schema,
-            base_sel.as_ref(),
-            rg_idx,
-            chunk_size,
-            path,
-        )
-        .await?;
-
-        let mut predicate_selectors: Vec<RowSelector> = Vec::new();
-        let mut filtered_pred_by_col: Vec<Vec<ArrayRef>> = (0..plan.pred_col_indices.len())
-            .map(|_| Vec::new())
-            .collect();
-        let mut processed_rows = 0usize;
-
-        loop {
-            let Some(chunks) = recv_one_chunk(&mut col_receivers).await? else {
-                break;
-            };
-            let chunk_rows = chunks[0].len();
-            let daft_pred =
-                record_batch_from_arrow(pred_arrow_schema.clone(), chunks.clone(), path.as_ref())?;
-            let mask = eval_predicate_mask(&daft_pred, &bound_pred)?;
-
-            let selected_rows = mask.true_count();
-            let (mask, selected_rows) = if selected_rows > selected_rows_remaining {
-                (
-                    truncate_mask_to_n_trues(&mask, selected_rows_remaining),
-                    selected_rows_remaining,
+        let (selection, pred_arrays) = match (&pred_groups, &group_decodes) {
+            (Some(groups), Some(decodes)) => {
+                prefilter_rg_pipelined(
+                    chunk_source,
+                    metadata,
+                    arrow_schema,
+                    &plan.read_daft_schema,
+                    &plan.pred_col_indices,
+                    groups,
+                    decodes,
+                    rg_idx,
+                    base_sel,
+                    path,
                 )
-            } else {
-                (mask, selected_rows)
-            };
-
-            let filtered = filter_arrays_by_mask(&chunks, &mask, path.as_ref())?;
-            for (col_pos, filtered) in filtered.into_iter().enumerate() {
-                filtered_pred_by_col[col_pos].push(filtered);
+                .await?
             }
-            predicate_selectors.extend(bool_array_to_row_selection(&mask).iter().copied());
-            processed_rows += chunk_rows;
-            selected_rows_remaining -= selected_rows;
-            if selected_rows_remaining == 0 {
-                break;
+            _ => {
+                prefilter_rg_monolithic(
+                    chunk_source,
+                    metadata,
+                    arrow_schema,
+                    &pred_arrow_schema,
+                    &bound_pred,
+                    &plan.pred_col_indices,
+                    rg_idx,
+                    base_sel,
+                    chunk_size,
+                    path,
+                    &mut selected_rows_remaining,
+                )
+                .await?
             }
-        }
-        // Dropping receivers closes the channels → spawned decoders abort.
-        drop(col_receivers);
-
-        // Concat per-col filtered chunks into one ArrayRef per col. Zero rows
-        // processed (e.g. base_sel selected 0 rows) → empty array of the col's
-        // data type.
-        let pred_arrays: Vec<ArrayRef> = plan
-            .pred_col_indices
-            .iter()
-            .enumerate()
-            .map(|(col_pos, &col_idx)| {
-                let chunks = &filtered_pred_by_col[col_pos];
-                if chunks.is_empty() {
-                    arrow::array::new_empty_array(arrow_schema.field(col_idx).data_type())
-                } else {
-                    let refs: Vec<&dyn arrow::array::Array> =
-                        chunks.iter().map(|a| a.as_ref()).collect();
-                    arrow::compute::concat(&refs).expect("concat per-col chunks")
-                }
-            })
-            .collect();
-
-        let unprocessed = total_selected - processed_rows;
-        if unprocessed > 0 {
-            predicate_selectors.push(RowSelector::skip(unprocessed));
-        }
-        let pred_sel = RowSelection::from(predicate_selectors);
-        let selection = Some(match &base_sel {
-            Some(base) => refine_selection(base, &pred_sel),
-            None => pred_sel,
-        });
+        };
 
         out.push(RgInputs {
             selection,
@@ -461,6 +437,269 @@ async fn build_rg_inputs(
     }
 
     Ok(out)
+}
+
+/// Monolithic per-RG prefilter: decode all predicate columns at `base_sel` and
+/// evaluate the whole conjunction as one mask per chunk. Handles the `num_rows`
+/// limit via chunked streaming + mask truncation + early break (mutating
+/// `selected_rows_remaining` across RGs).
+#[allow(clippy::too_many_arguments)]
+async fn prefilter_rg_monolithic(
+    chunk_source: &Arc<ChunkSource>,
+    metadata: &Arc<ParquetMetaData>,
+    arrow_schema: &Arc<ArrowSchema>,
+    pred_arrow_schema: &Arc<ArrowSchema>,
+    bound_pred: &BoundExpr,
+    pred_col_indices: &[usize],
+    rg_idx: usize,
+    base_sel: Option<RowSelection>,
+    chunk_size: usize,
+    path: &Arc<str>,
+    selected_rows_remaining: &mut usize,
+) -> DaftResult<(Option<RowSelection>, Vec<ArrayRef>)> {
+    let total_selected = base_sel
+        .as_ref()
+        .map(|s| s.row_count())
+        .unwrap_or_else(|| metadata.row_group(rg_idx).num_rows() as usize);
+
+    let (mut col_receivers, _col_handles) = spawn_col_decoders(
+        pred_col_indices,
+        chunk_source,
+        metadata,
+        arrow_schema,
+        base_sel.as_ref(),
+        rg_idx,
+        chunk_size,
+        path,
+    )
+    .await?;
+
+    let mut predicate_selectors: Vec<RowSelector> = Vec::new();
+    let mut filtered_pred_by_col: Vec<Vec<ArrayRef>> =
+        (0..pred_col_indices.len()).map(|_| Vec::new()).collect();
+    let mut processed_rows = 0usize;
+
+    loop {
+        let Some(chunks) = recv_one_chunk(&mut col_receivers).await? else {
+            break;
+        };
+        let chunk_rows = chunks[0].len();
+        let daft_pred =
+            record_batch_from_arrow(pred_arrow_schema.clone(), chunks.clone(), path.as_ref())?;
+        let mask = eval_predicate_mask(&daft_pred, bound_pred)?;
+
+        let selected_rows = mask.true_count();
+        let (mask, selected_rows) = if selected_rows > *selected_rows_remaining {
+            (
+                truncate_mask_to_n_trues(&mask, *selected_rows_remaining),
+                *selected_rows_remaining,
+            )
+        } else {
+            (mask, selected_rows)
+        };
+
+        let filtered = filter_arrays_by_mask(&chunks, &mask, path.as_ref())?;
+        for (col_pos, filtered) in filtered.into_iter().enumerate() {
+            filtered_pred_by_col[col_pos].push(filtered);
+        }
+        predicate_selectors.extend(bool_array_to_row_selection(&mask).iter().copied());
+        processed_rows += chunk_rows;
+        *selected_rows_remaining -= selected_rows;
+        if *selected_rows_remaining == 0 {
+            break;
+        }
+    }
+    // Dropping receivers closes the channels → spawned decoders abort.
+    drop(col_receivers);
+
+    // Concat per-col filtered chunks into one ArrayRef per col. Zero rows
+    // processed (e.g. base_sel selected 0 rows) → empty array of the col's
+    // data type.
+    let pred_arrays: Vec<ArrayRef> = pred_col_indices
+        .iter()
+        .enumerate()
+        .map(|(col_pos, &col_idx)| {
+            let chunks = &filtered_pred_by_col[col_pos];
+            if chunks.is_empty() {
+                arrow::array::new_empty_array(arrow_schema.field(col_idx).data_type())
+            } else {
+                let refs: Vec<&dyn arrow::array::Array> =
+                    chunks.iter().map(|a| a.as_ref()).collect();
+                arrow::compute::concat(&refs).expect("concat per-col chunks")
+            }
+        })
+        .collect();
+
+    let unprocessed = total_selected - processed_rows;
+    if unprocessed > 0 {
+        predicate_selectors.push(RowSelector::skip(unprocessed));
+    }
+    let pred_sel = RowSelection::from(predicate_selectors);
+    let selection = Some(match &base_sel {
+        Some(base) => refine_selection(base, &pred_sel),
+        None => pred_sel,
+    });
+
+    Ok((selection, pred_arrays))
+}
+
+/// Per-group decode artifacts, prepared once per file (RG-invariant): the
+/// physical column indices, the arrow schema over just those columns, and the
+/// sub-predicate bound against that schema.
+struct GroupDecode {
+    col_indices: Vec<usize>,
+    group_arrow_schema: Arc<ArrowSchema>,
+    bound: BoundExpr,
+}
+
+fn prepare_group_decodes(
+    groups: &[PredGroup],
+    arrow_schema: &Arc<ArrowSchema>,
+    pred_col_indices: &[usize],
+) -> DaftResult<Vec<GroupDecode>> {
+    groups
+        .iter()
+        .map(|g| {
+            let group_cols: HashSet<&str> = g.col_names.iter().map(String::as_str).collect();
+            // Preserve `pred_col_indices` order so kept-array assembly is stable.
+            let col_indices: Vec<usize> = pred_col_indices
+                .iter()
+                .copied()
+                .filter(|&ci| group_cols.contains(arrow_schema.field(ci).name().as_str()))
+                .collect();
+            let group_arrow_schema = schema_from_indices(arrow_schema, &col_indices);
+            let group_daft_schema = Arc::new(Schema::try_from(group_arrow_schema.as_ref())?);
+            let bound = BoundExpr::try_new(
+                substitute_missing_cols(&g.subpred, &group_daft_schema)?,
+                &group_daft_schema,
+            )?;
+            Ok(GroupDecode {
+                col_indices,
+                group_arrow_schema,
+                bound,
+            })
+        })
+        .collect()
+}
+
+/// LM-pipelined per-RG prefilter (#6340): evaluate one column-disjoint group at a
+/// time, narrowing `running_sel` after each so the next group decodes only the
+/// rows that survived all earlier groups.
+///
+/// Alignment invariant: `kept` arrays are *always* at `running_sel` granularity.
+/// Each group is decoded at `running_sel`, so its mask has exactly that many
+/// entries; re-filtering `kept` by the same mask keeps every array aligned.
+///
+/// Produces the identical contract to [`prefilter_rg_monolithic`]: since a row
+/// survives a conjunction iff it passes every conjunct, progressive narrowing
+/// yields the same surviving-row set regardless of group order — only the decode
+/// work differs.
+#[allow(clippy::too_many_arguments)]
+async fn prefilter_rg_pipelined(
+    chunk_source: &Arc<ChunkSource>,
+    metadata: &Arc<ParquetMetaData>,
+    arrow_schema: &Arc<ArrowSchema>,
+    read_daft_schema: &Schema,
+    pred_col_indices: &[usize],
+    groups: &[PredGroup],
+    decodes: &[GroupDecode],
+    rg_idx: usize,
+    base_sel: Option<RowSelection>,
+    path: &Arc<str>,
+) -> DaftResult<(Option<RowSelection>, Vec<ArrayRef>)> {
+    // Group order is per-RG: min/max selectivity estimates come from this RG's stats.
+    let order = order_groups(groups, metadata.row_group(rg_idx), read_daft_schema);
+    let rg_rows = metadata.row_group(rg_idx).num_rows() as usize;
+
+    let mut running_sel = base_sel;
+    // Kept predicate-column arrays, keyed by physical column index, all at
+    // `running_sel` granularity.
+    let mut kept: BTreeMap<usize, ArrayRef> = BTreeMap::new();
+
+    for &gi in &order {
+        // Rows still alive entering this group; if none, nothing left to decode.
+        let alive = running_sel
+            .as_ref()
+            .map(|s| s.row_count())
+            .unwrap_or(rg_rows);
+        if alive == 0 {
+            break;
+        }
+        let dec = &decodes[gi];
+
+        // No limit in the pipelined MVP → one chunk covering all alive rows.
+        let (mut col_receivers, _col_handles) = spawn_col_decoders(
+            &dec.col_indices,
+            chunk_source,
+            metadata,
+            arrow_schema,
+            running_sel.as_ref(),
+            rg_idx,
+            usize::MAX,
+            path,
+        )
+        .await?;
+        let chunks = match recv_one_chunk(&mut col_receivers).await? {
+            Some(c) => c,
+            // Decoder closed with no rows; alive rows already reflected in running_sel.
+            None => {
+                drop(col_receivers);
+                break;
+            }
+        };
+        drop(col_receivers);
+
+        let batch = record_batch_from_arrow(
+            dec.group_arrow_schema.clone(),
+            chunks.clone(),
+            path.as_ref(),
+        )?;
+        let mask = eval_predicate_mask(&batch, &dec.bound)?;
+
+        // Re-filter previously kept arrays by this mask, then keep this group's
+        // filtered columns. Both are at `alive`-row granularity, so they align.
+        for arr in kept.values_mut() {
+            *arr = arrow::compute::filter(&**arr, &mask)
+                .with_context(|_| ArrowSnafu {
+                    path: path.to_string(),
+                })
+                .map_err(common_error::DaftError::from)?;
+        }
+        let group_filtered = filter_arrays_by_mask(&chunks, &mask, path.as_ref())?;
+        for (&ci, arr) in dec.col_indices.iter().zip(group_filtered) {
+            kept.insert(ci, arr);
+        }
+
+        // Narrow: `mask` is relative to `running_sel`-selected rows.
+        let group_sel = bool_array_to_row_selection(&mask);
+        running_sel = Some(match running_sel {
+            Some(base) => refine_selection(&base, &group_sel),
+            None => group_sel,
+        });
+    }
+
+    let final_rows = running_sel
+        .as_ref()
+        .map(|s| s.row_count())
+        .unwrap_or(rg_rows);
+    // Assemble pred_arrays in pred_col_indices order. A column whose group never
+    // ran (alive hit 0) becomes an empty array — correct, since final_rows is 0
+    // in that case.
+    let pred_arrays: Vec<ArrayRef> = pred_col_indices
+        .iter()
+        .map(|&ci| {
+            kept.get(&ci).cloned().unwrap_or_else(|| {
+                arrow::array::new_empty_array(arrow_schema.field(ci).data_type())
+            })
+        })
+        .collect();
+    debug_assert!(
+        pred_arrays.iter().all(|a| a.len() == final_rows),
+        "pipelined pred_arrays length mismatch: lens={:?} final_rows={final_rows}",
+        pred_arrays.iter().map(|a| a.len()).collect::<Vec<_>>()
+    );
+
+    Ok((running_sel, pred_arrays))
 }
 
 /// Shared per-file state for an RG-decoding task. One `Arc<RgTaskCtx>` is

--- a/src/daft-parquet/src/reader/mod.rs
+++ b/src/daft-parquet/src/reader/mod.rs
@@ -316,6 +316,24 @@ struct RgInputs {
     pred_arrays: Vec<ArrayRef>,
 }
 
+fn plan_prefilter_groups(predicate: &ExprRef, num_rows: Option<usize>) -> Option<Vec<PredGroup>> {
+    (lm_pipeline_enabled() && num_rows.is_none())
+        .then(|| plan_pred_groups(predicate))
+        .flatten()
+}
+
+#[cfg(test)]
+pub(super) fn assert_prefilter_strategy(
+    predicate: &ExprRef,
+    num_rows: Option<usize>,
+    pipelined: bool,
+) {
+    assert_eq!(
+        plan_prefilter_groups(predicate, num_rows).is_some(),
+        pipelined
+    );
+}
+
 /// Build the per-RG input bundles for the streaming decoder.
 ///
 /// Without a pushed predicate prefilter, this just forwards offset/delete/limit
@@ -363,9 +381,7 @@ async fn build_rg_inputs(
     // Decide the strategy once per file. Pipelining needs >= 2 column-disjoint
     // groups; the MVP also skips it when a limit is set (limit + progressive
     // narrowing interacts subtly, deferred to a follow-up).
-    let pred_groups: Option<Vec<PredGroup>> = (lm_pipeline_enabled() && opts.num_rows.is_none())
-        .then(|| plan_pred_groups(prefilter_predicate))
-        .flatten();
+    let pred_groups = plan_prefilter_groups(prefilter_predicate, opts.num_rows);
     let group_decodes = match &pred_groups {
         Some(groups) => Some(prepare_group_decodes(
             groups,

--- a/src/daft-parquet/src/reader/pred_pipeline.rs
+++ b/src/daft-parquet/src/reader/pred_pipeline.rs
@@ -1,0 +1,452 @@
+//! LM-pipelined (Abadi et al. 2007, the "late materialization / pipelined
+//! predicate evaluation" line of work) conjunctive predicate planning for the
+//! Parquet reader.
+//!
+//! A pushed-down conjunction like `a > 5 AND b < 10 AND c = 'foo'` is split into
+//! per-column *groups*. The reader can then evaluate one group at a time,
+//! progressively narrowing the [`parquet::arrow::arrow_reader::RowSelection`] so
+//! each later group decodes only the rows that survived every earlier group —
+//! instead of decoding all predicate columns up-front and evaluating one
+//! monolithic mask.
+//!
+//! # Correctness
+//!
+//! This module only decides **split / group / order**. For a conjunction the
+//! surviving-row set is order-independent: a row survives iff *every* conjunct
+//! is true, and progressive narrowing only ever drops rows that already failed
+//! an earlier conjunct (which would fail the AND anyway). Reordering therefore
+//! changes **how many rows later groups decode**, never **which rows survive**.
+//! Any estimation failure degrades to a neutral ordering, not to a wrong result.
+
+use std::{collections::HashSet, ops::Index, sync::OnceLock};
+
+use daft_core::{
+    lit::Literal,
+    prelude::{DataType, Operator, Schema},
+};
+use daft_dsl::{
+    Expr, ExprRef,
+    common_treenode::{TreeNode, TreeNodeRecursion},
+    optimization::get_required_columns,
+};
+use daft_stats::{ColumnRangeStatistics, TableStatistics};
+use parquet::file::metadata::RowGroupMetaData;
+
+use crate::statistics::row_group_metadata_to_table_stats;
+
+/// Kill-switch for the pipelined path. Default on; set `DAFT_PARQUET_LM_PIPELINE=0`
+/// to force the monolithic prefilter (useful for A/B comparison and safe rollout).
+pub(super) fn lm_pipeline_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        std::env::var("DAFT_PARQUET_LM_PIPELINE")
+            .map(|v| v != "0")
+            .unwrap_or(true)
+    })
+}
+
+/// Split an AND-chain into its top-level conjuncts, skipping `Alias` wrappers and
+/// descending through nested `And` nodes. Mirrors `daft_algebra::boolean::
+/// split_conjunction`; inlined here so `daft-parquet` needn't take a new crate
+/// dependency for a ~10-line helper (the tree-node imports already exist in this
+/// crate).
+pub(super) fn split_conjunction(expr: &ExprRef) -> Vec<ExprRef> {
+    let mut splits = Vec::new();
+    let _ = expr.apply(|e| match e.as_ref() {
+        Expr::BinaryOp {
+            op: Operator::And, ..
+        }
+        | Expr::Alias(..) => Ok(TreeNodeRecursion::Continue),
+        _ => {
+            splits.push(e.clone());
+            Ok(TreeNodeRecursion::Jump)
+        }
+    });
+    splits
+}
+
+/// Re-AND a set of expressions. `None` for an empty iterator; a single expression
+/// is returned as-is. Mirrors `daft_algebra::boolean::combine_conjunction`.
+fn combine_conjunction(exprs: Vec<ExprRef>) -> Option<ExprRef> {
+    exprs.into_iter().reduce(|acc, e| acc.and(e))
+}
+
+/// A column-disjoint unit of predicate evaluation. All conjuncts that (transitively)
+/// share a column are merged into one group so each physical column is decoded
+/// exactly once; the group's `subpred` is the AND of its conjuncts.
+#[derive(Clone, Debug)]
+pub(super) struct PredGroup {
+    /// AND of every conjunct assigned to this group.
+    pub(super) subpred: ExprRef,
+    /// Distinct column names referenced by `subpred` (sorted, deduped).
+    pub(super) col_names: Vec<String>,
+}
+
+/// Merge conjuncts into column-disjoint groups.
+///
+/// Two conjuncts land in the same group if their required-column sets intersect,
+/// merged transitively (so `a>5`, `b<10`, `a<b` collapse into a single group —
+/// they cannot be narrowed independently). Returns groups in first-appearance
+/// order; ordering by selectivity happens later in [`order_groups`].
+pub(super) fn group_conjuncts(conjuncts: Vec<ExprRef>) -> Vec<PredGroup> {
+    // (accumulated column set, conjuncts) per group.
+    let mut groups: Vec<(HashSet<String>, Vec<ExprRef>)> = Vec::new();
+    for c in conjuncts {
+        let cols: HashSet<String> = get_required_columns(&c).into_iter().collect();
+        match groups
+            .iter()
+            .position(|(gc, _)| gc.iter().any(|n| cols.contains(n)))
+        {
+            Some(pos) => {
+                groups[pos].0.extend(cols);
+                groups[pos].1.push(c);
+            }
+            None => groups.push((cols, vec![c])),
+        }
+    }
+
+    // Transitive closure: a later conjunct may bridge two earlier groups.
+    let mut changed = true;
+    while changed {
+        changed = false;
+        'outer: for i in 0..groups.len() {
+            for j in (i + 1)..groups.len() {
+                if groups[i].0.iter().any(|n| groups[j].0.contains(n)) {
+                    let (jc, jconj) = groups.remove(j);
+                    groups[i].0.extend(jc);
+                    groups[i].1.extend(jconj);
+                    changed = true;
+                    break 'outer;
+                }
+            }
+        }
+    }
+
+    groups
+        .into_iter()
+        .filter_map(|(cols, conj)| {
+            let subpred = combine_conjunction(conj)?;
+            let mut col_names: Vec<String> = cols.into_iter().collect();
+            col_names.sort();
+            col_names.dedup();
+            Some(PredGroup { subpred, col_names })
+        })
+        .collect()
+}
+
+/// Plan the pipelined groups for `predicate`, or `None` if pipelining does not
+/// apply (fewer than two column-disjoint groups → the monolithic prefilter is
+/// already optimal, e.g. a single-column or fully column-overlapping predicate).
+pub(super) fn plan_pred_groups(predicate: &ExprRef) -> Option<Vec<PredGroup>> {
+    let conjuncts = split_conjunction(predicate);
+    if conjuncts.len() < 2 {
+        return None;
+    }
+    let groups = group_conjuncts(conjuncts);
+    (groups.len() >= 2).then_some(groups)
+}
+
+/// Order `groups` for a specific row group by an estimated rank, cheapest-and-
+/// most-selective first. Returns group indices into `groups` (a permutation).
+///
+/// Rank is the classic predicate-ordering heuristic `(selectivity - 1) / cost`:
+/// more negative = narrow more rows per unit of decode work = go first. Ties keep
+/// the caller's original order (stable sort).
+pub(super) fn order_groups(
+    groups: &[PredGroup],
+    rg_meta: &RowGroupMetaData,
+    schema: &Schema,
+) -> Vec<usize> {
+    let stats = row_group_metadata_to_table_stats(rg_meta, schema).ok();
+    let stats = stats.as_ref();
+
+    let mut order: Vec<usize> = (0..groups.len()).collect();
+    order.sort_by(|&a, &b| {
+        let ra = group_rank(&groups[a], stats, schema);
+        let rb = group_rank(&groups[b], stats, schema);
+        ra.partial_cmp(&rb).unwrap_or(std::cmp::Ordering::Equal)
+    });
+    order
+}
+
+fn group_rank(group: &PredGroup, stats: Option<&TableStatistics>, schema: &Schema) -> f64 {
+    let sel = group_selectivity(group, stats, schema);
+    // Decode cost proxy: number of physical columns in the group (>= 1).
+    let cost = group.col_names.len().max(1) as f64;
+    (sel - 1.0) / cost
+}
+
+/// Estimated surviving fraction for a group = product of its conjuncts'
+/// selectivities (independence assumption), clamped away from degenerate 0.
+fn group_selectivity(group: &PredGroup, stats: Option<&TableStatistics>, schema: &Schema) -> f64 {
+    let mut sel = 1.0f64;
+    for conj in split_conjunction(&group.subpred) {
+        sel *= conjunct_selectivity(&conj, stats, schema);
+    }
+    sel.clamp(0.01, 1.0)
+}
+
+/// Estimate the surviving fraction of a single `col <cmp> literal` conjunct from
+/// the row group's min/max stats. Only numeric range comparisons are estimated
+/// precisely; everything else (equality, strings, missing stats, non-numeric)
+/// falls back to a constant. Never panics — any failure yields a neutral value.
+fn conjunct_selectivity(expr: &ExprRef, stats: Option<&TableStatistics>, schema: &Schema) -> f64 {
+    let stats = match stats {
+        Some(s) => s,
+        None => return 0.5,
+    };
+    let Expr::BinaryOp { op, left, right } = expr.as_ref() else {
+        return 0.5;
+    };
+    // Exactly one referenced column, with a literal on the other side.
+    let cols = get_required_columns(expr);
+    if cols.len() != 1 {
+        return 0.5;
+    }
+    let (lit, flip) = match (lit_of(left), lit_of(right)) {
+        (None, Some(l)) => (l, false), // col <op> literal
+        (Some(l), None) => (l, true),  // literal <op> col  → flip the operator
+        _ => return eq_fallback(op),
+    };
+    let Some(litv) = lit_to_f64(lit) else {
+        return eq_fallback(op);
+    };
+    let Some((min, max)) = col_min_max(&cols[0], stats, schema) else {
+        return eq_fallback(op);
+    };
+    // Degenerate / inverted range → no usable signal.
+    if !(max - min).is_normal() || max <= min {
+        return 0.5;
+    }
+    let op = if flip { flip_op(*op) } else { *op };
+    let frac = match op {
+        Operator::Lt | Operator::LtEq => (litv - min) / (max - min),
+        Operator::Gt | Operator::GtEq => (max - litv) / (max - min),
+        _ => return 0.5,
+    };
+    frac.clamp(0.01, 1.0)
+}
+
+fn lit_of(e: &ExprRef) -> Option<&Literal> {
+    match e.as_ref() {
+        Expr::Literal(l) => Some(l),
+        _ => None,
+    }
+}
+
+fn lit_to_f64(l: &Literal) -> Option<f64> {
+    Some(match l {
+        Literal::Int8(v) => *v as f64,
+        Literal::Int16(v) => *v as f64,
+        Literal::Int32(v) => *v as f64,
+        Literal::Int64(v) => *v as f64,
+        Literal::UInt8(v) => *v as f64,
+        Literal::UInt16(v) => *v as f64,
+        Literal::UInt32(v) => *v as f64,
+        Literal::UInt64(v) => *v as f64,
+        Literal::Float32(v) => *v as f64,
+        Literal::Float64(v) => *v,
+        // Decimal(value, _precision, scale) → unscaled integer / 10^scale.
+        Literal::Decimal(v, _, scale) => *v as f64 / 10f64.powi(*scale as i32),
+        _ => return None,
+    })
+}
+
+fn col_min_max(name: &str, stats: &TableStatistics, schema: &Schema) -> Option<(f64, f64)> {
+    let idx = schema.field_names().position(|n| n == name)?;
+    match stats.index(idx) {
+        ColumnRangeStatistics::Loaded(lo, hi) => {
+            let lo = lo.cast(&DataType::Float64).ok()?.f64().ok()?.get(0)?;
+            let hi = hi.cast(&DataType::Float64).ok()?.f64().ok()?.get(0)?;
+            Some((lo, hi))
+        }
+        ColumnRangeStatistics::Missing => None,
+    }
+}
+
+/// Equality/inequality have no reliable range-fraction estimate from min/max
+/// alone; use modest constants so they still participate in ordering.
+fn eq_fallback(op: &Operator) -> f64 {
+    match op {
+        Operator::Eq | Operator::EqNullSafe => 0.25,
+        Operator::NotEq => 0.75,
+        _ => 0.5,
+    }
+}
+
+fn flip_op(op: Operator) -> Operator {
+    match op {
+        Operator::Lt => Operator::Gt,
+        Operator::LtEq => Operator::GtEq,
+        Operator::Gt => Operator::Lt,
+        Operator::GtEq => Operator::LtEq,
+        other => other,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use daft_core::prelude::*;
+    // Production predicates reaching the pipelined path are already resolved
+    // (the `predicate_pushed` guard implies `get_required_columns` succeeded), so
+    // tests use `resolved_col` to match — `get_required_columns` only extracts
+    // `Column::Resolved(Basic(..))`.
+    use daft_dsl::{lit, resolved_col as col};
+    use daft_recordbatch::RecordBatch;
+
+    use super::*;
+
+    fn names(groups: &[PredGroup]) -> Vec<Vec<String>> {
+        groups.iter().map(|g| g.col_names.clone()).collect()
+    }
+
+    #[test]
+    fn split_flattens_nested_and() {
+        // (a > 5 AND b < 10) AND c == 1  →  three conjuncts
+        let e = col("a")
+            .gt(lit(5))
+            .and(col("b").lt(lit(10)))
+            .and(col("c").eq(lit(1)));
+        let splits = split_conjunction(&e);
+        assert_eq!(splits.len(), 3, "nested AND should flatten to 3 conjuncts");
+
+        // A single non-AND predicate is one conjunct.
+        let single = col("a").gt(lit(5));
+        assert_eq!(split_conjunction(&single).len(), 1);
+    }
+
+    #[test]
+    fn groups_are_column_disjoint() {
+        // a>5 AND b<10  →  two disjoint groups.
+        let e = col("a").gt(lit(5)).and(col("b").lt(lit(10)));
+        let groups = group_conjuncts(split_conjunction(&e));
+        assert_eq!(groups.len(), 2);
+        let mut ns = names(&groups);
+        ns.sort();
+        assert_eq!(ns, vec![vec!["a".to_string()], vec!["b".to_string()]]);
+    }
+
+    #[test]
+    fn overlapping_columns_merge_into_one_group() {
+        // a>5 AND a<100  →  share `a`  →  one group.
+        let e = col("a").gt(lit(5)).and(col("a").lt(lit(100)));
+        let groups = group_conjuncts(split_conjunction(&e));
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].col_names, vec!["a".to_string()]);
+    }
+
+    #[test]
+    fn bridging_conjunct_merges_transitively() {
+        // a>5 AND b<10 AND (a < b)  →  the third references both a and b,
+        // bridging {a} and {b} into a single group.
+        let e = col("a")
+            .gt(lit(5))
+            .and(col("b").lt(lit(10)))
+            .and(col("a").lt(col("b")));
+        let groups = group_conjuncts(split_conjunction(&e));
+        assert_eq!(groups.len(), 1, "bridging conjunct must merge both groups");
+        assert_eq!(groups[0].col_names, vec!["a".to_string(), "b".to_string()]);
+    }
+
+    #[test]
+    fn plan_returns_none_for_single_group() {
+        // Not enough disjoint groups to pipeline.
+        let single = col("a").gt(lit(5));
+        assert!(plan_pred_groups(&single).is_none());
+
+        let overlapping = col("a").gt(lit(5)).and(col("a").lt(lit(100)));
+        assert!(plan_pred_groups(&overlapping).is_none());
+
+        let pipelineable = col("a").gt(lit(5)).and(col("b").lt(lit(10)));
+        assert!(plan_pred_groups(&pipelineable).is_some());
+    }
+
+    #[test]
+    fn three_way_split_groups_correctly() {
+        // a>5 AND b<10 AND a<100 AND c==1
+        //   → {a: a>5, a<100}, {b: b<10}, {c: c==1}
+        let e = col("a")
+            .gt(lit(5))
+            .and(col("b").lt(lit(10)))
+            .and(col("a").lt(lit(100)))
+            .and(col("c").eq(lit(1)));
+        let groups = group_conjuncts(split_conjunction(&e));
+        assert_eq!(groups.len(), 3);
+        let mut ns = names(&groups);
+        ns.sort();
+        assert_eq!(
+            ns,
+            vec![
+                vec!["a".to_string()],
+                vec!["b".to_string()],
+                vec!["c".to_string()]
+            ]
+        );
+        // The `a` group holds both a-conjuncts ANDed together.
+        let a_group = groups
+            .iter()
+            .find(|g| g.col_names == vec!["a".to_string()])
+            .unwrap();
+        assert_eq!(split_conjunction(&a_group.subpred).len(), 2);
+    }
+
+    #[test]
+    fn selectivity_orders_most_selective_first() {
+        // Both columns span [0, 1000].
+        //   `a > 900` keeps ~10%   → more selective → must rank first.
+        //   `b < 900` keeps ~90%.
+        let table = RecordBatch::from_nonempty_columns(vec![
+            Int64Array::from_slice("a", &[0, 1000]).into_series(),
+            Int64Array::from_slice("b", &[0, 1000]).into_series(),
+        ])
+        .unwrap();
+        let stats = TableStatistics::from_table(&table);
+        let schema = table.schema.as_ref();
+
+        let b_group = PredGroup {
+            subpred: col("b").lt(lit(900)),
+            col_names: vec!["b".into()],
+        };
+        let a_group = PredGroup {
+            subpred: col("a").gt(lit(900)),
+            col_names: vec!["a".into()],
+        };
+
+        let sel_a = group_selectivity(&a_group, Some(&stats), schema);
+        let sel_b = group_selectivity(&b_group, Some(&stats), schema);
+        assert!(
+            (sel_a - 0.1).abs() < 1e-9,
+            "a>900 over [0,1000] should estimate ~0.1, got {sel_a}"
+        );
+        assert!(
+            (sel_b - 0.9).abs() < 1e-9,
+            "b<900 over [0,1000] should estimate ~0.9, got {sel_b}"
+        );
+
+        let rank_a = group_rank(&a_group, Some(&stats), schema);
+        let rank_b = group_rank(&b_group, Some(&stats), schema);
+        assert!(
+            rank_a < rank_b,
+            "more-selective a>900 rank {rank_a} should sort before b<900 rank {rank_b}"
+        );
+    }
+
+    #[test]
+    fn selectivity_missing_stats_is_neutral() {
+        // No stats → neutral 0.5 for a range predicate (fallback path, no panic).
+        let table = RecordBatch::from_nonempty_columns(vec![
+            Int64Array::from_slice("a", &[0, 1000]).into_series(),
+        ])
+        .unwrap();
+        let schema = table.schema.as_ref();
+        let g = PredGroup {
+            subpred: col("a").gt(lit(900)),
+            col_names: vec!["a".into()],
+        };
+        let sel = group_selectivity(&g, None, schema);
+        assert!(
+            (sel - 0.5).abs() < 1e-9,
+            "no stats → neutral 0.5, got {sel}"
+        );
+    }
+}

--- a/src/daft-parquet/src/reader/pred_pipeline.rs
+++ b/src/daft-parquet/src/reader/pred_pipeline.rs
@@ -11,9 +11,9 @@
 //!
 //! # Correctness
 //!
-//! This module only decides **split / group / order**. For a conjunction the
-//! surviving-row set is order-independent: a row survives iff *every* conjunct
-//! is true, and progressive narrowing only ever drops rows that already failed
+//! This module only decides **split / group / order** for row-local expressions.
+//! Their surviving-row set is order-independent: a row survives iff *every*
+//! conjunct is true, and progressive narrowing only drops rows that already failed
 //! an earlier conjunct (which would fail the AND anyway). Reordering therefore
 //! changes **how many rows later groups decode**, never **which rows survive**.
 //! Any estimation failure degrades to a neutral ordering, not to a wrong result.
@@ -29,8 +29,9 @@ use daft_core::{
     prelude::{DataType, Operator, Schema},
 };
 use daft_dsl::{
-    Expr, ExprRef,
+    Column, Expr, ExprRef, ResolvedColumn,
     common_treenode::{TreeNode, TreeNodeRecursion},
+    is_udf,
     optimization::get_required_columns,
 };
 use daft_stats::{ColumnRangeStatistics, TableStatistics};
@@ -167,16 +168,48 @@ pub(super) fn group_conjuncts(conjuncts: Vec<ExprRef>) -> Vec<PredGroup> {
         .collect()
 }
 
-/// Plan the pipelined groups for `predicate`, or `None` if pipelining does not
-/// apply (fewer than two column-disjoint groups → the monolithic prefilter is
-/// already optimal, e.g. a single-column or fully column-overlapping predicate).
+fn is_row_local(predicate: &ExprRef) -> bool {
+    let mut row_local = true;
+    let result = predicate.apply(|expr| {
+        row_local = !is_udf(expr)
+            && match expr.as_ref() {
+                Expr::Column(Column::Resolved(ResolvedColumn::Basic(_)))
+                | Expr::Literal(_)
+                | Expr::Alias(..)
+                | Expr::BinaryOp { .. }
+                | Expr::Cast(..)
+                | Expr::Not(_)
+                | Expr::IsNull(_)
+                | Expr::NotNull(_)
+                | Expr::FillNull(..)
+                | Expr::Between(..)
+                | Expr::List(_)
+                | Expr::IfElse { .. }
+                | Expr::Coalesce(_) => true,
+                // IsIn builds a set over the entire RHS batch, not one set per row.
+                Expr::IsIn(_, items) => items
+                    .iter()
+                    .all(|item| get_required_columns(item).is_empty()),
+                _ => false,
+            };
+        Ok(if row_local {
+            TreeNodeRecursion::Continue
+        } else {
+            TreeNodeRecursion::Stop
+        })
+    });
+    result.is_ok() && row_local
+}
+
+/// Plan at least two nonempty, column-disjoint groups of row-local conjuncts,
+/// or fall back to the monolithic prefilter.
 pub(super) fn plan_pred_groups(predicate: &ExprRef) -> Option<Vec<PredGroup>> {
     let conjuncts = split_conjunction(predicate);
-    if conjuncts.len() < 2 {
+    if conjuncts.len() < 2 || !is_row_local(predicate) {
         return None;
     }
     let groups = group_conjuncts(conjuncts);
-    (groups.len() >= 2).then_some(groups)
+    (groups.len() >= 2 && groups.iter().all(|group| !group.col_names.is_empty())).then_some(groups)
 }
 
 /// Per-row-group estimation inputs for ordering. Bundling them keeps the
@@ -622,6 +655,79 @@ mod tests {
 
         let pipelineable = col("a").gt(lit(5)).and(col("b").lt(lit(10)));
         assert!(plan_pred_groups(&pipelineable).is_some());
+    }
+
+    #[test]
+    fn plan_rejects_column_dependent_is_in() {
+        for rhs in [col("c"), col("c").cast(&DataType::Int64).alias("items")] {
+            let pred = col("a")
+                .eq(lit(1))
+                .and(col("b").is_in(vec![rhs]).not().alias("predicate"));
+            assert!(plan_pred_groups(&pred).is_none());
+        }
+    }
+
+    #[test]
+    fn plan_allows_literal_is_in() {
+        let pred = col("a")
+            .eq(lit(1))
+            .and(col("b").is_in(vec![lit(5), lit(9)]));
+        let groups = plan_pred_groups(&pred).unwrap();
+        assert_eq!(
+            names(&groups),
+            vec![vec!["a".to_string()], vec!["b".to_string()]]
+        );
+    }
+
+    #[test]
+    fn plan_rejects_non_row_local_expressions() {
+        for expr in [col("b").sum(), col("b").offset(1, None)] {
+            let pred = col("a").eq(lit(1)).and(expr.gt(lit(0)));
+            assert!(plan_pred_groups(&pred).is_none());
+        }
+    }
+
+    #[test]
+    fn plan_rejects_udfs() {
+        use daft_dsl::functions::{
+            FunctionExpr,
+            python::{LegacyPythonUDF, MaybeInitializedUDF, RuntimePyObject},
+        };
+
+        #[cfg(feature = "python")]
+        pyo3::Python::initialize();
+        let udf: ExprRef = Expr::Function {
+            func: FunctionExpr::Python(LegacyPythonUDF {
+                name: "batch_predicate".to_string().into(),
+                func: MaybeInitializedUDF::Initialized(RuntimePyObject::new_none()),
+                bound_args: RuntimePyObject::new_none(),
+                num_expressions: 1,
+                return_dtype: DataType::Boolean,
+                resource_request: None,
+                batch_size: None,
+                concurrency: None,
+                use_process: None,
+                ray_options: None,
+            }),
+            inputs: vec![col("b")],
+        }
+        .into();
+        let pred = col("a").eq(lit(1)).and(udf.not().alias("predicate"));
+        assert!(plan_pred_groups(&pred).is_none());
+    }
+
+    #[test]
+    fn plan_rejects_zero_column_conjuncts() {
+        for constant in [
+            lit(true),
+            lit(false),
+            daft_dsl::null_lit(),
+            daft_dsl::null_lit().cast(&DataType::Boolean),
+            lit(1).eq(lit(1)),
+        ] {
+            let pred = col("a").eq(lit(1)).and(col("b").lt(lit(10))).and(constant);
+            assert!(plan_pred_groups(&pred).is_none());
+        }
     }
 
     #[test]

--- a/src/daft-parquet/src/reader/pred_pipeline.rs
+++ b/src/daft-parquet/src/reader/pred_pipeline.rs
@@ -18,7 +18,11 @@
 //! changes **how many rows later groups decode**, never **which rows survive**.
 //! Any estimation failure degrades to a neutral ordering, not to a wrong result.
 
-use std::{collections::HashSet, ops::Index, sync::OnceLock};
+use std::{
+    collections::{HashMap, HashSet},
+    ops::Index,
+    sync::OnceLock,
+};
 
 use daft_core::{
     lit::Literal,
@@ -40,6 +44,35 @@ pub(super) fn lm_pipeline_enabled() -> bool {
     static ENABLED: OnceLock<bool> = OnceLock::new();
     *ENABLED.get_or_init(|| {
         std::env::var("DAFT_PARQUET_LM_PIPELINE")
+            .map(|v| v != "0")
+            .unwrap_or(true)
+    })
+}
+
+/// Kill-switch for stats-based *string* selectivity in group ordering. Default
+/// on; set `DAFT_PARQUET_LM_STR_STATS=0` to fall back to the constant estimate
+/// for `Utf8` range/equality conjuncts. Lets the ordering improvement be A/B'd
+/// in isolation (both modes still take the pipelined path) and gives a safe
+/// rollout valve. Ordering never affects the result set, so this is purely a
+/// performance knob.
+fn lm_str_stats_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        std::env::var("DAFT_PARQUET_LM_STR_STATS")
+            .map(|v| v != "0")
+            .unwrap_or(true)
+    })
+}
+
+/// Kill-switch for the metadata-driven *cost* axis of the ordering rank. Default
+/// on: a group's decode cost is the summed uncompressed byte size of its column
+/// chunks in the row group (from [`RowGroupMetaData`]). Set
+/// `DAFT_PARQUET_LM_COST_BYTES=0` to fall back to the crude "number of columns"
+/// proxy. Like the other knobs this only affects ordering, hence performance.
+fn lm_cost_bytes_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        std::env::var("DAFT_PARQUET_LM_COST_BYTES")
             .map(|v| v != "0")
             .unwrap_or(true)
     })
@@ -146,55 +179,132 @@ pub(super) fn plan_pred_groups(predicate: &ExprRef) -> Option<Vec<PredGroup>> {
     (groups.len() >= 2).then_some(groups)
 }
 
+/// Per-row-group estimation inputs for ordering. Bundling them keeps the
+/// selectivity/cost helpers read-only and cheap to thread through the sort.
+struct SelCtx<'a> {
+    /// Column min/max ranges (Daft's [`TableStatistics`]), if convertible.
+    stats: Option<&'a TableStatistics>,
+    schema: &'a Schema,
+    /// top-level column name → distinct_count from Parquet stats (when written).
+    ndv: HashMap<String, usize>,
+    /// top-level column name → summed uncompressed chunk bytes in this row group.
+    cost: HashMap<String, f64>,
+    /// Row count of this row group (denominator context for NDV selectivity).
+    #[allow(dead_code)]
+    rg_rows: i64,
+}
+
 /// Order `groups` for a specific row group by an estimated rank, cheapest-and-
 /// most-selective first. Returns group indices into `groups` (a permutation).
 ///
-/// Rank is the classic predicate-ordering heuristic `(selectivity - 1) / cost`:
-/// more negative = narrow more rows per unit of decode work = go first. Ties keep
-/// the caller's original order (stable sort).
+/// Rank is the classic predicate-ordering heuristic `(selectivity - 1) / cost`,
+/// i.e. benefit `(1 - selectivity) / cost` sorted descending. Both axes come from
+/// Parquet metadata: selectivity from column stats (min/max, distinct_count) and
+/// cost from column-chunk byte sizes. More negative = narrow more rows per unit
+/// of decode work = go first. Ties keep the caller's original order (stable sort).
 pub(super) fn order_groups(
     groups: &[PredGroup],
     rg_meta: &RowGroupMetaData,
     schema: &Schema,
 ) -> Vec<usize> {
     let stats = row_group_metadata_to_table_stats(rg_meta, schema).ok();
-    let stats = stats.as_ref();
+    let ctx = SelCtx {
+        stats: stats.as_ref(),
+        schema,
+        ndv: column_ndv(rg_meta),
+        cost: column_costs(rg_meta),
+        rg_rows: rg_meta.num_rows(),
+    };
 
     let mut order: Vec<usize> = (0..groups.len()).collect();
     order.sort_by(|&a, &b| {
-        let ra = group_rank(&groups[a], stats, schema);
-        let rb = group_rank(&groups[b], stats, schema);
+        let ra = group_rank(&groups[a], &ctx);
+        let rb = group_rank(&groups[b], &ctx);
         ra.partial_cmp(&rb).unwrap_or(std::cmp::Ordering::Equal)
     });
     order
 }
 
-fn group_rank(group: &PredGroup, stats: Option<&TableStatistics>, schema: &Schema) -> f64 {
-    let sel = group_selectivity(group, stats, schema);
-    // Decode cost proxy: number of physical columns in the group (>= 1).
-    let cost = group.col_names.len().max(1) as f64;
+/// top-level column name → distinct_count, for columns whose Parquet stats carry
+/// it. Many writers omit distinct_count, so the map is often partial/empty and
+/// equality selectivity then falls back to a constant.
+fn column_ndv(rg_meta: &RowGroupMetaData) -> HashMap<String, usize> {
+    let mut ndv: HashMap<String, usize> = HashMap::new();
+    for col in rg_meta.columns() {
+        let Some(name) = top_level_name(col) else {
+            continue;
+        };
+        if let Some(d) = col.statistics().and_then(|s| s.distinct_count_opt()) {
+            let d = d as usize;
+            // A top-level column may span several physical chunks; keep the widest
+            // NDV (the least-selective, safest estimate for ordering).
+            ndv.entry(name)
+                .and_modify(|v| *v = (*v).max(d))
+                .or_insert(d);
+        }
+    }
+    ndv
+}
+
+/// top-level column name → summed uncompressed chunk bytes in this row group.
+/// Uncompressed size tracks the value/offset materialization work that late
+/// materialization saves (decompression is cheap relative to it).
+fn column_costs(rg_meta: &RowGroupMetaData) -> HashMap<String, f64> {
+    let mut cost = HashMap::new();
+    for col in rg_meta.columns() {
+        let Some(name) = top_level_name(col) else {
+            continue;
+        };
+        *cost.entry(name).or_insert(0.0) += col.uncompressed_size().max(0) as f64;
+    }
+    cost
+}
+
+fn top_level_name(col: &parquet::file::metadata::ColumnChunkMetaData) -> Option<String> {
+    col.column_descr()
+        .path()
+        .parts()
+        .first()
+        .map(|s| s.as_str().to_string())
+}
+
+fn group_rank(group: &PredGroup, ctx: &SelCtx) -> f64 {
+    let sel = group_selectivity(group, ctx);
+    let cost = group_cost(group, ctx);
     (sel - 1.0) / cost
+}
+
+/// Decode cost of a group: summed uncompressed bytes of its columns when the
+/// metadata-driven cost axis is on, else the crude column-count proxy. Clamped
+/// `>= 1` so the rank never divides by zero.
+fn group_cost(group: &PredGroup, ctx: &SelCtx) -> f64 {
+    if lm_cost_bytes_enabled() && !ctx.cost.is_empty() {
+        let bytes: f64 = group
+            .col_names
+            .iter()
+            .map(|n| ctx.cost.get(n).copied().unwrap_or(0.0))
+            .sum();
+        return bytes.max(1.0);
+    }
+    group.col_names.len().max(1) as f64
 }
 
 /// Estimated surviving fraction for a group = product of its conjuncts'
 /// selectivities (independence assumption), clamped away from degenerate 0.
-fn group_selectivity(group: &PredGroup, stats: Option<&TableStatistics>, schema: &Schema) -> f64 {
+fn group_selectivity(group: &PredGroup, ctx: &SelCtx) -> f64 {
     let mut sel = 1.0f64;
     for conj in split_conjunction(&group.subpred) {
-        sel *= conjunct_selectivity(&conj, stats, schema);
+        sel *= conjunct_selectivity(&conj, ctx);
     }
     sel.clamp(0.01, 1.0)
 }
 
 /// Estimate the surviving fraction of a single `col <cmp> literal` conjunct from
-/// the row group's min/max stats. Only numeric range comparisons are estimated
-/// precisely; everything else (equality, strings, missing stats, non-numeric)
-/// falls back to a constant. Never panics — any failure yields a neutral value.
-fn conjunct_selectivity(expr: &ExprRef, stats: Option<&TableStatistics>, schema: &Schema) -> f64 {
-    let stats = match stats {
-        Some(s) => s,
-        None => return 0.5,
-    };
+/// this row group's Parquet metadata. Equality/inequality uses the column's
+/// distinct_count (NDV) when present, else a string min/max range test, else a
+/// constant; range comparisons interpolate over the (numeric or lexicographic)
+/// min/max interval. Never panics — any unusable input yields a neutral value.
+fn conjunct_selectivity(expr: &ExprRef, ctx: &SelCtx) -> f64 {
     let Expr::BinaryOp { op, left, right } = expr.as_ref() else {
         return 0.5;
     };
@@ -208,17 +318,81 @@ fn conjunct_selectivity(expr: &ExprRef, stats: Option<&TableStatistics>, schema:
         (Some(l), None) => (l, true),  // literal <op> col  → flip the operator
         _ => return eq_fallback(op),
     };
+    let op = if flip { flip_op(*op) } else { *op };
+    let col = cols[0].as_str();
+
+    match op {
+        Operator::Eq | Operator::EqNullSafe | Operator::NotEq => eq_selectivity(col, lit, op, ctx),
+        _ => range_selectivity(col, lit, op, ctx),
+    }
+}
+
+/// Selectivity of an equality/inequality conjunct. Prefers the column's
+/// distinct_count (NDV) from Parquet stats: for a uniform column `col == v`
+/// survives ~1/NDV of rows, which can be far below any min/max-based guess.
+/// Falls back to a string min/max containment test, then to [`eq_fallback`].
+fn eq_selectivity(col: &str, lit: &Literal, op: Operator, ctx: &SelCtx) -> f64 {
+    // distinct_count (NDV): for a uniform column `col == v` survives ~1/NDV rows,
+    // far below any min/max guess. Many writers omit it → fall through.
+    if let Some(&ndv) = ctx.ndv.get(col)
+        && ndv > 0
+    {
+        let frac = (1.0 / ndv as f64).clamp(0.01, 1.0);
+        return match op {
+            Operator::NotEq => (1.0 - frac).clamp(0.01, 1.0),
+            _ => frac,
+        };
+    }
+    // String equality: a value strictly outside [min, max] cannot occur in this
+    // row group, so `==` filters everything and `!=` keeps everything. Bounds of
+    // >= STR_STATS_TRUNC_LEN bytes may be Parquet-truncated prefixes → skip.
+    if let Literal::Utf8(s) = lit
+        && lm_str_stats_enabled()
+        && let Some((min, max)) = col_min_max_str(col, ctx)
+        && min.len() < STR_STATS_TRUNC_LEN
+        && max.len() < STR_STATS_TRUNC_LEN
+        && (s.as_str() < min.as_str() || s.as_str() > max.as_str())
+    {
+        return match op {
+            Operator::NotEq => 1.0,
+            _ => 0.01,
+        };
+    }
+    eq_fallback(&op)
+}
+
+/// Selectivity of a range conjunct (`<`, `<=`, `>`, `>=`). Strings interpolate
+/// over the lexicographic min/max interval (when the string-stats axis is on);
+/// numerics over the float min/max interval. Everything else is neutral.
+fn range_selectivity(col: &str, lit: &Literal, op: Operator, ctx: &SelCtx) -> f64 {
+    if !matches!(
+        op,
+        Operator::Lt | Operator::LtEq | Operator::Gt | Operator::GtEq
+    ) {
+        return 0.5;
+    }
+    // String literal → estimate from the row group's lexicographic min/max so a
+    // cheap, highly-selective string range can order ahead of an expensive
+    // equality group. Without this, `s < 'p'` falls to a neutral 0.5 while
+    // `t = 'x'` gets 0.25, wrongly ranking the expensive group first.
+    if let Literal::Utf8(lit_s) = lit {
+        return if lm_str_stats_enabled() {
+            str_range_selectivity(col, lit_s, op, ctx)
+        } else {
+            eq_fallback(&op)
+        };
+    }
+
     let Some(litv) = lit_to_f64(lit) else {
-        return eq_fallback(op);
+        return eq_fallback(&op);
     };
-    let Some((min, max)) = col_min_max(&cols[0], stats, schema) else {
-        return eq_fallback(op);
+    let Some((min, max)) = col_min_max(col, ctx) else {
+        return eq_fallback(&op);
     };
     // Degenerate / inverted range → no usable signal.
     if !(max - min).is_normal() || max <= min {
         return 0.5;
     }
-    let op = if flip { flip_op(*op) } else { *op };
     let frac = match op {
         Operator::Lt | Operator::LtEq => (litv - min) / (max - min),
         Operator::Gt | Operator::GtEq => (max - litv) / (max - min),
@@ -252,8 +426,9 @@ fn lit_to_f64(l: &Literal) -> Option<f64> {
     })
 }
 
-fn col_min_max(name: &str, stats: &TableStatistics, schema: &Schema) -> Option<(f64, f64)> {
-    let idx = schema.field_names().position(|n| n == name)?;
+fn col_min_max(name: &str, ctx: &SelCtx) -> Option<(f64, f64)> {
+    let stats = ctx.stats?;
+    let idx = ctx.schema.field_names().position(|n| n == name)?;
     match stats.index(idx) {
         ColumnRangeStatistics::Loaded(lo, hi) => {
             let lo = lo.cast(&DataType::Float64).ok()?.f64().ok()?.get(0)?;
@@ -262,6 +437,71 @@ fn col_min_max(name: &str, stats: &TableStatistics, schema: &Schema) -> Option<(
         }
         ColumnRangeStatistics::Missing => None,
     }
+}
+
+/// Utf8 min/max for `name` from the row group's [`ColumnRangeStatistics`], when
+/// loaded and actually Utf8-typed. Returns owned strings (cheap: at most one per
+/// group per row group).
+fn col_min_max_str(name: &str, ctx: &SelCtx) -> Option<(String, String)> {
+    let stats = ctx.stats?;
+    let idx = ctx.schema.field_names().position(|n| n == name)?;
+    match stats.index(idx) {
+        ColumnRangeStatistics::Loaded(lo, hi) => {
+            let lo = lo.utf8().ok()?.get(0)?.to_string();
+            let hi = hi.utf8().ok()?.get(0)?.to_string();
+            Some((lo, hi))
+        }
+        ColumnRangeStatistics::Missing => None,
+    }
+}
+
+/// Project a string into `[0, 1)` by reading its first bytes as a base-256
+/// fraction. Monotonic in UTF-8 byte order (which equals Unicode scalar order),
+/// so a difference of two projections approximates their relative lexicographic
+/// distance — enough to interpolate an interval selectivity. Only the first 8
+/// bytes are used: beyond that the contribution is < 2^-64 and irrelevant to a
+/// heuristic ordering decision.
+fn str_to_unit(s: &str) -> f64 {
+    let mut acc = 0.0f64;
+    let mut scale = 1.0f64 / 256.0;
+    for &b in s.as_bytes().iter().take(8) {
+        acc += f64::from(b) * scale;
+        scale /= 256.0;
+    }
+    acc
+}
+
+/// Parquet truncates string column statistics at this many bytes by default; a
+/// truncated bound is a prefix of the true extreme, so interval math on it would
+/// bias the estimate. Daft's [`ColumnRangeStatistics`] drops arrow-rs's
+/// exactness flag, so we detect the risk by length and bail to the constant.
+const STR_STATS_TRUNC_LEN: usize = 64;
+
+/// Selectivity of `col <op> lit_s` for a Utf8 *range* conjunct, estimated from
+/// the row group's lexicographic min/max. Equality is handled separately in
+/// [`eq_selectivity`]. This only ever feeds group *ordering*, so an imprecise
+/// estimate costs performance, never correctness; any unusable input degrades to
+/// [`eq_fallback`].
+fn str_range_selectivity(col: &str, lit_s: &str, op: Operator, ctx: &SelCtx) -> f64 {
+    let Some((min, max)) = col_min_max_str(col, ctx) else {
+        return eq_fallback(&op);
+    };
+    // Possibly-truncated bounds → unreliable interval → neutral constant.
+    if min.len() >= STR_STATS_TRUNC_LEN || max.len() >= STR_STATS_TRUNC_LEN {
+        return eq_fallback(&op);
+    }
+    let (lo, hi) = (str_to_unit(&min), str_to_unit(&max));
+    // Degenerate / inverted range → no usable signal.
+    if !(hi - lo).is_normal() || hi <= lo {
+        return eq_fallback(&op);
+    }
+    let x = str_to_unit(lit_s);
+    let frac = match op {
+        Operator::Lt | Operator::LtEq => (x - lo) / (hi - lo),
+        Operator::Gt | Operator::GtEq => (hi - x) / (hi - lo),
+        _ => return eq_fallback(&op),
+    };
+    frac.clamp(0.01, 1.0)
 }
 
 /// Equality/inequality have no reliable range-fraction estimate from min/max
@@ -298,6 +538,29 @@ mod tests {
 
     fn names(groups: &[PredGroup]) -> Vec<Vec<String>> {
         groups.iter().map(|g| g.col_names.clone()).collect()
+    }
+
+    /// Build a [`SelCtx`] with loaded min/max stats but no NDV/cost metadata
+    /// (the default pyarrow-written case), for the selectivity/rank tests.
+    fn ctx_from<'a>(stats: &'a TableStatistics, schema: &'a Schema) -> SelCtx<'a> {
+        SelCtx {
+            stats: Some(stats),
+            schema,
+            ndv: HashMap::new(),
+            cost: HashMap::new(),
+            rg_rows: 0,
+        }
+    }
+
+    /// Build a [`SelCtx`] with no stats at all (neutral-fallback path).
+    fn ctx_missing(schema: &Schema) -> SelCtx<'_> {
+        SelCtx {
+            stats: None,
+            schema,
+            ndv: HashMap::new(),
+            cost: HashMap::new(),
+            rg_rows: 0,
+        }
     }
 
     #[test]
@@ -402,6 +665,7 @@ mod tests {
         .unwrap();
         let stats = TableStatistics::from_table(&table);
         let schema = table.schema.as_ref();
+        let ctx = ctx_from(&stats, schema);
 
         let b_group = PredGroup {
             subpred: col("b").lt(lit(900)),
@@ -412,8 +676,8 @@ mod tests {
             col_names: vec!["a".into()],
         };
 
-        let sel_a = group_selectivity(&a_group, Some(&stats), schema);
-        let sel_b = group_selectivity(&b_group, Some(&stats), schema);
+        let sel_a = group_selectivity(&a_group, &ctx);
+        let sel_b = group_selectivity(&b_group, &ctx);
         assert!(
             (sel_a - 0.1).abs() < 1e-9,
             "a>900 over [0,1000] should estimate ~0.1, got {sel_a}"
@@ -423,8 +687,8 @@ mod tests {
             "b<900 over [0,1000] should estimate ~0.9, got {sel_b}"
         );
 
-        let rank_a = group_rank(&a_group, Some(&stats), schema);
-        let rank_b = group_rank(&b_group, Some(&stats), schema);
+        let rank_a = group_rank(&a_group, &ctx);
+        let rank_b = group_rank(&b_group, &ctx);
         assert!(
             rank_a < rank_b,
             "more-selective a>900 rank {rank_a} should sort before b<900 rank {rank_b}"
@@ -443,10 +707,185 @@ mod tests {
             subpred: col("a").gt(lit(900)),
             col_names: vec!["a".into()],
         };
-        let sel = group_selectivity(&g, None, schema);
+        let ctx = ctx_missing(schema);
+        let sel = group_selectivity(&g, &ctx);
         assert!(
             (sel - 0.5).abs() < 1e-9,
             "no stats → neutral 0.5, got {sel}"
+        );
+    }
+
+    #[test]
+    fn str_range_orders_before_equality() {
+        // `s < "k01000"` over s∈["k00000","k99999"] is highly selective; a naive
+        // estimate would give the string range a neutral 0.5 and rank it AFTER
+        // the 0.25 equality on `t`. Stats-based string selectivity must flip
+        // that so the cheap selective range decodes first.
+        let table = RecordBatch::from_nonempty_columns(vec![
+            Utf8Array::from_slice("s", &["k00000", "k99999"]).into_series(),
+            Utf8Array::from_slice("t", &["aaa", "zzz"]).into_series(),
+        ])
+        .unwrap();
+        let stats = TableStatistics::from_table(&table);
+        let schema = table.schema.as_ref();
+        let ctx = ctx_from(&stats, schema);
+
+        let s_group = PredGroup {
+            subpred: col("s").lt(lit("k01000")),
+            col_names: vec!["s".into()],
+        };
+        let t_group = PredGroup {
+            subpred: col("t").eq(lit("mmm")),
+            col_names: vec!["t".into()],
+        };
+
+        let sel_s = group_selectivity(&s_group, &ctx);
+        assert!(
+            sel_s < 0.25,
+            "selective string range should estimate below the 0.25 equality constant, got {sel_s}"
+        );
+        let rank_s = group_rank(&s_group, &ctx);
+        let rank_t = group_rank(&t_group, &ctx);
+        assert!(
+            rank_s < rank_t,
+            "cheap selective string range (rank {rank_s}) must order before the equality group (rank {rank_t})"
+        );
+    }
+
+    #[test]
+    fn str_eq_outside_range_is_very_selective() {
+        // "zzzzzzz" > max "k99999" → cannot occur in this row group → ~0.01.
+        let table = RecordBatch::from_nonempty_columns(vec![
+            Utf8Array::from_slice("s", &["k00000", "k99999"]).into_series(),
+        ])
+        .unwrap();
+        let stats = TableStatistics::from_table(&table);
+        let schema = table.schema.as_ref();
+        let ctx = ctx_from(&stats, schema);
+        let g = PredGroup {
+            subpred: col("s").eq(lit("zzzzzzz")),
+            col_names: vec!["s".into()],
+        };
+        let sel = group_selectivity(&g, &ctx);
+        assert!(
+            (sel - 0.01).abs() < 1e-9,
+            "value above max cannot be present → ~0.01, got {sel}"
+        );
+    }
+
+    #[test]
+    fn str_truncated_stats_fall_back_to_constant() {
+        // A >= 64-byte max may be a Parquet-truncated prefix → interval math is
+        // unreliable → fall back to the neutral constant (0.5 for Lt).
+        let long_max = "x".repeat(70);
+        let table = RecordBatch::from_nonempty_columns(vec![
+            Utf8Array::from_slice("s", &["a", long_max.as_str()]).into_series(),
+        ])
+        .unwrap();
+        let stats = TableStatistics::from_table(&table);
+        let schema = table.schema.as_ref();
+        let ctx = ctx_from(&stats, schema);
+        let g = PredGroup {
+            subpred: col("s").lt(lit("m")),
+            col_names: vec!["s".into()],
+        };
+        let sel = group_selectivity(&g, &ctx);
+        assert!(
+            (sel - 0.5).abs() < 1e-9,
+            "possibly-truncated string max → neutral fallback, got {sel}"
+        );
+    }
+
+    #[test]
+    fn ndv_equality_is_highly_selective() {
+        // distinct_count (NDV) drives equality selectivity: a high-cardinality
+        // column's `== v` survives ~1/NDV of rows (clamped to 0.01), far below a
+        // low-cardinality column's. Stats are irrelevant here (NDV short-circuits).
+        let table = RecordBatch::from_nonempty_columns(vec![
+            Int64Array::from_slice("a", &[0, 1000]).into_series(),
+            Int64Array::from_slice("b", &[0, 1000]).into_series(),
+        ])
+        .unwrap();
+        let schema = table.schema.as_ref();
+        let mut ndv = HashMap::new();
+        ndv.insert("a".to_string(), 100_000usize); // very high cardinality
+        ndv.insert("b".to_string(), 4usize); // low cardinality
+        let ctx = SelCtx {
+            stats: None,
+            schema,
+            ndv,
+            cost: HashMap::new(),
+            rg_rows: 0,
+        };
+
+        let a_group = PredGroup {
+            subpred: col("a").eq(lit(5)),
+            col_names: vec!["a".into()],
+        };
+        let b_group = PredGroup {
+            subpred: col("b").eq(lit(2)),
+            col_names: vec!["b".into()],
+        };
+        let sel_a = group_selectivity(&a_group, &ctx);
+        let sel_b = group_selectivity(&b_group, &ctx);
+        assert!(
+            (sel_a - 0.01).abs() < 1e-9,
+            "high-NDV equality → ~1/NDV clamped to 0.01, got {sel_a}"
+        );
+        assert!(
+            (sel_b - 0.25).abs() < 1e-9,
+            "NDV=4 equality → 1/4 = 0.25, got {sel_b}"
+        );
+        assert!(
+            group_rank(&a_group, &ctx) < group_rank(&b_group, &ctx),
+            "high-NDV equality (more selective) must order before low-NDV equality"
+        );
+    }
+
+    #[test]
+    fn cost_from_bytes_orders_cheap_first() {
+        // Two columns with identical ranges and identical `> 900` predicates have
+        // equal selectivity, so the *cost* axis must break the tie: the cheaper
+        // column (fewer bytes to decode) ranks first.
+        let table = RecordBatch::from_nonempty_columns(vec![
+            Int64Array::from_slice("cheap", &[0, 1000]).into_series(),
+            Int64Array::from_slice("pricey", &[0, 1000]).into_series(),
+        ])
+        .unwrap();
+        let stats = TableStatistics::from_table(&table);
+        let schema = table.schema.as_ref();
+        let mut cost = HashMap::new();
+        cost.insert("cheap".to_string(), 100.0f64);
+        cost.insert("pricey".to_string(), 1_000_000.0f64);
+        let ctx = SelCtx {
+            stats: Some(&stats),
+            schema,
+            ndv: HashMap::new(),
+            cost,
+            rg_rows: 0,
+        };
+
+        let cheap_group = PredGroup {
+            subpred: col("cheap").gt(lit(900)),
+            col_names: vec!["cheap".into()],
+        };
+        let pricey_group = PredGroup {
+            subpred: col("pricey").gt(lit(900)),
+            col_names: vec!["pricey".into()],
+        };
+        let sel_c = group_selectivity(&cheap_group, &ctx);
+        let sel_p = group_selectivity(&pricey_group, &ctx);
+        assert!(
+            (sel_c - sel_p).abs() < 1e-9,
+            "identical predicates → equal selectivity, got {sel_c} vs {sel_p}"
+        );
+        assert!(
+            group_cost(&cheap_group, &ctx) < group_cost(&pricey_group, &ctx),
+            "cost axis should reflect the byte-size difference"
+        );
+        assert!(
+            group_rank(&cheap_group, &ctx) < group_rank(&pricey_group, &ctx),
+            "equal selectivity → cheaper column orders first"
         );
     }
 }


### PR DESCRIPTION
## What

Evaluate a pushed-down **conjunctive** predicate as a sequence of column-disjoint
groups instead of one monolithic mask, narrowing a `RowSelection` progressively so
later groups decode only the surviving rows — LM-pipelined predicate evaluation
(Abadi et al. 2007), building on the late-materialization groundwork in #6311.

The second part is *in which order* to run the groups: they are ranked by a
stats-derived **benefit** so the first-decoded group removes the most rows per unit
of decode work.

Closes #6340.

## How

**Splitting** (`pred_pipeline.rs`): a conjunction is split into conjuncts and grouped
by column set, merging transitively when a conjunct spans multiple groups, yielding
column-disjoint groups.

**Ranking principle.** For groups with selectivity `s_i` (fraction surviving) and
per-row decode cost `c_i`, evaluating in order `1..k` decodes roughly

```
N * (c_1 + s_1*c_2 + s_1*s_2*c_3 + ...)
```

values. For two groups, P before Q iff `c_P/(1-s_P) < c_Q/(1-s_Q)` — i.e. sort by
**benefit `(1-s_i)/c_i` descending** (equivalently rank `(s_i-1)/c_i` ascending). The
subtlety: it is *not* enough to put the "filters-the-most" group first; a
highly-selective but expensive column can lose to a moderately-selective cheap one, so
selectivity must be divided by cost.

**Both axes come from row-group Parquet metadata** (no data decode; recomputed per row
group so the order adapts to each RG's own stats):

- **Selectivity** — numeric ranges interpolate over column min/max, extended with:
  - *Utf8 lexicographic min/max*: strings are projected to a base-256 fraction of their
    leading bytes and the interval interpolated, so a selective string range
    (`s < 'k01000'`) gets a real estimate instead of a neutral constant. Guarded against
    Parquet's default 64-byte stat truncation (a truncated bound is only a prefix, so
    interval math on it would be biased → fall back to a constant).
  - *Equality via `distinct_count` (NDV)*: `col = v ≈ 1/NDV` when the writer provides
    distinct_count; else a min/max containment test (a value strictly outside
    `[min,max]` cannot occur in this RG → ~0); else a constant.
- **Cost** — summed **uncompressed column-chunk bytes** for the group's columns,
  replacing a crude column-count proxy. This lets a narrow selective group order ahead
  of a wide one when selectivity ties.

**Execution** (`reader/mod.rs`): the existing per-row-group prefilter is extracted into
`prefilter_rg_monolithic`, and `prefilter_rg_pipelined` does a single-pass
keep-and-filter over the ordered groups. Pipelining is chosen once per file when there
are ≥2 column-disjoint groups, no LIMIT is set, and the kill-switch is enabled;
otherwise it falls back to the monolithic path unchanged.

## Correctness

Ordering is a pure performance decision. For a conjunction a row survives iff *every*
conjunct is true, so reordering changes only how many rows later groups decode — never
which rows survive. Every estimator degrades to a neutral value on any miss or unusable
input (missing stats, truncated strings, non-numeric literal, degenerate/inverted
range), so a bad estimate costs performance, not correctness. All benchmark
configurations below return **identical row counts**.

## Rollout / A-B

Three env kill-switches, all default-on, each cached once per process so modes can be
A/B'd in isolation and rolled back independently:

- `DAFT_PARQUET_LM_PIPELINE` — the whole feature
- `DAFT_PARQUET_LM_STR_STATS` — string selectivity
- `DAFT_PARQUET_LM_COST_BYTES` — byte-cost vs column-count

## Tests

- `pred_pipeline.rs`: unit tests for group splitting/merging, selectivity ordering,
  missing-stats neutrality, NDV-driven equality selectivity, string range vs equality,
  truncated-string fallback, and byte-cost tie-breaking (shared `SelCtx`).
- `read.rs`: end-to-end tests over real multi-row-group files covering the pipelined
  path, monolithic fallbacks (single column, same-column conjunction), null handling,
  and a pipelined-vs-monolithic differential.
- Full `daft-parquet` suite green (33 tests), `cargo clippy` clean, `cargo fmt` clean.

## Measured

3M rows / 30 row groups, projecting only a cheap output column so timing isolates
predicate-column decode work:

| scenario | monolithic | axis OFF | axis ON | result rows |
|---|---|---|---|---|
| **string stats** `(s < 'k01000') & (text = <rare>)`, cost held equal | 0.66s | 0.63s | **0.115s (5.7x)** | 1 (identical) |
| **byte cost** `(sw < 'k10000') & (s < 'k10000')`, exact selectivity tie | 4.22s | 4.20s | **2.54s (1.66x)** | 300000 (identical) |

- *String stats*: "OFF" mis-orders the 47 MB/RG `text` column first (equality gets 0.25
  while the string range falls to a neutral 0.5), decoding `text` for all rows; "ON"
  estimates the 1%-selective narrow key correctly, decodes it first, and materializes
  `text` only for survivors.
- *Byte cost*: the two keys are built with bit-identical leading-byte string stats, so
  their selectivity estimates tie exactly and *only* the cost axis can break it — toward
  the ~5x-narrower column.

## Follow-ups (not in this PR)

Adaptive re-ranking from observed selectivity after the first group runs; using
bloom-filter offsets (already parsed but unused) for equality pruning; handling the
LIMIT case in the pipelined path (MVP keeps it monolithic).
