### PR TITLE
fix: Fix startup of IO-Integration Docker Compose

### DIFF
--- a/.github/workflows/nightly-publish-s3.yml
+++ b/.github/workflows/nightly-publish-s3.yml
@@ -267,6 +267,7 @@ jobs:
       uses: isbang/compose-action@v3.0.0
       with:
         compose-file: ./tests/integration/io/docker-compose/docker-compose.yml
+        up-flags: --wait --wait-timeout 60
         down-flags: --volumes
     - name: Run IO integration tests
       run: |
@@ -274,6 +275,11 @@ jobs:
         pytest tests/integration/io -m 'integration and not benchmark' --durations=50
       env:
         DAFT_RUNNER: ${{ matrix.daft-runner }}
+    - name: Show IO service diagnostics
+      if: failure()
+      run: |
+        docker compose -f ./tests/integration/io/docker-compose/docker-compose.yml ps -a
+        docker compose -f ./tests/integration/io/docker-compose/docker-compose.yml logs --no-color bigtable-emulator
     - name: Send Slack notification on failure
       uses: slackapi/slack-github-action@v3.0.3
       if: ${{ env.SLACK_WEBHOOK_URL && failure() && (github.ref == 'refs/heads/main') }}

--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -1030,7 +1030,14 @@ jobs:
       env:
         DAFT_RUNNER: native
 
-      # Cleanup docker services
+    # Cleanup docker services
+    - name: Show catalog service diagnostics
+      if: failure()
+      run: |
+        docker compose -f ./tests/integration/iceberg/docker-compose/docker-compose.yml ps -a || true
+        docker compose -f ./tests/integration/iceberg/docker-compose/docker-compose.yml logs --no-color || true
+        docker compose -f ./tests/integration/gravitino/docker-compose/docker-compose.yml ps -a || true
+        docker compose -f ./tests/integration/gravitino/docker-compose/docker-compose.yml logs --no-color || true
     - name: Cleanup Docker services
       if: always()
       run: |

--- a/tests/integration/iceberg/docker-compose/docker-compose.yml
+++ b/tests/integration/iceberg/docker-compose/docker-compose.yml
@@ -64,7 +64,10 @@ services:
       retries: 20
       start_period: 10s
   minio:
-    image: minio/minio
+    # MinIO no longer publishes this image on Docker Hub. Pin the multi-arch
+    # image from its supported Quay registry so CI does not depend on a
+    # mutable tag.
+    image: quay.io/minio/minio@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e
     container_name: pyiceberg-minio
     environment:
     - MINIO_ROOT_USER=admin
@@ -87,7 +90,7 @@ services:
     depends_on:
       minio:
         condition: service_healthy
-    image: minio/mc
+    image: quay.io/minio/mc@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727
     container_name: pyiceberg-mc
     networks:
       iceberg_net:

--- a/tests/integration/io/docker-compose/docker-compose.yml
+++ b/tests/integration/io/docker-compose/docker-compose.yml
@@ -36,13 +36,19 @@ services:
 
   # Bigtable emulator for integration testing
   bigtable-emulator:
-    image: google/cloud-sdk
+    # Use Google's multi-arch emulator image for native ARM and x86-64 support.
+    image: gcr.io/google.com/cloudsdktool/google-cloud-cli:emulators@sha256:45a15cc163d2df13137478856b4b9bb90426100fa8aec542269460c10110b727
     container_name: bigtable-emulator
     ports:
     - "127.0.0.1:8086:8086"
     command: gcloud beta emulators bigtable start --host-port=0.0.0.0:8086
     environment:
     - BIGTABLE_EMULATOR_HOST=0.0.0.0:8086
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c 'exec 3<>/dev/tcp/127.0.0.1/8086'"]
+      interval: 2s
+      timeout: 2s
+      retries: 30
 
   redpanda:
     image: redpandadata/redpanda:v25.1.3


### PR DESCRIPTION
## Changes Made

Update the Docker Compose for setting up the IO integration tests so that startup is properly tracked. Also switching the Google Cloud container to one that's compatible on both Arm and x86
