### PR TITLE
ci(integration): build Iceberg test image from python:3.10-bookworm

### DIFF
--- a/tests/integration/iceberg/docker-compose/Dockerfile
+++ b/tests/integration/iceberg/docker-compose/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3.10-bullseye
+FROM python:3.10-bookworm
 
 RUN apt-get -qq update && \
     apt-get -qq install -y --no-install-recommends \
@@ -21,7 +21,7 @@ RUN apt-get -qq update && \
       curl \
       vim \
       unzip \
-      openjdk-11-jdk \
+      openjdk-17-jdk \
       build-essential \
       software-properties-common \
       ssh && \


### PR DESCRIPTION
## Why

`integration-test-catalogs` currently fails on **every** PR at the *Spin up services* step (tracked in #7476). The Iceberg docker-compose image builds `FROM python:3.10-bullseye` and installs `openjdk-11-jdk` (plus friends) in a single `RUN`. bullseye's apt index and pool are now out of sync — and the `bullseye-security` `Release` file has expired — so `apt-get install` resolves package versions that then 404 on download:

```
E: Failed to fetch http://deb.debian.org/debian-security/pool/updates/main/o/openjdk-11/openjdk-11-jdk_11.0.32.1+1-1~deb11u1_amd64.deb  404  Not Found
E: Failed to fetch .../s/sudo/sudo_1.9.5p2-3+deb11u4_amd64.deb  404  Not Found
ERROR: process "/bin/sh -c apt-get -qq update && apt-get -qq install -y ..." exit code: 100
```

The failed build aborts `docker compose up`, so the `rest` catalog (port 8181) never starts and the four dependent catalog tests cascade-fail with connection-refused.

## What

Two-line change to `tests/integration/iceberg/docker-compose/Dockerfile`:

- `FROM python:3.10-bullseye` → `FROM python:3.10-bookworm` (Debian 12, whose security suite is actively synced)
- `openjdk-11-jdk` → `openjdk-17-jdk` (bookworm ships 17, not 11)

This is option 2 from the list in #7476 — the reporter explicitly called it out as an acceptable direction.

## Compatibility notes

- **Spark 3.4.2 supports Java 17** (Spark has supported 17 since 3.3), so the runtime is unaffected by the JDK bump.
- `check-license` uses `$JAVA_HOME/bin/java` when `JAVA_HOME` is set and otherwise falls back to `java` on `PATH`; Debian alternatives point `java` at 17. There is **no hardcoded java-11 path** anywhere in the compose directory (grepped).
- No other file references `bullseye` / `openjdk-11` / `deb11`.
- The **Gravitino** compose stack uses prebuilt images (`apache/gravitino`, `mysql`, `minio`) with no Dockerfile, so it is not affected by the bullseye breakage and needs no change here.

## Verification

Docker is not available in my environment, so I could not build the image locally. Relying on CI (`integration-test-catalogs`) to confirm the image builds and the `rest` catalog comes up. Happy to switch to a `snapshot.debian.org` pin or add an `apt-get` retry instead if maintainers prefer one of the other options from #7476.

Fixes #7476
