### PR TITLE
feat(io): add WebDataset reader

### DIFF
--- a/daft/__init__.py
+++ b/daft/__init__.py
@@ -155,6 +155,7 @@ from daft.io import (
     read_text,
     read_video_frames,
     read_warc,
+    read_webdataset,
     read_huggingface,
     read_mcap,
 )
@@ -295,6 +296,7 @@ __all__ = [
     "read_text",
     "read_video_frames",
     "read_warc",
+    "read_webdataset",
     "refresh_logger",
     "register_viz_hook",
     "runners",

--- a/daft/io/__init__.py
+++ b/daft/io/__init__.py
@@ -32,6 +32,7 @@ from daft.io._sql import read_sql
 from daft.io._warc import read_warc
 from daft.io.huggingface import read_huggingface
 from daft.io.mcap._mcap import read_mcap
+from daft.io.webdataset import read_webdataset
 from daft.io._range import _range
 from daft.io._files import from_files
 from daft.io.file_path import from_glob_path
@@ -88,4 +89,5 @@ __all__ = [
     "read_text",
     "read_video_frames",
     "read_warc",
+    "read_webdataset",
 ]

--- a/daft/io/huggingface/__init__.py
+++ b/daft/io/huggingface/__init__.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from daft.api_annotations import PublicAPI
 from daft.exceptions import DaftCoreException
 from daft.io._parquet import read_parquet
+from daft.io.webdataset import read_webdataset
 
 if TYPE_CHECKING:
     from daft.daft import IOConfig
@@ -35,15 +36,29 @@ def _fallback_to_datasets_library(repo: str, original_error: Exception) -> DataF
 
 
 @PublicAPI
-def read_huggingface(repo: str, io_config: IOConfig | None = None) -> DataFrame:
+def read_huggingface(
+    repo: str,
+    io_config: IOConfig | None = None,
+    format: Literal["parquet", "webdataset"] = "parquet",
+) -> DataFrame:
     """Create a DataFrame from a Hugging Face dataset.
 
-    Currently supports all public datasets and all private Parquet datasets. See [the Hugging Face docs](https://huggingface.co/docs/dataset-viewer/en/parquet) for more details.
+    Currently supports all public datasets, private Parquet datasets, and
+    repositories stored as WebDataset TAR shards. See the
+    [Hugging Face dataset docs](https://huggingface.co/docs/hub/en/datasets-overview)
+    for more details.
 
     Args:
         repo (str): repository to read in the form `username/dataset_name`
         io_config (IOConfig): Config to use when reading data
+        format: Dataset storage format. Defaults to ``"parquet"`` for backwards
+            compatibility. Use ``"webdataset"`` to read uncompressed TAR shards.
     """
+    if format == "webdataset":
+        return read_webdataset(f"hf://datasets/{repo}/**/*.tar", io_config=io_config)
+    if format != "parquet":
+        raise ValueError(f"Unsupported Hugging Face dataset format: {format!r}")
+
     try:
         # Try the fast path: read parquet files directly
         return read_parquet(f"hf://datasets/{repo}", io_config=io_config)

--- a/daft/io/huggingface/__init__.py
+++ b/daft/io/huggingface/__init__.py
@@ -39,7 +39,7 @@ def _fallback_to_datasets_library(repo: str, original_error: Exception) -> DataF
 def read_huggingface(
     repo: str,
     io_config: IOConfig | None = None,
-    format: Literal["parquet", "webdataset"] = "parquet",
+    format: Literal["parquet", "webdataset"] | None = None,
 ) -> DataFrame:
     """Create a DataFrame from a Hugging Face dataset.
 
@@ -51,12 +51,12 @@ def read_huggingface(
     Args:
         repo (str): repository to read in the form `username/dataset_name`
         io_config (IOConfig): Config to use when reading data
-        format: Dataset storage format. Defaults to ``"parquet"`` for backwards
-            compatibility. Use ``"webdataset"`` to read uncompressed TAR shards.
+        format: Dataset storage format. If ``None``, currently defaults to
+            ``"parquet"``. Use ``"webdataset"`` to read uncompressed TAR shards.
     """
     if format == "webdataset":
         return read_webdataset(f"hf://datasets/{repo}/**/*.tar", io_config=io_config)
-    if format != "parquet":
+    if format not in (None, "parquet"):
         raise ValueError(f"Unsupported Hugging Face dataset format: {format!r}")
 
     try:

--- a/daft/io/webdataset/__init__.py
+++ b/daft/io/webdataset/__init__.py
@@ -1,0 +1,3 @@
+from daft.io.webdataset._webdataset import read_webdataset
+
+__all__ = ["read_webdataset"]

--- a/daft/io/webdataset/_webdataset.py
+++ b/daft/io/webdataset/_webdataset.py
@@ -1,0 +1,442 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+import tarfile
+from collections.abc import AsyncIterator, Iterator
+from dataclasses import dataclass
+from itertools import islice
+from typing import TYPE_CHECKING
+
+from daft.api_annotations import PublicAPI
+from daft.context import get_context
+from daft.daft import io_glob
+from daft.datatype import DataType, MediaType
+from daft.file import File, open_file
+from daft.io.source import DataSource, DataSourceTask
+from daft.recordbatch import RecordBatch
+from daft.schema import Schema
+from daft.series import Series
+
+if TYPE_CHECKING:
+    from daft import DataFrame
+    from daft.daft import IOConfig
+    from daft.io.pushdowns import Pushdowns
+
+
+_SAMPLES_FOR_SCHEMA_INFERENCE = 5
+_BASE_PLUS_EXTENSION = re.compile(r"^((?:.*/|)[^.]+)[.]([^/]*)$")
+_ARCHIVE_METADATA = re.compile(r"__[^/]*__($|/)")
+
+_IMAGE_EXTENSIONS = frozenset(
+    {
+        "apng",
+        "avif",
+        "bmp",
+        "gif",
+        "heic",
+        "heif",
+        "jfif",
+        "jp2",
+        "jpeg",
+        "jpg",
+        "jxl",
+        "png",
+        "tif",
+        "tiff",
+        "webp",
+    }
+)
+_AUDIO_EXTENSIONS = frozenset(
+    {
+        "aac",
+        "aiff",
+        "au",
+        "caf",
+        "flac",
+        "m4a",
+        "mp3",
+        "ogg",
+        "opus",
+        "wav",
+        "wma",
+    }
+)
+_VIDEO_EXTENSIONS = frozenset(
+    {
+        "avi",
+        "m4v",
+        "mkv",
+        "mov",
+        "mp4",
+        "mpeg",
+        "mpg",
+        "ogv",
+        "webm",
+        "wmv",
+    }
+)
+_JSON_EXTENSIONS = frozenset({"json", "jsn"})
+_TEXT_EXTENSIONS = frozenset({"text", "transcript", "txt"})
+_INTEGER_EXTENSIONS = frozenset({"cls", "cls2", "id", "index", "inx"})
+_COMPRESSED_TAR_SUFFIXES = (".tar.bz2", ".tar.gz", ".tar.xz", ".tbz2", ".tgz", ".txz")
+_END_OF_ITERATOR = object()
+
+
+def _field_extension(field_name: str) -> str:
+    return field_name.rsplit(".", 1)[-1].lower()
+
+
+def _media_type(field_name: str) -> MediaType:
+    extension = _field_extension(field_name)
+    if extension in _IMAGE_EXTENSIONS:
+        return MediaType.image()
+    if extension in _AUDIO_EXTENSIONS:
+        return MediaType.audio()
+    if extension in _VIDEO_EXTENSIONS:
+        return MediaType.video()
+    return MediaType.unknown()
+
+
+def _is_eagerly_decoded(field_name: str) -> bool:
+    extension = _field_extension(field_name)
+    return extension in _JSON_EXTENSIONS | _TEXT_EXTENSIONS | _INTEGER_EXTENSIONS
+
+
+def _decode_member(archive: tarfile.TarFile, member: tarfile.TarInfo, field_name: str) -> object:
+    extracted = archive.extractfile(member)
+    if extracted is None:
+        raise ValueError(f"Unable to read regular file {member.name!r} from WebDataset archive")
+
+    data = extracted.read()
+    extension = _field_extension(field_name)
+    try:
+        if extension in _JSON_EXTENSIONS:
+            return json.loads(data)
+        if extension in _TEXT_EXTENSIONS:
+            return data.decode("utf-8")
+        if extension in _INTEGER_EXTENSIONS:
+            return int(data)
+    except (UnicodeDecodeError, ValueError) as error:
+        raise ValueError(f"Unable to decode WebDataset member {member.name!r}") from error
+
+    raise AssertionError(f"No eager decoder registered for WebDataset field {field_name!r}")
+
+
+def _member_value(
+    archive: tarfile.TarFile,
+    archive_path: str,
+    member: tarfile.TarInfo,
+    field_name: str,
+    io_config: IOConfig | None,
+) -> object:
+    if _is_eagerly_decoded(field_name):
+        return _decode_member(archive, member, field_name)
+
+    return File(
+        archive_path,
+        io_config=io_config,
+        media_type=_media_type(field_name),
+        position=member.offset_data,
+        size=member.size,
+    )
+
+
+def _iter_archive_samples(
+    archive_path: str,
+    io_config: IOConfig | None,
+    selected_columns: set[str] | None = None,
+    known_fields: set[str] | frozenset[str] | None = None,
+) -> Iterator[dict[str, object]]:
+    current_key: str | None = None
+    current_sample: dict[str, object] | None = None
+    seen_fields: set[str] = set()
+
+    with open_file(archive_path, "rb", io_config=io_config) as file:
+        try:
+            with tarfile.open(fileobj=file, mode="r:") as archive:
+                for member in archive:
+                    if not member.isreg() or _ARCHIVE_METADATA.match(member.name):
+                        continue
+
+                    match = _BASE_PLUS_EXTENSION.match(member.name)
+                    if match is None:
+                        continue
+
+                    sample_key, field_name = match.groups()
+                    field_name = field_name.lower()
+
+                    if known_fields is not None and field_name not in known_fields:
+                        raise ValueError(
+                            f"WebDataset field {field_name!r} in archive {archive_path!r} "
+                            "was not present during schema inference. WebDataset shards must "
+                            "use a consistent set of member suffixes."
+                        )
+
+                    if current_key != sample_key:
+                        if current_sample is not None:
+                            yield current_sample
+                        current_key = sample_key
+                        current_sample = {"__key__": sample_key, "__url__": archive_path}
+                        seen_fields = set()
+
+                    if field_name in seen_fields:
+                        raise ValueError(
+                            f"Duplicate WebDataset field {field_name!r} for sample {sample_key!r} "
+                            f"in archive {archive_path!r}"
+                        )
+                    seen_fields.add(field_name)
+
+                    if selected_columns is None or field_name in selected_columns:
+                        assert current_sample is not None
+                        current_sample[field_name] = _member_value(
+                            archive,
+                            archive_path,
+                            member,
+                            field_name,
+                            io_config,
+                        )
+        except tarfile.ReadError as error:
+            raise ValueError(
+                f"Unable to read {archive_path!r} as an uncompressed TAR archive. "
+                "Compressed WebDataset shards are not supported."
+            ) from error
+
+    if current_sample is not None:
+        yield current_sample
+
+
+def _field_dtype(field_name: str, samples: list[dict[str, object]]) -> DataType:
+    if field_name in {"__key__", "__url__"}:
+        return DataType.string()
+
+    extension = _field_extension(field_name)
+    if extension in _IMAGE_EXTENSIONS:
+        return DataType.file(MediaType.image())
+    if extension in _AUDIO_EXTENSIONS:
+        return DataType.file(MediaType.audio())
+    if extension in _VIDEO_EXTENSIONS:
+        return DataType.file(MediaType.video())
+    if extension in _TEXT_EXTENSIONS:
+        return DataType.string()
+    if extension in _INTEGER_EXTENSIONS:
+        return DataType.int64()
+    if extension in _JSON_EXTENSIONS:
+        values = [sample.get(field_name) for sample in samples]
+        return Series.from_pylist(values, name=field_name).datatype()
+    return DataType.file()
+
+
+def _infer_schema(archive_path: str, io_config: IOConfig | None) -> Schema:
+    samples = list(
+        islice(
+            _iter_archive_samples(archive_path, io_config),
+            _SAMPLES_FOR_SCHEMA_INFERENCE,
+        )
+    )
+    if not samples:
+        raise ValueError(f"WebDataset archive {archive_path!r} does not contain any valid samples")
+
+    field_names = ["__key__", "__url__"]
+    discovered = set(field_names)
+    for sample in samples:
+        for field_name in sample:
+            if field_name not in discovered:
+                discovered.add(field_name)
+                field_names.append(field_name)
+
+    return Schema.from_pydict({field_name: _field_dtype(field_name, samples) for field_name in field_names})
+
+
+def _is_compressed_tar(path: str) -> bool:
+    return path.lower().endswith(_COMPRESSED_TAR_SUFFIXES)
+
+
+def _glob_pattern(path: str) -> str:
+    if _is_compressed_tar(path):
+        raise ValueError("Compressed WebDataset shards are not supported; expected an uncompressed .tar file")
+    if any(character in path for character in "*?[") or path.lower().endswith(".tar"):
+        return path
+    return f"{path.rstrip('/')}/**/*.tar"
+
+
+def _resolve_archive_paths(paths: str | list[str], io_config: IOConfig | None) -> list[str]:
+    paths = [paths] if isinstance(paths, str) else paths
+    if not paths:
+        raise ValueError("Must specify at least one WebDataset path")
+
+    archive_paths: list[str] = []
+    seen_paths: set[str] = set()
+    for path in paths:
+        for file_info in io_glob(_glob_pattern(path), io_config=io_config):
+            archive_path = file_info["path"]
+            if file_info["type"] != "File" or not archive_path.lower().endswith(".tar"):
+                continue
+            if archive_path not in seen_paths:
+                seen_paths.add(archive_path)
+                archive_paths.append(archive_path)
+
+    if not archive_paths:
+        raise FileNotFoundError(f"No uncompressed WebDataset TAR shards found for: {paths}")
+    return archive_paths
+
+
+def _record_batch(samples: list[dict[str, object]], schema: Schema) -> RecordBatch:
+    series = []
+    for field in schema:
+        values = [sample.get(field.name) for sample in samples]
+        if _field_extension(field.name) in _JSON_EXTENSIONS and any(value is not None for value in values):
+            inferred_dtype = Series.from_pylist(values, name=field.name).datatype()
+            if inferred_dtype != field.dtype:
+                raise ValueError(
+                    f"WebDataset JSON field {field.name!r} does not match its inferred schema: "
+                    f"expected {field.dtype}, received {inferred_dtype}"
+                )
+        series.append(Series.from_pylist(values, name=field.name, dtype=field.dtype))
+    return RecordBatch._from_series(series, num_rows=len(samples))
+
+
+def _iter_record_batches(
+    archive_path: str,
+    schema: Schema,
+    known_fields: frozenset[str],
+    io_config: IOConfig | None,
+    batch_size: int,
+) -> Iterator[RecordBatch]:
+    selected_columns = set(schema.column_names())
+    samples: list[dict[str, object]] = []
+    for sample in _iter_archive_samples(
+        archive_path,
+        io_config,
+        selected_columns=selected_columns,
+        known_fields=known_fields,
+    ):
+        samples.append(sample)
+        if len(samples) >= batch_size:
+            yield _record_batch(samples, schema)
+            samples.clear()
+
+    if samples:
+        yield _record_batch(samples, schema)
+
+
+def _next_or_end(iterator: Iterator[RecordBatch]) -> RecordBatch | object:
+    try:
+        return next(iterator)
+    except StopIteration:
+        return _END_OF_ITERATOR
+
+
+@PublicAPI
+def read_webdataset(
+    path: str | list[str],
+    io_config: IOConfig | None = None,
+    batch_size: int = 1000,
+) -> DataFrame:
+    """Read one or more WebDataset TAR shards.
+
+    Consecutive TAR members with the same filename prefix are grouped into one row.
+    The member suffix becomes the column name, following the WebDataset convention.
+    Image, audio, video, and other binary members are represented by lazy
+    :class:`daft.File` references into the TAR archive. JSON, text, and class/index
+    sidecars are decoded eagerly.
+
+    Args:
+        path: An uncompressed TAR file, directory, glob, or list of paths. Directories
+            are searched recursively for ``*.tar`` files.
+        io_config: Configuration for local or remote storage.
+        batch_size: Maximum number of samples yielded per record batch.
+
+    Returns:
+        A DataFrame containing ``__key__``, ``__url__``, and one column per member
+        suffix discovered during schema inference.
+
+    Note:
+        Compressed TAR archives are not supported because member byte offsets cannot
+        be used for lazy range-backed file references.
+        Member suffixes and JSON shapes must be consistent across shards. The schema
+        is inferred from the first five samples of the first shard, and later
+        incompatibilities raise an error instead of discarding data.
+
+    Examples:
+        >>> df = daft.read_webdataset("/path/to/shards/*.tar")  # doctest: +SKIP
+        >>> images = df.select("jpg")  # The image bytes remain lazy until opened or decoded.
+    """
+    if batch_size <= 0:
+        raise ValueError(f"batch_size must be greater than zero, received {batch_size}")
+
+    io_config = get_context().daft_planning_config.default_io_config if io_config is None else io_config
+    return WebDatasetSource(path, io_config=io_config, batch_size=batch_size).read()
+
+
+class WebDatasetSource(DataSource):
+    def __init__(
+        self,
+        paths: str | list[str],
+        io_config: IOConfig | None,
+        batch_size: int,
+    ) -> None:
+        self._archive_paths = _resolve_archive_paths(paths, io_config)
+        self._io_config = io_config
+        self._batch_size = batch_size
+        self._schema = _infer_schema(self._archive_paths[0], io_config)
+
+    @property
+    def name(self) -> str:
+        return "WebDatasetSource"
+
+    @property
+    def schema(self) -> Schema:
+        return self._schema
+
+    async def get_tasks(self, pushdowns: Pushdowns) -> AsyncIterator[WebDatasetSourceTask]:
+        schema_columns = self._schema.column_names()
+        if pushdowns.columns is None:
+            projected_columns = schema_columns
+        else:
+            requested_columns = set(pushdowns.columns)
+            projected_columns = [column for column in schema_columns if column in requested_columns]
+
+        projected_schema = Schema.from_pydict({column: self._schema[column].dtype for column in projected_columns})
+        task_batch_size = (
+            min(self._batch_size, pushdowns.limit)
+            if pushdowns.limit is not None and pushdowns.limit > 0
+            else self._batch_size
+        )
+        for archive_path in self._archive_paths:
+            yield WebDatasetSourceTask(
+                _archive_path=archive_path,
+                _schema=projected_schema,
+                _known_fields=frozenset(schema_columns) - {"__key__", "__url__"},
+                _io_config=self._io_config,
+                _batch_size=task_batch_size,
+            )
+
+
+@dataclass
+class WebDatasetSourceTask(DataSourceTask):
+    _archive_path: str
+    _schema: Schema
+    _known_fields: frozenset[str]
+    _io_config: IOConfig | None
+    _batch_size: int
+
+    @property
+    def schema(self) -> Schema:
+        return self._schema
+
+    async def read(self) -> AsyncIterator[RecordBatch]:
+        batches = _iter_record_batches(
+            self._archive_path,
+            self._schema,
+            self._known_fields,
+            self._io_config,
+            self._batch_size,
+        )
+        while True:
+            batch = await asyncio.to_thread(_next_or_end, batches)
+            if batch is _END_OF_ITERATOR:
+                break
+            assert isinstance(batch, RecordBatch)
+            yield batch

--- a/daft/io/webdataset/_webdataset.py
+++ b/daft/io/webdataset/_webdataset.py
@@ -160,6 +160,12 @@ def _iter_archive_samples(
                     if not member.isreg() or _ARCHIVE_METADATA.match(member.name):
                         continue
 
+                    if member.issparse():
+                        raise ValueError(
+                            f"Sparse TAR member {member.name!r} in WebDataset archive {archive_path!r} "
+                            "is not supported because its contents are not stored as a contiguous byte range"
+                        )
+
                     match = _BASE_PLUS_EXTENSION.match(member.name)
                     if match is None:
                         continue
@@ -355,6 +361,8 @@ def read_webdataset(
     Note:
         Compressed TAR archives are not supported because member byte offsets cannot
         be used for lazy range-backed file references.
+        Sparse TAR members are not supported because their logical contents are not
+        stored as contiguous byte ranges.
         Member suffixes and JSON shapes must be consistent across shards. The schema
         is inferred from the first five samples of the first shard, and later
         incompatibilities raise an error instead of discarding data.

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -63,6 +63,7 @@
             * [Files](connectors/files.md)
             * [Text Files](connectors/text.md)
             * [Blob Files](connectors/blob.md)
+            * [WebDataset](connectors/webdataset.md)
             * [Generic File Source Options](connectors/generic-file-source-options.md)
         * Other Sources
             * [Apache Kafka](connectors/kafka.md)

--- a/docs/api/io.md
+++ b/docs/api/io.md
@@ -84,6 +84,10 @@ Daft offers a variety of approaches to creating a DataFrame from reading various
     options:
         heading_level: 3
 
+::: daft.read_webdataset
+    options:
+        heading_level: 3
+
 ::: daft.read_huggingface
     options:
         heading_level: 3

--- a/docs/connectors/huggingface.md
+++ b/docs/connectors/huggingface.md
@@ -46,10 +46,10 @@ columns does not download image, audio, or video payloads.
 
 !!! warning "Warning"
 
-    The default `format="parquet"` path is currently limited to either public
-    datasets, or PRO/ENTERPRISE datasets, where Hugging Face will
+    `daft.read_huggingface()` is currently limited to WebDataset repositories
+    or datasets that Hugging Face
     [automatically convert](https://huggingface.co/docs/dataset-viewer/en/parquet)
-    the dataset to Parquet.
+    to Parquet. When `format=None`, Daft currently uses the Parquet reader.
 
     For other datasets, you will need to manually specify the path or glob pattern to the files you want to read, similar to how you would read from a local file system. See the next section for an example.
 

--- a/docs/connectors/huggingface.md
+++ b/docs/connectors/huggingface.md
@@ -26,9 +26,30 @@ Using [`daft.read_huggingface()`][daft.read_huggingface], you can easily read a 
 
 This will read the entire dataset into a DataFrame.
 
+For repositories stored as uncompressed
+[WebDataset](https://huggingface.co/docs/hub/en/datasets-webdataset) TAR shards,
+select the WebDataset reader explicitly:
+
+=== "🐍 Python"
+
+    ```python
+    import daft
+
+    df = daft.read_huggingface(
+        "laion/conceptual-captions-12m-webdataset",
+        format="webdataset",
+    )
+    ```
+
+Media members remain lazy, range-backed file references, so selecting metadata
+columns does not download image, audio, or video payloads.
+
 !!! warning "Warning"
 
-    This is currently limited to either public datasets, or PRO/ENTERPRISE datasets, where Hugging Face will [automatically convert](https://huggingface.co/docs/dataset-viewer/en/parquet) the dataset to Parquet.
+    The default `format="parquet"` path is currently limited to either public
+    datasets, or PRO/ENTERPRISE datasets, where Hugging Face will
+    [automatically convert](https://huggingface.co/docs/dataset-viewer/en/parquet)
+    the dataset to Parquet.
 
     For other datasets, you will need to manually specify the path or glob pattern to the files you want to read, similar to how you would read from a local file system. See the next section for an example.
 

--- a/docs/connectors/index.md
+++ b/docs/connectors/index.md
@@ -331,6 +331,14 @@ See also [Text Files](text.md) and [Blob Files](blob.md) for detailed usage.
 |----------------------------------|----------------------------------------------------------|
 | [`read_warc`][daft.io.read_warc] | Read a WARC file or multiple WARC files into a DataFrame |
 
+### WebDataset
+
+| Function                                       | Description                                                    |
+|------------------------------------------------|----------------------------------------------------------------|
+| [`read_webdataset`][daft.io.read_webdataset]   | Read multimodal WebDataset TAR shards into a DataFrame          |
+
+See also [WebDataset](webdataset.md) for format details and lazy media reads.
+
 ### Video
 
 | Function                                         | Description                        |

--- a/docs/connectors/webdataset.md
+++ b/docs/connectors/webdataset.md
@@ -57,6 +57,8 @@ df = daft.read_webdataset(
 Daft currently requires:
 
 - Uncompressed `.tar` shards, because lazy member reads use byte offsets.
+- Non-sparse TAR members, because sparse file contents are not stored in one
+  contiguous byte range.
 - Consistent member suffixes and JSON shapes across shards.
 
 Schema inference uses the first five samples in the first shard. If a later

--- a/docs/connectors/webdataset.md
+++ b/docs/connectors/webdataset.md
@@ -1,0 +1,64 @@
+# WebDataset
+
+[WebDataset](https://github.com/webdataset/webdataset) stores multimodal samples
+as consecutive members of TAR shards. Daft reads these shards with
+[`daft.read_webdataset()`][daft.read_webdataset].
+
+## Reading shards
+
+Pass a TAR file, directory, glob, or list of paths:
+
+```python
+import daft
+
+df = daft.read_webdataset("/datasets/images/*.tar")
+```
+
+Each row represents one sample. Consecutive members with the same prefix are
+grouped together, and the suffix becomes the column name. For example,
+`000001.jpg`, `000001.json`, and `000001.txt` produce one row with `jpg`,
+`json`, and `txt` columns. Daft also includes:
+
+- `__key__`: the sample prefix
+- `__url__`: the shard containing the sample
+
+JSON, text, and class/index sidecars are decoded eagerly. Image, audio, video,
+and other binary members are represented as lazy [`File`][daft.File]
+references into their TAR shard. Selecting only metadata columns therefore
+avoids reading media payloads:
+
+```python
+metadata = df.select("__key__", "json", "txt")
+images = df.select("__key__", "jpg")
+```
+
+## Reading from Hugging Face
+
+Use `format="webdataset"` with
+[`daft.read_huggingface()`][daft.read_huggingface]:
+
+```python
+df = daft.read_huggingface(
+    "laion/conceptual-captions-12m-webdataset",
+    format="webdataset",
+)
+```
+
+You can also read explicit Hugging Face paths:
+
+```python
+df = daft.read_webdataset(
+    "hf://datasets/laion/conceptual-captions-12m-webdataset/data/*.tar"
+)
+```
+
+## Format requirements
+
+Daft currently requires:
+
+- Uncompressed `.tar` shards, because lazy member reads use byte offsets.
+- Consistent member suffixes and JSON shapes across shards.
+
+Schema inference uses the first five samples in the first shard. If a later
+sample introduces an incompatible suffix or JSON shape, Daft raises an error
+instead of silently discarding data.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,7 +188,7 @@ docs = [
 [tool.codespell]
 check-filenames = true
 check-hidden = true
-ignore-words-list = "crate,arithmetics,ser,acter,MOR,NotIn"
+ignore-words-list = "crate,arithmetics,ser,acter,MOR,NotIn,caf"
 # Feel free to un-skip examples, and experimental, you will just need to
 # work through many typos (--write-changes and --interactive will help)
 skip = "tests/series/*,target,.git,.venv,venv,data,*.csv,*.csv.*,*.html,*.json,*.jsonl,*.pdf,*.txt,*.ipynb,*.tiktoken,*.sql,tests/table/utf8/*,tests/table/binary/*,*.warc,tests/ai/*"

--- a/tests/integration/io/huggingface/test_read_huggingface.py
+++ b/tests/integration/io/huggingface/test_read_huggingface.py
@@ -79,6 +79,20 @@ def test_read_huggingface_fallback_on_400_error():
         assert_df_equals(actual, expected, "foo")
 
 
+def test_read_huggingface_webdataset_routes_to_webdataset_reader():
+    repo = "laion/conceptual-captions-12m-webdataset"
+    sentinel = object()
+
+    with patch("daft.io.huggingface.read_webdataset", return_value=sentinel) as mock_read_webdataset:
+        result = daft.read_huggingface(repo, format="webdataset")
+
+    assert result is sentinel
+    mock_read_webdataset.assert_called_once_with(
+        f"hf://datasets/{repo}/**/*.tar",
+        io_config=None,
+    )
+
+
 @pytest.mark.integration()
 def test_read_huggingface_multi_split_dataset():
     """Test that read_huggingface works with datasets that have multiple splits.

--- a/tests/integration/io/huggingface/test_read_huggingface.py
+++ b/tests/integration/io/huggingface/test_read_huggingface.py
@@ -93,6 +93,18 @@ def test_read_huggingface_webdataset_routes_to_webdataset_reader():
     )
 
 
+@pytest.mark.parametrize("format", [None, "parquet"])
+def test_read_huggingface_parquet_format(format):
+    repo = "Eventual-Inc/sample-parquet"
+    sentinel = object()
+
+    with patch("daft.io.huggingface.read_parquet", return_value=sentinel) as mock_read_parquet:
+        result = daft.read_huggingface(repo, format=format)
+
+    assert result is sentinel
+    mock_read_parquet.assert_called_once_with(f"hf://datasets/{repo}", io_config=None)
+
+
 @pytest.mark.integration()
 def test_read_huggingface_multi_split_dataset():
     """Test that read_huggingface works with datasets that have multiple splits.

--- a/tests/io/webdataset/test_webdataset.py
+++ b/tests/io/webdataset/test_webdataset.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import io
+import tarfile
+import threading
+from functools import partial
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+
+import daft
+from daft import DataType, MediaType
+
+
+class _QuietHTTPRequestHandler(SimpleHTTPRequestHandler):
+    def log_message(self, format: str, *args: object) -> None:
+        pass
+
+
+def _write_tar(path: Path, members: list[tuple[str, bytes]]) -> None:
+    with tarfile.open(path, "w") as archive:
+        for name, data in members:
+            info = tarfile.TarInfo(name)
+            info.size = len(data)
+            archive.addfile(info, io.BytesIO(data))
+
+
+@pytest.fixture
+def webdataset_path(tmp_path: Path) -> Path:
+    path = tmp_path / "samples.tar"
+    _write_tar(
+        path,
+        [
+            ("000001.jpg", b"first-image"),
+            ("000001.json", b'{"caption": "first", "score": 1}'),
+            ("000001.txt", b"first caption"),
+            ("000001.cls", b"7"),
+            ("000001.mp4", b"first-video"),
+            ("000001.wav", b"first-audio"),
+            ("000001.npy", b"first-array"),
+            ("000002.jpg", b"second-image"),
+            ("000002.json", b'{"caption": "second", "score": 2}'),
+            ("000002.txt", b"second caption"),
+            ("000002.cls", b"9"),
+            ("000002.mp4", b"second-video"),
+            ("000002.wav", b"second-audio"),
+            ("000002.npy", b"second-array"),
+        ],
+    )
+    return path
+
+
+@pytest.fixture
+def webdataset_http_url(webdataset_path: Path) -> str:
+    handler = partial(_QuietHTTPRequestHandler, directory=str(webdataset_path.parent))
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    try:
+        yield f"http://127.0.0.1:{server.server_port}/{webdataset_path.name}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def test_read_webdataset(webdataset_path: Path) -> None:
+    df = daft.read_webdataset(str(webdataset_path))
+
+    assert df.schema()["jpg"].dtype == DataType.file(MediaType.image())
+    assert df.schema()["mp4"].dtype == DataType.file(MediaType.video())
+    assert df.schema()["wav"].dtype == DataType.file(MediaType.audio())
+    assert df.schema()["npy"].dtype == DataType.file()
+    assert df.schema()["txt"].dtype == DataType.string()
+    assert df.schema()["cls"].dtype == DataType.int64()
+
+    result = df.collect().to_pydict()
+    assert result["__key__"] == ["000001", "000002"]
+    assert result["__url__"] == [webdataset_path.as_uri()] * 2
+    assert result["json"] == [
+        {"caption": "first", "score": 1},
+        {"caption": "second", "score": 2},
+    ]
+    assert result["txt"] == ["first caption", "second caption"]
+    assert result["cls"] == [7, 9]
+
+    images = result["jpg"]
+    assert all(isinstance(image, daft.ImageFile) for image in images)
+    with images[0].open() as image:
+        assert image.read() == b"first-image"
+    with images[1].open() as image:
+        assert image.read() == b"second-image"
+
+    assert all(isinstance(video, daft.VideoFile) for video in result["mp4"])
+    assert all(isinstance(audio, daft.AudioFile) for audio in result["wav"])
+    assert all(type(array) is daft.File for array in result["npy"])
+    with result["mp4"][0].open() as video:
+        assert video.read() == b"first-video"
+    with result["wav"][0].open() as audio:
+        assert audio.read() == b"first-audio"
+    with result["npy"][0].open() as array:
+        assert array.read() == b"first-array"
+
+
+def test_read_webdataset_http_range_references(webdataset_http_url: str) -> None:
+    result = daft.read_webdataset(webdataset_http_url).select("__key__", "jpg").collect().to_pydict()
+
+    assert result["__key__"] == ["000001", "000002"]
+    assert result["jpg"][0].path == webdataset_http_url
+    assert result["jpg"][0].position is not None
+    assert result["jpg"][0]._inner.size() == len(b"first-image")
+
+
+def test_read_webdataset_projection(webdataset_path: Path) -> None:
+    result = daft.read_webdataset(str(webdataset_path)).select("txt", "jpg").collect().to_pydict()
+
+    assert set(result) == {"txt", "jpg"}
+    assert result["txt"] == ["first caption", "second caption"]
+    with result["jpg"][0].open() as image:
+        assert image.read() == b"first-image"
+
+
+def test_read_webdataset_directory_and_multiple_shards(tmp_path: Path) -> None:
+    _write_tar(tmp_path / "first.tar", [("a.txt", b"first")])
+    _write_tar(tmp_path / "second.tar", [("b.txt", b"second")])
+
+    result = daft.read_webdataset(str(tmp_path), batch_size=1).sort("__key__").collect().to_pydict()
+
+    assert result["__key__"] == ["a", "b"]
+    assert result["txt"] == ["first", "second"]
+
+
+def test_read_webdataset_preserves_multipart_suffixes(tmp_path: Path) -> None:
+    path = tmp_path / "multipart.tar"
+    _write_tar(
+        path,
+        [
+            ("nested/sample.en.txt", b"caption"),
+            ("nested/sample.jpg", b"image"),
+        ],
+    )
+
+    result = daft.read_webdataset(str(path)).collect().to_pydict()
+
+    assert result["__key__"] == ["nested/sample"]
+    assert result["en.txt"] == ["caption"]
+    with result["jpg"][0].open() as image:
+        assert image.read() == b"image"
+
+
+def test_read_webdataset_missing_inferred_field_is_null(tmp_path: Path) -> None:
+    path = tmp_path / "missing.tar"
+    _write_tar(
+        path,
+        [
+            ("a.jpg", b"image-a"),
+            ("a.txt", b"caption-a"),
+            ("b.jpg", b"image-b"),
+        ],
+    )
+
+    result = daft.read_webdataset(str(path)).sort("__key__").collect().to_pydict()
+
+    assert result["txt"] == ["caption-a", None]
+
+
+def test_read_webdataset_rejects_field_missing_from_inferred_schema(tmp_path: Path) -> None:
+    path = tmp_path / "inconsistent-fields.tar"
+    members = [(f"{index:06d}.txt", b"caption") for index in range(6)]
+    members.append(("000005.json", b'{"caption": "late"}'))
+    _write_tar(path, members)
+
+    with pytest.raises(ValueError, match="was not present during schema inference"):
+        daft.read_webdataset(str(path)).collect()
+
+
+def test_read_webdataset_rejects_incompatible_json_schema(tmp_path: Path) -> None:
+    path = tmp_path / "inconsistent-json.tar"
+    members = [(f"{index:06d}.json", b'{"caption": "consistent"}') for index in range(5)]
+    members.append(("000005.json", b'{"different": "field"}'))
+    _write_tar(path, members)
+
+    with pytest.raises(ValueError, match="does not match its inferred schema"):
+        daft.read_webdataset(str(path)).collect()
+
+
+def test_read_webdataset_rejects_duplicate_fields(tmp_path: Path) -> None:
+    path = tmp_path / "duplicate.tar"
+    _write_tar(path, [("a.txt", b"first"), ("a.txt", b"second")])
+
+    with pytest.raises(ValueError, match="Duplicate WebDataset field"):
+        daft.read_webdataset(str(path))
+
+
+def test_read_webdataset_rejects_compressed_tar(tmp_path: Path) -> None:
+    path = tmp_path / "samples.tar.gz"
+    with tarfile.open(path, "w:gz") as archive:
+        info = tarfile.TarInfo("a.txt")
+        info.size = 5
+        archive.addfile(info, io.BytesIO(b"hello"))
+
+    with pytest.raises(ValueError, match="Compressed WebDataset shards are not supported"):
+        daft.read_webdataset(str(path))
+
+
+@pytest.mark.parametrize("batch_size", [0, -1])
+def test_read_webdataset_rejects_invalid_batch_size(webdataset_path: Path, batch_size: int) -> None:
+    with pytest.raises(ValueError, match="batch_size must be greater than zero"):
+        daft.read_webdataset(str(webdataset_path), batch_size=batch_size)

--- a/tests/io/webdataset/test_webdataset.py
+++ b/tests/io/webdataset/test_webdataset.py
@@ -26,6 +26,20 @@ def _write_tar(path: Path, members: list[tuple[str, bytes]]) -> None:
             archive.addfile(info, io.BytesIO(data))
 
 
+def _write_sparse_tar(path: Path) -> None:
+    info = tarfile.TarInfo("sample.bin")
+    info.type = tarfile.GNUTYPE_SPARSE
+    info.size = 4
+    header = bytearray(info.tobuf(format=tarfile.GNU_FORMAT))
+    header[386:398] = b"00000002000\0"
+    header[398:410] = b"00000000004\0"
+    header[483:495] = b"00000004000\0"
+    header[148:156] = b"        "
+    checksum = sum(header)
+    header[148:156] = f"{checksum:06o}\0 ".encode()
+    path.write_bytes(header + b"data" + bytes(508 + 1024))
+
+
 @pytest.fixture
 def webdataset_path(tmp_path: Path) -> Path:
     path = tmp_path / "samples.tar"
@@ -202,6 +216,14 @@ def test_read_webdataset_rejects_compressed_tar(tmp_path: Path) -> None:
         archive.addfile(info, io.BytesIO(b"hello"))
 
     with pytest.raises(ValueError, match="Compressed WebDataset shards are not supported"):
+        daft.read_webdataset(str(path))
+
+
+def test_read_webdataset_rejects_sparse_tar_member(tmp_path: Path) -> None:
+    path = tmp_path / "sparse.tar"
+    _write_sparse_tar(path)
+
+    with pytest.raises(ValueError, match="Sparse TAR member 'sample.bin'"):
         daft.read_webdataset(str(path))
 
 


### PR DESCRIPTION
Added read_webdataset for reading uncompressed WebDataset TAR shards through Daft's DataSource API.

- Group archive members into samples using their filename prefixes
- Decode JSON, text, and integer metadata fields
- expose binary media as lazy byte-range-backed File columns
- Support local and remote paths, globs, directories, and multiple shards
- Add WebDataset support to read_huggingface
- Document the API and add reader and integration tests

Closes Eventual-Inc/Daft#7342